### PR TITLE
Api routes cleanup

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -14,84 +14,63 @@ use Illuminate\Http\Request;
 */
 
 
-Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api'], function () {
+Route::group([
+    'prefix' => 'v1',
+    'namespace' => 'Api',
+    'middleware' => 'auth:api',
+    'as' => 'api.'
+], function () {
 
     Route::group(['prefix' => 'account'], function () {
 
-        Route::get('requestable/hardware',
-            [
-                'as' => 'api.assets.requestable',
+        Route::get('requestable/hardware', [
+                'as' => 'assets.requestable',
                 'uses' => 'AssetsController@requestable'
-            ]
-        );
+            ]);
 
-        Route::get('requests',
-            [
-                'as' => 'api.assets.requested',
+        Route::get('requests', [
+                'as' => 'assets.requested',
                 'uses' => 'ProfileController@requestedAssets'
-            ]
-        );
-
+            ]);
     });
 
-    /*--- Accessories API ---*/    
+    /*--- Accessories API ---*/
     Route::group(['prefix' => 'accessories'], function () {
 
-        Route::get('{accessory}/checkedout',
-            [
-                'as' => 'api.accessories.checkedout',
+        Route::get('{accessory}/checkedout', [
+                'as' => 'accessories.checkedout',
                 'uses' => 'AccessoriesController@checkedout'
-            ]
-        );
+            ]);
 
-        Route::get('selectlist',
-            [
-                'as' => 'api.accessories.selectlist',
+        Route::get('selectlist', [
+                'as' => 'accessories.selectlist',
                 'uses'=> 'AccessoriesController@selectlist'
-            ]
-        );
+            ]);
     });
 
     // Accessories group
-    Route::resource('accessories', 'AccessoriesController',
-        ['names' =>
-            [
-                'index' => 'api.accessories.index',
-                'show' => 'api.accessories.show',
-                'update' => 'api.accessories.update',
-                'store' => 'api.accessories.store',
-                'destroy' => 'api.accessories.destroy'
-            ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['accessory' => 'accessory_id']
-        ]
-    );
+    Route::apiResource('accessories', 'AccessoriesController', [
+        'parameters' => ['accessory' => 'accessory_id']
+    ]);
 
     // Accessories resource
 
     Route::group(['prefix' => 'accessories'], function () {
 
-        Route::get('{accessory}/checkedout',
-            [
-                'as' => 'api.accessories.checkedout',
+        Route::get('{accessory}/checkedout', [
+                'as' => 'accessories.checkedout',
                 'uses' => 'AccessoriesController@checkedout'
-            ]
-        );
+            ]);
 
-        Route::post('{accessory}/checkout',
-            [
-                'as' => 'api.accessories.checkout',
+        Route::post('{accessory}/checkout', [
+                'as' => 'accessories.checkout',
                 'uses' => 'AccessoriesController@checkout'
-            ]
-        );
+            ]);
 
-        Route::post('{accessory}/checkin',
-            [
-                'as' => 'api.accessories.checkin',
+        Route::post('{accessory}/checkin', [
+                'as' => 'accessories.checkin',
                 'uses' => 'AccessoriesController@checkin'
-            ]
-        );
-
+            ]);
     }); // Accessories group
 
 
@@ -99,55 +78,30 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
 
     Route::group(['prefix' => 'categories'], function () {
 
-        Route::get('{item_type}/selectlist',
-            [
-                'as' => 'api.categories.selectlist',
+        Route::get('{item_type}/selectlist', [
+                'as' => 'categories.selectlist',
                 'uses' => 'CategoriesController@selectlist'
-            ]
-        );
-
+            ]);
     });
 
     // Categories group
-    Route::resource('categories', 'CategoriesController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.categories.index',
-                    'show' => 'api.categories.show',
-                    'store' => 'api.categories.store',
-                    'update' => 'api.categories.update',
-                    'destroy' => 'api.categories.destroy'
-                ],
-            'except' => ['edit', 'create'],
-            'parameters' => ['category' => 'category_id']
-        ]
-    ); // Categories resource
+    Route::apiResource('categories', 'CategoriesController', [
+        'parameters' => ['category' => 'category_id']
+    ]); // Categories resource
 
 
     /*--- Companies API ---*/
 
-    Route::get( 'companies/selectlist',  [
+    Route::get('companies/selectlist', [
         'as' => 'companies.selectlist',
         'uses' => 'CompaniesController@selectlist'
     ]);
 
 
     // Companies resource
-    Route::resource('companies', 'CompaniesController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.companies.index',
-                    'show' => 'api.companies.show',
-                    'store' => 'api.companies.store',
-                    'update' => 'api.companies.update',
-                    'destroy' => 'api.companies.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['component' => 'component_id']
-        ]
-    ); // Companies resource
+    Route::apiResource('companies', 'CompaniesController', [
+        'parameters' => ['component' => 'component_id']
+    ]); // Companies resource
 
 
     /*--- Departments API ---*/
@@ -156,351 +110,204 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
     Route::group(['prefix' => 'departments'], function () {
 
 
-        Route::get('selectlist',
-            [
-                'as' => 'api.departments.selectlist',
-                'uses' => 'DepartmentsController@selectlist'
-            ]
-        );
+        Route::get('selectlist', [
+            'as' => 'departments.selectlist',
+            'uses' => 'DepartmentsController@selectlist'
+        ]);
     }); // Departments group
 
 
 
-    Route::resource('departments', 'DepartmentsController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.departments.index',
-                    'show' => 'api.departments.show',
-                    'store' => 'api.departments.store',
-                    'update' => 'api.departments.update',
-                    'destroy' => 'api.departments.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['department' => 'department_id']
-        ]
-    ); // Departments resource
+    Route::apiResource('departments', 'DepartmentsController', [
+        'parameters' => ['department' => 'department_id']
+    ]); // Departments resource
 
 
     /*--- Components API ---*/
 
-    Route::resource('components', 'ComponentsController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.components.index',
-                    'show' => 'api.components.show',
-                    'store' => 'api.components.store',
-                    'update' => 'api.components.update',
-                    'destroy' => 'api.components.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['component' => 'component_id']
-        ]
-    ); // Components resource
+    Route::apiResource('components', 'ComponentsController', [
+        'parameters' => ['component' => 'component_id']
+    ]); // Components resource
 
     Route::group(['prefix' => 'components'], function () {
 
-        Route::get('{component}/assets',
-            [
-                'as' =>'api.components.assets',
-                'uses' => 'ComponentsController@getAssets',
-            ]
-        );
+        Route::get('{component}/assets', [
+            'as' =>'components.assets',
+            'uses' => 'ComponentsController@getAssets',
+        ]);
     }); // Components group
 
 
     /*--- Consumables API ---*/
