### PR TITLE
Add requestable to asset model api results

### DIFF
--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -30,7 +30,7 @@ class AssetModelsController extends Controller
     public function index(Request $request)
     {
         $this->authorize('view', AssetModel::class);
-        $allowed_columns = ['id','image','name','model_number','eol','notes','created_at','manufacturer','assets_count'];
+        $allowed_columns = ['id','image','name','model_number','eol','notes','created_at','manufacturer','requestable', 'assets_count'];
 
         $assetmodels = AssetModel::select([
             'models.id',
@@ -38,6 +38,7 @@ class AssetModelsController extends Controller
             'models.name',
             'model_number',
             'eol',
+            'requestable',
             'models.notes',
             'models.created_at',
             'category_id',

--- a/app/Http/Transformers/AssetModelsTransformer.php
+++ b/app/Http/Transformers/AssetModelsTransformer.php
@@ -45,6 +45,7 @@ class AssetModelsTransformer
                 'name'=> e($assetmodel->fieldset->name)
             ]  : null,
             'eol' => ($assetmodel->eol > 0) ? $assetmodel->eol .' months': 'None',
+            'requestable' => ($assetmodel->requestable =='1') ? true : false,
             'notes' => e($assetmodel->notes),
             'created_at' => Helper::getFormattedDateObject($assetmodel->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($assetmodel->updated_at, 'datetime'),


### PR DESCRIPTION
This request adds the 'requestable' field (already available in v5 models table) to api requests for models (api/v1/models).