### PR TITLE
Make accessories checkout with quantities

### DIFF
--- a/app/Http/Controllers/AccessoriesController.php
+++ b/app/Http/Controllers/AccessoriesController.php
@@ -110,7 +110,8 @@ class AccessoriesController extends Controller
         if ($item = Accessory::find($accessoryId)) {
             $this->authorize($item);
             $category_type = 'accessory';
-            return view('accessories/edit', compact('item'))->with('category_type', $category_type);
+            $min_quantity = $item->qty - $item->numRemaining();
+            return view('accessories/edit', compact('item', 'min_quantity'))->with('category_type', $category_type);
         }
 
         return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.does_not_exist'));
@@ -133,6 +134,17 @@ class AccessoriesController extends Controller
 
         $this->authorize($accessory);
 
+        // check the quantity is equal to or greater than the checked out quantity
+        $min_edit = $accessory->qty - $accessory->numRemaining();
+        $validator = Validator::make($request->all(), [
+            "qty"  => "required|numeric|min:$min_edit"
+        ]);
+        if ($validator->fails()) {
+            return redirect()->back()
+                ->withErrors($validator)
+                ->withInput();
+        }
+
         // Update the accessory data
         $accessory->name                    = request('name');
         $accessory->location_id             = request('location_id');
@@ -144,7 +156,7 @@ class AccessoriesController extends Controller
         $accessory->model_number            = request('model_number');
         $accessory->purchase_date           = request('purchase_date');
         $accessory->purchase_cost           = request('purchase_cost');
-        $accessory->qty                     = request('qty');
+        $accessory->qty                     = $new_quantity;
         $accessory->supplier_id             = request('supplier_id');
 
         $accessory = $request->handleImages($accessory,600, public_path().'/uploads/accessories');