-    Route::get('consumables/selectlist',
-        [
-            'as' => 'api.consumables.selectlist',
-            'uses'=> 'ConsumablesController@selectlist'
-        ]
-    );
+    Route::get('consumables/selectlist', [
+        'as' => 'consumables.selectlist',
+        'uses'=> 'ConsumablesController@selectlist'
+    ]);
 
-    Route::resource('consumables', 'ConsumablesController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.consumables.index',
-                    'show' => 'api.consumables.show',
-                    'store' => 'api.consumables.store',
-                    'update' => 'api.consumables.update',
-                    'destroy' => 'api.consumables.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['consumable' => 'consumable_id']
-        ]
-    ); // Consumables resource
+    Route::apiResource('consumables', 'ConsumablesController', [
+        'parameters' => ['consumable' => 'consumable_id']
+    ]); // Consumables resource
 
-    Route::get('consumables/view/{id}/users',
-        [
-            'as' => 'api.consumables.showUsers',
-            'uses' => 'ConsumablesController@getDataView'
-        ]
-    );
+    Route::get('consumables/view/{id}/users', [
+        'as' => 'consumables.showUsers',
+        'uses' => 'ConsumablesController@getDataView'
+    ]);
 
     /*--- Depreciations API ---*/
 
-    Route::resource('depreciations', 'DepreciationsController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.depreciations.index',
-                    'show' => 'api.depreciations.show',
-                    'store' => 'api.depreciations.store',
-                    'update' => 'api.depreciations.update',
-                    'destroy' => 'api.depreciations.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['depreciation' => 'depreciation_id']
-        ]
-    ); // Depreciations resource
+    Route::apiResource('depreciations', 'DepreciationsController', [
+        'parameters' => ['depreciation' => 'depreciation_id']
+    ]); // Depreciations resource
 
 
     /*--- Fields API ---*/
 
