### PR TITLE
Upgrade develop to Laravel 6.6.1

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -64,12 +64,12 @@ class AccessoryCheckoutController extends Controller
 
         $this->authorize('checkout', $accessory);
 
-        if (!$user = User::find(Input::get('assigned_to'))) {
+        if (!$user = User::find(Request::get('assigned_to'))) {
             return redirect()->route('checkout/accessory', $accessory->id)->with('error', trans('admin/accessories/message.checkout.user_does_not_exist'));
         }
 
       // Update the accessory data
-        $accessory->assigned_to = e(Input::get('assigned_to'));
+        $accessory->assigned_to = e(Request::get('assigned_to'));
 
         $accessory->users()->attach($accessory->id, [
             'accessory_id' => $accessory->id,

--- a/app/Http/Controllers/Api/AssetMaintenancesController.php
+++ b/app/Http/Controllers/Api/AssetMaintenancesController.php
@@ -62,8 +62,8 @@ class AssetMaintenancesController extends Controller
                                 'asset_name',
                                 'user_id'
                             ];
-        $order = Input::get('order') === 'asc' ? 'asc' : 'desc';
-        $sort = in_array(Input::get('sort'), $allowed_columns) ? e($request->input('sort')) : 'created_at';
+        $order = Request::get('order') === 'asc' ? 'asc' : 'desc';
+        $sort = in_array(Request::get('sort'), $allowed_columns) ? e($request->input('sort')) : 'created_at';
 
         switch ($sort) {
             case 'user_id':

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -738,8 +738,8 @@ class AssetsController extends Controller
             $asset->location_id =  $request->input('location_id');
         }
 
-        if (Input::has('status_id')) {
-            $asset->status_id =  Input::get('status_id');
+        if (Request::has('status_id')) {
+            $asset->status_id =  Request::get('status_id');
         }
 
         if ($asset->save()) {

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -75,7 +75,7 @@ class AssetModelsController extends Controller
         $model->category_id         = $request->input('category_id');
         $model->notes               = $request->input('notes');
         $model->user_id             = Auth::id();
-        $model->requestable         = Input::has('requestable');
+        $model->requestable         = Request::has('requestable');
 
         if ($request->input('custom_fieldset')!='') {
             $model->fieldset_id = e($request->input('custom_fieldset'));
@@ -304,7 +304,7 @@ class AssetModelsController extends Controller
     public function postBulkEdit(Request $request)
     {
 
-        $models_raw_array = Input::get('ids');
+        $models_raw_array = Request::get('ids');
 
         // Make sure some IDs have been selected
         if ((is_array($models_raw_array)) && (count($models_raw_array) > 0)) {
@@ -353,7 +353,7 @@ class AssetModelsController extends Controller
     public function postBulkEditSave(Request $request)
     {
 
-        $models_raw_array = Input::get('ids');
+        $models_raw_array = Request::get('ids');
         $update_array = array();
 
 
@@ -394,7 +394,7 @@ class AssetModelsController extends Controller
      */
     public function postBulkDelete(Request $request)
     {
-        $models_raw_array = Input::get('ids');
+        $models_raw_array = Request::get('ids');
 
         if ((is_array($models_raw_array)) && (count($models_raw_array) > 0)) {
 

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -12,7 +12,6 @@ use Illuminate\Foundation\Auth\ThrottlesLogins;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Validator;
 use Log;
@@ -130,7 +129,7 @@ class LoginController extends Controller
             return view('errors.403');
         }
 
-        $validator = $this->validator(Input::all());
+        $validator = $this->validator($request->all());
 
         if ($validator->fails()) {
             return redirect()->back()->withInput()->withErrors($validator);

--- a/app/Http/Controllers/BulkAssetModelsController.php
+++ b/app/Http/Controllers/BulkAssetModelsController.php
@@ -20,7 +20,7 @@ class BulkAssetModelsController extends Controller
      */
     public function edit(Request $request)
     {
-        $models_raw_array = Input::get('ids');
+        $models_raw_array = Request::get('ids');
 
         // Make sure some IDs have been selected
         if ((is_array($models_raw_array)) && (count($models_raw_array) > 0)) {
@@ -64,7 +64,7 @@ class BulkAssetModelsController extends Controller
     public function update(Request $request)
     {
 
-        $models_raw_array = Input::get('ids');
+        $models_raw_array = Request::get('ids');
         $update_array = array();
 
         if (($request->filled('manufacturer_id') && ($request->input('manufacturer_id')!='NC'))) {
@@ -103,7 +103,7 @@ class BulkAssetModelsController extends Controller
      */
     public function destroy()
     {
-        $models_raw_array = Input::get('ids');
+        $models_raw_array = Request::get('ids');
 
         if ((is_array($models_raw_array)) && (count($models_raw_array) > 0)) {
 

--- a/app/Http/Controllers/Components/ComponentCheckoutController.php
+++ b/app/Http/Controllers/Components/ComponentCheckoutController.php
@@ -69,7 +69,7 @@ class ComponentCheckoutController extends Controller
         }
 
         $admin_user = Auth::user();
-        $asset_id = e(Input::get('asset_id'));
+        $asset_id = e(Request::get('asset_id'));
 
         // Check if the user exists
         if (is_null($asset = Asset::find($asset_id))) {
@@ -84,7 +84,7 @@ class ComponentCheckoutController extends Controller
             'component_id' => $component->id,
             'user_id' => $admin_user->id,
             'created_at' => date('Y-m-d H:i:s'),
-            'assigned_qty' => Input::get('assigned_qty'),
+            'assigned_qty' => Request::get('assigned_qty'),
             'asset_id' => $asset_id
         ]);
 

--- a/app/Http/Controllers/Components/ComponentsController.php
+++ b/app/Http/Controllers/Components/ComponentsController.php
@@ -125,16 +125,16 @@ class ComponentsController extends Controller
         $this->authorize('update', $component);
 
         // Update the component data
-        $component->name                   = Input::get('name');
-        $component->category_id            = Input::get('category_id');
-        $component->location_id            = Input::get('location_id');
-        $component->company_id             = Company::getIdForCurrentUser(Input::get('company_id'));
-        $component->order_number           = Input::get('order_number');
-        $component->min_amt                = Input::get('min_amt');
-        $component->serial                 = Input::get('serial');
-        $component->purchase_date          = Input::get('purchase_date');
+        $component->name                   = Request::get('name');
+        $component->category_id            = Request::get('category_id');
+        $component->location_id            = Request::get('location_id');
+        $component->company_id             = Company::getIdForCurrentUser(Request::get('company_id'));
+        $component->order_number           = Request::get('order_number');
+        $component->min_amt                = Request::get('min_amt');
+        $component->serial                 = Request::get('serial');
+        $component->purchase_date          = Request::get('purchase_date');
         $component->purchase_cost          = request('purchase_cost');
-        $component->qty                    = Input::get('qty');
+        $component->qty                    = Request::get('qty');
 
         $component = $request->handleImages($component);
 

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -51,7 +51,7 @@ class ConsumableCheckoutController extends Controller
         $this->authorize('checkout', $consumable);
 
         $admin_user = Auth::user();
-        $assigned_to = e(Input::get('assigned_to'));
+        $assigned_to = e(Request::get('assigned_to'));
 
         // Check if the user exists
         if (is_null($user = User::find($assigned_to))) {
@@ -60,12 +60,12 @@ class ConsumableCheckoutController extends Controller
         }
 
         // Update the consumable data
-        $consumable->assigned_to = e(Input::get('assigned_to'));
+        $consumable->assigned_to = e(Request::get('assigned_to'));
 
         $consumable->users()->attach($consumable->id, [
             'consumable_id' => $consumable->id,
             'user_id' => $admin_user->id,
-            'assigned_to' => e(Input::get('assigned_to'))
+            'assigned_to' => e(Request::get('assigned_to'))
         ]);
 
         event(new CheckoutableCheckedOut($consumable, $user, Auth::user(), $request->input('note')));

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -141,8 +141,8 @@ class ConsumablesController extends Controller
         $consumable->model_number           = $request->input('model_number');
         $consumable->item_no                = $request->input('item_no');
         $consumable->purchase_date          = $request->input('purchase_date');
-        $consumable->purchase_cost          = Helper::ParseFloat(Input::get('purchase_cost'));
-        $consumable->qty                    = Helper::ParseFloat(Input::get('qty'));
+        $consumable->purchase_cost          = Helper::ParseFloat(Request::get('purchase_cost'));
+        $consumable->qty                    = Helper::ParseFloat(Request::get('qty'));
 
         $consumable = $request->handleImages($consumable);
 

--- a/app/Http/Controllers/CustomFieldsetsController.php
+++ b/app/Http/Controllers/CustomFieldsetsController.php
@@ -102,7 +102,7 @@ class CustomFieldsetsController extends Controller
                 "user_id" => Auth::user()->id
         ]);
 
-        $validator = Validator::make(Input::all(), $cfset->rules);
+        $validator = Validator::make($request->all(), $cfset->rules);
         if ($validator->passes()) {
             $cfset->save();
             return redirect()->route("fieldsets.show", [$cfset->id])

--- a/app/Http/Controllers/CustomFieldsetsController.php
+++ b/app/Http/Controllers/CustomFieldsetsController.php
@@ -194,7 +194,7 @@ class CustomFieldsetsController extends Controller
             }
         }
 
-        $results = $set->fields()->attach(Input::get('field_id'), ["required" => ($request->input('required') == "on"),"order" => $request->input('order', 1)]);
+        $results = $set->fields()->attach(Request::get('field_id'), ["required" => ($request->input('required') == "on"),"order" => $request->input('order', 1)]);
 
         return redirect()->route("fieldsets.show", [$id])->with("success", trans('admin/custom_fields/message.field.create.assoc_success'));
     }

--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -42,7 +42,7 @@ class GroupsController extends Controller
         // Get all the available permissions
         $permissions = config('permissions');
         $groupPermissions = Helper::selectedPermissionsArray($permissions, $permissions);
-        $selectedPermissions = Input::old('permissions', $groupPermissions);
+        $selectedPermissions = Request::old('permissions', $groupPermissions);
 
         // Show the page
         return view('groups/edit', compact('permissions', 'selectedPermissions', 'groupPermissions'))->with('group', $group);

--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -60,8 +60,8 @@ class GroupsController extends Controller
     {
         // create a new group instance
         $group = new Group();
-        $group->name = e(Input::get('name'));
-        $group->permissions = json_encode(Input::get('permission'));
+        $group->name = e(Request::get('name'));
+        $group->permissions = json_encode(Request::get('permission'));
 
         if ($group->save()) {
             return redirect()->route("groups.index")->with('success', trans('admin/groups/message.success.create'));
@@ -106,8 +106,8 @@ class GroupsController extends Controller
         if (!$group = Group::find($id)) {
             return redirect()->route('groups.index')->with('error', trans('admin/groups/message.group_not_found', compact('id')));
         }
-        $group->name = e(Input::get('name'));
-        $group->permissions = json_encode(Input::get('permission'));
+        $group->name = e(Request::get('name'));
+        $group->permissions = json_encode(Request::get('permission'));
 
         if (!config('app.lock_passwords')) {
             if ($group->save()) {

--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -74,7 +74,7 @@ class LicenseCheckinController extends Controller
         ];
 
         // Create a new validator instance from our validation rules
-        $validator = Validator::make(Input::all(), $rules);
+        $validator = Validator::make($request->all(), $rules);
 
         // If validation fails, we'll exit the operation now.
         if ($validator->fails()) {

--- a/app/Http/Controllers/Licenses/LicenseFilesController.php
+++ b/app/Http/Controllers/Licenses/LicenseFilesController.php
@@ -34,7 +34,7 @@ class LicenseFilesController extends Controller
         if (isset($license->id)) {
             $this->authorize('update', $license);
 
-            if (Input::hasFile('file')) {
+            if (Request::hasFile('file')) {
 
                 if (!Storage::exists('private_uploads/licenses')) Storage::makeDirectory('private_uploads/licenses', 775);
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -470,7 +470,7 @@ class ReportsController extends Controller
 
 
             foreach ($customfields as $customfield) {
-                if (e(Input::get($customfield->db_column_name())) == '1') {
+                if (e(Request::get($customfield->db_column_name())) == '1') {
                     $header[] = $customfield->name;
                 }
             }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -184,7 +184,7 @@ class SettingsController extends Controller
             Auth::login($user, true);
             $settings->save();
 
-            if ('1' == Input::get('email_creds')) {
+            if ('1' == Request::get('email_creds')) {
                 $data               = [];
                 $data['email']      = $user->email;
                 $data['username']   = $user->username;
@@ -344,7 +344,7 @@ class SettingsController extends Controller
 
         $setting->depreciation_method = $request->input('depreciation_method');
 
-        if ('' != Input::get('per_page')) {
+        if ('' != Request::get('per_page')) {
             $setting->per_page = $request->input('per_page');
         } else {
             $setting->per_page = 200;
@@ -1136,7 +1136,7 @@ class SettingsController extends Controller
     public function postPurge()
     {
         if (! config('app.lock_passwords')) {
-            if ('DELETE' == Input::get('confirm_purge')) {
+            if ('DELETE' == Request::get('confirm_purge')) {
                 // Run a backup immediately before processing
                 Artisan::call('backup:run');
                 Artisan::call('snipeit:purge', ['--force' => 'true', '--no-interaction' => true]);

--- a/app/Http/Controllers/StatuslabelsController.php
+++ b/app/Http/Controllers/StatuslabelsController.php
@@ -78,15 +78,15 @@ class StatuslabelsController extends Controller
         $statusType = Statuslabel::getStatuslabelTypesForDB($request->input('statuslabel_types'));
 
         // Save the Statuslabel data
-        $statusLabel->name              = Input::get('name');
+        $statusLabel->name              = Request::get('name');
         $statusLabel->user_id           = Auth::id();
-        $statusLabel->notes             =  Input::get('notes');
+        $statusLabel->notes             =  Request::get('notes');
         $statusLabel->deployable        =  $statusType['deployable'];
         $statusLabel->pending           =  $statusType['pending'];
         $statusLabel->archived          =  $statusType['archived'];
-        $statusLabel->color             =  Input::get('color');
-        $statusLabel->show_in_nav       =  Input::get('show_in_nav', 0);
-        $statusLabel->default_label       =  Input::get('default_label', 0);
+        $statusLabel->color             =  Request::get('color');
+        $statusLabel->show_in_nav       =  Request::get('show_in_nav', 0);
+        $statusLabel->default_label       =  Request::get('default_label', 0);
 
 
         if ($statusLabel->save()) {
@@ -142,15 +142,15 @@ class StatuslabelsController extends Controller
 
 
         // Update the Statuslabel data
-        $statustype                 = Statuslabel::getStatuslabelTypesForDB(Input::get('statuslabel_types'));
-        $statuslabel->name              = Input::get('name');
-        $statuslabel->notes          =  Input::get('notes');
+        $statustype                 = Statuslabel::getStatuslabelTypesForDB(Request::get('statuslabel_types'));
+        $statuslabel->name              = Request::get('name');
+        $statuslabel->notes          =  Request::get('notes');
         $statuslabel->deployable          =  $statustype['deployable'];
         $statuslabel->pending          =  $statustype['pending'];
         $statuslabel->archived          =  $statustype['archived'];
-        $statuslabel->color          =  Input::get('color');
-        $statuslabel->show_in_nav          =  Input::get('show_in_nav', 0);
-        $statuslabel->default_label          =  Input::get('default_label', 0);
+        $statuslabel->color          =  Request::get('color');
+        $statuslabel->show_in_nav          =  Request::get('show_in_nav', 0);
+        $statuslabel->default_label          =  Request::get('default_label', 0);
 
 
         // Was the asset created?

--- a/app/Http/Controllers/Users/UserFilesController.php
+++ b/app/Http/Controllers/Users/UserFilesController.php
@@ -45,7 +45,7 @@ class UserFilesController extends Controller
                 $logAction->item_id = $user->id;
                 $logAction->item_type = User::class;
                 $logAction->user_id = Auth::id();
-                $logAction->note = e(Input::get('notes'));
+                $logAction->note = e(Request::get('notes'));
                 $logAction->target_id = null;
                 $logAction->created_at = date("Y-m-d H:i:s");
                 $logAction->filename = $filename;

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -62,12 +62,12 @@ class UsersController extends Controller
 
         $userGroups = collect();
 
-        if (Input::old('groups')) {
-            $userGroups = Group::whereIn('id', Input::old('groups'))->pluck('name', 'id');
+        if (Request::old('groups')) {
+            $userGroups = Group::whereIn('id', Request::old('groups'))->pluck('name', 'id');
         }
 
         $permissions = config('permissions');
-        $userPermissions = Helper::selectedPermissionsArray($permissions, Input::old('permissions', array()));
+        $userPermissions = Helper::selectedPermissionsArray($permissions, Request::old('permissions', array()));
         $permissions = $this->filterDisplayable($permissions);
 
         $user = new User;

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -18,6 +18,8 @@ use Redirect;
 use Str;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use View;
+use Request;
+
 
 /**
  * This controller handles all actions related to Users for
@@ -55,7 +57,7 @@ class UsersController extends Controller
      * @return \Illuminate\Contracts\View\View
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function create()
+    public function create(Request $request)
     {
         $this->authorize('create', User::class);
         $groups = Group::pluck('name', 'id');
@@ -462,7 +464,7 @@ class UsersController extends Controller
         $this->authorize('create', User::class);
         // We need to reverse the UI specific logic for our
         // permissions here before we update the user.
-        $permissions = Input::get('permissions', array());
+        $permissions = Request::get('permissions', array());
         app('request')->request->set('permissions', $permissions);
 
 

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -96,7 +96,7 @@ class ViewAssetsController extends Controller
         $logaction->target_id = $data['user_id'] = Auth::user()->id;
         $logaction->target_type = User::class;
 
-        $data['item_quantity'] = Input::has('request-quantity') ? e(Input::get('request-quantity')) : 1;
+        $data['item_quantity'] = Request::has('request-quantity') ? e(Request::get('request-quantity')) : 1;
         $data['requested_by'] = $user->present()->fullName();
         $data['item'] = $item;
         $data['item_type'] = $itemType;
@@ -254,7 +254,7 @@ class ViewAssetsController extends Controller
             return redirect()->to('account/view-assets')->with('error', trans('admin/users/message.error.asset_already_accepted'));
         }
 
-        if (!Input::has('asset_acceptance')) {
+        if (!Request::has('asset_acceptance')) {
             return redirect()->back()->with('error', trans('admin/users/message.error.accept_or_decline'));
         }
 
@@ -276,7 +276,7 @@ class ViewAssetsController extends Controller
 
         $logaction = new Actionlog();
 
-        if (Input::get('asset_acceptance')=='accepted') {
+        if (Request::get('asset_acceptance')=='accepted') {
             $logaction_msg  = 'accepted';
             $accepted="accepted";
             $return_msg = trans('admin/users/message.accepted');
@@ -290,7 +290,7 @@ class ViewAssetsController extends Controller
 
         // Asset
         if (($findlog->item_id!='') && ($findlog->item_type==Asset::class)) {
-            if (Input::get('asset_acceptance')!='accepted') {
+            if (Request::get('asset_acceptance')!='accepted') {
                 DB::table('assets')
                 ->where('id', $findlog->item_id)
                 ->update(array('assigned_to' => null));
@@ -299,7 +299,7 @@ class ViewAssetsController extends Controller
 
         $logaction->target_id = $findlog->target_id;
         $logaction->target_type = User::class;
-        $logaction->note = e(Input::get('note'));
+        $logaction->note = e(Request::get('note'));
         $logaction->updated_at = date("Y-m-d H:i:s");
 
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -89,6 +89,7 @@ class AuthServiceProvider extends ServiceProvider
         Passport::routes();
         Passport::tokensExpireIn(Carbon::now()->addYears(20));
         Passport::refreshTokensExpireIn(Carbon::now()->addYears(20));
+        Passport::withCookieSerialization();
 
 
         // --------------------------------

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -90,6 +90,24 @@ class ValidationServiceProvider extends ServiceProvider
 
         });
 
+
+        Validator::extend('letters', function ($attribute, $value, $parameters) {
+            return preg_match('/\pL/', $value);
+        });
+
+        Validator::extend('numbers', function ($attribute, $value, $parameters) {
+            return preg_match('/\pN/', $value);
+        });
+
+        Validator::extend('case_diff', function ($attribute, $value, $parameters) {
+            return preg_match('/(\p{Ll}+.*\p{Lu})|(\p{Lu}+.*\p{Ll})/u', $value);
+        });
+
+        Validator::extend('symbols', function ($attribute, $value, $parameters) {
+            return preg_match('/\p{Z}|\p{S}|\p{P}/', $value);
+        });
+
+
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "intervention/image": "^2.4",
     "javiereguiluz/easyslugger": "^1.0",
     "laravel/framework": "^6.0",
+    "laravel/helpers": "^1.1",
     "laravel/passport": "^8.0",
     "laravel/slack-notification-channel": "^2.0",
     "laravel/tinker": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
   "license": "AGPL-3.0-or-later",
   "type": "project",
   "require": {
-    "php": "^7.1.3",
+    "php": "^7.2",
     "ext-curl": "*",
     "ext-fileinfo": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
     "ext-pdo": "*",
-    "adldap2/adldap2": "^9.1",
+    "adldap2/adldap2": "^10.2",
     "bacon/bacon-qr-code": "^1.0",
     "barryvdh/laravel-cors": "^0.11.3",
     "barryvdh/laravel-debugbar": "^3.2",
@@ -32,11 +32,11 @@
     "guzzlehttp/guzzle": "^6.3",
     "intervention/image": "^2.4",
     "javiereguiluz/easyslugger": "^1.0",
-    "laravel/framework": "5.8.*",
-    "laravel/passport": "~6.0",
+    "laravel/framework": "^6.0",
+    "laravel/passport": "^8.0",
     "laravel/slack-notification-channel": "^2.0",
     "laravel/tinker": "^1.0",
-    "laravelcollective/html": "5.8.*",
+    "laravelcollective/html": "^6.0",
     "league/csv": "^9.2",
     "league/flysystem-aws-s3-v3": "~1.0",
     "league/flysystem-cached-adapter": "^1.0",
@@ -52,11 +52,10 @@
     "pragmarx/google2fa": "^5.0",
     "pragmarx/google2fa-laravel": "^1.0",
     "predis/predis": "^1.1",
-    "rollbar/rollbar-laravel": "^4.0",
-    "schuppo/password-strength": "~1.5",
-    "spatie/laravel-backup": "^5.12",
+    "rollbar/rollbar-laravel": "^5.0",
+    "spatie/laravel-backup": "^6.7",
     "tecnickcom/tc-lib-barcode": "^1.15",
-    "tightenco/ziggy": "^0.7.1",
+    "tightenco/ziggy": "^0.8.1",
     "unicodeveloper/laravel-password": "^1.0",
     "watson/validating": "^3.3"
   },
@@ -109,7 +108,7 @@
     "optimize-autoloader": true,
     "process-timeout": 3000,
     "platform": {
-      "php": "7.1.8"
+      "php": "7.2"
     }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6f7d423908b63b49b6e4a17d77e1bc0",
+    "content-hash": "2324dedbf5eaaf24f167f4a698f57f8f",
     "packages": [
         {
             "name": "adldap2/adldap2",
@@ -2213,6 +2213,59 @@
                 "laravel"
             ],
             "time": "2019-12-03T15:23:55+00:00"
+        },
+        {
+            "name": "laravel/helpers",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/helpers.git",
+                "reference": "b8eae9ddd461e89d0296f74fd069c413bf83b6fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/helpers/zipball/b8eae9ddd461e89d0296f74fd069c413bf83b6fa",
+                "reference": "b8eae9ddd461e89d0296f74fd069c413bf83b6fa",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "~5.8.0|^6.0",
+                "php": ">=7.1.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Dries Vints",
+                    "email": "dries.vints@gmail.com"
+                }
+            ],
+            "description": "Provides backwards compatibility for helpers in the latest Laravel release.",
+            "keywords": [
+                "helpers",
+                "laravel"
+            ],
+            "time": "2019-07-30T15:25:31+00:00"
         },
         {
             "name": "laravel/passport",

--- a/composer.lock
+++ b/composer.lock
@@ -4,31 +4,37 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "327c0cef15106b191124341bcd65452e",
+    "content-hash": "e6f7d423908b63b49b6e4a17d77e1bc0",
     "packages": [
         {
             "name": "adldap2/adldap2",
-            "version": "v9.1.6",
+            "version": "v10.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Adldap2/Adldap2.git",
-                "reference": "d50204d3eff587957b4bb9d7382d2eda5009ed16"
+                "reference": "c229325583e93d051f0d343ee356e4836cce8f74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Adldap2/Adldap2/zipball/d50204d3eff587957b4bb9d7382d2eda5009ed16",
-                "reference": "d50204d3eff587957b4bb9d7382d2eda5009ed16",
+                "url": "https://api.github.com/repos/Adldap2/Adldap2/zipball/c229325583e93d051f0d343ee356e4836cce8f74",
+                "reference": "c229325583e93d051f0d343ee356e4836cce8f74",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "ext-ldap": "*",
-                "illuminate/contracts": "~5.0",
+                "illuminate/contracts": "~5.0|~6.0",
                 "php": ">=7.0",
-                "tightenco/collect": "~5.0"
+                "psr/log": "~1.0",
+                "psr/simple-cache": "~1.0",
+                "tightenco/collect": "~5.0|~6.0"
             },
             "require-dev": {
                 "mockery/mockery": "~1.0",
                 "phpunit/phpunit": "~6.0"
+            },
+            "suggest": {
+                "ext-fileinfo": "fileinfo is required when retrieving user encoded thumbnails"
             },
             "type": "library",
             "autoload": {
@@ -57,7 +63,7 @@
                 "ldap",
                 "windows"
             ],
-            "time": "2019-04-03T19:41:38+00:00"
+            "time": "2019-11-06T15:50:29+00:00"
         },
         {
             "name": "asm89/stack-cors",
@@ -113,16 +119,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.118.0",
+            "version": "3.128.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "e4600c22cb69c94d1aa65bf91af5c225f2a109fd"
+                "reference": "811e55f20b6455a0cce07ecdebe1398b9668c255"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/e4600c22cb69c94d1aa65bf91af5c225f2a109fd",
-                "reference": "e4600c22cb69c94d1aa65bf91af5c225f2a109fd",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/811e55f20b6455a0cce07ecdebe1398b9668c255",
+                "reference": "811e55f20b6455a0cce07ecdebe1398b9668c255",
                 "shasum": ""
             },
             "require": {
@@ -147,7 +153,8 @@
                 "nette/neon": "^2.3",
                 "phpunit/phpunit": "^4.8.35|^5.4.3",
                 "psr/cache": "^1.0",
-                "psr/simple-cache": "^1.0"
+                "psr/simple-cache": "^1.0",
+                "sebastian/comparator": "^1.2.3"
             },
             "suggest": {
                 "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
@@ -192,7 +199,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-11-18T19:13:19+00:00"
+            "time": "2019-12-05T01:33:15+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -536,16 +543,16 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "89a5c76c39c292f7798f964ab3c836c3f8192a55"
+                "reference": "382e7f4db9a12dc6c19431743a2b096041bcdd62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/89a5c76c39c292f7798f964ab3c836c3f8192a55",
-                "reference": "89a5c76c39c292f7798f964ab3c836c3f8192a55",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/382e7f4db9a12dc6c19431743a2b096041bcdd62",
+                "reference": "382e7f4db9a12dc6c19431743a2b096041bcdd62",
                 "shasum": ""
             },
             "require": {
@@ -612,10 +619,9 @@
                 "memcached",
                 "php",
                 "redis",
-                "riak",
                 "xcache"
             ],
-            "time": "2019-11-15T14:31:57+00:00"
+            "time": "2019-11-29T15:36:20+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -772,31 +778,30 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "v2.9.3",
+            "version": "v2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "7345cd59edfa2036eb0fa4264b77ae2576842035"
+                "reference": "0c9a646775ef549eb0a213a4f9bd4381d9b4d934"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/7345cd59edfa2036eb0fa4264b77ae2576842035",
-                "reference": "7345cd59edfa2036eb0fa4264b77ae2576842035",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/0c9a646775ef549eb0a213a4f9bd4381d9b4d934",
+                "reference": "0c9a646775ef549eb0a213a4f9bd4381d9b4d934",
                 "shasum": ""
             },
             "require": {
                 "doctrine/cache": "^1.0",
                 "doctrine/event-manager": "^1.0",
                 "ext-pdo": "*",
-                "php": "^7.1"
+                "php": "^7.2"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^5.0",
-                "jetbrains/phpstorm-stubs": "^2018.1.2",
-                "phpstan/phpstan": "^0.10.1",
-                "phpunit/phpunit": "^7.4",
-                "symfony/console": "^2.0.5|^3.0|^4.0",
-                "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                "doctrine/coding-standard": "^6.0",
+                "jetbrains/phpstorm-stubs": "^2019.1",
+                "phpstan/phpstan": "^0.11.3",
+                "phpunit/phpunit": "^8.4.1",
+                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -807,7 +812,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.9.x-dev",
+                    "dev-master": "2.10.x-dev",
                     "dev-develop": "3.0.x-dev"
                 }
             },
@@ -843,14 +848,25 @@
             "keywords": [
                 "abstraction",
                 "database",
+                "db2",
                 "dbal",
+                "mariadb",
+                "mssql",
                 "mysql",
-                "persistence",
+                "oci8",
+                "oracle",
+                "pdo",
                 "pgsql",
-                "php",
-                "queryobject"
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlanywhere",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
             ],
-            "time": "2019-11-02T22:19:34+00:00"
+            "time": "2019-11-03T16:50:43+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -1053,28 +1069,30 @@
         },
         {
             "name": "doctrine/lexer",
-            "version": "1.0.2",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8"
+                "reference": "5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/1febd6c3ef84253d7c815bed85fc622ad207a9f8",
-                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6",
+                "reference": "5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5"
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1088,12 +1106,12 @@
             ],
             "authors": [
                 {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
                     "name": "Guilherme Blanco",
                     "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Johannes Schmitt",
@@ -1109,7 +1127,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-06-08T11:03:04+00:00"
+            "time": "2019-10-30T14:39:59+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -2052,43 +2070,43 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.8.35",
+            "version": "v6.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "5a9e4d241a8b815e16c9d2151e908992c38db197"
+                "reference": "0a8e3e6e96e5ec3af6b9f30026cb8e5551554875"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/5a9e4d241a8b815e16c9d2151e908992c38db197",
-                "reference": "5a9e4d241a8b815e16c9d2151e908992c38db197",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/0a8e3e6e96e5ec3af6b9f30026cb8e5551554875",
+                "reference": "0a8e3e6e96e5ec3af6b9f30026cb8e5551554875",
                 "shasum": ""
             },
             "require": {
                 "doctrine/inflector": "^1.1",
                 "dragonmantank/cron-expression": "^2.0",
-                "egulias/email-validator": "^2.0",
+                "egulias/email-validator": "^2.1.10",
                 "erusev/parsedown": "^1.7",
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "ext-openssl": "*",
                 "league/flysystem": "^1.0.8",
-                "monolog/monolog": "^1.12",
-                "nesbot/carbon": "^1.26.3 || ^2.0",
+                "monolog/monolog": "^1.12|^2.0",
+                "nesbot/carbon": "^2.0",
                 "opis/closure": "^3.1",
-                "php": "^7.1.3",
+                "php": "^7.2",
                 "psr/container": "^1.0",
                 "psr/simple-cache": "^1.0",
                 "ramsey/uuid": "^3.7",
                 "swiftmailer/swiftmailer": "^6.0",
-                "symfony/console": "^4.2",
-                "symfony/debug": "^4.2",
-                "symfony/finder": "^4.2",
-                "symfony/http-foundation": "^4.2",
-                "symfony/http-kernel": "^4.2",
-                "symfony/process": "^4.2",
-                "symfony/routing": "^4.2",
-                "symfony/var-dumper": "^4.2",
+                "symfony/console": "^4.3.4",
+                "symfony/debug": "^4.3.4",
+                "symfony/finder": "^4.3.4",
+                "symfony/http-foundation": "^4.3.4",
+                "symfony/http-kernel": "^4.3.4",
+                "symfony/process": "^4.3.4",
+                "symfony/routing": "^4.3.4",
+                "symfony/var-dumper": "^4.3.4",
                 "tijsverkoyen/css-to-inline-styles": "^2.2.1",
                 "vlucas/phpdotenv": "^3.3"
             },
@@ -2128,47 +2146,45 @@
             "require-dev": {
                 "aws/aws-sdk-php": "^3.0",
                 "doctrine/dbal": "^2.6",
-                "filp/whoops": "^2.1.4",
+                "filp/whoops": "^2.4",
                 "guzzlehttp/guzzle": "^6.3",
                 "league/flysystem-cached-adapter": "^1.0",
-                "mockery/mockery": "^1.0",
+                "mockery/mockery": "^1.2.3",
                 "moontoast/math": "^1.1",
-                "orchestra/testbench-core": "3.8.*",
+                "orchestra/testbench-core": "^4.0",
                 "pda/pheanstalk": "^4.0",
-                "phpunit/phpunit": "^7.5|^8.0",
+                "phpunit/phpunit": "^8.3",
                 "predis/predis": "^1.1.1",
-                "symfony/css-selector": "^4.2",
-                "symfony/dom-crawler": "^4.2",
+                "symfony/cache": "^4.3",
                 "true/punycode": "^2.1"
             },
             "suggest": {
-                "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (^3.0).",
+                "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.0).",
                 "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6).",
                 "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
+                "ext-memcached": "Required to use the memcache cache driver.",
                 "ext-pcntl": "Required to use all features of the queue worker.",
                 "ext-posix": "Required to use all features of the queue worker.",
-                "filp/whoops": "Required for friendly error pages in development (^2.1.4).",
+                "ext-redis": "Required to use the Redis cache and queue drivers.",
+                "filp/whoops": "Required for friendly error pages in development (^2.4).",
                 "fzaninotto/faker": "Required to use the eloquent factory builder (^1.4).",
-                "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers and the ping methods on schedules (^6.0).",
+                "guzzlehttp/guzzle": "Required to use the Mailgun mail driver and the ping methods on schedules (^6.0).",
                 "laravel/tinker": "Required to use the tinker console command (^1.0).",
                 "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",
                 "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
-                "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (^1.0).",
                 "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
                 "moontoast/math": "Required to use ordered UUIDs (^1.1).",
-                "nexmo/client": "Required to use the Nexmo transport (^1.0).",
                 "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
-                "predis/predis": "Required to use the redis cache and queue drivers (^1.0).",
-                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^3.0).",
-                "symfony/css-selector": "Required to use some of the crawler integration testing tools (^4.2).",
-                "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (^4.2).",
-                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.1).",
+                "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0)",
+                "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
+                "symfony/cache": "Required to PSR-6 cache bridge (^4.3.4).",
+                "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.2).",
                 "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.8-dev"
+                    "dev-master": "6.x-dev"
                 }
             },
             "autoload": {
@@ -2196,47 +2212,49 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2019-09-03T16:44:30+00:00"
+            "time": "2019-12-03T15:23:55+00:00"
         },
         {
             "name": "laravel/passport",
-            "version": "v6.0.7",
+            "version": "v8.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/passport.git",
-                "reference": "5a3dbeb0904573fcfecf11c018eaa42bfc935372"
+                "reference": "952722f4f1817485bd30190e45fe4dc87ba67441"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/passport/zipball/5a3dbeb0904573fcfecf11c018eaa42bfc935372",
-                "reference": "5a3dbeb0904573fcfecf11c018eaa42bfc935372",
+                "url": "https://api.github.com/repos/laravel/passport/zipball/952722f4f1817485bd30190e45fe4dc87ba67441",
+                "reference": "952722f4f1817485bd30190e45fe4dc87ba67441",
                 "shasum": ""
             },
             "require": {
-                "firebase/php-jwt": "~3.0|~4.0|~5.0",
-                "guzzlehttp/guzzle": "~6.0",
-                "illuminate/auth": "~5.6",
-                "illuminate/console": "~5.6",
-                "illuminate/container": "~5.6",
-                "illuminate/contracts": "~5.6",
-                "illuminate/database": "~5.6",
-                "illuminate/encryption": "~5.6",
-                "illuminate/http": "~5.6",
-                "illuminate/support": "~5.6",
-                "league/oauth2-server": "^7.0",
-                "php": ">=7.1",
+                "ext-json": "*",
+                "firebase/php-jwt": "^3.0|^4.0|^5.0",
+                "guzzlehttp/guzzle": "^6.0",
+                "illuminate/auth": "^6.0|^7.0",
+                "illuminate/console": "^6.0|^7.0",
+                "illuminate/container": "^6.0|^7.0",
+                "illuminate/contracts": "^6.0|^7.0",
+                "illuminate/cookie": "^6.0|^7.0",
+                "illuminate/database": "^6.0|^7.0",
+                "illuminate/encryption": "^6.0|^7.0",
+                "illuminate/http": "^6.0|^7.0",
+                "illuminate/support": "^6.0|^7.0",
+                "league/oauth2-server": "^8.0",
+                "php": "^7.2",
                 "phpseclib/phpseclib": "^2.0",
-                "symfony/psr-http-message-bridge": "~1.0",
-                "zendframework/zend-diactoros": "~1.0"
+                "symfony/psr-http-message-bridge": "^1.0",
+                "zendframework/zend-diactoros": "^2.0"
             },
             "require-dev": {
-                "mockery/mockery": "~1.0",
-                "phpunit/phpunit": "~6.0"
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "8.x-dev"
                 },
                 "laravel": {
                     "providers": [
@@ -2265,7 +2283,7 @@
                 "oauth",
                 "passport"
             ],
-            "time": "2018-08-09T19:10:08+00:00"
+            "time": "2019-11-26T17:35:30+00:00"
         },
         {
             "name": "laravel/slack-notification-channel",
@@ -2389,35 +2407,35 @@
         },
         {
             "name": "laravelcollective/html",
-            "version": "v5.8.1",
+            "version": "v6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/LaravelCollective/html.git",
-                "reference": "3a1c9974ea629eed96e101a24e3852ced382eb29"
+                "reference": "bcc317d21a7e04eebcc81c4109fa84feaab63590"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/LaravelCollective/html/zipball/3a1c9974ea629eed96e101a24e3852ced382eb29",
-                "reference": "3a1c9974ea629eed96e101a24e3852ced382eb29",
+                "url": "https://api.github.com/repos/LaravelCollective/html/zipball/bcc317d21a7e04eebcc81c4109fa84feaab63590",
+                "reference": "bcc317d21a7e04eebcc81c4109fa84feaab63590",
                 "shasum": ""
             },
             "require": {
-                "illuminate/http": "5.8.*",
-                "illuminate/routing": "5.8.*",
-                "illuminate/session": "5.8.*",
-                "illuminate/support": "5.8.*",
-                "illuminate/view": "5.8.*",
-                "php": ">=7.1.3"
+                "illuminate/http": "^6.0",
+                "illuminate/routing": "^6.0",
+                "illuminate/session": "^6.0",
+                "illuminate/support": "^6.0",
+                "illuminate/view": "^6.0",
+                "php": ">=7.2"
             },
             "require-dev": {
-                "illuminate/database": "5.8.*",
+                "illuminate/database": "^6.0",
                 "mockery/mockery": "~1.0",
                 "phpunit/phpunit": "~7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.8-dev"
+                    "dev-master": "6.0-dev"
                 },
                 "laravel": {
                     "providers": [
@@ -2453,7 +2471,7 @@
             ],
             "description": "HTML and Form Builders for the Laravel Framework",
             "homepage": "https://laravelcollective.com",
-            "time": "2019-09-05T12:32:25+00:00"
+            "time": "2019-10-02T00:37:39+00:00"
         },
         {
             "name": "lcobucci/jwt",
@@ -2499,8 +2517,8 @@
             "authors": [
                 {
                     "name": "Luís Otávio Cobucci Oblonczyk",
-                    "role": "Developer",
-                    "email": "lcobucci@gmail.com"
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
                 }
             ],
             "description": "A simple library to work with JSON Web Token and JSON Web Signature",
@@ -2898,24 +2916,25 @@
         },
         {
             "name": "league/oauth2-server",
-            "version": "7.4.0",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/oauth2-server.git",
-                "reference": "2eb1cf79e59d807d89c256e7ac5e2bf8bdbd4acf"
+                "reference": "e1dc4d708c56fcfa205be4bb1862b6d525b4baac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/2eb1cf79e59d807d89c256e7ac5e2bf8bdbd4acf",
-                "reference": "2eb1cf79e59d807d89c256e7ac5e2bf8bdbd4acf",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/e1dc4d708c56fcfa205be4bb1862b6d525b4baac",
+                "reference": "e1dc4d708c56fcfa205be4bb1862b6d525b4baac",
                 "shasum": ""
             },
             "require": {
-                "defuse/php-encryption": "^2.1",
+                "defuse/php-encryption": "^2.2.1",
+                "ext-json": "*",
                 "ext-openssl": "*",
-                "lcobucci/jwt": "^3.2.2",
-                "league/event": "^2.1",
-                "php": ">=7.0.0",
+                "lcobucci/jwt": "^3.3.1",
+                "league/event": "^2.2",
+                "php": ">=7.1.0",
                 "psr/http-message": "^1.0.1"
             },
             "replace": {
@@ -2923,12 +2942,11 @@
                 "lncd/oauth2": "*"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.9.2",
-                "phpstan/phpstan-phpunit": "^0.9.4",
-                "phpstan/phpstan-strict-rules": "^0.9.0",
-                "phpunit/phpunit": "^6.3 || ^7.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpstan/phpstan-phpunit": "^0.11.2",
+                "phpunit/phpunit": "^7.5.13 || ^8.2.3",
                 "roave/security-advisories": "dev-master",
-                "zendframework/zend-diactoros": "^1.3.2"
+                "zendframework/zend-diactoros": "^2.1.2"
             },
             "type": "library",
             "autoload": {
@@ -2943,15 +2961,15 @@
             "authors": [
                 {
                     "name": "Alex Bilbie",
-                    "role": "Developer",
                     "email": "hello@alexbilbie.com",
-                    "homepage": "http://www.alexbilbie.com"
+                    "homepage": "http://www.alexbilbie.com",
+                    "role": "Developer"
                 },
                 {
                     "name": "Andy Millington",
-                    "role": "Developer",
                     "email": "andrew@noexceptions.io",
-                    "homepage": "https://www.noexceptions.io"
+                    "homepage": "https://www.noexceptions.io",
+                    "role": "Developer"
                 }
             ],
             "description": "A lightweight and powerful OAuth 2.0 authorization and resource server library with support for all the core specification grants. This library will allow you to secure your API with OAuth and allow your applications users to approve apps that want to access their data from your API.",
@@ -2971,7 +2989,7 @@
                 "secure",
                 "server"
             ],
-            "time": "2019-05-05T09:22:01+00:00"
+            "time": "2019-07-13T18:58:26+00:00"
         },
         {
             "name": "maknz/slack",
@@ -3112,21 +3130,21 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.25.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "d5e2fb341cb44f7e2ab639d12a1e5901091ec287"
+                "reference": "f9d56fd2f5533322caccdfcddbb56aedd622ef1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/d5e2fb341cb44f7e2ab639d12a1e5901091ec287",
-                "reference": "d5e2fb341cb44f7e2ab639d12a1e5901091ec287",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f9d56fd2f5533322caccdfcddbb56aedd622ef1c",
+                "reference": "f9d56fd2f5533322caccdfcddbb56aedd622ef1c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
-                "psr/log": "~1.0"
+                "php": "^7.2",
+                "psr/log": "^1.0.1"
             },
             "provide": {
                 "psr/log-implementation": "1.0.0"
@@ -3134,33 +3152,36 @@
             "require-dev": {
                 "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                 "doctrine/couchdb": "~1.0@dev",
-                "graylog2/gelf-php": "~1.0",
-                "jakub-onderka/php-parallel-lint": "0.9",
+                "elasticsearch/elasticsearch": "^6.0",
+                "graylog2/gelf-php": "^1.4.2",
+                "jakub-onderka/php-parallel-lint": "^0.9",
                 "php-amqplib/php-amqplib": "~2.4",
                 "php-console/php-console": "^3.1.3",
-                "phpunit/phpunit": "~4.5",
-                "phpunit/phpunit-mock-objects": "2.3.0",
+                "phpspec/prophecy": "^1.6.1",
+                "phpunit/phpunit": "^8.3",
+                "predis/predis": "^1.1",
+                "rollbar/rollbar": "^1.3",
                 "ruflin/elastica": ">=0.90 <3.0",
-                "sentry/sentry": "^0.13",
                 "swiftmailer/swiftmailer": "^5.3|^6.0"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                 "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
                 "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
                 "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
                 "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
                 "php-console/php-console": "Allow sending log messages to Google Chrome",
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                "sentry/sentry": "Allow sending log messages to a Sentry server"
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
@@ -3186,7 +3207,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2019-11-13T10:00:05+00:00"
+            "time": "2019-11-13T10:27:43+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -3401,16 +3422,16 @@
         },
         {
             "name": "opis/closure",
-            "version": "3.4.1",
+            "version": "3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opis/closure.git",
-                "reference": "e79f851749c3caa836d7ccc01ede5828feb762c7"
+                "reference": "93ebc5712cdad8d5f489b500c59d122df2e53969"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opis/closure/zipball/e79f851749c3caa836d7ccc01ede5828feb762c7",
-                "reference": "e79f851749c3caa836d7ccc01ede5828feb762c7",
+                "url": "https://api.github.com/repos/opis/closure/zipball/93ebc5712cdad8d5f489b500c59d122df2e53969",
+                "reference": "93ebc5712cdad8d5f489b500c59d122df2e53969",
                 "shasum": ""
             },
             "require": {
@@ -3423,7 +3444,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3.x-dev"
+                    "dev-master": "3.5.x-dev"
                 }
             },
             "autoload": {
@@ -3458,7 +3479,7 @@
                 "serialization",
                 "serialize"
             ],
-            "time": "2019-10-19T18:38:51+00:00"
+            "time": "2019-11-29T22:36:02+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -3570,21 +3591,24 @@
         },
         {
             "name": "patchwork/utf8",
-            "version": "v1.3.1",
+            "version": "v1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tchwork/utf8.git",
-                "reference": "30ec6451aec7d2536f0af8fe535f70c764f2c47a"
+                "reference": "d296e0026e7ce10b2a9fe594feca9628ef00e9e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tchwork/utf8/zipball/30ec6451aec7d2536f0af8fe535f70c764f2c47a",
-                "reference": "30ec6451aec7d2536f0af8fe535f70c764f2c47a",
+                "url": "https://api.github.com/repos/tchwork/utf8/zipball/d296e0026e7ce10b2a9fe594feca9628ef00e9e8",
+                "reference": "d296e0026e7ce10b2a9fe594feca9628ef00e9e8",
                 "shasum": ""
             },
             "require": {
                 "lib-pcre": ">=7.3",
                 "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3.4|^4.4"
             },
             "suggest": {
                 "ext-iconv": "Use iconv for best performance",
@@ -3625,7 +3649,7 @@
                 "utf-8",
                 "utf8"
             ],
-            "time": "2016-05-18T13:57:10+00:00"
+            "time": "2019-12-03T14:44:12+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3775,33 +3799,33 @@
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.5.2",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "2ba2586380f8d2b44ad1b9feb61c371020b27793"
+                "reference": "f4e7a6a1382183412246f0d361078c29fb85089e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/2ba2586380f8d2b44ad1b9feb61c371020b27793",
-                "reference": "2ba2586380f8d2b44ad1b9feb61c371020b27793",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/f4e7a6a1382183412246f0d361078c29fb85089e",
+                "reference": "f4e7a6a1382183412246f0d361078c29fb85089e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^5.5.9 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.7|^5.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.0 || ^6.0 || ^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "PhpOption\\": "src/"
+                "psr-4": {
+                    "PhpOption\\": "src/PhpOption/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3812,6 +3836,10 @@
                 {
                     "name": "Johannes M. Schmitt",
                     "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com"
                 }
             ],
             "description": "Option Type for PHP",
@@ -3821,7 +3849,7 @@
                 "php",
                 "type"
             ],
-            "time": "2019-11-06T22:27:00+00:00"
+            "time": "2019-11-30T20:20:49+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -4309,6 +4337,58 @@
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2019-04-30T12:38:16+00:00"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -4455,16 +4535,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.9.9",
+            "version": "v0.9.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "9aaf29575bb8293206bb0420c1e1c87ff2ffa94e"
+                "reference": "75d9ac1c16db676de27ab554a4152b594be4748e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/9aaf29575bb8293206bb0420c1e1c87ff2ffa94e",
-                "reference": "9aaf29575bb8293206bb0420c1e1c87ff2ffa94e",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/75d9ac1c16db676de27ab554a4152b594be4748e",
+                "reference": "75d9ac1c16db676de27ab554a4152b594be4748e",
                 "shasum": ""
             },
             "require": {
@@ -4474,8 +4554,8 @@
                 "jakub-onderka/php-console-highlighter": "0.3.*|0.4.*",
                 "nikic/php-parser": "~1.3|~2.0|~3.0|~4.0",
                 "php": ">=5.4.0",
-                "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0",
-                "symfony/var-dumper": "~2.7|~3.0|~4.0"
+                "symfony/console": "~2.3.10|^2.4.2|~3.0|~4.0|~5.0",
+                "symfony/var-dumper": "~2.7|~3.0|~4.0|~5.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.2",
@@ -4525,7 +4605,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2018-10-13T15:16:03+00:00"
+            "time": "2019-11-27T22:44:29+00:00"
         },
         {
             "name": "rackspace/php-opencloud",
@@ -4626,44 +4706,46 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "3.8.0",
+            "version": "3.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "d09ea80159c1929d75b3f9c60504d613aeb4a1e3"
+                "reference": "5ac2740e0c8c599d2bbe7f113a939f2b5b216c67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/d09ea80159c1929d75b3f9c60504d613aeb4a1e3",
-                "reference": "d09ea80159c1929d75b3f9c60504d613aeb4a1e3",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/5ac2740e0c8c599d2bbe7f113a939f2b5b216c67",
+                "reference": "5ac2740e0c8c599d2bbe7f113a939f2b5b216c67",
                 "shasum": ""
             },
             "require": {
-                "paragonie/random_compat": "^1.0|^2.0|9.99.99",
-                "php": "^5.4 || ^7.0",
+                "ext-json": "*",
+                "paragonie/random_compat": "^1 | ^2 | 9.99.99",
+                "php": "^5.4 | ^7",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "replace": {
                 "rhumsaa/uuid": "self.version"
             },
             "require-dev": {
-                "codeception/aspect-mock": "^1.0 | ~2.0.0",
-                "doctrine/annotations": "~1.2.0",
-                "goaop/framework": "1.0.0-alpha.2 | ^1.0 | ~2.1.0",
-                "ircmaxell/random-lib": "^1.1",
+                "codeception/aspect-mock": "^1 | ^2",
+                "doctrine/annotations": "^1.2",
+                "goaop/framework": "1.0.0-alpha.2 | ^1 | ^2.1",
                 "jakub-onderka/php-parallel-lint": "^0.9.0",
                 "mockery/mockery": "^0.9.9",
                 "moontoast/math": "^1.1",
-                "php-mock/php-mock-phpunit": "^0.3|^1.1",
-                "phpunit/phpunit": "^4.7|^5.0|^6.5",
+                "paragonie/random-lib": "^2",
+                "php-mock/php-mock-phpunit": "^0.3 | ^1.1",
+                "phpunit/phpunit": "^4.8 | ^5.4 | ^6.5",
                 "squizlabs/php_codesniffer": "^2.3"
             },
             "suggest": {
                 "ext-ctype": "Provides support for PHP Ctype functions",
                 "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
+                "ext-openssl": "Provides the OpenSSL extension for use with the OpenSslGenerator",
                 "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
-                "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
                 "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
+                "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
                 "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
                 "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
             },
@@ -4676,7 +4758,10 @@
             "autoload": {
                 "psr-4": {
                     "Ramsey\\Uuid\\": "src/"
-                }
+                },
+                "files": [
+                    "src/functions.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4684,17 +4769,17 @@
             ],
             "authors": [
                 {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                },
+                {
                     "name": "Marijn Huizendveld",
                     "email": "marijn.huizendveld@gmail.com"
                 },
                 {
                     "name": "Thibaud Fabre",
                     "email": "thibaud@aztech.io"
-                },
-                {
-                    "name": "Ben Ramsey",
-                    "email": "ben@benramsey.com",
-                    "homepage": "https://benramsey.com"
                 }
             ],
             "description": "Formerly rhumsaa/uuid. A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
@@ -4704,25 +4789,25 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2018-07-19T23:38:55+00:00"
+            "time": "2019-12-01T04:55:27+00:00"
         },
         {
             "name": "rollbar/rollbar",
-            "version": "v1.8.1",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rollbar/rollbar-php.git",
-                "reference": "8a57ad9574d85bd818eaedfc8049fdcb16795f31"
+                "reference": "245670b32d8e6072d6b364eda242f245879cdee9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rollbar/rollbar-php/zipball/8a57ad9574d85bd818eaedfc8049fdcb16795f31",
-                "reference": "8a57ad9574d85bd818eaedfc8049fdcb16795f31",
+                "url": "https://api.github.com/repos/rollbar/rollbar-php/zipball/245670b32d8e6072d6b364eda242f245879cdee9",
+                "reference": "245670b32d8e6072d6b364eda242f245879cdee9",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
-                "monolog/monolog": "^1",
+                "monolog/monolog": "^1 || ^2",
                 "psr/log": "^1"
             },
             "require-dev": {
@@ -4730,7 +4815,7 @@
                 "mockery/mockery": "0.9.*",
                 "packfire/php5.3-compat": "*",
                 "phpmd/phpmd": "@stable",
-                "phpunit/phpunit": "4.8.*",
+                "phpunit/phpunit": "4.8.* || ^5",
                 "squizlabs/php_codesniffer": "2.*"
             },
             "suggest": {
@@ -4763,31 +4848,31 @@
                 "logging",
                 "monitoring"
             ],
-            "time": "2019-05-06T11:31:11+00:00"
+            "time": "2019-10-02T06:24:31+00:00"
         },
         {
             "name": "rollbar/rollbar-laravel",
-            "version": "v4.0.3",
+            "version": "v5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rollbar/rollbar-php-laravel.git",
-                "reference": "e4ea0343e32748123ee7d7da8c6bf98593c5f74c"
+                "reference": "85be2c97cce60c588dbacb0a37a56d4b199c1aa7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rollbar/rollbar-php-laravel/zipball/e4ea0343e32748123ee7d7da8c6bf98593c5f74c",
-                "reference": "e4ea0343e32748123ee7d7da8c6bf98593c5f74c",
+                "url": "https://api.github.com/repos/rollbar/rollbar-php-laravel/zipball/85be2c97cce60c588dbacb0a37a56d4b199c1aa7",
+                "reference": "85be2c97cce60c588dbacb0a37a56d4b199c1aa7",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": "^5.0",
+                "illuminate/support": "^6.0",
                 "php": ">=7.0",
-                "rollbar/rollbar": "^1"
+                "rollbar/rollbar": "^2"
             },
             "require-dev": {
                 "mockery/mockery": "^1",
-                "orchestra/testbench": "~3.6",
-                "phpunit/phpunit": "~7.0",
+                "orchestra/testbench": "^4",
+                "phpunit/phpunit": "^8",
                 "satooshi/php-coveralls": "^1.0",
                 "squizlabs/php_codesniffer": "3.*"
             },
@@ -4831,64 +4916,7 @@
                 "monitoring",
                 "rollbar"
             ],
-            "time": "2019-01-01T18:39:35+00:00"
-        },
-        {
-            "name": "schuppo/password-strength",
-            "version": "v1.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/schuppo/PasswordStrengthPackage.git",
-                "reference": "7ab466d43c6937a73003df450cde663ba7b685a9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/schuppo/PasswordStrengthPackage/zipball/7ab466d43c6937a73003df450cde663ba7b685a9",
-                "reference": "7ab466d43c6937a73003df450cde663ba7b685a9",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/support": "~5.0",
-                "illuminate/translation": "^5.1",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "illuminate/validation": "~5.0",
-                "phpunit/phpunit": "^4.8"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Schuppo\\PasswordStrength\\PasswordStrengthServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Schuppo\\PasswordStrength": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Oliver Schupp",
-                    "email": "oliver.schupp@yahoo.de"
-                }
-            ],
-            "description": "This package provides a validator for ensuring strong passwords in Laravel 4 applications.",
-            "keywords": [
-                "laravel",
-                "laravel 5",
-                "laravel5",
-                "password",
-                "password strength",
-                "validation"
-            ],
-            "time": "2018-02-08T20:05:59+00:00"
+            "time": "2019-10-02T07:15:39+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -5132,20 +5160,20 @@
         },
         {
             "name": "spatie/db-dumper",
-            "version": "2.14.0",
+            "version": "2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/db-dumper.git",
-                "reference": "eec21c55012b02fb8453c9929fa1c3150ca184ac"
+                "reference": "ccb7dd7557cd119b21ea853a893da4d1b0ff08b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/eec21c55012b02fb8453c9929fa1c3150ca184ac",
-                "reference": "eec21c55012b02fb8453c9929fa1c3150ca184ac",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/ccb7dd7557cd119b21ea853a893da4d1b0ff08b6",
+                "reference": "ccb7dd7557cd119b21ea853a893da4d1b0ff08b6",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
+                "php": "^7.2",
                 "symfony/process": "^4.2"
             },
             "require-dev": {
@@ -5178,42 +5206,44 @@
                 "mysqldump",
                 "spatie"
             ],
-            "time": "2019-04-17T07:03:19+00:00"
+            "time": "2019-11-11T10:40:42+00:00"
         },
         {
             "name": "spatie/laravel-backup",
-            "version": "5.12.1",
+            "version": "6.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-backup.git",
-                "reference": "553562557ef13fda0e823cc609cd7d4f2c4f2552"
+                "reference": "81e10ccb9f22307fb0ed548f895264ba5dcfff82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/553562557ef13fda0e823cc609cd7d4f2c4f2552",
-                "reference": "553562557ef13fda0e823cc609cd7d4f2c4f2552",
+                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/81e10ccb9f22307fb0ed548f895264ba5dcfff82",
+                "reference": "81e10ccb9f22307fb0ed548f895264ba5dcfff82",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-                "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-                "illuminate/events": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-                "illuminate/filesystem": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-                "illuminate/notifications": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-                "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-                "league/flysystem": "^1.0.27",
-                "php": "^7.1",
-                "spatie/db-dumper": "^2.11.1",
+                "illuminate/console": "^5.8.15|^6.0",
+                "illuminate/contracts": "^5.8.15|^6.0",
+                "illuminate/events": "^5.8.15|^6.0",
+                "illuminate/filesystem": "^5.8.15|^6.0",
+                "illuminate/notifications": "^5.8.15|^6.0",
+                "illuminate/support": "^5.8.15|^6.0",
+                "league/flysystem": "^1.0.49",
+                "php": "^7.2",
+                "spatie/db-dumper": "^2.12",
                 "spatie/temporary-directory": "^1.1",
-                "symfony/finder": "^3.3|^4.0"
+                "symfony/finder": "^4.2"
             },
             "require-dev": {
+                "laravel/slack-notification-channel": "^1.0",
+                "league/flysystem-aws-s3-v3": "^1.0",
                 "mockery/mockery": "^1.0",
-                "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
-                "phpunit/phpunit": "^7.3"
+                "orchestra/testbench": "3.8.*|4.*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
-                "guzzlehttp/guzzle": "Allows notifications to be sent via Slack"
+                "laravel/slack-notification-channel": "Required for sending notifications via Slack"
             },
             "type": "library",
             "extra": {
@@ -5243,7 +5273,7 @@
                     "role": "Developer"
                 }
             ],
-            "description": "A Laravel 5 package to backup your application",
+            "description": "A Laravel package to backup your application",
             "homepage": "https://github.com/spatie/laravel-backup",
             "keywords": [
                 "backup",
@@ -5251,27 +5281,27 @@
                 "laravel-backup",
                 "spatie"
             ],
-            "time": "2019-04-04T12:00:30+00:00"
+            "time": "2019-12-02T21:58:43+00:00"
         },
         {
             "name": "spatie/temporary-directory",
-            "version": "1.1.5",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/temporary-directory.git",
-                "reference": "539d0856c5d6344619b3c5ab472e1ff6c655df5a"
+                "reference": "3e51af9a8361f85cffc1fb2c52135f3e064758cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/539d0856c5d6344619b3c5ab472e1ff6c655df5a",
-                "reference": "539d0856c5d6344619b3c5ab472e1ff6c655df5a",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/3e51af9a8361f85cffc1fb2c52135f3e064758cc",
+                "reference": "3e51af9a8361f85cffc1fb2c52135f3e064758cc",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.3"
+                "phpunit/phpunit": "^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5297,7 +5327,7 @@
                 "spatie",
                 "temporary-directory"
             ],
-            "time": "2019-07-16T20:39:53+00:00"
+            "time": "2019-08-28T06:53:51+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -5363,27 +5393,28 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "831424efae0a1fe6642784bd52aae14ece6538e6"
+                "reference": "f0aea3df20d15635b3cb9730ca5eea1c65b7f201"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/831424efae0a1fe6642784bd52aae14ece6538e6",
-                "reference": "831424efae0a1fe6642784bd52aae14ece6538e6",
+                "url": "https://api.github.com/repos/symfony/console/zipball/f0aea3df20d15635b3cb9730ca5eea1c65b7f201",
+                "reference": "f0aea3df20d15635b3cb9730ca5eea1c65b7f201",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
-                "symfony/service-contracts": "^1.1"
+                "symfony/service-contracts": "^1.1|^2"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
-                "symfony/event-dispatcher": "<4.3",
+                "symfony/event-dispatcher": "<4.3|>=5",
+                "symfony/lock": "<4.4",
                 "symfony/process": "<3.3"
             },
             "provide": {
@@ -5391,12 +5422,12 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
                 "symfony/event-dispatcher": "^4.3",
-                "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.4|~4.0",
-                "symfony/var-dumper": "^4.3"
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/var-dumper": "^4.3|^5.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -5407,7 +5438,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -5434,20 +5465,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-13T07:29:07+00:00"
+            "time": "2019-12-01T10:06:17+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "f4b3ff6a549d9ed28b2b0ecd1781bf67cf220ee9"
+                "reference": "64acec7e0d67125e9f4656c68d4a38a42ab5a0b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/f4b3ff6a549d9ed28b2b0ecd1781bf67cf220ee9",
-                "reference": "f4b3ff6a549d9ed28b2b0ecd1781bf67cf220ee9",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/64acec7e0d67125e9f4656c68d4a38a42ab5a0b7",
+                "reference": "64acec7e0d67125e9f4656c68d4a38a42ab5a0b7",
                 "shasum": ""
             },
             "require": {
@@ -5456,7 +5487,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -5487,20 +5518,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-02T08:36:26+00:00"
+            "time": "2019-10-12T00:35:04+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "5ea9c3e01989a86ceaa0283f21234b12deadf5e2"
+                "reference": "b8600a1d7d20b0e80906398bb1f50612fa074a8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/5ea9c3e01989a86ceaa0283f21234b12deadf5e2",
-                "reference": "5ea9c3e01989a86ceaa0283f21234b12deadf5e2",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/b8600a1d7d20b0e80906398bb1f50612fa074a8e",
+                "reference": "b8600a1d7d20b0e80906398bb1f50612fa074a8e",
                 "shasum": ""
             },
             "require": {
@@ -5511,12 +5542,12 @@
                 "symfony/http-kernel": "<3.4"
             },
             "require-dev": {
-                "symfony/http-kernel": "~3.4|~4.0"
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -5543,20 +5574,76 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-28T17:07:32+00:00"
+            "time": "2019-11-28T13:33:56+00:00"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v4.3.8",
+            "name": "symfony/error-handler",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "0df002fd4f500392eabd243c2947061a50937287"
+                "url": "https://github.com/symfony/error-handler.git",
+                "reference": "a1ad02d62789efed1d2b2796f1c15e0c6a00fc3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0df002fd4f500392eabd243c2947061a50937287",
-                "reference": "0df002fd4f500392eabd243c2947061a50937287",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/a1ad02d62789efed1d2b2796f1c15e0c6a00fc3b",
+                "reference": "a1ad02d62789efed1d2b2796f1c15e0c6a00fc3b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "psr/log": "~1.0",
+                "symfony/debug": "^4.4",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/serializer": "^4.4|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ErrorHandler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ErrorHandler Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-12-01T08:46:01+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v4.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "b3c3068a72623287550fe20b84a2b01dcba2686f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b3c3068a72623287550fe20b84a2b01dcba2686f",
+                "reference": "b3c3068a72623287550fe20b84a2b01dcba2686f",
                 "shasum": ""
             },
             "require": {
@@ -5572,12 +5659,12 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/expression-language": "~3.4|~4.0",
-                "symfony/http-foundation": "^3.4|^4.0",
-                "symfony/service-contracts": "^1.1",
-                "symfony/stopwatch": "~3.4|~4.0"
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/stopwatch": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -5586,7 +5673,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -5613,7 +5700,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-03T09:04:05+00:00"
+            "time": "2019-11-28T13:33:56+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -5675,16 +5762,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "72a068f77e317ae77c0a0495236ad292cfb5ce6f"
+                "reference": "ce8743441da64c41e2a667b8eb66070444ed911e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/72a068f77e317ae77c0a0495236ad292cfb5ce6f",
-                "reference": "72a068f77e317ae77c0a0495236ad292cfb5ce6f",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ce8743441da64c41e2a667b8eb66070444ed911e",
+                "reference": "ce8743441da64c41e2a667b8eb66070444ed911e",
                 "shasum": ""
             },
             "require": {
@@ -5693,7 +5780,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -5720,35 +5807,35 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-30T12:53:54+00:00"
+            "time": "2019-11-17T21:56:56+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "cabe67275034e173350e158f3b1803d023880227"
+                "reference": "8bccc59e61b41963d14c3dbdb23181e5c932a1d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/cabe67275034e173350e158f3b1803d023880227",
-                "reference": "cabe67275034e173350e158f3b1803d023880227",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/8bccc59e61b41963d14c3dbdb23181e5c932a1d5",
+                "reference": "8bccc59e61b41963d14c3dbdb23181e5c932a1d5",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/mime": "^4.3",
+                "symfony/mime": "^4.3|^5.0",
                 "symfony/polyfill-mbstring": "~1.1"
             },
             "require-dev": {
                 "predis/predis": "~1.0",
-                "symfony/expression-language": "~3.4|~4.0"
+                "symfony/expression-language": "^3.4|^4.0|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -5775,37 +5862,37 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-12T13:07:20+00:00"
+            "time": "2019-11-28T13:33:56+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "5fdf186f26f9080de531d3f1d024348b2f0ab12f"
+                "reference": "e4187780ed26129ee86d5234afbebf085e144f88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/5fdf186f26f9080de531d3f1d024348b2f0ab12f",
-                "reference": "5fdf186f26f9080de531d3f1d024348b2f0ab12f",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/e4187780ed26129ee86d5234afbebf085e144f88",
+                "reference": "e4187780ed26129ee86d5234afbebf085e144f88",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "psr/log": "~1.0",
-                "symfony/debug": "~3.4|~4.0",
-                "symfony/event-dispatcher": "^4.3",
-                "symfony/http-foundation": "^4.1.1",
-                "symfony/polyfill-ctype": "~1.8",
+                "symfony/error-handler": "^4.4",
+                "symfony/event-dispatcher": "^4.4",
+                "symfony/http-foundation": "^4.4|^5.0",
+                "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-php73": "^1.9"
             },
             "conflict": {
                 "symfony/browser-kit": "<4.3",
                 "symfony/config": "<3.4",
+                "symfony/console": ">=5",
                 "symfony/dependency-injection": "<4.3",
                 "symfony/translation": "<4.2",
-                "symfony/var-dumper": "<4.1.1",
                 "twig/twig": "<1.34|<2.4,>=2"
             },
             "provide": {
@@ -5813,34 +5900,32 @@
             },
             "require-dev": {
                 "psr/cache": "~1.0",
-                "symfony/browser-kit": "^4.3",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/console": "~3.4|~4.0",
-                "symfony/css-selector": "~3.4|~4.0",
-                "symfony/dependency-injection": "^4.3",
-                "symfony/dom-crawler": "~3.4|~4.0",
-                "symfony/expression-language": "~3.4|~4.0",
-                "symfony/finder": "~3.4|~4.0",
-                "symfony/process": "~3.4|~4.0",
-                "symfony/routing": "~3.4|~4.0",
-                "symfony/stopwatch": "~3.4|~4.0",
-                "symfony/templating": "~3.4|~4.0",
-                "symfony/translation": "~4.2",
-                "symfony/translation-contracts": "^1.1",
-                "symfony/var-dumper": "^4.1.1",
-                "twig/twig": "^1.34|^2.4"
+                "symfony/browser-kit": "^4.3|^5.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/console": "^3.4|^4.0",
+                "symfony/css-selector": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^4.3|^5.0",
+                "symfony/dom-crawler": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/finder": "^3.4|^4.0|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/routing": "^3.4|^4.0|^5.0",
+                "symfony/stopwatch": "^3.4|^4.0|^5.0",
+                "symfony/templating": "^3.4|^4.0|^5.0",
+                "symfony/translation": "^4.2|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "twig/twig": "^1.34|^2.4|^3.0"
             },
             "suggest": {
                 "symfony/browser-kit": "",
                 "symfony/config": "",
                 "symfony/console": "",
-                "symfony/dependency-injection": "",
-                "symfony/var-dumper": ""
+                "symfony/dependency-injection": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -5867,20 +5952,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-13T09:07:28+00:00"
+            "time": "2019-12-01T14:06:38+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "22aecf6b11638ef378fab25d6c5a2da8a31a1448"
+                "reference": "010cc488e56cafe5f7494dea70aea93100c234df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/22aecf6b11638ef378fab25d6c5a2da8a31a1448",
-                "reference": "22aecf6b11638ef378fab25d6c5a2da8a31a1448",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/010cc488e56cafe5f7494dea70aea93100c234df",
+                "reference": "010cc488e56cafe5f7494dea70aea93100c234df",
                 "shasum": ""
             },
             "require": {
@@ -5888,14 +5973,17 @@
                 "symfony/polyfill-intl-idn": "^1.10",
                 "symfony/polyfill-mbstring": "^1.0"
             },
+            "conflict": {
+                "symfony/mailer": "<4.4"
+            },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10",
-                "symfony/dependency-injection": "~3.4|^4.1"
+                "symfony/dependency-injection": "^3.4|^4.1|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -5926,20 +6014,20 @@
                 "mime",
                 "mime-type"
             ],
-            "time": "2019-11-12T13:10:02+00:00"
+            "time": "2019-11-30T08:27:26+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
                 "shasum": ""
             },
             "require": {
@@ -5951,7 +6039,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -5984,20 +6072,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "685968b11e61a347c18bf25db32effa478be610f"
+                "reference": "a019efccc03f1a335af6b4f20c30f5ea8060be36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/685968b11e61a347c18bf25db32effa478be610f",
-                "reference": "685968b11e61a347c18bf25db32effa478be610f",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/a019efccc03f1a335af6b4f20c30f5ea8060be36",
+                "reference": "a019efccc03f1a335af6b4f20c30f5ea8060be36",
                 "shasum": ""
             },
             "require": {
@@ -6009,7 +6097,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -6043,20 +6131,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "6af626ae6fa37d396dc90a399c0ff08e5cfc45b2"
+                "reference": "6f9c239e61e1b0c9229a28ff89a812dc449c3d46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/6af626ae6fa37d396dc90a399c0ff08e5cfc45b2",
-                "reference": "6af626ae6fa37d396dc90a399c0ff08e5cfc45b2",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/6f9c239e61e1b0c9229a28ff89a812dc449c3d46",
+                "reference": "6f9c239e61e1b0c9229a28ff89a812dc449c3d46",
                 "shasum": ""
             },
             "require": {
@@ -6070,7 +6158,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -6105,20 +6193,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
-                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7b4aab9743c30be783b73de055d24a39cf4b954f",
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f",
                 "shasum": ""
             },
             "require": {
@@ -6130,7 +6218,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -6164,20 +6252,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T14:18:11+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "0e3b212e96a51338639d8ce175c046d7729c3403"
+                "reference": "53dd1cdf3cb986893ccf2b96665b25b3abb384f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/0e3b212e96a51338639d8ce175c046d7729c3403",
-                "reference": "0e3b212e96a51338639d8ce175c046d7729c3403",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/53dd1cdf3cb986893ccf2b96665b25b3abb384f4",
+                "reference": "53dd1cdf3cb986893ccf2b96665b25b3abb384f4",
                 "shasum": ""
             },
             "require": {
@@ -6187,7 +6275,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -6220,20 +6308,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "04ce3335667451138df4307d6a9b61565560199e"
+                "reference": "66fea50f6cb37a35eea048d75a7d99a45b586038"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/04ce3335667451138df4307d6a9b61565560199e",
-                "reference": "04ce3335667451138df4307d6a9b61565560199e",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/66fea50f6cb37a35eea048d75a7d99a45b586038",
+                "reference": "66fea50f6cb37a35eea048d75a7d99a45b586038",
                 "shasum": ""
             },
             "require": {
@@ -6242,7 +6330,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -6275,20 +6363,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188"
+                "reference": "4b0e2222c55a25b4541305a053013d5647d3a25f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/2ceb49eaccb9352bff54d22570276bb75ba4a188",
-                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/4b0e2222c55a25b4541305a053013d5647d3a25f",
+                "reference": "4b0e2222c55a25b4541305a053013d5647d3a25f",
                 "shasum": ""
             },
             "require": {
@@ -6297,7 +6385,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -6333,20 +6421,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T16:25:15+00:00"
         },
         {
             "name": "symfony/polyfill-util",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "4317de1386717b4c22caed7725350a8887ab205c"
+                "reference": "964a67f293b66b95883a5ed918a65354fcd2258f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/4317de1386717b4c22caed7725350a8887ab205c",
-                "reference": "4317de1386717b4c22caed7725350a8887ab205c",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/964a67f293b66b95883a5ed918a65354fcd2258f",
+                "reference": "964a67f293b66b95883a5ed918a65354fcd2258f",
                 "shasum": ""
             },
             "require": {
@@ -6355,7 +6443,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -6385,20 +6473,20 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "3b2e0cb029afbb0395034509291f21191d1a4db0"
+                "reference": "51c0135ef3f44c5803b33dc60e96bf4f77752726"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/3b2e0cb029afbb0395034509291f21191d1a4db0",
-                "reference": "3b2e0cb029afbb0395034509291f21191d1a4db0",
+                "url": "https://api.github.com/repos/symfony/process/zipball/51c0135ef3f44c5803b33dc60e96bf4f77752726",
+                "reference": "51c0135ef3f44c5803b33dc60e96bf4f77752726",
                 "shasum": ""
             },
             "require": {
@@ -6407,7 +6495,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -6434,30 +6522,30 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-28T17:07:32+00:00"
+            "time": "2019-11-28T13:33:56+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/psr-http-message-bridge.git",
-                "reference": "9ab9d71f97d5c7d35a121a7fb69f74fee95cd0ad"
+                "reference": "9d3e80d54d9ae747ad573cad796e8e247df7b796"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/9ab9d71f97d5c7d35a121a7fb69f74fee95cd0ad",
-                "reference": "9ab9d71f97d5c7d35a121a7fb69f74fee95cd0ad",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/9d3e80d54d9ae747ad573cad796e8e247df7b796",
+                "reference": "9d3e80d54d9ae747ad573cad796e8e247df7b796",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1",
                 "psr/http-message": "^1.0",
-                "symfony/http-foundation": "^3.4 || ^4.0"
+                "symfony/http-foundation": "^4.4 || ^5.0"
             },
             "require-dev": {
                 "nyholm/psr7": "^1.1",
-                "symfony/phpunit-bridge": "^3.4.20 || ^4.0",
+                "symfony/phpunit-bridge": "^4.4 || ^5.0",
                 "zendframework/zend-diactoros": "^1.4.1 || ^2.0"
             },
             "suggest": {
@@ -6466,7 +6554,7 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -6483,12 +6571,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
                 }
             ],
             "description": "PSR HTTP message bridge",
@@ -6499,20 +6587,20 @@
                 "psr-17",
                 "psr-7"
             ],
-            "time": "2019-03-11T18:22:33+00:00"
+            "time": "2019-11-25T19:33:50+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "533fd12a41fb9ce8d4e861693365427849487c0e"
+                "reference": "51f3f20ad29329a0bdf5c0e2f722d3764b065273"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/533fd12a41fb9ce8d4e861693365427849487c0e",
-                "reference": "533fd12a41fb9ce8d4e861693365427849487c0e",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/51f3f20ad29329a0bdf5c0e2f722d3764b065273",
+                "reference": "51f3f20ad29329a0bdf5c0e2f722d3764b065273",
                 "shasum": ""
             },
             "require": {
@@ -6526,11 +6614,11 @@
             "require-dev": {
                 "doctrine/annotations": "~1.2",
                 "psr/log": "~1.0",
-                "symfony/config": "~4.2",
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/expression-language": "~3.4|~4.0",
-                "symfony/http-foundation": "~3.4|~4.0",
-                "symfony/yaml": "~3.4|~4.0"
+                "symfony/config": "^4.2|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "doctrine/annotations": "For using the annotation loader",
@@ -6542,7 +6630,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -6575,7 +6663,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2019-11-04T20:23:03+00:00"
+            "time": "2019-12-01T08:39:58+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6637,26 +6725,27 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "bbce239b35b0cd47bd75848b23e969f17dd970e7"
+                "reference": "897fb68ee7933372517b551d6f08c6d4bb0b8c40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/bbce239b35b0cd47bd75848b23e969f17dd970e7",
-                "reference": "bbce239b35b0cd47bd75848b23e969f17dd970e7",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/897fb68ee7933372517b551d6f08c6d4bb0b8c40",
+                "reference": "897fb68ee7933372517b551d6f08c6d4bb0b8c40",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation-contracts": "^1.1.6"
+                "symfony/translation-contracts": "^1.1.6|^2"
             },
             "conflict": {
                 "symfony/config": "<3.4",
                 "symfony/dependency-injection": "<3.4",
+                "symfony/http-kernel": "<4.4",
                 "symfony/yaml": "<3.4"
             },
             "provide": {
@@ -6664,15 +6753,14 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/console": "~3.4|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/http-kernel": "~3.4|~4.0",
-                "symfony/intl": "~3.4|~4.0",
-                "symfony/service-contracts": "^1.1.2",
-                "symfony/var-dumper": "~3.4|~4.0",
-                "symfony/yaml": "~3.4|~4.0"
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/finder": "~2.8|~3.0|~4.0|^5.0",
+                "symfony/http-kernel": "^4.4",
+                "symfony/intl": "^3.4|^4.0|^5.0",
+                "symfony/service-contracts": "^1.1.2|^2",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "psr/log-implementation": "To use logging capability in translator",
@@ -6682,7 +6770,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -6709,7 +6797,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-06T23:21:49+00:00"
+            "time": "2019-11-12T17:18:47+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -6770,16 +6858,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "ea4940845535c85ff5c505e13b3205b0076d07bf"
+                "reference": "0a89a1dbbedd9fb2cfb2336556dec8305273c19a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/ea4940845535c85ff5c505e13b3205b0076d07bf",
-                "reference": "ea4940845535c85ff5c505e13b3205b0076d07bf",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/0a89a1dbbedd9fb2cfb2336556dec8305273c19a",
+                "reference": "0a89a1dbbedd9fb2cfb2336556dec8305273c19a",
                 "shasum": ""
             },
             "require": {
@@ -6793,9 +6881,9 @@
             },
             "require-dev": {
                 "ext-iconv": "*",
-                "symfony/console": "~3.4|~4.0",
-                "symfony/process": "~3.4|~4.0",
-                "twig/twig": "~1.34|~2.4"
+                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "twig/twig": "^1.34|^2.4|^3.0"
             },
             "suggest": {
                 "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
@@ -6808,7 +6896,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -6842,7 +6930,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2019-10-13T12:02:04+00:00"
+            "time": "2019-11-28T13:33:56+00:00"
         },
         {
             "name": "tecnickcom/tc-lib-barcode",
@@ -6999,25 +7087,25 @@
         },
         {
             "name": "tightenco/collect",
-            "version": "v5.8.35",
+            "version": "v6.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tightenco/collect.git",
-                "reference": "c93a7039e6207ad533a09109838fe80933fcc72c"
+                "reference": "402a89f11c55b86c5a081c267957a0c071375278"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tightenco/collect/zipball/c93a7039e6207ad533a09109838fe80933fcc72c",
-                "reference": "c93a7039e6207ad533a09109838fe80933fcc72c",
+                "url": "https://api.github.com/repos/tightenco/collect/zipball/402a89f11c55b86c5a081c267957a0c071375278",
+                "reference": "402a89f11c55b86c5a081c267957a0c071375278",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/var-dumper": ">=3.4 <5"
+                "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.0",
-                "nesbot/carbon": "^1.26.3",
+                "nesbot/carbon": "^2.23.0",
                 "phpunit/phpunit": "^7.0"
             },
             "type": "library",
@@ -7045,24 +7133,24 @@
                 "collection",
                 "laravel"
             ],
-            "time": "2019-09-17T18:57:01+00:00"
+            "time": "2019-11-22T20:59:40+00:00"
         },
         {
             "name": "tightenco/ziggy",
-            "version": "v0.7.1",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tightenco/ziggy.git",
-                "reference": "aa4c42aaec9516da892bc2e9f6e992582646af77"
+                "reference": "4c4b29bc658153f0771b0a145173ce83a7b6b885"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tightenco/ziggy/zipball/aa4c42aaec9516da892bc2e9f6e992582646af77",
-                "reference": "aa4c42aaec9516da892bc2e9f6e992582646af77",
+                "url": "https://api.github.com/repos/tightenco/ziggy/zipball/4c4b29bc658153f0771b0a145173ce83a7b6b885",
+                "reference": "4c4b29bc658153f0771b0a145173ce83a7b6b885",
                 "shasum": ""
             },
             "require": {
-                "laravel/framework": "~5.4"
+                "laravel/framework": ">=5.4@dev"
             },
             "require-dev": {
                 "mikey179/vfsstream": "^1.6",
@@ -7087,16 +7175,16 @@
             ],
             "authors": [
                 {
-                    "name": "Matt Stauffer",
-                    "email": "matt@tighten.co"
-                },
-                {
                     "name": "Daniel Coulbourne",
                     "email": "daniel@tighten.co"
+                },
+                {
+                    "name": "Matt Stauffer",
+                    "email": "matt@tighten.co"
                 }
             ],
             "description": "Generates a Blade directive exporting all of your named Laravel routes. Also provides a nice route() helper function in JavaScript.",
-            "time": "2019-04-26T22:03:47+00:00"
+            "time": "2019-10-18T22:42:36+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -7316,31 +7404,29 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -7362,39 +7448,45 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-08-24T08:43:50+00:00"
+            "time": "2019-11-24T13:36:37+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.8.7",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "a85e67b86e9b8520d07e6415fcbcb8391b44a75b"
+                "reference": "de5847b068362a88684a55b0dbb40d85986cfa52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/a85e67b86e9b8520d07e6415fcbcb8391b44a75b",
-                "reference": "a85e67b86e9b8520d07e6415fcbcb8391b44a75b",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/de5847b068362a88684a55b0dbb40d85986cfa52",
+                "reference": "de5847b068362a88684a55b0dbb40d85986cfa52",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "php": "^7.1",
+                "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0"
             },
             "provide": {
+                "psr/http-factory-implementation": "1.0",
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
+                "ext-curl": "*",
                 "ext-dom": "*",
                 "ext-libxml": "*",
+                "http-interop/http-factory-tests": "^0.5.0",
                 "php-http/psr7-integration-tests": "dev-master",
-                "phpunit/phpunit": "^5.7.16 || ^6.0.8 || ^7.2.7",
-                "zendframework/zend-coding-standard": "~1.0"
+                "phpunit/phpunit": "^7.0.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
+                    "dev-master": "2.1.x-dev",
+                    "dev-develop": "2.2.x-dev",
                     "dev-release-1.8": "1.8.x-dev"
                 }
             },
@@ -7415,16 +7507,15 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-2-Clause"
+                "BSD-3-Clause"
             ],
             "description": "PSR HTTP Message implementations",
-            "homepage": "https://github.com/zendframework/zend-diactoros",
             "keywords": [
                 "http",
                 "psr",
                 "psr-7"
             ],
-            "time": "2019-08-06T17:53:53+00:00"
+            "time": "2019-11-13T19:16:13+00:00"
         }
     ],
     "packages-dev": [
@@ -7585,16 +7676,16 @@
         },
         {
             "name": "codeception/phpunit-wrapper",
-            "version": "7.7.1",
+            "version": "7.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/phpunit-wrapper.git",
-                "reference": "ab04a956264291505ea84998f43cf91639b4575d"
+                "reference": "4ed12e8022f960e34fd78129e5dac34ce5b3a0ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/ab04a956264291505ea84998f43cf91639b4575d",
-                "reference": "ab04a956264291505ea84998f43cf91639b4575d",
+                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/4ed12e8022f960e34fd78129e5dac34ce5b3a0ef",
+                "reference": "4ed12e8022f960e34fd78129e5dac34ce5b3a0ef",
                 "shasum": ""
             },
             "require": {
@@ -7624,7 +7715,7 @@
                 }
             ],
             "description": "PHPUnit classes used by Codeception",
-            "time": "2019-02-26T20:35:32+00:00"
+            "time": "2019-11-23T18:21:46+00:00"
         },
         {
             "name": "codeception/stub",
@@ -8847,16 +8938,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.2",
+            "version": "4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
-                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
                 "shasum": ""
             },
             "require": {
@@ -8896,7 +8987,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-05-05T09:05:15+00:00"
+            "time": "2019-11-20T08:46:58+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -9128,16 +9219,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.2",
+            "version": "3.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "65b12cdeaaa6cd276d4c3033a95b9b88b12701e7"
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/65b12cdeaaa6cd276d4c3033a95b9b88b12701e7",
-                "reference": "65b12cdeaaa6cd276d4c3033a95b9b88b12701e7",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
                 "shasum": ""
             },
             "require": {
@@ -9175,31 +9266,31 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-10-28T04:36:32+00:00"
+            "time": "2019-12-04T04:46:47+00:00"
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "b14fa08508afd152257d5dcc7adb5f278654d972"
+                "reference": "e19e465c055137938afd40cfddd687e7511bbbf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/b14fa08508afd152257d5dcc7adb5f278654d972",
-                "reference": "b14fa08508afd152257d5dcc7adb5f278654d972",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/e19e465c055137938afd40cfddd687e7511bbbf0",
+                "reference": "e19e465c055137938afd40cfddd687e7511bbbf0",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/dom-crawler": "~3.4|~4.0"
+                "symfony/dom-crawler": "^3.4|^4.0|^5.0"
             },
             "require-dev": {
-                "symfony/css-selector": "~3.4|~4.0",
-                "symfony/http-client": "^4.3",
-                "symfony/mime": "^4.3",
-                "symfony/process": "~3.4|~4.0"
+                "symfony/css-selector": "^3.4|^4.0|^5.0",
+                "symfony/http-client": "^4.3|^5.0",
+                "symfony/mime": "^4.3|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/process": ""
@@ -9207,7 +9298,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -9234,20 +9325,20 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-28T17:07:32+00:00"
+            "time": "2019-10-28T20:30:34+00:00"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "4b9efd5708c3a38593e19b6a33e40867f4f89d72"
+                "reference": "36bbcab9369fc2f583220890efd43bf262d563fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/4b9efd5708c3a38593e19b6a33e40867f4f89d72",
-                "reference": "4b9efd5708c3a38593e19b6a33e40867f4f89d72",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/36bbcab9369fc2f583220890efd43bf262d563fd",
+                "reference": "36bbcab9369fc2f583220890efd43bf262d563fd",
                 "shasum": ""
             },
             "require": {
@@ -9260,7 +9351,7 @@
             },
             "require-dev": {
                 "masterminds/html5": "^2.6",
-                "symfony/css-selector": "~3.4|~4.0"
+                "symfony/css-selector": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/css-selector": ""
@@ -9268,7 +9359,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -9295,20 +9386,20 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-28T17:07:32+00:00"
+            "time": "2019-10-29T11:38:30+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.3.8",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "324cf4b19c345465fad14f3602050519e09e361d"
+                "reference": "76de473358fe802578a415d5bb43c296cf09d211"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/324cf4b19c345465fad14f3602050519e09e361d",
-                "reference": "324cf4b19c345465fad14f3602050519e09e361d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/76de473358fe802578a415d5bb43c296cf09d211",
+                "reference": "76de473358fe802578a415d5bb43c296cf09d211",
                 "shasum": ""
             },
             "require": {
@@ -9319,7 +9410,7 @@
                 "symfony/console": "<3.4"
             },
             "require-dev": {
-                "symfony/console": "~3.4|~4.0"
+                "symfony/console": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -9327,7 +9418,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -9354,7 +9445,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-30T12:58:49+00:00"
+            "time": "2019-11-12T14:51:11+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -9403,7 +9494,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-curl": "*",
         "ext-fileinfo": "*",
         "ext-json": "*",
@@ -9412,6 +9503,6 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.8"
+        "php": "7.2"
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -319,7 +319,7 @@ return [
         Laravel\Passport\PassportServiceProvider::class,
         Laravel\Tinker\TinkerServiceProvider::class,
         Unicodeveloper\DumbPassword\DumbPasswordServiceProvider::class,
-        Schuppo\PasswordStrength\PasswordStrengthServiceProvider::class,
+        //Schuppo\PasswordStrength\PasswordStrengthServiceProvider::class,
         Tightenco\Ziggy\ZiggyServiceProvider::class, // Laravel routes in vue
         Eduardokum\LaravelMailAutoEmbed\ServiceProvider::class,
 
@@ -388,7 +388,7 @@ return [
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
-        'Input' => Illuminate\Support\Facades\Input::class,
+        //'Input' => Illuminate\Support\Facades\Input::class,
         'Form'      => Collective\Html\FormFacade::class,
         'Html'      => Collective\Html\HtmlFacade::class,
         'Google2FA' => PragmaRX\Google2FALaravel\Facade::class,

--- a/config/auth.php
+++ b/config/auth.php
@@ -53,6 +53,7 @@ return [
         'api' => [
             'driver' => 'passport',
             'provider' => 'users',
+            'hash' => false,
         ],
     ],
 
@@ -86,10 +87,6 @@ return [
     | Resetting Passwords
     |--------------------------------------------------------------------------
     |
-    | Here you may set the options for resetting passwords including the view
-    | that is your password reset e-mail. You may also set the name of the
-    | table that maintains all of the reset tokens for your application.
-    |
     | You may specify multiple password reset configurations if you have more
     | than one user table or model in the application and you want to have
     | separate password reset settings based on the specific user types.
@@ -105,25 +102,22 @@ return [
             'provider' => 'users',
             'email' => 'auth.emails.password',
             'table' => 'password_resets',
-            'expire' => 60,
+            'expire' => env('LOGIN_LOCKOUT_DURATION', 60),
+            'throttle' => env('LOGIN_MAX_ATTEMPTS', 60),
         ],
     ],
 
     /*
-   |--------------------------------------------------------------------------
-   | Login throttling
-   |--------------------------------------------------------------------------
-   |
-   | This handles the max failed login attempt throttling.
-   | You should not change the values here, but should change them in your
-   | application's .env file instead, as future changes to this file could
-   | overwrite your changes here.
-   |
-   */
+    |--------------------------------------------------------------------------
+    | Password Confirmation Timeout
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define the amount of seconds before a password confirmation
+    | times out and the user is prompted to re-enter their password via the
+    | confirmation screen. By default, the timeout lasts for three hours.
+    |
+    */
 
-    'throttle' => [
-        'max_attempts' => env('LOGIN_MAX_ATTEMPTS', 10),
-        'lockout_duration' =>  env('LOGIN_LOCKOUT_DURATION', 60),
-    ],
+    'password_timeout' => 10800,
 
 ];

--- a/config/passport.php
+++ b/config/passport.php
@@ -1,0 +1,15 @@
+<?php
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption Keys
+    |--------------------------------------------------------------------------
+    |
+    | Passport uses encryption keys while generating secure access tokens for
+    | your application. By default, the keys are stored as local files but
+    | can be set via environment variables when that is more convenient.
+    |
+    */
+    'private_key' => env('PASSPORT_PRIVATE_KEY'),
+    'public_key' => env('PASSPORT_PUBLIC_KEY'),
+];

--- a/database/migrations/2019_12_04_223111_passport_upgrade.php
+++ b/database/migrations/2019_12_04_223111_passport_upgrade.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class PassportUpgrade extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->string('secret', 100)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->string('secret', 100)->change();
+        });
+    }
+}

--- a/database/seeds/SettingsSeeder.php
+++ b/database/seeds/SettingsSeeder.php
@@ -32,7 +32,7 @@ class SettingsSeeder extends Seeder
         $settings->locale = 'en';
         $settings->version_footer = 'on';
         $settings->support_footer = 'on';
-        $settings->pwd_secure_min = '542321';
+        $settings->pwd_secure_min = '8';
         $settings->save();
 
         if ($user = User::where('username', '=', 'admin')->first()) {

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -30,6 +30,7 @@ return array(
         'array'   => 'The :attribute must have between :min and :max items.',
     ],
     'boolean'              => 'The :attribute must be true or false.',
+    'case_diff'            => 'The :attribute must contain at least one uppercase and one lowercase letter.',
     'confirmed'            => 'The :attribute confirmation does not match.',
     'date'                 => 'The :attribute is not a valid date.',
     'date_format'          => 'The :attribute does not match the format :format.',
@@ -38,6 +39,7 @@ return array(
     'digits_between'       => 'The :attribute must be between :min and :max digits.',
     'dimensions'           => 'The :attribute has invalid image dimensions.',
     'distinct'             => 'The :attribute field has a duplicate value.',
+    'dumbpwd'             => 'That password is too common. Please choose another one.',
     'email'                => 'The :attribute format is invalid.',
     'exists'               => 'The selected :attribute is invalid.',
     'file'                 => 'The :attribute must be a file.',
@@ -59,6 +61,7 @@ return array(
     ],
     'mimes'                => 'The :attribute must be a file of type: :values.',
     'mimetypes'            => 'The :attribute must be a file of type: :values.',
+    'letters'              => 'The :attribute must contain letters',
     'min'                  => [
         'numeric' => 'The :attribute must be at least :min.',
         'file'    => 'The :attribute must be at least :min kilobytes.',
@@ -67,6 +70,7 @@ return array(
     ],
     'not_in'               => 'The selected :attribute is invalid.',
     'numeric'              => 'The :attribute must be a number.',
+    'numbers'              => 'The :attribute must contain at least one number.',
     'present'              => 'The :attribute field must be present.',
     'valid_regex'          => 'That is not a valid regex. ',
     'regex'                => 'The :attribute format is invalid.',
@@ -85,23 +89,13 @@ return array(
         'array'   => 'The :attribute must contain :size items.',
     ],
     'string'               => 'The :attribute must be a string.',
+    'symbols'              => 'The :attribute must contain at least one symbol.',
     'timezone'             => 'The :attribute must be a valid zone.',
     'unique'               => 'The :attribute has already been taken.',
     'uploaded'             => 'The :attribute failed to upload.',
     'url'                  => 'The :attribute format is invalid.',
     "unique_undeleted"     => "The :attribute must be unique.",
     "import_field_empty"   => "The value of the Import Field shouldn't be empty",
-    /*
-    |--------------------------------------------------------------------------
-    | Custom Validation Language Lines
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify custom validation messages for attributes using the
-    | convention "attribute.rule" to name the lines. This makes it quick to
-    | specify a specific custom language line for a given attribute rule.
-    |
-    */
-
 
     /*
     |--------------------------------------------------------------------------
@@ -118,7 +112,6 @@ return array(
         'alpha_space' => "The :attribute field contains a character that is not allowed.",
         "email_array"      => "One or more email addresses is invalid.",
         "hashed_pass"      => "Your current password is incorrect",
-        'dumbpwd'          => 'That password is too common.',
         "statuslabel_type" => "You must select a valid status label type",
     ],
 

--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -48,7 +48,7 @@
                                     <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
                                         <label for="note" class="col-md-2 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                                         <div class="col-md-7">
-                                            <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $accessory->note) }}</textarea>
+                                            <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note', $accessory->note) }}</textarea>
                                             {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                                         </div>
                                     </div>
@@ -58,7 +58,7 @@
                                 <div class="col-md-8">
                                     <div class="input-group col-md-5 required">
                                         <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-autoclose="true">
-                                            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkin_at" id="checkin_at" value="{{ Input::old('checkin_at', date('Y-m-d')) }}">
+                                            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkin_at" id="checkin_at" value="{{ Request::old('checkin_at', date('Y-m-d')) }}">
                                             <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                                         </div>
                                         {!! $errors->first('checkin_at', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}

--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -83,7 +83,7 @@
           <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
             <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
             <div class="col-md-7">
-              <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $accessory->note) }}</textarea>
+              <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note', $accessory->note) }}</textarea>
               {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
           </div>

--- a/resources/views/accessories/edit.blade.php
+++ b/resources/views/accessories/edit.blade.php
@@ -3,7 +3,7 @@
     'updateText' => trans('admin/accessories/general.update'),
     'helpPosition'  => 'right',
     'helpText' => trans('help.accessories'),
-    'formAction' => ($item) ? route('accessories.update', ['accessory' => $item->id]) : route('accessories.store'),
+    'formAction' => (isset($item->id)) ? route('accessories.update', ['accessory' => $item->id]) : route('accessories.store'),
 ])
 
 {{-- Page content --}}

--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -20,7 +20,7 @@
           <label for="first_name" class="col-md-3 control-label">{{ trans('general.first_name') }}
           </label>
           <div class="col-md-8 required">
-            <input class="form-control" type="text" name="first_name" id="first_name" value="{{ Input::old('first_name', $user->first_name) }}" />
+            <input class="form-control" type="text" name="first_name" id="first_name" value="{{ Request::old('first_name', $user->first_name) }}" />
             {!! $errors->first('first_name', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
           </div>
         </div>
@@ -31,7 +31,7 @@
             {{ trans('general.last_name') }}
           </label>
           <div class="col-md-8 required">
-            <input class="form-control" type="text" name="last_name" id="last_name" value="{{ Input::old('last_name', $user->last_name) }}" />
+            <input class="form-control" type="text" name="last_name" id="last_name" value="{{ Request::old('last_name', $user->last_name) }}" />
             {!! $errors->first('last_name', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
           </div>
         </div>
@@ -49,7 +49,7 @@
           <div class="col-md-9">
 
             @if (!config('app.lock_passwords'))
-              {!! Form::locales('locale', Input::old('locale', $user->locale), 'select2') !!}
+              {!! Form::locales('locale', Request::old('locale', $user->locale), 'select2') !!}
               {!! $errors->first('locale', '<span class="alert-msg">:message</span>') !!}
             @else
               <p class="help-block">{{ trans('general.feature_disabled') }}</p>
@@ -62,7 +62,7 @@
         <div class="form-group {{ $errors->has('phone') ? 'has-error' : '' }}">
           <label class="col-md-3 control-label" for="phone">{{ trans('admin/users/table.phone') }}</label>
           <div class="col-md-4">
-            <input class="form-control" type="text" name="phone" id="phone" value="{{ Input::old('phone', $user->phone) }}" />
+            <input class="form-control" type="text" name="phone" id="phone" value="{{ Request::old('phone', $user->phone) }}" />
             {!! $errors->first('phone', '<span class="alert-msg">:message</span>') !!}
           </div>
         </div>
@@ -73,7 +73,7 @@
         <div class="form-group {{ $errors->has('website') ? ' has-error' : '' }}">
           <label for="website" class="col-md-3 control-label">{{ trans('general.website') }}</label>
           <div class="col-md-8">
-            <input class="form-control" type="text" name="website" id="website" value="{{ Input::old('website', $user->website) }}" />
+            <input class="form-control" type="text" name="website" id="website" value="{{ Request::old('website', $user->website) }}" />
             {!! $errors->first('website', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
           </div>
         </div>
@@ -84,7 +84,7 @@
             <small>(Private)</small>
           </label>
           <div class="col-md-8">
-            <input class="form-control" type="text" name="gravatar" id="gravatar" value="{{ Input::old('gravatar', $user->gravatar) }}" />
+            <input class="form-control" type="text" name="gravatar" id="gravatar" value="{{ Request::old('gravatar', $user->gravatar) }}" />
             {!! $errors->first('gravatar', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             <p>
               <img src="//secure.gravatar.com/avatar/{{ md5(strtolower(trim($user->gravatar))) }}" width="30" height="30" />
@@ -124,9 +124,9 @@
         <div class="form-group {{ $errors->has('avatar') ? 'has-error' : '' }}">
           <div class="col-md-7 col-md-offset-3">
             @can('self.two_factor')
-              <label for="avatar">{{ Form::checkbox('two_factor_optin', '1', Input::old('two_factor_optin', $user->two_factor_optin),array('class' => 'minimal')) }}
+              <label for="avatar">{{ Form::checkbox('two_factor_optin', '1', Request::old('two_factor_optin', $user->two_factor_optin),array('class' => 'minimal')) }}
             @else
-                <label for="avatar">{{ Form::checkbox('two_factor_optin', '1', Input::old('two_factor_optin', $user->two_factor_optin),['class' => 'disabled minimal', 'disabled' => 'disabled']) }}
+                <label for="avatar">{{ Form::checkbox('two_factor_optin', '1', Request::old('two_factor_optin', $user->two_factor_optin),['class' => 'disabled minimal', 'disabled' => 'disabled']) }}
             @endcan
 
             {{ trans('admin/settings/general.two_factor_enabled_text') }}</label>

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -51,7 +51,7 @@
             {{ trans('admin/asset_maintenances/form.title') }}
           </label>
           <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'title')) ? ' required' : '' }}">
-            <input class="form-control" type="text" name="title" id="title" value="{{ Input::old('title', $item->title) }}" />
+            <input class="form-control" type="text" name="title" id="title" value="{{ Request::old('title', $item->title) }}" />
             {!! $errors->first('title', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
           </div>
         </div>
@@ -62,7 +62,7 @@
 
           <div class="input-group col-md-3{{  (\App\Helpers\Helper::checkIfRequired($item, 'start_date')) ? ' required' : '' }}">
             <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-              <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="start_date" id="start_date" value="{{ Input::old('start_date', $item->start_date) }}">
+              <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="start_date" id="start_date" value="{{ Request::old('start_date', $item->start_date) }}">
               <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
             </div>
             {!! $errors->first('start_date', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -77,7 +77,7 @@
 
           <div class="input-group col-md-3{{  (\App\Helpers\Helper::checkIfRequired($item, 'completion_date')) ? ' required' : '' }}">
             <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-              <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="completion_date" id="completion_date" value="{{ Input::old('completion_date', $item->completion_date) }}">
+              <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="completion_date" id="completion_date" value="{{ Request::old('completion_date', $item->completion_date) }}">
               <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
             </div>
             {!! $errors->first('completion_date', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -89,7 +89,7 @@
           <div class="col-sm-offset-3 col-sm-9">
             <div class="checkbox">
               <label>
-                <input type="checkbox" value="1" name="is_warranty" id="is_warranty" {{ Input::old('is_warranty', $item->is_warranty) == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/asset_maintenances/form.is_warranty') }}
+                <input type="checkbox" value="1" name="is_warranty" id="is_warranty" {{ Request::old('is_warranty', $item->is_warranty) == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/asset_maintenances/form.is_warranty') }}
               </label>
             </div>
           </div>
@@ -107,7 +107,7 @@
                   {{ $snipeSettings->default_currency }}
                 @endif
               </span>
-              <input class="col-md-2 form-control" type="text" name="cost" id="cost" value="{{ Input::old('cost', \App\Helpers\Helper::formatCurrencyOutput($item->cost)) }}" />
+              <input class="col-md-2 form-control" type="text" name="cost" id="cost" value="{{ Request::old('cost', \App\Helpers\Helper::formatCurrencyOutput($item->cost)) }}" />
               {!! $errors->first('cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
           </div>
@@ -117,7 +117,7 @@
         <div class="form-group {{ $errors->has('notes') ? ' has-error' : '' }}">
           <label for="notes" class="col-md-3 control-label">{{ trans('admin/asset_maintenances/form.notes') }}</label>
           <div class="col-md-7">
-            <textarea class="col-md-6 form-control" id="notes" name="notes">{{ Input::old('notes', $item->notes) }}</textarea>
+            <textarea class="col-md-6 form-control" id="notes" name="notes">{{ Request::old('notes', $item->notes) }}</textarea>
             {!! $errors->first('notes', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
           </div>
         </div>

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -14,7 +14,7 @@
 <div class="form-group {{ $errors->has('category_type') ? ' has-error' : '' }}">
     <label for="category_type" class="col-md-3 control-label">{{ trans('general.type') }}</label>
     <div class="col-md-7 required">
-        {{ Form::select('category_type', $category_types , Input::old('category_type', $item->category_type), array('class'=>'select2', 'style'=>'min-width:350px', $item->itemCount() > 0 ? 'disabled' : '')) }}
+        {{ Form::select('category_type', $category_types , Request::old('category_type', $item->category_type), array('class'=>'select2', 'style'=>'min-width:350px', $item->itemCount() > 0 ? 'disabled' : '')) }}
         {!! $errors->first('category_type', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -23,7 +23,7 @@
 <div class="form-group {{ $errors->has('eula_text') ? 'error' : '' }}">
     <label for="eula_text" class="col-md-3 control-label">{{ trans('admin/categories/general.eula_text') }}</label>
     <div class="col-md-7">
-        {{ Form::textarea('eula_text', Input::old('eula_text', $item->eula_text), array('class' => 'form-control')) }}
+        {{ Form::textarea('eula_text', Request::old('eula_text', $item->eula_text), array('class' => 'form-control')) }}
         <p class="help-block">{!! trans('admin/categories/general.eula_text_help') !!} </p>
         <p class="help-block">{!! trans('admin/settings/general.eula_markdown') !!} </p>
 

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -3,7 +3,7 @@
     'updateText' => trans('admin/categories/general.update'),
     'helpPosition'  => 'right',
     'helpText' => trans('help.categories'),
-    'formAction' => ($item) ? route('categories.update', ['category' => $item->id]) : route('categories.store'),
+    'formAction' => (isset($item->id)) ? route('categories.update', ['category' => $item->id]) : route('categories.store'),
 ])
 
 @section('inputFields')

--- a/resources/views/companies/edit.blade.php
+++ b/resources/views/companies/edit.blade.php
@@ -3,7 +3,7 @@
     'updateText' => trans('admin/companies/table.update'),
     'helpPosition'  => 'right',
     'helpText' => trans('help.companies'),
-    'formAction' => ($item) ? route('companies.update', ['company' => $item->id]) : route('companies.store'),
+    'formAction' => (isset($item->id)) ? route('companies.update', ['company' => $item->id]) : route('companies.store'),
 ])
 
 {{-- Page content --}}

--- a/resources/views/components/checkin.blade.php
+++ b/resources/views/components/checkin.blade.php
@@ -39,7 +39,7 @@
                         <div class="form-group {{ $errors->has('checkin_qty') ? 'error' : '' }}">
                             <label for="note" class="col-md-2 control-label">{{ trans('general.qty') }}</label>
                             <div class="col-md-3">
-                                <input type="text" class="form-control" name="checkin_qty" value="{{ Input::old('assigned_qty', $component_assets->assigned_qty) }}">
+                                <input type="text" class="form-control" name="checkin_qty" value="{{ Request::old('assigned_qty', $component_assets->assigned_qty) }}">
                             </div>
                             <div class="col-md-9 col-md-offset-2">
                             <p class="help-block">Must be {{ $component_assets->assigned_qty }} or less.</p>
@@ -52,7 +52,7 @@
                         <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
                             <label for="note" class="col-md-2 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                             <div class="col-md-7">
-                                <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $component->note) }}</textarea>
+                                <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note', $component->note) }}</textarea>
                                 {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                             </div>
                         </div>

--- a/resources/views/components/checkout.blade.php
+++ b/resources/views/components/checkout.blade.php
@@ -42,7 +42,7 @@
               <label for="assigned_qty" class="col-md-3 control-label">{{ trans('general.qty') }}
                 <i class='icon-asterisk'></i></label>
               <div class="col-md-9">
-                <input class="form-control" type="text" name="assigned_qty" id="assigned_qty" style="width: 70px;" value="{{ Input::old('assigned_qty') }}" />
+                <input class="form-control" type="text" name="assigned_qty" id="assigned_qty" style="width: 70px;" value="{{ Request::old('assigned_qty') }}" />
                 {!! $errors->first('assigned_qty', '<br><span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
               </div>
             </div>

--- a/resources/views/components/edit.blade.php
+++ b/resources/views/components/edit.blade.php
@@ -3,7 +3,7 @@
     'updateText' => trans('admin/components/general.update'),
     'helpPosition'  => 'right',
     'helpText' => trans('help.components'),
-    'formAction' => ($item) ? route('components.update', ['component' => $item->id]) : route('components.store'),
+    'formAction' => (isset($item->id)) ? route('components.update', ['component' => $item->id]) : route('components.store'),
 
 ])
 

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -70,7 +70,7 @@
           <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
             <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
             <div class="col-md-7">
-              <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $consumable->note) }}</textarea>
+              <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note', $consumable->note) }}</textarea>
               {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
           </div>

--- a/resources/views/consumables/edit.blade.php
+++ b/resources/views/consumables/edit.blade.php
@@ -3,7 +3,7 @@
     'updateText' => trans('admin/consumables/general.update'),
     'helpPosition'  => 'right',
     'helpText' => trans('help.consumables'),
-    'formAction' => ($item) ? route('consumables.update', ['accessory' => $item->id]) : route('consumables.store'),
+    'formAction' => (isset($item->id)) ? route('consumables.update', ['consumable' => $item->id]) : route('consumables.store'),
 ])
 {{-- Page content --}}
 @section('inputFields')

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -39,7 +39,7 @@
               {{ trans('admin/custom_fields/general.field_name') }}
             </label>
             <div class="col-md-6 required">
-                {{ Form::text('name', Input::old('name', $field->name), array('class' => 'form-control')) }}
+                {{ Form::text('name', Request::old('name', $field->name), array('class' => 'form-control')) }}
                 {!! $errors->first('name', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
           </div>
@@ -51,7 +51,7 @@
             </label>
             <div class="col-md-6 required">
 
-            {!! Form::customfield_elements('element', Input::old('element', $field->element), 'field_element select2 form-control') !!}
+            {!! Form::customfield_elements('element', Request::old('element', $field->element), 'field_element select2 form-control') !!}
             {!! $errors->first('element', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
 
             </div>
@@ -63,7 +63,7 @@
               {{ trans('admin/custom_fields/general.field_values') }}
             </label>
             <div class="col-md-6 required">
-              {!! Form::textarea('field_values', Input::old('name', $field->field_values), ['style' => 'width: 100%', 'rows' => 4, 'class' => 'form-control']) !!}
+              {!! Form::textarea('field_values', Request::old('name', $field->field_values), ['style' => 'width: 100%', 'rows' => 4, 'class' => 'form-control']) !!}
               {!! $errors->first('field_values', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
               <p class="help-block">{{ trans('admin/custom_fields/general.field_values_help') }}</p>
             </div>
@@ -86,7 +86,7 @@
               {{ trans('admin/custom_fields/general.field_custom_format') }}
             </label>
             <div class="col-md-6 required">
-                {{ Form::text('custom_format', Input::old('custom_format', $customFormat), array('class' => 'form-control', 'id' => 'custom_format', 'placeholder'=>'regex:/^[0-9]{15}$/')) }}
+                {{ Form::text('custom_format', Request::old('custom_format', $customFormat), array('class' => 'form-control', 'id' => 'custom_format', 'placeholder'=>'regex:/^[0-9]{15}$/')) }}
                 <p class="help-block">{!! trans('admin/custom_fields/general.field_custom_format_help') !!}</p>
 
               {!! $errors->first('custom_format', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -100,7 +100,7 @@
                   Help Text
               </label>
               <div class="col-md-6">
-                  {{ Form::text('help_text', Input::old('help_text', $field->help_text), array('class' => 'form-control')) }}
+                  {{ Form::text('help_text', Request::old('help_text', $field->help_text), array('class' => 'form-control')) }}
                   <p class="help-block">This is optional text that will appear below the form elements while editing an asset to provide context on the field.</p>
                   {!! $errors->first('help_text', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
               </div>
@@ -110,7 +110,7 @@
           <div class="form-group {{ $errors->has('show_in_email') ? ' has-error' : '' }}"  id="show_in_email">
               <div class="col-md-8 col-md-offset-4">
                   <label for="show_in_email">
-                      <input type="checkbox" name="show_in_email" value="1" class="minimal"{{ (Input::old('show_in_email') || $field->show_in_email) ? ' checked="checked"' : '' }}>
+                      <input type="checkbox" name="show_in_email" value="1" class="minimal"{{ (Request::old('show_in_email') || $field->show_in_email) ? ' checked="checked"' : '' }}>
                       {{ trans('admin/custom_fields/general.show_in_email') }}
                   </label>
               </div>
@@ -123,7 +123,7 @@
         <div class="form-group {{ $errors->has('encrypted') ? ' has-error' : '' }}">
           <div class="col-md-8 col-md-offset-4">
             <label for="field_encrypted">
-              <input type="checkbox" value="1" name="field_encrypted" id="field_encrypted" class="minimal"{{ (Input::old('field_encrypted') || $field->field_encrypted) ? ' checked="checked"' : '' }}>
+              <input type="checkbox" value="1" name="field_encrypted" id="field_encrypted" class="minimal"{{ (Request::old('field_encrypted') || $field->field_encrypted) ? ' checked="checked"' : '' }}>
               {{ trans('admin/custom_fields/general.encrypt_field') }}
             </label>
           </div>

--- a/resources/views/custom_fields/fieldsets/edit.blade.php
+++ b/resources/views/custom_fields/fieldsets/edit.blade.php
@@ -29,7 +29,7 @@
             <i class='fa fa-asterisk'></i>
           </label>
           <div class="col-md-6">
-            <input class="form-control" type="text" name="name" id="name" value="{{ Input::old('name') }}" />
+            <input class="form-control" type="text" name="name" id="name" value="{{ Request::old('name') }}" />
             {!! $errors->first('name', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
           </div>
         </div>

--- a/resources/views/departments/edit.blade.php
+++ b/resources/views/departments/edit.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts/edit-form', [
     'createText' => trans('admin/departments/table.create') ,
     'updateText' => trans('admin/departments/table.update'),
-    'formAction' => ($item) ? route('departments.update', ['department' => $item->id]) : route('departments.store'),
+    'formAction' => (isset($item->id)) ? route('departments.update', ['department' => $item->id]) : route('departments.store'),
 ])
 
 {{-- Page content --}}

--- a/resources/views/depreciations/edit.blade.php
+++ b/resources/views/depreciations/edit.blade.php
@@ -17,7 +17,7 @@
     </label>
     <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'months')) ? ' required' : '' }}">
         <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="months" id="months" value="{{ Input::old('months', $item->months) }}" style="width: 80px;" />
+            <input class="form-control" type="text" name="months" id="months" value="{{ Request::old('months', $item->months) }}" style="width: 80px;" />
         </div>
     </div>
     {!! $errors->first('months', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}

--- a/resources/views/depreciations/edit.blade.php
+++ b/resources/views/depreciations/edit.blade.php
@@ -3,7 +3,7 @@
     'updateText' => trans('admin/depreciations/general.update'),
     'helpPosition'  => 'right',
     'helpText' => trans('help.depreciations'),
-    'formAction' => ($item) ? route('depreciations.update', ['depreciation' => $item->id]) : route('depreciations.store'),
+    'formAction' => (isset($item->id)) ? route('depreciations.update', ['depreciation' => $item->id]) : route('depreciations.store'),
 ])
 
 {{-- Page content --}}

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -60,7 +60,7 @@
 <div class="form-group {{ $errors->has('name') ? ' has-error' : '' }}">
     <label for="name" class="col-md-3 control-label">{{ trans('admin/groups/titles.group_name') }}</label>
     <div class="col-md-6 required">
-        <input class="form-control" type="text" name="name" id="name" value="{{ Input::old('name', $group->name) }}" />
+        <input class="form-control" type="text" name="name" id="name" value="{{ Request::old('name', $group->name) }}" />
         {!! $errors->first('name', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/hardware/audit-due.blade.php
+++ b/resources/views/hardware/audit-due.blade.php
@@ -2,7 +2,7 @@
 
 @section('title0')
 
-    @if ((Input::get('company_id')) && ($company))
+    @if ((Request::get('company_id')) && ($company))
         {{ $company->name }}
     @endif
 

--- a/resources/views/hardware/audit-overdue.blade.php
+++ b/resources/views/hardware/audit-overdue.blade.php
@@ -2,7 +2,7 @@
 
 @section('title0')
 
-    @if ((Input::get('company_id')) && ($company))
+    @if ((Request::get('company_id')) && ($company))
         {{ $company->name }}
     @endif
 

--- a/resources/views/hardware/audit.blade.php
+++ b/resources/views/hardware/audit.blade.php
@@ -57,7 +57,7 @@
                         <div class="form-group">
                             <div class="col-sm-offset-3 col-md-9">
                                 <label>
-                                    <input type="checkbox" value="1" name="update_location" class="minimal" {{ Input::old('update_location') == '1' ? ' checked="checked"' : '' }}> Update asset location
+                                    <input type="checkbox" value="1" name="update_location" class="minimal" {{ Request::old('update_location') == '1' ? ' checked="checked"' : '' }}> Update asset location
                                 </label>
 
                                 @include ('partials.more-info', ['helpText' => trans('help.audit_help'), 'helpPosition' => 'right'])
@@ -73,7 +73,7 @@
                             {{ Form::label('name', trans('general.next_audit_date'), array('class' => 'col-md-3 control-label')) }}
                             <div class="col-md-9">
                                 <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd">
-                                    <input type="text" class="form-control" placeholder="{{ trans('general.next_audit_date') }}" name="next_audit_date" id="next_audit_date" value="{{ Input::old('next_audit_date', $next_audit_date) }}">
+                                    <input type="text" class="form-control" placeholder="{{ trans('general.next_audit_date') }}" name="next_audit_date" id="next_audit_date" value="{{ Request::old('next_audit_date', $next_audit_date) }}">
                                     <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                                 </div>
                                 {!! $errors->first('next_audit_date', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -85,7 +85,7 @@
                         <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
                             {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
                             <div class="col-md-8">
-                                <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $asset->note) }}</textarea>
+                                <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note', $asset->note) }}</textarea>
                                 {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                             </div>
                         </div>

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -39,7 +39,7 @@
                   {{ Form::label('name', trans('admin/hardware/form.checkout_date'), array('class' => 'col-md-3 control-label')) }}
                   <div class="col-md-8">
                       <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d">
-                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ Input::old('checkout_at') }}">
+                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ Request::old('checkout_at') }}">
                           <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                       </div>
                       {!! $errors->first('checkout_at', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -51,7 +51,7 @@
                   {{ Form::label('name', trans('admin/hardware/form.expected_checkin'), array('class' => 'col-md-3 control-label')) }}
                   <div class="col-md-8">
                       <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-start-date="0d">
-                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ Input::old('expected_checkin') }}">
+                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ Request::old('expected_checkin') }}">
                           <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                       </div>
                       {!! $errors->first('expected_checkin', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -63,7 +63,7 @@
           <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
             {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
             <div class="col-md-8">
-              <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note') }}</textarea>
+              <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note') }}</textarea>
               {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
           </div>

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -32,7 +32,7 @@
           <div class="form-group {{ $errors->has('purchase_date') ? ' has-error' : '' }}">
             <label for="purchase_date" class="col-md-3 control-label">{{ trans('admin/hardware/form.date') }}</label>
             <div class="input-group col-md-3">
-              <input type="date" class="datepicker form-control" data-date-format="yyyy-mm-dd" placeholder="Select Date" name="purchase_date" id="purchase_date" value="{{ Input::old('purchase_date') }}">
+              <input type="date" class="datepicker form-control" data-date-format="yyyy-mm-dd" placeholder="Select Date" name="purchase_date" id="purchase_date" value="{{ Request::old('purchase_date') }}">
               <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
               {!! $errors->first('purchase_date', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
@@ -44,7 +44,7 @@
               {{ trans('admin/hardware/form.status') }}
             </label>
             <div class="col-md-7">
-              {{ Form::select('status_id', $statuslabel_list , Input::old('status_id'), array('class'=>'select2', 'style'=>'width:350px')) }}
+              {{ Form::select('status_id', $statuslabel_list , Request::old('status_id'), array('class'=>'select2', 'style'=>'width:350px')) }}
               {!! $errors->first('status_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
           </div>
@@ -62,8 +62,8 @@
             <div class="col-sm-9">
               <div class="checkbox">
                 <label for="update_real_loc">
-                  {{ Form::radio('update_real_loc', '1', Input::old('update_real_loc')) }} Update default location AND actual location <br>
-                  {{ Form::radio('update_real_loc', '0', true, Input::old('update_real_loc')) }} Only update default location<br>
+                  {{ Form::radio('update_real_loc', '1', Request::old('update_real_loc')) }} Update default location AND actual location <br>
+                  {{ Form::radio('update_real_loc', '0', true, Request::old('update_real_loc')) }} Only update default location<br>
 
                 </label>
               </div>
@@ -79,7 +79,7 @@
             </label>
             <div class="input-group col-md-3">
               <span class="input-group-addon">{{ $snipeSettings->default_currency }}</span>
-                <input type="text" class="form-control" placeholder="{{ trans('admin/hardware/form.cost') }}" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost') }}">
+                <input type="text" class="form-control" placeholder="{{ trans('admin/hardware/form.cost') }}" name="purchase_cost" id="purchase_cost" value="{{ Request::old('purchase_cost') }}">
                 {!! $errors->first('purchase_cost', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
           </div>
@@ -95,7 +95,7 @@
               {{ trans('admin/hardware/form.order') }}
             </label>
             <div class="col-md-7">
-              <input class="form-control" type="text" name="order_number" id="order_number" value="{{ Input::old('order_number') }}" />
+              <input class="form-control" type="text" name="order_number" id="order_number" value="{{ Request::old('order_number') }}" />
               {!! $errors->first('order_number', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
           </div>
@@ -107,7 +107,7 @@
             </label>
             <div class="col-md-2">
               <div class="input-group">
-                <input class="col-md-3 form-control" type="text" name="warranty_months" id="warranty_months" value="{{ Input::old('warranty_months') }}" />
+                <input class="col-md-3 form-control" type="text" name="warranty_months" id="warranty_months" value="{{ Request::old('warranty_months') }}" />
                 <span class="input-group-addon">{{ trans('admin/hardware/form.months') }}</span>
                 {!! $errors->first('warranty_months', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
               </div>

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -51,7 +51,7 @@
               <div class="form-group {{ $errors->has('name') ? 'error' : '' }}">
                 {{ Form::label('name', trans('admin/hardware/form.name'), array('class' => 'col-md-3 control-label')) }}
                 <div class="col-md-8">
-                  <input class="form-control" type="text" name="name" id="name" value="{{ Input::old('name', $asset->name) }}" tabindex="1">
+                  <input class="form-control" type="text" name="name" id="name" value="{{ Request::old('name', $asset->name) }}" tabindex="1">
                   {!! $errors->first('name', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                 </div>
               </div>
@@ -83,7 +83,7 @@
               <div class="col-md-8">
               <div class="input-group col-md-5 required">
                 <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-autoclose="true">
-                  <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkin_at" id="checkin_at" value="{{ Input::old('checkin_at', date('Y-m-d')) }}">
+                  <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkin_at" id="checkin_at" value="{{ Request::old('checkin_at', date('Y-m-d')) }}">
                   <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                 </div>
                 {!! $errors->first('checkin_at', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -99,7 +99,7 @@
 
                 <div class="col-md-8">
                   <textarea class="col-md-6 form-control" id="note"
-                  name="note">{{ Input::old('note', $asset->note) }}</textarea>
+                  name="note">{{ Request::old('note', $asset->note) }}</textarea>
                   {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                 </div>
               </div>

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -42,7 +42,7 @@
                 <div class="form-group {{ $errors->has('name') ? 'error' : '' }}">
                   {{ Form::label('name', trans('admin/hardware/form.name'), array('class' => 'col-md-3 control-label')) }}
                   <div class="col-md-8">
-                    <input class="form-control" type="text" name="name" id="name" value="{{ Input::old('name', $asset->name) }}" tabindex="1">
+                    <input class="form-control" type="text" name="name" id="name" value="{{ Request::old('name', $asset->name) }}" tabindex="1">
                     {!! $errors->first('name', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                   </div>
                 </div>
@@ -73,7 +73,7 @@
               {{ Form::label('name', trans('admin/hardware/form.checkout_date'), array('class' => 'col-md-3 control-label')) }}
               <div class="col-md-8">
                   <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d">
-                      <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ Input::old('checkout_at') }}">
+                      <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ Request::old('checkout_at') }}">
                       <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                   </div>
                 {!! $errors->first('checkout_at', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -85,7 +85,7 @@
               {{ Form::label('name', trans('admin/hardware/form.expected_checkin'), array('class' => 'col-md-3 control-label')) }}
               <div class="col-md-8">
                   <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-start-date="0d">
-                      <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ Input::old('expected_checkin') }}">
+                      <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ Request::old('expected_checkin') }}">
                       <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                   </div>
                 {!! $errors->first('expected_checkin', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -96,7 +96,7 @@
             <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
               {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
               <div class="col-md-8">
-                <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $asset->note) }}</textarea>
+                <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note', $asset->note) }}</textarea>
                 {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
               </div>
             </div>

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -5,7 +5,7 @@
     'topSubmit' => true,
     'helpText' => trans('help.assets'),
     'helpPosition' => 'right',
-    'formAction' => ($item) ? route('hardware.update', ['hardware' => $item->id]) : route('hardware.store'),
+    'formAction' => ($item->id) ? route('hardware.update', ['hardware' => $item->id]) : route('hardware.store'),
 ])
 
 

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -23,14 +23,14 @@
       <!-- we are editing an existing asset -->
       @if  ($item->id)
           <div class="col-md-7 col-sm-12{{  (\App\Helpers\Helper::checkIfRequired($item, 'asset_tag')) ? ' required' : '' }}">
-          <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ Input::old('asset_tag', $item->asset_tag) }}" data-validation="required">
+          <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ Request::old('asset_tag', $item->asset_tag) }}" data-validation="required">
               {!! $errors->first('asset_tags', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
               {!! $errors->first('asset_tag', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
           </div>
       @else
           <!-- we are creating a new asset - let people use more than one asset tag -->
           <div class="col-md-7 col-sm-12{{  (\App\Helpers\Helper::checkIfRequired($item, 'asset_tag')) ? ' required' : '' }}">
-              <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ Input::old('asset_tag', \App\Models\Asset::autoincrement_asset()) }}" data-validation="required">
+              <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ Request::old('asset_tag', \App\Models\Asset::autoincrement_asset()) }}" data-validation="required">
               {!! $errors->first('asset_tags', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
               {!! $errors->first('asset_tag', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
           </div>
@@ -53,8 +53,8 @@
       @if ($item->model && $item->model->fieldset)
       <?php $model=$item->model; ?>
       @endif
-      @if (Input::old('model_id'))
-        <?php $model=\App\Models\AssetModel::find(Input::old('model_id')); ?>
+      @if (Request::old('model_id'))
+        <?php $model=\App\Models\AssetModel::find(Request::old('model_id')); ?>
       @elseif (isset($selected_model))
         <?php $model=$selected_model; ?>
       @endif
@@ -101,7 +101,7 @@
       <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
       <div class="col-md-5">
           <label class="control-label" for="image_delete">
-          <input type="checkbox" value="1" name="image_delete" id="image_delete" class="minimal" {{ Input::old('image_delete') == '1' ? ' checked="checked"' : '' }}>
+          <input type="checkbox" value="1" name="image_delete" id="image_delete" class="minimal" {{ Request::old('image_delete') == '1' ? ' checked="checked"' : '' }}>
           {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
           </label>
           <div style="margin-top: 0.5em">

--- a/resources/views/hardware/history.blade.php
+++ b/resources/views/hardware/history.blade.php
@@ -84,7 +84,7 @@
                     <div class="col-sm-2">
                     </div>
                     <div class="col-sm-10">
-                        {{ Form::checkbox('match_firstnamelastname', '1', Input::old('match_firstnamelastname')) }} Try to match users by firstname.lastname (jane.smith) format
+                        {{ Form::checkbox('match_firstnamelastname', '1', Request::old('match_firstnamelastname')) }} Try to match users by firstname.lastname (jane.smith) format
                     </div>
                 </div>
 
@@ -93,7 +93,7 @@
                     <div class="col-sm-2">
                     </div>
                     <div class="col-sm-10">
-                        {{ Form::checkbox('match_flastname', '1', Input::old('match_flastname')) }} Try to match users by first initial last name (jsmith) format
+                        {{ Form::checkbox('match_flastname', '1', Request::old('match_flastname')) }} Try to match users by first initial last name (jsmith) format
                     </div>
                 </div>
 
@@ -102,7 +102,7 @@
                     <div class="col-sm-2">
                     </div>
                     <div class="col-sm-10">
-                        {{ Form::checkbox('match_firstname', '1', Input::old('match_firstname')) }} Try to match users by first name (jane) format
+                        {{ Form::checkbox('match_firstname', '1', Request::old('match_firstname')) }} Try to match users by first name (jane) format
                     </div>
                 </div>
 
@@ -111,7 +111,7 @@
                     <div class="col-sm-2">
                     </div>
                     <div class="col-sm-10">
-                        {{ Form::checkbox('match_email', '1', Input::old('match_email')) }} Try to match users by email as username
+                        {{ Form::checkbox('match_email', '1', Request::old('match_email')) }} Try to match users by email as username
                     </div>
                 </div>
 

--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -2,28 +2,28 @@
 
 @section('title0')
 
-  @if ((Input::get('company_id')) && ($company))
+  @if ((Request::get('company_id')) && ($company))
     {{ $company->name }}
   @endif
 
 
 
-@if (Input::get('status'))
-  @if (Input::get('status')=='Pending')
+@if (Request::get('status'))
+  @if (Request::get('status')=='Pending')
     {{ trans('general.pending') }}
-  @elseif (Input::get('status')=='RTD')
+  @elseif (Request::get('status')=='RTD')
     {{ trans('general.ready_to_deploy') }}
-  @elseif (Input::get('status')=='Deployed')
+  @elseif (Request::get('status')=='Deployed')
     {{ trans('general.deployed') }}
-  @elseif (Input::get('status')=='Undeployable')
+  @elseif (Request::get('status')=='Undeployable')
     {{ trans('general.undeployable') }}
-  @elseif (Input::get('status')=='Deployable')
+  @elseif (Request::get('status')=='Deployable')
     {{ trans('general.deployed') }}
-  @elseif (Input::get('status')=='Requestable')
+  @elseif (Request::get('status')=='Requestable')
     {{ trans('admin/hardware/general.requestable') }}
-  @elseif (Input::get('status')=='Archived')
+  @elseif (Request::get('status')=='Archived')
     {{ trans('general.archived') }}
-  @elseif (Input::get('status')=='Deleted')
+  @elseif (Request::get('status')=='Deleted')
     {{ trans('general.deleted') }}
   @endif
 @else
@@ -31,8 +31,8 @@
 @endif
 {{ trans('general.assets') }}
 
-  @if (Input::has('order_number'))
-    : Order #{{ Input::get('order_number') }}
+  @if (Request::has('order_number'))
+    : Order #{{ Request::get('order_number') }}
   @endif
 @stop
 
@@ -64,7 +64,7 @@
            'id' => 'bulkForm']) }}
           <div class="row">
             <div class="col-md-12">
-              @if (Input::get('status')!='Deleted')
+              @if (Request::get('status')!='Deleted')
               <div id="toolbar">
                 <select name="bulk_actions" class="form-control select2">
                   <option value="edit">{{ trans('button.edit') }}</option>
@@ -94,12 +94,12 @@
                 id="assetsListingTable"
                 class="table table-striped snipe-table"
                 data-url="{{ route('api.assets.index',
-                    array('status' => e(Input::get('status')),
-                    'order_number'=>e(Input::get('order_number')),
-                    'company_id'=>e(Input::get('company_id')),
-                    'status_id'=>e(Input::get('status_id')))) }}"
+                    array('status' => e(Request::get('status')),
+                    'order_number'=>e(Request::get('order_number')),
+                    'company_id'=>e(Request::get('company_id')),
+                    'status_id'=>e(Request::get('status_id')))) }}"
                 data-export-options='{
-                "fileName": "export{{ (Input::has('status')) ? '-'.str_slug(Input::get('status')) : '' }}-assets-{{ date('Y-m-d') }}",
+                "fileName": "export{{ (Request::has('status')) ? '-'.str_slug(Request::get('status')) : '' }}-assets-{{ date('Y-m-d') }}",
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                 }'>
               </table>

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -33,7 +33,7 @@
                             {{ Form::label('asset_tag', trans('general.asset_tag'), array('class' => 'col-md-3 control-label', 'id' => 'audit_tag')) }}
                             <div class="col-md-9">
                                 <div class="input-group date col-md-5" data-date-format="yyyy-mm-dd">
-                                    <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ Input::old('asset_tag') }}">
+                                    <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ Request::old('asset_tag') }}">
 
                                 </div>
                                 {!! $errors->first('asset_tag', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -50,7 +50,7 @@
                         <div class="form-group">
                             <div class="col-sm-offset-3 col-md-9">
                                 <label>
-                                    <input type="checkbox" value="1" name="update_location" class="minimal" {{ Input::old('update_location') == '1' ? ' checked="checked"' : '' }}> Update asset location
+                                    <input type="checkbox" value="1" name="update_location" class="minimal" {{ Request::old('update_location') == '1' ? ' checked="checked"' : '' }}> Update asset location
                                 </label> <a href="#" class="text-dark-gray" tabindex="0" role="button" data-toggle="popover" data-trigger="focus" title="<i class='fa fa-life-ring'></i> More Info" data-html="true" data-content="Checking this box will edit the asset record to reflect this new location. Leaving it unchecked will simply note the location in the audit log.<br><br>Note that is this asset is checked out, it will not change the location of the person, asset or location it is checked out to."><i class="fa fa-life-ring"></i></a>
                             </div>
                         </div>
@@ -61,7 +61,7 @@
                             {{ Form::label('next_audit_date', trans('general.next_audit_date'), array('class' => 'col-md-3 control-label')) }}
                             <div class="col-md-9">
                                 <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd">
-                                    <input type="text" class="form-control" placeholder="{{ trans('general.next_audit_date') }}" name="next_audit_date" id="next_audit_date" value="{{ Input::old('next_audit_date', $next_audit_date) }}">
+                                    <input type="text" class="form-control" placeholder="{{ trans('general.next_audit_date') }}" name="next_audit_date" id="next_audit_date" value="{{ Request::old('next_audit_date', $next_audit_date) }}">
                                     <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                                 </div>
                                 {!! $errors->first('next_audit_date', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -73,7 +73,7 @@
                         <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
                             {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
                             <div class="col-md-8">
-                                <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note') }}</textarea>
+                                <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note') }}</textarea>
                                 {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                             </div>
                         </div>

--- a/resources/views/kits/accessory-edit.blade.php
+++ b/resources/views/kits/accessory-edit.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts/edit-form', [
     'createText' => 'Append accessory',          // TODO: trans
     'updateText' => 'Update appended accessory', // TODO: trans
-    'formAction' => ($item) ? route('kits.accessories.update', ['kit_id' => $kit->id, 'accessory_id' => $item->accessory_id]) : route('kits.accessories.store', ['kit_id' => $kit->id]),
+    'formAction' => (isset($item->id)) ? route('kits.accessories.update', ['kit_id' => $kit->id, 'accessory_id' => $item->accessory_id]) : route('kits.accessories.store', ['kit_id' => $kit->id]),
 ])
 
 {{-- Page content --}}

--- a/resources/views/kits/accessory-edit.blade.php
+++ b/resources/views/kits/accessory-edit.blade.php
@@ -11,13 +11,13 @@
     <label for="quantity" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
     <div class="col-md-7 required">
         <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Input::old('quantity', $item->quantity) }}" />
+            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" />
         </div>
         {!! $errors->first('quantity', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
 
 <input type="hidden" name="pivot_id" value="{{$item->id}}">
-{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Input::old('quantity', $item->quantity) }}" /> --}}
+{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" /> --}}
 
 @stop

--- a/resources/views/kits/checkout.blade.php
+++ b/resources/views/kits/checkout.blade.php
@@ -30,7 +30,7 @@
                   {{ Form::label('name', trans('admin/hardware/form.checkout_date'), array('class' => 'col-md-3 control-label')) }}
                   <div class="col-md-8">
                       <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d">
-                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ Input::old('checkout_at') }}">
+                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ Request::old('checkout_at') }}">
                           <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                       </div>
                       {!! $errors->first('checkout_at', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -42,7 +42,7 @@
                   {{ Form::label('name', trans('admin/hardware/form.expected_checkin'), array('class' => 'col-md-3 control-label')) }}
                   <div class="col-md-8">
                       <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-start-date="0d">
-                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ Input::old('expected_checkin') }}">
+                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ Request::old('expected_checkin') }}">
                           <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                       </div>
                       {!! $errors->first('expected_checkin', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -54,7 +54,7 @@
           <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
             {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
             <div class="col-md-8">
-              <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note') }}</textarea>
+              <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note') }}</textarea>
               {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
           </div>

--- a/resources/views/kits/consumable-edit.blade.php
+++ b/resources/views/kits/consumable-edit.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts/edit-form', [
     'createText' => 'Append consumable',          // TODO: trans
     'updateText' => 'Update appended consumable', // TODO: trans
-    'formAction' => ($item) ? route('kits.consumables.update', ['kit_id' => $kit->id, 'consumable_id' => $item->consumable_id]) : route('kits.consumables.store', ['kit_id' => $kit->id]),
+    'formAction' => (isset($item->id)) ? route('kits.consumables.update', ['kit_id' => $kit->id, 'consumable_id' => $item->consumable_id]) : route('kits.consumables.store', ['kit_id' => $kit->id]),
 ])
 
 {{-- Page content --}}

--- a/resources/views/kits/consumable-edit.blade.php
+++ b/resources/views/kits/consumable-edit.blade.php
@@ -12,13 +12,13 @@
     <label for="quantity" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
     <div class="col-md-7 required">
         <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Input::old('quantity', $item->quantity) }}" />
+            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" />
         </div>
         {!! $errors->first('quantity', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
 
 <input type="hidden" name="pivot_id" value="{{$item->id}}">
-{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Input::old('quantity', $item->quantity) }}" /> --}}
+{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" /> --}}
 
 @stop

--- a/resources/views/kits/create.blade.php
+++ b/resources/views/kits/create.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts/edit-form', [
     'createText' =>  trans('admin/kits/general.create'),
     'updateText' => trans('admin/kits/general.update'),
-    'formAction' => ($item) ? route('kits.update', ['kit' => $item->id]) : route('kits.store'),
+    'formAction' => (isset($item->id)) ? route('kits.update', ['kit' => $item->id]) : route('kits.store'),
 ])
 
 {{-- Page content --}}

--- a/resources/views/kits/edit.blade.php
+++ b/resources/views/kits/edit.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts/edit-form', [
     'createText' =>  trans('admin/kits/general.create'),
     'updateText' =>   trans('admin/kits/general.update'),
-    'formAction' => ($item) ? route('kits.update', ['kit' => $item->id]) : route('kits.store'),
+    'formAction' => (isset($item->id)) ? route('kits.update', ['kit' => $item->id]) : route('kits.store'),
 ])
 
 {{-- Page content --}}

--- a/resources/views/kits/license-edit.blade.php
+++ b/resources/views/kits/license-edit.blade.php
@@ -11,13 +11,13 @@
     <label for="quantity" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
     <div class="col-md-7 required">
         <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Input::old('quantity', $item->quantity) }}" />
+            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" />
         </div>
         {!! $errors->first('quantity', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
 
 <input type="hidden" name="pivot_id" value="{{$item->id}}">
-{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Input::old('quantity', $item->quantity) }}" /> --}}
+{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" /> --}}
 
 @stop

--- a/resources/views/kits/license-edit.blade.php
+++ b/resources/views/kits/license-edit.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts/edit-form', [
     'createText' => 'Append license',          // TODO: trans
     'updateText' => 'Update appended license', // TODO: trans
-    'formAction' => ($item) ? route('kits.licenses.update', ['kit_id' => $kit->id, 'license_id' => $item->license_id]) : route('kits.licenses.store', ['kit_id' => $kit->id]),
+    'formAction' => (isset($item->id)) ? route('kits.licenses.update', ['kit_id' => $kit->id, 'license_id' => $item->license_id]) : route('kits.licenses.store', ['kit_id' => $kit->id]),
 ])
 
 {{-- Page content --}}

--- a/resources/views/kits/model-edit.blade.php
+++ b/resources/views/kits/model-edit.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts/edit-form', [
     'createText' => 'Append model',          // TODO: trans
     'updateText' => 'Update appended model', // TODO: trans
-    'formAction' => ($item) ? route('kits.models.update', ['kit_id' => $kit->id, 'model_id' => $item->model_id]) : route('kits.models.store', ['kit_id' => $kit->id]),
+    'formAction' => (isset($item->id)) ? route('kits.models.update', ['kit_id' => $kit->id, 'model_id' => $item->model_id]) : route('kits.models.store', ['kit_id' => $kit->id]),
 ])
 
 {{-- Page content --}}

--- a/resources/views/kits/model-edit.blade.php
+++ b/resources/views/kits/model-edit.blade.php
@@ -11,13 +11,13 @@
     <label for="quantity" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
     <div class="col-md-7 required">
         <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Input::old('quantity', $item->quantity) }}" />
+            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" />
         </div>
         {!! $errors->first('quantity', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
 
 <input type="hidden" name="pivot_id" value="{{$item->id}}">
-{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Input::old('quantity', $item->quantity) }}" /> --}}
+{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" /> --}}
 
 @stop

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -18,7 +18,7 @@
 
 
       <meta name="csrf-token" content="{{ csrf_token() }}">
-    <meta name="baseUrl" content="{{ url('/') }}/">
+      <meta name="baseUrl" content="{{ url('/') }}/">
 
     <script nonce="{{ csrf_token() }}">
       window.Laravel = { csrfToken: '{{ csrf_token() }}' };

--- a/resources/views/licenses/checkin.blade.php
+++ b/resources/views/licenses/checkin.blade.php
@@ -52,7 +52,7 @@
             <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
                 <label for="note" class="col-md-2 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                 <div class="col-md-7">
-                    <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note', $licenseSeat->note) }}</textarea>
+                    <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note', $licenseSeat->note) }}</textarea>
                     {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                 </div>
             </div>

--- a/resources/views/licenses/checkout.blade.php
+++ b/resources/views/licenses/checkout.blade.php
@@ -58,7 +58,7 @@
                     <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
                         <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                         <div class="col-md-7">
-                            <textarea class="col-md-6 form-control" id="note" name="note">{{ Input::old('note') }}</textarea>
+                            <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note') }}</textarea>
                             {!! $errors->first('note', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                         </div>
                     </div>

--- a/resources/views/licenses/edit.blade.php
+++ b/resources/views/licenses/edit.blade.php
@@ -2,7 +2,7 @@
     'createText' => trans('admin/licenses/form.create'),
     'updateText' => trans('admin/licenses/form.update'),
     'topSubmit' => true,
-    'formAction' => ($item) ? route('licenses.update', ['license' => $item->id]) : route('license.store'),
+    'formAction' => ($item->id) ? route('licenses.update', ['license' => $item->id]) : route('licenses.store'),
 ])
 
 {{-- Page content --}}

--- a/resources/views/licenses/edit.blade.php
+++ b/resources/views/licenses/edit.blade.php
@@ -16,7 +16,7 @@
 <div class="form-group {{ $errors->has('serial') ? ' has-error' : '' }}">
     <label for="serial" class="col-md-3 control-label">{{ trans('admin/licenses/form.license_key') }}</label>
     <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'serial')) ? ' required' : '' }}">
-        <textarea class="form-control" type="text" name="serial" id="serial">{{ Input::old('serial', $item->serial) }}</textarea>
+        <textarea class="form-control" type="text" name="serial" id="serial">{{ Request::old('serial', $item->serial) }}</textarea>
         {!! $errors->first('serial', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -27,7 +27,7 @@
     <label for="seats" class="col-md-3 control-label">{{ trans('admin/licenses/form.seats') }}</label>
     <div class="col-md-7 col-sm-12 required">
         <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="seats" id="seats" value="{{ Input::old('seats', $item->seats) }}" />
+            <input class="form-control" type="text" name="seats" id="seats" value="{{ Request::old('seats', $item->seats) }}" />
         </div>
     </div>
     {!! $errors->first('seats', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg"><i class="fa fa-times"></i> :message</span></div>') !!}
@@ -40,7 +40,7 @@
 <div class="form-group {{ $errors->has('license_name') ? ' has-error' : '' }}">
     <label for="license_name" class="col-md-3 control-label">{{ trans('admin/licenses/form.to_name') }}</label>
     <div class="col-md-7">
-        <input class="form-control" type="text" name="license_name" id="license_name" value="{{ Input::old('license_name', $item->license_name) }}" />
+        <input class="form-control" type="text" name="license_name" id="license_name" value="{{ Request::old('license_name', $item->license_name) }}" />
         {!! $errors->first('license_name', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -49,7 +49,7 @@
 <div class="form-group {{ $errors->has('license_email') ? ' has-error' : '' }}">
     <label for="license_email" class="col-md-3 control-label">{{ trans('admin/licenses/form.to_email') }}</label>
     <div class="col-md-7">
-        <input class="form-control" type="text" name="license_email" id="license_email" value="{{ Input::old('license_email', $item->license_email) }}" />
+        <input class="form-control" type="text" name="license_email" id="license_email" value="{{ Request::old('license_email', $item->license_email) }}" />
         {!! $errors->first('license_email', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -58,7 +58,7 @@
 <div class="form-group {{ $errors->has('reassignable') ? ' has-error' : '' }}">
     <label for="reassignable" class="col-md-3 control-label">{{ trans('admin/licenses/form.reassignable') }}</label>
     <div class="col-md-7 input-group">
-        {{ Form::Checkbox('reassignable', '1', Input::old('reassignable', $item->id ? $item->reassignable : '1'),array('class' => 'minimal')) }}
+        {{ Form::Checkbox('reassignable', '1', Request::old('reassignable', $item->id ? $item->reassignable : '1'),array('class' => 'minimal')) }}
         {{ trans('general.yes') }}
     </div>
 </div>
@@ -75,7 +75,7 @@
 
     <div class="input-group col-md-3">
         <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expiration_date" id="expiration_date" value="{{ Input::old('expiration_date', $item->expiration_date) }}">
+            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expiration_date" id="expiration_date" value="{{ Request::old('expiration_date', $item->expiration_date) }}">
             <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
         </div>
         {!! $errors->first('expiration_date', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -89,7 +89,7 @@
 
     <div class="input-group col-md-3">
         <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="termination_date" id="termination_date" value="{{ Input::old('termination_date', $item->termination_date) }}">
+            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="termination_date" id="termination_date" value="{{ Request::old('termination_date', $item->termination_date) }}">
             <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
         </div>
         {!! $errors->first('termination_date', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
@@ -101,7 +101,7 @@
 <div class="form-group {{ $errors->has('purchase_order') ? ' has-error' : '' }}">
     <label for="purchase_order" class="col-md-3 control-label">{{ trans('admin/licenses/form.purchase_order') }}</label>
     <div class="col-md-3">
-        <input class="form-control" type="text" name="purchase_order" id="purchase_order" value="{{ Input::old('purchase_order', $item->purchase_order) }}" />
+        <input class="form-control" type="text" name="purchase_order" id="purchase_order" value="{{ Request::old('purchase_order', $item->purchase_order) }}" />
         {!! $errors->first('purchase_order', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -112,7 +112,7 @@
 <div class="form-group {{ $errors->has('maintained') ? ' has-error' : '' }}">
     <label for="maintained" class="col-md-3 control-label">{{ trans('admin/licenses/form.maintained') }}</label>
     <div class="checkbox col-md-7">
-        {{ Form::Checkbox('maintained', '1', Input::old('maintained', $item->maintained),array('class' => 'minimal')) }}
+        {{ Form::Checkbox('maintained', '1', Request::old('maintained', $item->maintained),array('class' => 'minimal')) }}
         {{ trans('general.yes') }}
     </div>
 </div>

--- a/resources/views/locations/edit.blade.php
+++ b/resources/views/locations/edit.blade.php
@@ -23,7 +23,7 @@
         {{ trans('admin/locations/table.currency') }}
     </label>
     <div class="col-md-9{{  (\App\Helpers\Helper::checkIfRequired($item, 'currency')) ? ' required' : '' }}">
-        {{ Form::text('currency', Input::old('currency', $item->currency), array('class' => 'form-control','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+        {{ Form::text('currency', Request::old('currency', $item->currency), array('class' => 'form-control','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
         {!! $errors->first('currency', '<span class="alert-msg">:message</span>') !!}
     </div>
 </div>
@@ -37,7 +37,7 @@
             {{ trans('admin/locations/table.ldap_ou') }}
         </label>
         <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'ldap_ou')) ? ' required' : '' }}">
-            {{ Form::text('ldap_ou', Input::old('ldap_ou', $item->ldap_ou), array('class' => 'form-control')) }}
+            {{ Form::text('ldap_ou', Request::old('ldap_ou', $item->ldap_ou), array('class' => 'form-control')) }}
             {!! $errors->first('ldap_ou', '<span class="alert-msg">:message</span>') !!}
         </div>
     </div>

--- a/resources/views/locations/edit.blade.php
+++ b/resources/views/locations/edit.blade.php
@@ -4,7 +4,7 @@
     'topSubmit' => true,
     'helpPosition' => 'right',
     'helpText' => trans('admin/locations/table.about_locations'),
-    'formAction' => ($item) ? route('locations.update', ['location' => $item->id]) : route('locations.store'),
+    'formAction' => (isset($item->id)) ? route('locations.update', ['location' => $item->id]) : route('locations.store'),
 ])
 
 {{-- Page content --}}

--- a/resources/views/manufacturers/edit.blade.php
+++ b/resources/views/manufacturers/edit.blade.php
@@ -15,7 +15,7 @@
         <label for="url" class="col-md-3 control-label">{{ trans('admin/manufacturers/table.url') }}
         </label>
         <div class="col-md-6">
-            <input class="form-control" type="text" name="url" id="url" value="{{ Input::old('url', $item->url) }}" />
+            <input class="form-control" type="text" name="url" id="url" value="{{ Request::old('url', $item->url) }}" />
             {!! $errors->first('url', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
         </div>
     </div>
@@ -25,7 +25,7 @@
         <label for="support_url" class="col-md-3 control-label">{{ trans('admin/manufacturers/table.support_url') }}
         </label>
         <div class="col-md-6">
-            <input class="form-control" type="text" name="support_url" id="support_url" value="{{ Input::old('support_url', $item->support_url) }}" />
+            <input class="form-control" type="text" name="support_url" id="support_url" value="{{ Request::old('support_url', $item->support_url) }}" />
             {!! $errors->first('support_url', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
         </div>
     </div>
@@ -35,7 +35,7 @@
         <label for="support_phone" class="col-md-3 control-label">{{ trans('admin/manufacturers/table.support_phone') }}
         </label>
         <div class="col-md-6">
-            <input class="form-control" type="text" name="support_phone" id="support_phone" value="{{ Input::old('support_phone', $item->support_phone) }}" />
+            <input class="form-control" type="text" name="support_phone" id="support_phone" value="{{ Request::old('support_phone', $item->support_phone) }}" />
             {!! $errors->first('support_phone', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
         </div>
     </div>
@@ -45,7 +45,7 @@
         <label for="support_email" class="col-md-3 control-label">{{ trans('admin/manufacturers/table.support_email') }}
         </label>
         <div class="col-md-6">
-            <input class="form-control" type="email" name="support_email" id="support_email" value="{{ Input::old('support_email', $item->support_email) }}" />
+            <input class="form-control" type="email" name="support_email" id="support_email" value="{{ Request::old('support_email', $item->support_email) }}" />
             {!! $errors->first('support_email', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
         </div>
     </div>

--- a/resources/views/manufacturers/edit.blade.php
+++ b/resources/views/manufacturers/edit.blade.php
@@ -3,7 +3,7 @@
     'updateText' => trans('admin/manufacturers/table.update'),
     'helpTitle' => trans('admin/manufacturers/table.about_manufacturers_title'),
     'helpText' => trans('admin/manufacturers/table.about_manufacturers_text'),
-    'formAction' => ($item) ? route('manufacturers.update', ['manufacturer' => $item->id]) : route('manufacturers.store'),
+    'formAction' => (isset($item->id)) ? route('manufacturers.update', ['manufacturer' => $item->id]) : route('manufacturers.store'),
 ])
 
 

--- a/resources/views/manufacturers/index.blade.php
+++ b/resources/views/manufacturers/index.blade.php
@@ -13,7 +13,7 @@
     {{ trans('general.create') }}</a>
   @endcan
 
-  @if (Input::get('deleted')=='true')
+  @if (Request::get('deleted')=='true')
     <a class="btn btn-default pull-right" href="{{ route('manufacturers.index') }}" style="margin-right: 5px;">{{ trans('general.show_current') }}</a>
   @else
     <a class="btn btn-default pull-right" href="{{ route('manufacturers.index', ['deleted' => 'true']) }}" style="margin-right: 5px;">
@@ -45,7 +45,7 @@
             data-sort-order="asc"
             id="manufacturersTable"
             class="table table-striped snipe-table"
-            data-url="{{route('api.manufacturers.index', ['deleted' => e(Input::get('deleted')) ]) }}"
+            data-url="{{route('api.manufacturers.index', ['deleted' => e(Request::get('deleted')) ]) }}"
             data-export-options='{
               "fileName": "export-manufacturers-{{ date('Y-m-d') }}",
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]

--- a/resources/views/modals/location.blade.php
+++ b/resources/views/modals/location.blade.php
@@ -22,7 +22,7 @@
 
                 <div class="dynamic-form-row">
                     <div class="col-md-4 col-xs-12 country"><label for="modal-country">{{ trans('general.country') }}:</label></div>
-                    <div class="col-md-8 col-xs-12">{!! Form::countries('country', Input::old('country'), 'select2 country',"modal-country") !!}</div>
+                    <div class="col-md-8 col-xs-12">{!! Form::countries('country', Request::old('country'), 'select2 country',"modal-country") !!}</div>
                 </div>
             </form>
         </div>

--- a/resources/views/modals/model.blade.php
+++ b/resources/views/modals/model.blade.php
@@ -38,7 +38,7 @@
 
                 <div class="dynamic-form-row">
                     <div class="col-md-4 col-xs-12"><label for="modal-fieldset_id">{{ trans('admin/models/general.fieldset') }}:</label></div>
-                    <div class="col-md-8 col-xs-12">{{ Form::select('fieldset_id', \App\Helpers\Helper::customFieldsetList(),Input::old('fieldset_id'), array('class'=>'select2', 'id'=>'modal-fieldset_id', 'style'=>'width:350px')) }}</div>
+                    <div class="col-md-8 col-xs-12">{{ Form::select('fieldset_id', \App\Helpers\Helper::customFieldsetList(),Request::old('fieldset_id'), array('class'=>'select2', 'id'=>'modal-fieldset_id', 'style'=>'width:350px')) }}</div>
                 </div>
         </div>
         <div class="modal-footer">

--- a/resources/views/modals/upload-file.blade.php
+++ b/resources/views/modals/upload-file.blade.php
@@ -31,7 +31,7 @@
                     </div>
 
                     <div class="col-md-12">
-                        {{ Form::textarea('notes', Input::old('notes', Input::old('notes')), ['class' => 'form-control','placeholder' => 'Notes (Optional)', 'rows'=>3]) }}
+                        {{ Form::textarea('notes', Request::old('notes', Request::old('notes')), ['class' => 'form-control','placeholder' => 'Notes (Optional)', 'rows'=>3]) }}
                     </div>
                 </div>
 

--- a/resources/views/models/bulk-edit.blade.php
+++ b/resources/views/models/bulk-edit.blade.php
@@ -39,7 +39,7 @@
                                 {{ trans('admin/models/general.fieldset') }}
                             </label>
                             <div class="col-md-7">
-                                {{ Form::select('fieldset_id', $fieldset_list , Input::old('fieldset_id', 'NC'), array('class'=>'select2 js-fieldset-field', 'style'=>'width:350px')) }}
+                                {{ Form::select('fieldset_id', $fieldset_list , Request::old('fieldset_id', 'NC'), array('class'=>'select2 js-fieldset-field', 'style'=>'width:350px')) }}
                                 {!! $errors->first('fieldset_id', '<span class="alert-msg"><br><i class="fa fa-times"></i> :message</span>') !!}
                             </div>
                         </div>
@@ -51,7 +51,7 @@
                                 {{ trans('general.depreciation') }}
                             </label>
                             <div class="col-md-7">
-                                {{ Form::select('depreciation_id', $depreciation_list , Input::old('depreciation_id', 'NC'), array('class'=>'select2', 'style'=>'width:350px')) }}
+                                {{ Form::select('depreciation_id', $depreciation_list , Request::old('depreciation_id', 'NC'), array('class'=>'select2', 'style'=>'width:350px')) }}
                                 {!! $errors->first('depreciation_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                             </div>
                         </div>

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -9,10 +9,10 @@
               <!-- Listbox -->
               @if ($field->element=='listbox')
                   {{ Form::select($field->db_column_name(), $field->formatFieldValuesAsArray(),
-                  Input::old($field->db_column_name(),(isset($item) ? $item->{$field->db_column_name()} : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
+                  Request::old($field->db_column_name(),(isset($item) ? $item->{$field->db_column_name()} : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
 
               @elseif ($field->element=='textarea')
-                      <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ Input::old($field->db_column_name(),(isset($item) ? $item->{$field->db_column_name()} : $field->defaultValue($model->id))) }}</textarea>
+                      <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ Request::old($field->db_column_name(),(isset($item) ? $item->{$field->db_column_name()} : $field->defaultValue($model->id))) }}</textarea>
 
 
               @elseif ($field->element=='checkbox')
@@ -21,7 +21,7 @@
 
                       <div>
                           <label>
-                              <input type="checkbox" value="1" name="{{ $field->db_column_name() }}[]" class="minimal" {{ Input::old($field->db_column_name()) != '' ? ' checked="checked"' : '' }}> key: {{ $key }} value: {{ $value }}
+                              <input type="checkbox" value="1" name="{{ $field->db_column_name() }}[]" class="minimal" {{ Request::old($field->db_column_name()) != '' ? ' checked="checked"' : '' }}> key: {{ $key }} value: {{ $value }}
                           </label>
                       </div>
                   @endforeach
@@ -36,7 +36,7 @@
 
                         <div class="input-group col-md-4" style="padding-left: 0px;">
                             <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-                                <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="{{ $field->db_column_name() }}" id="{{ $field->db_column_name() }}" value="{{ Input::old($field->db_column_name(),(isset($item) ? \App\Helpers\Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : "")) }}">
+                                <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="{{ $field->db_column_name() }}" id="{{ $field->db_column_name() }}" value="{{ Request::old($field->db_column_name(),(isset($item) ? \App\Helpers\Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : "")) }}">
                                 <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
                             </div>
                         </div>
@@ -44,7 +44,7 @@
 
                 @else
                     @if (($field->field_encrypted=='0') || (Gate::allows('admin')))
-                    <input type="text" value="{{ Input::old($field->db_column_name(),(isset($item) ? \App\Helpers\Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}" id="{{ $field->db_column_name() }}" class="form-control" name="{{ $field->db_column_name() }}" placeholder="Enter {{ strtolower($field->format) }} text">
+                    <input type="text" value="{{ Request::old($field->db_column_name(),(isset($item) ? \App\Helpers\Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}" id="{{ $field->db_column_name() }}" class="form-control" name="{{ $field->db_column_name() }}" placeholder="Enter {{ strtolower($field->format) }} text">
                         @else
                             <input type="text" value="{{ strtoupper(trans('admin/custom_fields/general.encrypted')) }}" class="form-control disabled" disabled>
                     @endif

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -22,7 +22,7 @@
     <label for="eol" class="col-md-3 control-label">{{ trans('general.eol') }}</label>
     <div class="col-md-2">
         <div class="input-group">
-            <input class="col-md-1 form-control" type="text" name="eol" id="eol" value="{{ Input::old('eol', isset($item->eol)) ? $item->eol : ''  }}" />
+            <input class="col-md-1 form-control" type="text" name="eol" id="eol" value="{{ Request::old('eol', isset($item->eol)) ? $item->eol : ''  }}" />
             <span class="input-group-addon">
                 {{ trans('general.months') }}
             </span>
@@ -38,10 +38,10 @@
     <div class="form-group {{ $errors->has('custom_fieldset') ? ' has-error' : '' }}">
         <label for="custom_fieldset" class="col-md-3 control-label">{{ trans('admin/models/general.fieldset') }}</label>
         <div class="col-md-7">
-            {{ Form::select('custom_fieldset', \App\Helpers\Helper::customFieldsetList(),Input::old('custom_fieldset', $item->fieldset_id), array('class'=>'select2 js-fieldset-field', 'style'=>'width:350px')) }}
+            {{ Form::select('custom_fieldset', \App\Helpers\Helper::customFieldsetList(),Request::old('custom_fieldset', $item->fieldset_id), array('class'=>'select2 js-fieldset-field', 'style'=>'width:350px')) }}
             {!! $errors->first('custom_fieldset', '<span class="alert-msg"><br><i class="fa fa-times"></i> :message</span>') !!}
             <label class="m-l-xs">
-                {{ Form::checkbox('add_default_values', 1, Input::old('add_default_values'), ['class' => 'js-default-values-toggler']) }}
+                {{ Form::checkbox('add_default_values', 1, Request::old('add_default_values'), ['class' => 'js-default-values-toggler']) }}
                 {{ trans('admin/models/general.add_default_values') }}
             </label>
         </div>
@@ -49,8 +49,8 @@
 
     <fieldset-default-values
         model-id="{{ $item->id ?: '' }}"
-        fieldset-id="{{ !empty($item->fieldset) ? $item->fieldset->id : Input::old('custom_fieldset') }}"
-        previous-input="{{ json_encode(Input::old('default_values')) }}">
+        fieldset-id="{{ !empty($item->fieldset) ? $item->fieldset->id : Request::old('custom_fieldset') }}"
+        previous-input="{{ json_encode(Request::old('default_values')) }}">
     </fieldset-default-values>
 </div>
 

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -4,7 +4,7 @@
     'topSubmit' => true,
     'helpPosition' => 'right',
     'helpText' => trans('admin/models/general.about_models_text'),
-    'formAction' => ($item) ? route('models.update', ['model' => $item->id]) : route('models.store'),
+    'formAction' => (isset($item->id)) ? route('models.update', ['model' => $item->id]) : route('models.store'),
 ])
 
 {{-- Page content --}}

--- a/resources/views/models/index.blade.php
+++ b/resources/views/models/index.blade.php
@@ -3,7 +3,7 @@
 {{-- Page title --}}
 @section('title')
 
-  @if (Input::get('status')=='deleted')
+  @if (Request::get('status')=='deleted')
     {{ trans('admin/models/general.view_deleted') }}
     {{ trans('admin/models/table.title') }}
     @else
@@ -18,7 +18,7 @@
     <a href="{{ route('models.create') }}" class="btn btn-primary pull-right"></i> {{ trans('general.create') }}</a>
   @endcan
 
-  @if (Input::get('status')=='deleted')
+  @if (Request::get('status')=='deleted')
     <a class="btn btn-default pull-right" href="{{ route('models.index') }}" style="margin-right: 5px;">{{ trans('admin/models/general.view_models') }}</a>
   @else
     <a class="btn btn-default pull-right" href="{{ route('models.index', ['status' => 'deleted']) }}" style="margin-right: 5px;">{{ trans('admin/models/general.view_deleted') }}</a>
@@ -43,7 +43,7 @@
         <div class="row">
           <div class="col-md-12">
 
-            @if (Input::get('status')!='deleted')
+            @if (Request::get('status')!='deleted')
               <div id="toolbar">
                 <select name="bulk_actions" class="form-control select2" style="width: 300px;">
                   <option value="edit">Bulk Edit</option>
@@ -65,7 +65,7 @@
                   data-show-refresh="true"
                   data-sort-order="asc"
                   id="modelsTable"
-                  data-url="{{ route('api.models.index', ['status'=> e(Input::get('status'))]) }}"
+                  data-url="{{ route('api.models.index', ['status'=> e(Request::get('status'))]) }}"
                   class="table table-striped snipe-table"
                   data-export-options='{
                 "fileName": "export-asset-models-{{ date('Y-m-d') }}",

--- a/resources/views/partials/forms/edit/accessory-select.blade.php
+++ b/resources/views/partials/forms/edit/accessory-select.blade.php
@@ -4,7 +4,7 @@
     <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
         <select class="js-data-ajax select2" data-endpoint="accessories" data-placeholder="{{ trans('general.select_accessory') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_accessory_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}>
 
-            @if ((!isset($unselect)) && ($accessory_id = Input::old($fieldname, (isset($accessory) ? $accessory->id  : (isset($item) ? $item->{$fieldname} : '')))))
+            @if ((!isset($unselect)) && ($accessory_id = Request::old($fieldname, (isset($accessory) ? $accessory->id  : (isset($item) ? $item->{$fieldname} : '')))))
                 <option value="{{ $accessory_id }}" selected="selected">
                     {{ (\App\Models\Accessory::find($accessory_id)) ? \App\Models\Accessory::find($accessory_id)->present()->name : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/address.blade.php
+++ b/resources/views/partials/forms/edit/address.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group {{ $errors->has('address') ? ' has-error' : '' }}">
     {{ Form::label('address', trans('general.address'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-        {{Form::text('address', Input::old('address', $item->address), array('class' => 'form-control')) }}
+        {{Form::text('address', Request::old('address', $item->address), array('class' => 'form-control')) }}
         {!! $errors->first('address', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -9,7 +9,7 @@
 <div class="form-group {{ $errors->has('address2') ? ' has-error' : '' }}">
     {{ Form::label('address2', ' ', array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-        {{Form::text('address2', Input::old('address2', $item->address2), array('class' => 'form-control')) }}
+        {{Form::text('address2', Request::old('address2', $item->address2), array('class' => 'form-control')) }}
         {!! $errors->first('address2', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -17,7 +17,7 @@
 <div class="form-group {{ $errors->has('city') ? ' has-error' : '' }}">
     {{ Form::label('city', trans('general.city'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-    {{Form::text('city', Input::old('city', $item->city), array('class' => 'form-control')) }}
+    {{Form::text('city', Request::old('city', $item->city), array('class' => 'form-control')) }}
         {!! $errors->first('city', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -25,7 +25,7 @@
 <div class="form-group {{ $errors->has('state') ? ' has-error' : '' }}">
     {{ Form::label('state', trans('general.state'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-    {{Form::text('state', Input::old('state', $item->state), array('class' => 'form-control')) }}
+    {{Form::text('state', Request::old('state', $item->state), array('class' => 'form-control')) }}
         {!! $errors->first('state', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -33,7 +33,7 @@
 <div class="form-group {{ $errors->has('country') ? ' has-error' : '' }}">
     {{ Form::label('country', trans('general.country'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-5">
-    {!! Form::countries('country', Input::old('country', $item->country), 'select2') !!}
+    {!! Form::countries('country', Request::old('country', $item->country), 'select2') !!}
         {!! $errors->first('country', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -41,7 +41,7 @@
 <div class="form-group {{ $errors->has('zip') ? ' has-error' : '' }}">
     {{ Form::label('zip', trans('general.zip'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-    {{Form::text('zip', Input::old('zip', $item->zip), array('class' => 'form-control')) }}
+    {{Form::text('zip', Request::old('zip', $item->zip), array('class' => 'form-control')) }}
         {!! $errors->first('zip', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/asset-select.blade.php
+++ b/resources/views/partials/forms/edit/asset-select.blade.php
@@ -4,7 +4,7 @@
     <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
         <select class="js-data-ajax select2" data-endpoint="hardware" data-placeholder="{{ trans('general.select_asset') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_asset_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}{!! (!empty($asset_status_type)) ? ' data-asset-status-type="' . $asset_status_type . '"' : '' !!}>
 
-            @if ((!isset($unselect)) && ($asset_id = Input::old($fieldname, (isset($asset) ? $asset->id  : (isset($item) ? $item->{$fieldname} : '')))))
+            @if ((!isset($unselect)) && ($asset_id = Request::old($fieldname, (isset($asset) ? $asset->id  : (isset($item) ? $item->{$fieldname} : '')))))
                 <option value="{{ $asset_id }}" selected="selected">
                     {{ (\App\Models\Asset::find($asset_id)) ? \App\Models\Asset::find($asset_id)->present()->fullName : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/category-select.blade.php
+++ b/resources/views/partials/forms/edit/category-select.blade.php
@@ -5,7 +5,7 @@
 
     <div class="col-md-7{{  ((isset($required)) && ($required=='true')) ? ' required' : '' }}">
         <select class="js-data-ajax" data-endpoint="categories/{{ (isset($category_type)) ? $category_type : 'assets' }}" data-placeholder="{{ trans('general.select_category') }}" name="{{ $fieldname }}" style="width: 100%" id="category_select_id">
-            @if ($category_id = Input::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
+            @if ($category_id = Request::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $category_id }}" selected="selected">
                     {{ (\App\Models\Category::find($category_id)) ? \App\Models\Category::find($category_id)->name : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/category.blade.php
+++ b/resources/views/partials/forms/edit/category.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('category_id') ? ' has-error' : '' }}">
     <label for="category_id" class="col-md-3 control-label">{{ trans('general.category') }}</label>
     <div class="col-md-7 col-sm-12{{  (\App\Helpers\Helper::checkIfRequired($item, 'category_id')) ? ' required' : '' }}">
-        {{ Form::select('category_id', $category_list , Input::old('category_id', $item->category_id), array('class'=>'select2', 'style'=>'width:100%')) }}
+        {{ Form::select('category_id', $category_list , Request::old('category_id', $item->category_id), array('class'=>'select2', 'style'=>'width:100%')) }}
         {!! $errors->first('category_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/company-select.blade.php
+++ b/resources/views/partials/forms/edit/company-select.blade.php
@@ -16,7 +16,7 @@
         {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
         <div class="col-md-7">
             <select class="js-data-ajax" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" id="company_select">
-                @if ($company_id = Input::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
+                @if ($company_id = Request::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                     <option value="{{ $company_id }}" selected="selected">
                         {{ (\App\Models\Company::find($company_id)) ? \App\Models\Company::find($company_id)->name : '' }}
                     </option>

--- a/resources/views/partials/forms/edit/company.blade.php
+++ b/resources/views/partials/forms/edit/company.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('company_id') ? ' has-error' : '' }}">
    <div class="col-md-3 control-label">{{ Form::label('company_id', trans('general.company')) }}</div>
     <div class="col-md-7 col-sm-12{{  (\App\Helpers\Helper::checkIfRequired($item, 'company_id')) ? ' required' : '' }}">
-       {{ Form::select('company_id', $company_list , Input::old('company_id', $item->company_id), array('class'=>'select2', 'style'=>'width:100%')) }}
+       {{ Form::select('company_id', $company_list , Request::old('company_id', $item->company_id), array('class'=>'select2', 'style'=>'width:100%')) }}
        {!! $errors->first('company_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
    </div>
 </div>

--- a/resources/views/partials/forms/edit/consumable-select.blade.php
+++ b/resources/views/partials/forms/edit/consumable-select.blade.php
@@ -4,7 +4,7 @@
     <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
         <select class="js-data-ajax select2" data-endpoint="consumables" data-placeholder="{{ trans('general.select_consumable') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_consumable_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}>
         
-            @if ((!isset($unselect)) && ($consumable_id = Input::old($fieldname, (isset($consumable) ? $consumable->id  : (isset($item) ? $item->{$fieldname} : '')))))
+            @if ((!isset($unselect)) && ($consumable_id = Request::old($fieldname, (isset($consumable) ? $consumable->id  : (isset($item) ? $item->{$fieldname} : '')))))
                 <option value="{{ $consumable_id }}" selected="selected">
                     {{ (\App\Models\Consumable::find($consumable_id)) ? \App\Models\Consumable::find($consumable_id)->present()->name : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/department-select.blade.php
+++ b/resources/views/partials/forms/edit/department-select.blade.php
@@ -4,7 +4,7 @@
 
     <div class="col-md-7">
         <select class="js-data-ajax" data-endpoint="departments" data-placeholder="{{ trans('general.select_department') }}" name="{{ $fieldname }}" style="width: 100%" id="department_select">
-            @if ($department_id = Input::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
+            @if ($department_id = Request::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $department_id }}" selected="selected">
                     {{ (\App\Models\Department::find($department_id)) ? \App\Models\Department::find($department_id)->name : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/depreciation.blade.php
+++ b/resources/views/partials/forms/edit/depreciation.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('depreciation_id') ? ' has-error' : '' }}">
     <label for="depreciation_id" class="col-md-3 control-label">{{ trans('general.depreciation') }}</label>
     <div class="col-md-7">
-        {{ Form::select('depreciation_id', $depreciation_list , Input::old('depreciation_id', $item->depreciation_id), array('class'=>'select2', 'style'=>'width:350px')) }}
+        {{ Form::select('depreciation_id', $depreciation_list , Request::old('depreciation_id', $item->depreciation_id), array('class'=>'select2', 'style'=>'width:350px')) }}
         {!! $errors->first('depreciation_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/email.blade.php
+++ b/resources/views/partials/forms/edit/email.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group {{ $errors->has('email') ? ' has-error' : '' }}">
     {{ Form::label('email', trans('admin/suppliers/table.email'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-    {{Form::text('email', Input::old('email', $item->email), array('class' => 'form-control')) }}
+    {{Form::text('email', Request::old('email', $item->email), array('class' => 'form-control')) }}
         {!! $errors->first('email', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/item_number.blade.php
+++ b/resources/views/partials/forms/edit/item_number.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('item_no') ? ' has-error' : '' }}">
    <label for="item_no" class="col-md-3 control-label">{{ trans('admin/consumables/general.item_no') }}</label>
    <div class="col-md-7 col-sm-12{{  (\App\Helpers\Helper::checkIfRequired($item, 'item_no')) ? ' required' : '' }}">
-       <input class="form-control" type="text" name="item_no" id="item_no" value="{{ Input::old('item_no', $item->item_no) }}" />
+       <input class="form-control" type="text" name="item_no" id="item_no" value="{{ Request::old('item_no', $item->item_no) }}" />
        {!! $errors->first('item_no', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
    </div>
 </div>

--- a/resources/views/partials/forms/edit/kit-select.blade.php
+++ b/resources/views/partials/forms/edit/kit-select.blade.php
@@ -4,7 +4,7 @@
 
     <div class="col-md-7{{  ((isset($required)) && ($required=='true')) ? ' required' : '' }}">
         <select class="js-data-ajax" data-endpoint="kits" data-placeholder="Select a kit{{-- TODO: trans --}}" name="{{ $fieldname }}" style="width: 100%" id="kit_id_select">
-            @if ($kit_id = Input::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
+            @if ($kit_id = Request::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $kit_id }}" selected="selected">
                     {{ (\App\Models\User::find($kit_id)) ? \App\Models\User::find($kit_id)->present()->fullName : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/license-select.blade.php
+++ b/resources/views/partials/forms/edit/license-select.blade.php
@@ -4,7 +4,7 @@
     <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
         <select class="js-data-ajax select2" data-endpoint="licenses" data-placeholder="{{ trans('general.select_license') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_license_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}>
 
-            @if ((!isset($unselect)) && ($license_id = Input::old($fieldname, (isset($license) ? $license->id  : (isset($item) ? $item->{$fieldname} : '')))))
+            @if ((!isset($unselect)) && ($license_id = Request::old($fieldname, (isset($license) ? $license->id  : (isset($item) ? $item->{$fieldname} : '')))))
                 <option value="{{ $license_id }}" selected="selected">
                     {{ (\App\Models\License::find($license_id)) ? \App\Models\License::find($license_id)->present()->fullName : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/location-profile-select.blade.php
+++ b/resources/views/partials/forms/edit/location-profile-select.blade.php
@@ -4,7 +4,7 @@
     {{ Form::label('location_id', $translated_name, array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
         <select class="js-data-ajax" data-endpoint="locations" data-placeholder="{{ trans('general.select_location') }}" name="location_id" style="width: 100%" id="location_id_location_select">
-            @if ($location_id = Input::old('location_id', (isset($user)) ? $user->location_id : ''))
+            @if ($location_id = Request::old('location_id', (isset($user)) ? $user->location_id : ''))
                 <option value="{{ $location_id }}" selected="selected">
                     {{ (\App\Models\Location::find($location_id)) ? \App\Models\Location::find($location_id)->name : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/location-select.blade.php
+++ b/resources/views/partials/forms/edit/location-select.blade.php
@@ -4,7 +4,7 @@
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
         <select class="js-data-ajax" data-endpoint="locations" data-placeholder="{{ trans('general.select_location') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ $fieldname }}_location_select">
-            @if ($location_id = Input::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
+            @if ($location_id = Request::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $location_id }}" selected="selected">
                     {{ (\App\Models\Location::find($location_id)) ? \App\Models\Location::find($location_id)->name : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/location.blade.php
+++ b/resources/views/partials/forms/edit/location.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('location_id') ? ' has-error' : '' }}">
     <label for="location_id" class="col-md-3 control-label">{{ trans('general.location') }}</label>
     <div class="col-md-7 col-sm-12{{  (\App\Helpers\Helper::checkIfRequired($item, 'location_id')) ? ' required' : '' }}">
-        {{ Form::select('location_id', $location_list , Input::old('location_id', $item->location_id), array('class'=>'select2', 'style'=>'width:350px')) }}
+        {{ Form::select('location_id', $location_list , Request::old('location_id', $item->location_id), array('class'=>'select2', 'style'=>'width:350px')) }}
         {!! $errors->first('location_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/maintenance_type.blade.php
+++ b/resources/views/partials/forms/edit/maintenance_type.blade.php
@@ -3,7 +3,7 @@
               <label for="asset_maintenance_type" class="col-md-3 control-label">{{ trans('admin/asset_maintenances/form.asset_maintenance_type') }}
               </label>
               <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'asset_maintenance_type')) ? ' required' : '' }}">
-                  {{ Form::select('asset_maintenance_type', $assetMaintenanceType , Input::old('asset_maintenance_type', $item->asset_maintenance_type), ['class'=>'select2', 'style'=>'min-width:350px']) }}
+                  {{ Form::select('asset_maintenance_type', $assetMaintenanceType , Request::old('asset_maintenance_type', $item->asset_maintenance_type), ['class'=>'select2', 'style'=>'min-width:350px']) }}
                   {!! $errors->first('asset_maintenance_type', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
               </div>
           </div>

--- a/resources/views/partials/forms/edit/manufacturer-select.blade.php
+++ b/resources/views/partials/forms/edit/manufacturer-select.blade.php
@@ -5,7 +5,7 @@
 
     <div class="col-md-7{{  ((isset($required)) && ($required=='true')) ? ' required' : '' }}">
         <select class="js-data-ajax" data-endpoint="manufacturers" data-placeholder="{{ trans('general.select_manufacturer') }}" name="{{ $fieldname }}" style="width: 100%" id="manufacturer_select_id">
-            @if ($manufacturer_id = Input::old($fieldname,  (isset($item)) ? $item->{$fieldname} : ''))
+            @if ($manufacturer_id = Request::old($fieldname,  (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $manufacturer_id }}" selected="selected">
                     {{ (\App\Models\Manufacturer::find($manufacturer_id)) ? \App\Models\Manufacturer::find($manufacturer_id)->name : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/manufacturer.blade.php
+++ b/resources/views/partials/forms/edit/manufacturer.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('manufacturer_id') ? ' has-error' : '' }}">
     <label for="manufacturer_id" class="col-md-3 control-label">{{ trans('general.manufacturer') }}</label>
     <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'manufacturer_id')) ? ' required' : '' }}">
-        {{ Form::select('manufacturer_id', $manufacturer_list , Input::old('manufacturer_id', $item->manufacturer_id), array('class'=>'select2', 'style'=>'width:100%')) }}
+        {{ Form::select('manufacturer_id', $manufacturer_list , Request::old('manufacturer_id', $item->manufacturer_id), array('class'=>'select2', 'style'=>'width:100%')) }}
         {!! $errors->first('manufacturer_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/minimum_quantity.blade.php
+++ b/resources/views/partials/forms/edit/minimum_quantity.blade.php
@@ -3,7 +3,7 @@
     <label for="min_amt" class="col-md-3 control-label">{{ trans('general.min_amt') }}</label>
     <div class="col-md-9{{  (\App\Helpers\Helper::checkIfRequired($item, 'min_amt')) ? ' required' : '' }}">
        <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control col-md-3" type="text" name="min_amt" id="min_amt" value="{{ Input::old('min_amt', $item->min_amt) }}" />
+            <input class="form-control col-md-3" type="text" name="min_amt" id="min_amt" value="{{ Request::old('min_amt', $item->min_amt) }}" />
         </div>
             <div class="col-md-7" style="margin-left: -15px;">
             <a href="#" data-toggle="tooltip" title="{{ trans('general.min_amt_help') }}"><i class="fa fa-info-circle"></i></a>

--- a/resources/views/partials/forms/edit/model-select.blade.php
+++ b/resources/views/partials/forms/edit/model-select.blade.php
@@ -5,7 +5,7 @@
 
     <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
         <select class="js-data-ajax" data-endpoint="models" data-placeholder="{{ trans('general.select_model') }}" name="{{ $fieldname }}" style="width: 100%" id="model_select_id" {!!  ((isset($required) && ($required =='true'))) ?  ' data-validation="required"' : '' !!}>
-            @if ($model_id = Input::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
+            @if ($model_id = Request::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $model_id }}" selected="selected">
                     {{ (\App\Models\AssetModel::find($model_id)) ? \App\Models\AssetModel::find($model_id)->name : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/model_number.blade.php
+++ b/resources/views/partials/forms/edit/model_number.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('model_number') ? ' has-error' : '' }}">
     <label for="model_number" class="col-md-3 control-label">{{ trans('general.model_no') }}</label>
     <div class="col-md-7">
-    <input class="form-control" type="text" name="model_number" id="model_number" value="{{ Input::old('model_number', $item->model_number) }}" />
+    <input class="form-control" type="text" name="model_number" id="model_number" value="{{ Request::old('model_number', $item->model_number) }}" />
         {!! $errors->first('model_number', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/name.blade.php
+++ b/resources/views/partials/forms/edit/name.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('name') ? ' has-error' : '' }}">
     <label for="name" class="col-md-3 control-label">{{ $translated_name }}</label>
     <div class="col-md-7 col-sm-12{{  (\App\Helpers\Helper::checkIfRequired($item, 'name')) ? ' required' : '' }}">
-        <input class="form-control" type="text" name="name" id="name" value="{{ Input::old('name', $item->name) }}" {!!   (\App\Helpers\Helper::checkIfRequired($item, 'name')) ? ' data-validation="required"' : '' !!}>
+        <input class="form-control" type="text" name="name" id="name" value="{{ Request::old('name', $item->name) }}" {!!   (\App\Helpers\Helper::checkIfRequired($item, 'name')) ? ' data-validation="required"' : '' !!}>
         {!! $errors->first('name', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/notes.blade.php
+++ b/resources/views/partials/forms/edit/notes.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('notes') ? ' has-error' : '' }}">
     <label for="notes" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
     <div class="col-md-7 col-sm-12">
-        <textarea class="col-md-6 form-control" id="notes" name="notes">{{ Input::old('notes', $item->notes) }}</textarea>
+        <textarea class="col-md-6 form-control" id="notes" name="notes">{{ Request::old('notes', $item->notes) }}</textarea>
         {!! $errors->first('notes', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/order_number.blade.php
+++ b/resources/views/partials/forms/edit/order_number.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('order_number') ? ' has-error' : '' }}">
    <label for="order_number" class="col-md-3 control-label">{{ trans('general.order_number') }}</label>
    <div class="col-md-7 col-sm-12">
-       <input class="form-control" type="text" name="order_number" id="order_number" value="{{ Input::old('order_number', $item->order_number) }}" />
+       <input class="form-control" type="text" name="order_number" id="order_number" value="{{ Request::old('order_number', $item->order_number) }}" />
        {!! $errors->first('order_number', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
    </div>
 </div>

--- a/resources/views/partials/forms/edit/phone.blade.php
+++ b/resources/views/partials/forms/edit/phone.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group {{ $errors->has('phone') ? ' has-error' : '' }}">
     {{ Form::label('phone', trans('admin/suppliers/table.phone'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-    {{Form::text('phone', Input::old('phone', $item->phone), array('class' => 'form-control')) }}
+    {{Form::text('phone', Request::old('phone', $item->phone), array('class' => 'form-control')) }}
         {!! $errors->first('phone', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/purchase_cost.blade.php
+++ b/resources/views/partials/forms/edit/purchase_cost.blade.php
@@ -3,7 +3,7 @@
     <label for="purchase_cost" class="col-md-3 control-label">{{ trans('general.purchase_cost') }}</label>
     <div class="col-md-9">
         <div class="input-group col-md-3" style="padding-left: 0px;">
-            <input class="form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Input::old('purchase_cost', \App\Helpers\Helper::formatCurrencyOutput($item->purchase_cost)) }}" />
+            <input class="form-control" type="text" name="purchase_cost" id="purchase_cost" value="{{ Request::old('purchase_cost', \App\Helpers\Helper::formatCurrencyOutput($item->purchase_cost)) }}" />
             <span class="input-group-addon">
                 @if (isset($currency_type))
                     {{ $currency_type }}

--- a/resources/views/partials/forms/edit/purchase_date.blade.php
+++ b/resources/views/partials/forms/edit/purchase_date.blade.php
@@ -3,7 +3,7 @@
    <label for="purchase_date" class="col-md-3 control-label">{{ trans('general.purchase_date') }}</label>
    <div class="input-group col-md-3">
         <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="purchase_date" id="purchase_date" value="{{ Input::old('purchase_date', ($item->purchase_date) ? $item->purchase_date->format('Y-m-d') : '') }}">
+            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="purchase_date" id="purchase_date" value="{{ Request::old('purchase_date', ($item->purchase_date) ? $item->purchase_date->format('Y-m-d') : '') }}">
             <span class="input-group-addon"><i class="fa fa-calendar"></i></span>
        </div>
        {!! $errors->first('purchase_date', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}

--- a/resources/views/partials/forms/edit/quantity.blade.php
+++ b/resources/views/partials/forms/edit/quantity.blade.php
@@ -4,7 +4,7 @@
     <label for="qty" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
     <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'qty')) ? ' required' : '' }}">
        <div class="col-md-2" style="padding-left:0px">
-           <input class="form-control" type="text" name="qty" id="qty" value="{{ Input::old('qty', $item->qty) }}" />
+           <input class="form-control" type="text" name="qty" id="qty" value="{{ Request::old('qty', $item->qty) }}" />
        </div>
        {!! $errors->first('qty', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
    </div>

--- a/resources/views/partials/forms/edit/requestable.blade.php
+++ b/resources/views/partials/forms/edit/requestable.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group">
     <div class="col-sm-offset-3 col-sm-10">
         <label>
-        <input type="checkbox" value="1" name="requestable" id="requestable" class="minimal" {{ Input::old('requestable', $item->requestable) == '1' ? ' checked="checked"' : '' }}> {{ $requestable_text }}
+        <input type="checkbox" value="1" name="requestable" id="requestable" class="minimal" {{ Request::old('requestable', $item->requestable) == '1' ? ' checked="checked"' : '' }}> {{ $requestable_text }}
         </label>
 
     </div>

--- a/resources/views/partials/forms/edit/serial.blade.php
+++ b/resources/views/partials/forms/edit/serial.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('serial') ? ' has-error' : '' }}">
     <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ trans('admin/hardware/form.serial') }} </label>
     <div class="col-md-7 col-sm-12{{  (\App\Helpers\Helper::checkIfRequired($item, 'serial')) ? ' required' : '' }}">
-        <input class="form-control" type="text" name="{{ $fieldname }}" id="serial" value="{{ Input::old('serial', $item->serial) }}" />
+        <input class="form-control" type="text" name="{{ $fieldname }}" id="serial" value="{{ Request::old('serial', $item->serial) }}" />
         {!! $errors->first('serial', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/status.blade.php
+++ b/resources/views/partials/forms/edit/status.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('status_id') ? ' has-error' : '' }}">
     <label for="status_id" class="col-md-3 control-label">{{ trans('admin/hardware/form.status') }}</label>
     <div class="col-md-7 col-sm-11{{  (\App\Helpers\Helper::checkIfRequired($item, 'status_id')) ? ' required' : '' }}">
-        {{ Form::select('status_id', $statuslabel_list , Input::old('status_id', $item->status_id), ['class'=>'select2 status_id', 'style'=>'width:100%','id'=>'status_select_id', 'placeholder' => trans('general.select_statuslabel'), 'required' => true, 'data-validation' => 'required']) }}
+        {{ Form::select('status_id', $statuslabel_list , Request::old('status_id', $item->status_id), ['class'=>'select2 status_id', 'style'=>'width:100%','id'=>'status_select_id', 'placeholder' => trans('general.select_statuslabel'), 'required' => true, 'data-validation' => 'required']) }}
         {!! $errors->first('status_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
     <div class="col-md-2 col-sm-2 text-left">

--- a/resources/views/partials/forms/edit/supplier-select.blade.php
+++ b/resources/views/partials/forms/edit/supplier-select.blade.php
@@ -4,7 +4,7 @@
 
     <div class="col-md-7{{  ((isset($required)) && ($required=='true')) ? ' required' : '' }}">
         <select class="js-data-ajax" data-endpoint="suppliers" data-placeholder="{{ trans('general.select_supplier') }}" name="{{ $fieldname }}" style="width: 100%" id="supplier_select">
-            @if ($supplier_id = Input::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
+            @if ($supplier_id = Request::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $supplier_id }}" selected="selected">
                     {{ (\App\Models\Supplier::find($supplier_id)) ? \App\Models\Supplier::find($supplier_id)->name : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/supplier.blade.php
+++ b/resources/views/partials/forms/edit/supplier.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('supplier_id') ? ' has-error' : '' }}">
     <label for="supplier_id" class="col-md-3 control-label">{{ trans('general.supplier') }}</label>
     <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'supplier_id')) ? ' required' : '' }}">
-        {{ Form::select('supplier_id', $supplier_list , Input::old('supplier_id', $item->supplier_id), ['class'=>'select2', 'style'=>'min-width:350px', 'id' => 'supplier_select_id']) }}
+        {{ Form::select('supplier_id', $supplier_list , Request::old('supplier_id', $item->supplier_id), ['class'=>'select2', 'style'=>'min-width:350px', 'id' => 'supplier_select_id']) }}
         {!! $errors->first('supplier_id', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
     <div class="col-md-1 col-sm-1 text-left">

--- a/resources/views/partials/forms/edit/uploadLogo.blade.php
+++ b/resources/views/partials/forms/edit/uploadLogo.blade.php
@@ -23,7 +23,7 @@
 
     @if ($setting->$logoVariable!='')
     <div class="col-md-9 col-md-offset-3">
-        {{ Form::checkbox($logoClearVariable, '1', Input::old($logoClearVariable),array('class' => 'minimal')) }} Remove current image
+        {{ Form::checkbox($logoClearVariable, '1', Request::old($logoClearVariable),array('class' => 'minimal')) }} Remove current image
     </div>
     @endif
 </div>

--- a/resources/views/partials/forms/edit/user-select.blade.php
+++ b/resources/views/partials/forms/edit/user-select.blade.php
@@ -4,7 +4,7 @@
 
     <div class="col-md-7{{  ((isset($required)) && ($required=='true')) ? ' required' : '' }}">
         <select class="js-data-ajax" data-endpoint="users" data-placeholder="{{ trans('general.select_user') }}" name="{{ $fieldname }}" style="width: 100%" id="assigned_user_select">
-            @if ($user_id = Input::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
+            @if ($user_id = Request::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $user_id }}" selected="selected">
                     {{ (\App\Models\User::find($user_id)) ? \App\Models\User::find($user_id)->present()->fullName : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/warranty.blade.php
+++ b/resources/views/partials/forms/edit/warranty.blade.php
@@ -3,7 +3,7 @@
     <label for="warranty_months" class="col-md-3 control-label">{{ trans('admin/hardware/form.warranty') }}</label>
     <div class="col-md-9">
         <div class="input-group col-md-3" style="padding-left: 0px;">
-            <input class="form-control" type="text" name="warranty_months" id="warranty_months" value="{{ Input::old('warranty_months', $item->warranty_months) }}" maxlength="3" />
+            <input class="form-control" type="text" name="warranty_months" id="warranty_months" value="{{ Request::old('warranty_months', $item->warranty_months) }}" maxlength="3" />
             <span class="input-group-addon">{{ trans('admin/hardware/form.months') }}</span>
         </div>
         <div class="col-md-9" style="padding-left: 0px;">

--- a/resources/views/reports/asset.blade.php
+++ b/resources/views/reports/asset.blade.php
@@ -25,13 +25,13 @@
                     data-toolbar="#toolbar"
                     class="table table-striped snipe-table"
                     id="table"
-                    data-url="{{route('api.assets.index', array(''=>e(Input::get('status')),'order_number'=>e(Input::get('order_number')), 'status_id'=>e(Input::get('status_id')), 'report'=>'true'))}}"
+                    data-url="{{route('api.assets.index', array(''=>e(Request::get('status')),'order_number'=>e(Request::get('order_number')), 'status_id'=>e(Request::get('status_id')), 'report'=>'true'))}}"
                     data-cookie="true"
                     data-click-to-select="true"
-                    data-cookie-id-table="{{ e(Input::get('status')) }}assetTable-{{ config('version.hash_version') }}">
+                    data-cookie-id-table="{{ e(Request::get('status')) }}assetTable-{{ config('version.hash_version') }}">
                         <thead>
                             <tr>
-                                @if (Input::get('status')!='Deleted')
+                                @if (Request::get('status')!='Deleted')
                                 <th data-class="hidden-xs" data-switchable="false" data-searchable="false" data-sortable="false" data-field="checkbox"><div class="text-center"><input type="checkbox" id="checkAll" style="padding-left: 0px;"></div></th>
                                 @endif
                                 <th data-sortable="true" data-field="id" data-visible="false">{{ trans('general.id') }}</th>

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -273,7 +273,7 @@
             <div class="form-group">
               <label for="status_id" class="col-md-3 control-label">{{ trans('admin/hardware/form.status') }}</label>
               <div class="col-md-7 col-sm-11">
-                {{ Form::select('by_status_id', \App\Helpers\Helper::statusLabelList() , Input::old('by_status_id'), array('class'=>'select2', 'style'=>'width:100%')) }}
+                {{ Form::select('by_status_id', \App\Helpers\Helper::statusLabelList() , Request::old('by_status_id'), array('class'=>'select2', 'style'=>'width:100%')) }}
               </div>
             </div>
 

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -46,7 +46,7 @@
                                 {{ Form::label('alerts_enabled', trans('admin/settings/general.alerts_enabled')) }}
                             </div>
                             <div class="col-md-5">
-                                {{ Form::checkbox('alerts_enabled', '1', Input::old('alerts_enabled', $setting->alerts_enabled),array('class' => 'minimal')) }}
+                                {{ Form::checkbox('alerts_enabled', '1', Request::old('alerts_enabled', $setting->alerts_enabled),array('class' => 'minimal')) }}
                                 {{ trans('general.yes') }}
                             </div>
                         </div>
@@ -57,7 +57,7 @@
                                 {{ Form::label('show_alerts_in_menu', trans('admin/settings/general.show_alerts_in_menu')) }}
                             </div>
                             <div class="col-md-5">
-                                {{ Form::checkbox('show_alerts_in_menu', '1', Input::old('show_alerts_in_menu', $setting->show_alerts_in_menu),array('class' => 'minimal')) }}
+                                {{ Form::checkbox('show_alerts_in_menu', '1', Request::old('show_alerts_in_menu', $setting->show_alerts_in_menu),array('class' => 'minimal')) }}
                                 {{ trans('general.yes') }}
                             </div>
                         </div>
@@ -70,7 +70,7 @@
                                 {{ Form::label('alert_email', trans('admin/settings/general.alert_email')) }}
                             </div>
                             <div class="col-md-7">
-                                {{ Form::text('alert_email', Input::old('alert_email', $setting->alert_email), array('class' => 'form-control','placeholder' => 'admin@yourcompany.com')) }}
+                                {{ Form::text('alert_email', Request::old('alert_email', $setting->alert_email), array('class' => 'form-control','placeholder' => 'admin@yourcompany.com')) }}
                                 {!! $errors->first('alert_email', '<span class="alert-msg">:message</span><br>') !!}
 
                                 <p class="help-block">Email addresses or distribution lists you want alerts to be sent to, comma separated</p>
@@ -86,7 +86,7 @@
                                 {{ Form::label('admin_cc_email', trans('admin/settings/general.admin_cc_email')) }}
                             </div>
                             <div class="col-md-7">
-                                {{ Form::text('admin_cc_email', Input::old('admin_cc_email', $setting->admin_cc_email), array('class' => 'form-control','placeholder' => 'admin@yourcompany.com')) }}
+                                {{ Form::text('admin_cc_email', Request::old('admin_cc_email', $setting->admin_cc_email), array('class' => 'form-control','placeholder' => 'admin@yourcompany.com')) }}
                                 {!! $errors->first('admin_cc_email', '<span class="alert-msg">:message</span><br>') !!}
 
                                 <p class="help-block">{{ trans('admin/settings/general.admin_cc_email_help') }}</p>
@@ -101,7 +101,7 @@
                                 {{ Form::label('alert_interval', trans('admin/settings/general.alert_interval')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('alert_interval', Input::old('alert_interval', $setting->alert_interval), array('class' => 'form-control','placeholder' => '30', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                                {{ Form::text('alert_interval', Request::old('alert_interval', $setting->alert_interval), array('class' => 'form-control','placeholder' => '30', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
                                 {!! $errors->first('alert_interval', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -112,7 +112,7 @@
                                 {{ Form::label('alert_threshold', trans('admin/settings/general.alert_inv_threshold')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('alert_threshold', Input::old('alert_threshold', $setting->alert_threshold), array('class' => 'form-control','placeholder' => '5', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                                {{ Form::text('alert_threshold', Request::old('alert_threshold', $setting->alert_threshold), array('class' => 'form-control','placeholder' => '5', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
                                 {!! $errors->first('alert_threshold', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -124,7 +124,7 @@
                                 {{ Form::label('audit_interval', trans('admin/settings/general.audit_interval')) }}
                             </div>
                             <div class="input-group col-md-2">
-                                {{ Form::text('audit_interval', Input::old('audit_interval', $setting->audit_interval), array('class' => 'form-control','placeholder' => '12', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                                {{ Form::text('audit_interval', Request::old('audit_interval', $setting->audit_interval), array('class' => 'form-control','placeholder' => '12', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
                                 <span class="input-group-addon">{{ trans('general.months') }}</span>
                             </div>
                             <div class="col-md-9 col-md-offset-3">
@@ -139,7 +139,7 @@
                                 {{ Form::label('audit_warning_days', trans('admin/settings/general.audit_warning_days')) }}
                             </div>
                             <div class="input-group col-md-2">
-                                {{ Form::text('audit_warning_days', Input::old('audit_warning_days', $setting->audit_warning_days), array('class' => 'form-control','placeholder' => '14', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                                {{ Form::text('audit_warning_days', Request::old('audit_warning_days', $setting->audit_warning_days), array('class' => 'form-control','placeholder' => '14', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
                                 <span class="input-group-addon">{{ trans('general.days') }}</span>
 
 

--- a/resources/views/settings/asset_tags.blade.php
+++ b/resources/views/settings/asset_tags.blade.php
@@ -46,7 +46,7 @@
                                 {{ Form::label('auto_increment_assets', trans('admin/settings/general.asset_ids')) }}
                             </div>
                             <div class="col-md-7">
-                                {{ Form::checkbox('auto_increment_assets', '1', Input::old('auto_increment_assets', $setting->auto_increment_assets),array('class' => 'minimal')) }}
+                                {{ Form::checkbox('auto_increment_assets', '1', Request::old('auto_increment_assets', $setting->auto_increment_assets),array('class' => 'minimal')) }}
                                 {{ trans('admin/settings/general.auto_increment_assets') }}
                             </div>
                         </div>
@@ -56,7 +56,7 @@
                                 {{ Form::label('next_auto_tag_base', trans('admin/settings/general.next_auto_tag_base')) }}
                             </div>
                             <div class="col-md-7">
-                                {{ Form::text('next_auto_tag_base', Input::old('next_auto_tag_base', $setting->next_auto_tag_base), array('class' => 'form-control', 'style'=>'width: 150px;')) }}
+                                {{ Form::text('next_auto_tag_base', Request::old('next_auto_tag_base', $setting->next_auto_tag_base), array('class' => 'form-control', 'style'=>'width: 150px;')) }}
                                 {!! $errors->first('next_auto_tag_base', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -69,10 +69,10 @@
                             </div>
                             <div class="col-md-7">
                                 @if ($setting->auto_increment_assets == 1)
-                                    {{ Form::text('auto_increment_prefix', Input::old('auto_increment_prefix', $setting->auto_increment_prefix), array('class' => 'form-control', 'style'=>'width: 150px;')) }}
+                                    {{ Form::text('auto_increment_prefix', Request::old('auto_increment_prefix', $setting->auto_increment_prefix), array('class' => 'form-control', 'style'=>'width: 150px;')) }}
                                     {!! $errors->first('auto_increment_prefix', '<span class="alert-msg">:message</span>') !!}
                                 @else
-                                    {{ Form::text('auto_increment_prefix', Input::old('auto_increment_prefix', $setting->auto_increment_prefix), array('class' => 'form-control', 'disabled'=>'disabled', 'style'=>'width: 150px;')) }}
+                                    {{ Form::text('auto_increment_prefix', Request::old('auto_increment_prefix', $setting->auto_increment_prefix), array('class' => 'form-control', 'disabled'=>'disabled', 'style'=>'width: 150px;')) }}
                                 @endif
                             </div>
                         </div>
@@ -83,7 +83,7 @@
                                 {{ Form::label('auto_increment_prefix', trans('admin/settings/general.zerofill_count')) }}
                             </div>
                             <div class="col-md-7">
-                                {{ Form::text('zerofill_count', Input::old('zerofill_count', $setting->zerofill_count), array('class' => 'form-control', 'style'=>'width: 150px;')) }}
+                                {{ Form::text('zerofill_count', Request::old('zerofill_count', $setting->zerofill_count), array('class' => 'form-control', 'style'=>'width: 150px;')) }}
                                 {!! $errors->first('zerofill_count', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>

--- a/resources/views/settings/barcodes.blade.php
+++ b/resources/views/settings/barcodes.blade.php
@@ -47,7 +47,7 @@
                                     {{ Form::label('qr_code', trans('admin/settings/general.display_qr')) }}
                                 </div>
                                 <div class="col-md-9">
-                                    {{ Form::checkbox('qr_code', '1', Input::old('qr_code', $setting->qr_code),array('class' => 'minimal')) }}
+                                    {{ Form::checkbox('qr_code', '1', Request::old('qr_code', $setting->qr_code),array('class' => 'minimal')) }}
                                     {{ trans('general.yes') }}
                                 </div>
                             </div>
@@ -58,7 +58,7 @@
                                     {{ Form::label('barcode_type', trans('admin/settings/general.barcode_type')) }}
                                 </div>
                                 <div class="col-md-9">
-                                    {!! Form::barcode_types('barcode_type', Input::old('barcode_type', $setting->barcode_type), 'select2') !!}
+                                    {!! Form::barcode_types('barcode_type', Request::old('barcode_type', $setting->barcode_type), 'select2') !!}
                                     {!! $errors->first('barcode_type', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                                 </div>
                             </div>
@@ -69,7 +69,7 @@
                                     {{ Form::label('qr_code', trans('admin/settings/general.display_alt_barcode')) }}
                                 </div>
                                 <div class="col-md-9">
-                                    {{ Form::checkbox('alt_barcode_enabled', '1', Input::old('alt_barcode_enabled', $setting->alt_barcode_enabled),array('class' => 'minimal')) }}
+                                    {{ Form::checkbox('alt_barcode_enabled', '1', Request::old('alt_barcode_enabled', $setting->alt_barcode_enabled),array('class' => 'minimal')) }}
                                     {{ trans('general.yes') }}
                                 </div>
                             </div>
@@ -80,7 +80,7 @@
                                     {{ Form::label('alt_barcode', trans('admin/settings/general.alt_barcode_type')) }}
                                 </div>
                                 <div class="col-md-9">
-                                    {!! Form::alt_barcode_types('alt_barcode', Input::old('alt_barcode', $setting->alt_barcode), 'select2') !!}
+                                    {!! Form::alt_barcode_types('alt_barcode', Request::old('alt_barcode', $setting->alt_barcode), 'select2') !!}
                                     {!! $errors->first('barcode_type', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                                 </div>
                             </div>
@@ -99,14 +99,14 @@
                             </div>
                             <div class="col-md-9">
                                 @if ($setting->qr_code == 1)
-                                    {{ Form::text('qr_text', Input::old('qr_text', $setting->qr_text), array('class' => 'form-control','placeholder' => 'Property of Your Company',
+                                    {{ Form::text('qr_text', Request::old('qr_text', $setting->qr_text), array('class' => 'form-control','placeholder' => 'Property of Your Company',
                                     'rel' => 'txtTooltip',
                                     'title' =>'Extra text that you would like to display on your labels. ',
                                     'data-toggle' =>'tooltip',
                                     'data-placement'=>'top')) }}
                                     {!! $errors->first('qr_text', '<span class="alert-msg">:message</span>') !!}
                                 @else
-                                    {{ Form::text('qr_text', Input::old('qr_text', $setting->qr_text), array('class' => 'form-control', 'disabled'=>'disabled','placeholder' => 'Property of Your Company')) }}
+                                    {{ Form::text('qr_text', Request::old('qr_text', $setting->qr_text), array('class' => 'form-control', 'disabled'=>'disabled','placeholder' => 'Property of Your Company')) }}
                                     <p class="help-block">{{ trans('admin/settings/general.qr_help') }}</p>
                                 @endif
                             </div>

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -47,10 +47,10 @@
                             </div>
                             <div class="col-md-7 required">
                                 @if (config('app.lock_passwords')===true)
-                                    {{ Form::text('site_name', Input::old('site_name', $setting->site_name), array('class' => 'form-control', 'disabled'=>'disabled','placeholder' => 'Snipe-IT Asset Management')) }}
+                                    {{ Form::text('site_name', Request::old('site_name', $setting->site_name), array('class' => 'form-control', 'disabled'=>'disabled','placeholder' => 'Snipe-IT Asset Management')) }}
                                 @else
                                     {{ Form::text('site_name',
-                                        Input::old('site_name', $setting->site_name), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management', 'data-validation' => 'required')) }}
+                                        Request::old('site_name', $setting->site_name), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management', 'data-validation' => 'required')) }}
                                 @endif
                                 {!! $errors->first('site_name', '<span class="alert-msg">:message</span>') !!}
                             </div>
@@ -62,7 +62,7 @@
                                 {{ Form::label('brand', trans('admin/settings/general.brand')) }}
                             </div>
                             <div class="col-md-9">
-                                {!! Form::select('brand', array('1'=>'Text','2'=>'Logo','3'=>'Logo + Text'), Input::old('brand', $setting->brand), array('class' => 'form-control select2', 'style'=>'width: 150px ;')) !!}
+                                {!! Form::select('brand', array('1'=>'Text','2'=>'Logo','3'=>'Logo + Text'), Request::old('brand', $setting->brand), array('class' => 'form-control select2', 'style'=>'width: 150px ;')) !!}
                                 {!! $errors->first('brand', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -111,7 +111,7 @@
                                 {{ Form::label('logo_print_assets', trans('admin/settings/general.logo_print_assets')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::checkbox('logo_print_assets', '1', Input::old('logo_print_assets', $setting->logo_print_assets),array('class' => 'minimal')) }}
+                                {{ Form::checkbox('logo_print_assets', '1', Request::old('logo_print_assets', $setting->logo_print_assets),array('class' => 'minimal')) }}
                                 {{ trans('admin/settings/general.logo_print_assets_help') }}
                             </div>
                         </div>
@@ -123,7 +123,7 @@
                                 {{ Form::label('show_url_in_emails', trans('admin/settings/general.show_url_in_emails')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::checkbox('show_url_in_emails', '1', Input::old('show_url_in_emails', $setting->show_url_in_emails),array('class' => 'minimal')) }}
+                                {{ Form::checkbox('show_url_in_emails', '1', Request::old('show_url_in_emails', $setting->show_url_in_emails),array('class' => 'minimal')) }}
                                 {{ trans('general.yes') }}
                                 <p class="help-block">{{ trans('admin/settings/general.show_url_in_emails_help_text') }}</p>
                             </div>
@@ -136,7 +136,7 @@
                             </div>
                             <div class="col-md-2">
                                 <div class="input-group header-color">
-                                    {{ Form::text('header_color', Input::old('header_color', $setting->header_color), array('class' => 'form-control', 'style' => 'width: 100px;','placeholder' => '#FF0000')) }}
+                                    {{ Form::text('header_color', Request::old('header_color', $setting->header_color), array('class' => 'form-control', 'style' => 'width: 100px;','placeholder' => '#FF0000')) }}
                                     <div class="input-group-addon">
                                         <i></i>
                                     </div>
@@ -151,7 +151,7 @@
                                 {{ Form::label('skin', trans('general.skin')) }}
                             </div>
                             <div class="col-md-9">
-                                {!! Form::skin('skin', Input::old('skin', $setting->skin), 'select2') !!}
+                                {!! Form::skin('skin', Request::old('skin', $setting->skin), 'select2') !!}
                                 {!! $errors->first('skin', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -164,11 +164,11 @@
                             </div>
                             <div class="col-md-9">
                                 @if (config('app.lock_passwords')===true)
-                                    {{ Form::textarea('custom_css', Input::old('custom_css', $setting->custom_css), array('class' => 'form-control','placeholder' => 'Add your custom CSS','disabled'=>'disabled')) }}
+                                    {{ Form::textarea('custom_css', Request::old('custom_css', $setting->custom_css), array('class' => 'form-control','placeholder' => 'Add your custom CSS','disabled'=>'disabled')) }}
                                     {!! $errors->first('custom_css', '<span class="alert-msg">:message</span>') !!}
                                     <p class="help-block">{{ trans('general.lock_passwords') }}</p>
                                 @else
-                                    {{ Form::textarea('custom_css', Input::old('custom_css', $setting->custom_css), array('class' => 'form-control','placeholder' => 'Add your custom CSS')) }}
+                                    {{ Form::textarea('custom_css', Request::old('custom_css', $setting->custom_css), array('class' => 'form-control','placeholder' => 'Add your custom CSS')) }}
                                     {!! $errors->first('custom_css', '<span class="alert-msg">:message</span>') !!}
                                 @endif
                                 <p class="help-block">{!! trans('admin/settings/general.custom_css_help') !!}</p>
@@ -183,9 +183,9 @@
                             </div>
                             <div class="col-md-9">
                                 @if (config('app.lock_passwords')===true)
-                                    {!! Form::select('support_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Input::old('support_footer', $setting->support_footer), ['class' => 'form-control select2 disabled', 'style'=>'width: 150px ;', 'disabled' => 'disabled']) !!}
+                                    {!! Form::select('support_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Request::old('support_footer', $setting->support_footer), ['class' => 'form-control select2 disabled', 'style'=>'width: 150px ;', 'disabled' => 'disabled']) !!}
                                 @else
-                                    {!! Form::select('support_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Input::old('support_footer', $setting->support_footer), array('class' => 'form-control select2', 'style'=>'width: 150px ;')) !!}
+                                    {!! Form::select('support_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Request::old('support_footer', $setting->support_footer), array('class' => 'form-control select2', 'style'=>'width: 150px ;')) !!}
                                 @endif
 
                                 <p class="help-block">{{ trans('admin/settings/general.support_footer_help') }}</p>
@@ -201,9 +201,9 @@
                             </div>
                             <div class="col-md-9">
                                 @if (config('app.lock_passwords')===true)
-                                    {!! Form::select('version_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Input::old('version_footer', $setting->version_footer), ['class' => 'form-control select2 disabled', 'style'=>'width: 150px ;', 'disabled' => 'disabled']) !!}
+                                    {!! Form::select('version_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Request::old('version_footer', $setting->version_footer), ['class' => 'form-control select2 disabled', 'style'=>'width: 150px ;', 'disabled' => 'disabled']) !!}
                                 @else
-                                    {!! Form::select('version_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Input::old('version_footer', $setting->version_footer), array('class' => 'form-control select2', 'style'=>'width: 150px ;')) !!}
+                                    {!! Form::select('version_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Request::old('version_footer', $setting->version_footer), array('class' => 'form-control select2', 'style'=>'width: 150px ;')) !!}
                                 @endif
 
                                 <p class="help-block">{{ trans('admin/settings/general.version_footer_help') }}</p>
@@ -218,10 +218,10 @@
                             </div>
                             <div class="col-md-9">
                                 @if (config('app.lock_passwords')===true)
-                                    {{ Form::textarea('footer_text', Input::old('footer_text', $setting->footer_text), array('class' => 'form-control', 'rows' => '4', 'placeholder' => 'Optional footer text','disabled'=>'disabled')) }}
+                                    {{ Form::textarea('footer_text', Request::old('footer_text', $setting->footer_text), array('class' => 'form-control', 'rows' => '4', 'placeholder' => 'Optional footer text','disabled'=>'disabled')) }}
                                     <p class="help-block">{{ trans('general.lock_passwords') }}</p>
                                 @else
-                                    {{ Form::textarea('footer_text', Input::old('footer_text', $setting->footer_text), array('class' => 'form-control','rows' => '4','placeholder' => 'Optional footer text')) }}
+                                    {{ Form::textarea('footer_text', Request::old('footer_text', $setting->footer_text), array('class' => 'form-control','rows' => '4','placeholder' => 'Optional footer text')) }}
                                 @endif
                                 <p class="help-block">{!! trans('admin/settings/general.footer_text_help') !!}</p>
                                  {!! $errors->first('footer_text', '<span class="alert-msg">:message</span>') !!}

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -47,7 +47,7 @@
                             {{ Form::label('full_multiple_companies_support', trans('admin/settings/general.full_multiple_companies_support_text')) }}
                         </div>
                         <div class="col-md-9">
-                            {{ Form::checkbox('full_multiple_companies_support', '1', Input::old('full_multiple_companies_support', $setting->full_multiple_companies_support),array('class' => 'minimal')) }}
+                            {{ Form::checkbox('full_multiple_companies_support', '1', Request::old('full_multiple_companies_support', $setting->full_multiple_companies_support),array('class' => 'minimal')) }}
                             {{ trans('admin/settings/general.full_multiple_companies_support_text') }}
                             {!! $errors->first('full_multiple_companies_support', '<span class="alert-msg">:message</span>') !!}
                             <p class="help-block">
@@ -65,7 +65,7 @@
                                            trans('admin/settings/general.require_accept_signature')) }}
                         </div>
                         <div class="col-md-9">
-                            {{ Form::checkbox('require_accept_signature', '1', Input::old('require_accept_signature', $setting->require_accept_signature),array('class' => 'minimal')) }}
+                            {{ Form::checkbox('require_accept_signature', '1', Request::old('require_accept_signature', $setting->require_accept_signature),array('class' => 'minimal')) }}
                             {{ trans('general.yes') }}
                             {!! $errors->first('require_accept_signature', '<span class="alert-msg">:message</span>') !!}
                             <p class="help-block">{{ trans('admin/settings/general.require_accept_signature_help_text') }}</p>
@@ -80,7 +80,7 @@
                             {{ Form::label('email_domain', trans('general.email_domain')) }}
                         </div>
                         <div class="col-md-9">
-                            {{ Form::text('email_domain', Input::old('email_domain', $setting->email_domain), array('class' => 'form-control','placeholder' => 'example.com')) }}
+                            {{ Form::text('email_domain', Request::old('email_domain', $setting->email_domain), array('class' => 'form-control','placeholder' => 'example.com')) }}
                             <span class="help-block">{{ trans('general.email_domain_help')  }}</span>
                             {!! $errors->first('email_domain', '<span class="alert-msg">:message</span>') !!}
                         </div>
@@ -93,7 +93,7 @@
                             {{ Form::label('email_format', trans('general.email_format')) }}
                         </div>
                         <div class="col-md-9">
-                            {!! Form::username_format('email_format', Input::old('email_format', $setting->email_format), 'select2') !!}
+                            {!! Form::username_format('email_format', Request::old('email_format', $setting->email_format), 'select2') !!}
                             {!! $errors->first('email_format', '<span class="alert-msg">:message</span>') !!}
                         </div>
                     </div>
@@ -104,7 +104,7 @@
                             {{ Form::label('username_format', trans('general.username_format')) }}
                         </div>
                         <div class="col-md-9">
-                            {!! Form::username_format('username_format', Input::old('username_format', $setting->username_format), 'select2') !!}
+                            {!! Form::username_format('username_format', Request::old('username_format', $setting->username_format), 'select2') !!}
                             {!! $errors->first('username_format', '<span class="alert-msg">:message</span>') !!}
 
                             <p class="help-block">
@@ -119,7 +119,7 @@
                                {{ Form::label('show_images_in_email', trans('admin/settings/general.show_images_in_email')) }}
                            </div>
                            <div class="col-md-9">
-                               {{ Form::checkbox('show_images_in_email', '1', Input::old('show_images_in_email', $setting->show_images_in_email),array('class' => 'minimal')) }}
+                               {{ Form::checkbox('show_images_in_email', '1', Request::old('show_images_in_email', $setting->show_images_in_email),array('class' => 'minimal')) }}
                                {{ trans('general.yes') }}
                                {!! $errors->first('show_images_in_email', '<span class="alert-msg">:message</span>') !!}
 
@@ -132,7 +132,7 @@
                                {{ Form::label('unique_serial', trans('admin/settings/general.unique_serial')) }}
                            </div>
                            <div class="col-md-9">
-                               {{ Form::checkbox('unique_serial', '1', Input::old('unique_serial', $setting->unique_serial),array('class' => 'minimal')) }}
+                               {{ Form::checkbox('unique_serial', '1', Request::old('unique_serial', $setting->unique_serial),array('class' => 'minimal')) }}
                                {{ trans('general.yes') }}
                                {!! $errors->first('unique_serial', '<span class="alert-msg">:message</span>') !!}
                                <p class="help-block">
@@ -148,7 +148,7 @@
                             {{ Form::label('per_page', trans('admin/settings/general.per_page')) }}
                         </div>
                         <div class="col-md-9">
-                            {{ Form::text('per_page', Input::old('per_page', $setting->per_page), array('class' => 'form-control','placeholder' => '5', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                            {{ Form::text('per_page', Request::old('per_page', $setting->per_page), array('class' => 'form-control','placeholder' => '5', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
                             {!! $errors->first('per_page', '<span class="alert-msg">:message</span>') !!}
                         </div>
                     </div>
@@ -159,7 +159,7 @@
                            {{ Form::label('thumbnail_max_h', trans('admin/settings/general.thumbnail_max_h')) }}
                        </div>
                        <div class="col-md-9">
-                           {{ Form::text('thumbnail_max_h', Input::old('thumbnail_max_h', $setting->thumbnail_max_h), array('class' => 'form-control','placeholder' => '50', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                           {{ Form::text('thumbnail_max_h', Request::old('thumbnail_max_h', $setting->thumbnail_max_h), array('class' => 'form-control','placeholder' => '50', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
                            <p class="help-block">{{ trans('admin/settings/general.thumbnail_max_h_help') }}</p>
                            {!! $errors->first('thumbnail_max_h', '<span class="alert-msg">:message</span>') !!}
                        </div>
@@ -171,7 +171,7 @@
                            {{ Form::label('default_eula_text', trans('admin/settings/general.default_eula_text')) }}
                        </div>
                        <div class="col-md-9">
-                           {{ Form::textarea('default_eula_text', Input::old('default_eula_text', $setting->default_eula_text), array('class' => 'form-control','placeholder' => 'Add your default EULA text')) }}
+                           {{ Form::textarea('default_eula_text', Request::old('default_eula_text', $setting->default_eula_text), array('class' => 'form-control','placeholder' => 'Add your default EULA text')) }}
                            {!! $errors->first('default_eula_text', '<span class="alert-msg">:message</span>') !!}
                            <p class="help-block">{{ trans('admin/settings/general.default_eula_help_text') }}</p>
                            <p class="help-block">{!! trans('admin/settings/general.eula_markdown') !!}</p>
@@ -187,11 +187,11 @@
                         <div class="col-md-9">
                             @if (config('app.lock_passwords'))
 
-                                <textarea class="form-control disabled" name="login_note" placeholder="If you do not have a login or have found a device belonging to this company, please call technical support at 888-555-1212. Thank you." rows="2" readonly>{{ Input::old('login_note', $setting->login_note) }}</textarea>
+                                <textarea class="form-control disabled" name="login_note" placeholder="If you do not have a login or have found a device belonging to this company, please call technical support at 888-555-1212. Thank you." rows="2" readonly>{{ Request::old('login_note', $setting->login_note) }}</textarea>
                                 {!! $errors->first('login_note', '<span class="alert-msg">:message</span>') !!}
                                 <p class="help-block">{{ trans('general.lock_passwords') }}</p>
                             @else
-                                <textarea class="form-control" name="login_note" placeholder="If you do not have a login or have found a device belonging to this company, please call technical support at 888-555-1212. Thank you." rows="2">{{ Input::old('login_note', $setting->login_note) }}</textarea>
+                                <textarea class="form-control" name="login_note" placeholder="If you do not have a login or have found a device belonging to this company, please call technical support at 888-555-1212. Thank you." rows="2">{{ Request::old('login_note', $setting->login_note) }}</textarea>
                                 {!! $errors->first('login_note', '<span class="alert-msg">:message</span>') !!}
                             @endif
                             <p class="help-block">{!!  trans('admin/settings/general.login_note_help') !!}</p>
@@ -227,11 +227,11 @@
                            <div class="col-md-9">
                                @if (config('app.lock_passwords'))
 
-                                   <textarea class="form-control disabled" name="login_note" placeholder="If you do not have a login or have found a device belonging to this company, please call technical support at 888-555-1212. Thank you." rows="2" readonly>{{ Input::old('dashboard_message', $setting->login_note) }}</textarea>
+                                   <textarea class="form-control disabled" name="login_note" placeholder="If you do not have a login or have found a device belonging to this company, please call technical support at 888-555-1212. Thank you." rows="2" readonly>{{ Request::old('dashboard_message', $setting->login_note) }}</textarea>
                                    {!! $errors->first('dashboard_message', '<span class="alert-msg">:message</span>') !!}
                                    <p class="help-block">{{ trans('general.lock_passwords') }}</p>
                                @else
-                                   <textarea class="form-control" name="dashboard_message" rows="2">{{ Input::old('login_note', $setting->dashboard_message) }}</textarea>
+                                   <textarea class="form-control" name="dashboard_message" rows="2">{{ Request::old('login_note', $setting->dashboard_message) }}</textarea>
                                    {!! $errors->first('dashboard_message', '<span class="alert-msg">:message</span>') !!}
                                @endif
                                <p class="help-block">
@@ -250,7 +250,7 @@
                                               trans('admin/settings/general.show_archived_in_list')) }}
                            </div>
                            <div class="col-md-9">
-                               {{ Form::checkbox('show_archived_in_list', '1', Input::old('show_archived_in_list', $setting->show_archived_in_list),array('class' => 'minimal')) }}
+                               {{ Form::checkbox('show_archived_in_list', '1', Request::old('show_archived_in_list', $setting->show_archived_in_list),array('class' => 'minimal')) }}
                                {{ trans('admin/settings/general.show_archived_in_list_text') }}
                                {!! $errors->first('show_archived_in_list', '<span class="alert-msg">:message</span>') !!}
 
@@ -264,10 +264,10 @@
                                               trans('admin/settings/general.show_in_model_list')) }}
                            </div>
                            <div class="col-md-9">
-                               {{ Form::checkbox('show_in_model_list[]', 'image', Input::old('show_in_model_list', $snipeSettings->modellistCheckedValue('image')),array('class' => 'minimal')) }} {{ trans('general.image') }} <br>
-                               {{ Form::checkbox('show_in_model_list[]', 'category', Input::old('show_in_model_list', $snipeSettings->modellistCheckedValue('category')),array('class' => 'minimal')) }} {{ trans('general.category') }} <br>
-                               {{ Form::checkbox('show_in_model_list[]', 'manufacturer', Input::old('show_in_model_list', $snipeSettings->modellistCheckedValue('manufacturer')),array('class' => 'minimal')) }}  {{ trans('general.manufacturer') }} <br>
-                               {{ Form::checkbox('show_in_model_list[]', 'model_number', Input::old('show_in_model_list', $snipeSettings->modellistCheckedValue('model_number')),array('class' => 'minimal')) }} {{ trans('general.model_no') }}<br>
+                               {{ Form::checkbox('show_in_model_list[]', 'image', Request::old('show_in_model_list', $snipeSettings->modellistCheckedValue('image')),array('class' => 'minimal')) }} {{ trans('general.image') }} <br>
+                               {{ Form::checkbox('show_in_model_list[]', 'category', Request::old('show_in_model_list', $snipeSettings->modellistCheckedValue('category')),array('class' => 'minimal')) }} {{ trans('general.category') }} <br>
+                               {{ Form::checkbox('show_in_model_list[]', 'manufacturer', Request::old('show_in_model_list', $snipeSettings->modellistCheckedValue('manufacturer')),array('class' => 'minimal')) }}  {{ trans('general.manufacturer') }} <br>
+                               {{ Form::checkbox('show_in_model_list[]', 'model_number', Request::old('show_in_model_list', $snipeSettings->modellistCheckedValue('model_number')),array('class' => 'minimal')) }} {{ trans('general.model_no') }}<br>
                            </div>
                        </div>
                        
@@ -281,7 +281,7 @@
                                     'default' => 'Linear (default)', 
                                     'half_1' => 'Half-year convention, always applied', 
                                     'half_2' => 'Half-year convention, applied with condition', 
-                                ), Input::old('username_format', $setting->depreciation_method), ['class' =>'select2', 'style' => 'width: 80%']) }}
+                                ), Request::old('username_format', $setting->depreciation_method), ['class' =>'select2', 'style' => 'width: 80%']) }}
                            </div>
                        </div>
                        <!-- /.form-group -->
@@ -293,9 +293,9 @@
                            </div>
                            <div class="col-md-9">
                                @if (config('app.lock_passwords'))
-                                   {{ Form::text('privacy_policy_link', Input::old('privacy_policy_link', $setting->privacy_policy_link), array('class' => 'form-control disabled', 'disabled' => 'disabled')) }}
+                                   {{ Form::text('privacy_policy_link', Request::old('privacy_policy_link', $setting->privacy_policy_link), array('class' => 'form-control disabled', 'disabled' => 'disabled')) }}
                                @else
-                                   {{ Form::text('privacy_policy_link', Input::old('privacy_policy_link', $setting->privacy_policy_link), array('class' => 'form-control')) }}
+                                   {{ Form::text('privacy_policy_link', Request::old('privacy_policy_link', $setting->privacy_policy_link), array('class' => 'form-control')) }}
 
                                @endif
 

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -45,7 +45,7 @@
                                 {{ Form::label('labels_per_page', trans('admin/settings/general.labels_per_page')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('labels_per_page', Input::old('labels_per_page', $setting->labels_per_page), ['class' => 'form-control','style' => 'width: 100px;']) }}
+                                {{ Form::text('labels_per_page', Request::old('labels_per_page', $setting->labels_per_page), ['class' => 'form-control','style' => 'width: 100px;']) }}
                                 {!! $errors->first('labels_per_page', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -56,7 +56,7 @@
                             </div>
                             <div class="col-md-2 form-group">
                                 <div class="input-group">
-                                    {{ Form::text('labels_fontsize', Input::old('labels_fontsize', $setting->labels_fontsize), ['class' => 'form-control']) }}
+                                    {{ Form::text('labels_fontsize', Request::old('labels_fontsize', $setting->labels_fontsize), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.text_pt') }}</div>
                                 </div>
                             </div>
@@ -71,13 +71,13 @@
                             </div>
                             <div class="col-md-3 form-group">
                                 <div class="input-group">
-                                    {{ Form::text('labels_width', Input::old('labels_width', $setting->labels_width), ['class' => 'form-control']) }}
+                                    {{ Form::text('labels_width', Request::old('labels_width', $setting->labels_width), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.width_w') }}</div>
                                 </div>
                             </div>
                             <div class="col-md-3 form-group" style="margin-left: 10px">
                                 <div class="input-group">
-                                    {{ Form::text('labels_height', Input::old('labels_height', $setting->labels_height), ['class' => 'form-control']) }}
+                                    {{ Form::text('labels_height', Request::old('labels_height', $setting->labels_height), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.height_h') }}</div>
                                 </div>
                             </div>
@@ -93,13 +93,13 @@
                             </div>
                             <div class="col-md-3 form-group">
                                 <div class="input-group">
-                                    {{ Form::text('labels_display_sgutter', Input::old('labels_display_sgutter', $setting->labels_display_sgutter), ['class' => 'form-control']) }}
+                                    {{ Form::text('labels_display_sgutter', Request::old('labels_display_sgutter', $setting->labels_display_sgutter), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.horizontal') }}</div>
                                 </div>
                             </div>
                             <div class="col-md-3 form-group" style="margin-left: 10px">
                                 <div class="input-group">
-                                    {{ Form::text('labels_display_bgutter', Input::old('labels_display_bgutter', $setting->labels_display_bgutter), ['class' => 'form-control']) }}
+                                    {{ Form::text('labels_display_bgutter', Request::old('labels_display_bgutter', $setting->labels_display_bgutter), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.vertical') }}</div>
                                 </div>
                             </div>
@@ -115,21 +115,21 @@
                             </div>
                             <div class="col-md-3 form-group">
                                 <div class="input-group" style="margin-bottom: 15px;">
-                                    {{ Form::text('labels_pmargin_top', Input::old('labels_pmargin_top', $setting->labels_pmargin_top), ['class' => 'form-control']) }}
+                                    {{ Form::text('labels_pmargin_top', Request::old('labels_pmargin_top', $setting->labels_pmargin_top), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.top') }}</div>
                                 </div>
                                 <div class="input-group">
-                                    {{ Form::text('labels_pmargin_left', Input::old('labels_pmargin_left', $setting->labels_pmargin_left), ['class' => 'form-control']) }}
+                                    {{ Form::text('labels_pmargin_left', Request::old('labels_pmargin_left', $setting->labels_pmargin_left), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.left') }}</div>
                                 </div>
                             </div>
                             <div class="col-md-3 form-group" style="margin-left: 10px; ">
                                 <div class="input-group" style="margin-bottom: 15px;">
-                                    {{ Form::text('labels_pmargin_bottom', Input::old('labels_pmargin_bottom', $setting->labels_pmargin_bottom), ['class' => 'form-control']) }}
+                                    {{ Form::text('labels_pmargin_bottom', Request::old('labels_pmargin_bottom', $setting->labels_pmargin_bottom), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.bottom') }}</div>
                                 </div>
                                 <div class="input-group">
-                                    {{ Form::text('labels_pmargin_right', Input::old('labels_pmargin_right', $setting->labels_pmargin_right), ['class' => 'form-control']) }}
+                                    {{ Form::text('labels_pmargin_right', Request::old('labels_pmargin_right', $setting->labels_pmargin_right), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.right') }}</div>
                                 </div>
 
@@ -146,13 +146,13 @@
                             </div>
                             <div class="col-md-3 form-group">
                                 <div class="input-group">
-                                    {{ Form::text('labels_pagewidth', Input::old('labels_pagewidth', $setting->labels_pagewidth), ['class' => 'form-control']) }}
+                                    {{ Form::text('labels_pagewidth', Request::old('labels_pagewidth', $setting->labels_pagewidth), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.width_w') }}</div>
                                 </div>
                             </div>
                             <div class="col-md-3 form-group" style="margin-left: 10px">
                                 <div class="input-group">
-                                    {{ Form::text('labels_pageheight', Input::old('labels_pageheight', $setting->labels_pageheight), ['class' => 'form-control']) }}
+                                    {{ Form::text('labels_pageheight', Request::old('labels_pageheight', $setting->labels_pageheight), ['class' => 'form-control']) }}
                                     <div class="input-group-addon">{{ trans('admin/settings/general.height_h') }}</div>
                                 </div>
                             </div>
@@ -169,23 +169,23 @@
                             <div class="col-md-9">
                                 <div class="checkbox">
                                     <label>
-                                        {{ Form::checkbox('labels_display_name', '1', Input::old('labels_display_name',   $setting->labels_display_name),['class' => 'minimal']) }}
+                                        {{ Form::checkbox('labels_display_name', '1', Request::old('labels_display_name',   $setting->labels_display_name),['class' => 'minimal']) }}
                                         {{ trans('admin/hardware/form.name') }}
                                     </label>
                                     <label>
-                                        {{ Form::checkbox('labels_display_serial', '1', Input::old('labels_display_serial',   $setting->labels_display_serial),['class' => 'minimal']) }}
+                                        {{ Form::checkbox('labels_display_serial', '1', Request::old('labels_display_serial',   $setting->labels_display_serial),['class' => 'minimal']) }}
                                         {{ trans('admin/hardware/form.serial') }}
                                     </label>
                                     <label>
-                                        {{ Form::checkbox('labels_display_tag', '1', Input::old('labels_display_tag',   $setting->labels_display_tag),['class' => 'minimal']) }}
+                                        {{ Form::checkbox('labels_display_tag', '1', Request::old('labels_display_tag',   $setting->labels_display_tag),['class' => 'minimal']) }}
                                         {{ trans('admin/hardware/form.tag') }}
 				    </label>
 				    <label>
-                                        {{ Form::checkbox('labels_display_model', '1', Input::old('labels_display_model',   $setting->labels_display_model),['class' => 'minimal']) }}
+                                        {{ Form::checkbox('labels_display_model', '1', Request::old('labels_display_model',   $setting->labels_display_model),['class' => 'minimal']) }}
                                         {{ trans('admin/hardware/form.model') }}
                                     </label>
                                     <label>
-                                        {{ Form::checkbox('labels_display_company_name', '1', Input::old('labels_display_company_name',   $setting->labels_display_company_name),['class' => 'minimal']) }}
+                                        {{ Form::checkbox('labels_display_company_name', '1', Request::old('labels_display_company_name',   $setting->labels_display_company_name),['class' => 'minimal']) }}
                                         {{ trans('admin/companies/table.name') }}
 				    </label>
 

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -63,7 +63,7 @@
                                 {{ Form::label('ldap_integration', trans('admin/settings/general.ldap_integration')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::checkbox('ldap_enabled', '1', Input::old('ldap_enabled', $setting->ldap_enabled), ['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                {{ Form::checkbox('ldap_enabled', '1', Request::old('ldap_enabled', $setting->ldap_enabled), ['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('admin/settings/general.ldap_enabled') }}
                                 {!! $errors->first('ldap_enabled', '<span class="alert-msg">:message</span>') !!}
                             </div>
@@ -75,7 +75,7 @@
                                 {{ Form::label('ldap_pw_sync', trans('admin/settings/general.ldap_pw_sync')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::checkbox('ldap_pw_sync', '1', Input::old('ldap_pw_sync', $setting->ldap_pw_sync),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                {{ Form::checkbox('ldap_pw_sync', '1', Request::old('ldap_pw_sync', $setting->ldap_pw_sync),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('general.yes') }}
                                 <p class="help-block">{{ trans('admin/settings/general.ldap_pw_sync_help') }}</p>
                                 {!! $errors->first('ldap_pw_sync', '<span class="alert-msg">:message</span>') !!}
@@ -88,7 +88,7 @@
                                 {{ Form::label('is_ad', trans('admin/settings/general.ad')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::checkbox('is_ad', '1', Input::old('is_ad', $setting->is_ad),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                {{ Form::checkbox('is_ad', '1', Request::old('is_ad', $setting->is_ad),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('admin/settings/general.is_ad') }}
                                 {!! $errors->first('is_ad', '<span class="alert-msg">:message</span>') !!}
                             </div>
@@ -100,7 +100,7 @@
                                 {{ Form::label('ad_domain', trans('admin/settings/general.ad_domain')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ad_domain', Input::old('ad_domain', $setting->ad_domain), ['class' => 'form-control','placeholder' => 'example.com', $setting->demoMode]) }}
+                                {{ Form::text('ad_domain', Request::old('ad_domain', $setting->ad_domain), ['class' => 'form-control','placeholder' => 'example.com', $setting->demoMode]) }}
                                 <p class="help-block">{{ trans('admin/settings/general.ad_domain_help') }}</p>
                                 {!! $errors->first('ad_domain', '<span class="alert-msg">:message</span>') !!}
                             </div>
@@ -112,7 +112,7 @@
                                 {{ Form::label('ldap_server', trans('admin/settings/general.ldap_server')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_server', Input::old('ldap_server', $setting->ldap_server), ['class' => 'form-control','placeholder' => 'ldap://ldap.example.com', $setting->demoMode]) }}
+                                {{ Form::text('ldap_server', Request::old('ldap_server', $setting->ldap_server), ['class' => 'form-control','placeholder' => 'ldap://ldap.example.com', $setting->demoMode]) }}
                                 <p class="help-block">{{ trans('admin/settings/general.ldap_server_help') }}</p>
                                 {!! $errors->first('ldap_server', '<span class="alert-msg">:message</span>') !!}
                             </div>
@@ -124,7 +124,7 @@
                                 {{ Form::label('ldap_tls', trans('admin/settings/general.ldap_tls')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::checkbox('ldap_tls', '1', Input::old('ldap_tls', $setting->ldap_tls),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                {{ Form::checkbox('ldap_tls', '1', Request::old('ldap_tls', $setting->ldap_tls),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('admin/settings/general.ldap_tls_help') }}
                                 {!! $errors->first('ldap_tls', '<span class="alert-msg">:message</span>') !!}
                             </div>
@@ -136,7 +136,7 @@
                                 {{ Form::label('ldap_server_cert_ignore', trans('admin/settings/general.ldap_server_cert')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::checkbox('ldap_server_cert_ignore', '1', Input::old('ldap_server_cert_ignore', $setting->ldap_server_cert_ignore),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                {{ Form::checkbox('ldap_server_cert_ignore', '1', Request::old('ldap_server_cert_ignore', $setting->ldap_server_cert_ignore),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('admin/settings/general.ldap_server_cert_ignore') }}
                                 {!! $errors->first('ldap_server_cert_ignore', '<span class="alert-msg">:message</span>') !!}
                                 <p class="help-block">{{ trans('admin/settings/general.ldap_server_cert_help') }}</p>
@@ -149,7 +149,7 @@
                                 {{ Form::label('ldap_uname', trans('admin/settings/general.ldap_uname')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_uname', Input::old('ldap_uname', $setting->ldap_uname), ['class' => 'form-control','placeholder' => 'binduser@example.com', $setting->demoMode]) }}
+                                {{ Form::text('ldap_uname', Request::old('ldap_uname', $setting->ldap_uname), ['class' => 'form-control','placeholder' => 'binduser@example.com', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_uname', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -171,7 +171,7 @@
                                 {{ Form::label('ldap_basedn', trans('admin/settings/general.ldap_basedn')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_basedn', Input::old('ldap_basedn', $setting->ldap_basedn), ['class' => 'form-control', 'placeholder' => 'cn=users/authorized,dc=example,dc=com', $setting->demoMode]) }}
+                                {{ Form::text('ldap_basedn', Request::old('ldap_basedn', $setting->ldap_basedn), ['class' => 'form-control', 'placeholder' => 'cn=users/authorized,dc=example,dc=com', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_basedn', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -182,7 +182,7 @@
                                 {{ Form::label('ldap_filter', trans('admin/settings/general.ldap_filter')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_filter', Input::old('ldap_filter', $setting->ldap_filter), ['class' => 'form-control','placeholder' => '&(cn=*)', $setting->demoMode]) }}
+                                {{ Form::text('ldap_filter', Request::old('ldap_filter', $setting->ldap_filter), ['class' => 'form-control','placeholder' => '&(cn=*)', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_filter', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -193,7 +193,7 @@
                                 {{ Form::label('ldap_username_field', trans('admin/settings/general.ldap_username_field')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_username_field', Input::old('ldap_username_field', $setting->ldap_username_field), ['class' => 'form-control','placeholder' => 'samaccountname', $setting->demoMode]) }}
+                                {{ Form::text('ldap_username_field', Request::old('ldap_username_field', $setting->ldap_username_field), ['class' => 'form-control','placeholder' => 'samaccountname', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_username_field', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -204,7 +204,7 @@
                                 {{ Form::label('ldap_lname_field', trans('admin/settings/general.ldap_lname_field')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_lname_field', Input::old('ldap_lname_field', $setting->ldap_lname_field), ['class' => 'form-control','placeholder' => 'sn', $setting->demoMode]) }}
+                                {{ Form::text('ldap_lname_field', Request::old('ldap_lname_field', $setting->ldap_lname_field), ['class' => 'form-control','placeholder' => 'sn', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_lname_field', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -215,7 +215,7 @@
                                 {{ Form::label('ldap_fname_field', trans('admin/settings/general.ldap_fname_field')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_fname_field', Input::old('ldap_fname_field', $setting->ldap_fname_field), ['class' => 'form-control', 'placeholder' => 'givenname', $setting->demoMode]) }}
+                                {{ Form::text('ldap_fname_field', Request::old('ldap_fname_field', $setting->ldap_fname_field), ['class' => 'form-control', 'placeholder' => 'givenname', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_fname_field', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -226,7 +226,7 @@
                                 {{ Form::label('ldap_auth_filter_query', trans('admin/settings/general.ldap_auth_filter_query')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_auth_filter_query', Input::old('ldap_auth_filter_query', $setting->ldap_auth_filter_query), ['class' => 'form-control','placeholder' => '"uid="', $setting->demoMode]) }}
+                                {{ Form::text('ldap_auth_filter_query', Request::old('ldap_auth_filter_query', $setting->ldap_auth_filter_query), ['class' => 'form-control','placeholder' => '"uid="', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_auth_filter_query', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -237,7 +237,7 @@
                                 {{ Form::label('ldap_version', trans('admin/settings/general.ldap_version')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_version', Input::old('ldap_version', $setting->ldap_version), ['class' => 'form-control','placeholder' => '3', $setting->demoMode]) }}
+                                {{ Form::text('ldap_version', Request::old('ldap_version', $setting->ldap_version), ['class' => 'form-control','placeholder' => '3', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_version', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -248,7 +248,7 @@
                                 {{ Form::label('ldap_active_flag', trans('admin/settings/general.ldap_active_flag')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_active_flag', Input::old('ldap_active_flag', $setting->ldap_active_flag), ['class' => 'form-control','placeholder' => '', $setting->demoMode]) }}
+                                {{ Form::text('ldap_active_flag', Request::old('ldap_active_flag', $setting->ldap_active_flag), ['class' => 'form-control','placeholder' => '', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_active_flag', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -259,7 +259,7 @@
                                 {{ Form::label('ldap_emp_num', trans('admin/settings/general.ldap_emp_num')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_emp_num', Input::old('ldap_emp_num', $setting->ldap_emp_num), ['class' => 'form-control','placeholder' => '', $setting->demoMode]) }}
+                                {{ Form::text('ldap_emp_num', Request::old('ldap_emp_num', $setting->ldap_emp_num), ['class' => 'form-control','placeholder' => '', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_emp_num', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -270,7 +270,7 @@
                                 {{ Form::label('ldap_email', trans('admin/settings/general.ldap_email')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('ldap_email', Input::old('ldap_email', $setting->ldap_email), ['class' => 'form-control','placeholder' => '', $setting->demoMode]) }}
+                                {{ Form::text('ldap_email', Request::old('ldap_email', $setting->ldap_email), ['class' => 'form-control','placeholder' => '', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_email', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -304,7 +304,7 @@
                                 {{ Form::label('custom_forgot_pass_url', trans('admin/settings/general.custom_forgot_pass_url')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('custom_forgot_pass_url', Input::old('custom_forgot_pass_url', $setting->custom_forgot_pass_url), ['class' => 'form-control','placeholder' => 'https://my.ldapserver-forgotpass.com', $setting->demoMode]) }}
+                                {{ Form::text('custom_forgot_pass_url', Request::old('custom_forgot_pass_url', $setting->custom_forgot_pass_url), ['class' => 'form-control','placeholder' => 'https://my.ldapserver-forgotpass.com', $setting->demoMode]) }}
                                 <p class="help-block">{{ trans('admin/settings/general.custom_forgot_pass_url_help') }}</p>
                                 {!! $errors->first('custom_forgot_pass_url', '<span class="alert-msg">:message</span>') !!}
                             </div>

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -46,7 +46,7 @@
                                 {{ Form::label('site_name', trans('admin/settings/general.default_language')) }}
                             </div>
                             <div class="col-md-9">
-                                {!! Form::locales('locale', Input::old('locale', $setting->locale), 'select2') !!}
+                                {!! Form::locales('locale', Request::old('locale', $setting->locale), 'select2') !!}
 
                                 {!! $errors->first('locale', '<span class="alert-msg">:message</span>') !!}
                             </div>
@@ -58,9 +58,9 @@
                                 {{ Form::label('time_display_format', trans('general.time_and_date_display')) }}
                             </div>
                             <div class="col-md-9">
-                                {!! Form::date_display_format('date_display_format', Input::old('date_display_format', $setting->date_display_format), 'select2') !!}
+                                {!! Form::date_display_format('date_display_format', Request::old('date_display_format', $setting->date_display_format), 'select2') !!}
 
-                                {!! Form::time_display_format('time_display_format', Input::old('time_display_format', $setting->time_display_format), 'select2') !!}
+                                {!! Form::time_display_format('time_display_format', Request::old('time_display_format', $setting->time_display_format), 'select2') !!}
 
                                 {!! $errors->first('time_display_format', '<span class="alert-msg">:message</span>') !!}
                             </div>
@@ -72,7 +72,7 @@
                                 {{ Form::label('default_currency', trans('admin/settings/general.default_currency')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('default_currency', Input::old('default_currency', $setting->default_currency), array('class' => 'form-control','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                                {{ Form::text('default_currency', Request::old('default_currency', $setting->default_currency), array('class' => 'form-control','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
                                 {!! $errors->first('default_currency', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>

--- a/resources/views/settings/purge-form.blade.php
+++ b/resources/views/settings/purge-form.blade.php
@@ -30,9 +30,9 @@
                     </div>
                     <div class="col-md-9{{ $errors->has('confirm_purge') ? 'error' : '' }}">
                         @if (config('app.lock_passwords')===true)
-                            {{ Form::text('confirm_purge', Input::old('confirm_purge'), array('class' => 'form-control', 'disabled'=>'disabled')) }}
+                            {{ Form::text('confirm_purge', Request::old('confirm_purge'), array('class' => 'form-control', 'disabled'=>'disabled')) }}
                         @else
-                            {{ Form::text('confirm_purge', Input::old('confirm_purge'), array('class' => 'form-control')) }}
+                            {{ Form::text('confirm_purge', Request::old('confirm_purge'), array('class' => 'form-control')) }}
                         @endif
                         {!! $errors->first('ldap_version', '<span class="alert-msg">:message</span>') !!}
                     </div>

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -43,7 +43,7 @@
                             </div>
                             <div class="col-md-9">
 
-                                {!! Form::two_factor_options('two_factor_enabled', Input::old('two_factor_enabled', $setting->two_factor_enabled), 'select2') !!}
+                                {!! Form::two_factor_options('two_factor_enabled', Request::old('two_factor_enabled', $setting->two_factor_enabled), 'select2') !!}
                                 <p class="help-block">{{ trans('admin/settings/general.two_factor_enabled_warning') }}</p>
 
                                 @if (config('app.lock_passwords'))
@@ -60,7 +60,7 @@
                                 {{ Form::label('pwd_secure_min', trans('admin/settings/general.pwd_secure_min')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('pwd_secure_min', Input::old('pwd_secure_min', $setting->pwd_secure_min), array('class' => 'form-control',  'style'=>'width: 50px;')) }}
+                                {{ Form::text('pwd_secure_min', Request::old('pwd_secure_min', $setting->pwd_secure_min), array('class' => 'form-control',  'style'=>'width: 50px;')) }}
 
                                 {!! $errors->first('pwd_secure_min', '<span class="alert-msg">:message</span>') !!}
                                 <p class="help-block">
@@ -80,7 +80,7 @@
 
                             </div>
                             <div class="col-md-9">
-                                {{ Form::checkbox('pwd_secure_uncommon', '1', Input::old('pwd_secure_uncommon', $setting->pwd_secure_uncommon),array('class' => 'minimal')) }}
+                                {{ Form::checkbox('pwd_secure_uncommon', '1', Request::old('pwd_secure_uncommon', $setting->pwd_secure_uncommon),array('class' => 'minimal')) }}
                                 {{ Form::label('pwd_secure_uncommon',  trans('general.yes')) }}
                                 {!! $errors->first('pwd_secure_uncommon', '<span class="alert-msg">:message</span>') !!}
                                 <p class="help-block">
@@ -97,16 +97,16 @@
                             </div>
                             <div class="col-md-9">
 
-                                {{ Form::checkbox("pwd_secure_complexity['letters']", 'letters', Input::old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'letters')!==false), array('class' => 'minimal')) }}
+                                {{ Form::checkbox("pwd_secure_complexity['letters']", 'letters', Request::old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'letters')!==false), array('class' => 'minimal')) }}
                                 Require at least one letter <br>
 
-                                {{ Form::checkbox("pwd_secure_complexity['numbers']", 'numbers', Input::old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'numbers')!==false), array('class' => 'minimal')) }}
+                                {{ Form::checkbox("pwd_secure_complexity['numbers']", 'numbers', Request::old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'numbers')!==false), array('class' => 'minimal')) }}
                                 Require at least one number<br>
 
-                                {{ Form::checkbox("pwd_secure_complexity['symbols']", 'symbols', Input::old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'symbols')!==false), array('class' => 'minimal')) }}
+                                {{ Form::checkbox("pwd_secure_complexity['symbols']", 'symbols', Request::old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'symbols')!==false), array('class' => 'minimal')) }}
                                 Require at least one symbol<br>
 
-                                {{ Form::checkbox("pwd_secure_complexity['case_diff']", 'case_diff', Input::old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'case_diff')!==false), array('class' => 'minimal')) }}
+                                {{ Form::checkbox("pwd_secure_complexity['case_diff']", 'case_diff', Request::old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'case_diff')!==false), array('class' => 'minimal')) }}
                                 Require at least one uppercase and one lowercase
 
                                 <p class="help-block">
@@ -127,7 +127,7 @@
                                 @if (config('app.lock_passwords'))
                                     <p class="help-block">{{ trans('general.feature_disabled') }}</p>
                                 @else
-                                    {{ Form::checkbox('login_remote_user_enabled', '1', Input::old('login_remote_user_enabled', $setting->login_remote_user_enabled),array('class' => 'minimal')) }}
+                                    {{ Form::checkbox('login_remote_user_enabled', '1', Request::old('login_remote_user_enabled', $setting->login_remote_user_enabled),array('class' => 'minimal')) }}
                                     {{ Form::label('login_remote_user_enabled',  trans('admin/settings/general.login_remote_user_enabled_text')) }}
                                     {!! $errors->first('login_remote_user_enabled', '<span class="alert-msg">:message</span>') !!}
                                     <p class="help-block">
@@ -135,21 +135,21 @@
                                     </p>
                                     <!-- Use custom remote user header name -->
                                     {{ Form::label('login_remote_user_header_name',  trans('admin/settings/general.login_remote_user_header_name_text')) }}
-                                    {{ Form::text('login_remote_user_header_name', Input::old('login_remote_user_header_name', $setting->login_remote_user_header_name),array('class' => 'form-control')) }}
+                                    {{ Form::text('login_remote_user_header_name', Request::old('login_remote_user_header_name', $setting->login_remote_user_header_name),array('class' => 'form-control')) }}
                                     {!! $errors->first('login_remote_user_header_name', '<span class="alert-msg">:message</span>') !!}
                                     <p class="help-block">
                                         {{ trans('admin/settings/general.login_remote_user_header_name_help') }}
                                     </p>
                                     <!-- Custom logout url to redirect to authentication provider -->
                                     {{ Form::label('login_remote_user_custom_logout_url',  trans('admin/settings/general.login_remote_user_custom_logout_url_text')) }}
-                                    {{ Form::text('login_remote_user_custom_logout_url', Input::old('login_remote_user_custom_logout_url', $setting->login_remote_user_custom_logout_url),array('class' => 'form-control')) }}
+                                    {{ Form::text('login_remote_user_custom_logout_url', Request::old('login_remote_user_custom_logout_url', $setting->login_remote_user_custom_logout_url),array('class' => 'form-control')) }}
 
                                     {!! $errors->first('login_remote_user_custom_logout_url', '<span class="alert-msg">:message</span>') !!}
                                     <p class="help-block">
                                         {{ trans('admin/settings/general.login_remote_user_custom_logout_url_help') }}
                                     </p>
                                     <!--  Disable other logins mechanism -->
-                                    {{ Form::checkbox('login_common_disabled', '1', Input::old('login_common_disabled', $setting->login_common_disabled),array('class' => 'minimal')) }}
+                                    {{ Form::checkbox('login_common_disabled', '1', Request::old('login_common_disabled', $setting->login_common_disabled),array('class' => 'minimal')) }}
                                     {{ Form::label('login_common_disabled',  trans('admin/settings/general.login_common_disabled_text')) }}
                                     {!! $errors->first('login_common_disabled', '<span class="alert-msg">:message</span>') !!}
                                     <p class="help-block">

--- a/resources/views/settings/slack.blade.php
+++ b/resources/views/settings/slack.blade.php
@@ -57,9 +57,9 @@
                             </div>
                             <div class="col-md-8">
                                 @if (config('app.lock_passwords')===true)
-                                    {{ Form::text('slack_endpoint', Input::old('slack_endpoint', $setting->slack_endpoint), array('class' => 'form-control','disabled'=>'disabled','placeholder' => 'https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXX')) }}
+                                    {{ Form::text('slack_endpoint', Request::old('slack_endpoint', $setting->slack_endpoint), array('class' => 'form-control','disabled'=>'disabled','placeholder' => 'https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXX')) }}
                                 @else
-                                    {{ Form::text('slack_endpoint', Input::old('slack_endpoint', $setting->slack_endpoint), array('class' => 'form-control','placeholder' => 'https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXX')) }}
+                                    {{ Form::text('slack_endpoint', Request::old('slack_endpoint', $setting->slack_endpoint), array('class' => 'form-control','placeholder' => 'https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXX')) }}
                                 @endif
                                 {!! $errors->first('slack_endpoint', '<span class="alert-msg">:message</span>') !!}
                             </div>
@@ -72,9 +72,9 @@
                             </div>
                             <div class="col-md-8">
                                 @if (config('app.lock_passwords')===true)
-                                    {{ Form::text('slack_channel', Input::old('slack_channel', $setting->slack_channel), array('class' => 'form-control','disabled'=>'disabled','placeholder' => '#IT-Ops')) }}
+                                    {{ Form::text('slack_channel', Request::old('slack_channel', $setting->slack_channel), array('class' => 'form-control','disabled'=>'disabled','placeholder' => '#IT-Ops')) }}
                                 @else
-                                    {{ Form::text('slack_channel', Input::old('slack_channel', $setting->slack_channel), array('class' => 'form-control','placeholder' => '#IT-Ops')) }}
+                                    {{ Form::text('slack_channel', Request::old('slack_channel', $setting->slack_channel), array('class' => 'form-control','placeholder' => '#IT-Ops')) }}
                                 @endif
                                 {!! $errors->first('slack_channel', '<span class="alert-msg">:message</span>') !!}
                             </div>
@@ -87,9 +87,9 @@
                             </div>
                             <div class="col-md-8">
                                 @if (config('app.lock_passwords')===true)
-                                    {{ Form::text('slack_botname', Input::old('slack_botname', $setting->slack_botname), array('class' => 'form-control','disabled'=>'disabled','placeholder' => 'Snipe-Bot')) }}
+                                    {{ Form::text('slack_botname', Request::old('slack_botname', $setting->slack_botname), array('class' => 'form-control','disabled'=>'disabled','placeholder' => 'Snipe-Bot')) }}
                                 @else
-                                    {{ Form::text('slack_botname', Input::old('slack_botname', $setting->slack_botname), array('class' => 'form-control','placeholder' => 'Snipe-Bot')) }}
+                                    {{ Form::text('slack_botname', Request::old('slack_botname', $setting->slack_botname), array('class' => 'form-control','placeholder' => 'Snipe-Bot')) }}
                                 @endif
                                 {!! $errors->first('slack_botname', '<span class="alert-msg">:message</span>') !!}
                             </div>

--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -20,7 +20,7 @@ Create a User ::
     <div class="row">
       <div class="form-group col-lg-12 required {{ $errors->has('site_name') ? 'error' : '' }}">
         {{ Form::label('site_name', trans('general.site_name')) }}
-        {{ Form::text('site_name', Input::old('site_name'), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management')) }}
+        {{ Form::text('site_name', Request::old('site_name'), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management')) }}
 
         {!! $errors->first('site_name', '<span class="alert-msg">:message</span>') !!}
       </div>
@@ -31,7 +31,7 @@ Create a User ::
     <!-- Language -->
     <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'default_language')) ? ' required' : '' }} {{$errors->has('default_language') ? 'error' : ''}}">
       {{ Form::label('locale', trans('admin/settings/general.default_language')) }}
-      {!! Form::locales('locale', Input::old('locale', "en"), 'select2') !!}
+      {!! Form::locales('locale', Request::old('locale', "en"), 'select2') !!}
 
       {!! $errors->first('locale', '<span class="alert-msg">:message</span>') !!}
     </div>
@@ -39,7 +39,7 @@ Create a User ::
     <!-- Currency -->
     <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'default_currency')) ? ' required' : '' }} {{$errors->has('default_currency') ? 'error' : ''}}">
       {{ Form::label('default_currency', trans('admin/settings/general.default_currency')) }}
-      {{ Form::text('default_currency', Input::old('default_currency'), array('class' => 'form-control','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+      {{ Form::text('default_currency', Request::old('default_currency'), array('class' => 'form-control','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
 
       {!! $errors->first('default_currency', '<span class="alert-msg">:message</span>') !!}
     </div>
@@ -74,14 +74,14 @@ Create a User ::
 
     <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'auto_increment_prefix')) ? ' required' : '' }} {{ $errors->has('auto_increment_prefix') ? 'error' : '' }}">
       {{ Form::label('auto_increment_prefix', trans('admin/settings/general.auto_increment_prefix')) }}
-      {{ Form::text('auto_increment_prefix', Input::old('auto_increment_prefix'), array('class' => 'form-control')) }}
+      {{ Form::text('auto_increment_prefix', Request::old('auto_increment_prefix'), array('class' => 'form-control')) }}
 
       {!! $errors->first('auto_increment_prefix', '<span class="alert-msg">:message</span>') !!}
     </div>
 
     <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'zerofill_count')) ? ' required' : '' }} {{ $errors->has('zerofill_count') ? 'error' : '' }}">
       {{ Form::label('zerofill_count', trans('admin/settings/general.zerofill_count')) }}
-      {{ Form::text('zerofill_count', Input::old('zerofill_count', 5), array('class' => 'form-control')) }}
+      {{ Form::text('zerofill_count', Request::old('zerofill_count', 5), array('class' => 'form-control')) }}
 
       {!! $errors->first('zerofill_count', '<span class="alert-msg">:message</span>') !!}
     </div>
@@ -92,7 +92,7 @@ Create a User ::
     <div class="row">
       <div class="form-group col-lg-6 required {{ $errors->has('email_domain') ? 'error' : '' }}">
         {{ Form::label('email_domain', trans('general.email_domain')) }}
-        {{ Form::text('email_domain', Input::old('email_domain'), array('class' => 'form-control','placeholder' => 'example.com')) }}
+        {{ Form::text('email_domain', Request::old('email_domain'), array('class' => 'form-control','placeholder' => 'example.com')) }}
         <span class="help-block">{{ trans('general.email_domain_help')  }}</span>
 
         {!! $errors->first('email_domain', '<span class="alert-msg">:message</span>') !!}
@@ -101,7 +101,7 @@ Create a User ::
       <!-- email format  -->
       <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'email_format')) ? ' required' : '' }} {{ $errors->has('email_format') ? 'error' : '' }}">
         {{ Form::label('email_format', trans('general.email_format')) }}
-        {!! Form::username_format('email_format', Input::old('email_format', 'filastname'), 'select2') !!}
+        {!! Form::username_format('email_format', Request::old('email_format', 'filastname'), 'select2') !!}
         {!! $errors->first('email_format', '<span class="alert-msg">:message</span>') !!}
       </div>
     </div>
@@ -111,14 +111,14 @@ Create a User ::
       <!-- first name -->
       <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'first_name')) ? ' required' : '' }} {{ $errors->has('first_name') ? 'error' : '' }}">
         {{ Form::label('first_name', trans('general.first_name')) }}
-        {{ Form::text('first_name', Input::old('first_name'), array('class' => 'form-control','placeholder' => 'Jane')) }}
+        {{ Form::text('first_name', Request::old('first_name'), array('class' => 'form-control','placeholder' => 'Jane')) }}
         {!! $errors->first('first_name', '<span class="alert-msg">:message</span>') !!}
       </div>
 
       <!-- last name -->
       <div class="form-group col-lg-6 required {{ $errors->has('last_name') ? 'error' : '' }}">
         {{ Form::label('last_name', trans('general.last_name')) }}
-        {{ Form::text('last_name', Input::old('last_name'), array('class' => 'form-control','placeholder' => 'Smith')) }}
+        {{ Form::text('last_name', Request::old('last_name'), array('class' => 'form-control','placeholder' => 'Smith')) }}
         {!! $errors->first('last_name', '<span class="alert-msg">:message</span>') !!}
       </div>
     </div>
@@ -134,7 +134,7 @@ Create a User ::
       <!-- username -->
       <div class="form-group col-lg-6{{  (\App\Helpers\Helper::checkIfRequired(\App\Models\User::class, 'username')) ? ' required' : '' }} {{ $errors->has('username') ? 'error' : '' }}">
         {{ Form::label('username', trans('admin/users/table.username')) }}
-        {{ Form::text('username', Input::old('username'), array('class' => 'form-control','placeholder' => 'jsmith')) }}
+        {{ Form::text('username', Request::old('username'), array('class' => 'form-control','placeholder' => 'jsmith')) }}
         {!! $errors->first('username', '<span class="alert-msg">:message</span>') !!}
       </div>
     </div>

--- a/resources/views/statuslabels/edit.blade.php
+++ b/resources/views/statuslabels/edit.blade.php
@@ -3,7 +3,7 @@
     'updateText' => trans('admin/statuslabels/table.update'),
     'helpTitle' => trans('admin/statuslabels/table.about'),
     'helpText' => trans('admin/statuslabels/table.info'),
-    'formAction' => ($item) ? route('statuslabels.update', ['statuslabel' => $item->id]) : route('statuslabels.store'),
+    'formAction' => (isset($item->id)) ? route('statuslabels.update', ['statuslabel' => $item->id]) : route('statuslabels.store'),
 ])
 
 {{-- Page content --}}

--- a/resources/views/statuslabels/edit.blade.php
+++ b/resources/views/statuslabels/edit.blade.php
@@ -35,7 +35,7 @@
     {{ Form::label('color', trans('admin/statuslabels/table.color'), ['class' => 'col-md-3 control-label']) }}
     <div class="col-md-2">
         <div class="input-group color">
-            {{ Form::text('color', Input::old('color', $item->color), array('class' => 'form-control', 'style' => 'width: 100px;', 'maxlength'=>'10')) }}
+            {{ Form::text('color', Request::old('color', $item->color), array('class' => 'form-control', 'style' => 'width: 100px;', 'maxlength'=>'10')) }}
             <div class="input-group-addon"><i></i></div>
         </div><!-- /.input group -->
         {!! $errors->first('header_color', '<span class="alert-msg">:message</span>') !!}
@@ -48,7 +48,7 @@
 <div class="form-group{{ $errors->has('notes') ? ' has-error' : '' }}">
 
     <label class="col-md-offset-3" style="padding-left: 15px;">
-        <input type="checkbox" value="1" name="show_in_nav" id="show_in_nav" class="minimal" {{ Input::old('show_in_nav', $item->show_in_nav) == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/statuslabels/table.show_in_nav') }}
+        <input type="checkbox" value="1" name="show_in_nav" id="show_in_nav" class="minimal" {{ Request::old('show_in_nav', $item->show_in_nav) == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/statuslabels/table.show_in_nav') }}
     </label>
 </div>
 
@@ -56,7 +56,7 @@
 <div class="form-group{{ $errors->has('default_label') ? ' has-error' : '' }}">
 
     <label class="col-md-offset-3" style="padding-left: 15px;">
-        <input type="checkbox" value="1" name="default_label" id="default_label" class="minimal" {{ Input::old('default_label', $item->default_label) == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/statuslabels/table.default_label') }}
+        <input type="checkbox" value="1" name="default_label" id="default_label" class="minimal" {{ Request::old('default_label', $item->default_label) == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/statuslabels/table.default_label') }}
     </label>
     <p class="col-md-offset-3 help-block"> {{ trans('admin/statuslabels/table.default_label_help') }}</p>
 </div>

--- a/resources/views/statuslabels/view.blade.php
+++ b/resources/views/statuslabels/view.blade.php
@@ -20,7 +20,7 @@
                        'id' => 'bulkForm']) }}
                     <div class="row">
                         <div class="col-md-12">
-                            @if (Input::get('status')!='Deleted')
+                            @if (Request::get('status')!='Deleted')
                                 <div id="toolbar">
                                     <select name="bulk_actions" class="form-control select2">
                                         <option value="edit">Edit</option>

--- a/resources/views/suppliers/edit.blade.php
+++ b/resources/views/suppliers/edit.blade.php
@@ -3,7 +3,7 @@
     'updateText' => trans('admin/suppliers/table.update'),
     'helpTitle' => trans('admin/suppliers/table.about_suppliers_title'),
     'helpText' => trans('admin/suppliers/table.about_suppliers_text'),
-    'formAction' => ($item) ? route('suppliers.update', ['supplier' => $item->id]) : route('suppliers.store'),
+    'formAction' => (isset($item->id)) ? route('suppliers.update', ['supplier' => $item->id]) : route('suppliers.store'),
 ])
 
 

--- a/resources/views/suppliers/edit.blade.php
+++ b/resources/views/suppliers/edit.blade.php
@@ -16,7 +16,7 @@
 <div class="form-group {{ $errors->has('contact') ? ' has-error' : '' }}">
     {{ Form::label('contact', trans('admin/suppliers/table.contact'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-        {{Form::text('contact', Input::old('contact', $item->contact), array('class' => 'form-control')) }}
+        {{Form::text('contact', Request::old('contact', $item->contact), array('class' => 'form-control')) }}
         {!! $errors->first('contact', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -26,7 +26,7 @@
 <div class="form-group {{ $errors->has('fax') ? ' has-error' : '' }}">
     {{ Form::label('fax', trans('admin/suppliers/table.fax'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-        {{Form::text('fax', Input::old('fax', $item->fax), array('class' => 'form-control')) }}
+        {{Form::text('fax', Request::old('fax', $item->fax), array('class' => 'form-control')) }}
         {!! $errors->first('fax', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>
@@ -36,7 +36,7 @@
 <div class="form-group {{ $errors->has('url') ? ' has-error' : '' }}">
     {{ Form::label('url', trans('admin/suppliers/table.url'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-        {{Form::text('url', Input::old('url', $item->url), array('class' => 'form-control')) }}
+        {{Form::text('url', Request::old('url', $item->url), array('class' => 'form-control')) }}
         {!! $errors->first('url', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -50,7 +50,7 @@
                         <div class="form-group {{ $errors->has('locale') ? 'has-error' : '' }}">
                             <label class="col-md-3 control-label" for="locale">{{ trans('general.language') }}</label>
                             <div class="col-md-8">
-                                {!! Form::locales('locale', Input::old('locale', $user->locale), 'select2') !!}
+                                {!! Form::locales('locale', Request::old('locale', $user->locale), 'select2') !!}
                                 {!! $errors->first('locale', '<span class="alert-msg">:message</span>') !!}
                             </div>
                         </div>
@@ -64,8 +64,8 @@
                                 <div class="checkbox">
                                     <label for="activated">
                                         {{ Form::radio('activated', '', true) }} Do not change activation status <br>
-                                        {{ Form::radio('activated', '1', Input::old('activated')) }}  User is activated<br>
-                                        {{ Form::radio('activated', '0', Input::old('activated')) }}  User is de-activated
+                                        {{ Form::radio('activated', '1', Request::old('activated')) }}  User is activated<br>
+                                        {{ Form::radio('activated', '0', Request::old('activated')) }}  User is de-activated
 
                                     </label>
                                 </div>

--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -84,7 +84,7 @@ Bulk Checkin &amp; Delete
                 <tfoot>
                   <tr>
                     <td colspan="6" class="warning">
-                      {{ Form::select('status_id', $statuslabel_list , Input::old('status_id'), array('class'=>'select2', 'style'=>'width:250px')) }}
+                      {{ Form::select('status_id', $statuslabel_list , Request::old('status_id'), array('class'=>'select2', 'style'=>'width:250px')) }}
                       <label>Update all assets for these users to this status</label>
                     </td>
                   </tr>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -67,7 +67,7 @@
 
 <div class="row">
   <div class="col-md-8 col-md-offset-2">
-    <form class="form-horizontal" method="post" autocomplete="off" action="{{ ($user) ? route('users.update', ['user' => $user->id]) : route('users.store') }}" id="userForm">
+    <form class="form-horizontal" method="post" autocomplete="off" action="{{ (isset($user->id)) ? route('users.update', ['user' => $user->id]) : route('users.store') }}" id="userForm">
       {{csrf_field()}}
 
       @if($user->id)

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -88,7 +88,7 @@
                 <div class="form-group {{ $errors->has('first_name') ? 'has-error' : '' }}">
                   <label class="col-md-3 control-label" for="first_name">{{ trans('general.first_name') }}</label>
                   <div class="col-md-8 {{  (\App\Helpers\Helper::checkIfRequired($user, 'first_name')) ? ' required' : '' }}">
-                    <input class="form-control" type="text" name="first_name" id="first_name" value="{{ Input::old('first_name', $user->first_name) }}" />
+                    <input class="form-control" type="text" name="first_name" id="first_name" value="{{ Request::old('first_name', $user->first_name) }}" />
                     {!! $errors->first('first_name', '<span class="alert-msg">:message</span>') !!}
                   </div>
                 </div>
@@ -97,7 +97,7 @@
                 <div class="form-group {{ $errors->has('last_name') ? 'has-error' : '' }}">
                   <label class="col-md-3 control-label" for="last_name">{{ trans('general.last_name') }} </label>
                   <div class="col-md-8{{  (\App\Helpers\Helper::checkIfRequired($user, 'last_name')) ? ' required' : '' }}">
-                    <input class="form-control" type="text" name="last_name" id="last_name" value="{{ Input::old('last_name', $user->last_name) }}" />
+                    <input class="form-control" type="text" name="last_name" id="last_name" value="{{ Request::old('last_name', $user->last_name) }}" />
                     {!! $errors->first('last_name', '<span class="alert-msg">:message</span>') !!}
                   </div>
                 </div>
@@ -112,7 +112,7 @@
                         type="text"
                         name="username"
                         id="username"
-                        value="{{ Input::old('username', $user->username) }}"
+                        value="{{ Request::old('username', $user->username) }}"
                         autocomplete="off"
                         readonly
                         onfocus="this.removeAttribute('readonly');"
@@ -123,7 +123,7 @@
                       @endif
                     @else
                       (Managed via LDAP)
-                          <input type="hidden" name="username" value="{{ Input::old('username', $user->username) }}">
+                          <input type="hidden" name="username" value="{{ Request::old('username', $user->username) }}">
 
                     @endif
 
@@ -196,7 +196,7 @@
                       type="text"
                       name="email"
                       id="email"
-                      value="{{ Input::old('email', $user->email) }}"
+                      value="{{ Request::old('email', $user->email) }}"
                       {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }}
                       autocomplete="off"
                       readonly
@@ -217,7 +217,7 @@
                 <div class="form-group {{ $errors->has('locale') ? 'has-error' : '' }}">
                   <label class="col-md-3 control-label" for="locale">{{ trans('general.language') }}</label>
                   <div class="col-md-8">
-                    {!! Form::locales('locale', Input::old('locale', $user->locale), 'select2') !!}
+                    {!! Form::locales('locale', Request::old('locale', $user->locale), 'select2') !!}
                     {!! $errors->first('locale', '<span class="alert-msg">:message</span>') !!}
                   </div>
                 </div>
@@ -231,7 +231,7 @@
                       type="text"
                       name="employee_num"
                       id="employee_num"
-                      value="{{ Input::old('employee_num', $user->employee_num) }}"
+                      value="{{ Request::old('employee_num', $user->employee_num) }}"
                     />
                     {!! $errors->first('employee_num', '<span class="alert-msg">:message</span>') !!}
                   </div>
@@ -247,7 +247,7 @@
                       type="text"
                       name="jobtitle"
                       id="jobtitle"
-                      value="{{ Input::old('jobtitle', $user->jobtitle) }}"
+                      value="{{ Request::old('jobtitle', $user->jobtitle) }}"
                     />
                     {!! $errors->first('jobtitle', '<span class="alert-msg">:message</span>') !!}
                   </div>
@@ -268,7 +268,7 @@
                 <div class="form-group {{ $errors->has('phone') ? 'has-error' : '' }}">
                   <label class="col-md-3 control-label" for="phone">{{ trans('admin/users/table.phone') }}</label>
                   <div class="col-md-4">
-                    <input class="form-control" type="text" name="phone" id="phone" value="{{ Input::old('phone', $user->phone) }}" />
+                    <input class="form-control" type="text" name="phone" id="phone" value="{{ Request::old('phone', $user->phone) }}" />
                     {!! $errors->first('phone', '<span class="alert-msg">:message</span>') !!}
                   </div>
                 </div>
@@ -277,7 +277,7 @@
                   <div class="form-group {{ $errors->has('website') ? ' has-error' : '' }}">
                       <label for="website" class="col-md-3 control-label">{{ trans('general.website') }}</label>
                       <div class="col-md-8">
-                          <input class="form-control" type="text" name="website" id="website" value="{{ Input::old('website', $user->website) }}" />
+                          <input class="form-control" type="text" name="website" id="website" value="{{ Request::old('website', $user->website) }}" />
                           {!! $errors->first('website', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                       </div>
                   </div>
@@ -286,7 +286,7 @@
                   <div class="form-group{{ $errors->has('address') ? ' has-error' : '' }}">
                       <label class="col-md-3 control-label" for="address">{{ trans('general.address') }}</label>
                       <div class="col-md-4">
-                          <input class="form-control" type="text" name="address" id="address" value="{{ Input::old('address', $user->address) }}" />
+                          <input class="form-control" type="text" name="address" id="address" value="{{ Request::old('address', $user->address) }}" />
                           {!! $errors->first('address', '<span class="alert-msg">:message</span>') !!}
                       </div>
                   </div>
@@ -295,7 +295,7 @@
                   <div class="form-group{{ $errors->has('city') ? ' has-error' : '' }}">
                       <label class="col-md-3 control-label" for="city">{{ trans('general.city') }}</label>
                       <div class="col-md-4">
-                          <input class="form-control" type="text" name="city" id="city" value="{{ Input::old('city', $user->city) }}" />
+                          <input class="form-control" type="text" name="city" id="city" value="{{ Request::old('city', $user->city) }}" />
                           {!! $errors->first('city', '<span class="alert-msg">:message</span>') !!}
                       </div>
                   </div>
@@ -304,7 +304,7 @@
                   <div class="form-group{{ $errors->has('state') ? ' has-error' : '' }}">
                       <label class="col-md-3 control-label" for="state">{{ trans('general.state') }}</label>
                       <div class="col-md-4">
-                          <input class="form-control" type="text" name="state" id="state" value="{{ Input::old('state', $user->state) }}" maxlength="3" />
+                          <input class="form-control" type="text" name="state" id="state" value="{{ Request::old('state', $user->state) }}" maxlength="3" />
                           {!! $errors->first('state', '<span class="alert-msg">:message</span>') !!}
                       </div>
                   </div>
@@ -313,7 +313,7 @@
                   <div class="form-group{{ $errors->has('country') ? ' has-error' : '' }}">
                       <label class="col-md-3 control-label" for="city">{{ trans('general.country') }}</label>
                       <div class="col-md-4">
-                          {!! Form::countries('country', Input::old('country', $user->country), 'select2') !!}
+                          {!! Form::countries('country', Request::old('country', $user->country), 'select2') !!}
                           {!! $errors->first('country', '<span class="alert-msg">:message</span>') !!}
                       </div>
                   </div>
@@ -322,7 +322,7 @@
                   <div class="form-group{{ $errors->has('zip') ? ' has-error' : '' }}">
                       <label class="col-md-3 control-label" for="zip">{{ trans('general.zip') }}</label>
                       <div class="col-md-4">
-                          <input class="form-control" type="text" name="zip" id="zip" value="{{ Input::old('zip', $user->zip) }}" maxlength="10" />
+                          <input class="form-control" type="text" name="zip" id="zip" value="{{ Request::old('zip', $user->zip) }}" maxlength="10" />
                           {!! $errors->first('zip', '<span class="alert-msg">:message</span>') !!}
                       </div>
                   </div>
@@ -374,7 +374,7 @@
                         </div>
                         <div class="col-md-9">
                             <div class="icheckbox disabled" id="email_user_div">
-                                {{ Form::checkbox('email_user', '1', Input::old('email_user'),['class' => 'minimal', 'disabled'=>true, 'id' => 'email_user_checkbox']) }}
+                                {{ Form::checkbox('email_user', '1', Request::old('email_user'),['class' => 'minimal', 'disabled'=>true, 'id' => 'email_user_checkbox']) }}
                                 Email this user their credentials?
 
                             </div>
@@ -396,11 +396,11 @@
                     <div class="col-md-9">
                         @if (config('app.lock_passwords'))
                             <div class="icheckbox disabled">
-                            {{ Form::checkbox('two_factor_optin', '1', Input::old('two_factor_optin', $user->two_factor_optin),['class' => 'minimal', 'disabled'=>'disabled']) }} {{ trans('admin/settings/general.two_factor_enabled_text') }}
+                            {{ Form::checkbox('two_factor_optin', '1', Request::old('two_factor_optin', $user->two_factor_optin),['class' => 'minimal', 'disabled'=>'disabled']) }} {{ trans('admin/settings/general.two_factor_enabled_text') }}
                                 <p class="help-block">{{ trans('general.feature_disabled') }}</p>
                             </div>
                         @else
-                            {{ Form::checkbox('two_factor_optin', '1', Input::old('two_factor_optin', $user->two_factor_optin),['class' => 'minimal']) }} {{ trans('admin/settings/general.two_factor_enabled_text') }}
+                            {{ Form::checkbox('two_factor_optin', '1', Request::old('two_factor_optin', $user->two_factor_optin),['class' => 'minimal']) }} {{ trans('admin/settings/general.two_factor_enabled_text') }}
                             <p class="help-block">{{ trans('admin/users/general.two_factor_admin_optin_help') }}</p>
 
                         @endif
@@ -430,7 +430,7 @@
                 <div class="form-group{!! $errors->has('notes') ? ' has-error' : '' !!}">
                   <label for="notes" class="col-md-3 control-label">{{ trans('admin/users/table.notes') }}</label>
                   <div class="col-md-8">
-                    <textarea class="form-control" id="notes" name="notes">{{ Input::old('notes', $user->notes) }}</textarea>
+                    <textarea class="form-control" id="notes" name="notes">{{ Request::old('notes', $user->notes) }}</textarea>
                     {!! $errors->first('notes', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                   </div>
                 </div>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -3,7 +3,7 @@
 {{-- Page title --}}
 @section('title')
 
-@if (Input::get('status')=='deleted')
+@if (Request::get('status')=='deleted')
     {{ trans('general.deleted') }}
 @else
     {{ trans('general.current') }}
@@ -21,7 +21,7 @@
       <a href="{{ route('users.create') }}" class="btn btn-primary pull-right" style="margin-right: 5px;">  {{ trans('general.create') }}</a>
     @endcan
 
-    @if (Input::get('status')=='deleted')
+    @if (Request::get('status')=='deleted')
       <a class="btn btn-default pull-right" href="{{ route('users.index') }}" style="margin-right: 5px;">{{ trans('admin/users/table.show_current') }}</a>
     @else
       <a class="btn btn-default pull-right" href="{{ route('users.index', ['status' => 'deleted']) }}" style="margin-right: 5px;">{{ trans('admin/users/table.show_deleted') }}</a>
@@ -44,7 +44,7 @@
                'class' => 'form-inline',
                 'id' => 'bulkForm']) }}
 
-            @if (Input::get('status')!='deleted')
+            @if (Request::get('status')!='deleted')
               @can('delete', \App\Models\User::class)
                 <div id="toolbar">
                   <select name="bulk_actions" class="form-control select2" style="width: 200px;">
@@ -74,7 +74,7 @@
                     id="usersTable"
                     class="table table-striped snipe-table"
                     data-url="{{ route('api.users.index',
-              array('deleted'=> (Input::get('status')=='deleted') ? 'true' : 'false','company_id'=>e(Input::get('company_id')))) }}"
+              array('deleted'=> (Request::get('status')=='deleted') ? 'true' : 'false','company_id'=>e(Request::get('company_id')))) }}"
                     data-export-options='{
                 "fileName": "export-users-{{ date('Y-m-d') }}",
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,7 +14,7 @@ use Illuminate\Http\Request;
 */
 
 
-Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'api'], function () {
+Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api'], function () {
 
     Route::group(['prefix' => 'account'], function () {
 


### PR DESCRIPTION
This isn't working yet, but when (if?) it is, it will drag Laravel up to 6.6.1 and Passport up to ^8.0.

## ToDo:

### <del>1. Fix Passport auth for the API when consumed within the app javascript</del>

<del>If I edit the vendor file (just for troubleshooting, calm down) `vendor/laravel/framework/src/Illuminate/Auth/Middleware/Authenticate.php`, it looks like `$guards` isn’t being set/passed to the `authenticate()` method, which is why it returns unauthenticated.</del>

<del>It looks like `$guards` array isn’t being set at all, so the:</del>

 <del>`if ($empty($guards)) { `</del>

<del>doesn’t fire. (Seems like that should check if it’s set, no?)</del>

<del>https://github.com/laravel/framework/blob/874c4f6135a4c23d5c3040aa020b84aaaa41a3ca/src/Illuminate/Auth/Middleware/Authenticate.php#L47-L60</del>

<del>If I (just for testing) add `$guard = []` in that vendor `authenticate()` method, the API authenticates correctly. I've pored over the upgrade docs and didn't see anything that would relate to this, so I'm not sure exactly where to go next on this. </del>

<img width="998" alt="Screen Shot 2019-12-05 at 6 01 44 PM" src="https://user-images.githubusercontent.com/197404/70291350-c0c32c80-178f-11ea-90b3-85e4c91bd6e8.png"></del>

<del>I also tried downgrading Passport from 8.0.2 to 8.0.1 and 8.0.0 with no change and downgrading Laravel to 6.0.0 with no change.</del>

### <del>2. Refactor the password security functionality - the previous library we were using doesn't support Laravel 6 :( </del>

<del>Our choices are to fork that library and pull it forward to Laravel 6 compatibility, or use something else like [this](https://github.com/langleyfoxall/laravel-nist-password-rules), which will require some research and refactoring. </del>

Update: The library still has not been updated, but the rules were pretty simple, so I've just implemented them manually using the Validation extension. 

### <del>3. Weird bug when trying to create a thing through the web UI. </del>

<del>It looks like an empty `$item` is being passed in the controllers, so the logic in the form edit blades throws an error complaining about the route parameter missing instead of using the  `store` route that doesn't need a route parameter. </del>

<del>for example here:</del>
https://github.com/snipe/snipe-it/blob/5b946087c4d857cf2f9cd3124bb97084d840b0bb/resources/views/departments/edit.blade.php#L6

<del>It's not necessarily a big deal to change those `($item)` calls to `($item->id)`, but not knowing why  the behavior changed is a bigger issue and could mean bigger problems ahead. (I'd suggest this was an artifact of a later PHP version, but I'd have expected to see that in previous versions of Snipe-IT if that were true.)</del>

### 4. Flysystem stuff still seems broken?

Can't tell, since I can't create anything new :( It's broken omg develop anyway, at least on the demo, so I don't think it's related to the v6.6.1 upgrade, but changes between 5.8 and 6.6.1 might need to be reviewed.
