### PR TITLE
Added #6695: add API endpoint for license seats

### DIFF
--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Helpers\Helper;
+use App\Http\Controllers\Controller;
+use App\Http\Transformers\LicenseSeatsTransformer;
+use App\Models\Asset;
+use App\Models\License;
+use App\Models\LicenseSeat;
+use App\Models\User;
+use Auth;
+use Illuminate\Http\Request;
+
+class LicenseSeatsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request, $licenseId)
+    {
+        //
+        if ($license = License::find($licenseId)) {
+            $this->authorize('view', $license);
+
+            $seats = LicenseSeat::with('license', 'user', 'asset', 'user.department')
+                ->where('license_seats.license_id', $licenseId);
+
+            $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
+
+            if ($request->input('sort')=='department') {
+                $seats->OrderDepartments($order);
+            } else {
+                $seats->orderBy('id', $order);
+            }
+
+            $total = $seats->count();
+            $offset = (($seats) && (request('offset') > $total)) ? 0 : request('offset', 0);
+            $limit = request('limit', 50);
+            
+            $seats = $seats->skip($offset)->take($limit)->get();
+
+            if ($seats) {
+                return (new LicenseSeatsTransformer)->transformLicenseSeats($seats, $total);
+            }
+        }
+
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/licenses/message.does_not_exist')), 200);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($licenseId, $seatId)
+    {
+        //
+        $this->authorize('view', License::class);
+        $licenseSeat = LicenseSeat::findOrFail($seatId);
+        return (new LicenseSeatsTransformer)->transformLicenseSeat($licenseSeat);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $licenseId
+     * @param  int  $seatId
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $licenseId, $seatId)
+    {
+        $this->authorize('checkout', License::class);
+
+        // sanity checks:
+        // 1. does the license seat exist?
+        if (!$licenseSeat = LicenseSeat::find($seatId)) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, 'Seat not found'));
+        }
+        // 2. does the seat belong to the specified license?
+        if (!$license = $licenseSeat->license()->first() || $license->id != intval($licenseId)) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, 'Seat does not belong to the specified license'));
+        }
+
+        // attempt to update the license seat
+        $licenseSeat->fill($request->all());
+        $licenseSeat->user_id = Auth::user()->id;
+        
+        // check if this update is a checkin operation
+        $touched = FALSE;
+        $is_checkin = FALSE;
+        // 1. are relevant fields touched at all?
+        $dirty = $licenseSeat->getDirty();
+        if (isset($dirty->assigned_to) || isset($dirty->asset_id)) {
+            $touched = TRUE;
+            // 2. are they cleared? if yes then this is a checkin operation
+            $is_checkin = ($licenseSeat->assigned_to === null && $licenseSeat->asset_id === null);
+        }
+
+        if ($licenseSeat->save()) {
+            if ($touched) {
+                // the logging functions expect only one "target". if both asset and user are present in the request,
+                // we simply let assets take precedence over users...
+                if (isset($dirty->assigned_to)) {
+                    $target = User::find($dirty->assigned_to);
+                }
+                if (isset($dirty->assigned_to)) {
+                    $target = Asset::find($dirty->assigned_to);
+                }
+
+                if ($is_checkin) {
+                    $licenseSeat->logCheckin($target, $request->input('note'));
+                }
+                else {
+                    // in this case, relevant fields are touched but it's not a checkin operation. so it must be a checkout operation.
+                    $licenseSeat->logCheckout($request->input('note'), $target);
+                }
+            }
+
+            return response()->json(Helper::formatStandardApiResponse('success', $licenseSeat, trans('admin/licenses/message.update.success')));
+        }
+
+        return Helper::formatStandardApiResponse('error', null, $licenseSeat->getErrors());
+    }
+}

--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -60,7 +60,15 @@ class LicenseSeatsController extends Controller
     {
         //
         $this->authorize('view', License::class);
-        $licenseSeat = LicenseSeat::findOrFail($seatId);
+        // sanity checks:
+        // 1. does the license seat exist?
+        if (!$licenseSeat = LicenseSeat::find($seatId)) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, 'Seat not found'));
+        }
+        // 2. does the seat belong to the specified license?
+        if (!$license = $licenseSeat->license()->first() || $license->id != intval($licenseId)) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, 'Seat does not belong to the specified license'));
+        }
         return (new LicenseSeatsTransformer)->transformLicenseSeat($licenseSeat);
     }
 

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -215,50 +215,6 @@ class LicensesController extends Controller
         }
         return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/licenses/message.assoc_users')));
     }
