### PR TITLE
Alpine linux docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,13 @@
 .git
+.github
+.gitattributes
+.gitignore
 .dockerignore
 app/storage/logs/*
 app/storage/views/*
 vendor/*
+storage/framework/cache/*
+node_modules
+.vagrant
+.idea
+

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -43,6 +43,8 @@ COPY . /var/www/html
 
 WORKDIR /var/www/html
 
+COPY docker/docker.env /var/www/html/.env
+
 RUN chown -R apache:apache /var/www/html
 
 RUN \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,78 @@
+FROM alpine:3.8
+# Apache + PHP
+RUN  apk add --update --no-cache \
+        apache2 \
+        php7 \
+        php7-common \
+        php7-apache2 \
+        php7-curl \
+        php7-ldap \
+        php7-mysqli \
+        php7-gd \
+        php7-xml \
+        php7-mbstring \
+        php7-zip \
+        php7-ctype \
+        php7-tokenizer \
+        php7-pdo_mysql \
+        php7-openssl \
+        php7-bcmath \
+        php7-phar \
+        php7-json \
+        php7-iconv \
+        php7-fileinfo \
+        php7-simplexml \
+        php7-session \
+        curl \
+        wget \
+        vim \
+        git \
+        mysql-client \
+        tini
+
+# Where apache's PID lives
+RUN mkdir -p /run/apache2 && chown apache:apache /run/apache2
+
+RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php7/php.ini
+COPY  docker/000-default-2.4.conf /etc/apache2/conf.d/default.conf
+
+# Enable mod_rewrite
+RUN sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf
+
+COPY . /var/www/html
+
+WORKDIR /var/www/html
+
+RUN chown -R apache:apache /var/www/html
+
+RUN \
+	rm -r "/var/www/html/storage/private_uploads" \
+	&& mkdir -p "/var/lib/snipeit/data/private_uploads" && ln -fs "/var/lib/snipeit/data/private_uploads" "/var/www/html/storage/private_uploads" \
+    && rm -rf "/var/www/html/public/uploads" \
+    && mkdir -p "/var/lib/snipeit/data/uploads" && ln -fs "/var/lib/snipeit/data/uploads" "/var/www/html/public/uploads" \
+    && mkdir -p "/var/lib/snipeit/dumps" && rm -r "/var/www/html/storage/app/backups" && ln -fs "/var/lib/snipeit/dumps" "/var/www/html/storage/app/backups" \
+    && mkdir -p "/var/lib/snipeit/keys" && ln -fs "/var/lib/snipeit/keys/oauth-private.key" "/var/www/html/storage/oauth-private.key" \
+    && ln -fs "/var/lib/snipeit/keys/oauth-public.key" "/var/www/html/storage/oauth-public.key" \
+    && chown -R apache "/var/lib/snipeit"
+
+# Install composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+RUN mkdir -p /var/www/.composer && chown apache /var/www/.composer
+
+# Install dependencies
+USER apache
+RUN COMPOSER_CACHE_DIR=/dev/null composer install --no-dev --working-dir=/var/www/html
+
+USER root
+
+VOLUME ["/var/lib/snipeit"]
+
+# Entrypoints
+COPY docker/entrypoint_alpine.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/sbin/tini", "--"]
+
+CMD ["/entrypoint.sh"]
+
+EXPOSE 80

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -246,7 +246,7 @@ class SettingsController extends Controller
         Artisan::call('migrate', ['--force' => true]);
 
         if ((! file_exists(storage_path() . '/oauth-private.key')) || (! file_exists(storage_path() . '/oauth-public.key'))) {
-            Artisan::call('migrate', ['--path' => 'vendor/laravel/passport/database/migrations']);
+            Artisan::call('migrate', ['--path' => 'vendor/laravel/passport/database/migrations', '--force' => true]);
             Artisan::call('passport:install');
         }
 

--- a/docker/000-default-2.4.conf
+++ b/docker/000-default-2.4.conf
@@ -1,0 +1,19 @@
+<VirtualHost *:80>
+	ServerAdmin webmaster@localhost
+
+	DocumentRoot "/var/www/html/public"
+	DirectoryIndex index.php index.html
+	<Directory "/var/www/html/public">
+		Options All +MultiViews -ExecCGI -Indexes
+		<IfModule mod_dav.c>
+			DAV Off
+		</IfModule>
+		AllowOverride All
+		Require all granted
+	</Directory>
+	LogLevel warn
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/docker/entrypoint_alpine.sh
+++ b/docker/entrypoint_alpine.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# fix key if needed
+if [ -z "$APP_KEY" ]
+then
+  echo "Please re-run this container with an environment variable \$APP_KEY"
+  echo "An example APP_KEY you could use is: "
+  php artisan key:generate --show
+  exit
+fi
+
+#if [ ! -f /var/lib/snipeit/ssl/snipeit-ssl.crt -o ! -f /var/lib/snipeit/ssl/snipeit-ssl.key ]
+#then
+ # rm /etc/apache2/conf.d/ssl.conf && rm /etc/apache2/conf.d/default-ssl.conf
+#fi
+
+# create data directories
+for dir in \
+  'data/private_uploads' \
+  'data/uploads/accessories' \
+  'data/uploads/avatars' \
+  'data/uploads/barcodes' \
+  'data/uploads/categories' \
+  'data/uploads/companies' \
+  'data/uploads/components' \
+  'data/uploads/consumables' \
+  'data/uploads/departments' \
+  'data/uploads/locations' \
+  'data/uploads/manufacturers' \
+  'data/uploads/models' \
+  'data/uploads/suppliers' \
+  'dumps' \
+  'keys'
+do
+  [ ! -d "/var/lib/snipeit/$dir" ] && mkdir -p "/var/lib/snipeit/$dir"
+done
+
+chown -R apache:root /var/lib/snipeit/data/*
+chown -R apache:root /var/lib/snipeit/dumps
+chown -R apache:root /var/lib/snipeit/keys
+
+# If the Oauth DB files are not present copy the vendor files over to the db migrations
+if [ ! -f "/var/www/html/database/migrations/*create_oauth*" ]
+then
+  cp -a /var/www/html/vendor/laravel/passport/database/migrations/* /var/www/html/database/migrations/
+fi
+export APACHE_LOG_DIR=/var/log/apache2
+exec httpd -DNO_DETACH < /dev/null


### PR DESCRIPTION
Minimalist Alpine linux Docker image for those of us that use Alpine.

- Apache 2.4.38 / PHP 7.2.13
- Image size 189MB ( vs Ubuntu Bionic 614MB )
- Apache 2.4 compatible vhost
- No SSL support ( use with SSL terminator )
- No deprecated mcrypt ( No LegacyEncrypter )

Fixes:
- Small fix for initial passport migration ( Added '--force': In production mode, artisan will warn and ask for confirmation, which can throw an exception, due to missing STDIN )