### PR TITLE
Make Accessories checkout with a quantity

### DIFF
--- a/app/Http/Controllers/AccessoriesController.php
+++ b/app/Http/Controllers/AccessoriesController.php
@@ -85,6 +85,7 @@ class AccessoriesController extends Controller
         $accessory->qty                     = request('qty');
         $accessory->user_id                 = Auth::user()->id;
         $accessory->supplier_id             = request('supplier_id');
+        $accessory->department_id           = request('department_id');
         $accessory = $request->handleImages($accessory,600, public_path().'/uploads/accessories');
 
 
@@ -145,6 +146,7 @@ class AccessoriesController extends Controller
         $accessory->purchase_cost           = request('purchase_cost');
         $accessory->qty                     = request('qty');
         $accessory->supplier_id             = request('supplier_id');
+        $accessory->department_id             = request('department_id');
 
         $accessory = $request->handleImages($accessory,600, public_path().'/uploads/accessories');
 

--- a/app/Http/Controllers/AccessoriesController.php
+++ b/app/Http/Controllers/AccessoriesController.php
@@ -17,6 +17,7 @@ use Illuminate\Http\Request;
 use Slack;
 use Str;
 use View;
+use Validator;
 use Image;
 use App\Http\Requests\ImageUploadRequest;
 
@@ -252,24 +253,45 @@ class AccessoriesController extends Controller
 
         $this->authorize('checkout', $accessory);
 
-        if (!$user = User::find(Input::get('assigned_to'))) {
+        // Validate quantity and assigned_user ID
+        $max_to_checkout = $accessory->numRemaining();
+        if ($max_to_checkout <= 0) {
+            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.error'));
+        }
+        $validator = Validator::make($request->all(), [
+            "assigned_to"   => "required",
+            "qty"  => "required|numeric|between:1,$max_to_checkout"
+        ]);
+        if ($validator->fails()) {
+            return redirect()->back()
+                ->withErrors($validator)
+                ->withInput();
+        }
+
+        if (!$assigned_user = User::find(request('assigned_to'))) {
             return redirect()->route('checkout/accessory', $accessory->id)->with('error', trans('admin/accessories/message.checkout.user_does_not_exist'));
         }
 
-      // Update the accessory data
-        $accessory->assigned_to = e(Input::get('assigned_to'));
+        // check if accessory is assigned already and add quantity
+        $checkout_qty = (int)request('qty');
+        $accessory_user = DB::table('accessories_users')->where('assigned_to', '=', request('assigned_to'))->where('accessory_id', '=', $accessory->id)->first();
+        if ($accessory_user) {
+            $updated_qty = $accessory_user->assigned_qty + $checkout_qty;
+            DB::table('accessories_users')->where('id', $accessory_user->id)->update(['assigned_qty' => $updated_qty]);
+        } else {
+            $accessory->users()->attach($accessory->id, [
+                'accessory_id' => $accessory->id,
+                'created_at' => Carbon::now(),
+                'user_id' => Auth::id(),
+                'assigned_to' => request('assigned_to'),
+                'assigned_qty' => $checkout_qty
+            ]);
+        }
 
-        $accessory->users()->attach($accessory->id, [
-            'accessory_id' => $accessory->id,
-            'created_at' => Carbon::now(),
-            'user_id' => Auth::id(),
-            'assigned_to' => $request->get('assigned_to')
-        ]);
+        $logaction = $accessory->logCheckout(e(request('note')), $assigned_user);
 
-        $logaction = $accessory->logCheckout(e(Input::get('note')), $user);
-
-        DB::table('accessories_users')->where('assigned_to', '=', $accessory->assigned_to)->where('accessory_id', '=', $accessory->id)->first();
-
+        // Not used?  remove?
+        /*
         $data['log_id'] = $logaction->id;
         $data['eula'] = $accessory->getEula();
         $data['first_name'] = $user->first_name;
@@ -279,8 +301,9 @@ class AccessoriesController extends Controller
         $data['expected_checkin'] = '';
         $data['note'] = $logaction->note;
         $data['require_acceptance'] = $accessory->requireAcceptance();
+        */
 
-      // Redirect to the new accessory page
+        // Redirect to the new accessory page
         return redirect()->route('accessories.index')->with('success', trans('admin/accessories/message.checkout.success'));
     }
 
@@ -298,14 +321,21 @@ class AccessoriesController extends Controller
     public function getCheckin(Request $request, $accessoryUserId = null, $backto = null)
     {
         // Check if the accessory exists
-        if (is_null($accessory_user = DB::table('accessories_users')->find($accessoryUserId))) {
-            // Redirect to the accessory management page with error
-            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.not_found'));
+        if ($accessory_user = DB::table('accessories_users')->find($accessoryUserId)) {
+            if (is_null($accessory = Accessory::find($accessory_user->accessory_id))) {
+                return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.does_not_exist'));
+            }
+            if (is_null($user = User::find($accessory_user->assigned_to))) {
+                return redirect()->route('accessories.index')->with('error',
+                    trans('admin/users/message.user_not_found'));
+            }
+            $this->authorize('checkin', $accessory);
+            return view('accessories/checkin', compact('accessory_user', 'accessory', 'user'))->with('backto', $backto);
         }
 
-        $accessory = Accessory::find($accessory_user->accessory_id);
-        $this->authorize('checkin', $accessory);
-        return view('accessories/checkin', compact('accessory'))->with('backto', $backto);
+        // Redirect to the accessory management page with error
+        return redirect()->route('accessories.index')->with('error', trans('admin/components/messages.does_not_exist'));
+
     }
 
 
@@ -329,33 +359,55 @@ class AccessoriesController extends Controller
         }
 
         $accessory = Accessory::find($accessory_user->accessory_id);
-
         $this->authorize('checkin', $accessory);
 
-        $return_to = e($accessory_user->assigned_to);
-        $logaction = $accessory->logCheckin(User::find($return_to), e(Input::get('note')));
+        $assigned_user = User::find($accessory_user->assigned_to);
 
-        // Was the accessory updated?
-        if (DB::table('accessories_users')->where('id', '=', $accessory_user->id)->delete()) {
-            if (!is_null($accessory_user->assigned_to)) {
-                $user = User::find($accessory_user->assigned_to);
-            }
-
-            $data['log_id'] = $logaction->id;
-            $data['first_name'] = e($user->first_name);
-            $data['last_name'] = e($user->last_name);
-            $data['item_name'] = e($accessory->name);
-            $data['checkin_date'] = e($logaction->created_at);
-            $data['item_tag'] = '';
-            $data['note'] = e($logaction->note);
-
-            if ($backto=='user') {
-                return redirect()->route("users.show", $return_to)->with('success', trans('admin/accessories/message.checkin.success'));
-            }
-            return redirect()->route("accessories.show", $accessory->id)->with('success', trans('admin/accessories/message.checkin.success'));
+        // Quantity check
+        $max_to_checkin = $accessory_user->assigned_qty;
+        if ($max_to_checkin <= 0) {
+            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.error'));
         }
-        // Redirect to the accessory management page with error
-        return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkin.error'));
+        $validator = Validator::make($request->all(), [
+            "qty" => "required|numeric|between:1,$max_to_checkin"
+        ]);
+        if ($validator->fails()) {
+            return redirect()->back()
+                ->withErrors($validator)
+                ->withInput();
+        }
+        // Quantity check was successful
+
+        // Quantity adjust
+        $checkin_qty = (int)request('qty');
+        $qty_remaining_in_checkout = ($accessory_user->assigned_qty - $checkin_qty);
+        if ($qty_remaining_in_checkout > 0) {
+            // Update to correct checked out quantity
+            DB::table('accessories_users')->where('id', $accessoryUserId)->update(['assigned_qty' => $qty_remaining_in_checkout]);
+        } else {
+            if (is_null(DB::table('accessories_users')->where('id', '=', $accessory_user->id)->delete())) {
+                return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkin.error'));
+            }
+        }
+
+
+        $logaction = $accessory->logCheckin($assigned_user, e(request('note')));
+
+        // Unused anywhere ?, should delete ?
+        /*
+        $data['log_id'] = $logaction->id;
+        $data['first_name'] = e($assigned_user->first_name);
+        $data['last_name'] = e($assigned_user->last_name);
+        $data['item_name'] = e($accessory->name);
+        $data['checkin_date'] = e($logaction->created_at);
+        $data['item_tag'] = '';
+        $data['note'] = e($logaction->note);
+        */
+
+        if ($backto=='user') {
+            return redirect()->route("users.show", $assigned_user->id)->with('success', trans('admin/accessories/message.checkin.success'));
+        }
+        return redirect()->route("accessories.show", $accessory->id)->with('success', trans('admin/accessories/message.checkin.success'));
     }
 
 

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -27,7 +27,7 @@ class AccessoriesController extends Controller
         $this->authorize('view', Accessory::class);
         $allowed_columns = ['id','name','model_number','eol','notes','created_at','min_amt','company_id'];
 
-        $accessories = Accessory::with('category', 'company', 'manufacturer', 'users', 'location');
+        $accessories = Accessory::with('category', 'company', 'department', 'manufacturer', 'users', 'location');
 
         if ($request->filled('search')) {
             $accessories = $accessories->TextSearch($request->input('search'));
@@ -47,6 +47,10 @@ class AccessoriesController extends Controller
 
         if ($request->filled('supplier_id')) {
             $accessories->where('supplier_id','=',$request->input('supplier_id'));
+        }
+
+        if ($request->filled('department_id')) {
+          $accessories->where('department_id','=',$request->input('department_id'));
         }
 
         $offset = (($accessories) && (request('offset') > $accessories->count())) ? 0 : request('offset', 0);

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -95,8 +95,7 @@ class AssetsController extends Controller
 
         $assets = Company::scopeCompanyables(Asset::select('assets.*'),"company_id","assets")
             ->with('location', 'assetstatus', 'assetlog', 'company', 'defaultLoc','assignedTo',
-                'model.category', 'model.manufacturer', 'model.fieldset','supplier');
-
+                'model.category', 'model.manufacturer', 'model.fieldset','supplier', 'department');
 
         // These are used by the API to query against specific ID numbers.
         // They are also used by the individual searches on detail pages like
@@ -123,6 +122,10 @@ class AssetsController extends Controller
 
         if ($request->filled('supplier_id')) {
             $assets->where('assets.supplier_id', '=', $request->input('supplier_id'));
+        }
+
+        if ($request->filled('department_id')) {
+          $assets->where('assets.department_id', '=', $request->input('department_id'));
         }
 
         if (($request->filled('assigned_to')) && ($request->filled('assigned_type'))) {
@@ -279,6 +282,9 @@ class AssetsController extends Controller
                 break;
             case 'supplier':
                 $assets->OrderSupplier($order);
+                break;
+            case 'department':
+                $assets->OrderDepartment($order);
                 break;
             case 'assigned_to':
                 $assets->OrderAssigned($order);
@@ -443,6 +449,7 @@ class AssetsController extends Controller
         $asset->purchase_date           = $request->get('purchase_date', null);
         $asset->assigned_to             = $request->get('assigned_to', null);
         $asset->supplier_id             = $request->get('supplier_id', 0);
+        $asset->department_id           = $request->get('department_id', null);
         $asset->requestable             = $request->get('requestable', 0);
         $asset->rtd_location_id         = $request->get('rtd_location_id', null);
 
@@ -770,7 +777,7 @@ class AssetsController extends Controller
 
         $assets = Company::scopeCompanyables(Asset::select('assets.*'),"company_id","assets")
             ->with('location', 'assetstatus', 'assetlog', 'company', 'defaultLoc','assignedTo',
-                'model.category', 'model.manufacturer', 'model.fieldset','supplier')->where('assets.requestable', '=', '1');
+                'model.category', 'model.manufacturer', 'model.fieldset','supplier', 'department')->where('assets.requestable', '=', '1');
 
         $offset = request('offset', 0);
         $limit = $request->input('limit', 50);

