### PR TITLE
Fixes search by serial or tag even if they have slashes in them

### DIFF
--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -439,7 +439,20 @@ class AssetsController extends Controller
 
 
     /**
-     * Searches the assets table by tag, and redirects if it finds one
+     * Searches the assets table by tag, and redirects if it finds one.
+     *
+     * This is used by the top search box in Snipe-IT, but as of 4.9.x
+     * can also be used as a url segment.
+     *
+     * https://yoursnipe.com/hardware/bytag/?assetTag=foo
+     *
+     * OR
+     *
+     * https://yoursnipe.com/hardware/bytag/foo
+     *
+     * The latter is useful if you're doing home-grown barcodes, or
+     * some other automation where you don't always know the internal ID of
+     * an asset and don't want to query for it.
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v3.0]
@@ -450,6 +463,8 @@ class AssetsController extends Controller
 
         $topsearch = ($request->get('topsearch')=="true");
 
+        // We need this part to determine whether a url query parameter has been passed, OR
+        // whether it's the url fragment we need to look at
         $tag = ($request->get('assetTag')) ? $request->get('assetTag') : $tag;
 
         if (!$asset = Asset::where('asset_tag', '=', $tag)->first()) {

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -439,22 +439,46 @@ class AssetsController extends Controller
 
 
     /**
+     * Searches the assets table by serial, and redirects if it finds one
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v3.0]
+     * @return Redirect
+     */
+    public function getAssetByTag(Request $request, $tag = null)
+    {
+
+        $topsearch = ($request->get('topsearch')=="true");
+
+        $tag = ($request->get('assetTag')) ? $request->get('assetTag') : $tag;
+
+        if (!$asset = Asset::where('asset_tag', '=', $tag)->first()) {
+            return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.does_not_exist'));
+        }
+        $this->authorize('view', $asset);
+        return redirect()->route('hardware.show', $asset->id)->with('topsearch', $topsearch);
+    }
+
+
+    /**
      * Searches the assets table by asset tag, and redirects if it finds one
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v3.0]
      * @return Redirect
      */
-    public function getAssetByTag(Request $request)
+    public function getAssetBySerial(Request $request, $serial = null)
     {
-        $topsearch = ($request->get('topsearch')=="true");
 
-        if (!$asset = Asset::where('asset_tag', '=', $request->get('assetTag'))->first()) {
+        $serial = ($request->get('serial')) ? $request->get('serial') : $serial;
+        if (!$asset = Asset::where('serial', '=', $serial)->first()) {
             return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.does_not_exist'));
         }
         $this->authorize('view', $asset);
-        return redirect()->route('hardware.show', $asset->id)->with('topsearch', $topsearch);
+        return redirect()->route('hardware.show', $asset->id);
     }
+
+
     /**
      * Return a QR code for the asset
      *

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -439,7 +439,7 @@ class AssetsController extends Controller
 
 
     /**
-     * Searches the assets table by serial, and redirects if it finds one
+     * Searches the assets table by tag, and redirects if it finds one
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v3.0]
@@ -461,7 +461,7 @@ class AssetsController extends Controller
 
 
     /**
-     * Searches the assets table by asset tag, and redirects if it finds one
+     * Searches the assets table by serial, and redirects if it finds one
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v3.0]

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -455,6 +455,7 @@ class AssetsController extends Controller
      * an asset and don't want to query for it.
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @param string $tag
      * @since [v3.0]
      * @return Redirect
      */
@@ -479,7 +480,8 @@ class AssetsController extends Controller
      * Searches the assets table by serial, and redirects if it finds one
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v3.0]
+     * @param string $serial
+     * @since [v4.9.1]
      * @return Redirect
      */
     public function getAssetBySerial(Request $request, $serial = null)

