### PR TITLE
Fix for weird JSON parsing in actionlogs

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -53,22 +53,19 @@ class ActionlogsTransformer
                             
                             foreach ($meta_value as $meta_value_key => $meta_value_value) {
 
-                                \Log::debug('meta value key is '.$meta_value->value);
                                 if ($meta_value_key == 'value') {
                                     $clean_meta[$key]['old'] = null;
-                                    $clean_meta[$key]['new'] = $meta_value->value;
+                                    $clean_meta[$key]['new'] = e($meta_value->value);
                                 } else {
                                     $clean_meta[$meta_value_key]['old'] = null;
-                                    $clean_meta[$meta_value_key]['new'] = $meta_value_value;
+                                    $clean_meta[$meta_value_key]['new'] = e($meta_value_value);
                                 }
-
-                                \Log::debug(print_r($meta_value_value, true));
                             }
 
 
 
                         } else {
-                            $clean_meta[$key][$meta_key] = $meta_value;
+                            $clean_meta[$key][$meta_key] = e($meta_value);
                         }
                     }
 

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -30,6 +30,7 @@ class ActionlogsTransformer
         // This is necessary since we can't escape special characters within a JSON object
         if (($actionlog->log_meta) && ($actionlog->log_meta!='')) {
             $meta_array = json_decode($actionlog->log_meta);
+
             foreach ($meta_array as $key => $value) {
                 foreach ($value as $meta_key => $meta_value) {
 
@@ -38,10 +39,41 @@ class ActionlogsTransformer
                             $clean_meta[$key][$meta_value_key] = e($meta_value_value);
                         }
                     } else {
-                        $clean_meta[$key][$meta_key] = e($meta_value);
+
+                        // This object stuff is weird, and is used to make up for the fact that
+                        // older data can get strangely formatted if an asset existed,
+                        // then a new custom field is added, and the asset is saved again.
+                        // It can result in funnily-formatted strings like:
+                        //
+                        // {"_snipeit_right_sized_fault_tolerant_localareanetwo_1":
+                        // {"old":null,"new":{"value":"1579490695972","_snipeit_new_field_2":2,"_snipeit_new_field_3":"Monday, 20 January 2020 2:24:55 PM"}}
+                        // so we have to walk down that next level
+
+                        if (is_object($meta_value)) {
+                            
+                            foreach ($meta_value as $meta_value_key => $meta_value_value) {
+
+                                \Log::debug('meta value key is '.$meta_value->value);
+                                if ($meta_value_key == 'value') {
+                                    $clean_meta[$key]['old'] = null;
+                                    $clean_meta[$key]['new'] = $meta_value->value;
+                                } else {
+                                    $clean_meta[$meta_value_key]['old'] = null;
+                                    $clean_meta[$meta_value_key]['new'] = $meta_value_value;
+                                }
+
+                                \Log::debug(print_r($meta_value_value, true));
+                            }
+
+
+
+                        } else {
+                            $clean_meta[$key][$meta_key] = $meta_value;
+                        }
                     }
 
                 }
+
             }
         }
 

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -31,44 +31,46 @@ class ActionlogsTransformer
         if (($actionlog->log_meta) && ($actionlog->log_meta!='')) {
             $meta_array = json_decode($actionlog->log_meta);
 
-            foreach ($meta_array as $key => $value) {
-                foreach ($value as $meta_key => $meta_value) {
+            if ($meta_array) {
+                foreach ($meta_array as $key => $value) {
+                    foreach ($value as $meta_key => $meta_value) {
 
-                    if (is_array($meta_value)) {
-                        foreach ($meta_value as $meta_value_key => $meta_value_value) {
-                            $clean_meta[$key][$meta_value_key] = e($meta_value_value);
-                        }
-                    } else {
-
-                        // This object stuff is weird, and is used to make up for the fact that
-                        // older data can get strangely formatted if an asset existed,
-                        // then a new custom field is added, and the asset is saved again.
-                        // It can result in funnily-formatted strings like:
-                        //
-                        // {"_snipeit_right_sized_fault_tolerant_localareanetwo_1":
-                        // {"old":null,"new":{"value":"1579490695972","_snipeit_new_field_2":2,"_snipeit_new_field_3":"Monday, 20 January 2020 2:24:55 PM"}}
-                        // so we have to walk down that next level
-
-                        if (is_object($meta_value)) {
-                            
+                        if (is_array($meta_value)) {
                             foreach ($meta_value as $meta_value_key => $meta_value_value) {
-
-                                if ($meta_value_key == 'value') {
-                                    $clean_meta[$key]['old'] = null;
-                                    $clean_meta[$key]['new'] = e($meta_value->value);
-                                } else {
-                                    $clean_meta[$meta_value_key]['old'] = null;
-                                    $clean_meta[$meta_value_key]['new'] = e($meta_value_value);
-                                }
+                                $clean_meta[$key][$meta_value_key] = e($meta_value_value);
                             }
-
-
-
                         } else {
-                            $clean_meta[$key][$meta_key] = e($meta_value);
-                        }
-                    }
 
+                            // This object stuff is weird, and is used to make up for the fact that
+                            // older data can get strangely formatted if an asset existed,
+                            // then a new custom field is added, and the asset is saved again.
+                            // It can result in funnily-formatted strings like:
+                            //
+                            // {"_snipeit_right_sized_fault_tolerant_localareanetwo_1":
+                            // {"old":null,"new":{"value":"1579490695972","_snipeit_new_field_2":2,"_snipeit_new_field_3":"Monday, 20 January 2020 2:24:55 PM"}}
+                            // so we have to walk down that next level
+
+                            if (is_object($meta_value)) {
+
+                                foreach ($meta_value as $meta_value_key => $meta_value_value) {
+
+                                    if ($meta_value_key == 'value') {
+                                        $clean_meta[$key]['old'] = null;
+                                        $clean_meta[$key]['new'] = e($meta_value->value);
+                                    } else {
+                                        $clean_meta[$meta_value_key]['old'] = null;
+                                        $clean_meta[$meta_value_key]['new'] = e($meta_value_value);
+                                    }
+                                }
+
+
+
+                            } else {
+                                $clean_meta[$key][$meta_key] = e($meta_value);
+                            }
+                        }
+
+                    }
                 }
 
             }


### PR DESCRIPTION
This is a super janky fix that handles the scenario that:

1) user creates an asset
2) user then adds new custom fields/fieldsets to that model
3) user updates the asset

Since the old values didn't exist before, it was storing the JSON with an additional node:

```
{"_snipeit_mac_address_1":
	{
		"old":null,
		"new":"11:E7:C3:3T:7F:46"
	},
	"_snipeit_active_directory_id_6":
		{
			"old":null,
			"new":"snipe"
		},
	"_snipeit_ip_address_10":
		{
			"old":null,
			"new":"10.10.10.10"
		},
	"_snipeit_date_last_autoupdate_11":
		{
			"old":null,"new":
			{
				"value":"1579490695972","DisplayHint":2,"DateTime":"Monday, 20 January 2020 2:24:55 PM"}
			}
}
```

(That last bit is the borked part.)

This would break the ActionLogs transformer with an error of `ErrorException: htmlspecialchars() expects parameter 1 to be string, object given (Most recent call first)`, since it's really a nested stdObj, not a string. 

This tragic eyesore walks through the data and tries to normalize it so that it can be displayed properly in the ActionlogsTransformer, which is used by asset history and the activity report.

