### PR TITLE
CORS for api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,7 @@ SECURE_COOKIES=false
 # --------------------------------------------
 REFERRER_POLICY=same-origin
 ENABLE_CSP=false
+APP_CORS_ALLOWED_ORIGINS=null
 
 # --------------------------------------------
 # OPTIONAL: CACHE SETTINGS

--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ SECURE_COOKIES=false
 # --------------------------------------------
 REFERRER_POLICY=same-origin
 ENABLE_CSP=false
-APP_CORS_ALLOWED_ORIGINS=null
+CORS_ALLOWED_ORIGINS=null
 
 # --------------------------------------------
 # OPTIONAL: CACHE SETTINGS

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -44,9 +44,9 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
+            \Barryvdh\Cors\HandleCors::class,
             'throttle:120,1',
             'auth:api',
-            \Barryvdh\Cors\HandleCors::class,
         ],
     ];
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -46,6 +46,7 @@ class Kernel extends HttpKernel
         'api' => [
             'throttle:120,1',
             'auth:api',
+            \Barryvdh\Cors\HandleCors::class,
         ],
     ];
 

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
   "type": "project",
     "require": {
     "php": ">=7.1.2",
+    "barryvdh/laravel-cors": "^0.11.3",
     "barryvdh/laravel-debugbar": "^3.2",
     "doctrine/cache": "^1.8",
     "doctrine/common": "^2.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,60 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8b40b743ea544f650ac6c4d8c7a6eda",
+    "content-hash": "83584cbcfed9d4b063847283c0472606",
     "packages": [
+        {
+            "name": "asm89/stack-cors",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/asm89/stack-cors.git",
+                "reference": "c163e2b614550aedcf71165db2473d936abbced6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/asm89/stack-cors/zipball/c163e2b614550aedcf71165db2473d936abbced6",
+                "reference": "c163e2b614550aedcf71165db2473d936abbced6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/http-foundation": "~2.7|~3.0|~4.0",
+                "symfony/http-kernel": "~2.7|~3.0|~4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^4.8.10",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Asm89\\Stack\\": "src/Asm89/Stack/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander",
+                    "email": "iam.asm89@gmail.com"
+                }
+            ],
+            "description": "Cross-origin resource sharing library and stack middleware",
+            "homepage": "https://github.com/asm89/stack-cors",
+            "keywords": [
+                "cors",
+                "stack"
+            ],
+            "time": "2017-12-20T14:37:45+00:00"
+        },
         {
             "name": "bacon/bacon-qr-code",
             "version": "2.0.0",
@@ -54,6 +106,68 @@
             "description": "BaconQrCode is a QR code generator for PHP.",
             "homepage": "https://github.com/Bacon/BaconQrCode",
             "time": "2018-04-25T17:53:56+00:00"
+        },
+        {
+            "name": "barryvdh/laravel-cors",
+            "version": "v0.11.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-cors.git",
+                "reference": "c95ac944f2f20a17949aae6645692dfd3b402bca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-cors/zipball/c95ac944f2f20a17949aae6645692dfd3b402bca",
+                "reference": "c95ac944f2f20a17949aae6645692dfd3b402bca",
+                "shasum": ""
+            },
+            "require": {
+                "asm89/stack-cors": "^1.2",
+                "illuminate/support": "5.5.x|5.6.x|5.7.x|5.8.x",
+                "php": ">=7",
+                "symfony/http-foundation": "^3.1|^4",
+                "symfony/http-kernel": "^3.1|^4"
+            },
+            "require-dev": {
+                "laravel/framework": "^5.5",
+                "orchestra/testbench": "3.3.x|3.4.x|3.5.x|3.6.x|3.7.x",
+                "phpunit/phpunit": "^4.8|^5.2|^7.0",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.11-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\Cors\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\Cors\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Adds CORS (Cross-Origin Resource Sharing) headers support in your Laravel application",
+            "keywords": [
+                "api",
+                "cors",
+                "crossdomain",
+                "laravel"
+            ],
+            "time": "2019-02-26T18:08:30+00:00"
         },
         {
             "name": "barryvdh/laravel-debugbar",

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Laravel CORS
+    |--------------------------------------------------------------------------
+    |
+    | allowedOrigins, allowedHeaders and allowedMethods can be set to array('*')
+    | to accept any value.
+    |
+    */
+   
+    'supportsCredentials' => false,
+    'allowedOrigins' => ['*'],
+    'allowedOriginsPatterns' => [],
+    'allowedHeaders' => ['*'],
+    'allowedMethods' => ['*'],
+    'exposedHeaders' => [],
+    'maxAge' => 0,
+
+];

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,5 +1,25 @@
 <?php
 
