### PR TITLE
Fixed #7456 - Update child assets to reflect asset parent location

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -525,6 +525,10 @@ class AssetsController extends Controller
                     $location = $target->location_id;
                 } elseif (($request->filled('assigned_asset')) && ($target = Asset::find($request->get('assigned_asset')))) {
                     $location = $target->location_id;
+
+                    Asset::where('assigned_type', '\\App\\Models\\Asset')->where('assigned_to', $id)
+                        ->update(['location_id' => $target->location_id]);
+
                 } elseif (($request->filled('assigned_location')) && ($target = Location::find($request->get('assigned_location')))) {
                     $location = $target->id;
                 }

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -394,6 +394,12 @@ class AssetsController extends Controller
 
 
         if ($asset->save()) {
+
+             // Update any assigned assets with the new location_id from the parent asset
+
+            Asset::where('assigned_type', '\\App\\Models\\Asset')->where('assigned_to', $asset->id)
+                ->update(['location_id' => $asset->location_id]);
+
             // Redirect to the new asset page
             \Session::flash('success', trans('admin/hardware/message.update.success'));
             return response()->json(['redirect_url' => route("hardware.show", $assetId)]);


### PR DESCRIPTION
I'm not sure this is going to cover all bases here, since it's possible to break this chain:

- if the parent asset is assigned to a person and that person's location changes
-  if the parent asset is *also* assigned to an asset (making the asset's children grandchildren)
- some other variety of cases I haven't considered yet

This gets pretty messy with what equates to infinite nesting, and no real way to pop up the stack to find the "for really real" location, but I'm not sure how far down that rabbit hole we want to go.