### PR TITLE
Fixes a controllers AssetsController does not exist exception in Develop (v5).

### DIFF
--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -41,22 +41,22 @@ Route::group(
 
         Route::get('audit/due', [
             'as' => 'assets.audit.due',
-            'uses' => 'AssetsController@dueForAudit'
+            'uses' => 'Assets\AssetsController@dueForAudit'
         ]);
 
         Route::get('audit/overdue', [
             'as' => 'assets.audit.overdue',
-            'uses' => 'AssetsController@overdueForAudit'
+            'uses' => 'Assets\AssetsController@overdueForAudit'
         ]);
 
         Route::get('audit/due', [
             'as' => 'assets.audit.due',
-            'uses' => 'AssetsController@dueForAudit'
+            'uses' => 'Assets\AssetsController@dueForAudit'
         ]);
 
         Route::get('audit/overdue', [
             'as' => 'assets.audit.overdue',
-            'uses' => 'AssetsController@overdueForAudit'
+            'uses' => 'Assets\AssetsController@overdueForAudit'
         ]);
 
         Route::get('audit/{id}', [


### PR DESCRIPTION
Small fix to correct issue when hitting the "http://snipe-it.app/hardware/audit/due" and "http://snipe-it.app/hardware/audit/overdue" endpoints, resulting in Class AssetsController doesn't exist exception.