### PR TITLE
fix syntax error in CustomFieldsetsController::show()

### DIFF
--- a/app/Http/Controllers/CustomFieldsetsController.php
+++ b/app/Http/Controllers/CustomFieldsetsController.php
@@ -56,12 +56,6 @@ class CustomFieldsetsController extends Controller
             return view("custom_fields.fieldsets.view")->with("custom_fieldset", $cfset)->with("maxid", $maxid+1)->with("custom_fields_list", $custom_fields_list);
         }
 
-            return view("custom_fields.fieldsets.view")
-                ->with("custom_fieldset", $cfset)
-                ->with("maxid", $maxid+1)
-                ->with("custom_fields_list", $custom_fields_list);
-        }
-
         return redirect()->route("fields.index")
             ->with("error", trans('admin/custom_fields/message.fieldset.does_not_exist'));
 


### PR DESCRIPTION
Someone left behind a double return statement (+ closing bracket) here, just removed the older one.. :)