### PR TITLE
Fixes/missing required parameters for fieldsets.show in Develop

### DIFF
--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -53,7 +53,7 @@
             @foreach($custom_fieldsets AS $fieldset)
             <tr>
               <td>
-                {{ link_to_route("fieldsets.show",$fieldset->name,['id' => $fieldset->id]) }}
+                {{ link_to_route("fieldsets.show",$fieldset->name,['fieldset' => $fieldset->id]) }}
               </td>
               <td>
                 {{ $fieldset->fields->count() }}


### PR DESCRIPTION
In the view a route was called, but the expected parameter for that route was declared with a different name than required which broke functionality.