### PR TITLE
Adding Dept to license seats

### DIFF
--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -228,14 +228,21 @@ class LicensesController extends Controller
 
             $this->authorize('view', $license);
 
-            $seats = LicenseSeat::where('license_id', $licenseId)->with('license', 'user', 'asset', 'user.department');
+            $seats = LicenseSeat::where('license_seats.license_id', $licenseId)
+                ->with('license', 'user', 'asset', 'user.department');
 
-            $offset = (($seats) && (request('offset') > $seats->count())) ? 0 : request('offset', 0);
-
-            $limit = request('limit', 50);
             $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
 
+            if ($request->input('sort')=='department') {
+                $seats->OrderDepartments($order);
+            } else {
+                $seats->orderBy('id', $order);
+            }
+
             $total = $seats->count();
+            $offset = (($seats) && (request('offset') > $total)) ? 0 : request('offset', 0);
+            $limit = request('limit', 50);
+            
             $seats = $seats->skip($offset)->take($limit)->get();
 
             if ($seats) {

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -228,7 +228,7 @@ class LicensesController extends Controller
 
             $this->authorize('view', $license);
 
-            $seats = LicenseSeat::where('license_id', $licenseId)->with('license', 'user', 'asset');
+            $seats = LicenseSeat::where('license_id', $licenseId)->with('license', 'user', 'asset', 'user.department');
 
             $offset = (($seats) && (request('offset') > $seats->count())) ? 0 : request('offset', 0);
 

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -29,7 +29,14 @@ class LicenseSeatsTransformer
             'name' => 'Seat '.$seat_count,
             'assigned_user' => ($seat->user) ? [
                 'id' => (int) $seat->user->id,
-                'name'=> e($seat->user->present()->fullName)
+                'name'=> e($seat->user->present()->fullName),
+                'department'=>
+                    ($seat->user->department) ?
+                        [
+                            "id" => (int) $seat->user->department->id,
+                            "name" => e($seat->user->department->name)
+
+                        ] : null
             ] : null,
             'assigned_asset' => ($seat->asset) ? [
                 'id' => (int) $seat->asset->id,

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -55,4 +55,23 @@ class LicenseSeat extends Model implements ICompanyableChild
         return false;
 
     }
+
+    /**
+     * Query builder scope to order on department
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query  Query builder instance
+     * @param  text                              $order         Order
+     *
+     * @return \Illuminate\Database\Query\Builder          Modified query builder
+     */
+    public function scopeOrderDepartments($query, $order)
+    {
+        return $query->leftJoin('users as license_seat_users',  'license_seats.assigned_to', '=', 'license_seat_users.id')
+            ->leftJoin('departments as license_user_dept',  'license_user_dept.id', '=', 'license_seat_users.department_id')
+            ->orderBy('license_user_dept.name', $order);
+    }
+
+
+
+
 }

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -176,6 +176,15 @@ class LicensePresenter extends Presenter
                 "visible" => true,
                 "formatter" => "usersLinkObjFormatter"
             ], [
+                "field" => "department",
+                "searchable" => false,
+                "sortable" => false,
+                "switchable" => true,
+                "title" => trans('general.department'),
+                "visible" => false,
+                "formatter" => "departmentNameLinkFormatter"
+            ],
+            [
                 "field" => "assigned_asset",
                 "searchable" => false,
                 "sortable" => false,
@@ -191,7 +200,8 @@ class LicensePresenter extends Presenter
                 "title" => trans('general.location'),
                 "visible" => true,
                 "formatter" => "locationsLinkObjFormatter"
-            ], [
+            ],
+            [
                 "field" => "checkincheckout",
                 "searchable" => false,
                 "sortable" => false,

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -178,7 +178,7 @@ class LicensePresenter extends Presenter
             ], [
                 "field" => "department",
                 "searchable" => false,
-                "sortable" => false,
+                "sortable" => true,
                 "switchable" => true,
                 "title" => trans('general.department'),
                 "visible" => false,

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -48,7 +48,7 @@
                         data-id-table="seatsTable-{{ $license->id }}"
                         id="seatsTable-{{$license->id}}"
                         data-pagination="true"
-                        data-search="true"
+                        data-search="false"
                         data-side-pagination="server"
                         data-show-columns="true"
                         data-show-export="true"

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -447,6 +447,13 @@
 
     }
 
+    function departmentNameLinkFormatter(value, row) {
+        if ((row.assigned_user) && (row.assigned_user.department) && (row.assigned_user.department.name)) {
+            return '<a href="{{ url('/') }}/department/' + row.assigned_user.department.id + '"> ' + row.assigned_user.department.name + '</a>';
+        }
+
+    }
+
     function assetNameLinkFormatter(value, row) {
         if ((row.asset) && (row.asset.name)) {
             return '<a href="{{ url('/') }}/hardware/' + row.asset.id + '"> ' + row.asset.name + '</a>';


### PR DESCRIPTION
This adds the functionality to display and sort by department name (when a user is assigned a license seat *and* that user has a department assigned to it.)

<img width="947" alt="Screen Shot 2019-11-21 at 8 02 44 PM" src="https://user-images.githubusercontent.com/197404/69397154-e8979800-0c99-11ea-8189-ba3b54f4ad81.png">

I also removed the search from that interface, since it... never actually searched on anything. Something to revisit in v5 once we've refactored how licenses and seats work. 