### PR TITLE
VAGRANT: Fix Ubuntu Development VMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ tests/_support/_generated/*
 *.cache
 
 .vagrant
+*.log
+*.retry
 
 \.php_cs\.dist
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,25 +8,34 @@ Vagrant.configure("2") do |config|
   config.vm.define "bionic" do |bionic|
     bionic.vm.box = "ubuntu/bionic64"
     bionic.vm.hostname = 'bionic'
-    bionic.vm.network "public_network", bridge: NETWORK_BRIDGE
-    bionic.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    bionic.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+    bionic.vm.network "forwarded_port", guest: 80, host: 8080
+    bionic.vm.synced_folder ".", "/vagrant", :owner => 'www-data',
+      :group => 'vagrant', :mount_options => ['dmode=775', 'fmode=775']
+    bionic.vm.provision "ansible_local" do |ansible|
+      ansible.playbook = "ansible/ubuntu/vagrant_playbook.yml"
+    end
   end
 
   config.vm.define "xenial" do |xenial|
     xenial.vm.box = "ubuntu/xenial64"
     xenial.vm.hostname = 'xenial'
-    xenial.vm.network "public_network", bridge: NETWORK_BRIDGE
-    xenial.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    xenial.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+    xenial.vm.network "forwarded_port", guest: 80, host: 8080
+    xenial.vm.synced_folder ".", "/vagrant", :owner => 'www-data',
+      :group => 'vagrant', :mount_options => ['dmode=775', 'fmode=775']
+    xenial.vm.provision "ansible_local" do |ansible|
+      ansible.playbook = "ansible/ubuntu/vagrant_playbook.yml"
+    end
   end
 
   config.vm.define "trusty" do |trusty|
     trusty.vm.box = "ubuntu/trusty32"
     trusty.vm.hostname = 'trusty'
-    trusty.vm.network "public_network", bridge: NETWORK_BRIDGE
-    trusty.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    trusty.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+    trusty.vm.network "forwarded_port", guest: 80, host: 8080
+    trusty.vm.synced_folder ".", "/vagrant", :owner => 'www-data',
+      :group => 'vagrant', :mount_options => ['dmode=775', 'fmode=775']
+    trusty.vm.provision "ansible_local" do |ansible|
+      ansible.playbook = "ansible/ubuntu/vagrant_playbook.yml"
+    end
   end
 
   config.vm.define "centos7" do |centos7|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,102 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-SNIPEIT_SH_URL= "https://raw.githubusercontent.com/snipe/snipe-it/master/snipeit.sh"
-NETWORK_BRIDGE= "en0: Wi-Fi (AirPort)"
-
 Vagrant.configure("2") do |config|
-  config.vm.define "bionic" do |bionic|
-    bionic.vm.box = "ubuntu/bionic64"
-    bionic.vm.hostname = 'bionic'
-    bionic.vm.network "public_network", bridge: NETWORK_BRIDGE
-    bionic.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    bionic.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+  config.vm.box = "ubuntu/bionic64"
+  config.vm.hostname = 'bionic'
+  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.synced_folder ".", "/vagrant", :owner => 'www-data',
+    :group => 'vagrant', :mount_options => ['dmode=775', 'fmode=775']
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.playbook = "ansible/ubuntu/vagrant_playbook.yml"
   end
-
-  config.vm.define "xenial" do |xenial|
-    xenial.vm.box = "ubuntu/xenial64"
-    xenial.vm.hostname = 'xenial'
-    xenial.vm.network "public_network", bridge: NETWORK_BRIDGE
-    xenial.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    xenial.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
-  end
-
-  config.vm.define "trusty" do |trusty|
-    trusty.vm.box = "ubuntu/trusty32"
-    trusty.vm.hostname = 'trusty'
-    trusty.vm.network "public_network", bridge: NETWORK_BRIDGE
-    trusty.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    trusty.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
-  end
-
-  config.vm.define "centos7" do |centos7|
-    centos7.vm.box = "centos/7"
-    centos7.vm.hostname = 'centos7'
-    centos7.vm.network "public_network", bridge: NETWORK_BRIDGE
-    centos7.vm.provision :shell, :inline => "sudo yum -y update"
-    centos7.vm.provision :shell, :inline => "yum install -y wget"
-    centos7.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    centos7.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
-  end
-
-  config.vm.define "centos6" do |centos6|
-    centos6.vm.box = "centos/6"
-    centos6.vm.hostname = 'centos6'
-    centos6.vm.network "public_network", bridge: NETWORK_BRIDGE
-    centos6.vm.provision :shell, :inline => "sudo yum -y update"
-    centos6.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    centos6.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
-  end
-
-  config.vm.define "jessie" do |jessie|
-    jessie.vm.box = "debian/jessie64"
-    jessie.vm.hostname = 'debian8'
-    jessie.vm.network "public_network", bridge: NETWORK_BRIDGE
-    jessie.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    jessie.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
-  end
-
-  config.vm.define "stretch" do |stretch|
-    stretch.vm.box = "debian/stretch64"
-    stretch.vm.hostname = 'debian9'
-    stretch.vm.network "public_network", bridge: NETWORK_BRIDGE
-    stretch.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    stretch.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
-  end
-
-  config.vm.define "fedora27" do |fedora27|
-    fedora27.vm.box = "fedora/27-cloud-base"
-    fedora27.vm.hostname = 'fedora27'
-    fedora27.vm.network "public_network", bridge: NETWORK_BRIDGE
-    fedora27.vm.provision :shell, :inline => "dnf -y install wget"
-    fedora27.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    fedora27.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
-  end
-
-    config.vm.define "fedora26" do |fedora26|
-    fedora26.vm.box = "fedora/26-cloud-base"
-    fedora26.vm.hostname = 'fedora26'
-    fedora26.vm.network "public_network", bridge: NETWORK_BRIDGE
-    fedora26.vm.provision :shell, :inline => "dnf -y install wget"
-    fedora26.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
-    fedora26.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
-  end
-
-  config.vm.define "freebsd" do |freebsd|
-    freebsd.vm.box = "freebsd/FreeBSD-11.2-RELEASE"
-    freebsd.vm.hostname = 'freebsd12'
-    freebsd.vm.network "forwarded_port", guest: 80, host: 8080
-    freebsd.vm.network "forwarded_port", guest:3306, host:3306 # mysql    
-    freebsd.vm.network "private_network", type: "dhcp"
-    freebsd.ssh.shell = "sh"
-    freebsd.vm.base_mac = "080027D14C66"
-    freebsd.vm.synced_folder ".", "/vagrant", :nfs => true, id: "vagrant-root",
-    :mount_options => ['rw', 'vers=3', 'tcp', 'actimeo=2']    
-    freebsd.vm.provision "shell", inline: <<-SHELL
-        pkg install -y python27;
-    SHELL
-    freebsd.vm.provision "ansible" do |ansible|
-        ansible.playbook = "ansible/freebsd/vagrant_playbook.yml"
-    end    
-  end  
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,13 +1,102 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+SNIPEIT_SH_URL= "https://raw.githubusercontent.com/snipe/snipe-it/master/snipeit.sh"
+NETWORK_BRIDGE= "en0: Wi-Fi (AirPort)"
+
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/bionic64"
-  config.vm.hostname = 'bionic'
-  config.vm.network "forwarded_port", guest: 80, host: 8080
-  config.vm.synced_folder ".", "/vagrant", :owner => 'www-data',
-    :group => 'vagrant', :mount_options => ['dmode=775', 'fmode=775']
-  config.vm.provision "ansible_local" do |ansible|
-    ansible.playbook = "ansible/ubuntu/vagrant_playbook.yml"
+  config.vm.define "bionic" do |bionic|
+    bionic.vm.box = "ubuntu/bionic64"
+    bionic.vm.hostname = 'bionic'
+    bionic.vm.network "public_network", bridge: NETWORK_BRIDGE
+    bionic.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
+    bionic.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
   end
+
+  config.vm.define "xenial" do |xenial|
+    xenial.vm.box = "ubuntu/xenial64"
+    xenial.vm.hostname = 'xenial'
+    xenial.vm.network "public_network", bridge: NETWORK_BRIDGE
+    xenial.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
+    xenial.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+  end
+
+  config.vm.define "trusty" do |trusty|
+    trusty.vm.box = "ubuntu/trusty32"
+    trusty.vm.hostname = 'trusty'
+    trusty.vm.network "public_network", bridge: NETWORK_BRIDGE
+    trusty.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
+    trusty.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+  end
+
+  config.vm.define "centos7" do |centos7|
+    centos7.vm.box = "centos/7"
+    centos7.vm.hostname = 'centos7'
+    centos7.vm.network "public_network", bridge: NETWORK_BRIDGE
+    centos7.vm.provision :shell, :inline => "sudo yum -y update"
+    centos7.vm.provision :shell, :inline => "yum install -y wget"
+    centos7.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
+    centos7.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+  end
+
+  config.vm.define "centos6" do |centos6|
+    centos6.vm.box = "centos/6"
+    centos6.vm.hostname = 'centos6'
+    centos6.vm.network "public_network", bridge: NETWORK_BRIDGE
+    centos6.vm.provision :shell, :inline => "sudo yum -y update"
+    centos6.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
+    centos6.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+  end
+
+  config.vm.define "jessie" do |jessie|
+    jessie.vm.box = "debian/jessie64"
+    jessie.vm.hostname = 'debian8'
+    jessie.vm.network "public_network", bridge: NETWORK_BRIDGE
+    jessie.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
+    jessie.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+  end
+
+  config.vm.define "stretch" do |stretch|
+    stretch.vm.box = "debian/stretch64"
+    stretch.vm.hostname = 'debian9'
+    stretch.vm.network "public_network", bridge: NETWORK_BRIDGE
+    stretch.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
+    stretch.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+  end
+
+  config.vm.define "fedora27" do |fedora27|
+    fedora27.vm.box = "fedora/27-cloud-base"
+    fedora27.vm.hostname = 'fedora27'
+    fedora27.vm.network "public_network", bridge: NETWORK_BRIDGE
+    fedora27.vm.provision :shell, :inline => "dnf -y install wget"
+    fedora27.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
+    fedora27.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+  end
+
+    config.vm.define "fedora26" do |fedora26|
+    fedora26.vm.box = "fedora/26-cloud-base"
+    fedora26.vm.hostname = 'fedora26'
+    fedora26.vm.network "public_network", bridge: NETWORK_BRIDGE
+    fedora26.vm.provision :shell, :inline => "dnf -y install wget"
+    fedora26.vm.provision :shell, :inline => "wget #{SNIPEIT_SH_URL}"
+    fedora26.vm.provision :shell, :inline => "chmod 755 snipeit.sh"
+  end
+
+  config.vm.define "freebsd" do |freebsd|
+    freebsd.vm.box = "freebsd/FreeBSD-11.2-RELEASE"
+    freebsd.vm.hostname = 'freebsd12'
+    freebsd.vm.network "forwarded_port", guest: 80, host: 8080
+    freebsd.vm.network "forwarded_port", guest:3306, host:3306 # mysql    
+    freebsd.vm.network "private_network", type: "dhcp"
+    freebsd.ssh.shell = "sh"
+    freebsd.vm.base_mac = "080027D14C66"
+    freebsd.vm.synced_folder ".", "/vagrant", :nfs => true, id: "vagrant-root",
+    :mount_options => ['rw', 'vers=3', 'tcp', 'actimeo=2']    
+    freebsd.vm.provision "shell", inline: <<-SHELL
+        pkg install -y python27;
+    SHELL
+    freebsd.vm.provision "ansible" do |ansible|
+        ansible.playbook = "ansible/freebsd/vagrant_playbook.yml"
+    end    
+  end  
 end

--- a/ansible/ubuntu/apachevirtualhost.conf.j2
+++ b/ansible/ubuntu/apachevirtualhost.conf.j2
@@ -1,0 +1,10 @@
+<VirtualHost *:80>
+    <Directory {{ app_path }}/public>
+        Allow From All
+        AllowOverride All
+        Options -Indexes
+    </Directory>
+
+    DocumentRoot {{ app_path }}/public
+    ServerName {{ fqdn }}
+</VirtualHost>

--- a/ansible/ubuntu/vagrant_playbook.yml
+++ b/ansible/ubuntu/vagrant_playbook.yml
@@ -1,0 +1,194 @@
+---
+- name: Set up local server
+  hosts: all
+  remote_user: vagrant
+  become_user: root
+  become_method: sudo
+  vars:
+    app_path: "/var/www/snipeit"
+    fqdn: "localhost"
+  tasks:
+    - name: Update and upgrade existing apt packages
+      become: true
+      apt:
+        upgrade: yes
+        update_cache: yes
+    - name: Install Utilities
+      become: true          
+      apt:
+        name: "{{ packages }}"
+        state: present 
+      vars: 
+        packages:
+          - nano
+          - vim
+    - name: Installing Apache httpd, PHP, MariaDB and other requirements.
+      become: true
+      apt:
+        name: "{{ packages }}"
+        state: present
+      vars:
+        packages:
+          - mariadb-client
+          - php
+          - php-curl
+          - php-mysql
+          - php-gd
+          - php-ldap
+          - php-zip
+          - php-mbstring
+          - php-xml
+          - php-bcmath
+          - curl
+          - git
+          - unzip
+          - python-pymysql
+    #
+    # Install the lastest version of composer
+    #
+    - name: Composer check
+      stat:
+        path: /usr/local/bin/composer
+      register: composer_exits
+    - name: Install Composer
+      shell: |
+        EXPECTED_SIGNATURE=$(wget -q -O - https://composer.github.io/installer.sig)
+        php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+        ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+        if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+        then
+            >&2 echo 'ERROR: Invalid installer signature'
+            rm composer-setup.php
+            exit 1
+        fi
+
+        php composer-setup.php --quiet
+        RESULT=$?
+        rm composer-setup.php
+        mv composer.phar /usr/local/bin/composer
+        exit $RESULT
+      when: not composer_exits.stat.exists
+      args:
+        creates: /usr/local/bin/composer
+      become: true
+    #
+    # Install and Configure MariaDB
+    #
+    - name: Install MariaDB
+      become: true
+      apt:
+        name: mariadb-server
+        state: present
+      register: sql_server
+    - name: Start and Enable MySQL server
+      become: true 
+      systemd:
+        state: started
+        enabled: yes
+        name: mariadb
+    - name: Create Vagrant mysql password
+      become: true
+      mysql_user:
+        name: vagrant
+        password: vagrant
+        login_unix_socket: /var/run/mysqld/mysqld.sock
+        priv: "*.*:ALL"
+        state: present
+    - name: Enable remote mysql
+      replace:
+        path: /etc/mysql/mariadb.conf.d/50-server.cnf
+        regexp: "127.0.0.1"
+        replace: "0.0.0.0" 
+      become: true         
+      notify:
+        - restart mysql
+    - name: Create snipeit database
+      become: true
+      mysql_db:
+        name: snipeit
+        state: present
+        login_unix_socket: /var/run/mysqld/mysqld.sock
+    #  
+    # Install Apache Web Server
+    #
+    - name: Install Apache 2.4
+      apt:
+        name: "{{ packages }}"
+        state: present
+      vars:
+        packages:
+          - apache2
+          - libapache2-mod-php
+      become: true    
+      register: apache2_server     
+    - name: Start and Enable Apache2 Server
+      become: true
+      systemd:
+        name: apache2
+        state: started
+        enabled: yes
+    #- name: Disable Apache modules
+    #  become: true 
+    #  apache2_module:
+    #    state: absent
+    #    name: "{{ item }}"
+    #  with_items: 
+    #    #- mpm_prefork
+    #  notify:
+    #    - restart apache2
+    - name: Enable Apache modules
+      become: true
+      apache2_module:
+        state: present
+        name: "{{ item }}"
+      with_items:
+        - rewrite
+        - vhost_alias
+        - deflate
+        - expires
+        - proxy_fcgi
+        - proxy
+      notify:
+        - restart apache2
+    - name: Install Apache VirtualHost File
+      become: true
+      template:
+        src: apachevirtualhost.conf.j2
+        dest: "/etc/apache2/sites-available/snipeit.conf"
+    - name: Enable VirtualHost
+      become: true
+      command: a2ensite snipeit
+      args:
+        creates: /etc/apache2/sites-enabled/snipeit.conf
+      notify:
+        - restart apache2
+    - name: Map apache dir to local folder
+      become: true
+      file:
+        src: /vagrant
+        dest: "{{ app_path }}"
+        state: link
+      notify:
+        - restart apache2
+    #
+    # Install dependencies from composer
+    #
+    - name: Install dependencies from composer
+      composer:
+        command: install
+        working_dir: "{{ app_path }}"
+      notify:
+        - restart apache2
+  handlers:
+    - name: restart apache2
+      become: true
+      systemd:
+        name: apache2
+        state: restarted
+    - name: restart mysql
+      become: true
+      systemd:
+        name: mysql
+        state: restarted
+

--- a/ansible/ubuntu/vagrant_playbook.yml
+++ b/ansible/ubuntu/vagrant_playbook.yml
@@ -180,6 +180,38 @@
         working_dir: "{{ app_path }}"
       notify:
         - restart apache2
+    #
+    # Configure .env file
+    #
+    - name: Copy .env file
+      copy:
+        src: "{{ app_path }}/.env.example"
+        dest: "{{ app_path }}/.env"
+    - name: Configure .env file
+      lineinfile:
+        path: "{{ app_path }}/.env"
+        regexp: "{{ item.regexp }}"
+        line: "{{ item.line }}"
+      with_items:
+        - { regexp: '^DB_HOST=', line: 'DB_HOST=127.0.0.1'}
+        - { regexp: '^DB_DATABASE=', line: 'DB_DATABASE=snipeit' }
+        - { regexp: '^DB_USERNAME=', line: 'DB_USERNAME=vagrant' }
+        - { regexp: '^DB_PASSWORD=', line: 'DB_PASSWORD=vagrant' }
+        - { regexp: '^APP_URL=', line: "APP_URL=http://{{ fqdn }}" }
+        - { regexp: '^APP_ENV=', line: "APP_ENV=development" }
+        - { regexp: '^APP_DEBUG=', line: "APP_ENV=true" }
+    - name: Generate application key
+      shell: "php {{ app_path }}/artisan key:generate --force"
+    - name: Artisan Migrate
+      shell: "php {{ app_path }}/artisan migrate --force"
+    #
+    # Create Cron Job
+    #
+    - name: Create scheduler cron job
+      become: true
+      cron:
+        name: "Snipe-IT Artisan Scheduler"
+        job: "/usr/bin/php {{ app_path }}/artisan schedule:run"
   handlers:
     - name: restart apache2
       become: true


### PR DESCRIPTION
I have some other items I want to look at addressing but first needed a good development environment.

### The Objective

The existing Vagrant configuration for everything except Freebsd does not function properly as a development environment for the following reasons:
  - By downloading the `snipeit.sh` file from snipe/snipe-it/master it does not allow that file to be changed. There is already a local copy so it would be better to use it.
    - That same `snipeit.sh` itself is not useful for local development due to the fact that it also does not use the local development directories. Ideally this script would utilize the mapped `/vagrant` directory but instead clones from snipe/snipe-it/master.
    - The `snipeit.sh` file also included several blocking sections that required user input.
  - By using the network bridge `en0: Wi-Fi (AirPort)` the Vagrantfile will not work correctly for any developer not running MacOS with their Wi-Fi card turned on and connected. Ideally this should use the default network behavior and just define ports to make available to the host rather than bridging the entire network out.

My goal is to address all of these to make developing for Snipe-IT easier.

### The Changes

- Discontinue use of the downloaded `snipeit.sh` file.
- Utilize default Vagrant networking rather than using a network bridge.
- The `snipeit.sh` file itself ended up being fairly impenetrable when it came to adding all the logic to support discriminating between development and production installation so I wrote an Ansible-Local playbook which provisions a new development VM from scratch using only the locally downloaded git repository.

To get a new, clean development environment the following steps must be taken (I'm writing this up here because I had a difficult time finding this procedure on the internet):

1. Destroy your existing Vagrant VMs.
```shell
vagrant destroy
```
2. Clean your git repository to remove everything that Laravel created *(This command will interactively prompt you to confirm each file it will delete. If you need a file to stay add it to the tracked git files with `git add`)*:
```shell
git clean -xdi
```
3. Provision the new machine
```shell
vagrant up $VM # ex. vagrant up bionic
```

The below animation demonstrates the above steps and demonstrates that this PR actually functions:

[![asciicast](https://asciinema.org/a/240872.svg)](https://asciinema.org/a/240872)