### PR TITLE
fix ldap ad authentication filter query mechanism

### DIFF
--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -93,8 +93,12 @@ class Ldap extends Model
 
         \Log::debug('Attempting to login using distinguished name:'.$userDn);
 
-
+        
         $filterQuery = $settings->ldap_auth_filter_query . $username;
+        $filter = Setting::getSettings()->ldap_filter;
+        $filterQuery = "({$filter}({$filterQuery}))";
+
+        \Log::debug('Filter query: '.$filterQuery);
 
 
         if (!$ldapbind = @ldap_bind($connection, $userDn, $password)) {


### PR DESCRIPTION
I have improved the ldap ad authentication mechanism. You can now use the filter like "membersOf" and so on. Prior to trying to log in with ldap, the filter could not be applied properly in ldap_search function.
Also I have added a new debug log entry to crosscheck the filter mechanism.

an example debug log output:
Filter query: (&(sAMAccountType=805306368)(!(userAccountControl:1.2.840.113556.1.4.803:=2))(memberOf:1.2.840.113556.1.4.1941:=CN=Snipeit users,OU=Domain Users,DC=example,DC=com)(samaccountname=pottom))