### PR TITLE
CheckoutableCheckedIn: added default action date

### DIFF
--- a/app/Events/CheckoutableCheckedIn.php
+++ b/app/Events/CheckoutableCheckedIn.php
@@ -21,12 +21,17 @@ class CheckoutableCheckedIn
      *
      * @return void
      */
-    public function __construct($checkoutable, $checkedOutTo, User $checkedInBy, $note, $action_date)
+    public function __construct($checkoutable, $checkedOutTo, User $checkedInBy, $note, $action_date = null)
     {
         $this->checkoutable = $checkoutable;
         $this->checkedOutTo = $checkedOutTo;
         $this->checkedInBy  = $checkedInBy;
         $this->note         = $note;
+
+        if (! $action_date) {
+            $action_date = date('Y-m-d');
+        }
+
         $this->action_date  = $action_date;
     }
 }


### PR DESCRIPTION
Hi,

I am just testing the new beta for us and found an error on checking out items.

` Too few arguments to function App\Events\CheckoutableCheckedIn::__construct()`

I did a quick search and the 5th arguments needs to be there for assets:
`Http/Controllers/Assets/AssetCheckinController.php:            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $checkin_at));`

But for everything else there is better a default value:
`Http/Controllers/Components/ComponentCheckinController.php:            event(new CheckoutableCheckedIn($component, $asset, Auth::user(), $request->input('note')));`

`Http/Controllers/Accessories/AccessoryCheckinController.php:            event(new CheckoutableCheckedIn($accessory, User::find($return_to), Auth::user(), $request->input('note')));`

`Http/Controllers/Licenses/LicenseCheckinController.php:            event(new CheckoutableCheckedIn($licenseSeat, $return_to, Auth::user(), $request->input('note')));`

I tested the change on my development and testing instance.

Cheers
Johannes