### PR TITLE
Fixed #7834:  Do not override per table data-id-cookie-table attribute

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -35,7 +35,6 @@
             iconsPrefix: 'fa',
             cookie: true,
             cookieExpire: '2y',
-            cookieIdTable: '{{ Route::currentRouteName() }}',
             mobileResponsive: true,
             maintainSelected: true,
             trimOnSearch: false,


### PR DESCRIPTION
Do not override per table data-id-cookie-table attribute by current route name.
It is bad idea when we have two+ different table on page from one route.
