### PR TITLE
Fix message for checkin/out accessories

### DIFF
--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -267,7 +267,7 @@ class AccessoriesController extends Controller
         $accessory = Accessory::find($accessory_user->accessory_id);
         $this->authorize('checkin', $accessory);
 
-        $logaction = $accessory->logCheckin(User::find($accessoryUserId), $request->input('note'));
+        $logaction = $accessory->logCheckin(User::find($accessory_user->assigned_to), $request->input('note'));
 
         // Was the accessory updated?
         if (DB::table('accessories_users')->where('id', '=', $accessory_user->id)->delete()) {

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -51,7 +51,6 @@ trait Loggable
         $log->target_type = get_class($target);
         $log->target_id = $target->id;
 
-
         // Figure out what the target is
         if ($log->target_type == Location::class) {
             $log->location_id = $target->id;
@@ -76,15 +75,19 @@ trait Loggable
 
         $checkoutClass = null;
 
-        if (method_exists($target, 'notify')) {
-            $target->notify(new static::$checkoutClass($params));
-        }
+        try {
+	        if (method_exists($target, 'notify')) {
+	            $target->notify(new static::$checkoutClass($params));
+	        }
 
-        // Send to the admin, if settings dictate
-        $recipient = new \App\Models\Recipients\AdminRecipient();
+	        // Send to the admin, if settings dictate
+	        $recipient = new \App\Models\Recipients\AdminRecipient();
 
-        if (($settings->admin_cc_email!='') && (static::$checkoutClass!='')) {
-            $recipient->notify(new static::$checkoutClass($params));
+	        if (($settings->admin_cc_email!='') && (static::$checkoutClass!='')) {
+	            $recipient->notify(new static::$checkoutClass($params));
+	        }
+        } catch(\Swift_TransportException $e) {
+            // no valid Recipients
         }
 
         return $log;


### PR DESCRIPTION
1, Slack message in checkin was using relation ID, that caused wrong user was logged in slack.
2, No Valid Recipients was response everytime when user already had accessory, but that accessory was still given to him.