### PR TITLE
Fixed #7989 - Converted table heading icons in People to CSS glyphs

### DIFF
--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -171,21 +171,22 @@ class UserPresenter extends Presenter
                 "formatter" => "usersLinkObjFormatter"
             ],
             [
-                "field" => "assets_count",
-                "searchable" => false,
-                "sortable" => true,
-                "switchable" => true,
-                "title" => ' <span class="hidden-md hidden-lg">Assets</span>'
-                            .'<span class="hidden-xs"><i class="fa fa-barcode fa-lg"></i></span>',
-                "visible" => true,
+                'field' => 'assets_count',
+                'searchable' => false,
+                'sortable' => true,
+                'switchable' => true,
+                'escape' => true,
+                'class' => 'css-barcode',
+                'title' => 'Assets',
+                'visible' => true,
             ],
             [
                 "field" => "licenses_count",
                 "searchable" => false,
                 "sortable" => true,
                 "switchable" => true,
-                "title" => ' <span class="hidden-md hidden-lg">Licenses</span>'
-                    .'<span class="hidden-xs"><i class="fa fa-floppy-o fa-lg"></i></span>',
+                'class' => 'css-license',
+                "title" => 'License',
                 "visible" => true,
             ],
             [
@@ -193,8 +194,8 @@ class UserPresenter extends Presenter
                 "searchable" => false,
                 "sortable" => true,
                 "switchable" => true,
-                "title" => ' <span class="hidden-md hidden-lg">Consumables</span>'
-                    .'<span class="hidden-xs"><i class="fa fa-tint fa-lg"></i></span>',
+                'class' => 'css-consumable',
+                "title" => 'Consumables',
                 "visible" => true,
             ],
             [
@@ -202,8 +203,8 @@ class UserPresenter extends Presenter
                 "searchable" => false,
                 "sortable" => true,
                 "switchable" => true,
-                "title" => ' <span class="hidden-md hidden-lg">Accessories</span>'
-                    .'<span class="hidden-xs"><i class="fa fa-keyboard-o fa-lg"></i></span>',
+                'class' => 'css-accessory',
+                "title" => 'Accessories',
                 "visible" => true,
             ],
             [

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -16,7 +16,16 @@
 @section('header_right')
 
 <style>
+    /**
+    This is kind of weird, but it is necessary to prevent the column-selector code from barfing, since
+    any HTML used in the UserPresenter "title" attribute breaks the HTML.
 
+    Instead, we use CSS to add the icon into the table header, which leaves the column selector
+    "title" text as-is.
+
+    See https://github.com/snipe/snipe-it/issues/7989
+
+     */
     th.css-barcode > .th-inner,
     th.css-license > .th-inner,
     th.css-consumable > .th-inner,

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -18,7 +18,7 @@
 <style>
     /**
     This is kind of weird, but it is necessary to prevent the column-selector code from barfing, since
-    any HTML used in the UserPresenter "title" attribute breaks the HTML.
+    any HTML used in the UserPresenter "title" attribute breaks the column selector HTML.
 
     Instead, we use CSS to add the icon into the table header, which leaves the column selector
     "title" text as-is.
@@ -32,9 +32,8 @@
     th.css-accessory > .th-inner
     {
         font-size: 0px;
-        line-height: 0;
         line-height: 4!important;
-        text-align: center;
+        text-align: left;
         text-rendering: auto;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
@@ -55,7 +54,7 @@
 
     th.css-barcode > .th-inner::before
     {
-    content: "\f02a";
+        content: "\f02a";
     }
 
     th.css-license > .th-inner::before

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -14,6 +14,59 @@
 @stop
 
 @section('header_right')
+
+<style>
+
+    th.css-barcode > .th-inner,
+    th.css-license > .th-inner,
+    th.css-consumable > .th-inner,
+    th.css-accessory > .th-inner
+    {
+        font-size: 0px;
+        line-height: 0;
+        line-height: 4!important;
+        text-align: center;
+        text-rendering: auto;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+    }
+
+
+    th.css-barcode > .th-inner::before,
+    th.css-license > .th-inner::before,
+    th.css-consumable > .th-inner::before,
+    th.css-accessory > .th-inner::before
+
+    {
+        display: inline-block;
+        font: normal normal normal 14px/1 FontAwesome;
+        font-size: 20px;
+    }
+
+
+    th.css-barcode > .th-inner::before
+    {
+    content: "\f02a";
+    }
+
+    th.css-license > .th-inner::before
+    {
+        content: "\f0c7";
+    }
+
+    th.css-consumable > .th-inner::before
+    {
+        content: "\f043";
+    }
+
+    th.css-accessory > .th-inner::before
+    {
+        content: "\f11c";
+    }
+
+
+</style>
+
     @can('create', \App\Models\User::class)
       @if ($snipeSettings->ldap_enabled == 1)
       <a href="{{ route('ldap/user') }}" class="btn btn-default pull-right"><span class="fa fa-sitemap"></span> LDAP Sync</a>
@@ -90,7 +143,9 @@
 
 @stop
 
-@section('moar_scripts')
+@section('moar_scripts')val
+
+
 @include ('partials.bootstrap-table')
 
 

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -152,7 +152,7 @@
 
 @stop
 
-@section('moar_scripts')val
+@section('moar_scripts')
 
 
 @include ('partials.bootstrap-table')


### PR DESCRIPTION
This is a weird workaround, but I'm not sure how else to handle it. (I tried fiddling with jQuery's `replaceWith` and `empty().html('icon text here)` but it didn't work without repainting the table after page load.)

### The Problem:

Because of the way the column selector in Bootstrap Tables works, any HTML code we try to use in the table headings breaks the column selector (because we have `<` and `>` tags inside of the actual table's  `<` and `>` tags).

### The Solution:

Instead of manually inserting the icon, we instead now send a `class` value through the `UserPresenter.php` (which we use to conveniently generate those table headings wherever user lists appear). In the People index blade, we handle some CSS magic that effectively makes the text super small so as to be invisible and uses the `::before` pseudo-element to present the icon.