### PR TITLE
Fixed XSS vulnerability in SVG image uploads [ch10476]

### DIFF
--- a/app/Http/Controllers/AccessoriesController.php
+++ b/app/Http/Controllers/AccessoriesController.php
@@ -85,26 +85,7 @@ class AccessoriesController extends Controller
         $accessory->qty                     = request('qty');
         $accessory->user_id                 = Auth::user()->id;
         $accessory->supplier_id             = request('supplier_id');
-
-        if ($request->hasFile('image')) {
-
-            if (!config('app.lock_passwords')) {
-                $image = $request->file('image');
-                $ext = $image->getClientOriginalExtension();
-                $file_name = "accessory-".str_random(18).'.'.$ext;
-                $path = public_path('/uploads/accessories');
-                if ($image->getClientOriginalExtension()!='svg') {
-                    Image::make($image->getRealPath())->resize(null, 800, function ($constraint) {
-                        $constraint->aspectRatio();
-                        $constraint->upsize();
-                    })->save($path.'/'.$file_name);
-                } else {
-                    $image->move($path, $file_name);
-                }
-                $accessory->image = $file_name;
-            }
-        }
-
+        $accessory = $request->handleImages($accessory,600, public_path().'/uploads/accessories');
 
 
         // Was the accessory created?
@@ -165,28 +146,7 @@ class AccessoriesController extends Controller
         $accessory->qty                     = request('qty');
         $accessory->supplier_id             = request('supplier_id');
 
-        if ($request->hasFile('image')) {
-
-            if (!config('app.lock_passwords')) {
-                $image = $request->file('image');
-                $ext = $image->getClientOriginalExtension();
-                $file_name = "accessory-".str_random(18).'.'.$ext;
-                $path = public_path('/uploads/accessories');
-                if ($image->getClientOriginalExtension()!='svg') {
-                    Image::make($image->getRealPath())->resize(null, 800, function ($constraint) {
-                        $constraint->aspectRatio();
-                        $constraint->upsize();
-                    })->save($path.'/'.$file_name);
-                } else {
-                    $image->move($path, $file_name);
-                }
-                if (($accessory->image) && (file_exists($path.'/'.$accessory->image))) {
-                    unlink($path.'/'.$accessory->image);
-                }
-
-                $accessory->image = $file_name;
-            }
-        }
+        $accessory = $request->handleImages($accessory,600, public_path().'/uploads/accessories');
 
 
         // Was the accessory updated?

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -90,23 +90,7 @@ class AssetModelsController extends Controller
             $model->fieldset_id = e($request->input('custom_fieldset'));
         }
 
-        if (Input::file('image')) {
-
-            $image = Input::file('image');
-            $file_name = str_slug($image->getClientOriginalName()) . "." . $image->getClientOriginalExtension();
-            $path = app('models_upload_path');
-
-            if ($image->getClientOriginalExtension()!='svg') {
-                Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                })->save($path.'/'.$file_name);
-            } else {
-                $image->move($path, $file_name);
-            }
-            $model->image = $file_name;
-
-        }
+        $model = $request->handleImages($model,600, public_path().'/uploads/models');
 
             // Was it created?
         if ($model->save()) {
@@ -182,37 +166,7 @@ class AssetModelsController extends Controller
             }
         }
 
