### PR TITLE
Extract model relationships into single use traits.

### DIFF
--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -1,6 +1,8 @@
 <?php
 namespace App\Models;
 
+use App\Models\Relationships\AccessoryRelationships;
+use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -18,6 +20,7 @@ class Accessory extends SnipeModel
     protected $presenter = 'App\Presenters\AccessoryPresenter';
     use CompanyableTrait;
     use Loggable, Presentable;
+    use AccessoryRelationships;
     use SoftDeletes;
 
     protected $dates = ['deleted_at', 'purchase_date'];
@@ -100,14 +103,6 @@ class Accessory extends SnipeModel
     ];
 
 
-
-
-    public function supplier()
-    {
-        return $this->belongsTo('\App\Models\Supplier', 'supplier_id');
-    }
-    
-
     public function setRequestableAttribute($value)
     {
         if ($value == '') {
@@ -117,28 +112,6 @@ class Accessory extends SnipeModel
         return;
     }
 
-    public function company()
-    {
-        return $this->belongsTo('\App\Models\Company', 'company_id');
-    }
-
-    public function location()
-    {
-        return $this->belongsTo('\App\Models\Location', 'location_id');
-    }
-
-    public function category()
-    {
-        return $this->belongsTo('\App\Models\Category', 'category_id')->where('category_type', '=', 'accessory');
-    }
-
-    /**
-    * Get action logs for this accessory
-    */
-    public function assetlog()
-    {
-        return $this->hasMany('\App\Models\Actionlog', 'item_id')->where('item_type', Accessory::class)->orderBy('created_at', 'desc')->withTrashed();
-    }
 
     public function getImageUrl() {
         if ($this->image) {
@@ -148,30 +121,18 @@ class Accessory extends SnipeModel
 
     }
 
-    public function users()
-    {
-        return $this->belongsToMany('\App\Models\User', 'accessories_users', 'accessory_id', 'assigned_to')->withPivot('id')->withTrashed();
-    }
-
-    public function hasUsers()
-    {
-        return $this->belongsToMany('\App\Models\User', 'accessories_users', 'accessory_id', 'assigned_to')->count();
-    }
-
-    public function manufacturer()
-    {
-        return $this->belongsTo('\App\Models\Manufacturer', 'manufacturer_id');
-    }
 
     public function checkin_email()
     {
         return $this->category->checkin_email;
     }
 
+
     public function requireAcceptance()
     {
         return $this->category->require_acceptance;
     }
+
 
     public function getEula()
     {
@@ -186,6 +147,7 @@ class Accessory extends SnipeModel
             return null;
     }
 
+
     public function numRemaining()
     {
         $checkedout = $this->users->count();
@@ -193,6 +155,7 @@ class Accessory extends SnipeModel
         $remaining = $total - $checkedout;
         return $remaining;
     }
+
 
     /**
     * Query builder scope to order on company

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -1,5 +1,6 @@
 <?php
 namespace App\Models;
+use App\Models\Relationships\ActionlogRelationships;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Model;
@@ -19,6 +20,7 @@ class Actionlog extends SnipeModel
     protected $presenter = "App\Presenters\ActionlogPresenter";
     use SoftDeletes;
     use Presentable;
+    use ActionlogRelationships;
     protected $dates = [ 'deleted_at' ];
 
     protected $table      = 'action_logs';
@@ -60,16 +62,6 @@ class Actionlog extends SnipeModel
             }
         });
     }
-    // Eloquent Relationships below
-    public function item()
-    {
-        return $this->morphTo('item')->withTrashed();
-    }
-
-    public function company()
-    {
-        return $this->hasMany('\App\Models\Company', 'id', 'company_id');
-    }
 
     public function itemType()
     {
@@ -107,45 +99,6 @@ class Actionlog extends SnipeModel
         return $itemroute;
     }
 
-
-
-
-    public function uploads()
-    {
-        return $this->morphTo('item')
-                    ->where('action_type', '=', 'uploaded')
-                    ->withTrashed();
-    }
-
-    public function userlog()
-    {
-        return $this->target();
-    }
-
-    public function user()
-    {
-        return $this->belongsTo(User::class, 'user_id')
-                    ->withTrashed();
-    }
-
-    public function target()
-    {
-        return $this->morphTo('target')->withTrashed();
-    }
-
-    public function childlogs()
-    {
-        return $this->hasMany('\App\Models\ActionLog', 'thread_id');
-    }
-
-    public function parentlog()
-    {
-        return $this->belongsTo('\App\Models\ActionLog', 'thread_id');
-    }
-
-    public function location() {
-        return $this->belongsTo('\App\Models\Location', 'location_id' )->withTrashed();
-    }
 
     /**
        * Check if the file exists, and if it does, force a download

--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -2,6 +2,7 @@
 namespace App\Models;
 
 use App\Helpers\Helper;
+use App\Models\Relationships\AssetMaintenanceRelationships;
 use App\Models\Traits\Searchable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Lang;
@@ -18,7 +19,7 @@ class AssetMaintenance extends Model implements ICompanyableChild
     use SoftDeletes;
     use CompanyableChildTrait;
     use ValidatingTrait;
-
+    use AssetMaintenanceRelationships;
 
     protected $dates = [ 'deleted_at', 'start_date' , 'completion_date'];
     protected $table = 'asset_maintenances';
@@ -115,42 +116,6 @@ class AssetMaintenance extends Model implements ICompanyableChild
             $value = null;
         }
         $this->attributes['completion_date'] = $value;
-    }
-
-    /**
-       * asset
-       * Get asset for this improvement
-       *
-       * @return mixed
-       * @author  Vincent Sposato <vincent.sposato@gmail.com>
-       * @version v1.0
-       */
-    public function asset()
-    {
-
-        return $this->belongsTo('\App\Models\Asset', 'asset_id')
-                    ->withTrashed();
-    }
-
-    /**
-     * Get the admin who created the maintenance
-     *
-     * @return mixed
-     * @author  A. Gianotto <snipe@snipe.net>
-     * @version v3.0
-     */
-    public function admin()
-    {
-
-        return $this->belongsTo('\App\Models\User', 'user_id')
-            ->withTrashed();
-    }
-
-    public function supplier()
-    {
-
-        return $this->belongsTo('\App\Models\Supplier', 'supplier_id')
-                    ->withTrashed();
     }
 
     /**

--- a/app/Models/AssetModel.php
+++ b/app/Models/AssetModel.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Models;
 
+use App\Models\Relationships\AssetModelRelationships;
 use App\Models\Requestable;
 use App\Models\SnipeModel;
 use App\Models\Traits\Searchable;
@@ -19,7 +20,7 @@ class AssetModel extends SnipeModel
 {
     use SoftDeletes;
     protected $presenter = 'App\Presenters\AssetModelPresenter';
-    use Requestable, Presentable;
+    use Requestable, Presentable, AssetModelRelationships;
     protected $dates = ['deleted_at'];
     protected $table = 'models';
     protected $hidden = ['user_id','deleted_at'];
@@ -88,41 +89,6 @@ class AssetModel extends SnipeModel
         'category'     => ['name'],
         'manufacturer' => ['name'],
     ];      
-
-    public function assets()
-    {
-        return $this->hasMany('\App\Models\Asset', 'model_id');
-    }
-
-    public function category()
-    {
-        return $this->belongsTo('\App\Models\Category', 'category_id');
-    }
-
-    public function depreciation()
-    {
-        return $this->belongsTo('\App\Models\Depreciation', 'depreciation_id');
-    }
-
-    public function adminuser()
-    {
-        return $this->belongsTo('\App\Models\User', 'user_id');
-    }
-
-    public function manufacturer()
-    {
-        return $this->belongsTo('\App\Models\Manufacturer', 'manufacturer_id');
-    }
-
-    public function fieldset()
-    {
-        return $this->belongsTo('\App\Models\CustomFieldset', 'fieldset_id');
-    }
-
-    public function defaultValues()
-    {
-        return $this->belongsToMany('\App\Models\CustomField', 'models_custom_fields')->withPivot('default_value');
-    }
 
 
     public function getImageUrl() {

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -2,6 +2,7 @@
 namespace App\Models;
 
 use App\Http\Traits\UniqueUndeletedTrait;
+use App\Models\Relationships\CategoryRelationships;
 use App\Models\SnipeModel;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
@@ -22,6 +23,7 @@ class Category extends SnipeModel
     protected $presenter = 'App\Presenters\CategoryPresenter';
     use Presentable;
     use SoftDeletes;
+    use CategoryRelationships;
     protected $dates = ['deleted_at'];
     protected $table = 'categories';
     protected $hidden = ['user_id','deleted_at'];
@@ -80,30 +82,6 @@ class Category extends SnipeModel
      */
     protected $searchableRelations = [];
 
-    public function has_models()
-    {
-        return $this->hasMany('\App\Models\AssetModel', 'category_id')->count();
-    }
-
-    public function accessories()
-    {
-        return $this->hasMany('\App\Models\Accessory');
-    }
-
-    public function licenses()
-    {
-        return $this->hasMany('\App\Models\License');
-    }
-
-    public function consumables()
-    {
-        return $this->hasMany('\App\Models\Consumable');
-    }
-
-    public function components()
-    {
-        return $this->hasMany('\App\Models\Component');
-    }
 
     public function itemCount()
     {
@@ -118,16 +96,6 @@ class Category extends SnipeModel
                 return $this->consumables()->count();
         }
         return '0';
-    }
-
-    public function assets()
-    {
-        return $this->hasManyThrough('\App\Models\Asset', '\App\Models\AssetModel', 'category_id', 'model_id');
-    }
-
-    public function models()
-    {
-        return $this->hasMany('\App\Models\AssetModel', 'category_id');
     }
 
     public function getEula()

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -1,6 +1,8 @@
 <?php
 namespace App\Models;
 
+use App\Models\Relationships\ComponentRelationships;
+use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -17,6 +19,7 @@ class Component extends SnipeModel
     use CompanyableTrait;
     use Loggable, Presentable;
     use SoftDeletes;
+    use ComponentRelationships;
 
     protected $dates = ['deleted_at', 'purchase_date'];
     protected $table = 'components';
@@ -87,40 +90,6 @@ class Component extends SnipeModel
         'company'      => ['name'],
         'location'     => ['name'],
     ];      
