### PR TITLE
Permissions edit cleanups.

### DIFF
--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -26,20 +26,16 @@
             margin: 15px;
             margin-top: 0px;
         }
-        .permissions.table > tbody+tbody {
-
+        .permissions.table > tbody {
+            border: 1px solid;
         }
         .header-row {
             border-bottom: 1px solid #ccc;
         }
-
-        .header-row h3 {
-            margin:0px;
-        }
         .permissions-row {
             display: flex;
             justify-content: space-between;
-            align-items: flex-start;
+            align-items: center;
         }
         .table > tbody > tr > td.permissions-item {
             padding: 1px;
@@ -74,18 +70,21 @@
             <th class="col-md-1">Deny</th>
         </tr>
         </thead>
-        <tbody class="permissions-group">
         @foreach ($permissions as $area => $area_permission)
             <!-- handle superadmin and reports, and anything else with only one option -->
             <?php $localPermission = $area_permission[0]; ?>
             @if (count($area_permission) == 1)
-
+            <tbody class="permissions-group">
                 <tr class="header-row permissions-row">
                     <td class="col-md-5 tooltip-base permissions-item"
                         data-toggle="tooltip"
                         data-placement="right"
                         title="{{ $localPermission['note'] }}">
-                        <h2>{{ $area . ': ' . $localPermission['label'] }}</h2>
+                            @unless (empty($localPermission['label']))
+                                <h2>{{ $area . ': ' . $localPermission['label'] }}</h2>
+                            @else
+                                <h2>{{ $area }}</h2>
+                            @endunless
                     </td>
                     <td class="col-md-1 permissions-item">
                         <label for="{{ 'permission['.$localPermission['permission'].']' }}"><span class="sr-only">Allow {{ 'permission['.$localPermission['permission'].']' }}</span></label>
@@ -96,15 +95,15 @@
                         {{ Form::radio('permission['.$localPermission['permission'].']', '0',(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '0' : null),['value'=>"grant", 'class'=>'minimal', 'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
                     </td>
                 </tr>
-
+            </tbody>
             @else
-
+            <tbody class="permission-group">
                 <tr class="header-row permissions-row">
                     <td class="col-md-5 tooltip-base permissions-item header-name"
                         data-toggle="tooltip"
                         data-placement="right"
                         title="{{ $localPermission['note'] }}">
-                        <h2>{{ $area . ': ' . $localPermission['label'] }}</h2>
+                        <h2>{{ $area }}</h2>
 
 
                     </td>
@@ -143,9 +142,8 @@
                 @endforeach
 
             @endif
-
-        @endforeach
         </tbody>
+        @endforeach
     </table>
 
 </div>

--- a/resources/views/partials/forms/edit/permissions-base.blade.php
+++ b/resources/views/partials/forms/edit/permissions-base.blade.php
@@ -1,0 +1,104 @@
+@foreach ($permissions as $area => $permissionsArray)
+  @if (count($permissionsArray) == 1)
+    <?php $localPermission = $permissionsArray[0]; ?>
+    <tbody class="permissions-group">
+    <tr class="header-row permissions-row">
+      <td class="col-md-5 tooltip-base permissions-item"
+        data-toggle="tooltip"
+        data-placement="right"
+        title="{{ $localPermission['note'] }}"
+      >
+        @unless (empty($localPermission['label']))
+         <h2>{{ $area . ': ' . $localPermission['label'] }}</h2>
+        @else
+          <h2>{{ $area }}</h2>
+        @endunless
+      </td>
+
+      <td class="col-md-1 permissions-item">
+        <label class="sr-only" for="{{ 'permission['.$localPermission['permission'].']' }}">{{ 'permission['.$localPermission['permission'].']' }}</label>
+        @if (($localPermission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+          {{ Form::radio('permission['.$localPermission['permission'].']', '1',$userPermissions[$localPermission['permission'] ] == '1',['disabled'=>"disabled", 'class'=>'minimal', 'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+        @else
+          {{ Form::radio('permission['.$localPermission['permission'].']', '1',$userPermissions[$localPermission['permission'] ] == '1',['value'=>"grant", 'class'=>'minimal',  'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+        @endif
+      </td>
+      <td class="col-md-1 permissions-item">
+        <label class="sr-only" for="{{ 'permission['.$localPermission['permission'].']' }}">{{ 'permission['.$localPermission['permission'].']' }}</label>
+        @if (($localPermission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+          {{ Form::radio('permission['.$localPermission['permission'].']', '-1',$userPermissions[$localPermission['permission'] ] == '-1',['disabled'=>"disabled", 'class'=>'minimal', 'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+        @else
+          {{ Form::radio('permission['.$localPermission['permission'].']', '-1',$userPermissions[$localPermission['permission'] ] == '-1',['value'=>"deny", 'class'=>'minimal',  'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+        @endif
+      </td>
+      <td class="col-md-1 permissions-item">
+        <label class="sr-only" for="{{ 'permission['.$localPermission['permission'].']' }}">{{ 'permission['.$localPermission['permission'].']' }}</label>
+        @if (($localPermission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+          {{ Form::radio('permission['.$localPermission['permission'].']','0',$userPermissions[$localPermission['permission'] ] == '0',['disabled'=>"disabled",'class'=>'minimal',  'aria-label'=> 'permission['.$localPermission['permission'].']'] ) }}
+        @else
+          {{ Form::radio('permission['.$localPermission['permission'].']','0',$userPermissions[$localPermission['permission'] ] == '0',['value'=>"inherit", 'class'=>'minimal',  'aria-label'=> 'permission['.$localPermission['permission'].']'] ) }}
+        @endif
+      </td>
+    </tr>
+  </tbody>
+
+  @else <!-- count($permissionsArray) == 1-->
+  <tbody class="permissions-group">
+    <tr class="header-row permissions-row">
+      <td class="col-md-5 header-name">
+        <h2> {{ $area }}</h2>
+      </td>
+      <td class="col-md-1 permissions-item">
+        <label for="{{ $area }}" class="sr-only">{{ $area }}</label>
+        {{ Form::radio("$area", '1',false,['value'=>"grant", 'class'=>'minimal', 'data-checker-group' => str_slug($area), 'aria-label' => $area]) }}
+      </td>
+      <td class="col-md-1 permissions-item">
+        <label for="{{ $area }}" class="sr-only">{{ $area }}</label>
+        {{ Form::radio("$area", '-1',false,['value'=>"deny", 'class'=>'minimal', 'data-checker-group' => str_slug($area), 'aria-label' => $area]) }}
+      </td>
+      <td class="col-md-1 permissions-item">
+        <label for="{{ $area }}" class="sr-only">{{ $area }}</label>
+        {{ Form::radio("$area", '0',false,['value'=>"inherit", 'class'=>'minimal', 'data-checker-group' => str_slug($area), 'aria-label' => $area] ) }}
+      </td>
+    </tr>
+
+    @foreach ($permissionsArray as $index => $permission)
+      <tr class="permissions-row">
+        @if ($permission['display'])
+          <td
+            class="col-md-5 tooltip-base permissions-item"
+            data-toggle="tooltip"
+            data-placement="right"
+            title="{{ $permission['note'] }}"
+          >
+            {{ $permission['label'] }}
+          </td>
+          <td class="col-md-1 permissions-item">
+            <label class="sr-only" for="{{ 'permission['.$permission['permission'].']' }}">{{ 'permission['.$permission['permission'].']' }}</label>
+
+            @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+              {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[$permission['permission'] ] == '1', ["value"=>"grant", 'disabled'=>'disabled', 'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
+            @else
+              {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[ $permission['permission'] ] == '1', ["value"=>"grant",'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label' =>'permission['.$permission['permission'].']']) }}
+            @endif
+          </td>
+          <td class="col-md-1 permissions-item">
+            @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+              {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ["value"=>"deny", 'disabled'=>'disabled', 'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
+            @else
+              {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ["value"=>"deny",'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
+            @endif
+          </td>
+          <td class="col-md-1 permissions-item">
+            @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+              {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ["value"=>"inherit", 'disabled'=>'disabled', 'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
+            @else
+              {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ["value"=>"inherit", 'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
+            @endif
+          </td>
+        @endif
+      </tr>
+    @endforeach
+    </tbody>
+  @endif
+@endforeach

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -39,21 +39,21 @@
       margin: 15px;
       margin-top: 0px;
     }
-    .permissions.table > tbody+tbody {
 
+    .permissions.table > tbody {
+        border: 1px solid;
     }
+
     .header-row {
       border-bottom: 1px solid #ccc;
     }
 
-    .header-row h3 {
-      margin:0px;
-    }
     .permissions-row {
       display: flex;
       justify-content: space-between;
-      align-items: flex-start;
+      align-items: center;
     }
+
     .table > tbody > tr > td.permissions-item {
       padding: 1px;
       padding-left: 8px;
@@ -516,108 +516,7 @@
                   <th class="col-md-1">Inherit</th>
                 </tr>
               </thead>
-
-
-              @foreach ($permissions as $area => $permissionsArray)
-              @if (count($permissionsArray) == 1)
-                <?php $localPermission = $permissionsArray[0]; ?>
-                <tr class="header-row permissions-row">
-                  <td class="col-md-5 tooltip-base permissions-item"
-                    data-toggle="tooltip"
-                    data-placement="right"
-                    title="{{ $localPermission['note'] }}">
-                    <h2>{{ $area . ': ' . $localPermission['label'] }}</h2>
-                  </td>
-
-                  <td class="col-md-1 permissions-item">
-                      <label class="sr-only" for="{{ 'permission['.$localPermission['permission'].']' }}">{{ 'permission['.$localPermission['permission'].']' }}</label>
-                    @if (($localPermission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-                      {{ Form::radio('permission['.$localPermission['permission'].']', '1',$userPermissions[$localPermission['permission'] ] == '1',['disabled'=>"disabled", 'class'=>'minimal', 'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
-                    @else
-                      {{ Form::radio('permission['.$localPermission['permission'].']', '1',$userPermissions[$localPermission['permission'] ] == '1',['value'=>"grant", 'class'=>'minimal',  'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
-                    @endif
-                  </td>
-                  <td class="col-md-1 permissions-item">
-                      <label class="sr-only" for="{{ 'permission['.$localPermission['permission'].']' }}">{{ 'permission['.$localPermission['permission'].']' }}</label>
-                    @if (($localPermission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-                      {{ Form::radio('permission['.$localPermission['permission'].']', '-1',$userPermissions[$localPermission['permission'] ] == '-1',['disabled'=>"disabled", 'class'=>'minimal', 'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
-                    @else
-                      {{ Form::radio('permission['.$localPermission['permission'].']', '-1',$userPermissions[$localPermission['permission'] ] == '-1',['value'=>"deny", 'class'=>'minimal',  'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
-                    @endif
-                  </td>
-                  <td class="col-md-1 permissions-item">
-                      <label class="sr-only" for="{{ 'permission['.$localPermission['permission'].']' }}">{{ 'permission['.$localPermission['permission'].']' }}</label>
-                    @if (($localPermission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-                      {{ Form::radio('permission['.$localPermission['permission'].']','0',$userPermissions[$localPermission['permission'] ] == '0',['disabled'=>"disabled",'class'=>'minimal',  'aria-label'=> 'permission['.$localPermission['permission'].']'] ) }}
-                    @else
-                      {{ Form::radio('permission['.$localPermission['permission'].']','0',$userPermissions[$localPermission['permission'] ] == '0',['value'=>"inherit", 'class'=>'minimal',  'aria-label'=> 'permission['.$localPermission['permission'].']'] ) }}
-                    @endif
-                  </td>
-                </tr>
-
-              @else
-
-                <tr class="header-row permissions-row">
-                  <td class="col-md-5 header-name">
-                    <h2>{{ $area }}</h2>
-                  </td>
-                  <td class="col-md-1 permissions-item">
-                      <br><br>
-                      <label for="{{ $area }}" class="sr-only">{{ $area }}</label>
-                    {{ Form::radio("$area", '1',false,['value'=>"grant", 'class'=>'minimal', 'data-checker-group' => str_slug($area), 'aria-label' => $area]) }}
-                  </td>
-                  <td class="col-md-1 permissions-item">
-                      <br><br>
-                      <label for="{{ $area }}" class="sr-only">{{ $area }}</label>
-                    {{ Form::radio("$area", '-1',false,['value'=>"deny", 'class'=>'minimal', 'data-checker-group' => str_slug($area), 'aria-label' => $area]) }}
-                  </td>
-                  <td class="col-md-1 permissions-item">
-                      <br><br>
-                      <label for="{{ $area }}" class="sr-only">{{ $area }}</label>
-                    {{ Form::radio("$area", '0',false,['value'=>"inherit", 'class'=>'minimal', 'data-checker-group' => str_slug($area), 'aria-label' => $area] ) }}
-                  </td>
-                </tr>
-
-                @foreach ($permissionsArray as $index => $permission)
-                <tr class="permissions-row">
-                  @if ($permission['display'])
-                    <td
-                      class="col-md-5 tooltip-base permissions-item"
-                      data-toggle="tooltip"
-                      data-placement="right"
-                      title="{{ $permission['note'] }}">
-                      {{ $permission['label'] }}
-                    </td>
-                    <td class="col-md-1 permissions-item">
-                        <label class="sr-only" for="{{ 'permission['.$permission['permission'].']' }}">{{ 'permission['.$permission['permission'].']' }}</label>
-
-                      @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-                      {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[$permission['permission'] ] == '1', ["value"=>"grant", 'disabled'=>'disabled', 'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
-                      @else
-                      {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[ $permission['permission'] ] == '1', ["value"=>"grant",'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label' =>'permission['.$permission['permission'].']']) }}
-                      @endif
-                    </td>
-                    <td class="col-md-1 permissions-item">
-                      @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-                      {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ["value"=>"deny", 'disabled'=>'disabled', 'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
-                      @else
-                      {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ["value"=>"deny",'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
-                      @endif
-                    </td>
-                    <td class="col-md-1 permissions-item">
-                      @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-                      {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ["value"=>"inherit", 'disabled'=>'disabled', 'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
-                      @else
-                      {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ["value"=>"inherit", 'class'=>'minimal radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
-                      @endif
-                    </td>
-                  @endif
-                </tr>
-                @endforeach
-
-              @endif
-              @endforeach
-              </tbody>
+                @include('partials.forms.edit.permissions-base')
             </table>
           </div><!-- /.tab-pane -->
         </div><!-- /.tab-content -->


### PR DESCRIPTION
- Make each section of permissions it's own tbody for better styling
- Remove extra separators when theres nothing to separate
- Vertically center radio buttons in header rows.

Still on the ideal list:
 - Unify code between users and groups into one partial with
conditionals.
 - Sticky header row or put the header row in each section.  The form is really long and remembering where grant/deny/inherit are is a pain.  This gets into the CSS is gross world though.

Now looks like the below.

![image](https://user-images.githubusercontent.com/3803132/80621815-d8889f00-8a15-11ea-96d0-0739cd2d6980.png)
