### PR TITLE
Implement #3088: Add "Generate Label" option to "Actions" dropdown menu in individual Asset Details view.

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -477,6 +477,29 @@ class AssetsController extends Controller
         }
     }
 
+
+    /**
+     * Return a label for an individual asset.
+     *
+     * @author [L. Swartzendruber] [<logan.swartzendruber@gmail.com>
+     * @param int $assetId
+     * @return View
+     */
+    public function getLabel($assetId = null)
+    {
+        if (isset($assetId)) {
+            $asset = Asset::find($assetId);
+            $this->authorize('view', $asset);
+
+            return view('hardware/labels')
+                ->with('assets', Asset::find($asset))
+                ->with('settings', Setting::getSettings())
+                ->with('bulkedit', False)
+                ->with('count', 0);
+        }
+    }
+
+
     /**
      * Returns a view that presents a form to clone an asset.
      *

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -494,7 +494,7 @@ class AssetsController extends Controller
             return view('hardware/labels')
                 ->with('assets', Asset::find($asset))
                 ->with('settings', Setting::getSettings())
-                ->with('bulkedit', False)
+                ->with('bulkedit', false)
                 ->with('count', 0);
         }
     }

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -40,6 +40,7 @@ class BulkAssetsController extends Controller
                     return view('hardware/labels')
                         ->with('assets', Asset::find($asset_ids))
                         ->with('settings', Setting::getSettings())
+                        ->with('bulkedit', True)
                         ->with('count', 0);
                 case 'delete':
                     $assets = Asset::with('assignedTo', 'location')->find($asset_ids);

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -40,7 +40,7 @@ class BulkAssetsController extends Controller
                     return view('hardware/labels')
                         ->with('assets', Asset::find($asset_ids))
                         ->with('settings', Setting::getSettings())
-                        ->with('bulkedit', True)
+                        ->with('bulkedit', true)
                         ->with('count', 0);
                 case 'delete':
                     $assets = Asset::with('assignedTo', 'location')->find($asset_ids);

--- a/resources/lang/en/button.php
+++ b/resources/lang/en/button.php
@@ -13,4 +13,5 @@ return array(
     'upload'                    => 'Upload',
 	'select_file'				=> 'Select File...',
     'select_files'				=> 'Select Files...',
+    'generate_labels'           => '{1} Generate Label|[2,*] Generate Labels',
 );

--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -67,9 +67,9 @@
               @if (Input::get('status')!='Deleted')
               <div id="toolbar">
                 <select name="bulk_actions" class="form-control select2">
-                  <option value="edit">Edit</option>
-                  <option value="delete">Delete</option>
-                  <option value="labels">Generate Labels</option>
+                  <option value="edit">{{ trans('button.edit') }}</option>
+                  <option value="delete">{{ trans('button.delete') }}</option>
+                  <option value="labels">{{ trans_choice('button.generate_labels', 2) }}</option>
                 </select>
                 <button class="btn btn-primary" id="bulkEdit" disabled>Go</button>
               </div>

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -186,7 +186,11 @@
 
     @if ((($settings->alt_barcode_enabled=='1') && $settings->alt_barcode!=''))
         <div class="label-alt_barcode barcode_container">
+        @if ($bulkedit==False)
+            <img src="./barcode" class="barcode">
+        @else
             <img src="./{{ $asset->id }}/barcode" class="barcode">
+        @endif
         </div>
     @endif
 

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -135,7 +135,11 @@
 
       @if ($settings->qr_code=='1')
     <div class="label-qr_img qr_img">
+        @if ($bulkedit==False)
+      <img src="./qr_code" class="qr_img">
+        @else
       <img src="./{{ $asset->id }}/qr_code" class="qr_img">
+        @endif
     </div>
       @endif
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -35,6 +35,7 @@
       @can('audit', \App\Models\Asset::class)
       <li role="presentation"><a href="{{ route('asset.audit.create', $asset->id)  }}">{{ trans('general.audit') }}</a></li>
      @endcan
+      <li role="presentation"><a href="{{ route('label/hardware', $asset->id)  }}">{{ trans_choice('button.generate_labels', 1) }}</a></li>
   </ul>
 </div>
 @endcan

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -80,6 +80,11 @@ Route::group(
             'uses' => 'Assets\AssetsController@getClone'
         ]);
 
+        Route::get('{assetId}/label', [
+            'as' => 'label/hardware',
+            'uses' => 'Assets\AssetsController@getLabel'
+        ]);
+
         Route::post('{assetId}/clone', 'Assets\AssetsController@postCreate');
 
         Route::get('{assetId}/checkout', [


### PR DESCRIPTION
These changes implement the feature request of #3088 for a way to generate a label for an individual asset on the Asset Details view.

I created a new route ('{assetId}/label') that shows the label of an asset via a new function in AssetController.php. I also added a variable called 'bulkedit' (used when calling the Label view) which indicates whether the view is being generated through the bulkedit path or through the individual asset page, since the QR code / barcode path needs to be tweaked depending on the requested URL (without it, the images are broken due to the path being created as, "https://snipe.example.com/hardware/1/1/qr_code" instead of the correct path, "https://snipe.example.com/hardware/1/qr_code"). Finally, I added in the "Generate Label" option to the Actions menu in the Asset view.

I've done some quick testing just to make sure it works, but I didn't do anything intensive / try to break it, so adding in some additional checks may or may not be a good idea.