### PR TITLE
Fix Missing Category selection in Asset Model Modal dialog.

### DIFF
--- a/resources/views/modals/kit-accessory.blade.php
+++ b/resources/views/modals/kit-accessory.blade.php
@@ -16,7 +16,7 @@
                     <div class="col-md-4 col-xs-12"><label for="modal-accessory_id">{{ trans('general.accessory') }}:
                         </label></div>
                     <div class="col-md-8 col-xs-12 required">
-                        <select class="js-data-ajax" data-endpoint="accessories" name="accessory" style="width: 100%" id="modal-accessory_id" />
+                        <select class="js-data-ajax" data-endpoint="accessories" name="accessory" style="width: 100%" id="modal-accessory_id"></select>
                     </div>
                 </div>
 

--- a/resources/views/modals/kit-consumable.blade.php
+++ b/resources/views/modals/kit-consumable.blade.php
@@ -16,7 +16,7 @@
                     <div class="col-md-4 col-xs-12"><label for="modal-consumable_id">{{ trans('general.consumable') }}:
                         </label></div>
                     <div class="col-md-8 col-xs-12 required">
-                        <select class="js-data-ajax" data-endpoint="consumables" name="consumable" style="width: 100%" id="modal-consumable_id" />
+                        <select class="js-data-ajax" data-endpoint="consumables" name="consumable" style="width: 100%" id="modal-consumable_id"></select>
                     </div>
                 </div>
 

--- a/resources/views/modals/kit-license.blade.php
+++ b/resources/views/modals/kit-license.blade.php
@@ -16,7 +16,7 @@
                     <div class="col-md-4 col-xs-12"><label for="modal-license_id">{{ trans('general.license') }}:
                         </label></div>
                     <div class="col-md-8 col-xs-12 required">
-                        <select class="js-data-ajax" data-endpoint="licenses" name="license" style="width: 100%" id="modal-license_id" />
+                        <select class="js-data-ajax" data-endpoint="licenses" name="license" style="width: 100%" id="modal-license_id"></select>
                     </div>
                 </div>
 

--- a/resources/views/modals/kit-model.blade.php
+++ b/resources/views/modals/kit-model.blade.php
@@ -16,7 +16,7 @@
                     <div class="col-md-4 col-xs-12"><label for="modal-model_id">{{ trans('general.asset_model') }}:
                         </label></div>
                     <div class="col-md-8 col-xs-12 required">
-                        <select class="js-data-ajax" data-endpoint="models" name="model" style="width: 100%" id="modal-model_id" />
+                        <select class="js-data-ajax" data-endpoint="models" name="model" style="width: 100%" id="modal-model_id"></select>
                     </div>
                 </div>
 

--- a/resources/views/modals/model.blade.php
+++ b/resources/views/modals/model.blade.php
@@ -16,18 +16,16 @@
                 </div>
 
                 <div class="dynamic-form-row">
-                    <div class="col-md-4 col-xs-12"><label for="modal-manufacturer_id">{{ trans('general.manufacturer') }}:
-                        </label></div>
+                    <div class="col-md-4 col-xs-12"><label for="modal-manufacturer_id">{{ trans('general.manufacturer') }}:</label></div>
                     <div class="col-md-8 col-xs-12 required">
-                        <select class="js-data-ajax" data-endpoint="manufacturers" name="manufacturer_id" style="width: 100%" id="modal-manufactuer_id" />
+                        <select class="js-data-ajax" data-endpoint="manufacturers" name="manufacturer_id" style="width: 100%" id="modal-manufactuer_id"></select>
                     </div>
                 </div>
 
                 <div class="dynamic-form-row">
-                    <div class="col-md-4 col-xs-12"><label for="modal-category_id">{{ trans('general.category') }}:
-                        </label></div>
+                    <div class="col-md-4 col-xs-12"><label for="modal-category_id">{{ trans('general.category') }}:</label></div>
                     <div class="col-md-8 col-xs-12 required">
-                        <select class="js-data-ajax" data-endpoint="categories/asset" name="category_id" style="width: 100%" id="modal-category_id" />
+                        <select class="js-data-ajax" data-endpoint="categories/asset" name="category_id" style="width: 100%" id="modal-category_id"></select
                     </div>
                 </div>
 


### PR DESCRIPTION
A select html tag needs a full closing tag.  <select /> is not valid.
This was causing the select2 js to barf and eat additional information.