-
-    public function location()
-    {
-        return $this->belongsTo('\App\Models\Location', 'location_id');
-    }
-
-    public function assets()
-    {
-        return $this->belongsToMany('\App\Models\Asset', 'components_assets')->withPivot('id', 'assigned_qty', 'created_at', 'user_id');
-    }
-
-    public function admin()
-    {
-        return $this->belongsTo('\App\Models\User', 'user_id');
-    }
-
-    public function company()
-    {
-        return $this->belongsTo('\App\Models\Company', 'company_id');
-    }
-
-
-    public function category()
-    {
-        return $this->belongsTo('\App\Models\Category', 'category_id');
-    }
-
-    /**
-    * Get action logs for this consumable
-    */
-    public function assetlog()
-    {
-        return $this->hasMany('\App\Models\Actionlog', 'item_id')->where('item_type', Component::class)->orderBy('created_at', 'desc')->withTrashed();
-    }
 
 
     public function numRemaining()

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -1,6 +1,8 @@
 <?php
 namespace App\Models;
 
+use App\Models\Relationships\ConsumableRelationships;
+use App\Models\Traits\CompanyableTrait;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -13,6 +15,7 @@ class Consumable extends SnipeModel
     use CompanyableTrait;
     use Loggable, Presentable;
     use SoftDeletes;
+    use ConsumableRelationships;
 
     protected $dates = ['deleted_at', 'purchase_date'];
     protected $table = 'consumables';
@@ -99,61 +102,12 @@ class Consumable extends SnipeModel
         return;
     }
 
-    public function admin()
-    {
-        return $this->belongsTo('\App\Models\User', 'user_id');
-    }
-
-    public function consumableAssignments()
-    {
-        return $this->hasMany('\App\Models\ConsumableAssignment');
-    }
-
-    public function company()
-    {
-        return $this->belongsTo('\App\Models\Company', 'company_id');
-    }
-
-    public function manufacturer()
-    {
-        return $this->belongsTo('\App\Models\Manufacturer', 'manufacturer_id');
-    }
-
-    public function location()
-    {
-        return $this->belongsTo('\App\Models\Location', 'location_id');
-    }
-
-    public function category()
-    {
-        return $this->belongsTo('\App\Models\Category', 'category_id');
-    }
-
-    /**
-    * Get action logs for this consumable
-    */
-    public function assetlog()
-    {
-        return $this->hasMany('\App\Models\Actionlog', 'item_id')->where('item_type', Consumable::class)->orderBy('created_at', 'desc')->withTrashed();
-    }
-
     public function getImageUrl() {
         if ($this->image) {
             return url('/').'/uploads/consumables/'.$this->image;
         }
         return false;
 
-    }
-
-
-    public function users()
-    {
-        return $this->belongsToMany('\App\Models\User', 'consumables_users', 'consumable_id', 'assigned_to')->withPivot('user_id')->withTrashed()->withTimestamps();
-    }
-
-    public function hasUsers()
-    {
-        return $this->belongsToMany('\App\Models\User', 'consumables_users', 'consumable_id', 'assigned_to')->count();
     }
 
     public function checkin_email()

--- a/app/Models/ConsumableAssignment.php
+++ b/app/Models/ConsumableAssignment.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Models;
 
