### PR TITLE
Fix saving of REMOTE_USER setting broken by 1a64879b6

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -482,13 +482,12 @@ class SettingsController extends Controller
                 $setting->two_factor_enabled = null;
             } else {
                 $setting->two_factor_enabled = $request->input('two_factor_enabled');
-
-                # remote user login
-                $setting->login_remote_user_enabled = (int)$request->input('login_remote_user_enabled');
-                $setting->login_common_disabled= (int)$request->input('login_common_disabled');
-                $setting->login_remote_user_custom_logout_url = $request->input('login_remote_user_custom_logout_url');
             }
 
+            # remote user login
+            $setting->login_remote_user_enabled = (int)$request->input('login_remote_user_enabled');
+            $setting->login_common_disabled = (int)$request->input('login_common_disabled');
+            $setting->login_remote_user_custom_logout_url = $request->input('login_remote_user_custom_logout_url');
         }
 
         $setting->pwd_secure_uncommon = (int) $request->input('pwd_secure_uncommon');


### PR DESCRIPTION
The previous commit made it such that remote user login could only
be enabled if two factor authentication was also enabled. Unnest
the configuration so that the setting can be applied without.