-        $old_image = $model->image;
-
-        // Set the model's image property to null if the image is being deleted
-        if ($request->input('image_delete') == 1) {
-            $model->image = null;
-        }
-
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = $model->id.'-'.str_slug($image->getClientOriginalName()) . "." . $image->getClientOriginalExtension();
-
-            if ($image->getClientOriginalExtension()!='svg') {
-                Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                })->save(app('models_upload_path').$file_name);
-            } else {
-                $image->move(app('models_upload_path'), $file_name);
-            }
-            $model->image = $file_name;
-
-        }
-
-        if ((($request->file('image')) && (isset($old_image)) && ($old_image!='')) || ($request->input('image_delete') == 1)) {
-            try  {
-                unlink(app('models_upload_path').$old_image);
-            } catch (\Exception $e) {
-                \Log::info($e);
-            }
-        }
-
+        $model = $request->handleImages($model,600, public_path().'/uploads/models');
 
         if ($model->save()) {
             return redirect()->route("models.index")->with('success', trans('admin/models/message.update.success'));

--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -142,8 +142,6 @@ class CategoriesController extends Controller
         $category->require_acceptance   = $request->input('require_acceptance', '0');
         $category->checkin_email        = $request->input('checkin_email', '0');
 
-        $old_image = $category->image;
-
         // Set the model's image property to null if the image is being deleted
         if ($request->input('image_delete') == 1) {
             $category->image = null;

--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -83,17 +83,7 @@ class CategoriesController extends Controller
         $category->checkin_email        = $request->input('checkin_email', '0');
         $category->user_id              = Auth::id();
 
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = str_random(25).".".$image->getClientOriginalExtension();
-            $path = public_path('uploads/categories/'.$file_name);
-            Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            })->save($path);
-            $category->image = $file_name;
-        }
-
+        $category = $request->handleImages($category,600, public_path().'/uploads/categories');
 
         if ($category->save()) {
             return redirect()->route('categories.index')->with('success', trans('admin/categories/message.create.success'));
@@ -159,30 +149,7 @@ class CategoriesController extends Controller
             $category->image = null;
         }
 
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = $category->id.'-'.str_slug($image->getClientOriginalName()) . "." . $image->getClientOriginalExtension();
-
-            if ($image->getClientOriginalExtension()!='svg') {
-                Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                })->save(app('categories_upload_path').$file_name);
-            } else {
-                $image->move(app('categories_upload_path'), $file_name);
-            }
-            $category->image = $file_name;
-
-        }
-
-        if ((($request->file('image')) && (isset($old_image)) && ($old_image!='')) || ($request->input('image_delete') == 1)) {
-            try  {
-                unlink(app('categories_upload_path').$old_image);
-            } catch (\Exception $e) {
-                \Log::info($e);
-            }
-        }
-
+        $category = $request->handleImages($category,600, public_path().'/uploads/categories');
 
         if ($category->save()) {
             // Redirect to the new category page

--- a/app/Http/Controllers/CompaniesController.php
+++ b/app/Http/Controllers/CompaniesController.php
@@ -63,16 +63,7 @@ final class CompaniesController extends Controller
         $company = new Company;
         $company->name = $request->input('name');
 
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = str_random(25).".".$image->getClientOriginalExtension();
-            $path = public_path('uploads/companies/'.$file_name);
-            Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            })->save($path);
-            $company->image = $file_name;
-        }
+        $company = $request->handleImages($company,600, public_path().'/uploads/companies');
 
         if ($company->save()) {
             return redirect()->route('companies.index')
@@ -128,29 +119,7 @@ final class CompaniesController extends Controller
             $company->image = null;
         }
 
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = $company->id.'-'.str_slug($image->getClientOriginalName()) . "." . $image->getClientOriginalExtension();
-
-            if ($image->getClientOriginalExtension()!='svg') {
-                Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                })->save(app('companies_upload_path').$file_name);
-            } else {
-                $image->move(app('companies_upload_path'), $file_name);
-            }
-            $company->image = $file_name;
-
-        }
-
-        if ((($request->file('image')) && (isset($old_image)) && ($old_image!='')) || ($request->input('image_delete') == 1)) {
-            try  {
-                unlink(app('companies_upload_path').$old_image);
-            } catch (\Exception $e) {
-                \Log::info($e);
-            }
-        }
+        $company = $request->handleImages($company,600, public_path().'/uploads/companies');
 
 
         if ($company->save()) {

--- a/app/Http/Controllers/CompaniesController.php
+++ b/app/Http/Controllers/CompaniesController.php
@@ -112,8 +112,6 @@ final class CompaniesController extends Controller
 
         $company->name = $request->input('name');
 
-        $old_image = $company->image;
-
         // Set the model's image property to null if the image is being deleted
         if ($request->input('image_delete') == 1) {
             $company->image = null;

--- a/app/Http/Controllers/ComponentsController.php
+++ b/app/Http/Controllers/ComponentsController.php
@@ -91,16 +91,7 @@ class ComponentsController extends Controller
         $component->user_id                = Auth::id();
 
 
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = str_random(25).".".$image->getClientOriginalExtension();
-            $path = public_path('uploads/components/'.$file_name);
-            Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            })->save($path);
-            $component->image = $file_name;
-        }
+        $component = $request->handleImages($component,600, public_path().'/uploads/components');
 
         if ($component->save()) {
             return redirect()->route('components.index')->with('success', trans('admin/components/message.create.success'));
@@ -164,18 +155,7 @@ class ComponentsController extends Controller
         $component->purchase_cost          = request('purchase_cost');
         $component->qty                    = Input::get('qty');
 
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = str_random(25).".".$image->getClientOriginalExtension();
-            $path = public_path('uploads/components/'.$file_name);
-            Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            })->save($path);
-            $component->image = $file_name;
-        } elseif ($request->input('image_delete')=='1') {
-            $component->image = null;
-        }
+        $component = $request->handleImages($component,600, public_path().'/uploads/components');
 
         if ($component->save()) {
             return redirect()->route('components.index')->with('success', trans('admin/components/message.update.success'));

--- a/app/Http/Controllers/ConsumablesController.php
+++ b/app/Http/Controllers/ConsumablesController.php
@@ -87,16 +87,8 @@ class ConsumablesController extends Controller
         $consumable->user_id                = Auth::id();
 
 
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = str_random(25).".".$image->getClientOriginalExtension();
-            $path = public_path('uploads/consumables/'.$file_name);
-            Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            })->save($path);
-            $consumable->image = $file_name;
-        }
+        $consumable = $request->handleImages($consumable,600, public_path().'/uploads/components');
+
 
         if ($consumable->save()) {
             return redirect()->route('consumables.index')->with('success', trans('admin/consumables/message.create.success'));

--- a/app/Http/Controllers/DepartmentsController.php
+++ b/app/Http/Controllers/DepartmentsController.php
@@ -155,8 +155,6 @@ class DepartmentsController extends Controller
         $department->fill($request->all());
         $department->manager_id = ($request->filled('manager_id' ) ? $request->input('manager_id') : null);
 
-        $old_image = $department->image;
-
         $department = $request->handleImages($department,600, public_path().'/uploads/departments');
 
         if ($department->save()) {

--- a/app/Http/Controllers/DepartmentsController.php
+++ b/app/Http/Controllers/DepartmentsController.php
@@ -53,16 +53,7 @@ class DepartmentsController extends Controller
         $department->user_id = Auth::user()->id;
         $department->manager_id = ($request->filled('manager_id' ) ? $request->input('manager_id') : null);
 
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = str_random(25).".".$image->getClientOriginalExtension();
-            $path = public_path('uploads/departments/'.$file_name);
-            Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            })->save($path);
-            $department->image = $file_name;
-        }
+        $department = $request->handleImages($department,600, public_path().'/uploads/departments');
 
         if ($department->save()) {
             return redirect()->route("departments.index")->with('success', trans('admin/departments/message.create.success'));
@@ -166,34 +157,7 @@ class DepartmentsController extends Controller
 
         $old_image = $department->image;
 
-        // Set the model's image property to null if the image is being deleted
-        if ($request->input('image_delete') == 1) {
-            $department->image = null;
-        }
-
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = $department->id.'-'.str_slug($image->getClientOriginalName()) . "." . $image->getClientOriginalExtension();
-
-            if ($image->getClientOriginalExtension()!='svg') {
-                Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                })->save(app('departments_upload_path').$file_name);
-            } else {
-                $image->move(app('departments_upload_path'), $file_name);
-            }
-            $department->image = $file_name;
-
-        }
-
-        if ((($request->file('image')) && (isset($old_image)) && ($old_image!='')) || ($request->input('image_delete') == 1)) {
-            try  {
-                unlink(app('departments_upload_path').$old_image);
-            } catch (\Exception $e) {
-                \Log::info($e);
-            }
-        }
+        $department = $request->handleImages($department,600, public_path().'/uploads/departments');
 
         if ($department->save()) {
             return redirect()->route("departments.index")->with('success', trans('admin/departments/message.update.success'));

--- a/app/Http/Controllers/ManufacturersController.php
+++ b/app/Http/Controllers/ManufacturersController.php
@@ -131,9 +131,7 @@ class ManufacturersController extends Controller
         $manufacturer->support_url     = $request->input('support_url');
         $manufacturer->support_phone    = $request->input('support_phone');
         $manufacturer->support_email    = $request->input('support_email');
-
-        $old_image = $manufacturer->image;
-
+        
         // Set the model's image property to null if the image is being deleted
         if ($request->input('image_delete') == 1) {
             $manufacturer->image = null;

--- a/app/Http/Controllers/ManufacturersController.php
+++ b/app/Http/Controllers/ManufacturersController.php
@@ -75,18 +75,7 @@ class ManufacturersController extends Controller
         $manufacturer->support_url     = $request->input('support_url');
         $manufacturer->support_phone    = $request->input('support_phone');
         $manufacturer->support_email    = $request->input('support_email');
-
-
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = str_slug($image->getClientOriginalName()).".".$image->getClientOriginalExtension();
-            $path = public_path('uploads/manufacturers/'.$file_name);
-            Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            })->save($path);
-            $manufacturer->image = $file_name;
-        }
+        $manufacturer = $request->handleImages($manufacturer,600, public_path().'/uploads/manufacturers');
 
 
 