-    Route::resource('fields', 'CustomFieldsController', [
-        'names' => [
-            'index' => 'api.customfields.index',
-            'show' => 'api.customfields.show',
-            'store' => 'api.customfields.store',
-            'update' => 'api.customfields.update',
-            'destroy' => 'api.customfields.destroy'
-        ],
-        'except' => [ 'create', 'edit' ],
+    Route::apiResource('fields', 'CustomFieldsController', [
         'parameters' => [ 'field' => 'field_id' ]
     ]);
 
     Route::group(['prefix' => 'fields'], function () {
-        Route::post('fieldsets/{id}/order',
-            [
-                'as' => 'api.customfields.order',
-                'uses' => 'CustomFieldsController@postReorder'
-            ]
-        );
-        Route::post('{field}/associate',
-            [
-                'as' => 'api.customfields.associate',
-                'uses' => 'CustomFieldsController@associate'
-            ]
-        );
-        Route::post('{field}/disassociate',
-            [
-                'as' => 'api.customfields.disassociate',
-                'uses' => 'CustomFieldsController@disassociate'
-            ]
-        );
+        Route::post('fieldsets/{id}/order', [
+            'as' => 'customfields.order',
+            'uses' => 'CustomFieldsController@postReorder'
+        ]);
+        Route::post('{field}/associate', [
+            'as' => 'customfields.associate',
+            'uses' => 'CustomFieldsController@associate'
+        ]);
+        Route::post('{field}/disassociate', [
+            'as' => 'customfields.disassociate',
+            'uses' => 'CustomFieldsController@disassociate'
+        ]);
     }); // Fields group
 
 
     /*--- Fieldsets API ---*/
 
     Route::group(['prefix' => 'fieldsets'], function () {
-        Route::get('{fieldset}/fields',
-            [
-                'as' => 'api.fieldsets.fields',
-                'uses' => 'CustomFieldsetsController@fields'
-            ]
-        );
-        Route::get('/{fieldset}/fields/{model}',
-            [
-                'as' => 'api.fieldsets.fields-with-default-value',
-                'uses' => 'CustomFieldsetsController@fieldsWithDefaultValues'
-            ]
-        );
+        Route::get('{fieldset}/fields', [
+            'as' => 'fieldsets.fields',
+            'uses' => 'CustomFieldsetsController@fields'
+        ]);
+        Route::get('/{fieldset}/fields/{model}', [
+            'as' => 'fieldsets.fields-with-default-value',
+            'uses' => 'CustomFieldsetsController@fieldsWithDefaultValues'
+        ]);
     });
 
-    Route::resource('fieldsets', 'CustomFieldsetsController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.fieldsets.index',
-                    'show' => 'api.fieldsets.show',
-                    'store' => 'api.fieldsets.store',
-                    'update' => 'api.fieldsets.update',
-                    'destroy' => 'api.fieldsets.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['fieldset' => 'fieldset_id']
-        ]
-    ); // Custom fieldset resource
+    Route::apiResource('fieldsets', 'CustomFieldsetsController', [
+        'parameters' => ['fieldset' => 'fieldset_id']
+    ]); // Custom fieldset resource
 
 
     /*--- Groups API ---*/
 
-    Route::resource('groups', 'GroupsController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.groups.index',
-                    'show' => 'api.groups.show',
-                    'store' => 'api.groups.store',
-                    'update' => 'api.groups.update',
-                    'destroy' => 'api.groups.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['group' => 'group_id']
-        ]
-    ); // Groups resource
+    Route::apiResource('groups', 'GroupsController', [
+        'parameters' => ['group' => 'group_id']
+    ]); // Groups resource
 
 
     /*--- Hardware API ---*/
 
     Route::group(['prefix' => 'hardware'], function () {
-    
-        Route::get('{asset_id}/licenses',  [
-            'as' => 'api.assets.licenselist',
+
+        Route::get('{asset_id}/licenses', [
+            'as' => 'assets.licenselist',
             'uses' => 'AssetsController@licenses'
         ]);
-        
-        Route::get( 'bytag/{tag}',  [
+
+        Route::get('bytag/{tag}', [
             'as' => 'assets.show.bytag',
             'uses' => 'AssetsController@showByTag'
         ]);
 
-        Route::get('bytag/{any}',
-            [
-                'as' => 'api.assets.show.bytag',
-                'uses' => 'AssetsController@showByTag'
-            ]
-        )->where('any', '.*');
+        Route::get('bytag/{any}', [
+            'as' => 'assets.show.bytag',
+            'uses' => 'AssetsController@showByTag'
+        ])->where('any', '.*');
 
-
-        Route::get('byserial/{any}',
-            [
-                'as' => 'api.assets.show.byserial',
+        Route::get('byserial/{any}', [
+                'as' => 'assets.show.byserial',
                 'uses' => 'AssetsController@showBySerial'
-            ]
-         )->where('any', '.*');
-        
+        ])->where('any', '.*');
 
-        Route::get( 'selectlist',  [
+        Route::get('selectlist', [
             'as' => 'assets.selectlist',
             'uses' => 'AssetsController@selectlist'
         ]);
 
         Route::get('audit/{audit}', [
-            'as' => 'api.asset.to-audit',
+            'as' => 'asset.to-audit',
             'uses' => 'AssetsController@index'
         ]);
 
-
         Route::post('audit', [
-            'as' => 'api.asset.audit',
+            'as' => 'asset.audit',
             'uses' => 'AssetsController@audit'
         ]);
 
-        Route::post('{asset_id}/checkout',
-            [
-                'as' => 'api.assets.checkout',
-                'uses' => 'AssetsController@checkout'
-            ]
-        );
+        Route::post('{asset_id}/checkout', [
+            'as' => 'assets.checkout',
+            'uses' => 'AssetsController@checkout'
+        ]);
 
-        Route::post('{asset_id}/checkin',
-            [
-                'as' => 'api.assets.checkin',
-                'uses' => 'AssetsController@checkin'
-            ]
-        );
-
+        Route::post('{asset_id}/checkin', [
+            'as' => 'assets.checkin',
+            'uses' => 'AssetsController@checkin'
+        ]);
     });
 
     /*--- Asset Maintenances API ---*/
-    Route::resource('maintenances', 'AssetMaintenancesController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.maintenances.index',
-                    'show' => 'api.maintenances.show',
-                    'store' => 'api.maintenances.store',
-                    'update' => 'api.maintenances.update',
-                    'destroy' => 'api.maintenances.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['maintenance' => 'maintenance_id']
-        ]
-    ); // Consumables resource
+    Route::apiResource('maintenances', 'AssetMaintenancesController', [
+        'parameters' => ['maintenance' => 'maintenance_id']
+    ]); // Consumables resource
 
 
-    Route::resource('hardware', 'AssetsController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.assets.index',
-                    'show' => 'api.assets.show',
-                    'store' => 'api.assets.store',
-                    'update' => 'api.assets.update',
-                    'destroy' => 'api.assets.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['asset' => 'asset_id']
-        ]
-    ); // Hardware resource
+    Route::apiResource('hardware', 'AssetsController', [
+        // Names need to remain here as laravel defaults to 'hardware' given the routes used.
+        'names' => [
+            'index' => 'assets.index',
+            'show' => 'assets.show',
+            'store' => 'assets.store',
+            'update' => 'assets.update',
+            'destroy' => 'assets.destroy'
+        ],
+        'parameters' => ['asset' => 'asset_id']
+    ]); // Hardware resource
 
 
     /*--- Imports API ---*/
 
-    Route::resource('imports', 'ImportController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.imports.index',
-                    'show' => 'api.imports.show',
-                    'store' => 'api.imports.store',
-                    'update' => 'api.imports.update',
-                    'destroy' => 'api.imports.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['import' => 'import_id']
-        ]
-    ); // Imports resource
+    Route::apiResource('imports', 'ImportController', [
+        'parameters' => ['import' => 'import_id']
+    ]); // Imports resource
 
     Route::group(['prefix' => 'imports'], function () {
 
-        Route::post('process/{import}',
-            [
-                'as' => 'api.imports.importFile',
-                'uses'=> 'ImportController@process'
-            ]
-        );
+        Route::post('process/{import}', [
+            'as' => 'imports.importFile',
+            'uses'=> 'ImportController@process'
+        ]);
     }); // Imports group
-
-
 
 
     /*--- Licenses API ---*/
 
     Route::group(['prefix' => 'licenses'], function () {
         Route::get('{licenseId}/seats', [
-            'as' => 'api.license.seats',
+            'as' => 'license.seats',
             'uses' => 'LicensesController@seats'
         ]);
-        
-        Route::get('selectlist',
-            [
-                'as' => 'api.licenses.selectlist',
-                'uses'=> 'LicensesController@selectlist'
-            ]
-        );
 
+        Route::get('selectlist', [
+            'as' => 'licenses.selectlist',
+            'uses'=> 'LicensesController@selectlist'
+        ]);
     }); // Licenses group
 
-    Route::resource('licenses', 'LicensesController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.licenses.index',
-                    'show' => 'api.licenses.show',
-                    'store' => 'api.licenses.store',
-                    'update' => 'api.licenses.update',
-                    'destroy' => 'api.licenses.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['license' => 'license_id']
-        ]
-    ); // Licenses resource
+    Route::apiResource('licenses', 'LicensesController', [
+        'parameters' => ['license' => 'license_id']
+    ]); // Licenses resource
 
 
 
@@ -508,29 +315,23 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
 
     Route::group(['prefix' => 'locations'], function () {
 
-        Route::get('{location}/users',
-            [
-                'as'=>'api.locations.viewusers',
-                'uses'=>'LocationsController@getDataViewUsers'
-            ]
-        );
+        Route::get('{location}/users', [
+            'as'=>'locations.viewusers',
+            'uses'=>'LocationsController@getDataViewUsers'
+        ]);
 
-        Route::get('{location}/assets',
-            [
-                'as'=>'api.locations.viewassets',
-                'uses'=>'LocationsController@getDataViewAssets'
-            ]
-        );
+        Route::get('{location}/assets', [
+            'as'=>'locations.viewassets',
+            'uses'=>'LocationsController@getDataViewAssets'
+        ]);
 
         // Do we actually still need this, now that we have an API?
-        Route::get('{location}/check',
-            [
-                'as' => 'api.locations.check',
-                'uses' => 'LocationsController@show'
-            ]
-        );
+        Route::get('{location}/check', [
+            'as' => 'locations.check',
+            'uses' => 'LocationsController@show'
+        ]);
 
-        Route::get( 'selectlist',  [
+        Route::get('selectlist', [
             'as' => 'locations.selectlist',
             'uses' => 'LocationsController@selectlist'
         ]);
@@ -538,134 +339,77 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
 
 
 
-    Route::resource('locations', 'LocationsController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.locations.index',
-                    'show' => 'api.locations.show',
-                    'store' => 'api.locations.store',
-                    'update' => 'api.locations.update',
-                    'destroy' => 'api.locations.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['location' => 'location_id']
-        ]
-    ); // Locations resource
-
-
+    Route::apiResource('locations', 'LocationsController', [
+        'parameters' => ['location' => 'location_id']
+    ]); // Locations resource
 
 
     /*--- Manufacturers API ---*/
 
     Route::group(['prefix' => 'manufacturers'], function () {
-
-        Route::get( 'selectlist',  [
+        Route::get('selectlist', [
             'as' => 'manufacturers.selectlist',
             'uses' => 'ManufacturersController@selectlist'
         ]);
     }); // Locations group
 
 
-    Route::resource('manufacturers', 'ManufacturersController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.manufacturers.index',
-                    'show' => 'api.manufacturers.show',
-                    'store' => 'api.manufacturers.store',
-                    'update' => 'api.manufacturers.update',
-                    'destroy' => 'api.manufacturers.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['manufacturer' => 'manufacturer_id']
-        ]
-    ); // Manufacturers resource
+    Route::apiResource('manufacturers', 'ManufacturersController', [
+        'parameters' => ['manufacturer' => 'manufacturer_id']
+    ]); // Manufacturers resource
 
 
     /*--- Models API ---*/
 
     Route::group(['prefix' => 'models'], function () {
-
-        Route::get('assets',
-            [
-                'as' => 'api.models.assets',
-                'uses'=> 'AssetModelsController@assets'
-            ]
-        );
-        Route::get('selectlist',
-            [
-                'as' => 'api.models.selectlist',
-                'uses'=> 'AssetModelsController@selectlist'
-            ]
-        );
+        Route::get('assets', [
+            'as' => 'models.assets',
+            'uses'=> 'AssetModelsController@assets'
+        ]);
+        Route::get('selectlist', [
+            'as' => 'models.selectlist',
+            'uses'=> 'AssetModelsController@selectlist'
+        ]);
     }); // Models group
 
 
-    Route::resource('models', 'AssetModelsController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.models.index',
-                    'show' => 'api.models.show',
-                    'store' => 'api.models.store',
-                    'update' => 'api.models.update',
-                    'destroy' => 'api.models.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['model' => 'model_id']
-        ]
-    ); // Models resource
-
-
-
+    Route::apiResource('models', 'AssetModelsController', [
+        'parameters' => ['model' => 'model_id']
+    ]); // Models resource
 
     /*--- Settings API ---*/
     Route::get('settings/ldaptest', [
-        'as' => 'api.settings.ldaptest',
+        'as' => 'settings.ldaptest',
         'uses' => 'SettingsController@ldapAdSettingsTest'
     ]);
 
     Route::get('settings/login-attempts', [
         'middleware' => ['auth', 'authorize:superuser'],
-        'as' => 'api.settings.login_attempts',
+        'as' => 'settings.login_attempts',
         'uses' => 'SettingsController@showLoginAttempts'
     ]);
 
 
     Route::post('settings/ldaptestlogin', [
-        'as' => 'api.settings.ldaptestlogin',
+        'as' => 'settings.ldaptestlogin',
         'uses' => 'SettingsController@ldaptestlogin'
     ]);
 
     Route::post('settings/slacktest', [
-        'as' => 'api.settings.slacktest',
+        'as' => 'settings.slacktest',
         'uses' => 'SettingsController@slacktest'
     ]);
 
-    Route::post(
-        'settings/mailtest',
-        [
-            'as'  => 'api.settings.mailtest',
-            'uses' => 'SettingsController@ajaxTestEmail'
+    Route::post('settings/mailtest', [
+        'as'  => 'settings.mailtest',
+        'uses' => 'SettingsController@ajaxTestEmail'
     ]);
 
 
-    Route::resource('settings', 'SettingsController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.settings.index',
-                    'store' => 'api.settings.store',
-                    'show' => 'api.settings.show',
-                    'update' => 'api.settings.update'
-                ],
-            'except' => ['create', 'edit', 'destroy'],
-            'parameters' => ['setting' => 'setting_id']
-        ]
-    ); // Settings resource
-
-
+    Route::apiResource('settings', 'SettingsController', [
+        'except' => ['destroy'],
+        'parameters' => ['setting' => 'setting_id']
+    ]); // Settings resource
 
 
     /*--- Status Labels API ---*/
@@ -674,81 +418,41 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
     Route::group(['prefix' => 'statuslabels'], function () {
 
         // Pie chart for dashboard
-        Route::get('assets',
-            [
-                'as' => 'api.statuslabels.assets.bytype',
-                'uses' => 'StatuslabelsController@getAssetCountByStatuslabel'
-            ]
-        );
+        Route::get('assets', [
+            'as' => 'statuslabels.assets.bytype',
+            'uses' => 'StatuslabelsController@getAssetCountByStatuslabel'
+        ]);
 
-        Route::get('{statuslabel}/assetlist',
-            [
-                'as' => 'api.statuslabels.assets',
-                'uses' => 'StatuslabelsController@assets'
-            ]
-        );
+        Route::get('{statuslabel}/assetlist', [
+            'as' => 'statuslabels.assets',
+            'uses' => 'StatuslabelsController@assets'
+        ]);
 
-        Route::get('{statuslabel}/deployable',
-            [
-                'as' => 'api.statuslabels.deployable',
-                'uses' => 'StatuslabelsController@checkIfDeployable'
-            ]
-        );
-
-
+        Route::get('{statuslabel}/deployable', [
+            'as' => 'statuslabels.deployable',
+            'uses' => 'StatuslabelsController@checkIfDeployable'
+        ]);
     });
 
-    Route::resource('statuslabels', 'StatuslabelsController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.statuslabels.index',
-                    'store' => 'api.statuslabels.store',
-                    'show' => 'api.statuslabels.show',
-                    'update' => 'api.statuslabels.update',
-                    'destroy' => 'api.statuslabels.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['statuslabel' => 'statuslabel_id']
-        ]
-    );
+    Route::apiResource('statuslabels', 'StatuslabelsController', [
+        'parameters' => ['statuslabel' => 'statuslabel_id']
+    ]);
 
     // Status labels group
 
 
     /*--- Suppliers API ---*/
     Route::group(['prefix' => 'suppliers'], function () {
-
-        Route::get('list',
-            [
-                'as'=>'api.suppliers.list',
-                'uses'=>'SuppliersController@getDatatable'
-            ]
-        );
-
-        Route::get('selectlist',
-            [
-                'as' => 'api.suppliers.selectlist',
-                'uses' => 'SuppliersController@selectlist'
-            ]
-        );
+        Route::get('selectlist', [
+            'as' => 'suppliers.selectlist',
+            'uses' => 'SuppliersController@selectlist'
+        ]);
     }); // Suppliers group
 
 
-    Route::resource('suppliers', 'SuppliersController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.suppliers.index',
-                    'show' => 'api.suppliers.show',
-                    'store' => 'api.suppliers.store',
-                    'update' => 'api.suppliers.update',
-                    'destroy' => 'api.suppliers.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['supplier' => 'supplier_id']
-        ]
-    ); // Suppliers resource
+    Route::apiResource('suppliers', 'SuppliersController', [
+        'parameters' => ['supplier' => 'supplier_id']
+    ]); // Suppliers resource
 
 
 
@@ -758,224 +462,143 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
 
     Route::group([ 'prefix' => 'users' ], function () {
 
-        Route::post('two_factor_reset',
-            [
-                'as' => 'api.users.two_factor_reset',
-                'uses' => 'UsersController@postTwoFactorReset'
-            ]
-        );
+        Route::post('two_factor_reset', [
+            'as' => 'users.two_factor_reset',
+            'uses' => 'UsersController@postTwoFactorReset'
+        ]);
 
-        Route::get('me',
-            [
-                'as' => 'api.users.me',
-                'uses' => 'UsersController@getCurrentUserInfo'
-            ]
-        );
+        Route::get('me', [
+            'as' => 'users.me',
+            'uses' => 'UsersController@getCurrentUserInfo'
+        ]);
 
-        Route::get('list/{status?}',
-            [
-                'as' => 'api.users.list',
-                'uses' => 'UsersController@getDatatable'
-            ]
-        );
+        Route::get('selectlist', [
+            'as' => 'users.selectlist',
+            'uses' => 'UsersController@selectList'
+        ]);
 
-        Route::get('selectlist',
-            [
-                'as' => 'api.users.selectlist',
-                'uses' => 'UsersController@selectList'
-            ]
-        );
+        Route::get('{user}/assets', [
+            'as' => 'users.assetlist',
+            'uses' => 'UsersController@assets'
+        ]);
 
-        Route::get('{user}/assets',
-            [
-                'as' => 'api.users.assetlist',
-                'uses' => 'UsersController@assets'
-            ]
-        );
+        Route::get('{user}/licenses', [
+            'as' => 'users.licenselist',
+            'uses' => 'UsersController@licenses'
+        ]);
 
+        Route::get('{user}/licenses', [
+            'as' => 'users.licenselist',
+            'uses' => 'UsersController@licenses'
+        ]);
 
-        Route::get('{user}/licenses',
-            [
-                'as' => 'api.users.licenselist',
-                'uses' => 'UsersController@licenses'
-            ]
-        );
-
-
-        Route::get('{user}/licenses',
-            [
-                'as' => 'api.users.licenselist',
-                'uses' => 'UsersController@licenses'
-            ]
-        );
-
-        Route::post('{user}/upload',
-            [
-                'as' => 'api.users.uploads',
-                'uses' => 'UsersController@postUpload'
-            ]
-        );
+        Route::post('{user}/upload', [
+            'as' => 'users.uploads',
+            'uses' => 'UsersController@postUpload'
+        ]);
     }); // Users group
 
-    Route::resource('users', 'UsersController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.users.index',
-                    'show' => 'api.users.show',
-                    'store' => 'api.users.store',
-                    'update' => 'api.users.update',
-                    'destroy' => 'api.users.destroy'
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['user' => 'user_id']
-        ]
-    ); // Users resource
+    Route::apiResource('users', 'UsersController', [
+        'parameters' => ['user' => 'user_id']
+    ]); // Users resource
 
 
-    Route::get(
-        'reports/activity',
-        [ 'as' => 'api.activity.index', 'uses' => 'ReportsController@index' ]
-    );
+    Route::get('reports/activity', [
+        'as' => 'activity.index',
+        'uses' => 'ReportsController@index',
+    ]);
 
     /*--- Kits API ---*/
 
-    Route::resource('kits', 'PredefinedKitsController',
-        [
-            'names' =>
-                [
-                    'index' => 'api.kits.index',
-                    'show' => 'api.kits.show',
-                    'store' => 'api.kits.store',
-                    'update' => 'api.kits.update',
-                    'destroy' => 'api.kits.destroy',
-                ],
-            'except' => ['create', 'edit'],
-            'parameters' => ['kit' => 'kit_id']
-        ]
-    );
+    Route::apiResource('kits', 'PredefinedKitsController', [
+        'parameters' => ['kit' => 'kit_id']
+    ]);
 
 
     Route::group([ 'prefix' => 'kits/{kit_id}' ], function () {
 
         // kit licenses
-        Route::get('licenses', 
-            [
-                'as' => 'api.kits.licenses.index',
-                'uses' => 'PredefinedKitsController@indexLicenses',
-            ]
-        );
-        
-        Route::post('licenses', 
-            [
-                'as' => 'api.kits.licenses.store',
-                'uses' => 'PredefinedKitsController@storeLicense',
-            ]
-        );
-        
-        Route::put('licenses/{license_id}', 
-            [
-                'as' => 'api.kits.licenses.update',
-                'uses' => 'PredefinedKitsController@updateLicense',
-            ]
-        );
+        Route::get('licenses', [
+            'as' => 'kits.licenses.index',
+            'uses' => 'PredefinedKitsController@indexLicenses',
+        ]);
 
-        Route::delete('licenses/{license_id}', 
-            [
-                'as' => 'api.kits.licenses.destroy',
-                'uses' => 'PredefinedKitsController@detachLicense',
-            ]
-        );
-        
+        Route::post('licenses', [
+            'as' => 'kits.licenses.store',
+            'uses' => 'PredefinedKitsController@storeLicense',
+        ]);
+
+        Route::put('licenses/{license_id}', [
+            'as' => 'kits.licenses.update',
+            'uses' => 'PredefinedKitsController@updateLicense',
+        ]);
+
+        Route::delete('licenses/{license_id}', [
+            'as' => 'kits.licenses.destroy',
+            'uses' => 'PredefinedKitsController@detachLicense',
+        ]);
+
         // kit models
-        Route::get('models', 
-            [
-                'as' => 'api.kits.models.index',
-                'uses' => 'PredefinedKitsController@indexModels',
-            ]
-        );
-        
-        Route::post('models', 
-            [
-                'as' => 'api.kits.models.store',
-                'uses' => 'PredefinedKitsController@storeModel',
-            ]
-        );
-        
-        Route::put('models/{model_id}', 
-            [
-                'as' => 'api.kits.models.update',
-                'uses' => 'PredefinedKitsController@updateModel',
-            ]
-        );
+        Route::get('models', [
+            'as' => 'kits.models.index',
+            'uses' => 'PredefinedKitsController@indexModels',
+        ]);
 
-        Route::delete('models/{model_id}', 
-            [
-                'as' => 'api.kits.models.destroy',
-                'uses' => 'PredefinedKitsController@detachModel',
-            ]
-        );
+        Route::post('models', [
+            'as' => 'kits.models.store',
+            'uses' => 'PredefinedKitsController@storeModel',
+        ]);
+
+        Route::put('models/{model_id}', [
+            'as' => 'kits.models.update',
+            'uses' => 'PredefinedKitsController@updateModel',
+        ]);
+
+        Route::delete('models/{model_id}', [
+            'as' => 'kits.models.destroy',
+            'uses' => 'PredefinedKitsController@detachModel',
+        ]);
 
         // kit accessories
-        Route::get('accessories', 
-            [
-                'as' => 'api.kits.accessories.index',
-                'uses' => 'PredefinedKitsController@indexAccessories',
-            ]
-        );
-        
-        Route::post('accessories', 
-            [
-                'as' => 'api.kits.accessories.store',
-                'uses' => 'PredefinedKitsController@storeAccessory',
-            ]
-        );
-        
-        Route::put('accessories/{accessory_id}', 
-            [
-                'as' => 'api.kits.accessories.update',
-                'uses' => 'PredefinedKitsController@updateAccessory',
-            ]
-        );
+        Route::get('accessories', [
+            'as' => 'kits.accessories.index',
+            'uses' => 'PredefinedKitsController@indexAccessories',
+        ]);
 
-        Route::delete('accessories/{accessory_id}', 
-            [
-                'as' => 'api.kits.accessories.destroy',
-                'uses' => 'PredefinedKitsController@detachAccessory',
-            ]
-        );
+        Route::post('accessories', [
+            'as' => 'kits.accessories.store',
+            'uses' => 'PredefinedKitsController@storeAccessory',
+        ]);
+
+        Route::put('accessories/{accessory_id}', [
+            'as' => 'kits.accessories.update',
+            'uses' => 'PredefinedKitsController@updateAccessory',
+        ]);
+
+        Route::delete('accessories/{accessory_id}', [
+            'as' => 'kits.accessories.destroy',
+            'uses' => 'PredefinedKitsController@detachAccessory',
+        ]);
 
         // kit consumables
-        Route::get('consumables', 
-            [
-                'as' => 'api.kits.consumables.index',
-                'uses' => 'PredefinedKitsController@indexConsumables',
-            ]
-        );
-        
-        Route::post('consumables', 
-            [
-                'as' => 'api.kits.consumables.store',
-                'uses' => 'PredefinedKitsController@storeConsumable',
-            ]
-        );
-        
-        Route::put('consumables/{consumable_id}', 
-            [
-                'as' => 'api.kits.consumables.update',
-                'uses' => 'PredefinedKitsController@updateConsumable',
-            ]
-        );
+        Route::get('consumables', [
+            'as' => 'kits.consumables.index',
+            'uses' => 'PredefinedKitsController@indexConsumables',
+        ]);
 
-        Route::delete('consumables/{consumable_id}', 
-            [
-                'as' => 'api.kits.consumables.destroy',
-                'uses' => 'PredefinedKitsController@detachConsumable',
-            ]
-        );
+        Route::post('consumables', [
+            'as' => 'kits.consumables.store',
+            'uses' => 'PredefinedKitsController@storeConsumable',
+        ]);
 
+        Route::put('consumables/{consumable_id}', [
+            'as' => 'kits.consumables.update',
+            'uses' => 'PredefinedKitsController@updateConsumable',
+        ]);
+
+        Route::delete('consumables/{consumable_id}', [
+            'as' => 'kits.consumables.destroy',
+            'uses' => 'PredefinedKitsController@detachConsumable',
+        ]);
     }); // kits group
-
 });
