### PR TITLE
Update local instance of composer.phar on upgrade.

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -109,6 +109,10 @@ echo "--------------------------------------------------------\n\n";
 // Composer install
 if (file_exists('composer.phar')) {
     echo "-- Local composer.phar detected, so we'll use that.\n\n";
+    echo "-- Updating local composer.phar\n\n";
+    $composer_update = shell_exec('php composer.phar self-update');
+    echo $composer_update."\n\n";
+
     $composer_dump = shell_exec('php composer.phar dump');
     $composer = shell_exec('php composer.phar install --no-dev --prefer-source');
 


### PR DESCRIPTION
If the snipe-it installation is done using the installer script, it will install composer local to the base directory.
This pull request addresses the fact that the local composer will not be updated unless manually done.

I also experienced issue #7799 and resolved it by updating composer.

The upgrade looked like it ran successfully but it was actually unable to update vendor packages because composer was too far out of date.