@@ -150,29 +139,8 @@ class ManufacturersController extends Controller
             $manufacturer->image = null;
         }
 
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = $manufacturer->id.'-'.str_slug($image->getClientOriginalName()) . "." . $image->getClientOriginalExtension();
+        $manufacturer = $request->handleImages($manufacturer,600, public_path().'/uploads/manufacturers');
 
-            if ($image->getClientOriginalExtension()!='svg') {
-                Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                })->save(app('manufacturers_upload_path').$file_name);
-            } else {
-                $image->move(app('manufacturers_upload_path'), $file_name);
-            }
-            $manufacturer->image = $file_name;
-
-        }
-
-        if ((($request->file('image')) && (isset($old_image)) && ($old_image!='')) || ($request->input('image_delete') == 1)) {
-            try  {
-                unlink(app('manufacturers_upload_path').$old_image);
-            } catch (\Exception $e) {
-                \Log::info($e);
-            }
-        }
 
 
         if ($manufacturer->save()) {

--- a/app/Http/Controllers/SuppliersController.php
+++ b/app/Http/Controllers/SuppliersController.php
@@ -78,17 +78,8 @@ class SuppliersController extends Controller
         $supplier->notes                = request('notes');
         $supplier->url                  = $supplier->addhttp(request('url'));
         $supplier->user_id              = Auth::id();
+        $supplier = $request->handleImages($supplier,600, public_path().'/uploads/suppliers');
 
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = str_random(25).".".$image->getClientOriginalExtension();
-            $path = public_path('uploads/suppliers/'.$file_name);
-            Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                $constraint->aspectRatio();
-                $constraint->upsize();
-            })->save($path);
-            $supplier->image = $file_name;
-        }
 
         if ($supplier->save()) {
             return redirect()->route('suppliers.index')->with('success', trans('admin/suppliers/message.create.success'));
@@ -145,39 +136,7 @@ class SuppliersController extends Controller
         $supplier->email                = request('email');
         $supplier->url                  = $supplier->addhttp(request('url'));
         $supplier->notes                = request('notes');
-
-
-        $old_image = $supplier->image;
-
-        // Set the model's image property to null if the image is being deleted
-        if ($request->input('image_delete') == 1) {
-            $supplier->image = null;
-        }
-
-        if ($request->file('image')) {
-            $image = $request->file('image');
-            $file_name = $supplier->id.'-'.str_slug($image->getClientOriginalName()) . "." . $image->getClientOriginalExtension();
-
-            if ($image->getClientOriginalExtension()!='svg') {
-                Image::make($image->getRealPath())->resize(800, null, function ($constraint) {
-                    $constraint->aspectRatio();
-                    $constraint->upsize();
-                })->save(app('suppliers_upload_path').$file_name);
-            } else {
-                $image->move(app('suppliers_upload_path'), $file_name);
-            }
-            $supplier->image = $file_name;
-
-        }
-
-        if ((($request->file('image')) && (isset($old_image)) && ($old_image!='')) || ($request->input('image_delete') == 1)) {
-            try  {
-                unlink(app('suppliers_upload_path').$old_image);
-            } catch (\Exception $e) {
-                \Log::info($e);
-            }
-        }
-
+        $supplier = $request->handleImages($supplier,600, public_path().'/uploads/suppliers');
 
         if ($supplier->save()) {
             return redirect()->route('suppliers.index')->with('success', trans('admin/suppliers/message.update.success'));

--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests;
 
-use App\Http\Requests\Request;
+use App\Models\SnipeModel;
+use Intervention\Image\Facades\Image;
+use enshrined\svgSanitize\Sanitizer;
 
 class ImageUploadRequest extends Request
 {
@@ -32,5 +34,84 @@ class ImageUploadRequest extends Request
     public function response(array $errors)
     {
         return $this->redirector->back()->withInput()->withErrors($errors, $this->errorBag);
+    }
+
+    /**
+     * Handle and store any images attached to request
+     * @param SnipeModel $item Item the image is associated with
+     * @param String $path  location for uploaded images, defaults to uploads/plural of item type.
+     * @return SnipeModel        Target asset is being checked out to.
+     */
+    public function handleImages($item, $w = 600, $path = null)
+    {
+
+        $type = strtolower(class_basename(get_class($item)));
+
+        if (is_null($path)) {
+            $path =  str_plural($type);
+        }
+
+        \Log::debug('Trying to upload to '. $path);
+
+        if ($this->hasFile('image')) {
+
+            if (!config('app.lock_passwords')) {
+
+
+                if (!is_dir($path)) {
+                    \Log::debug($path.' does not exist');
+                    mkdir($path);
+                }
+
+                $image = $this->file('image');
+                $ext = $image->getClientOriginalExtension();
+                $file_name = $type.'-'.str_random(18).'.'.$ext;
+                \Log::debug('File name will be: '.$file_name);
+
+                if ($image->getClientOriginalExtension()!=='svg') {
+                    \Log::debug('Not an SVG - resize');
+                    \Log::debug('Trying to upload to: '.$path.'/'.$file_name);
+                    $upload = Image::make($image->getRealPath())->resize(null, $w, function ($constraint) {
+                        $constraint->aspectRatio();
+                        $constraint->upsize();
+                    })->save($path.'/'.$file_name);
+                } else {
+                    \Log::debug('This is an SVG');
+                    $sanitizer = new Sanitizer();
+                    $dirtySVG = file_get_contents($image->getRealPath());
+                    $cleanSVG = $sanitizer->sanitize($dirtySVG);
+
+                    try {
+                        \Log::debug('Trying to upload to: '.$path.'/'.$file_name);
+                        file_put_contents($path.'/'.$file_name, $cleanSVG);
+                    } catch (\Exception $e) {
+                        \Log::debug($e);
+                    }
+                }
+
+
+                // Remove Current image if exists
+                if (($item->image) && (file_exists($path.'/'.$item->image))) {
+                    try {
+                        unlink($path.'/'.$item->image);
+                    } catch (\Exception $e) {
+                        \Log::debug($e);
+                    }
+                }
+
+                $item->image = $file_name;
+            }
+
+        } elseif ($this->input('image_delete')=='1') {
+
+            try {
+                unlink($path.'/'.$item->image);
+            } catch (\Exception $e) {
+                \Log::debug($e);
+            }
+
+            $item->image = null;
+        }
+        return $item;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "doctrine/inflector": "^1.3",
     "doctrine/instantiator": "^1.2",
     "eduardokum/laravel-mail-auto-embed": "^1.0",
+    "enshrined/svg-sanitize": "^0.13.0",
     "erusev/parsedown": "^1.7",
     "fideloper/proxy": "^4.1",
     "guzzlehttp/guzzle": "^6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb4aca6c49fd1fd08aef1832b3e6762e",
+    "content-hash": "745e56814dad4b004d4d815075801416",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1285,6 +1285,47 @@
                 "validator"
             ],
             "time": "2019-08-13T17:33:27+00:00"
+        },
+        {
+            "name": "enshrined/svg-sanitize",
+            "version": "0.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/darylldoyle/svg-sanitizer.git",
+                "reference": "4cf8d0f61edf9f00b84e162fc229176a362da247"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/4cf8d0f61edf9f00b84e162fc229176a362da247",
+                "reference": "4cf8d0f61edf9f00b84e162fc229176a362da247",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "^0.1.2",
+                "phpunit/phpunit": "^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "enshrined\\svgSanitize\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Daryll Doyle",
+                    "email": "daryll@enshrined.co.uk"
+                }
+            ],
+            "description": "An SVG sanitizer for PHP",
+            "time": "2019-11-07T09:16:31+00:00"
         },
         {
             "name": "erusev/parsedown",


### PR DESCRIPTION
This breaks the image upload handling (resizing, etc) into a new  method in the ImageUploadRequest that also checks for SVGs and sanitizes them. (This improved method of handling uploads is already on v5.)

The severity of this vulnerability is reduced since attack requires interaction, the attacker would need to be an authenticated user of the system, and the attacker would have to either trick the victim into opening the poisoned SVG in a new window, or host it within an iframe (which we prevent.)

It will sanitize an SVG from:

```
<?xml version="1.0" standalone="no"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" baseProfile="full" xmlns="http://www.w3.org/2000/svg">
<polygon id="triangle" points="0,0 0,50 50,0" fill="#009900" stroke="#004400"/>
<script type="text/javascript">
alert(1);
</script>
</svg>
```

to 

```
<?xml version="1.0" standalone="no"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" baseProfile="full" xmlns="http://www.w3.org/2000/svg">
<polygon id="triangle" points="0,0 0,50 50,0" fill="#009900" stroke="#004400"/>
</svg>
```
