### PR TITLE
Fix for searching on child location names

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -232,23 +232,28 @@ class LocationsController extends Controller
         }
 
         if ($request->filled('search')) {
-            \Log::debug('Searching... ');
             $locations = $locations->where('locations.name', 'LIKE', '%'.$request->input('search').'%');
         }
 
         $locations = $locations->orderBy('name', 'ASC')->get();
 
         $locations_with_children = [];
+
         foreach ($locations as $location) {
-            if(!array_key_exists($location->parent_id, $locations_with_children)) {
+            if (!array_key_exists($location->parent_id, $locations_with_children)) {
                 $locations_with_children[$location->parent_id] = [];
             }
             $locations_with_children[$location->parent_id][] = $location;
         }
 
-        $location_options = Location::indenter($locations_with_children);
+        if ($request->filled('search')) {
+            $locations_formatted =  $locations;
+        } else {
+            $location_options = Location::indenter($locations_with_children);
+            $locations_formatted = new Collection($location_options);
 
-        $locations_formatted = new Collection($location_options);
+        }
+
         $paginated_results =  new LengthAwarePaginator($locations_formatted->forPage($page, 500), $locations_formatted->count(), 500, $page, []);
 
         //return [];

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -148,12 +148,14 @@ class Location extends SnipeModel
      * @return Illuminate\Database\Query\Builder          Modified query builder
      */
 
-    public static function indenter($locations_with_children, $parent_id = null, $prefix = '') {
+    public static function indenter($locations_with_children, $parent_id = '', $prefix = '') {
         $results = Array();
+
         
-        if (!array_key_exists($parent_id, $locations_with_children)) {
+        if (!array_key_exists($parent_id, $locations_with_children) && $parent_id) {
             return [];
         }
+
 
         foreach ($locations_with_children[$parent_id] as $location) {
             $location->use_text = $prefix.' '.$location->name;

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -148,11 +148,11 @@ class Location extends SnipeModel
      * @return Illuminate\Database\Query\Builder          Modified query builder
      */
 
-    public static function indenter($locations_with_children, $parent_id = '', $prefix = '') {
+    public static function indenter($locations_with_children, $parent_id = null, $prefix = '') {
         $results = Array();
 
         
-        if (!array_key_exists($parent_id, $locations_with_children) && $parent_id) {
+        if (!array_key_exists($parent_id, $locations_with_children)) {
             return [];
         }
 


### PR DESCRIPTION
This fixes a new issue that was created in a different fix, whereby the child locations in the locations dropdown were no longer searchable.

This is, at best, a temporary fix. The UX on this is janky, and not at all up to our standards (IMHO), but it does at least work, and returns the functionality of searching on child locations by name. 

There is probably a bigger fix we need to make for locations once v5 is out, but for now it at least gives back expected functionality. 