### PR TITLE
Quotes in custom field names breaks list [ch10435]

### DIFF
--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -258,13 +258,17 @@ class AssetPresenter extends Presenter
             $query->whereHas('models');
         })->get();
 
+
+        // Note: We do not need to e() escape the field names here, as they are already escaped when
+        // they are presented in the blade view. If we escape them here, custom fields with quotes in their
+        // name can break the listings page. - snipe
         foreach ($fields as $field) {
             $layout[] = [
                 "field" => 'custom_fields.'.$field->convertUnicodeDbSlug(),
                 "searchable" => true,
                 "sortable" => true,
                 "switchable" => true,
-                "title" => ($field->field_encrypted=='1') ?'<i class="fa fa-lock"></i> '.e($field->name) : e($field->name),
+                "title" => ($field->field_encrypted=='1') ?'<i class="fa fa-lock"></i> '.$field->name : $field->name,
                 "formatter" => "customFieldsFormatter"
             ];
 


### PR DESCRIPTION
This fix prevents the listing layout from breaking when a custom field has quotes in it, for example `Passed "100 mile check"`. Prior to this, the values would be escaped twice, once here in the Presenter, and then again when we use the Presenter in the blade itself.