+/**
+ * ---------------------------------------------------------------------
+ * THIS IS NOT PART OF THE ORIGINAL CORS PACKAGE. IT IS A MODIFICATION
+ * BY SNIPE-IT TO ALLOW ADDING ALLOWED ORIGINS VIA THE ENV.
+ * ---------------------------------------------------------------------
+ *
+ * Since we don't really want people editing config files (lest they get
+ * overwritten later), this enables the person managing the Snipe-IT
+ * installation to modify these values without modifying the code.
+ *
+ * If APP_CORS_ALLOWED_ORIGINS is not set in the .env or is null (for example if no one added it
+ * after amn upgrade from a previous version that didn't include it in the .env.example),
+ * set it to * to allow all. If there is a value, either a single url or a comma-delimited
+ * list of urls, explode that out into an array to whitelist just those urls.
+ *
+ */
+
+$allowed_origins = env('APP_CORS_ALLOWED_ORIGINS') !== null ?
+    explode(',', env('APP_CORS_ALLOWED_ORIGINS')) : ['*'];
+
 return [
 
     /*
@@ -13,10 +33,10 @@ return [
     */
    
     'supportsCredentials' => false,
-    'allowedOrigins' => ['*'],
+    'allowedOrigins' => $allowed_origins,
     'allowedOriginsPatterns' => [],
     'allowedHeaders' => ['*'],
-    'allowedMethods' => ['*'],
+    'allowedMethods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
     'exposedHeaders' => [],
     'maxAge' => 0,
 

--- a/config/cors.php
+++ b/config/cors.php
@@ -16,8 +16,8 @@
  * list of urls, explode that out into an array to whitelist just those urls.
  */
 
-$allowed_origins = env('APP_CORS_ALLOWED_ORIGINS') !== null ?
-    explode(',', env('APP_CORS_ALLOWED_ORIGINS')) : ['*'];
+$allowed_origins = env('CORS_ALLOWED_ORIGINS') !== null ?
+    explode(',', env('CORS_ALLOWED_ORIGINS')) : [];
 
 /**
  * Original Laravel CORS package config file modifications end here

--- a/config/cors.php
+++ b/config/cors.php
@@ -2,8 +2,8 @@
 
 /**
  * ---------------------------------------------------------------------
- * THIS IS NOT PART OF THE ORIGINAL CORS PACKAGE. IT IS A MODIFICATION
- * BY SNIPE-IT TO ALLOW ADDING ALLOWED ORIGINS VIA THE ENV.
+ * THIS IS $allowed_origins code IS NOT PART OF THE ORIGINAL CORS PACKAGE.
+ * IT IS A MODIFICATION BY SNIPE-IT TO ALLOW ADDING ALLOWED ORIGINS VIA THE ENV.
  * ---------------------------------------------------------------------
  *
  * Since we don't really want people editing config files (lest they get
@@ -14,11 +14,16 @@
  * after an upgrade from a previous version that didn't include it in the .env.example) or is null,
  * set it to * to allow all. If there is a value, either a single url or a comma-delimited
  * list of urls, explode that out into an array to whitelist just those urls.
- *
  */
 
 $allowed_origins = env('APP_CORS_ALLOWED_ORIGINS') !== null ?
     explode(',', env('APP_CORS_ALLOWED_ORIGINS')) : ['*'];
+
+/**
+ * Original Laravel CORS package config file modifications end here
+ *
+ */
+
 
 return [
 

--- a/config/cors.php
+++ b/config/cors.php
@@ -10,8 +10,8 @@
  * overwritten later), this enables the person managing the Snipe-IT
  * installation to modify these values without modifying the code.
  *
- * If APP_CORS_ALLOWED_ORIGINS is not set in the .env or is null (for example if no one added it
- * after an upgrade from a previous version that didn't include it in the .env.example),
+ * If APP_CORS_ALLOWED_ORIGINS is not set in the .env (for example if no one added it
+ * after an upgrade from a previous version that didn't include it in the .env.example) or is null,
  * set it to * to allow all. If there is a value, either a single url or a comma-delimited
  * list of urls, explode that out into an array to whitelist just those urls.
  *

--- a/config/cors.php
+++ b/config/cors.php
@@ -11,7 +11,7 @@
  * installation to modify these values without modifying the code.
  *
  * If APP_CORS_ALLOWED_ORIGINS is not set in the .env or is null (for example if no one added it
- * after amn upgrade from a previous version that didn't include it in the .env.example),
+ * after an upgrade from a previous version that didn't include it in the .env.example),
  * set it to * to allow all. If there is a value, either a single url or a comma-delimited
  * list of urls, explode that out into an array to whitelist just those urls.
  *


### PR DESCRIPTION
If `APP_CORS_ALLOWED_ORIGINS` is not set in the `.env` (for example if no one added it after an upgrade from a previous version that didn't include it in the .env.example) or is null , set it to `[]` to allow none, as is the current behavior. 

If there is a value, either a single url or a comma-delimited list of urls, explode that out into an array to whitelist just those urls.

### It's questionable as to whether we even want to allow this behavior, to be honest, since most naive implementations will likely expose bearer tokens in the javascript itself (which could then be used to gain API access to the Snipe-IT system by a nefarious or unauthorized party).

I'm open to discussion about this. 

I don't really need reports of Snipe-IT getting "hacked" circulating on the internet because some chowderhead left credentials in the front-end source code.

Laravel supports encrypted JWTs, documented [here](https://laravel.com/docs/5.5/passport#consuming-your-api-with-javascript), which is arguably better, but there currently isn't anything implemented to *prevent* developers from exposing bearer tokens in their source code - which is NOT helped by the fact that the auto-generated code we provide on the API documentation site hardcodes those bearer tokens. (Our choice there is remove javascript examples, since I don't think the documentation site supports JWT tokens. Checking now tho.)