-
-    /**
-     * Get license seat listing
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v1.0]
-     * @param int $licenseId
-     * @return \Illuminate\Contracts\View\View
-     */
-    public function seats(Request $request, $licenseId)
-    {
-
-        if ($license = License::find($licenseId)) {
-
-            $this->authorize('view', $license);
-
-            $seats = LicenseSeat::with('license', 'user', 'asset', 'user.department')
-                ->where('license_seats.license_id', $licenseId);
-
-            $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
-
-            if ($request->input('sort')=='department') {
-                $seats->OrderDepartments($order);
-            } else {
-                $seats->orderBy('id', $order);
-            }
-
-            $offset = (($seats) && (request('offset') > $seats->count())) ? 0 : request('offset', 0);
-            $limit = request('limit', 50);
-            
-            $total = $seats->count();
-
-            $seats = $seats->skip($offset)->take($limit)->get();
-
-            if ($seats) {
-                return (new LicenseSeatsTransformer)->transformLicenseSeats($seats, $total);
-            }
-
-        }
-
-        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/licenses/message.does_not_exist')), 200);
-
-    }
-
     
     /**
      * Gets a paginated collection for the select2 menus

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -20,12 +20,11 @@ class LicenseSeatsTransformer
         return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
-    public function transformLicenseSeat (LicenseSeat $seat, $seat_count)
+    public function transformLicenseSeat (LicenseSeat $seat, $seat_count=0)
     {
         $array = [
             'id' => (int) $seat->id,
             'license_id' => (int) $seat->license->id,
-            'name' => 'Seat '.$seat_count,
             'assigned_user' => ($seat->user) ? [
                 'id' => (int) $seat->user->id,
                 'name'=> e($seat->user->present()->fullName),
@@ -48,6 +47,10 @@ class LicenseSeatsTransformer
             'reassignable' => (bool) $seat->license->reassignable,
             'user_can_checkout' => (($seat->assigned_to=='') && ($seat->asset_id=='')) ? true : false,
         ];
+
+        if($seat_count != 0) {
+            $array['name'] = 'Seat '.$seat_count;
+        }
 
         $permissions_array['available_actions'] = [
             'checkout' => Gate::allows('checkout', License::class) ? true : false,

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -20,6 +20,16 @@ class LicenseSeat extends SnipeModel implements ICompanyableChild
     protected $guarded = 'id';
     protected $table = 'license_seats';
 
+    /**
+    * The attributes that are mass assignable.
+    *
+    * @var array
+    */
+    protected $fillable = [
+        'assigned_to',
+        'asset_id'
+    ];
+
     use Acceptable;
 
     public function getCompanyableParents()

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -338,7 +338,7 @@
                         data-sort-order="asc"
                         data-sort-name="name"
                         class="table table-striped snipe-table"
-                        data-url="{{ route('api.license.seats', $license->id) }}"
+                        data-url="{{ route('api.licenses.seats.index', $license->id) }}"
                         data-export-options='{
                         "fileName": "export-seats-{{ str_slug($license->name) }}-{{ date('Y-m-d') }}",
                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]

--- a/routes/api.php
+++ b/routes/api.php
@@ -152,7 +152,6 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
 
     /*--- Departments API ---*/
 
