### PR TITLE
Fixed #7870: fixed SSL connectivity for PaaS DBs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,7 @@ DB_COLLATION=utf8mb4_unicode_ci
 # OPTIONAL: SSL DATABASE SETTINGS
 # --------------------------------------------
 DB_SSL=false
+DB_SSL_IS_PAAS=false
 DB_SSL_KEY_PATH=null
 DB_SSL_CERT_PATH=null
 DB_SSL_CA_PATH=null

--- a/config/database.php
+++ b/config/database.php
@@ -87,12 +87,14 @@ return [
                 //'exclude_tables' => ['table1', 'table2'],
                 //'add_extra_option' => '--optionname=optionvalue',
             ],
-            'options' => (env('DB_SSL')) ? [
-                PDO::MYSQL_ATTR_SSL_KEY    => env('DB_SSL_KEY_PATH'),  // /path/to/key.pem
-                PDO::MYSQL_ATTR_SSL_CERT   => env('DB_SSL_CERT_PATH'), // /path/to/cert.pem
-                PDO::MYSQL_ATTR_SSL_CA     => env('DB_SSL_CA_PATH'),   // /path/to/ca.pem
-                PDO::MYSQL_ATTR_SSL_CIPHER => env('DB_SSL_CIPHER')
-            ] : []
+            'options' => (env('DB_SSL')) ? ((env('DB_SSL_IS_PAAS')) ? [
+                PDO::MYSQL_ATTR_SSL_CA                  => env('DB_SSL_CA_PATH'),   // /path/to/ca.pem
+            ] : [
+                PDO::MYSQL_ATTR_SSL_KEY                 => env('DB_SSL_KEY_PATH'),  // /path/to/key.pem
+                PDO::MYSQL_ATTR_SSL_CERT                => env('DB_SSL_CERT_PATH'), // /path/to/cert.pem
+                PDO::MYSQL_ATTR_SSL_CA                  => env('DB_SSL_CA_PATH'),   // /path/to/ca.pem
+                PDO::MYSQL_ATTR_SSL_CIPHER              => env('DB_SSL_CIPHER')
+            ]) : []
         ],
 
         'pgsql' => [


### PR DESCRIPTION
Resolves #7870

This configuration seems (from some stack overflow perusing) to affect Azure PaaS and AWS as well. 
Solution hinted at here: https://stackoverflow.com/questions/29884353/pdo-ssl-strange-behavior