### PR TITLE
Propose workaround for #7661 — suppress E_DEPRECATED on ldap_control_paged_result()

### DIFF
--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -286,7 +286,7 @@ class Ldap extends Model
         // Clean up after search
         $result_set['count'] = $global_count;
         $results = $result_set;
-        ldap_control_paged_result($ldapconn, 0);
+        @ldap_control_paged_result($ldapconn, 0);
 
         return $results;
 


### PR DESCRIPTION
A proposed workaround for #7661. In line with other calls to similar deprecated functions in this file (e.g. calls to `@ldap_control_paged_result`), we use the error suppression operator `@` in the call `ldap_control_paged_result()` on line 289.

This avoids the `E_DEPRECATED` error on PHP 7.4 that causes this function to invoke the exception handler and therefore not return any LDAP results.

Given that the results are populated in `$results` up to this line in this scenario, suppressing the error allows the `$results` to be returned and not break the LDAP functionality.

Note that this obviously does not actually deal with the deprecation of this function — but does keep LDAP functionality working on PHP 7.4 for now.