### PR TITLE
Closes #6440 Print All Assigned - New Tab

### DIFF
--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -293,7 +293,7 @@
 
               @can('view', $user)
                 <div class="col-md-12" style="padding-top: 5px;">
-                  <a href="{{ route('users.print', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-default hidden-print">{{ trans('admin/users/general.print_assigned') }}</a>
+                  <a href="{{ route('users.print', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-default hidden-print target=_blank rel=noopener">{{ trans('admin/users/general.print_assigned') }}</a>
                 </div>
               @endcan
 


### PR DESCRIPTION
Should add the functionality to, by default open in a new tab and not reference back to the source page. Reduces overhead and should resolve #6440. 

Untested, need confirmation.