-
-

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Http\Request;
-
 /*
 |--------------------------------------------------------------------------
 | API Routes
@@ -35,68 +33,54 @@ Route::group([
     });
 
     /*--- Accessories API ---*/
-    Route::group(['prefix' => 'accessories'], function () {
-
-        Route::get('{accessory}/checkedout', [
-                'as' => 'accessories.checkedout',
-                'uses' => 'AccessoriesController@checkedout'
-            ]);
-
-        Route::get('selectlist', [
-                'as' => 'accessories.selectlist',
-                'uses'=> 'AccessoriesController@selectlist'
-            ]);
-    });
-
-    // Accessories group
+    // Accessories resource
     Route::apiResource('accessories', 'AccessoriesController', [
         'parameters' => ['accessory' => 'accessory_id']
     ]);
 
-    // Accessories resource
-
+    // Accessories group
     Route::group(['prefix' => 'accessories'], function () {
 
         Route::get('{accessory}/checkedout', [
-                'as' => 'accessories.checkedout',
-                'uses' => 'AccessoriesController@checkedout'
-            ]);
+            'as' => 'accessories.checkedout',
+            'uses' => 'AccessoriesController@checkedout'
+        ]);
 
         Route::post('{accessory}/checkout', [
-                'as' => 'accessories.checkout',
-                'uses' => 'AccessoriesController@checkout'
-            ]);
+            'as' => 'accessories.checkout',
+            'uses' => 'AccessoriesController@checkout'
+        ]);
 
         Route::post('{accessory}/checkin', [
-                'as' => 'accessories.checkin',
-                'uses' => 'AccessoriesController@checkin'
-            ]);
+            'as' => 'accessories.checkin',
+            'uses' => 'AccessoriesController@checkin'
+        ]);
+
+        Route::get('selectlist', [
+            'as' => 'accessories.selectlist',
+            'uses' => 'AccessoriesController@selectlist'
+        ]);
     }); // Accessories group
 
 
     /*--- Categories API ---*/
