### PR TITLE
Tweak to Flysystem's filesystems.php to make it work with Snipe-IT

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -45,11 +45,11 @@ $config = [
 
         'local' => [
             'driver' => 'local',
-            'root' => storage_path('app'),
+            'root' => storage_path(),
         ],
 
         // This applies the LOCAL public only, not S3/FTP/etc
-        'public' => [
+        'local_public' => [
             'driver' => 'local',
             'root' => public_path('uploads'),
             'url' => env('APP_URL').'/uploads',
@@ -64,6 +64,20 @@ $config = [
             'bucket' => env('AWS_BUCKET'),
             'url' => env('AWS_URL'),
             'root'   => env('AWS_BUCKET_ROOT'),
+            //'visibility' => 'public'
+        ],
+
+        's3_private' => [
+            // This bucket (if different than the 's3' bucket above) can be configured within AWS to *never* permit public documents
+            // For security reasons, its best to use separate buckets for public and private documents in S3
+            'driver' => 's3',
+            'key' => env('PRIVATE_AWS_ACCESS_KEY_ID'),
+            'secret' => env('PRIVATE_AWS_SECRET_ACCESS_KEY'),
+            'region' => env('PRIVATE_AWS_DEFAULT_REGION'),
+            'bucket' => env('PRIVATE_AWS_BUCKET'),
+            'url' => env('PRIVATE_AWS_URL'),
+            'root'   => env('PRIVATE_AWS_BUCKET_ROOT'),
+            'visibility' => 'private'
         ],
 
         'rackspace' => [
@@ -80,11 +94,8 @@ $config = [
 
 ];
 
-// When you're dealing with local file storage, the paths will be different than S3
-if  (env('FILESYSTEM_DISK','local')!='local')
-{
-    $config['disks']['public'] = $config['disks'][env('FILESYSTEM_DISK')];
-    $config['disks']['public']['visibility'] = 'public';
-}
+// copy the selected PUBLIC_FILESYSTEM_DISK's configuration to the 'public' key for easy use
+// (by default, the PUBLIC_FILESYSTEM DISK is 'local_public', in the public/uploads directory)
+$config['disks']['public'] = $config['disks'][env('PUBLIC_FILESYSTEM_DISK','local_public')];
 
 return $config;


### PR DESCRIPTION
This tweaks the default 'local' disk to refer to the previous path that we had been using in all previous versions of Snipe-IT.

It renames the 'public' disk to be 'local_public'. It adds a sample configuration (with env vars) for `s3_private` - a fully private bucket in S3 for private, protected resources.

It finally adds a `PUBLIC_FILESYSTEM_DISK` which defaults to the new `local_public` disk, and sets a new Flysystem 'disk' with the name `public` to the configuration for that driver.