### PR TITLE
Apache site configurations shouldn't be written to sites-enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,11 @@ COPY docker/000-default.conf /etc/apache2/sites-enabled/000-default.conf
 
 #SSL
 RUN mkdir -p /var/lib/snipeit/ssl
-COPY docker/001-default-ssl.conf /etc/apache2/sites-enabled/001-default-ssl.conf
-#COPY docker/001-default-ssl.conf /etc/apache2/sites-available/001-default-ssl.conf
+#COPY docker/001-default-ssl.conf /etc/apache2/sites-enabled/001-default-ssl.conf
+COPY docker/001-default-ssl.conf /etc/apache2/sites-available/001-default-ssl.conf
 
 RUN a2enmod ssl
-#RUN a2ensite 001-default-ssl.conf
+RUN a2ensite 001-default-ssl.conf
 
 COPY . /var/www/html
 


### PR DESCRIPTION
It is better (best) practice to write configurations to sites-available and then let Apache create the symlink for the configuration to sites-enabled via 'a2ensite' command