--- a/routes/api.php
+++ b/routes/api.php
@@ -320,16 +320,21 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'api'], fun
 
     Route::group(['prefix' => 'hardware'], function () {
 
-        Route::get( 'bytag/{tag}',  [
-            'as' => 'assets.show.bytag',
-            'uses' => 'AssetsController@showByTag'
-        ]);
+        Route::get('bytag/{any}',
+            [
+                'as' => 'api.assets.show.bytag',
+                'uses' => 'AssetsController@showByTag'
+            ]
+        )->where('any', '.*');
 
-        Route::get( 'byserial/{serial}',  [
-            'as' => 'assets.show.byserial',
-            'uses' => 'AssetsController@showBySerial'
-        ]);
 
+        Route::get('byserial/{any}',
+            [
+                'as' => 'api.assets.show.byserial',
+                'uses' => 'AssetsController@showBySerial'
+            ]
+         )->where('any', '.*');
+        
 
         Route::get( 'selectlist',  [
             'as' => 'assets.selectlist',

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -60,10 +60,21 @@ Route::group(
             'uses' => 'AssetsController@postImportHistory'
         ]);
 
-        Route::get('/bytag', [
-            'as'   => 'findbytag/hardware',
-            'uses' => 'AssetsController@getAssetByTag'
-        ]);
+        Route::get('bytag/{any?}',
+            [
+                'as'   => 'findbytag/hardware',
+                'uses' => 'AssetsController@getAssetByTag'
+            ]
+        )->where('any', '.*');
+
+        Route::get('byserial/{any?}',
+            [
+                'as'   => 'findbyserial/hardware',
+                'uses' => 'AssetsController@getAssetBySerial'
+            ]
+        )->where('any', '.*');
+
+
 
         Route::get('{assetId}/clone', [
             'as' => 'clone/hardware',


### PR DESCRIPTION
Fixes a bug where when you use the API endpoint `/hardware/byserial/foo` wth a serial (`foo`) that had problematic url-ish characters in it (like a serial with `/` in it). 

For example:

API endpoint: `https://your-awesome-snipe-it-app.com/api/v1/hardware/byserial/348579579475696` <-- works fine

API endpoint: `https://your-awesome-snipe-it-app.com/api/v1/hardware/byserial/348/57//957/9475696` <-- 404s

So I think this is an imperfect fix, because if you're already urlencoding the stuff after the `/api/v1/hardware/byserial` it's not going to go well. But I think it would have already been broken from the start? This is better than what we had, so I'll take it. 

I can't actually figure out why the `{any}` won't pick up the urlencoded version, since it's kinda supposed to take *anything* after the `byserial`, but heck computers are hard. 

If you use a urlencoded serial that actually has urlencodable stuff in it, it will 404. This is happening at the route level and not the controller level, so it's a bit confusing, but as I mentioned, I don't think this API would have worked with path-related characters in the serial/tags (`/`s, etc) before, urlencoded or not, so... 

This fix also affects the `bytag` endpoint, since it's the same fix for both.

This also adds a web (non-API) method to grab an asset by its serial number via URL. It's a fringe case, but if you're (for example) growing your own barcodes/QR codes/etc and don't want to have to look up an internal Snipe-IT ID and want to search by serial instead, you can do that now.

Potential issues would be if two different assets have the same serial number, it will return the first it finds. That seems pretty unusual though, so I think it's a good addition.

### Testing

To test this PR:

- hit the API endpoints (`/api/v1/hardware/byserial/foo` and `/api/v1/hardware/bytag/foo`) with a "normal" (no slashes) asset tag or serial number - it should return the correct asset info
- hit the API endpoints (`/api/v1/hardware/byserial/foo` and `/api/v1/hardware/bytag/foo`)  with an asset tag and serial that DO have slashes - it should return the correct asset info
- hit the endpoints with a nonsense tag/serial and it should return an "asset not found" error
- hit the web endpoints  (`/hardware/byserial/foo` and `/hardware/bytag/foo`)  in a browser using the same tests as above
- use the top search bar and search for an asset tag that is "normal" - it should redirect you to the correct asset
- use the top search bar and search for an asset tag that  has slashes - it should redirect you to the correct asset
- use the top search bar and search for an asset tag that does not exist - it should redirect you to the assets listing page with an error