### PR TITLE
BACKPORT: Fix Missing Category selection in Asset Model Modal dialog - [ch14635]

### DIFF
--- a/resources/views/modals/model.blade.php
+++ b/resources/views/modals/model.blade.php
@@ -19,7 +19,7 @@
                     <div class="col-md-4 col-xs-12"><label for="modal-manufacturer_id">{{ trans('general.manufacturer') }}:
                         </label></div>
                     <div class="col-md-8 col-xs-12 required">
-                        <select class="js-data-ajax" data-endpoint="manufacturers" name="manufacturer_id" style="width: 100%" id="modal-manufactuer_id" />
+                        <select class="js-data-ajax" data-endpoint="manufacturers" name="manufacturer_id" style="width: 100%" id="modal-manufactuer_id"></select>
                     </div>
                 </div>
 
@@ -27,7 +27,7 @@
                     <div class="col-md-4 col-xs-12"><label for="modal-category_id">{{ trans('general.category') }}:
                         </label></div>
                     <div class="col-md-8 col-xs-12 required">
-                        <select class="js-data-ajax" data-endpoint="categories/asset" name="category_id" style="width: 100%" id="modal-category_id" />
+                        <select class="js-data-ajax" data-endpoint="categories/asset" name="category_id" style="width: 100%" id="modal-category_id"></select>
                     </div>
                 </div>
 


### PR DESCRIPTION
A select html tag needs a full closing tag. is not valid. This was causing the select2 js to barf and eat additional information.