+use App\Models\Traits\CompanyableTrait;
 use Illuminate\Database\Eloquent\Model;
 
 class ConsumableAssignment extends Model

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Models;
 
+use App\Models\Relationships\CustomFieldRelationships;
 use Illuminate\Database\Eloquent\Model;
 use Schema;
 use Watson\Validating\ValidatingTrait;
@@ -12,7 +13,7 @@ use Illuminate\Validation\Rule;
 
 class CustomField extends Model
 {
-    use ValidatingTrait, UniqueUndeletedTrait;
+    use ValidatingTrait, UniqueUndeletedTrait, CustomFieldRelationships;
     public $guarded=["id"];
     public static $PredefinedFormats=[
         "ANY" => "",
@@ -138,21 +139,6 @@ class CustomField extends Model
         });
     }
 
-    public function fieldset()
-    {
-        return $this->belongsToMany('\App\Models\CustomFieldset');
-    }
-
-    public function user()
-    {
-        return $this->belongsTo('\App\Models\User');
-    }
-
-    public function defaultValues()
-    {
-        return $this->belongsToMany('\App\Models\AssetModel', 'models_custom_fields')->withPivot('default_value');
-    }
-
     /**
      * Returns the default value for a given model using the defaultValues
      * relationship
@@ -188,7 +174,7 @@ class CustomField extends Model
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v3.4]
-     * @return Array
+     * @return array
      */
     public function getFormatAttribute($value)
     {
@@ -205,7 +191,8 @@ class CustomField extends Model
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v3.4]
-     * @return Array
+     * @param $value
+     * @return void
      */
     public function setFormatAttribute($value)
     {
@@ -283,12 +270,11 @@ class CustomField extends Model
     }
 
     /**
-    * Get validation rules for custom fields to use with Validator
-    * @author [V. Cordes] [<volker@fdatek.de>]
-    * @param int $id
-    * @since [v4.1.10]
-    * @return Array
-    */
+     * Get validation rules for custom fields to use with Validator
+     * @author [V. Cordes] [<volker@fdatek.de>]
+     * @return array
+     * @since [v4.1.10]
+     */
     public function validationRules()
     {
         return [

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -1,12 +1,14 @@
 <?php
 namespace App\Models;
 
+use App\Models\Relationships\CustomFieldsetRelationships;
 use Illuminate\Database\Eloquent\Model;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Watson\Validating\ValidatingTrait;
 
 class CustomFieldset extends Model
 {
+    use CustomFieldsetRelationships;
     protected $guarded=["id"];
 
     public $rules=[
@@ -24,20 +26,6 @@ class CustomFieldset extends Model
     use ValidatingTrait;
     
 
-    public function fields()
-    {
-        return $this->belongsToMany('\App\Models\CustomField')->withPivot(["required","order"])->orderBy("pivot_order");
-    }
-
-    public function models()
-    {
-        return $this->hasMany('\App\Models\AssetModel', "fieldset_id");
-    }
-
-    public function user()
-    {
-        return $this->belongsTo('\App\Models\User'); //WARNING - not all CustomFieldsets have a User!!
-    }
 
     public function validation_rules()
     {

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Http\Traits\UniqueUndeletedTrait;
+use App\Models\Relationships\DepartmentRelationships;
 use App\Models\Traits\Searchable;
 use Illuminate\Database\Eloquent\Model;
 use Log;
@@ -22,7 +23,7 @@ class Department extends SnipeModel
      */
     protected $injectUniqueIdentifier = true;
 
-    use ValidatingTrait, UniqueUndeletedTrait;
+    use ValidatingTrait, UniqueUndeletedTrait, DepartmentRelationships;
 
     protected $rules = [
         'name'            => 'required|max:255',
@@ -63,36 +64,6 @@ class Department extends SnipeModel
     protected $searchableRelations = [];    
 
 
-    public function company()
-    {
-        return $this->belongsTo('\App\Models\Company', 'company_id');
-    }
-
-    /**
-     * Even though we allow allow for checkout to things beyond users
-     * this method is an easy way of seeing if we are checked out to a user.
-     * @return mixed
-     */
-    public function users()
-    {
-        return $this->hasMany('\App\Models\User', 'department_id');
-    }
-
-
-    /**
-    * Return the manager in charge of the dept
-    * @return mixed
-    */
-    public function manager()
-    {
-        return $this->belongsTo('\App\Models\User', 'manager_id');
-    }
-
-
-    public function location()
-    {
-        return $this->belongsTo('\App\Models\Location', 'location_id');
-    }
     
     /**
      * Query builder scope to order on location name

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -2,6 +2,7 @@
 namespace App\Models;
 
 use App\Models\Loggable;
+use App\Models\Relationships\LicenseSeatRelationships;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Notifications\CheckoutLicenseNotification;
@@ -9,9 +10,7 @@ use App\Notifications\CheckinLicenseNotification;
 
 class LicenseSeat extends Model implements ICompanyableChild
 {
-    use CompanyableChildTrait;
-    use SoftDeletes;
-    use Loggable;
+    use CompanyableChildTrait,SoftDeletes,Loggable,LicenseSeatRelationships;
 
     protected $dates = ['deleted_at'];
     protected $guarded = 'id';
@@ -26,21 +25,6 @@ class LicenseSeat extends Model implements ICompanyableChild
     public function getCompanyableParents()
     {
         return ['asset', 'license'];
-    }
-
-    public function license()
-    {
-        return $this->belongsTo('\App\Models\License', 'license_id');
-    }
-
-    public function user()
-    {
-        return $this->belongsTo('\App\Models\User', 'assigned_to')->withTrashed();
-    }
-
-    public function asset()
-    {
-        return $this->belongsTo('\App\Models\Asset', 'asset_id')->withTrashed();
     }
 
     public function location()

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -3,6 +3,7 @@ namespace App\Models;
 
 use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Asset;
+use App\Models\Relationships\LocationRelationships;
 use App\Models\SnipeModel;
 use App\Models\Traits\Searchable;
 use App\Models\User;
@@ -39,6 +40,7 @@ class Location extends SnipeModel
     protected $injectUniqueIdentifier = true;
     use ValidatingTrait;
     use UniqueUndeletedTrait;
+    use LocationRelationships;
 
 
     /**
@@ -78,58 +80,6 @@ class Location extends SnipeModel
     protected $searchableRelations = [
       'parent' => ['name']
     ];
-
-    public function users()
-    {
-        return $this->hasMany('\App\Models\User', 'location_id');
-    }
-
-    public function assets()
-    {
-        return $this->hasMany('\App\Models\Asset', 'location_id')
-            ->whereHas('assetstatus', function ($query) {
-                    $query->where('status_labels.deployable', '=', 1)
-                        ->orWhere('status_labels.pending', '=', 1)
-                        ->orWhere('status_labels.archived', '=', 0);
-            });
-    }
-
-    public function rtd_assets()
-    {
-        /* This used to have an ...->orHas() clause that referred to
-           assignedAssets, and that was probably incorrect, as well as
-           definitely was setting fire to the query-planner. So don't do that.
-
-           It is arguable that we should have a '...->whereNull('assigned_to')
-           bit in there, but that isn't always correct either (in the case 
-           where a user has no location, for example).
-
-           In all likelyhood, we need to denorm an "effective_location" column
-           into Assets to make this slightly less miserable.
-        */
-        return $this->hasMany('\App\Models\Asset', 'rtd_location_id');
-    }
-
-    public function parent()
-    {
-        return $this->belongsTo('\App\Models\Location', 'parent_id','id');
-    }
-
-    public function manager()
-    {
-        return $this->belongsTo('\App\Models\User', 'manager_id');
-    }
-
-    public function childLocations()
-    {
-        return $this->hasMany('\App\Models\Location', 'parent_id');
-    }
-
-    // I don't think we need this anymore since we de-normed location_id in assets?
-    public function assignedAssets()
-    {
-        return $this->morphMany('App\Models\Asset', 'assigned', 'assigned_type', 'assigned_to')->withTrashed();
-    }
 
     public function setLdapOuAttribute($ldap_ou)
     {

--- a/app/Models/Manufacturer.php
+++ b/app/Models/Manufacturer.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Models;
 
+use App\Models\Relationships\ManufacturerRelationships;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -11,6 +12,7 @@ class Manufacturer extends SnipeModel
     protected $presenter = 'App\Presenters\ManufacturerPresenter';
     use Presentable;
     use SoftDeletes;
+    use ManufacturerRelationships;
     protected $dates = ['deleted_at'];
     protected $table = 'manufacturers';
 
@@ -64,35 +66,4 @@ class Manufacturer extends SnipeModel
      */
     protected $searchableRelations = [];    
 
-
-
-    public function has_models()
-    {
-        return $this->hasMany('\App\Models\AssetModel', 'manufacturer_id')->count();
-    }
-
-    public function assets()
-    {
-        return $this->hasManyThrough('\App\Models\Asset', '\App\Models\AssetModel', 'manufacturer_id', 'model_id');
-    }
-
-    public function models()
-    {
-        return $this->hasMany('\App\Models\AssetModel', 'manufacturer_id');
-    }
-
-    public function licenses()
-    {
-        return $this->hasMany('\App\Models\License', 'manufacturer_id');
-    }
-
-    public function accessories()
-    {
-        return $this->hasMany('\App\Models\Accessory', 'manufacturer_id');
-    }
-
-    public function consumables()
-    {
-        return $this->hasMany('\App\Models\Consumable', 'manufacturer_id');
-    }
 }

--- a/app/Models/Relationships/AccessoryRelationships.php
+++ b/app/Models/Relationships/AccessoryRelationships.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+use App\Models\Accessory;
+
+/**
+ * This trait wraps all accessory model relationships,
+ *
+ */
+trait AccessoryRelationships {
+
+    /**
+     * Get action logs for this accessory
+     */
+    public function assetlog()
+    {
+        return $this->hasMany('\App\Models\Actionlog', 'item_id')->where('item_type', Accessory::class)->orderBy('created_at', 'desc')->withTrashed();
+    }
+
+    public function category()
+    {
+        return $this->belongsTo('\App\Models\Category', 'category_id')->where('category_type', '=', 'accessory');
+    }
+
+    public function company()
+    {
+        return $this->belongsTo('\App\Models\Company', 'company_id');
+    }
+
+    public function hasUsers()
+    {
+        return $this->belongsToMany('\App\Models\User', 'accessories_users', 'accessory_id', 'assigned_to')->count();
+    }
+
+    public function location()
+    {
+        return $this->belongsTo('\App\Models\Location', 'location_id');
+    }
+
+    public function manufacturer()
+    {
+        return $this->belongsTo('\App\Models\Manufacturer', 'manufacturer_id');
+    }
+
+    public function supplier()
+    {
+        return $this->belongsTo('\App\Models\Supplier', 'supplier_id');
+    }
+
+    public function users()
+    {
+        return $this->belongsToMany('\App\Models\User', 'accessories_users', 'accessory_id', 'assigned_to')->withPivot('id')->withTrashed();
+    }
+
+}

--- a/app/Models/Relationships/ActionlogRelationships.php
+++ b/app/Models/Relationships/ActionlogRelationships.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+
+use App\Models\User;
+
+/**
+ * This trait wraps all actionlog model relationships,
+ *
+ */
+trait ActionlogRelationships {
+
+
+    public function childlogs()
+    {
+        return $this->hasMany('\App\Models\ActionLog', 'thread_id');
+    }
+
+    public function company()
+    {
+        return $this->hasMany('\App\Models\Company', 'id', 'company_id');
+    }
+
+    public function item()
+    {
+        return $this->morphTo('item')->withTrashed();
+    }
+
+    public function location() {
+        return $this->belongsTo('\App\Models\Location', 'location_id' )->withTrashed();
+    }
+
+    public function parentlog()
+    {
+        return $this->belongsTo('\App\Models\ActionLog', 'thread_id');
+    }
+
+    public function target()
+    {
+        return $this->morphTo('target')->withTrashed();
+    }
+
+    public function uploads()
+    {
+        return $this->morphTo('item')
+            ->where('action_type', '=', 'uploaded')
+            ->withTrashed();
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id')
+            ->withTrashed();
+    }
+
+    public function userlog()
+    {
+        return $this->target();
+    }
+
+}

--- a/app/Models/Relationships/AssetMaintenanceRelationships.php
+++ b/app/Models/Relationships/AssetMaintenanceRelationships.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+use App\Models\Accessory;
+
+/**
+ * This trait wraps all asset maintenance model relationships,
+ *
+ */
+trait AssetMaintenanceRelationships {
+
+    /**
+     * Get the admin who created the maintenance
+     *
+     * @return mixed
+     * @author  A. Gianotto <snipe@snipe.net>
+     * @version v3.0
+     */
+    public function admin()
+    {
+
+        return $this->belongsTo('\App\Models\User', 'user_id')
+            ->withTrashed();
+    }
+
+    /**
+     * asset
+     * Get asset for this improvement
+     *
+     * @return mixed
+     * @author  Vincent Sposato <vincent.sposato@gmail.com>
+     * @version v1.0
+     */
+    public function asset()
+    {
+
+        return $this->belongsTo('\App\Models\Asset', 'asset_id')
+            ->withTrashed();
+    }
+
+    public function supplier()
+    {
+
+        return $this->belongsTo('\App\Models\Supplier', 'supplier_id')
+            ->withTrashed();
+    }
+}

--- a/app/Models/Relationships/AssetModelRelationships.php
+++ b/app/Models/Relationships/AssetModelRelationships.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+use App\Models\Accessory;
+
+/**
+ * This trait wraps all assetmodel model relationships,
+ *
+ */
+trait AssetModelRelationships {
+
+    public function adminuser()
+    {
+        return $this->belongsTo('\App\Models\User', 'user_id');
+    }
+
+    public function assets()
+    {
+        return $this->hasMany('\App\Models\Asset', 'model_id');
+    }
+
+    public function category()
+    {
+        return $this->belongsTo('\App\Models\Category', 'category_id');
+    }
+
+    public function defaultValues()
+    {
+        return $this->belongsToMany('\App\Models\CustomField', 'models_custom_fields')->withPivot('default_value');
+    }
+
+    public function depreciation()
+    {
+        return $this->belongsTo('\App\Models\Depreciation', 'depreciation_id');
+    }
+
+    public function fieldset()
+    {
+        return $this->belongsTo('\App\Models\CustomFieldset', 'fieldset_id');
+    }
+
+    public function manufacturer()
+    {
+        return $this->belongsTo('\App\Models\Manufacturer', 'manufacturer_id');
+    }
+
+
+}

--- a/app/Models/Relationships/AssetRelationships.php
+++ b/app/Models/Relationships/AssetRelationships.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+
+use App\Models\Asset;
+
+/**
+ * This trait wraps all asset model relationships,
+ *
+ */
+trait AssetRelationships {
+
+
+    /**
+     * Get action logs for this asset
+     */
+    public function adminuser()
+    {
+        return $this->belongsTo('\App\Models\User', 'user_id');
+    }
+
+    /**
+     * Get total assets
+     */
+    public static function assetcount()
+    {
+        return Company::scopeCompanyables(Asset::where('physical', '=', '1'))
+            ->whereNull('deleted_at', 'and')
+            ->count();
+    }
+
+    /**
+     * Get action logs for this asset
+     */
+    public function assetlog()
+    {
+        return $this->hasMany('\App\Models\Actionlog', 'item_id')
+            ->where('item_type', '=', Asset::class)
+            ->orderBy('created_at', 'desc')
+            ->withTrashed();
+    }
+
+    /**
+     * assetmaintenances
+     * Get improvements for this asset
+     *
+     * @return mixed
+     * @author  Vincent Sposato <vincent.sposato@gmail.com>
+     * @version v1.0
+     */
+    public function assetmaintenances()
+    {
+        return $this->hasMany('\App\Models\AssetMaintenance', 'asset_id')
+            ->orderBy('created_at', 'desc');
+    }
+
+    /**
+     * Get asset status
+     */
+    public function assetstatus()
+    {
+        return $this->belongsTo('\App\Models\Statuslabel', 'status_id');
+    }
+
+    /**
+     * Get total assets not checked out
+     */
+    public static function availassetcount()
+    {
+        return Asset::RTD()
+            ->whereNull('deleted_at')
+            ->count();
+    }
+
+    /**
+     * Get checkins
+     */
+    public function checkins()
+    {
+        return $this->assetlog()
+            ->where('action_type', '=', 'checkin from')
+            ->orderBy('created_at', 'desc')
+            ->withTrashed();
+    }
+
+    /**
+     * Get checkouts
+     */
+    public function checkouts()
+    {
+        return $this->assetlog()->where('action_type', '=', 'checkout')
+            ->orderBy('created_at', 'desc')
+            ->withTrashed();
+    }
+
+    public function company()
+    {
+        return $this->belongsTo('\App\Models\Company', 'company_id');
+    }
+
+    /**
+     * Get components assigned to this asset
+     */
+    public function components()
+    {
+        return $this->belongsToMany('\App\Models\Component', 'components_assets', 'asset_id', 'component_id')->withPivot('id', 'assigned_qty')->withTrashed();
+    }
+
+    /**
+     * Get the asset's location based on default RTD location
+     **/
+    public function defaultLoc()
+    {
+        return $this->belongsTo('\App\Models\Location', 'rtd_location_id');
+    }
+
+    /**
+     * Set depreciation relationship
+     */
+    public function depreciation()
+    {
+        return $this->model->belongsTo('\App\Models\Depreciation', 'depreciation_id');
+    }
+
+    /**
+     * Get requestable assets
+     */
+    public static function getRequestable()
+    {
+        return Asset::Requestable()
+            ->whereNull('deleted_at')
+            ->count();
+    }
+
+    /**
+     * Get the license seat information
+     **/
+    public function licenses()
+    {
+        return $this->belongsToMany('\App\Models\License', 'license_seats', 'asset_id', 'license_id');
+    }
+
+    public function licenseseats()
+    {
+        return $this->hasMany('\App\Models\LicenseSeat', 'asset_id');
+    }
+
+    public function location()
+    {
+        return $this->belongsTo('\App\Models\Location', 'location_id');
+    }
+
+    public function model()
+    {
+        return $this->belongsTo('\App\Models\AssetModel', 'model_id')->withTrashed();
+    }
+
+    public function supplier()
+    {
+        return $this->belongsTo('\App\Models\Supplier', 'supplier_id');
+    }
+
+    /**
+     * Get uploads for this asset
+     */
+    public function uploads()
+    {
+        return $this->hasMany('\App\Models\Actionlog', 'item_id')
+            ->where('item_type', '=', Asset::class)
+            ->where('action_type', '=', 'uploaded')
+            ->whereNotNull('filename')
+            ->orderBy('created_at', 'desc');
+    }
+
+    /**
+     * Get user requests
+     */
+    public function userRequests()
+    {
+        return $this->assetlog()
+            ->where('action_type', '=', 'requested')
+            ->orderBy('created_at', 'desc')
+            ->withTrashed();
+    }
+
+}

--- a/app/Models/Relationships/CategoryRelationships.php
+++ b/app/Models/Relationships/CategoryRelationships.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+
+/**
+ * This trait wraps all category model relationships,
+ *
+ */
+trait CategoryRelationships {
+
+    public function accessories()
+    {
+        return $this->hasMany('\App\Models\Accessory');
+    }
+
+    public function assets()
+    {
+        return $this->hasManyThrough('\App\Models\Asset', '\App\Models\AssetModel', 'category_id', 'model_id');
+    }
+
+    public function components()
+    {
+        return $this->hasMany('\App\Models\Component');
+    }
+
+    public function consumables()
+    {
+        return $this->hasMany('\App\Models\Consumable');
+    }
+
+    public function has_models()
+    {
+        return $this->hasMany('\App\Models\AssetModel', 'category_id')->count();
+    }
+
+    public function licenses()
+    {
+        return $this->hasMany('\App\Models\License');
+    }
+
+    public function models()
+    {
+        return $this->hasMany('\App\Models\AssetModel', 'category_id');
+    }
+}

--- a/app/Models/Relationships/ComponentRelationships.php
+++ b/app/Models/Relationships/ComponentRelationships.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+/**
+ * This trait wraps all component model relationships,
+ *
+ */
+trait ComponentRelationships {
+
+    /**
+     * Get action logs for this consumable
+     */
+    public function assetlog()
+    {
+        return $this->hasMany('\App\Models\Actionlog', 'item_id')->where('item_type', Component::class)->orderBy('created_at', 'desc')->withTrashed();
+    }
+
+    public function assets()
+    {
+        return $this->belongsToMany('\App\Models\Asset', 'components_assets')->withPivot('id', 'assigned_qty', 'created_at', 'user_id');
+    }
+
+    public function admin()
+    {
+        return $this->belongsTo('\App\Models\User', 'user_id');
+    }
+
+    public function category()
+    {
+        return $this->belongsTo('\App\Models\Category', 'category_id');
+    }
+
+    public function company()
+    {
+        return $this->belongsTo('\App\Models\Company', 'company_id');
+    }
+
+    public function location()
+    {
+        return $this->belongsTo('\App\Models\Location', 'location_id');
+    }
+
+}

--- a/app/Models/Relationships/ConsumableRelationships.php
+++ b/app/Models/Relationships/ConsumableRelationships.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+/**
+ * This trait wraps all accessory model relationships,
+ *
+ */
+trait ConsumableRelationships {
+
+    public function admin()
+    {
+        return $this->belongsTo('\App\Models\User', 'user_id');
+    }
+
+    /**
+     * Get action logs for this consumable
+     */
+    public function assetlog()
+    {
+        return $this->hasMany('\App\Models\Actionlog', 'item_id')->where('item_type', Consumable::class)->orderBy('created_at', 'desc')->withTrashed();
+    }
+
+    public function category()
+    {
+        return $this->belongsTo('\App\Models\Category', 'category_id');
+    }
+
+    public function company()
+    {
+        return $this->belongsTo('\App\Models\Company', 'company_id');
+    }
+
+    public function consumableAssignments()
+    {
+        return $this->hasMany('\App\Models\ConsumableAssignment');
+    }
+
+    public function hasUsers()
+    {
+        return $this->belongsToMany('\App\Models\User', 'consumables_users', 'consumable_id', 'assigned_to')->count();
+    }
+
+    public function location()
+    {
+        return $this->belongsTo('\App\Models\Location', 'location_id');
+    }
+
+    public function manufacturer()
+    {
+        return $this->belongsTo('\App\Models\Manufacturer', 'manufacturer_id');
+    }
+
+    public function users()
+    {
+        return $this->belongsToMany('\App\Models\User', 'consumables_users', 'consumable_id', 'assigned_to')->withPivot('user_id')->withTrashed()->withTimestamps();
+    }
+}

--- a/app/Models/Relationships/CustomFieldRelationships.php
+++ b/app/Models/Relationships/CustomFieldRelationships.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+/**
+ * This trait wraps all accessory model relationships,
+ *
+ */
+trait CustomFieldRelationships {
+
+    public function defaultValues()
+    {
+        return $this->belongsToMany('\App\Models\AssetModel', 'models_custom_fields')->withPivot('default_value');
+    }
+
+    public function fieldset()
+    {
+        return $this->belongsToMany('\App\Models\CustomFieldset');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo('\App\Models\User');
+    }
+
+}

--- a/app/Models/Relationships/CustomFieldsetRelationships.php
+++ b/app/Models/Relationships/CustomFieldsetRelationships.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+use App\Models\Accessory;
+
+/**
+ * This trait wraps all custom fieldset model relationships,
+ *
+ */
+trait CustomFieldsetRelationships {
+
+    public function fields()
+    {
+        return $this->belongsToMany('\App\Models\CustomField')->withPivot(["required","order"])->orderBy("pivot_order");
+    }
+
+    public function models()
+    {
+        return $this->hasMany('\App\Models\AssetModel', "fieldset_id");
+    }
+
+    public function user()
+    {
+        return $this->belongsTo('\App\Models\User'); //WARNING - not all CustomFieldsets have a User!!
+    }
+}

--- a/app/Models/Relationships/DepartmentRelationships.php
+++ b/app/Models/Relationships/DepartmentRelationships.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models\Relationships;
+
+/**
+ * This trait wraps all department model relationships,
+ *
+ */
+trait DepartmentRelationships {
+
+    public function company()
+    {
+        return $this->belongsTo('\App\Models\Company', 'company_id');
+    }
+
+    public function location()
+    {
+        return $this->belongsTo('\App\Models\Location', 'location_id');
+    }
+
+    /**
+     * Return the manager in charge of the dept
+     * @return mixed
+     */
+    public function manager()
+    {
+        return $this->belongsTo('\App\Models\User', 'manager_id');
+    }
+
+    /**
+     * Even though we allow allow for checkout to things beyond users
+     * this method is an easy way of seeing if we are checked out to a user.
+     * @return mixed
+     */
+    public function users()
+    {
+        return $this->hasMany('\App\Models\User', 'department_id');
+    }
+}

--- a/app/Models/Relationships/LicenseRelationships.php
+++ b/app/Models/Relationships/LicenseRelationships.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+use App\Models\License;
+use App\Models\LicenseSeat;
+
+/**
+ * This trait wraps all accessory model relationships,
+ *
+ */
+trait LicenseRelationships {
+
+    /**
+     * Get admin user for this asset
+     */
+    public function adminuser()
+    {
+        return $this->belongsTo('\App\Models\User', 'user_id');
+    }
+
+    /**
+     * Get total licenses
+     */
+    public static function assetcount()
+    {
+        return LicenseSeat::whereNull('deleted_at')
+            ->count();
+    }
+
+    /**
+     * Get asset logs for this asset
+     */
+    public function assetlog()
+    {
+        return $this->hasMany('\App\Models\Actionlog', 'item_id')
+            ->where('item_type', '=', License::class)
+            ->orderBy('created_at', 'desc');
+    }
+
+    /**
+     * Get the number of assigned seats
+     *
+     */
+    public function assignedCount()
+    {
+        return $this->licenseSeatsRelation()->where(function ($query) {
+            $query->whereNotNull('assigned_to')
+                ->orWhereNotNull('asset_id');
+        });
+    }
+
+    /**
+     * Get the assigned user
+     */
+    public function assignedusers()
+    {
+        return $this->belongsToMany('\App\Models\User', 'license_seats', 'assigned_to', 'license_id');
+    }
+
+
+    /**
+     * Get the number of available seats
+     */
+    public function availCount()
+    {
+        return $this->licenseSeatsRelation()
+            ->whereNull('asset_id')
+            ->whereNull('assigned_to')
+            ->whereNull('deleted_at');
+    }
+
+    /**
+     * Get total licenses not checked out
+     */
+    public static function availassetcount()
+    {
+        return LicenseSeat::whereNull('assigned_to')
+            ->whereNull('asset_id')
+            ->whereNull('deleted_at')
+            ->count();
+    }
+
+    public function category()
+    {
+        return $this->belongsTo('\App\Models\Category', 'category_id');
+    }
+
+    public function company()
+    {
+        return $this->belongsTo('\App\Models\Company', 'company_id');
+    }
+    /**
+     * Get the next available free seat - used by
+     * the API to populate next_seat
+     */
+    public function freeSeats()
+    {
+        return $this->hasMany('\App\Models\LicenseSeat')->whereNull('assigned_to')->whereNull('deleted_at')->whereNull('asset_id');
+    }
+
+    /**
+     * Get license seat data
+     */
+    public function licenseseats()
+    {
+        return $this->hasMany('\App\Models\LicenseSeat');
+    }
+
+    // We do this to eager load the "count" of seats from the controller.  Otherwise calling "count()" on each model results in n+1
+    public function licenseSeatsRelation()
+    {
+        return $this->hasMany(LicenseSeat::class)->whereNull('deleted_at')->selectRaw('license_id, count(*) as count')->groupBy('license_id');
+    }
+
+    public function manufacturer()
+    {
+        return $this->belongsTo('\App\Models\Manufacturer', 'manufacturer_id');
+    }
+
+    public function supplier()
+    {
+        return $this->belongsTo('\App\Models\Supplier', 'supplier_id');
+    }
+
+    /**
+     * Get total licenses
+     */
+    public function totalSeatsByLicenseID()
+    {
+        return LicenseSeat::where('license_id', '=', $this->id)
+            ->whereNull('deleted_at')
+            ->count();
+    }
+
+    /**
+     * Get uploads for this asset
+     */
+    public function uploads()
+    {
+        return $this->hasMany('\App\Models\Actionlog', 'item_id')
+            ->where('item_type', '=', License::class)
+            ->where('action_type', '=', 'uploaded')
+            ->whereNotNull('filename')
+            ->orderBy('created_at', 'desc');
+    }
+
+}

--- a/app/Models/Relationships/LicenseSeatRelationships.php
+++ b/app/Models/Relationships/LicenseSeatRelationships.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+/**
+ * This trait wraps all licenseseat model relationships,
+ *
+ */
+trait LicenseSeatRelationships {
+
+    public function asset()
+    {
+        return $this->belongsTo('\App\Models\Asset', 'asset_id')->withTrashed();
+    }
+
+    public function license()
+    {
+        return $this->belongsTo('\App\Models\License', 'license_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo('\App\Models\User', 'assigned_to')->withTrashed();
+    }
+
+}

--- a/app/Models/Relationships/LocationRelationships.php
+++ b/app/Models/Relationships/LocationRelationships.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+/**
+ * This trait wraps all accessory model relationships,
+ *
+ */
+trait LocationRelationships {
+
+    public function users()
+    {
+        return $this->hasMany('\App\Models\User', 'location_id');
+    }
+
+    public function assets()
+    {
+        return $this->hasMany('\App\Models\Asset', 'location_id')
+            ->whereHas('assetstatus', function ($query) {
+                $query->where('status_labels.deployable', '=', 1)
+                    ->orWhere('status_labels.pending', '=', 1)
+                    ->orWhere('status_labels.archived', '=', 0);
+            });
+    }
+
+    public function rtd_assets()
+    {
+        /* This used to have an ...->orHas() clause that referred to
+           assignedAssets, and that was probably incorrect, as well as
+           definitely was setting fire to the query-planner. So don't do that.
+
+           It is arguable that we should have a '...->whereNull('assigned_to')
+           bit in there, but that isn't always correct either (in the case
+           where a user has no location, for example).
+
+           In all likelyhood, we need to denorm an "effective_location" column
+           into Assets to make this slightly less miserable.
+        */
+        return $this->hasMany('\App\Models\Asset', 'rtd_location_id');
+    }
+
+    public function parent()
+    {
+        return $this->belongsTo('\App\Models\Location', 'parent_id','id');
+    }
+
+    public function manager()
+    {
+        return $this->belongsTo('\App\Models\User', 'manager_id');
+    }
+
+    public function childLocations()
+    {
+        return $this->hasMany('\App\Models\Location', 'parent_id');
+    }
+
+    // I don't think we need this anymore since we de-normed location_id in assets?
+    public function assignedAssets()
+    {
+        return $this->morphMany('App\Models\Asset', 'assigned', 'assigned_type', 'assigned_to')->withTrashed();
+    }
+
+}

--- a/app/Models/Relationships/ManufacturerRelationships.php
+++ b/app/Models/Relationships/ManufacturerRelationships.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+/**
+ * This trait wraps all accessory model relationships,
+ *
+ */
+trait ManufacturerRelationships {
+
+    public function has_models()
+    {
+        return $this->hasMany('\App\Models\AssetModel', 'manufacturer_id')->count();
+    }
+
+    public function assets()
+    {
+        return $this->hasManyThrough('\App\Models\Asset', '\App\Models\AssetModel', 'manufacturer_id', 'model_id');
+    }
+
+    public function models()
+    {
+        return $this->hasMany('\App\Models\AssetModel', 'manufacturer_id');
+    }
+
+    public function licenses()
+    {
+        return $this->hasMany('\App\Models\License', 'manufacturer_id');
+    }
+
+    public function accessories()
+    {
+        return $this->hasMany('\App\Models\Accessory', 'manufacturer_id');
+    }
+
+    public function consumables()
+    {
+        return $this->hasMany('\App\Models\Consumable', 'manufacturer_id');
+    }
+}

--- a/app/Models/Relationships/SupplierRelationships.php
+++ b/app/Models/Relationships/SupplierRelationships.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+/**
+ * This trait wraps all accessory model relationships,
+ *
+ */
+trait SupplierRelationships {
+
+    // Eager load counts.
+    // We do this to eager load the "count" of seats from the controller.  Otherwise calling "count()" on each model results in n+1
+    public function assetsRelation()
+    {
+        return $this->hasMany(Asset::class)->whereNull('deleted_at')->selectRaw('supplier_id, count(*) as count')->groupBy('supplier_id');
+    }
+
+    public function assets()
+    {
+        return $this->hasMany('\App\Models\Asset', 'supplier_id');
+    }
+
+    public function accessories()
+    {
+        return $this->hasMany('\App\Models\Accessory', 'supplier_id');
+    }
+
+    public function asset_maintenances()
+    {
+        return $this->hasMany('\App\Models\AssetMaintenance', 'supplier_id');
+    }
+
+    public function licenses()
+    {
+        return $this->hasMany('\App\Models\License', 'supplier_id');
+    }
+
+}

--- a/app/Models/Relationships/UserRelationships.php
+++ b/app/Models/Relationships/UserRelationships.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Models\Relationships;
+
+
+/**
+ * This trait wraps all accessory model relationships,
+ *
+ */
+trait UserRelationships {
+
+    /**
+     * Get accessories assigned to this user
+     */
+    public function accessories()
+    {
+        return $this->belongsToMany('\App\Models\Accessory', 'accessories_users', 'assigned_to', 'accessory_id')->withPivot('id')->withTrashed();
+    }
+
+    public function assetlog()
+    {
+        return $this->hasMany('\App\Models\Asset', 'id')->withTrashed();
+    }
+
+    /**
+     * Get assets assigned to this user
+     */
+    public function assetmaintenances()
+    {
+        return $this->hasMany('\App\Models\AssetMaintenance', 'user_id')->withTrashed();
+    }
+
+    /**
+     * Get assets assigned to this user
+     */
+    public function assets()
+    {
+        return $this->morphMany('App\Models\Asset', 'assigned', 'assigned_type', 'assigned_to')->withTrashed();
+    }
+
+    /**
+     * Fetch Items User has requested
+     */
+    public function checkoutRequests()
+    {
+        return $this->belongsToMany(Asset::class, 'checkout_requests', 'user_id', 'requestable_id')->whereNull('canceled_at');
+    }
+
+    public function company()
+    {
+        return $this->belongsTo('\App\Models\Company', 'company_id');
+    }
+
+    /**
+     * Get consumables assigned to this user
+     */
+    public function consumables()
+    {
+        return $this->belongsToMany('\App\Models\Consumable', 'consumables_users', 'assigned_to', 'consumable_id')->withPivot('id')->withTrashed();
+    }
+
+    public function department()
+    {
+        return $this->belongsTo('\App\Models\Department', 'department_id');
+    }
+
+    /**
+     * Get user groups
+     */
+    public function groups()
+    {
+        return $this->belongsToMany('\App\Models\Group', 'users_groups');
+    }
+
+    /**
+     * Get licenses assigned to this user
+     */
+    public function licenses()
+    {
+        return $this->belongsToMany('\App\Models\License', 'license_seats', 'assigned_to', 'license_id')->withPivot('id');
+    }
+
+    /**
+     * Get the asset's location based on the assigned user
+     **/
+    public function location()
+    {
+        return $this->belongsTo('\App\Models\Location', 'location_id')->withTrashed();
+    }
+
+    /**
+     * Get the user's manager based on the assigned user
+     **/
+    public function manager()
+    {
+        return $this->belongsTo('\App\Models\User', 'manager_id')->withTrashed();
+    }
+
+    /**
+     * Get any locations the user manages.
+     **/
+    public function managedLocations()
+    {
+        return $this->hasMany('\App\Models\Location', 'manager_id')->withTrashed();
+    }
+
+    public function throttle()
+    {
+        return $this->hasOne('\App\Models\Throttle');
+    }
+
+    /**
+     * Get the asset's location based on the assigned user
+     * @todo - this should be removed once we're sure we've switched it
+     * to location()
+     **/
+    public function userloc()
+    {
+        return $this->belongsTo('\App\Models\Location', 'location_id')->withTrashed();
+    }
+
+    /**
+     * Get action logs for this user
+     */
+    public function userlog()
+    {
+        return $this->hasMany('\App\Models\Actionlog', 'target_id')->orderBy('created_at', 'DESC')->withTrashed();
+    }
+
+    /**
+     * Get uploads for this asset
+     */
+    public function uploads()
+    {
+        return $this->hasMany('\App\Models\Actionlog', 'item_id')
+            ->where('item_type', User::class)
+            ->where('action_type', '=', 'uploaded')
+            ->whereNotNull('filename')
+            ->orderBy('created_at', 'desc');
+    }
+
+}

--- a/app/Models/Statuslabel.php
+++ b/app/Models/Statuslabel.php
@@ -50,13 +50,13 @@ class Statuslabel extends SnipeModel
      * 
      * @var array
      */
-    protected $searchableRelations = [];    
+    protected $searchableRelations = [];
 
 
     /**
      * Get assets with associated status label
      *
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function assets()
     {

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -2,6 +2,7 @@
 namespace App\Models;
 
 use App\Http\Traits\UniqueUndeletedTrait;
+use App\Models\Relationships\SupplierRelationships;
 use App\Models\SnipeModel;
 use App\Models\Traits\Searchable;
 use Illuminate\Database\Eloquent\Model;
@@ -40,6 +41,7 @@ class Supplier extends SnipeModel
     protected $injectUniqueIdentifier = true;
     use ValidatingTrait;
     use UniqueUndeletedTrait;
+    use SupplierRelationships;
 
     use Searchable;
     
@@ -66,36 +68,6 @@ class Supplier extends SnipeModel
     protected $fillable = ['name','address','address2','city','state','country','zip','phone','fax','email','contact','url','notes'];
 
 
-    // Eager load counts.
-    // We do this to eager load the "count" of seats from the controller.  Otherwise calling "count()" on each model results in n+1
-    public function assetsRelation()
-    {
-        return $this->hasMany(Asset::class)->whereNull('deleted_at')->selectRaw('supplier_id, count(*) as count')->groupBy('supplier_id');
-    }
-
-    public function getLicenseSeatsCountAttribute()
-    {
-        if ($this->licenseSeatsRelation->first()) {
-            return $this->licenseSeatsRelation->first()->count;
-        }
-
-        return 0;
-    }
-    public function assets()
-    {
-        return $this->hasMany('\App\Models\Asset', 'supplier_id');
-    }
-
-    public function accessories()
-    {
-        return $this->hasMany('\App\Models\Accessory', 'supplier_id');
-    }
-
-    public function asset_maintenances()
-    {
-        return $this->hasMany('\App\Models\AssetMaintenance', 'supplier_id');
-    }
-
     public function num_assets()
     {
         if ($this->assetsRelation->first()) {
@@ -103,11 +75,6 @@ class Supplier extends SnipeModel
         }
 
         return 0;
-    }
-
-    public function licenses()
-    {
-        return $this->hasMany('\App\Models\License', 'supplier_id');
     }
 
     public function num_licenses()

--- a/app/Models/Traits/CompanyableTrait.php
+++ b/app/Models/Traits/CompanyableTrait.php
@@ -1,5 +1,7 @@
 <?php
-namespace App\Models;
+namespace App\Models\Traits;
+
+use App\Models\CompanyableScope;
 
 trait CompanyableTrait
 {


### PR DESCRIPTION
Why not one more gigantic PR. (Don't worry, this took me about 15 minutes so if you don't like the idea we can move on with our lives :) )

No functional changes, just moves the relationships themselves into
files in the App/Models/Relationships directory, to clean up the model
files themselves a bit.