@@ -254,7 +266,7 @@ class AccessoriesController extends Controller
         // Validate quantity and assigned_user ID
         $max_to_checkout = $accessory->numRemaining();
         if ($max_to_checkout <= 0) {
-            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.error'));
+            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.not_enough'));
         }
         $validator = Validator::make($request->all(), [
             "assigned_to"   => "required",
@@ -364,7 +376,7 @@ class AccessoriesController extends Controller
         // Quantity check
         $max_to_checkin = $accessory_user->assigned_qty;
         if ($max_to_checkin <= 0) {
-            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.error'));
+            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkin.error'));
         }
         $validator = Validator::make($request->all(), [
             "qty" => "required|numeric|between:1,$max_to_checkin"

--- a/app/Http/Controllers/AccessoriesController.php
+++ b/app/Http/Controllers/AccessoriesController.php
@@ -298,7 +298,7 @@ class AccessoriesController extends Controller
             ]);
         }
 
-        $logaction = $accessory->logCheckout(e(request('note')), $assigned_user);
+        $accessory->logCheckout(e(request('note')), $assigned_user);
 
         // Not used?  remove?
         /*
@@ -401,7 +401,7 @@ class AccessoriesController extends Controller
         }
 
 
-        $logaction = $accessory->logCheckin($assigned_user, e(request('note')));
+        $accessory->logCheckin($assigned_user, e(request('note')));
 
         // Unused anywhere ?, should delete ?
         /*

--- a/app/Http/Controllers/AccessoriesController.php
+++ b/app/Http/Controllers/AccessoriesController.php
@@ -156,7 +156,7 @@ class AccessoriesController extends Controller
         $accessory->model_number            = request('model_number');
         $accessory->purchase_date           = request('purchase_date');
         $accessory->purchase_cost           = request('purchase_cost');
-        $accessory->qty                     = $new_quantity;
+        $accessory->qty                     = request('qty');
         $accessory->supplier_id             = request('supplier_id');
 
         $accessory = $request->handleImages($accessory,600, public_path().'/uploads/accessories');

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -10,6 +10,7 @@ use App\Http\Transformers\AccessoriesTransformer;
 use App\Models\Company;
 use App\Models\User;
 use Carbon\Carbon;
+use Validator;
 use Auth;
 use DB;
 
@@ -169,6 +170,16 @@ class AccessoriesController extends Controller
     {
         $this->authorize('edit', Accessory::class);
         $accessory = Accessory::findOrFail($id);
+
+        // check the quantity is equal to or greater than the checked out quantity
+        $min_edit = $accessory->qty - $accessory->numRemaining();
+        $validator = Validator::make($request->all(), [
+            "qty"  => "required|numeric|min:$min_edit"
+        ]);
+        if ($validator->fails()) {
+          return response()->json(Helper::formatStandardApiResponse('error', null, $validator->errors()->all()));
+        }
+        
         $accessory->fill($request->all());
 
         if ($accessory->save()) {
@@ -221,30 +232,42 @@ class AccessoriesController extends Controller
 
         $this->authorize('checkout', $accessory);
 
+        // Validate quantity and assigned_user ID
+        $max_to_checkout = $accessory->numRemaining();
+        if ($max_to_checkout <= 0) {
+          return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/accessories/message.checkout.not_enough')));
+        }
+        $validator = Validator::make($request->all(), [
+            "assigned_to"   => "required|exists:users,id",
+            "qty"  => "required|numeric|between:1,$max_to_checkout"
+        ]);
+        if ($validator->fails()) {
+          return response()->json(Helper::formatStandardApiResponse('error', null, $validator->errors()->all()));
+        }
 
-        if ($accessory->numRemaining() > 0) {
+        if (!$assigned_user = User::find(request('assigned_to'))) {
+          return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/accessories/message.checkout.user_does_not_exist')));
+        }
 
-            if (!$user = User::find($request->input('assigned_to'))) {
-                return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/accessories/message.checkout.user_does_not_exist')));
-            }
-
-            // Update the accessory data
-            $accessory->assigned_to = $request->input('assigned_to');
-
+        // check if accessory is assigned already and add quantity
+        $checkout_qty = (int)request('qty');
+        $accessory_user = DB::table('accessories_users')->where('assigned_to', '=', request('assigned_to'))->where('accessory_id', '=', $accessory->id)->first();
+        if ($accessory_user) {
+            $updated_qty = $accessory_user->assigned_qty + $checkout_qty;
+            DB::table('accessories_users')->where('id', $accessory_user->id)->update(['assigned_qty' => $updated_qty]);
+        } else {
             $accessory->users()->attach($accessory->id, [
                 'accessory_id' => $accessory->id,
                 'created_at' => Carbon::now(),
                 'user_id' => Auth::id(),
-                'assigned_to' => $request->get('assigned_to')
+                'assigned_to' => request('assigned_to'),
+                'assigned_qty' => $checkout_qty
             ]);
-
-            $accessory->logCheckout($request->input('note'), $user);
-
-            return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/accessories/message.checkout.success')));
         }
 
-        return response()->json(Helper::formatStandardApiResponse('error', null, 'No accessories remaining'));
+        $logaction = $accessory->logCheckout(e(request('note')), $assigned_user);
 
+        return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/accessories/message.checkout.success')));
     }
 
     /**
@@ -267,27 +290,49 @@ class AccessoriesController extends Controller
         $accessory = Accessory::find($accessory_user->accessory_id);
         $this->authorize('checkin', $accessory);
 
-        $logaction = $accessory->logCheckin(User::find($accessoryUserId), $request->input('note'));
+        $assigned_user = User::find($accessory_user->assigned_to);
 
-        // Was the accessory updated?
-        if (DB::table('accessories_users')->where('id', '=', $accessory_user->id)->delete()) {
-            if (!is_null($accessory_user->assigned_to)) {
-                $user = User::find($accessory_user->assigned_to);
+        // Quantity check
+        $max_to_checkin = $accessory_user->assigned_qty;
+        // should never happen
+        if ($max_to_checkin <= 0) {
+            return response()->json(Helper::formatStandardApiResponse('error', null,  trans('admin/accessories/message.checkin.error')));
+        }
+        //validate
+        $validator = Validator::make($request->all(), [
+            "qty" => "required|numeric|between:1,$max_to_checkin"
+        ]);
+        if ($validator->fails()) {
+          return response()->json(Helper::formatStandardApiResponse('error', null, $validator->errors()->all()));
+        }
+        // Quantity check was successful
+
+        // Quantity adjust
+        $checkin_qty = (int)request('qty');
+        $qty_remaining_in_checkout = ($accessory_user->assigned_qty - $checkin_qty);
+        if ($qty_remaining_in_checkout > 0) {
+            // Update to correct checked out quantity
+            DB::table('accessories_users')->where('id', $accessoryUserId)->update(['assigned_qty' => $qty_remaining_in_checkout]);
+        } else {
+            if (is_null(DB::table('accessories_users')->where('id', '=', $accessory_user->id)->delete())) {
+              return response()->json(Helper::formatStandardApiResponse('error', null,  trans('admin/accessories/message.checkin.error')));
             }
-
-            $data['log_id'] = $logaction->id;
-            $data['first_name'] = $user->first_name;
-            $data['last_name'] = $user->last_name;
-            $data['item_name'] = $accessory->name;
-            $data['checkin_date'] = $logaction->created_at;
-            $data['item_tag'] = '';
-            $data['note'] = $logaction->note;
-
-            return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/accessories/message.checkin.success')));
         }
 
-        return response()->json(Helper::formatStandardApiResponse('error', null,  trans('admin/accessories/message.checkin.error')));
+        $logaction = $accessory->logCheckin($assigned_user, e(request('note')));
 
+        // Unused anywhere ?, should delete ?
+        /*
+        $data['log_id'] = $logaction->id;
+        $data['first_name'] = $user->first_name;
+        $data['last_name'] = $user->last_name;
+        $data['item_name'] = $accessory->name;
+        $data['checkin_date'] = $logaction->created_at;
+        $data['item_tag'] = '';
+        $data['note'] = $logaction->note;
+        */
+
+        return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/accessories/message.checkin.success')));
+        
     }
