### PR TITLE
Use filled instead of has.

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -141,7 +141,7 @@ class BulkAssetsController extends Controller
      */
     protected function conditionallyAddItem($field)
     {
-        if(request()->has($field)) {
+        if(request()->filled($field)) {
             $this->update_array[$field] = request()->input($field);
         }
         return $this;

--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -142,7 +142,7 @@ class BulkUsersController extends Controller
      */
     protected function conditionallyAddItem($field)
     {
-        if(request()->has($field)) {
+        if(request()->filled($field)) {
             $this->update_array[$field] = request()->input($field);
         }
         return $this;


### PR DESCRIPTION
I think this merged in a weird order and was missed by the global
find/replace.  This fixes bulkassets/bulkusers editing.

At some point we should look at refactoring BulkAssetsController@edit to
only run one DB query, rather than one per item.