### PR TITLE
Fix print label formatting

### DIFF
--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -3,18 +3,15 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
   <title>Labels</title>
-
 </head>
 <body>
 
   <?php
-    $settings->labels_width = $settings->labels_width - $settings->labels_display_sgutter;
-    $settings->labels_height = $settings->labels_height - $settings->labels_display_bgutter;
     // Leave space on bottom for 1D barcode if necessary
     $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='') ? $settings->labels_height - .3 : $settings->labels_height;
     // Leave space on left for QR code if necessary
     $qr_txt_size = ($settings->qr_code=='1' ? $settings->labels_width - $qr_size - .1 : $settings->labels_width);
-    ?>
+  ?>
 
   <style>
 
@@ -22,8 +19,12 @@
     font-family: arial, helvetica, sans-serif;
     width: {{ $settings->labels_pagewidth }}in;
     height: {{ $settings->labels_pageheight }}in;
-    margin: {{ $settings->labels_pmargin_top }}in {{ $settings->labels_pmargin_right }}in {{ $settings->labels_pmargin_bottom }}in {{ $settings->labels_pmargin_left }}in;
-    font-size: {{ $settings->labels_fontsize }}pt;
+    margin: 0;
+  }
+
+  .label-container {
+    font-size: 0;
+    padding: {{ $settings->labels_pmargin_top }}in {{ $settings->labels_pmargin_right - $settings->labels_display_sgutter }}in {{ $settings->labels_pmargin_bottom - $settings->labels_display_bgutter }}in {{ $settings->labels_pmargin_left }}in;
   }
 
   .label {
@@ -34,6 +35,7 @@
     margin-bottom: {{ $settings->labels_display_bgutter }}in;
     display: inline-block;
     overflow: hidden;
+    font-size: {{ $settings->labels_fontsize }}pt;
   }
 
   .page-break  {
@@ -64,7 +66,7 @@
     height: 0.5in;
   }
 
- .qr_text {
+  .qr_text {
     width: {{ $qr_txt_size }}in;
     height: {{ $qr_size }}in;
     padding-top: .10in;
@@ -77,14 +79,10 @@
   }
 
   div.barcode_container {
-      float: left;
-      width: 100%;
-      display: inline;
-      height: 50px;
-  }
-  
-  .next-padding {
-      margin: {{ $settings->labels_pmargin_top }}in {{ $settings->labels_pmargin_right }}in {{ $settings->labels_pmargin_bottom }}in {{ $settings->labels_pmargin_left }}in;
+    float: left;
+    width: 100%;
+    display: inline;
+    height: 50px;
   }
 
   .label-model::before {
@@ -101,15 +99,11 @@
   }
   .label-name::before {
     content: "N: "
-  }  
+  }
 
   @media print {
     .noprint {
       display: none !important;
-    }
-    .next-padding {
-      margin: {{ $settings->labels_pmargin_top }}in {{ $settings->labels_pmargin_right }}in {{ $settings->labels_pmargin_bottom }}in {{ $settings->labels_pmargin_left }}in;
-      font-size: 0;
     }
   }
 
@@ -129,17 +123,17 @@
 
   </style>
 
-@foreach ($assets as $asset)
-	<?php $count++; ?>
-  <div class="label"> 
-
+  <div class="label-container">
+    @foreach ($assets as $asset)
+    <?php $count++; ?>
+    <div class="label">
       @if ($settings->qr_code=='1')
-    <div class="label-qr_img qr_img">
-      <img src="./{{ $asset->id }}/qr_code" class="qr_img">
-    </div>
+      <div class="label-qr_img qr_img">
+        <img src="./{{ $asset->id }}/qr_code" class="qr_img">
+      </div>
       @endif
 
-    <div class="qr_text">
+      <div class="qr_text">
         @if ($settings->label_logo)
         <div class="label-logo">
           <img class="label-logo" src="{{ Storage::disk('public')->url('').e($snipeSettings->label_logo) }}">
@@ -148,8 +142,8 @@
 
         @if ($settings->qr_text!='')
         <div class="label-qr_text pull-left">
-            <strong>{{ $settings->qr_text }}</strong>
-            <br>
+          <strong>{{ $settings->qr_text }}</strong>
+          <br>
         </div>
         @endif
         @if (($settings->labels_display_company_name=='1') && ($asset->company))
@@ -159,44 +153,37 @@
         @endif
         @if (($settings->labels_display_name=='1') && ($asset->name!=''))
         <div class="label-name pull-left">
-            {{ $asset->name }}
+          {{ $asset->name }}
         </div>
         @endif
         @if (($settings->labels_display_tag=='1') && ($asset->asset_tag!=''))
-	      <div class="label-asset_tag pull-left">
-            {{ $asset->asset_tag }}
+        <div class="label-asset_tag pull-left">
+          {{ $asset->asset_tag }}
         </div>
         @endif
         @if (($settings->labels_display_serial=='1') && ($asset->serial!=''))
         <div class="label-serial pull-left">
-            {{ $asset->serial }}
+          {{ $asset->serial }}
         </div>
-	@endif
-	@if (($settings->labels_display_model=='1') && ($asset->model->name!=''))
-	<div class="label-model pull-left">
-            {{ $asset->model->name }} {{ $asset->model->model_number }}
-	</div>
-	@endif
+      	@endif
+      	@if (($settings->labels_display_model=='1') && ($asset->model->name!=''))
+      	<div class="label-model pull-left">
+          {{ $asset->model->name }} {{ $asset->model->model_number }}
+      	</div>
+      	@endif
+      </div>
 
+      @if ((($settings->alt_barcode_enabled=='1') && $settings->alt_barcode!=''))
+      <div class="label-alt_barcode barcode_container">
+        <img src="./{{ $asset->id }}/barcode" class="barcode">
+      </div>
+      @endif
     </div>
 
-    @if ((($settings->alt_barcode_enabled=='1') && $settings->alt_barcode!=''))
-        <div class="label-alt_barcode barcode_container">
-            <img src="./{{ $asset->id }}/barcode" class="barcode">
-        </div>
+    @if ($count % $settings->labels_per_page == 0 && count($assets) > $count)
+    <div class="page-break"></div>
     @endif
-
-
-
-</div>
-
-@if ($count % $settings->labels_per_page == 0)
-<div class="page-break"></div>
-<div class="next-padding">&nbsp;</div>
-@endif
-
-@endforeach
-
-
+    @endforeach
+  </div>
 </body>
 </html>


### PR DESCRIPTION
There were a couple of margin issues. We need to subtract the
horizontal guttering from the right margin, and the vertical
guttering from the bottom margin. There was also an issue where
inline-block's add whitespace between the elements when there's
whitespace in the HTML. The solution is to set the font-size to 0 on
the parent element, and back to the correct size on the labels.

Also fixed an issue whereby it added a blank page if your page had
exactly the number of assets as the page limit.