### PR TITLE
Use bind user to search LDAP, then bind as user to authenticate them

### DIFF
--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -152,6 +152,8 @@ class Ldap extends Model
             throw new Exception('Could not bind to LDAP: '.ldap_error($connection));
         }
 
+        return true;
+
     }
 
 


### PR DESCRIPTION
Hey! Our shop recently migrated to a new LDAP provider, and the IT team discovered that login via LDAP no longer worked. The reason for this is that our current LDAP provider allows users to _bind_ but not to _search_ the directory. Only the service account/bind user may search the directory, and since this is essential LDAPaaS we don't have too many levers to pull.

As far as I can tell, `findAndBindUserLdap` currently works by:

* Binding as the user
  * Falling back to binding as the service-account if the user can't bind
* Searching the directory as whoever succeeded at binding

In our case if the user succeeds at binding, they cannot search the directory, so login fails. If the user fails to bind, then the service account will bind successfully instead and then... I'm not actually sure. It almost seems like someone who enters the right username but the wrong password would succeed at logging in, since they'll fail their own bind, but succeed with the service-account. The code reads that way, but I'm almost definitely misunderstanding it because I'm (thankfully) not able to login with an incorrect password. In our audit logs I would see the user bind fail, the service-account bind succeed, but no search query.

_Anyway._

The convention in the other LDAP-bound services we use all follow a very similar flow:

* Bind as the service-account
* Search the directory as the service-account
* If there is a matching result, bind as the user to verify their credentials

In this way the user that is trying to log in doesn't need to search the directory but still must submit valid credentials to authenticate.

I'm looking at https://github.com/snipe/snipe-it/pull/3069 and https://github.com/snipe/snipe-it/pull/6571 and I'm a bit worried that I might be undoing @fanta8897 's working. One PR is titled "Don't require users to be binded to the LDAP server to do a search" which is what I'm trying to go for with this PR; the other is titled "Updating LDAP such that each user is not required to be bindable to LDAP" which I'm less sure about, since a user must be able to bind to authenticate, but shouldn't be required to search.

Very open to feedback. While this is ostensibly to solve a problem at our shop, I'd like to not cause problems for other users. :)

(Full disclosure: I'm still figuring out a way to actually test this since I need to bake a docker image to deploy it to our infra. I yolo-wrote the commit and am just hoping very hard that it works until I have the opportunity to test it. I'll try to come up with a way to actually deploy and test this to our network.)