### PR TITLE
Feature: Group IDs can be passed to User Create.

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -199,7 +199,11 @@ class UsersController extends Controller
         $tmp_pass = substr(str_shuffle("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"), 0, 20);
         $user->password = bcrypt($request->get('password', $tmp_pass));
 
+
         if ($user->save()) {
+            if ($request->filled('groups')) {
+                $user->groups()->sync($request->input('groups'));
+            }
             return response()->json(Helper::formatStandardApiResponse('success', (new UsersTransformer)->transformUser($user), trans('admin/users/message.success.create')));
         }
         return response()->json(Helper::formatStandardApiResponse('error', null, $user->getErrors()));
@@ -249,6 +253,9 @@ class UsersController extends Controller
             ->where('assigned_to', $user->id)->update(['location_id' => $request->input('location_id', null)]);
 
         if ($user->save()) {
+            if ($request->filled('groups')) {
+                $user->groups()->sync($request->input('groups'));
+            }
             return response()->json(Helper::formatStandardApiResponse('success', (new UsersTransformer)->transformUser($user), trans('admin/users/message.success.update')));
         }
 

--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -97,8 +97,4 @@ class UsersTransformer
         return (new DatatablesTransformer)->transformDatatables($users);
     }
 
-
-
-
-
 }

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -45,6 +45,11 @@ $factory->define(App\Models\Component::class, function (Faker\Generator $faker) 
     ];
 });
 
+$factory->define(App\Models\Group::class, function (Faker\Generator $faker) {
+    return [
+    'name' => $faker->name,
+    ];
+});
 
 $factory->define(App\Models\Location::class, function (Faker\Generator $faker) {
     return [

--- a/tests/api/ApiUsersCest.php
+++ b/tests/api/ApiUsersCest.php
@@ -2,8 +2,9 @@
 
 use App\Helpers\Helper;
 use App\Http\Transformers\UsersTransformer;
-use App\Models\User;
+use App\Models\Group;
 use App\Models\Setting;
+use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 
 class ApiUsersCest
@@ -44,7 +45,8 @@ class ApiUsersCest
         $temp_user = factory(\App\Models\User::class)->make([
             'name' => "Test User Name",
         ]);
-
+        factory(Group::class, 2)->create();
+        $groups = Group::pluck('id');
         // setup
         $data = [
             'activated' => $temp_user->activated,
@@ -67,11 +69,14 @@ class ApiUsersCest
             'state' => $temp_user->state,
             'username' => $temp_user->username,
             'zip' => $temp_user->zip,
+            'groups' => $groups
         ];
 
         // create
         $I->sendPOST('/users', $data);
         $I->seeResponseIsJson();
+        $user = User::where('username', $temp_user->username)->first();
+        $I->assertEquals($groups, $user->groups()->pluck('id'));
         $I->seeResponseCodeIs(200);
     }
 
@@ -96,6 +101,9 @@ class ApiUsersCest
             'location_id' => 1,
         ]);
 
+        factory(Group::class, 2)->create();
+        $groups = Group::pluck('id');
+
         $data = [
             'activated' => $temp_user->activated,
             'address' => $temp_user->address,
@@ -106,6 +114,7 @@ class ApiUsersCest
             'email' => $temp_user->email,
             'employee_num' => $temp_user->employee_num,
             'first_name' => $temp_user->first_name,
+            'groups' => $groups,
             'jobtitle' => $temp_user->jobtitle,
             'last_name' => $temp_user->last_name,
             'locale' => $temp_user->locale,
@@ -134,6 +143,8 @@ class ApiUsersCest
         $I->assertEquals($temp_user->company_id, $response->payload->company->id); // company_id updated
         $I->assertEquals($temp_user->first_name, $response->payload->first_name); // user name updated
         $I->assertEquals($temp_user->location_id, $response->payload->location->id); // user location_id updated
+        $newUser = User::where('username', $temp_user->username)->first();
+        $I->assertEquals($groups, $newUser->groups()->pluck('id'));
         $temp_user->created_at = Carbon::parse($response->payload->created_at->datetime);
         $temp_user->updated_at = Carbon::parse($response->payload->updated_at->datetime);
         $temp_user->id = $user->id;


### PR DESCRIPTION
Also added to update, and adjusted api tests to confirm.  Long term it
might be nice to look at support for passing group names instead.

Bug: 5964