-    /*--- Suppliers API ---*/
     Route::group(['prefix' => 'departments'], function () {
 
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -472,11 +472,6 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
     /*--- Licenses API ---*/
 
     Route::group(['prefix' => 'licenses'], function () {
-        Route::get('{licenseId}/seats', [
-            'as' => 'api.license.seats',
-            'uses' => 'LicensesController@seats'
-        ]);
-        
         Route::get('selectlist',
             [
                 'as' => 'api.licenses.selectlist',
@@ -501,7 +496,18 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
         ]
     ); // Licenses resource
 
-
+    Route::resource('licenses.seats', 'LicenseSeatsController',
+        [
+            'names' =>
+                [
+                    'index' => 'api.licenses.seats.index',
+                    'show' => 'api.licenses.seats.show',
+                    'update' => 'api.licenses.seats.update'
+                ],
+            'except' => ['create', 'edit', 'destroy', 'store'],
+            'parameters' => ['licenseseat' => 'licenseseat_id']
+        ]
+    ); // Licenseseats resource
 
     /*--- Locations API ---*/
 

--- a/tests/api/ApiLicenseSeatsCest.php
+++ b/tests/api/ApiLicenseSeatsCest.php
@@ -1,0 +1,161 @@
+<?php
+
+use App\Http\Transformers\LicenseSeatsTransformer;
+use App\Models\Asset;
+use App\Models\License;
+use App\Models\LicenseSeat;
+use App\Models\User;
+
+class ApiLicenseSeatsCest
+{
+    protected $license;
+    protected $timeFormat;
+
+    public function _before(ApiTester $I)
+    {
+        $this->user = \App\Models\User::find(1);
+        $I->haveHttpHeader('Accept', 'application/json');
+        $I->amBearerAuthenticated($I->getToken($this->user));
+    }
+
+    /** @test */
+    public function indexLicenseSeats(ApiTester $I)
+    {
+        $I->wantTo('Get a list of license seats for a specific license');
+
+        // call
+        $I->sendGET('/licenses/1/seats?limit=10&order=desc');
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        // sample verify
+        $licenseSeats = App\Models\LicenseSeat::where('license_id', 1)
+            ->orderBy('id','desc')->take(10)->get();
+        // pick a random seat
+        $licenseSeat = $licenseSeats->random();
+        // need the index in the original list so that the "name" field is determined correctly
+        $licenseSeatNumber = 0;
+        foreach($licenseSeats as $index=>$seat) {
+            if ($licenseSeat === $seat) {
+                $licenseSeatNumber = $index+1;
+            }
+        }
+        $I->seeResponseContainsJson($I->removeTimestamps((new LicenseSeatsTransformer)->transformLicenseSeat($licenseSeat, $licenseSeatNumber)));
+    }
+
+    /** @test */
+    public function showLicenseSeat(ApiTester $I)
+    {
+        $I->wantTo('Get a license seat');
+
+        // call
+        $I->sendGET('/licenses/1/seats/10');
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        // sample verify
+        $licenseSeat = App\Models\LicenseSeat::findOrFail(10);
+        $I->seeResponseContainsJson($I->removeTimestamps((new LicenseSeatsTransformer)->transformLicenseSeat($licenseSeat)));
+    }
+
+    /** @test */
+    public function checkoutLicenseSeatToUser(ApiTester $I)
+    {
+        $I->wantTo('Checkout a license seat to a user');
+
+        $user = App\Models\User::all()->random();
+        $licenseSeat = App\Models\LicenseSeat::all()->random();
+        $endpoint = '/licenses/'.$licenseSeat->license_id.'/seats/'.$licenseSeat->id;
+
+        $data = [
+            'assigned_to' => $user->id,
+            'note' => 'Test Checkout to User via API'
+        ];
+
+        // update
+        $I->sendPATCH($endpoint, $data);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse());
+        $I->assertEquals('success', $response->status);
+        $I->assertEquals(trans('admin/licenses/message.update.success'), $response->messages);
+        $I->assertEquals($licenseSeat->license_id, $response->payload->license_id); // license id does not change
+        $I->assertEquals($licenseSeat->id, $response->payload->id); // license seat id does not change
+
+        // verify
+        $licenseSeat = $licenseSeat->fresh();
+        $I->sendGET($endpoint);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson($I->removeTimestamps((new LicenseSeatsTransformer)->transformLicenseSeat($licenseSeat)));
+    }
+
+    /** @test */
+    public function checkoutLicenseSeatToAsset(ApiTester $I)
+    {
+        $I->wantTo('Checkout a license seat to an asset');
+
+        $asset = App\Models\Asset::all()->random();
+        $licenseSeat = App\Models\LicenseSeat::all()->random();
+        $endpoint = '/licenses/'.$licenseSeat->license_id.'/seats/'.$licenseSeat->id;
+
+        $data = [
+            'asset_id' => $asset->id,
+            'note' => 'Test Checkout to Asset via API'
+        ];
+
+        // update
+        $I->sendPATCH($endpoint, $data);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse());
+        $I->assertEquals('success', $response->status);
+        $I->assertEquals(trans('admin/licenses/message.update.success'), $response->messages);
+        $I->assertEquals($licenseSeat->license_id, $response->payload->license_id); // license id does not change
+        $I->assertEquals($licenseSeat->id, $response->payload->id); // license seat id does not change
+
+        // verify
+        $licenseSeat = $licenseSeat->fresh();
+        $I->sendGET($endpoint);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson($I->removeTimestamps((new LicenseSeatsTransformer)->transformLicenseSeat($licenseSeat)));
+    }
+
+    /** @test */
+    public function checkoutLicenseSeatToUserAndAsset(ApiTester $I)
+    {
+        $I->wantTo('Checkout a license seat to a user AND an asset');
+
+        $asset = App\Models\Asset::all()->random();
+        $user = App\Models\User::all()->random();
+        $licenseSeat = App\Models\LicenseSeat::all()->random();
+        $endpoint = '/licenses/'.$licenseSeat->license_id.'/seats/'.$licenseSeat->id;
+
+        $data = [
+            'asset_id' => $asset->id,
+            'assigned_to' => $user->id,
+            'note' => 'Test Checkout to User and Asset via API'
+        ];
+
+        // update
+        $I->sendPATCH($endpoint, $data);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+
+        $response = json_decode($I->grabResponse());
+        $I->assertEquals('success', $response->status);
+        $I->assertEquals(trans('admin/licenses/message.update.success'), $response->messages);
+        $I->assertEquals($licenseSeat->license_id, $response->payload->license_id); // license id does not change
+        $I->assertEquals($licenseSeat->id, $response->payload->id); // license seat id does not change
+
+        // verify
+        $licenseSeat = $licenseSeat->fresh();
+        $I->sendGET($endpoint);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson($I->removeTimestamps((new LicenseSeatsTransformer)->transformLicenseSeat($licenseSeat)));
+    }
+}

--- a/tests/api/ApiLicenseSeatsCest.php
+++ b/tests/api/ApiLicenseSeatsCest.php
@@ -89,6 +89,14 @@ class ApiLicenseSeatsCest
         $I->seeResponseIsJson();
         $I->seeResponseCodeIs(200);
         $I->seeResponseContainsJson($I->removeTimestamps((new LicenseSeatsTransformer)->transformLicenseSeat($licenseSeat)));
+
+        // verify that the last logged action is a checkout
+        $I->sendGET('/reports/activity?item_type=license&limit=1&item_id='.$licenseSeat->license_id);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson([
+            "action_type" => "checkout"
+        ]);
     }
 
     /** @test */
@@ -122,6 +130,14 @@ class ApiLicenseSeatsCest
         $I->seeResponseIsJson();
         $I->seeResponseCodeIs(200);
         $I->seeResponseContainsJson($I->removeTimestamps((new LicenseSeatsTransformer)->transformLicenseSeat($licenseSeat)));
+
+        // verify that the last logged action is a checkout
+        $I->sendGET('/reports/activity?item_type=license&limit=1&item_id='.$licenseSeat->license_id);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson([
+            "action_type" => "checkout"
+        ]);
     }
 
     /** @test */
@@ -157,5 +173,13 @@ class ApiLicenseSeatsCest
         $I->seeResponseIsJson();
         $I->seeResponseCodeIs(200);
         $I->seeResponseContainsJson($I->removeTimestamps((new LicenseSeatsTransformer)->transformLicenseSeat($licenseSeat)));
+
+        // verify that the last logged action is a checkout
+        $I->sendGET('/reports/activity?item_type=license&limit=1&item_id='.$licenseSeat->license_id);
+        $I->seeResponseIsJson();
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseContainsJson([
+            "action_type" => "checkout"
+        ]);
     }
 }


### PR DESCRIPTION
This PR implements a dedicated API endpoint for license seats. The endpoint can be used to get all seats of a particular license, get one specific seat aswell as update one specific seat's assignments. The new controller contains logic to determine whether an update operation is a checkin or checkout and adds logs accordingly.

- Implements #6695 
- Implements #6875

It also deprecates the existing /licenses/{id}/seats route, which was only used in one instance anyway. It the output format remains the same, so should be backwards compatible.

There are also a bunch of tests. I haven't yet fully understood on what data the testing framework operates. But the seeded DB data only contains licenses that haven't been checked out to anyone. Hence i think a proper test for checkin cannot be implemented at the moment.