-
 }

--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -69,6 +69,7 @@ class AccessoriesTransformer
         foreach ($accessory_users as $user) {
             $array[] = [
                 'assigned_pivot_id' => $user->pivot->id,
+                'qty' => $user->pivot->assigned_qty,
                 'id' => (int) $user->id,
                 'username' => e($user->username),
                 'name' => e($user->getFullNameAttribute()),

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -150,7 +150,7 @@ class Accessory extends SnipeModel
 
     public function users()
     {
-        return $this->belongsToMany('\App\Models\User', 'accessories_users', 'accessory_id', 'assigned_to')->withPivot('id')->withTrashed();
+        return $this->belongsToMany('\App\Models\User', 'accessories_users', 'accessory_id', 'assigned_to')->withPivot('id', 'assigned_qty')->withTrashed();
     }
 
     public function hasUsers()
@@ -188,7 +188,12 @@ class Accessory extends SnipeModel
 
     public function numRemaining()
     {
-        $checkedout = $this->users->count();
+        $checkedout = 0;
+
+        foreach ($this->users as $checkout) {
+            $checkedout += $checkout->pivot->assigned_qty;
+        }
+
         $total = $this->qty;
         $remaining = $total - $checkedout;
         return $remaining;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -213,7 +213,7 @@ class User extends SnipeModel implements AuthenticatableContract, CanResetPasswo
      */
     public function accessories()
     {
-        return $this->belongsToMany('\App\Models\Accessory', 'accessories_users', 'assigned_to', 'accessory_id')->withPivot('id')->withTrashed();
+        return $this->belongsToMany('\App\Models\Accessory', 'accessories_users', 'assigned_to', 'accessory_id')->withPivot('id', 'assigned_qty')->withTrashed();
     }
 
     /**

--- a/app/Presenters/AccessoryPresenter.php
+++ b/app/Presenters/AccessoryPresenter.php
@@ -132,6 +132,32 @@ class AccessoryPresenter extends Presenter
         return json_encode($layout);
     }
 
+    public static function dataTableCheckoutsLayout()
+    {
+        $layout = [
+            [
+                "field" => "name",
+                "searchable" => false,
+                "sortable" => false,
+                "title" => trans('general.name'),
+                "formatter" => "usersLinkFormatter"
+            ], [
+                "field" => "qty",
+                "searchable" => false,
+                "sortable" => false,
+                "title" => trans('admin/accessories/general.total'),
+            ], [
+                "field" => "actions",
+                "searchable" => false,
+                "sortable" => false,
+                "title" => trans('table.actions'),
+                "formatter" => "accessoriesInOutFormatter",
+            ]
+        ];
+
+        return json_encode($layout);
+    }
+
 
     /**
      * Pregenerated link to this accessories view page.

--- a/database/migrations/2020_02_24_195100_add_assigned_qty_to_accessories_users.php
+++ b/database/migrations/2020_02_24_195100_add_assigned_qty_to_accessories_users.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddAssignedQtyToAccessoriesUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('accessories_users', function ($table) {
+          $table->integer('assigned_qty')->nullable()->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('accessories_users', function ($table) {
+            $table->dropColumn('assigned_qty');
+        });
+    }
+}

--- a/resources/lang/en/admin/accessories/general.php
+++ b/resources/lang/en/admin/accessories/general.php
@@ -18,5 +18,6 @@ return array(
     'update'  							=> 'Update Accessory',
     'use_default_eula'					=> 'Use the <a href="#" data-toggle="modal" data-target="#eulaModal">primary default EULA</a> instead.',
     'use_default_eula_disabled'			=> '<del>Use the primary default EULA instead.</del> No primary default EULA is set. Please add one in Settings.',
+    'checkout_qty_help'         => 'Will add to the users checked out quantity if they have some already'
 
 );

--- a/resources/lang/en/admin/accessories/message.php
+++ b/resources/lang/en/admin/accessories/message.php
@@ -24,7 +24,8 @@ return array(
      'checkout' => array(
         'error'   		=> 'Accessory was not checked out, please try again',
         'success' 		=> 'Accessory checked out successfully.',
-        'user_does_not_exist' => 'That user is invalid. Please try again.'
+        'user_does_not_exist' => 'That user is invalid. Please try again.',
+        'not_enough'  => 'The accessory does not have enough quantity to check out',
     ),
 
     'checkin' => array(

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -41,6 +41,7 @@
     'checkout'  			=> 'Checkout',
     'checkouts_count'       => 'Checkouts',
     'checkins_count'        => 'Checkins',
+    'checkout_count_message' => 'Currently :count are checked out',
     'user_requests_count'   => 'Requests',
     'city'  				=> 'City',
 	'click_here'			=> 'Click here',

--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -46,6 +46,19 @@
                                     </div>
                                     @endif
 
+                                                            <!-- Qty -->
+                        <div class="form-group {{ $errors->has('qty') ? 'error' : '' }}">
+                          <label for="qty" class="col-md-2 control-label">{{ trans('general.qty') }}</label>
+                          <div class="col-md-3">
+                              <input type="text" class="form-control" name="qty" value="{{ Input::old('assigned_qty', $accessory_user->assigned_qty) }}">
+                          </div>
+                          <div class="col-md-9 col-md-offset-2">
+                          <p class="help-block">Must be {{ $accessory_user->assigned_qty }} or less.</p>
+                          {!! $errors->first('qty', '<span class="alert-msg"><i class="fa fa-times"></i>
+                          :message</span>') !!}
+                          </div>
+                      </div>
+
                                     <!-- Note -->
                                     <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
                                         <label for="note" class="col-md-2 control-label">{{ trans('admin/hardware/form.notes') }}</label>

--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -79,6 +79,16 @@
                      </div>
                  </div>
              @endif
+
+             <div class="form-group {{ $errors->has('qty') ? ' has-error' : '' }}">
+              <label for="qty" class="col-md-3 control-label">{{ trans('general.qty') }}
+                <i class='icon-asterisk'></i></label>
+              <div class="col-md-9">
+                <input class="form-control" type="text" required name="qty" id="qty" style="width: 70px;" value="{{ Input::old('qty', 1) }}" /><span>{{ trans('admin/accessories/general.checkout_qty_help') }}</span>
+                {!! $errors->first('qty', '<br><span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
+              </div>
+            </div>
+
           <!-- Note -->
           <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
             <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>

--- a/resources/views/accessories/edit.blade.php
+++ b/resources/views/accessories/edit.blade.php
@@ -19,7 +19,11 @@
 @include ('partials.forms.edit.order_number')
 @include ('partials.forms.edit.purchase_date')
 @include ('partials.forms.edit.purchase_cost')
+@if (isset($min_quantity))
+@include ('partials.forms.edit.quantity', ['note' => trans('general.checkout_count_message', ['count' => $min_quantity])])
+@else
 @include ('partials.forms.edit.quantity')
+@endif
 @include ('partials.forms.edit.minimum_quantity')
 
 

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -2,9 +2,9 @@
 
 {{-- Page title --}}
 @section('title')
-
+{{ trans('general.accessory') }}:
  {{ $accessory->name }}
- {{ trans('general.accessory') }}
+
  @if ($accessory->model_number!='')
      ({{ $accessory->model_number }})
  @endif
@@ -55,29 +55,23 @@
         <div class="table table-responsive">
 
             <table
-                    data-cookie-id-table="usersTable"
-                    data-pagination="true"
-                    data-id-table="usersTable"
-                    data-search="true"
-                    data-side-pagination="server"
-                    data-show-columns="true"
-                    data-show-export="true"
-                    data-show-refresh="true"
-                    data-sort-order="asc"
-                    id="usersTable"
-                    class="table table-striped snipe-table"
-                    data-url="{{ route('api.accessories.checkedout', $accessory->id) }}"
-                    data-export-options='{
-                    "fileName": "export-accessories-{{ str_slug($accessory->name) }}-users-{{ date('Y-m-d') }}",
-                    "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                    }'>
-                <thead>
-                <tr>
-                    <th data-searchable="false" data-formatter="usersLinkFormatter" data-sortable="false" data-field="name">{{ trans('general.user') }}</th>
-                    <th data-searchable="false" data-sortable="false" data-field="actions" data-formatter="accessoriesInOutFormatter">{{ trans('table.actions') }}</th>
-                </tr>
-                </thead>
-
+                data-columns="{{ \App\Presenters\AccessoryPresenter::dataTableCheckoutsLayout() }}"
+                data-cookie-id-table="usersTable"
+                data-pagination="true"
+                data-id-table="usersTable"
+                data-search="true"
+                data-side-pagination="server"
+                data-show-columns="true"
+                data-show-export="true"
+                data-show-refresh="true"
+                data-sort-order="asc"
+                id="usersTable"
+                class="table table-striped snipe-table"
+                data-url="{{ route('api.accessories.checkedout', $accessory->id) }}"
+                data-export-options='{
+                "fileName": "export-accessories-{{ str_slug($accessory->name) }}-users-{{ date('Y-m-d') }}",
+                "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                }'>
             </table>
         </div>
       </div>
@@ -88,17 +82,150 @@
   <!-- side address column -->
   <div class="col-md-3">
 
-      @if ($accessory->image!='')
-          <div class="col-md-12 text-center" style="padding-bottom: 15px;">
-              <a href="{{ app('accessories_upload_url') }}{{ $accessory->image }}" data-toggle="lightbox"><img src="{{ app('accessories_upload_url') }}{{ $accessory->image }}" class="img-responsive img-thumbnail" alt="{{ $accessory->name }}"></a>
-          </div>
-      @endif
+    <div class="text-center">
+        @can('checkout', \App\Models\Accessory::class)
+            <a href="{{ route('checkout/accessory', $accessory->id) }}" style="margin-right:5px;" class="btn btn-info btn-sm" {{ (($accessory->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
+        @endcan
+    </div>
+    <br />
 
-      <div class="text-center">
-          @can('checkout', \App\Models\Accessory::class)
-              <a href="{{ route('checkout/accessory', $accessory->id) }}" style="margin-right:5px;" class="btn btn-info btn-sm" {{ (($accessory->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
-          @endcan
-      </div>
+    @if ($accessory->image!='')
+        <div class="col-md-12 text-center" style="padding-bottom: 15px;">
+            <a href="{{ app('accessories_upload_url') }}{{ $accessory->image }}" data-toggle="lightbox"><img src="{{ app('accessories_upload_url') }}{{ $accessory->image }}" class="img-responsive img-thumbnail" alt="{{ $accessory->name }}"></a>
+        </div>
+    @endif
+
+
+
+    <div class="col-md-12">
+        <ul class="list-unstyled" style="line-height: 25px; padding-bottom: 20px;">
+            @if ($accessory->model_number!='')
+            <li>
+                <strong>{{ trans('general.model_no') }}: </strong>
+                {{ $accessory->model_number }}
+            </li>
+            @endif
+
+            @if ($accessory->company)
+            <li>
+                <strong>{{ trans('general.company') }}: </strong>
+                <a href="{{ route('companies.show', $accessory->company->id) }}">{{ $accessory->company->name }}</a>
+            </li>
+            @endif
+            
+            @if ($accessory->department)
+            <li>
+                <strong>{{ trans('general.department') }}: </strong>
+                <a href="{{ route('departments.show', $accessory->department->id) }}">{{ $accessory->department->name }}</a>
+            </li>
+            @endif
+
+            @if ($accessory->category)
+            <li>
+                <strong>{{ trans('general.category') }}: </strong>
+                @can('view', \App\Models\Category::class)
+                  <a href="{{ route('categories.show', $accessory->category->id) }}">{{ $accessory->category->name }}</a>
+                @else
+                  {{ $accessory->category->name }}
+                @endcan
+            </li>
+            @endif
+
+            @if ($accessory->location)
+            <li><strong>{{ trans('general.location') }}: </strong>
+                @can('superuser')
+                    <a href="{{ route('locations.show', ['location' => $accessory->location->id]) }}">
+                    {{ $accessory->location->name }}
+                    </a>
+                @else
+                    {{ $accessory->location->name }}
+                @endcan
+            </li>
+            @endif
+
+            <br />
+            <li>
+                <strong>{{ trans('admin/accessories/general.total') }}: </strong>
+                {{ $accessory->qty }}
+            </li>
+            <li>
+                <strong>{{ trans('admin/accessories/general.remaining') }}: </strong>
+                {{ $accessory->numRemaining() }}
+            </li>
+            <li>
+                <strong>{{ trans('general.min_amt') }}: </strong>
+                {{ $accessory->min_amt }}
+            </li>
+
+
+            @if ($accessory->supplier)
+            <br />
+            <li>
+                <strong>{{ trans('general.supplier') }}</strong>
+                <br />
+                {{ $accessory->supplier->name }}
+                <br />
+                
+                @if (($accessory->supplier->url))
+                    <i class="fa fa-globe"></i> <a href="{{ $accessory->supplier->url }}">{{ $accessory->supplier->url }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->supplier->contact))
+                    <i class="fa fa-user"></i> <a href="{{ $accessory->supplier->contact }}">{{ $accessory->supplier->contact }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->supplier->phone))
+                    <i class="fa fa-phone"></i><a href="tel:{{ $accessory->supplier->phone }}">{{ $accessory->supplier->phone }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->supplier->email))
+                    <i class="fa fa-envelope"></i> <a href="mailto:{{ $accessory->supplier->email }}">{{ $accessory->supplier->email }}</a>
+                    <br />
+                @endif
+            </li>
+            @endif
+
+            @if ($accessory->manufacturer)
+            <br />
+            <li>
+                <strong>{{ trans('general.manufacturer') }}</strong>
+                <br />
+                {{ $accessory->manufacturer->name }}
+                <br />
+                @if (($accessory->manufacturer->url))
+                    <i class="fa fa-globe"></i> <a href="{{ $accessory->manufacturer->url }}">{{ $accessory->manufacturer->url }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->manufacturer->support_url))
+                    <i class="fa fa-life-ring"></i> <a href="{{ $accessory->manufacturer->support_url }}">{{ $accessory->manufacturer->support_url }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->manufacturer->support_phone))
+                    <i class="fa fa-phone"></i><a href="tel:{{ $accessory->manufacturer->support_phone }}">{{ $accessory->manufacturer->support_phone }}</a>
+                    <br />
+                @endif
+
+                @if (($accessory->manufacturer->support_email))
+                    <i class="fa fa-envelope"></i> <a href="mailto:{{ $accessory->manufacturer->support_email }}">{{ $accessory->manufacturer->support_email }}</a>
+                    <br />
+                @endif
+                </li>
+            @endif
+
+
+
+
+
+
+
+
+        </ul>
+    </div>
 
 
     <h4>{{ trans('admin/accessories/general.about_accessories_title') }}</h4>

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -149,6 +149,10 @@
                 {{ $accessory->qty }}
             </li>
             <li>
+                <strong>{{ trans('general.checkouts_count') }}: </strong>
+                {{ $accessory->qty - $accessory->numRemaining() }}
+            </li>
+            <li>
                 <strong>{{ trans('admin/accessories/general.remaining') }}: </strong>
                 {{ $accessory->numRemaining() }}
             </li>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -172,7 +172,7 @@
 
                     @if (($asset->model) && ($asset->model->manufacturer))
                     <tr>
-                      <td>{{ trans('admin/hardware/form.manufacturer') }}</td>
+                      <td>{{ trans('general.manufacturer') }}</td>
                       <td>
                         <ul class="list-unstyled" style="line-height: 25px;">
                         @can('view', \App\Models\Manufacturer::class)

--- a/resources/views/partials/forms/edit/quantity.blade.php
+++ b/resources/views/partials/forms/edit/quantity.blade.php
@@ -6,6 +6,9 @@
        <div class="col-md-2" style="padding-left:0px">
            <input class="form-control" type="text" name="qty" id="qty" value="{{ Input::old('qty', $item->qty) }}" />
        </div>
+       @if (isset($note))
+          <p class="help-block" id="upload-file-status">{{ $note }}</p>
+       @endif
        {!! $errors->first('qty', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
    </div>
 </div>

--- a/resources/views/suppliers/view.blade.php
+++ b/resources/views/suppliers/view.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Page title --}}
 @section('title')
-{{ trans('admin/suppliers/table.view') }} -
+{{ trans('admin/suppliers/table.view') }}:
 {{ $supplier->name }}
 @parent
 @stop

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -407,7 +407,8 @@
             <table class="display table table-hover">
               <thead>
                 <tr>
-                  <th class="col-md-5">{{ trans('general.name') }}</th>
+                  <th class="col-md-4">{{ trans('general.name') }}</th>
+                  <th class="col-md-4">{{ trans('admin/accessories/general.total') }}</th>
                   <th class="col-md-1 hidden-print">{{ trans('general.action') }}</th>
                 </tr>
               </thead>
@@ -415,6 +416,7 @@
                   @foreach ($user->accessories as $accessory)
                   <tr>
                     <td>{!!$accessory->present()->nameUrl()!!}</td>
+                    <td>{{ $accessory->pivot->assigned_qty }}</td>
                     <td class="hidden-print">
                       @can('checkin', $accessory)
                         <a href="{{ route('checkin/accessory', array('accessory_id'=> $accessory->pivot->id, 'backto'=>'user')) }}" class="btn btn-primary btn-sm hidden-print">{{ trans('general.checkin') }}</a>


### PR DESCRIPTION
This will make accessories a lot easier to check out when you have to do more than one.

It adds:
- Quantity on checkout
- Check to not allow going over remaining quantity
- Update when user and accessory are the same
- Updated info on accessory side bar


**Language edit**
Unsure how to handle the 2 additions I made to the language only for en.  I feel these would be a good addition.  I was trying very hard not to add to the translation table but I could not find anything that would work in those cases.  I also tried to make them generic so they could be reused later.

Issues this helps:
- fixes #7605
- #5104 - partially


We run into this issue because we have assets where we wanted to check out 30 of the same accessory to a person or location.  This doesn't solve the location yet but does with the quantity.  A simple case would be giving 2 USB sticks to the same person.  Now it will be a single transaction than multiple transactions.

This also will allow you to check out an accessory later to that person and will just increase the amount they have instead of making a second row for them.