### PR TITLE
Add categories dropdown to filter by category on Assets list

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -8,6 +8,7 @@ use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\CheckoutRequest;
+use App\Models\Category;
 use App\Models\Company;
 use App\Models\Location;
 use App\Models\Setting;
@@ -68,7 +69,13 @@ class AssetsController extends Controller
         } else {
             $company = null;
         }
-        return view('hardware/index')->with('company', $company);
+
+        $data = [
+            'company' => $company,
+            'categories' => Category::all()
+        ];
+
+        return view('hardware/index')->with($data);
     }
 
     /**

--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -72,6 +72,14 @@
                   <option value="labels">{{ trans_choice('button.generate_labels', 2) }}</option>
                 </select>
                 <button class="btn btn-primary" id="bulkEdit" disabled>Go</button>
+                <label for="category" style="margin-left: 30px;margin-right: 10px">
+                  {{ trans('admin/categories/general.category_name') }}
+                </label>
+                <select id="category" name="category" class="form-control select2">
+                  @foreach ($categories as $category)
+                    <option value="{{$category->id}}">{{$category->name}}</option>
+                  @endforeach
+                </select>
               </div>
               @endif
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -569,6 +569,15 @@
         });
     });
 
+    $(() => {
+        $('#category').change(() => {
+            $('.snipe-table').bootstrapTable('refresh', {
+                query: {
+                    category_id: $('#category option:selected').val()
+                }
+            });
+        });
+    });
 
     // This is necessary to make the bootstrap tooltips work inside of the
     // wenzhixin/bootstrap-table formatters


### PR DESCRIPTION
This feature add a dropdown to filter the assets based on specific category.

<img width="1195" alt="image" src="https://user-images.githubusercontent.com/15105462/66513277-a55edc80-ead2-11e9-89d8-d9d00da101e5.png">
