### PR TITLE
Add dynamic hyperlink to fields named "Ticket"

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -282,6 +282,8 @@
                             @else
                               @if (($field->format=='URL') && ($asset->{$field->db_column_name()}!=''))
                                 <a href="{{ $asset->{$field->db_column_name()} }}" target="_new">{{ $asset->{$field->db_column_name()} }}</a>
+                              @elseif (($field->format=='NUMERIC') && ($asset->{$field->db_column_name()}!='') && ($field->name== 'Ticket'))
+                                <a href="{{ 'https://serviceit.uconn.edu/MRcgi/MRlogin.pl?DL='.$asset->{$field->db_column_name()}.'DA31' }}" target="_new">{{ $asset->{$field->db_column_name()} }}</a>
                               @else
                                 {!! nl2br(e($asset->{$field->db_column_name()})) !!}
                               @endif


### PR DESCRIPTION
# Ticket Hyperlinks

**At UCONN, we use Footprints service desk for ticketing service. I'm guessing other orgs use similar ticketing services, where you can view a support ticket via URL: `http://some_url.com/ticket/{ticket#}`.**

This is what we're using to do it.

Issues: I could add the option to load the URL from a config file, or even add a new field type. With a new custom field format, a user could specify their own custom URL in the UI. Currently you have your field formats setup in a way that makes it very hard to add a new custom format. The validation code is sorta hard-coded to regex. 

I thought I would share this idea/concept to you guys in the spirit of open source.

Aside: Editor wanted to redo all the spacing, had to rebase to get just my changes.