### PR TITLE
Test fixes pt 2.

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -14,8 +14,9 @@ use App\Models\Asset;
 use App\Models\Company;
 use App\Models\License;
 use App\Models\User;
-use Illuminate\Http\Request;
 use Auth;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 class UsersController extends Controller
 {

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -62,9 +62,7 @@ class AssetCheckoutController extends Controller
             $admin = Auth::user();
 
             $target = $this->determineCheckoutTarget($asset);
-            if ($asset->is($target)) {
-                throw new CheckoutNotAllowed('You cannot check an asset out to itself.');
-            }
+
             $asset = $this->updateAssetLocation($asset, $target);
 
             $checkout_at = date("Y-m-d H:i:s");

--- a/app/Http/Requests/AssetCheckoutRequest.php
+++ b/app/Http/Requests/AssetCheckoutRequest.php
@@ -23,7 +23,7 @@ class AssetCheckoutRequest extends Request
     {
         $rules = [
             "assigned_user"         => 'required_without_all:assigned_asset,assigned_location',
-            "assigned_asset"        => 'required_without_all:assigned_user,assigned_location|different:'.$this->id,
+            "assigned_asset"        => 'required_without_all:assigned_user,assigned_location',
             "assigned_location"     => 'required_without_all:assigned_user,assigned_asset',
             "checkout_to_type"      => 'required|in:asset,location,user'
         ];

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -3,6 +3,7 @@ namespace App\Models;
 
 use App\Events\AssetCheckedOut;
 use App\Events\CheckoutableCheckedOut;
+use App\Exceptions\CheckoutNotAllowed;
 use App\Http\Traits\UniqueSerialTrait;
 use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Traits\Acceptable;
@@ -270,6 +271,9 @@ class Asset extends Depreciable
     {
         if (!$target) {
             return false;
+        }
+        if ($this->is($target)) {
+            throw new CheckoutNotAllowed('You cannot check an asset out to itself.');
         }
 
         if ($expected_checkin) {

--- a/tests/api/ApiLicensesCest.php
+++ b/tests/api/ApiLicensesCest.php
@@ -116,7 +116,8 @@ class ApiLicensesCest
             'category_id' => $temp_license->category_id,
             'termination_date' => $temp_license->termination_date,
         ];
-
+        // We aren't checking anyhting out in this test, so this fakes the withCount() that happens on a normal db fetch.
+        $temp_license->free_seats_count = $temp_license->seats;
         $I->assertNotEquals($license->name, $data['name']);
 
         // update

--- a/tests/api/ApiUsersCest.php
+++ b/tests/api/ApiUsersCest.php
@@ -65,6 +65,7 @@ class ApiUsersCest
             'notes' => $temp_user->notes,
             'manager_id' => $temp_user->manager_id,
             'password' => $temp_user->password,
+            'password_confirmation' => $temp_user->password,
             'phone' => $temp_user->phone,
             'state' => $temp_user->state,
             'username' => $temp_user->username,

--- a/tests/functional/GroupsCest.php
+++ b/tests/functional/GroupsCest.php
@@ -58,10 +58,7 @@ class GroupsCest
 
     public function allowsDelete(FunctionalTester $I, $scenario)
     {
-        $scenario->incomplete('Fix this test to generate a group for deleting');
-
         $I->wantTo('Ensure I can delete a group');
-
         // create a group
         $I->amOnPage(route('groups.create'));
         $I->seeResponseCodeIs(200);
@@ -70,16 +67,9 @@ class GroupsCest
         $I->dontSee('&lt;span class=&quot;');
         $I->seeElement('.alert-success');
 
-        // delete it
-        $I->amOnPage(route('groups.delete', Group::doesntHave('users')->first()->id));
+        $I->sendDelete(route('groups.destroy', Group::whereName('TestGroup')->doesntHave('users')->first()->id));
         $I->seeResponseCodeIs(200);
         $I->seeElement('.alert-success');
-        // $I->seeResponseCodeIs(200);
-    }
-
-    public function allowsEditing(FunctionalTester $I, $scenario)
-    {
-        $scenario->incomplete('Fix this test to generate a group for editing');
-        $I->wantTo('Ensure i can edit a group');
+        $I->seeResponseCodeIs(200);
     }
 }

--- a/tests/unit/AssetTest.php
+++ b/tests/unit/AssetTest.php
@@ -287,6 +287,11 @@ class AssetTest extends BaseTest
              'target_id'     => $target->id
          ]);
 
+         // An Asset cannot be checked out to itself.
+         $target = $this->createValidAsset();
+         $this->expectException(CheckoutNotAllowed::class);
+         $target->checkOut($target, $adminUser);
+
          // An Asset Can be checked out to a location, and this should be logged.
          $target = $this->createValidLocation();
 


### PR DESCRIPTION
This should fix all remaining tests and (maybe??) make travis green again.

I did remove the asset checkout controller validation that checked if the target asset was different than the checked out asset because it was triggering weird errors when checking out to a user or location.  There was already a check in the controller for this, but I moved it to the model checkout method instead to handle times when the checkout might not go through the controller.