### PR TITLE
Remove not existent variable 'id' in the redirect causing [ch10602]

### DIFF
--- a/app/Http/Controllers/ConsumablesController.php
+++ b/app/Http/Controllers/ConsumablesController.php
@@ -204,7 +204,7 @@ class ConsumablesController extends Controller
         if (isset($consumable->id)) {
             return view('consumables/view', compact('consumable'));
         }
-        return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.does_not_exist', compact('id')));
+        return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.does_not_exist'));
     }
 
     /**


### PR DESCRIPTION
First I just rename the variable in `compact` as `consumableId` instead of just `id` and that makes the redirect works, but then I thought that as the variable is not used I just remove the `compact` completely. Let me know if I need to put it back.