### PR TITLE
Select Import File fails in Develop [ch10598]

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -10,7 +10,6 @@ use App\Models\Asset;
 use App\Models\Company;
 use App\Models\Import;
 use Artisan;
-use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
 use League\Csv\Reader;
@@ -41,7 +40,7 @@ class ImportController extends Controller
     {
         $this->authorize('import');
         if (!config('app.lock_passwords')) {
-            $files = Input::file('files');
+            $files = Request::file('files');
             $path = config('app.private_uploads').'/imports';
             $results = [];
             $import = new Import;

--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -10,6 +10,7 @@ use App\Models\Asset;
 use App\Models\Company;
 use App\Models\Import;
 use Artisan;
+use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
 use League\Csv\Reader;


### PR DESCRIPTION
The importer on develop still was using the `Illuminate\Support\Facades\Input` that is now deprecated. This should take care of that.