-
     Route::group(['prefix' => 'categories'], function () {
-
         Route::get('{item_type}/selectlist', [
                 'as' => 'categories.selectlist',
                 'uses' => 'CategoriesController@selectlist'
             ]);
-    });
+    }); // Categories group
 
-    // Categories group
     Route::apiResource('categories', 'CategoriesController', [
         'parameters' => ['category' => 'category_id']
     ]); // Categories resource
 
 
     /*--- Companies API ---*/
-
     Route::get('companies/selectlist', [
         'as' => 'companies.selectlist',
         'uses' => 'CompaniesController@selectlist'
     ]);
-
 
     // Companies resource
     Route::apiResource('companies', 'CompaniesController', [
@@ -104,33 +88,12 @@ Route::group([
     ]); // Companies resource
 
 
-    /*--- Departments API ---*/
-
-    /*--- Suppliers API ---*/
-    Route::group(['prefix' => 'departments'], function () {
-
-
-        Route::get('selectlist', [
-            'as' => 'departments.selectlist',
-            'uses' => 'DepartmentsController@selectlist'
-        ]);
-    }); // Departments group
-
-
-
-    Route::apiResource('departments', 'DepartmentsController', [
-        'parameters' => ['department' => 'department_id']
-    ]); // Departments resource
-
-
     /*--- Components API ---*/
-
     Route::apiResource('components', 'ComponentsController', [
         'parameters' => ['component' => 'component_id']
     ]); // Components resource
 
     Route::group(['prefix' => 'components'], function () {
-
         Route::get('{component}/assets', [
             'as' =>'components.assets',
             'uses' => 'ComponentsController@getAssets',
@@ -139,29 +102,43 @@ Route::group([
 
 
     /*--- Consumables API ---*/
-    Route::get('consumables/selectlist', [
-        'as' => 'consumables.selectlist',
-        'uses'=> 'ConsumablesController@selectlist'
-    ]);
+    Route::group(['prefix' => 'consumables'], function () {
+        Route::get('selectlist', [
+            'as' => 'consumables.selectlist',
+            'uses' => 'ConsumablesController@selectlist'
+        ]);
+
+        Route::get('view/{id}/users', [
+            'as' => 'consumables.showUsers',
+            'uses' => 'ConsumablesController@getDataView'
+        ]);
+    });
 
     Route::apiResource('consumables', 'ConsumablesController', [
         'parameters' => ['consumable' => 'consumable_id']
     ]); // Consumables resource
 
-    Route::get('consumables/view/{id}/users', [
-        'as' => 'consumables.showUsers',
-        'uses' => 'ConsumablesController@getDataView'
-    ]);
+
+    /*--- Departments API ---*/
+    Route::group(['prefix' => 'departments'], function () {
+        Route::get('selectlist', [
+            'as' => 'departments.selectlist',
+            'uses' => 'DepartmentsController@selectlist'
+        ]);
+    }); // Departments group
+
+    Route::apiResource('departments', 'DepartmentsController', [
+        'parameters' => ['department' => 'department_id']
+    ]); // Departments resource
+
 
     /*--- Depreciations API ---*/
-
     Route::apiResource('depreciations', 'DepreciationsController', [
         'parameters' => ['depreciation' => 'depreciation_id']
     ]); // Depreciations resource
 
 
     /*--- Fields API ---*/
-
     Route::apiResource('fields', 'CustomFieldsController', [
         'parameters' => [ 'field' => 'field_id' ]
     ]);
@@ -201,16 +178,13 @@ Route::group([
 
 
     /*--- Groups API ---*/
-
     Route::apiResource('groups', 'GroupsController', [
         'parameters' => ['group' => 'group_id']
     ]); // Groups resource
 
 
     /*--- Hardware API ---*/
-
     Route::group(['prefix' => 'hardware'], function () {
-
         Route::get('{asset_id}/licenses', [
             'as' => 'assets.licenselist',
             'uses' => 'AssetsController@licenses'
@@ -257,12 +231,6 @@ Route::group([
         ]);
     });
 
-    /*--- Asset Maintenances API ---*/
-    Route::apiResource('maintenances', 'AssetMaintenancesController', [
-        'parameters' => ['maintenance' => 'maintenance_id']
-    ]); // Consumables resource
-
-
     Route::apiResource('hardware', 'AssetsController', [
         // Names need to remain here as laravel defaults to 'hardware' given the routes used.
         'names' => [
@@ -277,13 +245,11 @@ Route::group([
 
 
     /*--- Imports API ---*/
-
     Route::apiResource('imports', 'ImportController', [
         'parameters' => ['import' => 'import_id']
-    ]); // Imports resource
+    ]);
 
     Route::group(['prefix' => 'imports'], function () {
-
         Route::post('process/{import}', [
             'as' => 'imports.importFile',
             'uses'=> 'ImportController@process'
@@ -292,7 +258,6 @@ Route::group([
 
 
     /*--- Licenses API ---*/
-
     Route::group(['prefix' => 'licenses'], function () {
         Route::get('{licenseId}/seats', [
             'as' => 'license.seats',
@@ -310,11 +275,8 @@ Route::group([
     ]); // Licenses resource
 
 
-
     /*--- Locations API ---*/
-
     Route::group(['prefix' => 'locations'], function () {
-
         Route::get('{location}/users', [
             'as'=>'locations.viewusers',
             'uses'=>'LocationsController@getDataViewUsers'
@@ -337,30 +299,29 @@ Route::group([
         ]);
     }); // Locations group
 
-
-
     Route::apiResource('locations', 'LocationsController', [
         'parameters' => ['location' => 'location_id']
-    ]); // Locations resource
+    ]);
 
+    /*--- Asset Maintenances API ---*/
+    Route::apiResource('maintenances', 'AssetMaintenancesController', [
+        'parameters' => ['maintenance' => 'maintenance_id']
+    ]); // Consumables resource
 
     /*--- Manufacturers API ---*/
-
     Route::group(['prefix' => 'manufacturers'], function () {
         Route::get('selectlist', [
             'as' => 'manufacturers.selectlist',
             'uses' => 'ManufacturersController@selectlist'
         ]);
-    }); // Locations group
-
+    }); // Manufacturers group
 
     Route::apiResource('manufacturers', 'ManufacturersController', [
         'parameters' => ['manufacturer' => 'manufacturer_id']
-    ]); // Manufacturers resource
+    ]);
 
 
     /*--- Models API ---*/
-
     Route::group(['prefix' => 'models'], function () {
         Route::get('assets', [
             'as' => 'models.assets',
@@ -372,49 +333,46 @@ Route::group([
         ]);
     }); // Models group
 
-
     Route::apiResource('models', 'AssetModelsController', [
         'parameters' => ['model' => 'model_id']
-    ]); // Models resource
+    ]);
 
     /*--- Settings API ---*/
-    Route::get('settings/ldaptest', [
-        'as' => 'settings.ldaptest',
-        'uses' => 'SettingsController@ldapAdSettingsTest'
-    ]);
+    Route::group(['prefix' => 'settings'], function () {
+        Route::get('ldaptest', [
+            'as' => 'settings.ldaptest',
+            'uses' => 'SettingsController@ldapAdSettingsTest'
+        ]);
 
-    Route::get('settings/login-attempts', [
-        'middleware' => ['auth', 'authorize:superuser'],
-        'as' => 'settings.login_attempts',
-        'uses' => 'SettingsController@showLoginAttempts'
-    ]);
+        Route::get('login-attempts', [
+            'middleware' => ['auth', 'authorize:superuser'],
+            'as' => 'settings.login_attempts',
+            'uses' => 'SettingsController@showLoginAttempts'
+        ]);
 
+        Route::post('ldaptestlogin', [
+            'as' => 'settings.ldaptestlogin',
+            'uses' => 'SettingsController@ldaptestlogin'
+        ]);
 
-    Route::post('settings/ldaptestlogin', [
-        'as' => 'settings.ldaptestlogin',
-        'uses' => 'SettingsController@ldaptestlogin'
-    ]);
+        Route::post('slacktest', [
+            'as' => 'settings.slacktest',
+            'uses' => 'SettingsController@slacktest'
+        ]);
 
-    Route::post('settings/slacktest', [
-        'as' => 'settings.slacktest',
-        'uses' => 'SettingsController@slacktest'
-    ]);
-
-    Route::post('settings/mailtest', [
-        'as'  => 'settings.mailtest',
-        'uses' => 'SettingsController@ajaxTestEmail'
-    ]);
-
+        Route::post('mailtest', [
+            'as'  => 'settings.mailtest',
+            'uses' => 'SettingsController@ajaxTestEmail'
+        ]);
+    }); // Settings group
 
     Route::apiResource('settings', 'SettingsController', [
         'except' => ['destroy'],
         'parameters' => ['setting' => 'setting_id']
-    ]); // Settings resource
+    ]);
 
 
     /*--- Status Labels API ---*/
-
-
     Route::group(['prefix' => 'statuslabels'], function () {
 
         // Pie chart for dashboard
@@ -432,13 +390,11 @@ Route::group([
             'as' => 'statuslabels.deployable',
             'uses' => 'StatuslabelsController@checkIfDeployable'
         ]);
-    });
+    });  // Status labels group
 
     Route::apiResource('statuslabels', 'StatuslabelsController', [
         'parameters' => ['statuslabel' => 'statuslabel_id']
     ]);
-
-    // Status labels group
 
 
     /*--- Suppliers API ---*/
@@ -449,17 +405,12 @@ Route::group([
         ]);
     }); // Suppliers group
 
-
     Route::apiResource('suppliers', 'SuppliersController', [
         'parameters' => ['supplier' => 'supplier_id']
-    ]); // Suppliers resource
-
-
+    ]);
 
 
     /*--- Users API ---*/
-
-
     Route::group([ 'prefix' => 'users' ], function () {
 
         Route::post('two_factor_reset', [
@@ -480,11 +431,6 @@ Route::group([
         Route::get('{user}/assets', [
             'as' => 'users.assetlist',
             'uses' => 'UsersController@assets'
-        ]);
-
-        Route::get('{user}/licenses', [
-            'as' => 'users.licenselist',
-            'uses' => 'UsersController@licenses'
         ]);
 
         Route::get('{user}/licenses', [
@@ -591,7 +537,7 @@ Route::group([
             'uses' => 'PredefinedKitsController@storeConsumable',
         ]);
 
-        Route::put('consumables/{consumable_id}', [
+        Route::put('{consumable_id}', [
             'as' => 'kits.consumables.update',
             'uses' => 'PredefinedKitsController@updateConsumable',
         ]);


### PR DESCRIPTION
Due to formatting changes the diff is a bit of a mess to read.  This does the following:

* Migrates to using Route::apiResource() instead of Route::resource() where appropriate.  This allows the removal of the `"except" => ['create','edit']` lines in many of the route declarations.

* Applies a top level prefix of 'api.' to the route names.  This allows removing all of the `names` keys in Route::resources with the exception of hardware (discrepency between assets and hardware name usage).  There seems to be an inconsistency in laravel where the "as" key at the group level requires a trailing period, but the "as" key at the action level does not.  Worth keeping an eye on in case this is fixed in a later version of laravel in a future upgrade. This has a side effect of standardizing on a name of "api.{foo}.selectlist" -- previously the api prefix was inconsistent across these, although the named route is not used anywhere in current code.

* Speaking of selectlists, I took a look at a few ways of cleaning up the code surrounding these, but I felt like both a catchall route that directed to the appropriate controllers, as well as a SelectListController, ended up messier by the time one worked through all of the special casing required.  I think there's probably a better way in the future but it's probably dependant on some of the bigger architecture changes that have been discussed.