### PR TITLE
Add support for custom remote user header

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -99,9 +99,10 @@ class LoginController extends Controller
 
     private function loginViaRemoteUser(Request $request)
     {
-        $remote_user = $request->server('REMOTE_USER');
+        $header_name = Setting::getSettings()->login_remote_user_header_name ?: 'REMOTE_USER';
+        $remote_user = $request->server($header_name);
         if (Setting::getSettings()->login_remote_user_enabled == "1" && isset($remote_user) && !empty($remote_user)) {
-            Log::debug("Authenticatiing via REMOTE_USER.");
+            Log::debug("Authenticating via HTTP header $header_name.");
 
             $pos = strpos($remote_user, '\\');
             if ($pos > 0) {

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -572,6 +572,7 @@ class SettingsController extends Controller
             $setting->login_remote_user_enabled           = (int) $request->input('login_remote_user_enabled');
             $setting->login_common_disabled               = (int) $request->input('login_common_disabled');
             $setting->login_remote_user_custom_logout_url = $request->input('login_remote_user_custom_logout_url');
+            $setting->login_remote_user_header_name = $request->input('login_remote_user_header_name');
         }
 
         $setting->pwd_secure_uncommon   = (int) $request->input('pwd_secure_uncommon');

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -71,6 +71,7 @@ class Setting extends Model
           'login_remote_user_enabled'           => 'numeric|nullable',
           'login_common_disabled'               => 'numeric|nullable',
           'login_remote_user_custom_logout_url' => 'string|nullable',
+          'login_remote_user_header_name'       => 'string|nullable',
           'thumbnail_max_h'                     => 'numeric|max:500|min:25',
           'pwd_secure_min'                      => 'numeric|required|min:5',
           'audit_warning_days'                  => 'numeric|nullable',

--- a/database/migrations/2019_08_20_084049_add_custom_remote_user_header.php
+++ b/database/migrations/2019_08_20_084049_add_custom_remote_user_header.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCustomRemoteUserHeader extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->string('login_remote_user_header_name')->default("");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('login_remote_user_header_name');
+        });
+    }
+}

--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -94,6 +94,8 @@ return array(
     'login_common_disabled_help' => 'This option disables other authentication mechanisms. Just enable this option if you are sure that your REMOTE_USER login is already working',
     'login_remote_user_custom_logout_url_text' => 'Custom logout URL',
     'login_remote_user_custom_logout_url_help' => 'If a url is provided here, users will get redirected to this URL after the user logs out of Snipe-IT. This is useful to close the user sessions of your Authentication provider correctly.',
+    'login_remote_user_header_name_text' => 'Custom user name header',
+    'login_remote_user_header_name_help' => 'Use the specified header instead of REMOTE_USER',
     'logo'                    	=> 'Logo',
     'logo_print_assets'         => 'Use in Print',
     'logo_print_assets_help'    => 'Use branding on printable asset lists ',

--- a/resources/lang/sv-SE/admin/settings/general.php
+++ b/resources/lang/sv-SE/admin/settings/general.php
@@ -87,6 +87,8 @@ return array(
     'login_common_disabled_help' => 'This option disables other authentication mechanisms. Just enable this option if you are sure that your REMOTE_USER login is already working',
     'login_remote_user_custom_logout_url_text' => 'Anpassad logga ut URL',
     'login_remote_user_custom_logout_url_help' => 'Om en URL tillhandahålls här kommer användarna att omdirigeras till den här webbadressen efter att användaren loggat ut från Snipe-IT. Det här är användbart för att stänga användarsessionerna i din autentiseringsleverantör korrekt.',
+    'login_remote_user_header_name_text' => 'Anpassat headernamn',
+    'login_remote_user_header_name_help' => 'Använd en annan header för inloggning än REMOTE_USER',
     'logo'                    	=> 'Logotyp',
     'logo_print_assets'         => 'Använd vid utskrift',
     'logo_print_assets_help'    => 'Använda branding på utskrivbara tillgångs-listor ',

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -133,6 +133,13 @@
                                     <p class="help-block">
                                         {{ trans('admin/settings/general.login_remote_user_enabled_help') }}
                                     </p>
+                                    <!-- Use custom remote user header name -->
+                                    {{ Form::label('login_remote_user_header_name',  trans('admin/settings/general.login_remote_user_header_name_text')) }}
+                                    {{ Form::text('login_remote_user_header_name', Input::old('login_remote_user_header_name', $setting->login_remote_user_header_name),array('class' => 'form-control')) }}
+                                    {!! $errors->first('login_remote_user_header_name', '<span class="alert-msg">:message</span>') !!}
+                                    <p class="help-block">
+                                        {{ trans('admin/settings/general.login_remote_user_header_name_help') }}
+                                    </p>
                                     <!-- Custom logout url to redirect to authentication provider -->
                                     {{ Form::label('login_remote_user_custom_logout_url',  trans('admin/settings/general.login_remote_user_custom_logout_url_text')) }}
                                     {{ Form::text('login_remote_user_custom_logout_url', Input::old('login_remote_user_custom_logout_url', $setting->login_remote_user_custom_logout_url),array('class' => 'form-control')) }}


### PR DESCRIPTION
PR [5142](https://github.com/snipe/snipe-it/pull/5142) adds support for external authentication through use of the REMOTE_USER header. However using this method is in practice (at least according to my experience) only possible when using Apache with an authentication module such as Shibboleth which seems a bit painful to set up right, especially under Docker. Using [oauth2_proxy](https://github.com/pusher/oauth2_proxy) or one of its forks is a much more appealing way of getting SSO support for a number of identity providers (Google, Azure AD, Okta, etc.) and is very easy to set up.

A problem with this solution when used with Snipe-IT is that the user name is passed on by the proxy as a header named _X-Forwarded-User_ (or _X-Forwarded-Mail_ if you want to use email for username). This PR makes it possible to configure a custom header name instead of REMOTE_USER which really broadens the options for external authentication.