--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -25,7 +25,7 @@ class ComponentsController extends Controller
     {
         $this->authorize('view', Component::class);
         $components = Company::scopeCompanyables(Component::select('components.*')
-            ->with('company', 'location', 'category'));
+            ->with('company', 'department', 'location', 'category'));
 
         if ($request->filled('search')) {
             $components = $components->TextSearch($request->input('search'));
@@ -33,6 +33,10 @@ class ComponentsController extends Controller
 
         if ($request->filled('company_id')) {
             $components->where('company_id','=',$request->input('company_id'));
+        }
+
+        if ($request->filled('department_id')) {
+          $components->where('department_id','=',$request->input('department_id'));
         }
 
         if ($request->filled('category_id')) {
@@ -48,7 +52,7 @@ class ComponentsController extends Controller
         // Check to make sure the limit is not higher than the max allowed
         ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
 
-        $allowed_columns = ['id','name','min_amt','order_number','serial','purchase_date','purchase_cost','company','category','qty','location','image'];
+        $allowed_columns = ['id','name','min_amt','order_number','serial','purchase_date','purchase_cost','company','category','qty','location', 'department','image'];
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
 
@@ -61,6 +65,9 @@ class ComponentsController extends Controller
                 break;
             case 'company':
                 $components = $components->OrderCompany($order);
+                break;
+            case 'department':
+                $components = $components->OrderDepartment($order);
                 break;
             default:
                 $components = $components->orderBy($sort, $order);

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -24,7 +24,7 @@ class ConsumablesController extends Controller
         $this->authorize('index', Consumable::class);
         $consumables = Company::scopeCompanyables(
             Consumable::select('consumables.*')
-                ->with('company', 'location', 'category', 'users', 'manufacturer')
+                ->with('company', 'department', 'location', 'category', 'users', 'manufacturer')
         );
 
         if ($request->filled('search')) {
@@ -33,6 +33,10 @@ class ConsumablesController extends Controller
 
         if ($request->filled('company_id')) {
             $consumables->where('company_id','=',$request->input('company_id'));
+        }
+
+        if ($request->filled('department_id')) {
+            $consumables->where('department_id','=',$request->input('department_id'));
         }
 
         if ($request->filled('category_id')) {
@@ -49,7 +53,7 @@ class ConsumablesController extends Controller
         // Check to make sure the limit is not higher than the max allowed
         ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
 
-        $allowed_columns = ['id','name','order_number','min_amt','purchase_date','purchase_cost','company','category','model_number', 'item_no', 'manufacturer','location','qty','image'];
+        $allowed_columns = ['id','name','order_number','min_amt','purchase_date','purchase_cost','company','category', 'department','model_number', 'item_no', 'manufacturer','location','qty','image'];
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
 
@@ -57,6 +61,9 @@ class ConsumablesController extends Controller
         switch ($sort) {
             case 'category':
                 $consumables = $consumables->OrderCategory($order);
+                break;
+            case 'department':
+                $consumables = $consumables->OrderDepartment($order);
                 break;
             case 'location':
                 $consumables = $consumables->OrderLocation($order);

--- a/app/Http/Controllers/Api/DepartmentsController.php
+++ b/app/Http/Controllers/Api/DepartmentsController.php
@@ -22,7 +22,17 @@ class DepartmentsController extends Controller
     public function index(Request $request)
     {
         $this->authorize('view', Department::class);
-        $allowed_columns = ['id','name','image','users_count'];
+        $allowed_columns = [
+          'id',
+          'name',
+          'image',
+          'users_count',
+          'assets_count',
+          'licenses_count',
+          'accessories_count',
+          'consumables_count',
+          'components_count',
+        ];
 
         $departments = Department::select([
             'departments.id',
@@ -33,7 +43,12 @@ class DepartmentsController extends Controller
             'departments.created_at',
             'departments.updated_at',
             'departments.image'
-        ])->with('users')->with('location')->with('manager')->with('company')->withCount('users as users_count');
+        ])
+        ->with('users')
+        ->with('location')
+        ->with('manager')
+        ->with('company')
+        ->withCount('users as users_count','assets as assets_count','licenses as licenses_count','accessories as accessories_count','consumables as consumables_count','components as components_count');
 
         if ($request->filled('search')) {
             $departments = $departments->TextSearch($request->input('search'));

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -25,7 +25,7 @@ class LicensesController extends Controller
     public function index(Request $request)
     {
         $this->authorize('view', License::class);
-        $licenses = Company::scopeCompanyables(License::with('company', 'manufacturer', 'freeSeats', 'supplier','category')->withCount('freeSeats as free_seats_count'));
+        $licenses = Company::scopeCompanyables(License::with('company', 'manufacturer', 'freeSeats', 'supplier','department','category')->withCount('freeSeats as free_seats_count'));
 
 
         if ($request->filled('company_id')) {
@@ -63,6 +63,9 @@ class LicensesController extends Controller
         if ($request->filled('supplier_id')) {
             $licenses->where('supplier_id','=',$request->input('supplier_id'));
         }
+        if ($request->filled('department_id')) {
+          $licenses->where('department_id','=',$request->input('department_id'));
+        }
 
         if ($request->filled('category_id')) {
             $licenses->where('category_id','=',$request->input('category_id'));
@@ -70,10 +73,6 @@ class LicensesController extends Controller
 
         if ($request->filled('depreciation_id')) {
             $licenses->where('depreciation_id','=',$request->input('depreciation_id'));
-        }
-
-        if ($request->filled('supplier_id')) {
-            $licenses->where('supplier_id','=',$request->input('supplier_id'));
         }
 
 
@@ -96,6 +95,9 @@ class LicensesController extends Controller
                 break;
             case 'supplier':
                 $licenses = $licenses->leftJoin('suppliers', 'licenses.supplier_id', '=', 'suppliers.id')->orderBy('suppliers.name', $order);
+                break;
+            case 'department':
+                $licenses = $licenses->leftJoin('departments', 'departments.department_id', '=', 'departments.id')->orderBy('departments.name', $order);
                 break;
             case 'category':
                 $licenses = $licenses->leftJoin('categories', 'licenses.category_id', '=', 'categories.id')->orderBy('categories.name', $order);

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -11,6 +11,7 @@ use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Company;
+use App\Models\Department;
 use App\Models\CustomField;
 use App\Models\Import;
 use App\Models\Location;
@@ -135,6 +136,7 @@ class AssetsController extends Controller
         $asset->purchase_date           = request('purchase_date', null);
         $asset->assigned_to             = request('assigned_to', null);
         $asset->supplier_id             = request('supplier_id', 0);
+        $asset->department_id           = request('department_id', null);
         $asset->requestable             = request('requestable', 0);
         $asset->rtd_location_id         = request('rtd_location_id', null);
 
@@ -311,6 +313,7 @@ class AssetsController extends Controller
         $asset->purchase_cost = Helper::ParseFloat($request->input('purchase_cost', null));
         $asset->purchase_date = $request->input('purchase_date', null);
         $asset->supplier_id = $request->input('supplier_id', null);
+        $asset->department_id = $request->input('department_id', null);
 
         // If the box isn't checked, it's not in the request at all.
         $asset->requestable = $request->filled('requestable');

--- a/app/Http/Controllers/BulkAssetsController.php
+++ b/app/Http/Controllers/BulkAssetsController.php
@@ -77,6 +77,7 @@ class BulkAssetsController extends Controller
         if (($request->filled('purchase_date'))
             || ($request->filled('purchase_cost'))
             || ($request->filled('supplier_id'))
+            || ($request->filled('department_id'))
             || ($request->filled('order_number'))
             || ($request->filled('warranty_months'))
             || ($request->filled('rtd_location_id'))
@@ -94,6 +95,7 @@ class BulkAssetsController extends Controller
                     ->conditionallyAddItem('requestable')
                     ->conditionallyAddItem('status_id')
                     ->conditionallyAddItem('supplier_id')
+                    ->conditionallyAddItem('department_id')
                     ->conditionallyAddItem('warranty_months');
 
                 if ($request->filled('purchase_cost')) {

--- a/app/Http/Controllers/ComponentsController.php
+++ b/app/Http/Controllers/ComponentsController.php
@@ -5,6 +5,7 @@ use App\Helpers\Helper;
 use App\Http\Requests\ImageUploadRequest;
 use App\Models\Actionlog;
 use App\Models\Company;
+use App\Models\Department;
 use App\Models\Component;
 use App\Models\CustomField;
 use App\Models\Setting;
@@ -82,6 +83,7 @@ class ComponentsController extends Controller
         $component->category_id            = $request->input('category_id');
         $component->location_id            = $request->input('location_id');
         $component->company_id             = Company::getIdForCurrentUser($request->input('company_id'));
+        $component->department_id          = $request->input('department_id');
         $component->order_number           = $request->input('order_number', null);
         $component->min_amt                = $request->input('min_amt', null);
         $component->serial                 = $request->input('serial', null);
@@ -148,6 +150,7 @@ class ComponentsController extends Controller
         $component->category_id            = Input::get('category_id');
         $component->location_id            = Input::get('location_id');
         $component->company_id             = Company::getIdForCurrentUser(Input::get('company_id'));
+        $component->department_id          = Input::get('department_id');
         $component->order_number           = Input::get('order_number');
         $component->min_amt                = Input::get('min_amt');
         $component->serial                 = Input::get('serial');

--- a/app/Http/Controllers/ConsumablesController.php
+++ b/app/Http/Controllers/ConsumablesController.php
@@ -76,6 +76,7 @@ class ConsumablesController extends Controller
         $consumable->category_id            = $request->input('category_id');
         $consumable->location_id            = $request->input('location_id');
         $consumable->company_id             = Company::getIdForCurrentUser($request->input('company_id'));
+        $consumable->department_id          = $request->input('department_id');
         $consumable->order_number           = $request->input('order_number');
         $consumable->min_amt                = $request->input('min_amt');
         $consumable->manufacturer_id        = $request->input('manufacturer_id');
@@ -141,6 +142,7 @@ class ConsumablesController extends Controller
         $consumable->category_id            = $request->input('category_id');
         $consumable->location_id            = $request->input('location_id');
         $consumable->company_id             = Company::getIdForCurrentUser($request->input('company_id'));
+        $consumable->department_id          = $request->input('department_id');
         $consumable->order_number           = $request->input('order_number');
         $consumable->min_amt                = $request->input('min_amt');
         $consumable->manufacturer_id        = $request->input('manufacturer_id');

--- a/app/Http/Controllers/LicensesController.php
+++ b/app/Http/Controllers/LicensesController.php
@@ -108,6 +108,7 @@ class LicensesController extends Controller
         $license->seats             = $request->input('seats');
         $license->serial            = $request->input('serial');
         $license->supplier_id       = $request->input('supplier_id');
+        $license->department_id     = $request->input('department_id');
         $license->category_id       = $request->input('category_id');
         $license->termination_date  = $request->input('termination_date');
         $license->user_id           = Auth::id();
@@ -186,6 +187,7 @@ class LicensesController extends Controller
         $license->seats             = e($request->input('seats'));
         $license->manufacturer_id   =  $request->input('manufacturer_id');
         $license->supplier_id       = $request->input('supplier_id');
+        $license->department_id       = $request->input('department_id');
         $license->category_id       = $request->input('category_id');
 
         if ($license->save()) {

--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -70,6 +70,7 @@ class AccessoriesTransformer
         foreach ($accessory_users as $user) {
             $array[] = [
                 'assigned_pivot_id' => $user->pivot->id,
+                'qty' => $user->pivot->assigned_qty,
                 'id' => (int) $user->id,
                 'username' => e($user->username),
                 'name' => e($user->getFullNameAttribute()),

--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -24,6 +24,7 @@ class AccessoriesTransformer
             'id' => $accessory->id,
             'name' => e($accessory->name),
             'company' => ($accessory->company) ? ['id' => $accessory->company->id,'name'=> e($accessory->company->name)] : null,
+            'department' => ($accessory->department) ? ['id' => $accessory->department->id,'name'=> e($accessory->department->name)] : null,
             'manufacturer' => ($accessory->manufacturer) ? ['id' => $accessory->manufacturer->id,'name'=> e($accessory->manufacturer->name)] : null,
             'supplier' => ($accessory->supplier) ? ['id' => $accessory->supplier->id,'name'=> e($accessory->supplier->name)] : null,
             'model_number' => ($accessory->model_number) ? e($accessory->model_number) : null,

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -50,6 +50,10 @@ class AssetsTransformer
                 'id' => (int) $asset->supplier->id,
                 'name'=> e($asset->supplier->name)
             ]  : null,
+            'department' => ($asset->department) ? [
+              'id' => (int) $asset->department->id,
+              'name'=> e($asset->department->name)
+            ]  : null,
             'notes' => ($asset->notes) ? e($asset->notes) : null,
             'order_number' => ($asset->order_number) ? e($asset->order_number) : null,
             'company' => ($asset->company) ? [

--- a/app/Http/Transformers/ComponentsTransformer.php
+++ b/app/Http/Transformers/ComponentsTransformer.php
@@ -46,6 +46,10 @@ class ComponentsTransformer
                 'id' => (int) $component->company->id,
                 'name' => e($component->company->name)
             ] : null,
+            'department'   => ($component->department) ? [
+                'id' => (int) $component->department->id,
+                'name' => e($component->department->name)
+            ] : null,
             'created_at' => Helper::getFormattedDateObject($component->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($component->updated_at, 'datetime'),
             'user_can_checkout' =>  ($component->numRemaining() > 0) ? 1 : 0,

--- a/app/Http/Transformers/ConsumablesTransformer.php
+++ b/app/Http/Transformers/ConsumablesTransformer.php
@@ -26,6 +26,7 @@ class ConsumablesTransformer
             'image' =>   ($consumable->image) ? e(url('/').'/uploads/consumables/'.e($consumable->image)) : null,
             'category'      => ($consumable->category) ? ['id' => $consumable->category->id, 'name' => e($consumable->category->name)] : null,
             'company'   => ($consumable->company) ? ['id' => (int) $consumable->company->id, 'name' => e($consumable->company->name)] : null,
+            'department'      => ($consumable->department) ? ['id' => $consumable->department->id, 'name' => e($consumable->department->name)] : null,
             'item_no'       => e($consumable->item_no),
             'location'      => ($consumable->location) ? ['id' => (int) $consumable->location->id, 'name' => e($consumable->location->name)] : null,
             'manufacturer'  => ($consumable->manufacturer) ? ['id' => (int) $consumable->manufacturer->id, 'name' => e($consumable->manufacturer->name)] : null,

--- a/app/Http/Transformers/DepartmentsTranformer.php
+++ b/app/Http/Transformers/DepartmentsTranformer.php
@@ -41,6 +41,11 @@ class DepartmentsTransformer
                     'name' => e($department->location->name)
                 ] : null,
                 'users_count' => e($department->users_count),
+                "assets_count" => (int) $department->assets_count,
+                "licenses_count" => (int) $department->licenses_count,
+                "accessories_count" => (int) $department->accessories_count,
+                "consumables_count" => (int) $department->consumables_count,
+                "components_count" => (int) $department->components_count,
                 'created_at' => Helper::getFormattedDateObject($department->created_at, 'datetime'),
                 'updated_at' => Helper::getFormattedDateObject($department->updated_at, 'datetime'),
             ];

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -24,6 +24,7 @@ class LicensesTransformer
             'id' => (int) $license->id,
             'name' => e($license->name),
             'company' => ($license->company) ? ['id' => (int) $license->company->id,'name'=> e($license->company->name)] : null,
+            'department' =>  ($license->department) ? ['id' => (int)  $license->department->id,'name'=> e($license->department->name)] : null, 
             'manufacturer' =>  ($license->manufacturer) ? ['id' => (int) $license->manufacturer->id,'name'=> e($license->manufacturer->name)] : null,
             'product_key' => (Gate::allows('viewKeys', License::class)) ? e($license->serial) : '------------',
             'order_number' => e($license->order_number),

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -43,6 +43,7 @@ class Accessory extends SnipeModel
     protected $searchableRelations = [
         'category'     => ['name'],
         'company'      => ['name'],
+        'department'   => ['name'],
         'manufacturer' => ['name'],
         'supplier'     => ['name'],
         'location'     => ['name']
@@ -94,6 +95,7 @@ class Accessory extends SnipeModel
         'model_number',
         'manufacturer_id',
         'supplier_id',
+        'department_id',
         'image',
         'qty',
         'requestable'
@@ -105,6 +107,11 @@ class Accessory extends SnipeModel
     public function supplier()
     {
         return $this->belongsTo('\App\Models\Supplier', 'supplier_id');
+    }
+
+    public function department()
+    {
+        return $this->belongsTo('\App\Models\Department', 'department_id');
     }
     
 
@@ -206,6 +213,20 @@ class Accessory extends SnipeModel
     {
         return $query->leftJoin('companies', 'accessories.company_id', '=', 'companies.id')
         ->orderBy('companies.name', $order);
+    }
+
+    /**
+    * Query builder scope to order on company
+    *
+    * @param  \Illuminate\Database\Query\Builder  $query  Query builder instance
+    * @param  text                              $order       Order
+    *
+    * @return \Illuminate\Database\Query\Builder          Modified query builder
+    */
+    public function scopeOrderDepartment($query, $order)
+    {
+        return $query->leftJoin('departments', 'accessories.department_id', '=', 'departments.id')
+        ->orderBy('departments.name', $order);
     }
 
     /**

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -157,7 +157,7 @@ class Accessory extends SnipeModel
 
     public function users()
     {
-        return $this->belongsToMany('\App\Models\User', 'accessories_users', 'accessory_id', 'assigned_to')->withPivot('id')->withTrashed();
+        return $this->belongsToMany('\App\Models\User', 'accessories_users', 'accessory_id', 'assigned_to')->withPivot('id', 'assigned_qty')->withTrashed();
     }
 
     public function hasUsers()
@@ -195,7 +195,12 @@ class Accessory extends SnipeModel
 
     public function numRemaining()
     {
-        $checkedout = $this->users->count();
+        $checkedout = 0;
+
+        foreach ($this->users as $checkout) {
+            $checkedout += $checkout->pivot->assigned_qty;
+        }
+
         $total = $this->qty;
         $remaining = $total - $checkedout;
         return $remaining;

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -36,6 +36,7 @@ class Component extends SnipeModel
         'qty'     => 'required|integer|min:1',
         'category_id' => 'required|integer',
         'company_id'  => 'integer|nullable',
+        'department_id' => 'required|integer|exists:departments,id',
         'purchase_date'  => 'date|nullable',
         'purchase_cost'   => 'numeric|nullable',
     );
@@ -58,6 +59,7 @@ class Component extends SnipeModel
     protected $fillable = [
         'category_id',
         'company_id',
+        'department_id',
         'location_id',
         'name',
         'purchase_cost',
@@ -85,6 +87,7 @@ class Component extends SnipeModel
     protected $searchableRelations = [
         'category'     => ['name'],
         'company'      => ['name'],
+        'department'   => ['name'],
         'location'     => ['name'],
     ];      
 
@@ -108,6 +111,10 @@ class Component extends SnipeModel
         return $this->belongsTo('\App\Models\Company', 'company_id');
     }
 
+    public function department()
+    {
+        return $this->belongsTo('\App\Models\Department', 'department_id');
+    }
 
     public function category()
     {

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -35,6 +35,7 @@ class Consumable extends SnipeModel
         'qty'         => 'required|integer|min:0',
         'category_id' => 'required|integer',
         'company_id'  => 'integer|nullable',
+        'department_id'  => 'integer|nullable|exists:departments,id',
         'min_amt'     => 'integer|min:0|nullable',
         'purchase_cost'   => 'numeric|nullable',
     );
@@ -57,6 +58,7 @@ class Consumable extends SnipeModel
     protected $fillable = [
         'category_id',
         'company_id',
+        'department_id',
         'item_no',
         'location_id',
         'manufacturer_id',
@@ -86,6 +88,7 @@ class Consumable extends SnipeModel
     protected $searchableRelations = [
         'category'     => ['name'],
         'company'      => ['name'],
+        'department'   => ['name'],
         'location'     => ['name'],  
         'manufacturer' => ['name'],
     ];     
@@ -112,6 +115,11 @@ class Consumable extends SnipeModel
     public function company()
     {
         return $this->belongsTo('\App\Models\Company', 'company_id');
+    }
+
+    public function department()
+    {
+        return $this->belongsTo('\App\Models\Department', 'department_id');
     }
 
     public function manufacturer()
@@ -190,7 +198,7 @@ class Consumable extends SnipeModel
     }
 
     /**
-    * Query builder scope to order on company
+    * Query builder scope to order on category
     *
     * @param  Illuminate\Database\Query\Builder  $query  Query builder instance
     * @param  text                              $order       Order
@@ -240,5 +248,18 @@ class Consumable extends SnipeModel
     public function scopeOrderCompany($query, $order)
     {
         return $query->leftJoin('companies', 'consumables.company_id', '=', 'companies.id')->orderBy('companies.name', $order);
+    }
+
+    /**
+    * Query builder scope to order on department
+    *
+    * @param  Illuminate\Database\Query\Builder  $query  Query builder instance
+    * @param  text                              $order       Order
+    *
+    * @return Illuminate\Database\Query\Builder          Modified query builder
+    */
+    public function scopeOrderDepartment($query, $order)
+    {
+        return $query->join('departments', 'consumables.department_id', '=', 'departments.id')->orderBy('departments.name', $order);
     }
 }

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -68,6 +68,15 @@ class Department extends SnipeModel
     }
 
     /**
+     * Department in charge of the asset
+     * @return mixed
+     */
+    public function assets()
+    {
+        return $this->hasMany('\App\Models\User', 'department_id');
+    }
+
+    /**
      * Even though we allow allow for checkout to things beyond users
      * this method is an easy way of seeing if we are checked out to a user.
      * @return mixed

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Traits\Searchable;
 use Illuminate\Database\Eloquent\Model;
+use App\Presenters\Presentable;
 use Log;
 use Watson\Validating\ValidatingTrait;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -30,6 +31,9 @@ class Department extends SnipeModel
         'company_id'            => 'numeric|nullable',
         'manager_id'            => 'numeric|nullable',
     ];
+
+    protected $presenter = 'App\Presenters\DepartmentPresenter';
+    use Presentable;
 
     /**
      * The attributes that are mass assignable.
@@ -67,6 +71,16 @@ class Department extends SnipeModel
         return $this->belongsTo('\App\Models\Company', 'company_id');
     }
 
+
+    /**
+     * Users assigned to this department
+     * @return mixed
+     */
+    public function users()
+    {
+        return $this->hasMany('\App\Models\User', 'department_id');
+    }
+
     /**
      * Department in charge of the asset
      * @return mixed
@@ -75,16 +89,23 @@ class Department extends SnipeModel
     {
         return $this->hasMany('\App\Models\Asset', 'department_id');
     }
-
-    /**
-     * Even though we allow allow for checkout to things beyond users
-     * this method is an easy way of seeing if we are checked out to a user.
-     * @return mixed
-     */
-    public function users()
+    public function licenses()
     {
-        return $this->hasMany('\App\Models\User', 'department_id');
+        return $this->hasMany(License::class, 'department_id');
     }
+    public function accessories()
+    {
+        return $this->hasMany(Accessory::class, 'department_id');
+    }
+    public function consumables()
+    {
+        return $this->hasMany(Consumable::class, 'department_id');
+    }
+    public function components()
+    {
+        return $this->hasMany(Component::class, 'department_id');
+    }
+
 
 
     /**

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -78,7 +78,7 @@ class Department extends SnipeModel
      */
     public function users()
     {
-        return $this->hasMany('\App\Models\User', 'department_id');
+        return $this->hasMany(User::class, 'department_id');
     }
 
     /**
@@ -87,7 +87,7 @@ class Department extends SnipeModel
      */
     public function assets()
     {
-        return $this->hasMany('\App\Models\Asset', 'department_id');
+        return $this->hasMany(Asset::class, 'department_id');
     }
     public function licenses()
     {

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -73,7 +73,7 @@ class Department extends SnipeModel
      */
     public function assets()
     {
-        return $this->hasMany('\App\Models\User', 'department_id');
+        return $this->hasMany('\App\Models\Asset', 'department_id');
     }
 
     /**

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -80,6 +80,7 @@ class License extends Depreciable
         'seats',
         'serial',
         'supplier_id',
+        'department_id',
         'termination_date',
         'user_id',
     ];
@@ -409,6 +410,11 @@ class License extends Depreciable
         return $this->belongsTo('\App\Models\Supplier', 'supplier_id');
     }
 
+    public function department()
+    {
+        return $this->belongsTo('\App\Models\Department', 'department_id');
+    }
+
     /*
      * Get the next available free seat - used by
      * the API to populate next_seat
@@ -472,6 +478,20 @@ class License extends Depreciable
     {
         return $query->leftJoin('suppliers', 'licenses.supplier_id', '=', 'suppliers.id')->select('licenses.*')
             ->orderBy('suppliers.name', $order);
+    }
+
+        /**
+     * Query builder scope to order on department
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query  Query builder instance
+     * @param  text                              $order         Order
+     *
+     * @return \Illuminate\Database\Query\Builder          Modified query builder
+     */
+    public function scopeOrderDepartment($query, $order)
+    {
+        return $query->leftJoin('departments', 'licenses.department_id', '=', 'departments.id')->select('licenses.*')
+            ->orderBy('departments.name', $order);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -213,7 +213,7 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
      */
     public function accessories()
     {
-        return $this->belongsToMany('\App\Models\Accessory', 'accessories_users', 'assigned_to', 'accessory_id')->withPivot('id')->withTrashed();
+        return $this->belongsToMany('\App\Models\Accessory', 'accessories_users', 'assigned_to', 'accessory_id')->withPivot('id', 'assigned_qty')->withTrashed();
     }
 
     /**

--- a/app/Presenters/AccessoryPresenter.php
+++ b/app/Presenters/AccessoryPresenter.php
@@ -41,6 +41,13 @@ class AccessoryPresenter extends Presenter
                 "visible" => false,
                 "formatter" => "companiesLinkObjFormatter"
             ], [
+                "field" => "department",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('general.department'),
+                "visible" => false,
+                "formatter" => "departmentsLinkObjFormatter"
+            ], [
                 "field" => "name",
                 "searchable" => true,
                 "sortable" => true,

--- a/app/Presenters/AccessoryPresenter.php
+++ b/app/Presenters/AccessoryPresenter.php
@@ -139,6 +139,32 @@ class AccessoryPresenter extends Presenter
         return json_encode($layout);
     }
 
+    public static function dataTableCheckoutsLayout()
+    {
+        $layout = [
+            [
+                "field" => "name",
+                "searchable" => false,
+                "sortable" => false,
+                "title" => trans('general.name'),
+                "formatter" => "usersLinkFormatter"
+            ], [
+                "field" => "qty",
+                "searchable" => false,
+                "sortable" => false,
+                "title" => trans('admin/accessories/general.total'),
+            ], [
+                "field" => "actions",
+                "searchable" => false,
+                "sortable" => false,
+                "title" => trans('table.actions'),
+                "formatter" => "accessoriesInOutFormatter",
+            ]
+        ];
+
+        return json_encode($layout);
+    }
+
 
     /**
      * Pregenerated link to this accessories view page.

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -134,6 +134,13 @@ class AssetPresenter extends Presenter
                 "title" => trans('general.supplier'),
                 "visible" => false,
                 "formatter" => "suppliersLinkObjFormatter"
+            ],[
+                "field" => "department",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('general.department'),
+                "visible" => true,
+                "formatter" => "departmentsLinkObjFormatter"
             ], [
                 "field" => "purchase_date",
                 "searchable" => true,

--- a/app/Presenters/ComponentPresenter.php
+++ b/app/Presenters/ComponentPresenter.php
@@ -25,8 +25,7 @@ class ComponentPresenter extends Presenter
                 "switchable" => true,
                 "title" => trans('general.id'),
                 "visible" => false
-            ],
-            [
+            ], [
                 "field" => "company",
                 "searchable" => true,
                 "sortable" => true,
@@ -34,8 +33,14 @@ class ComponentPresenter extends Presenter
                 "title" => trans('general.company'),
                 "visible" => false,
                 "formatter" => 'companiesLinkObjFormatter',
-            ],
-            [
+            ], [
+                "field" => "department",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('general.department'),
+                "visible" => false,
+                "formatter" => "departmentsLinkObjFormatter"
+            ], [
                 "field" => "name",
                 "searchable" => true,
                 "sortable" => true,

--- a/app/Presenters/ConsumablePresenter.php
+++ b/app/Presenters/ConsumablePresenter.php
@@ -24,8 +24,7 @@ class ConsumablePresenter extends Presenter
                 "switchable" => true,
                 "title" => trans('general.id'),
                 "visible" => false
-            ],
-            [
+            ], [
                 "field" => "company",
                 "searchable" => true,
                 "sortable" => true,
@@ -33,16 +32,21 @@ class ConsumablePresenter extends Presenter
                 "title" => trans('general.company'),
                 "visible" => false,
                 "formatter" => 'companiesLinkObjFormatter',
-            ],
-            [
+            ], [
+                "field" => "department",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('general.department'),
+                "visible" => false,
+                "formatter" => "departmentsLinkObjFormatter"
+            ], [
                 "field" => "name",
                 "searchable" => true,
                 "sortable" => true,
                 "title" => trans('general.name'),
                 "visible" => true,
                 "formatter" => 'consumablesLinkFormatter',
-            ],
-            [
+            ], [
                 "field" => "image",
                 "searchable" => false,
                 "sortable" => true,

--- a/app/Presenters/DepartmentPresenter.php
+++ b/app/Presenters/DepartmentPresenter.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Presenters;
+
+/**
+ * Class CompanyPresenter
+ * @package App\Presenters
+ */
+class DepartmentPresenter extends Presenter
+{
+    /**
+     * Json Column Layout for bootstrap table
+     * @return string
+     */
+    public static function dataTableLayout()
+    {
+        $layout = [
+            [
+                "field" => "id",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.id'),
+                "visible" => false
+            ],[
+                "field" => "name",
+                "searchable" => true,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('admin/departments/table.name'),
+                "visible" => true,
+                "formatter" => 'departmentsLinkFormatter',
+            ],[
+                "field" => "company",
+                "searchable" => true,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('admin/companies/table.name'),
+                "visible" => true,
+                "formatter" => 'companiesLinkObjFormatter',
+            ],[
+                "field" => "location",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('admin/departments/table.location'),
+                "visible" => true,
+                "formatter" => 'locationsLinkObjFormatter',
+            ],[
+                "field" => "manager",
+                "searchable" => true,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('admin/departments/table.manager'),
+                "visible" => true,
+                "formatter" => 'usersLinkObjFormatter',
+            ],[
+                "field" => "image",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.image'),
+                "visible" => true,
+                "formatter" => 'imageFormatter',
+            ],[
+                "field" => "users_count",
+                "searchable" => false,
+                "sortable" => true,
+                "title" => '<span class="hidden-xs"><i class="fa fa-users"></i></span><span class="hidden-md hidden-lg">'.trans('general.users').'</span></th>',
+                "visible" => true,
+ 
+            ],[
+                "field" => "assets_count",
+                "searchable" => false,
+                "sortable" => true,
+                "title" => '<span class="hidden-xs"><i class="fa fa-barcode"></i></span><span class="hidden-md hidden-lg">'.trans('general.assets').'</span>',
+                "visible" => true,
+
+            ],[
+                "field" => "licenses_count",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => true,
+                "title" => ' <span class="hidden-xs"><i class="fa fa-floppy-o"></i></span><span class="hidden-md hidden-lg">'.trans('general.licenses').'</span>',
+            ],[
+                "field" => "accessories_count",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => true,
+                "title" => ' <span class="hidden-xs"><i class="fa fa-keyboard-o"></i></span><span class="hidden-md hidden-lg">'.trans('general.accessories').'</span>',
+            ],[
+                "field" => "consumables_count",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => true,
+                "title" => ' <span class="hidden-xs"><i class="fa fa-tint"></i></span><span class="hidden-md hidden-lg">'.trans('general.consumables').'</span>',
+            ],[
+                "field" => "components_count",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => true,
+                "title" => ' <span class="hidden-xs"><i class="fa fa-hdd-o"></i></span><span class="hidden-md hidden-lg">'.trans('general.components').'</span>',
+            ],[
+                "field" => "updated_at",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.updated_at'),
+            ],[
+                "field" => "created_at",
+                "searchable" => false,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('general.created_at'),
+            ],[
+                "field" => "actions",
+                "searchable" => false,
+                "sortable" => false,
+                "switchable" => false,
+                "title" => trans('table.actions'),
+                "visible" => true,
+                "formatter" => "departmentsActionsFormatter",
+            ]
+        ];
+
+        return json_encode($layout);
+    }
+
+
+    /**
+     * Link to this departments name
+     * @return string
+     */
+    public function nameUrl()
+    {
+        return (string) link_to_route('departments.show', $this->name, $this->id);
+    }
+
+    /**
+     * Url to view this item.
+     * @return string
+     */
+    public function viewUrl()
+    {
+        return route('departments.show', $this->id);
+    }
+}

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -34,6 +34,13 @@ class LicensePresenter extends Presenter
                 "visible" => false,
                 "formatter" => "companiesLinkObjFormatter"
             ], [
+                "field" => "department",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('general.department'),
+                "visible" => false,
+                "formatter" => "departmentsLinkObjFormatter"
+            ], [
                 "field" => "name",
                 "searchable" => true,
                 "sortable" => true,

--- a/database/migrations/2020_02_23_173732_add_department_id_to_assets_table.php
+++ b/database/migrations/2020_02_23_173732_add_department_id_to_assets_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDepartmentIdToAssetsTable extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('assets', function(Blueprint $table)
+        {
+            $table->integer('department_id')->unsigned()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('assets', function(Blueprint $table)
+        {
+           $table->dropColumn('department_id');
+        });
+    }
+}

--- a/database/migrations/2020_02_24_145409_add_department_id_to_consumables_table.php
+++ b/database/migrations/2020_02_24_145409_add_department_id_to_consumables_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDepartmentIdToConsumablesTable extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('consumables', function(Blueprint $table)
+        {
+            $table->integer('department_id')->unsigned()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('consumables', function(Blueprint $table)
+        {
+            $table->dropColumn('department_id');
+        });
+    }
+}

--- a/database/migrations/2020_02_24_145422_add_department_id_to_components_table.php
+++ b/database/migrations/2020_02_24_145422_add_department_id_to_components_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDepartmentIdToComponentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('components', function(Blueprint $table)
+        {
+            $table->integer('department_id')->unsigned()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('components', function(Blueprint $table)
+        {
+            $table->dropColumn('department_id');
+        });
+    }
+}

--- a/database/migrations/2020_02_24_152117_add_department_id_to_licenses_table.php
+++ b/database/migrations/2020_02_24_152117_add_department_id_to_licenses_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDepartmentIdToLicensesTable extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('licenses', function(Blueprint $table)
+        {
+            $table->integer('department_id')->unsigned()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('licenses', function(Blueprint $table)
+        {
+            $table->dropColumn('department_id');
+        });
+    }
+}

--- a/database/migrations/2020_02_24_152806_add_department_id_to_accessories_table.php
+++ b/database/migrations/2020_02_24_152806_add_department_id_to_accessories_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDepartmentIdToAccessoriesTable extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('accessories', function(Blueprint $table)
+        {
+            $table->integer('department_id')->unsigned()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('accessories', function(Blueprint $table)
+        {
+            $table->dropColumn('department_id');
+        });
+    }
+}

--- a/database/migrations/2020_02_24_195100_add_assigned_qty_to_accessories_users.php
+++ b/database/migrations/2020_02_24_195100_add_assigned_qty_to_accessories_users.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddAssignedQtyToAccessoriesUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('accessories_users', function ($table) {
+          $table->integer('assigned_qty')->nullable()->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('accessories_users', function ($table) {
+            $table->dropColumn('assigned_qty');
+        });
+    }
+}

--- a/resources/lang/en/admin/accessories/general.php
+++ b/resources/lang/en/admin/accessories/general.php
@@ -18,5 +18,6 @@ return array(
     'update'  							=> 'Update Accessory',
     'use_default_eula'					=> 'Use the <a href="#" data-toggle="modal" data-target="#eulaModal">primary default EULA</a> instead.',
     'use_default_eula_disabled'			=> '<del>Use the primary default EULA instead.</del> No primary default EULA is set. Please add one in Settings.',
+    'checkout_qty_help'         => 'Will add to the users checked out quantity if they have some already'
 
 );

--- a/resources/lang/en/admin/accessories/message.php
+++ b/resources/lang/en/admin/accessories/message.php
@@ -24,7 +24,8 @@ return array(
      'checkout' => array(
         'error'   		=> 'Accessory was not checked out, please try again',
         'success' 		=> 'Accessory checked out successfully.',
-        'user_does_not_exist' => 'That user is invalid. Please try again.'
+        'user_does_not_exist' => 'That user is invalid. Please try again.',
+        'not_enough'  => 'The accessory does not have enough quantity to check out',
     ),
 
     'checkin' => array(

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -41,6 +41,7 @@
     'checkout'  			=> 'Checkout',
     'checkouts_count'       => 'Checkouts',
     'checkins_count'        => 'Checkins',
+    'checkout_count_message' => 'Currently :count are checked out',
     'user_requests_count'   => 'Requests',
     'city'  				=> 'City',
 	'click_here'			=> 'Click here',

--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -46,6 +46,19 @@
                                     </div>
                                     @endif
 
+                                                            <!-- Qty -->
+                        <div class="form-group {{ $errors->has('qty') ? 'error' : '' }}">
+                          <label for="qty" class="col-md-2 control-label">{{ trans('general.qty') }}</label>
+                          <div class="col-md-3">
+                              <input type="text" class="form-control" name="qty" value="{{ Input::old('assigned_qty', $accessory_user->assigned_qty) }}">
+                          </div>
+                          <div class="col-md-9 col-md-offset-2">
+                          <p class="help-block">Must be {{ $accessory_user->assigned_qty }} or less.</p>
+                          {!! $errors->first('qty', '<span class="alert-msg"><i class="fa fa-times"></i>
+                          :message</span>') !!}
+                          </div>
+                      </div>
+
                                     <!-- Note -->
                                     <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
                                         <label for="note" class="col-md-2 control-label">{{ trans('admin/hardware/form.notes') }}</label>

--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -79,6 +79,16 @@
                      </div>
                  </div>
              @endif
+
+             <div class="form-group {{ $errors->has('qty') ? ' has-error' : '' }}">
+              <label for="qty" class="col-md-3 control-label">{{ trans('general.qty') }}
+                <i class='icon-asterisk'></i></label>
+              <div class="col-md-9">
+                <input class="form-control" type="text" required name="qty" id="qty" style="width: 70px;" value="{{ Input::old('qty', 1) }}" /><span>{{ trans('admin/accessories/general.checkout_qty_help') }}</span>
+                {!! $errors->first('qty', '<br><span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
+              </div>
+            </div>
+
           <!-- Note -->
           <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
             <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>

--- a/resources/views/accessories/edit.blade.php
+++ b/resources/views/accessories/edit.blade.php
@@ -20,7 +20,11 @@
 @include ('partials.forms.edit.order_number')
 @include ('partials.forms.edit.purchase_date')
 @include ('partials.forms.edit.purchase_cost')
+@if (isset($min_quantity))
+@include ('partials.forms.edit.quantity', ['note' => trans('general.checkout_count_message', ['count' => $min_quantity])])
+@else
 @include ('partials.forms.edit.quantity')
+@endif
 @include ('partials.forms.edit.minimum_quantity')
 
 

--- a/resources/views/accessories/edit.blade.php
+++ b/resources/views/accessories/edit.blade.php
@@ -10,6 +10,7 @@
 @section('inputFields')
 
 @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
+@include ('partials.forms.edit.department-select', ['translated_name' => trans('general.department'), 'fieldname' => 'department_id'])
 @include ('partials.forms.edit.name', ['translated_name' => trans('admin/accessories/general.accessory_name')])
 @include ('partials.forms.edit.category-select', ['translated_name' => trans('general.category'), 'fieldname' => 'category_id', 'required' => 'true','category_type' => 'accessory'])
 @include ('partials.forms.edit.supplier-select', ['translated_name' => trans('general.supplier'), 'fieldname' => 'supplier_id'])

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -2,9 +2,9 @@
 
 {{-- Page title --}}
 @section('title')
-
+{{ trans('general.accessory') }}:
  {{ $accessory->name }}
- {{ trans('general.accessory') }}
+
  @if ($accessory->model_number!='')
      ({{ $accessory->model_number }})
  @endif
@@ -55,29 +55,23 @@
         <div class="table table-responsive">
 
             <table
-                    data-cookie-id-table="usersTable"
-                    data-pagination="true"
-                    data-id-table="usersTable"
-                    data-search="true"
-                    data-side-pagination="server"
-                    data-show-columns="true"
-                    data-show-export="true"
-                    data-show-refresh="true"
-                    data-sort-order="asc"
-                    id="usersTable"
-                    class="table table-striped snipe-table"
-                    data-url="{{ route('api.accessories.checkedout', $accessory->id) }}"
-                    data-export-options='{
-                    "fileName": "export-accessories-{{ str_slug($accessory->name) }}-users-{{ date('Y-m-d') }}",
-                    "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                    }'>
-                <thead>
-                <tr>
-                    <th data-searchable="false" data-formatter="usersLinkFormatter" data-sortable="false" data-field="name">{{ trans('general.user') }}</th>
-                    <th data-searchable="false" data-sortable="false" data-field="actions" data-formatter="accessoriesInOutFormatter">{{ trans('table.actions') }}</th>
-                </tr>
-                </thead>
-
+                data-columns="{{ \App\Presenters\AccessoryPresenter::dataTableCheckoutsLayout() }}"
+                data-cookie-id-table="usersTable"
+                data-pagination="true"
+                data-id-table="usersTable"
+                data-search="true"
+                data-side-pagination="server"
+                data-show-columns="true"
+                data-show-export="true"
+                data-show-refresh="true"
+                data-sort-order="asc"
+                id="usersTable"
+                class="table table-striped snipe-table"
+                data-url="{{ route('api.accessories.checkedout', $accessory->id) }}"
+                data-export-options='{
+                "fileName": "export-accessories-{{ str_slug($accessory->name) }}-users-{{ date('Y-m-d') }}",
+                "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                }'>
             </table>
         </div>
       </div>
@@ -88,17 +82,150 @@
   <!-- side address column -->
   <div class="col-md-3">
 
-      @if ($accessory->image!='')
-          <div class="col-md-12 text-center" style="padding-bottom: 15px;">
-              <a href="{{ app('accessories_upload_url') }}{{ $accessory->image }}" data-toggle="lightbox"><img src="{{ app('accessories_upload_url') }}{{ $accessory->image }}" class="img-responsive img-thumbnail" alt="{{ $accessory->name }}"></a>
-          </div>
-      @endif
+    <div class="text-center">
+        @can('checkout', \App\Models\Accessory::class)
+            <a href="{{ route('checkout/accessory', $accessory->id) }}" style="margin-right:5px;" class="btn btn-info btn-sm" {{ (($accessory->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
+        @endcan
+    </div>
+    <br />
 
-      <div class="text-center">
-          @can('checkout', \App\Models\Accessory::class)
-              <a href="{{ route('checkout/accessory', $accessory->id) }}" style="margin-right:5px;" class="btn btn-info btn-sm" {{ (($accessory->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
-          @endcan
-      </div>
+    @if ($accessory->image!='')
+        <div class="col-md-12 text-center" style="padding-bottom: 15px;">
+            <a href="{{ app('accessories_upload_url') }}{{ $accessory->image }}" data-toggle="lightbox"><img src="{{ app('accessories_upload_url') }}{{ $accessory->image }}" class="img-responsive img-thumbnail" alt="{{ $accessory->name }}"></a>
+        </div>
+    @endif
+
+
+
+    <div class="col-md-12">
+        <ul class="list-unstyled" style="line-height: 25px; padding-bottom: 20px;">
+            @if ($accessory->model_number!='')
+            <li>
+                <strong>{{ trans('general.model_no') }}: </strong>
+                {{ $accessory->model_number }}
+            </li>
+            @endif
+
+            @if ($accessory->company)
+            <li>
+                <strong>{{ trans('general.company') }}: </strong>
+                <a href="{{ route('companies.show', $accessory->company->id) }}">{{ $accessory->company->name }}</a>
+            </li>
+            @endif
+            
+            @if ($accessory->department)
+            <li>
+                <strong>{{ trans('general.department') }}: </strong>
+                <a href="{{ route('departments.show', $accessory->department->id) }}">{{ $accessory->department->name }}</a>
+            </li>
+            @endif
+
+            @if ($accessory->category)
+            <li>
+                <strong>{{ trans('general.category') }}: </strong>
+                @can('view', \App\Models\Category::class)
+                  <a href="{{ route('categories.show', $accessory->category->id) }}">{{ $accessory->category->name }}</a>
+                @else
+                  {{ $accessory->category->name }}
+                @endcan
+            </li>
+            @endif
+
+            @if ($accessory->location)
+            <li><strong>{{ trans('general.location') }}: </strong>
+                @can('superuser')
+                    <a href="{{ route('locations.show', ['location' => $accessory->location->id]) }}">
+                    {{ $accessory->location->name }}
+                    </a>
+                @else
+                    {{ $accessory->location->name }}
+                @endcan
+            </li>
+            @endif
+
+            <br />
+            <li>
+                <strong>{{ trans('admin/accessories/general.total') }}: </strong>
+                {{ $accessory->qty }}
+            </li>
+            <li>
+                <strong>{{ trans('admin/accessories/general.remaining') }}: </strong>
+                {{ $accessory->numRemaining() }}
+            </li>
+            <li>
+                <strong>{{ trans('general.min_amt') }}: </strong>
+                {{ $accessory->min_amt }}
+            </li>
+
+
+            @if ($accessory->supplier)
+            <br />
+            <li>
+                <strong>{{ trans('general.supplier') }}</strong>
+                <br />
+                {{ $accessory->supplier->name }}
+                <br />
+                
+                @if (($accessory->supplier->url))
+                    <i class="fa fa-globe"></i> <a href="{{ $accessory->supplier->url }}">{{ $accessory->supplier->url }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->supplier->contact))
+                    <i class="fa fa-user"></i> <a href="{{ $accessory->supplier->contact }}">{{ $accessory->supplier->contact }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->supplier->phone))
+                    <i class="fa fa-phone"></i><a href="tel:{{ $accessory->supplier->phone }}">{{ $accessory->supplier->phone }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->supplier->email))
+                    <i class="fa fa-envelope"></i> <a href="mailto:{{ $accessory->supplier->email }}">{{ $accessory->supplier->email }}</a>
+                    <br />
+                @endif
+            </li>
+            @endif
+
+            @if ($accessory->manufacturer)
+            <br />
+            <li>
+                <strong>{{ trans('general.manufacturer') }}</strong>
+                <br />
+                {{ $accessory->manufacturer->name }}
+                <br />
+                @if (($accessory->manufacturer->url))
+                    <i class="fa fa-globe"></i> <a href="{{ $accessory->manufacturer->url }}">{{ $accessory->manufacturer->url }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->manufacturer->support_url))
+                    <i class="fa fa-life-ring"></i> <a href="{{ $accessory->manufacturer->support_url }}">{{ $accessory->manufacturer->support_url }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->manufacturer->support_phone))
+                    <i class="fa fa-phone"></i><a href="tel:{{ $accessory->manufacturer->support_phone }}">{{ $accessory->manufacturer->support_phone }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->manufacturer->support_email))
+                    <i class="fa fa-envelope"></i> <a href="mailto:{{ $accessory->manufacturer->support_email }}">{{ $accessory->manufacturer->support_email }}</a>
+                    <br />
+                @endif
+                </li>
+            @endif
+
+
+
+
+
+
+
+
+        </ul>
+    </div>
 
 
     <h4>{{ trans('admin/accessories/general.about_accessories_title') }}</h4>

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -149,6 +149,10 @@
                 {{ $accessory->qty }}
             </li>
             <li>
+                <strong>{{ trans('general.checkouts_count') }}: </strong>
+                {{ $accessory->qty - $accessory->numRemaining() }}
+            </li>
+            <li>
                 <strong>{{ trans('admin/accessories/general.remaining') }}: </strong>
                 {{ $accessory->numRemaining() }}
             </li>

--- a/resources/views/companies/view.blade.php
+++ b/resources/views/companies/view.blade.php
@@ -16,7 +16,7 @@
 
 
                     <li class="active">
-                        <a href="#asset_tab" data-toggle="tab">
+                        <a href="#assets_tab" data-toggle="tab">
                             <span class="hidden-lg hidden-md">
                             <i class="fa fa-barcode"></i>
                             </span>
@@ -71,7 +71,7 @@
 
                 <div class="tab-content">
 
-                    <div class="tab-pane fade in active" id="asset_tab">
+                    <div class="tab-pane fade in active" id="assets_tab">
                         <!-- checked out assets table -->
                         <div class="table-responsive">
                             <table

--- a/resources/views/components/edit.blade.php
+++ b/resources/views/components/edit.blade.php
@@ -16,6 +16,7 @@
 @include ('partials.forms.edit.minimum_quantity')
 @include ('partials.forms.edit.serial')
 @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
+@include ('partials.forms.edit.department-select', ['translated_name' => trans('general.department'), 'fieldname' => 'department_id'])
 @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'location_id'])
 @include ('partials.forms.edit.order_number')
 @include ('partials.forms.edit.purchase_date')

--- a/resources/views/consumables/edit.blade.php
+++ b/resources/views/consumables/edit.blade.php
@@ -9,6 +9,7 @@
 @section('inputFields')
 
 @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
+@include ('partials.forms.edit.department-select', ['translated_name' => trans('general.department'), 'fieldname' => 'department_id'])
 @include ('partials.forms.edit.name', ['translated_name' => trans('admin/consumables/table.title')])
 @include ('partials.forms.edit.category-select', ['translated_name' => trans('general.category'), 'fieldname' => 'category_id', 'required' => 'true', 'category_type' => 'consumable'])
 @include ('partials.forms.edit.manufacturer-select', ['translated_name' => trans('general.manufacturer'), 'fieldname' => 'manufacturer_id', 'required' => 'true'])

--- a/resources/views/departments/index.blade.php
+++ b/resources/views/departments/index.blade.php
@@ -19,6 +19,7 @@
                     <div class="table-responsive">
 
                         <table
+                                data-columns="{{ \App\Presenters\DepartmentPresenter::dataTableLayout() }}"
                                 data-cookie-id-table="departmentsTable"
                                 data-pagination="true"
                                 data-id-table="departmentsTable"
@@ -35,19 +36,6 @@
                               "fileName": "export-departments-{{ date('Y-m-d') }}",
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
-                            <thead>
-                            <tr>
-                                <th data-sortable="true" data-field="id" data-visible="false">{{ trans('general.id') }}</th>
-                                <th data-sortable="true" data-field="company" data-visible="false" data-formatter="companiesLinkObjFormatter">{{ trans('general.company') }}</th>
-                                <th data-sortable="true" data-formatter="departmentsLinkFormatter" data-field="name" data-searchable="false">{{ trans('admin/departments/table.name') }}</th>
-                                <th data-sortable="true" data-field="image" data-visible="false" data-formatter="imageFormatter">{{ trans('general.image') }}</th>
-                                <th data-sortable="true" data-formatter="usersLinkObjFormatter" data-field="manager" data-searchable="false">{{ trans('admin/departments/table.manager') }}</th>
-                                <th data-sortable="true" data-field="users_count" data-searchable="false">{{ trans('general.users') }}</th>
-                                <th data-sortable="true" data-formatter="locationsLinkObjFormatter" data-field="location" data-searchable="false">{{ trans('admin/departments/table.location') }}</th>
-                                <th data-sortable="false" data-formatter="departmentsActionsFormatter" data-field="actions" data-searchable="false">{{ trans('table.actions') }}</th>
-
-                            </tr>
-                            </thead>
                         </table>
                     </div>
                 </div>

--- a/resources/views/departments/view.blade.php
+++ b/resources/views/departments/view.blade.php
@@ -2,9 +2,9 @@
 
 {{-- Page title --}}
 @section('title')
-
+    {{ trans('general.department') }}:
     {{ $department->name }}
-    {{ trans('general.department') }}
+    
     @parent
 @stop
 
@@ -16,14 +16,11 @@
 @section('content')
 
     <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-9">
 
             <!-- Custom Tabs -->
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs">
-                    <li class="active">
-                        <a href="#details" data-toggle="tab"><span class="hidden-lg hidden-md"><i class="fa fa-info-circle"></i></span> <span class="hidden-xs hidden-sm">{{ trans('general.details') }}</span></a>
-                    </li>
                     <li>
                         <a href="#users" data-toggle="tab"><span class="hidden-lg hidden-md"><i class="fa fa-users"></i></span> <span class="hidden-xs hidden-sm">{{ trans('general.users') }}</span></a>
                     </li>
@@ -33,58 +30,7 @@
 
                 </ul>
                 <div class="tab-content">
-                    <div class="tab-pane fade in active" id="details">
-                        <div class="row">
-                            <div class="col-md-2 text-center">
-                                <a href="{{ url('/') }}/uploads/departments/{{ $department->image }}" data-toggle="lightbox"><img src="{{ url('/') }}/uploads/departments/{{{ $department->image }}}" class="assetimg img-responsive"></a>
-                            </div>
-                  
-                            <div class="col-md-10">
-                                <div class="table table-responsive" style="margin-top: 10px;">
-                                    <table class="table">
-                                        <tbody>
-                         
-                                            @if ($department->company)
-                                            <tr>
-                                                <td>{{ trans('general.company') }}</td>
-                                                <td><a href="{{ url('/companies/' . $department->company->id) }}">{{ $department->company->name }}</a></td>
-                                            </tr>
-                                            @endif
-
-
-                                            @if ($department->location)
-                                            <tr>
-                                              <td>{{ trans('general.location') }}</td>
-                                              <td>
-                                                @can('superuser')
-                                                  <a href="{{ route('locations.show', ['location' => $department->location->id]) }}">
-                                                    {{ $department->location->name }}
-                                                  </a>
-                                                @else
-                                                  {{ $department->location->name }}
-                                                @endcan
-                                              </td>
-                                            </tr>
-                                            @endif
-
-
-                                            @if ($department->manager)
-                                            <tr>
-                                              <td>{{ trans('admin/users/table.manager') }}</td>
-                                              <td>
-                                                {!! $department->manager->present()->nameUrl() !!}
-                                              </td>
-                                            </tr>
-                                            @endif
-
-                                        </tbody>
-                                    </table>
-
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="tab-pane fade" id="users">
+                    <div class="tab-pane fade in active" id="users">
                         <div class="row">
                             <div class="col-md-12">
                                 <div class="table table-responsive" style="margin-top: 10px;">
@@ -145,6 +91,7 @@
                                       data-show-export="true"
                                       data-show-refresh="true"
                                       data-sort-order="asc"
+                                      data-toolbar="#toolbar"
                                       id="assetsListingTable"
                                       class="table table-striped snipe-table"
                                       data-url="{{route('api.assets.index',['department_id' => $department->id]) }}"
@@ -161,10 +108,44 @@
                           </div><!-- /col -->
                         </div> <!-- row -->
                       </div> <!-- /.tab-pane assets -->
+
                 
                 </div>
             </div>
-        </div>
+        </div><!-- left panel -->
+
+        <div class="col-md-3">
+
+            @if ($department->image!='')
+              <div class="col-md-12 text-center" style="padding-bottom: 20px;">
+                <a href="{{ url('/') }}/uploads/departments/{{ $department->image }}" data-toggle="lightbox"><img src="{{ url('/') }}/uploads/departments/{{{ $department->image }}}" class="assetimg img-responsive"></a>
+            </div>
+            @endif
+              <div class="col-md-12">
+                <ul class="list-unstyled" style="line-height: 25px; padding-bottom: 20px;">
+                  @if ($department->company!='')
+                    <li><strong>{{ trans('general.company') }}: </strong><a href="{{ url('/companies/' . $department->company->id) }}">{{ $department->company->name }}</a></li>
+                   @endif
+                    @if ($department->location!='')
+                    <li><strong>{{ trans('general.location') }}: </strong>
+                        @can('superuser')
+                            <a href="{{ route('locations.show', ['location' => $department->location->id]) }}">
+                            {{ $department->location->name }}
+                            </a>
+                        @else
+                            {{ $department->location->name }}
+                        @endcan
+                    </li>
+                    @endif
+                    @if (($department->manager))
+                      <li><strong>{{ trans('admin/users/table.manager') }}: </strong> {!! $department->manager->present()->nameUrl() !!}</li>
+                    @endif
+                </ul>
+      
+        
+              </div>
+        </div><!-- right panel -->
+
     </div>
 
 @stop

--- a/resources/views/departments/view.blade.php
+++ b/resources/views/departments/view.blade.php
@@ -17,13 +17,79 @@
 
     <div class="row">
         <div class="col-md-12">
-            <div class="box box-default">
-                <div class="box-body">
-                    <div class="row">
-                        <div class="col-md-12">
-                            <div class="table table-responsive">
 
-                                <table
+            <!-- Custom Tabs -->
+            <div class="nav-tabs-custom">
+                <ul class="nav nav-tabs">
+                    <li class="active">
+                        <a href="#details" data-toggle="tab"><span class="hidden-lg hidden-md"><i class="fa fa-info-circle"></i></span> <span class="hidden-xs hidden-sm">{{ trans('general.details') }}</span></a>
+                    </li>
+                    <li>
+                        <a href="#users" data-toggle="tab"><span class="hidden-lg hidden-md"><i class="fa fa-users"></i></span> <span class="hidden-xs hidden-sm">{{ trans('general.users') }}</span></a>
+                    </li>
+                    <li>
+                        <a href="#assets" data-toggle="tab"><span class="hidden-lg hidden-md"><i class="fa fa-barcode"></i></span> <span class="hidden-xs hidden-sm">{{ trans('general.assets') }}</span></a>
+                    </li>
+
+                </ul>
+                <div class="tab-content">
+                    <div class="tab-pane fade in active" id="details">
+                        <div class="row">
+                            <div class="col-md-2 text-center">
+                                <a href="{{ url('/') }}/uploads/departments/{{ $department->image }}" data-toggle="lightbox"><img src="{{ url('/') }}/uploads/departments/{{{ $department->image }}}" class="assetimg img-responsive"></a>
+                            </div>
+                  
+                            <div class="col-md-10">
+                                <div class="table table-responsive" style="margin-top: 10px;">
+                                    <table class="table">
+                                        <tbody>
+                         
+                                            @if ($department->company)
+                                            <tr>
+                                                <td>{{ trans('general.company') }}</td>
+                                                <td><a href="{{ url('/companies/' . $department->company->id) }}">{{ $department->company->name }}</a></td>
+                                            </tr>
+                                            @endif
+
+
+                                            @if ($department->location)
+                                            <tr>
+                                              <td>{{ trans('general.location') }}</td>
+                                              <td>
+                                                @can('superuser')
+                                                  <a href="{{ route('locations.show', ['location' => $department->location->id]) }}">
+                                                    {{ $department->location->name }}
+                                                  </a>
+                                                @else
+                                                  {{ $department->location->name }}
+                                                @endcan
+                                              </td>
+                                            </tr>
+                                            @endif
+
+
+                                            @if ($department->manager)
+                                            <tr>
+                                              <td>{{ trans('admin/users/table.manager') }}</td>
+                                              <td>
+                                                {!! $department->manager->present()->nameUrl() !!}
+                                              </td>
+                                            </tr>
+                                            @endif
+
+                                        </tbody>
+                                    </table>
+
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="tab-pane fade" id="users">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="table table-responsive" style="margin-top: 10px;">
+
+                                    <table
                                         data-columns="{{ \App\Presenters\UserPresenter::dataTableLayout() }}"
                                         data-cookie-id-table="departmentsUsersTable"
                                         data-pagination="true"
@@ -39,15 +105,63 @@
                                         class="table table-striped snipe-table"
                                         data-url="{{ route('api.users.index',['department_id'=> $department->id]) }}"
                                         data-export-options='{
-                              "fileName": "export-departments-{{ str_slug($department->name) }}-{{ date('Y-m-d') }}",
-                              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                              }'>
+                                    "fileName": "export-departments-{{ str_slug($department->name) }}-{{ date('Y-m-d') }}",
+                                    "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                                    }'>
+                                    </table>
 
-
-                                </table>
+                                </div>
                             </div>
                         </div>
                     </div>
+                    <div class="tab-pane fade" id="assets">
+                        <div class="row">
+                          <div class="col-md-12">
+                            {{ Form::open([
+                                      'method' => 'POST',
+                                      'route' => ['hardware/bulkedit'],
+                                      'class' => 'form-inline',
+                                       'id' => 'bulkForm']) }}
+                            <div id="toolbar">
+                              <select name="bulk_actions" class="form-control select2" style="width: 150px;">
+                                <option value="edit">Edit</option>
+                                <option value="delete">Delete</option>
+                                <option value="labels">Generate Labels</option>
+                              </select>
+                              <button class="btn btn-primary" id="bulkEdit" disabled>Go</button>
+                            </div>
+              
+                            <!-- checked out assets table -->
+                            <div class="table-responsive">
+              
+                              <table
+                                      data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
+                                      data-cookie-id-table="assetsTable"
+                                      data-pagination="true"
+                                      data-id-table="assetsTable"
+                                      data-search="true"
+                                      data-side-pagination="server"
+                                      data-show-columns="true"
+                                      data-show-export="true"
+                                      data-show-refresh="true"
+                                      data-sort-order="asc"
+                                      id="assetsListingTable"
+                                      class="table table-striped snipe-table"
+                                      data-url="{{route('api.assets.index',['department_id' => $department->id]) }}"
+                                      data-export-options='{
+                                            "fileName": "export-departments-{{ str_slug($department->name) }}-assets-{{ date('Y-m-d') }}",
+                                            "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                                            }'>
+              
+                              </table>
+              
+              
+                              {{ Form::close() }}
+                            </div>
+                          </div><!-- /col -->
+                        </div> <!-- row -->
+                      </div> <!-- /.tab-pane assets -->
+                
                 </div>
             </div>
         </div>
@@ -56,10 +170,6 @@
 @stop
 
 @section('moar_scripts')
-    @include ('partials.bootstrap-table',
-    ['exportFile' => 'departments-users-export',
-    'search' => true,
-    'columns' => \App\Presenters\UserPresenter::dataTableLayout()
-])
+    @include ('partials.bootstrap-table')
 
 @stop

--- a/resources/views/departments/view.blade.php
+++ b/resources/views/departments/view.blade.php
@@ -21,16 +21,58 @@
             <!-- Custom Tabs -->
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs">
+                  <li>
+                    <a href="#users_tab" data-toggle="tab">
+                        <span class="hidden-lg hidden-md">
+                        <i class="fa fa-users"></i></span>
+                        <span class="hidden-xs hidden-sm">{{ trans('general.people') }}</span>
+                    </a>
+                </li>
+                    <li class="active">
+                      <a href="#assets_tab" data-toggle="tab">
+                          <span class="hidden-lg hidden-md">
+                          <i class="fa fa-barcode"></i>
+                          </span>
+                          <span class="hidden-xs hidden-sm">{{ trans('general.assets') }}</span>
+                      </a>
+                  </li>
                     <li>
-                        <a href="#users" data-toggle="tab"><span class="hidden-lg hidden-md"><i class="fa fa-users"></i></span> <span class="hidden-xs hidden-sm">{{ trans('general.users') }}</span></a>
-                    </li>
-                    <li>
-                        <a href="#assets" data-toggle="tab"><span class="hidden-lg hidden-md"><i class="fa fa-barcode"></i></span> <span class="hidden-xs hidden-sm">{{ trans('general.assets') }}</span></a>
-                    </li>
+                      <a href="#licenses_tab" data-toggle="tab">
+                          <span class="hidden-lg hidden-md">
+                          <i class="fa fa-floppy-o"></i>
+                          </span>
+                          <span class="hidden-xs hidden-sm">{{ trans('general.licenses') }}</span>
+                      </a>
+                  </li>
+
+                  <li>
+                      <a href="#accessories_tab" data-toggle="tab">
+                          <span class="hidden-lg hidden-md">
+                          <i class="fa fa-keyboard-o"></i>
+                          </span> <span class="hidden-xs hidden-sm">{{ trans('general.accessories') }}</span>
+                      </a>
+                  </li>
+
+                  <li>
+                      <a href="#consumables_tab" data-toggle="tab">
+                          <span class="hidden-lg hidden-md">
+                          <i class="fa fa-tint"></i></span>
+                          <span class="hidden-xs hidden-sm">{{ trans('general.consumables') }}</span>
+                      </a>
+                  </li>
+
+                  <li>
+                      <a href="#components_tab" data-toggle="tab">
+                          <span class="hidden-lg hidden-md">
+                          <i class="fa fa-hdd-o"></i></span>
+                          <span class="hidden-xs hidden-sm">{{ trans('general.components') }}</span>
+                      </a>
+                  </li>
+
 
                 </ul>
                 <div class="tab-content">
-                    <div class="tab-pane fade in active" id="users">
+                    <div class="tab-pane fade in active" id="users_tab">
                         <div class="row">
                             <div class="col-md-12">
                                 <div class="table table-responsive" style="margin-top: 10px;">
@@ -60,7 +102,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="tab-pane fade" id="assets">
+                    <div class="tab-pane fade" id="assets_tab">
                         <div class="row">
                           <div class="col-md-12">
                             {{ Form::open([
@@ -108,6 +150,110 @@
                           </div><!-- /col -->
                         </div> <!-- row -->
                       </div> <!-- /.tab-pane assets -->
+                      <div class="tab-pane" id="licenses_tab">
+                        <div class="table-responsive">
+
+                            <table
+                                    data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayout() }}"
+                                    data-cookie-id-table="licensesTable"
+                                    data-pagination="true"
+                                    data-id-table="licensesTable"
+                                    data-search="true"
+                                    data-side-pagination="server"
+                                    data-show-columns="true"
+                                    data-show-export="true"
+                                    data-show-refresh="true"
+                                    data-sort-order="asc"
+                                    id="licensesTable"
+                                    class="table table-striped snipe-table"
+                                    data-url="{{route('api.licenses.index',['department_id' => $department->id]) }}"
+                                    data-export-options='{
+                              "fileName": "export-companies-{{ str_slug($department->name) }}-licenses-{{ date('Y-m-d') }}",
+                              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                              }'>
+                            </table>
+
+                        </div>
+                    </div><!-- /licenses-tab -->
+
+                    <div class="tab-pane" id="accessories_tab">
+                        <div class="table-responsive">
+
+                            <table
+                                    data-columns="{{ \App\Presenters\AccessoryPresenter::dataTableLayout() }}"
+                                    data-cookie-id-table="accessoriesTable"
+                                    data-pagination="true"
+                                    data-id-table="accessoriesTable"
+                                    data-search="true"
+                                    data-side-pagination="server"
+                                    data-show-columns="true"
+                                    data-show-export="true"
+                                    data-show-refresh="true"
+                                    data-sort-order="asc"
+                                    id="accessoriesTable"
+                                    class="table table-striped snipe-table"
+                                    data-url="{{route('api.accessories.index',['department_id' => $department->id]) }}"
+                                    data-export-options='{
+                              "fileName": "export-companies-{{ str_slug($department->name) }}-accessories-{{ date('Y-m-d') }}",
+                              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                              }'>
+                            </table>
+
+                        </div>
+                    </div><!-- /accessories-tab -->
+
+                    <div class="tab-pane" id="consumables_tab">
+                        <div class="table-responsive">
+
+                            <table
+                                    data-columns="{{ \App\Presenters\ConsumablePresenter::dataTableLayout() }}"
+                                    data-cookie-id-table="consumablesTable"
+                                    data-pagination="true"
+                                    data-id-table="consumablesTable"
+                                    data-search="true"
+                                    data-side-pagination="server"
+                                    data-show-columns="true"
+                                    data-show-export="true"
+                                    data-show-refresh="true"
+                                    data-sort-order="asc"
+                                    id="consumablesTable"
+                                    class="table table-striped snipe-table"
+                                    data-url="{{route('api.consumables.index',['department_id' => $department->id]) }}"
+                                    data-export-options='{
+                              "fileName": "export-companies-{{ str_slug($department->name) }}-consumables-{{ date('Y-m-d') }}",
+                              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                              }'>
+                            </table>
+
+                        </div>
+                    </div><!-- /consumables-tab -->
+
+                    <div class="tab-pane" id="components_tab">
+                        <div class="table-responsive">
+
+                            <table
+                                    data-columns="{{ \App\Presenters\ComponentPresenter::dataTableLayout() }}"
+                                    data-cookie-id-table="componentsTable"
+                                    data-pagination="true"
+                                    data-id-table="componentsTable"
+                                    data-search="true"
+                                    data-side-pagination="server"
+                                    data-show-columns="true"
+                                    data-show-export="true"
+                                    data-show-refresh="true"
+                                    data-sort-order="asc"
+                                    id="componentsTable"
+                                    class="table table-striped snipe-table"
+                                    data-url="{{route('api.components.index',['department_id' => $department->id]) }}"
+                                    data-export-options='{
+                              "fileName": "export-companies-{{ str_slug($department->name) }}-components-{{ date('Y-m-d') }}",
+                              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                              }'>
+
+                            </table>
+                        </div>
+                    </div><!-- /consumables-tab -->
+
 
                 
                 </div>

--- a/resources/views/departments/view.blade.php
+++ b/resources/views/departments/view.blade.php
@@ -21,55 +21,42 @@
             <!-- Custom Tabs -->
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs">
-                  <li>
-                    <a href="#users_tab" data-toggle="tab">
-                        <span class="hidden-lg hidden-md">
-                        <i class="fa fa-users"></i></span>
-                        <span class="hidden-xs hidden-sm">{{ trans('general.people') }}</span>
-                    </a>
-                </li>
                     <li class="active">
-                      <a href="#assets_tab" data-toggle="tab">
-                          <span class="hidden-lg hidden-md">
-                          <i class="fa fa-barcode"></i>
-                          </span>
-                          <span class="hidden-xs hidden-sm">{{ trans('general.assets') }}</span>
-                      </a>
-                  </li>
+                        <a href="#users_tab" data-toggle="tab">
+                            <span class="hidden-lg hidden-md"><i class="fa fa-users"></i></span>
+                            <span class="hidden-xs hidden-sm">{{ trans('general.people') }}</span>
+                        </a>
+                    </li>
                     <li>
-                      <a href="#licenses_tab" data-toggle="tab">
-                          <span class="hidden-lg hidden-md">
-                          <i class="fa fa-floppy-o"></i>
-                          </span>
-                          <span class="hidden-xs hidden-sm">{{ trans('general.licenses') }}</span>
-                      </a>
-                  </li>
-
-                  <li>
-                      <a href="#accessories_tab" data-toggle="tab">
-                          <span class="hidden-lg hidden-md">
-                          <i class="fa fa-keyboard-o"></i>
-                          </span> <span class="hidden-xs hidden-sm">{{ trans('general.accessories') }}</span>
-                      </a>
-                  </li>
-
-                  <li>
-                      <a href="#consumables_tab" data-toggle="tab">
-                          <span class="hidden-lg hidden-md">
-                          <i class="fa fa-tint"></i></span>
-                          <span class="hidden-xs hidden-sm">{{ trans('general.consumables') }}</span>
-                      </a>
-                  </li>
-
-                  <li>
-                      <a href="#components_tab" data-toggle="tab">
-                          <span class="hidden-lg hidden-md">
-                          <i class="fa fa-hdd-o"></i></span>
-                          <span class="hidden-xs hidden-sm">{{ trans('general.components') }}</span>
-                      </a>
-                  </li>
-
-
+                        <a href="#assets_tab" data-toggle="tab">
+                            <span class="hidden-lg hidden-md"><i class="fa fa-barcode"></i></span>
+                            <span class="hidden-xs hidden-sm">{{ trans('general.assets') }}</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#licenses_tab" data-toggle="tab">
+                            <span class="hidden-lg hidden-md"><i class="fa fa-floppy-o"></i></span>
+                            <span class="hidden-xs hidden-sm">{{ trans('general.licenses') }}</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#accessories_tab" data-toggle="tab">
+                            <span class="hidden-lg hidden-md"><i class="fa fa-keyboard-o"></i></span>
+                            <span class="hidden-xs hidden-sm">{{ trans('general.accessories') }}</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#consumables_tab" data-toggle="tab">
+                            <span class="hidden-lg hidden-md"><i class="fa fa-tint"></i></span>
+                            <span class="hidden-xs hidden-sm">{{ trans('general.consumables') }}</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#components_tab" data-toggle="tab">
+                            <span class="hidden-lg hidden-md"><i class="fa fa-hdd-o"></i></span>
+                            <span class="hidden-xs hidden-sm">{{ trans('general.components') }}</span>
+                        </a>
+                    </li>
                 </ul>
                 <div class="tab-content">
                     <div class="tab-pane fade in active" id="users_tab">

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -89,6 +89,9 @@
           <!-- Company -->
           @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
 
+          <!--  Department -->
+          @include ('partials.forms.edit.department-select', ['translated_name' => trans('general.department'), 'fieldname' => 'department_id'])
+
           <!-- Order Number -->
           <div class="form-group {{ $errors->has('order_number') ? ' has-error' : '' }}">
             <label for="order_number" class="col-md-3 control-label">

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -60,6 +60,10 @@
   @include ('partials.forms.edit.name', ['translated_name' => trans('admin/hardware/form.name')])
   @include ('partials.forms.edit.purchase_date')
   @include ('partials.forms.edit.supplier-select', ['translated_name' => trans('general.supplier'), 'fieldname' => 'supplier_id'])
+
+  <!--  Department -->
+  @include ('partials.forms.edit.department-select', ['translated_name' => trans('general.department'), 'fieldname' => 'department_id'])
+
   @include ('partials.forms.edit.order_number')
     <?php
     $currency_type=null;

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -187,7 +187,7 @@
 
                     @if (($asset->model) && ($asset->model->manufacturer))
                     <tr>
-                      <td>{{ trans('admin/hardware/form.manufacturer') }}</td>
+                      <td>{{ trans('general.manufacturer') }}</td>
                       <td>
                         <ul class="list-unstyled" style="line-height: 25px;">
                         @can('view', \App\Models\Manufacturer::class)

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -710,7 +710,7 @@
               </div>
             </div><!-- /col -->
           </div> <!-- row -->
-        </div> <!-- /.tab-pane software -->
+        </div> <!-- /.tab-pane assets -->
 
 
         <div class="tab-pane fade" id="maintenances">

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -144,6 +144,21 @@
                     </tr>
                     @endif
 
+                    @if ($asset->department)
+                      <tr>
+                        <td>{{ trans('general.department') }}</td>
+                        <td>
+                          @can ('superuser')
+                            <a href="{{ route('departments.show', $asset->department_id) }}">
+                              {{ $asset->department->name }}
+                            </a>
+                          @else
+                            {{ $asset->department->name }}
+                          @endcan
+                        </td>
+                      </tr>
+                    @endif
+
                     @if ($asset->name)
                     <tr>
                       <td>{{ trans('admin/hardware/form.name') }}</td>

--- a/resources/views/licenses/edit.blade.php
+++ b/resources/views/licenses/edit.blade.php
@@ -35,6 +35,10 @@
 </div>
 
 @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
+
+<!--  Department -->
+@include ('partials.forms.edit.department-select', ['translated_name' => trans('general.department'), 'fieldname' => 'department_id'])
+
 @include ('partials.forms.edit.manufacturer-select', ['translated_name' => trans('general.manufacturer'), 'fieldname' => 'manufacturer_id', 'required' => 'true'])
 
 <!-- Licensed to name -->

--- a/resources/views/partials/forms/edit/quantity.blade.php
+++ b/resources/views/partials/forms/edit/quantity.blade.php
@@ -6,6 +6,9 @@
        <div class="col-md-2" style="padding-left:0px">
            <input class="form-control" type="text" name="qty" id="qty" value="{{ Input::old('qty', $item->qty) }}" />
        </div>
+       @if (isset($note))
+          <p class="help-block" id="upload-file-status">{{ $note }}</p>
+       @endif
        {!! $errors->first('qty', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
    </div>
 </div>

--- a/resources/views/suppliers/view.blade.php
+++ b/resources/views/suppliers/view.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Page title --}}
 @section('title')
-{{ trans('admin/suppliers/table.view') }} -
+{{ trans('admin/suppliers/table.view') }}:
 {{ $supplier->name }}
 @parent
 @stop

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -407,7 +407,8 @@
             <table class="display table table-hover">
               <thead>
                 <tr>
-                  <th class="col-md-5">{{ trans('general.name') }}</th>
+                  <th class="col-md-4">{{ trans('general.name') }}</th>
+                  <th class="col-md-4">{{ trans('admin/accessories/general.total') }}</th>
                   <th class="col-md-1 hidden-print">{{ trans('general.action') }}</th>
                 </tr>
               </thead>
@@ -415,6 +416,7 @@
                   @foreach ($user->accessories as $accessory)
                   <tr>
                     <td>{!!$accessory->present()->nameUrl()!!}</td>
+                    <td>{{ $accessory->pivot->assigned_qty }}</td>
                     <td class="hidden-print">
                       @can('checkin', $accessory)
                         <a href="{{ route('checkin/accessory', array('accessory_id'=> $accessory->pivot->id, 'backto'=>'user')) }}" class="btn btn-primary btn-sm hidden-print">{{ trans('general.checkin') }}</a>

--- a/routes/api.php
+++ b/routes/api.php
@@ -130,7 +130,6 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'api'], fun
 
     /*--- Departments API ---*/
 
-    /*--- Suppliers API ---*/
     Route::group(['prefix' => 'departments'], function () {
 
 


### PR DESCRIPTION
This will make accessories a lot easier to check out when you have to do more than one.

It adds:
- Quantity on checkout
- Check to not allow going over remaining quantity
- Update when user and accessory are the same
- All updates on web and api

**Language edit**
Unsure how to handle the 2 additions I made to the language only for en.  I feel these would be a good addition.  I was trying very hard not to add to the translation table but I could not find anything that would work in those cases.  I also tried to make them generic so they could be reused later.

Issues this helps:
- #7605 - completely
- #5104 - partially


We run into this issue because we have no IT assets where we wanted to check out 30 to a person or location.  This doesn't solve the location yet but does with the quantity.