### PR TITLE
Fix AD Accounts with delegation disabled

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -188,7 +188,7 @@ class LdapSync extends Command
                 // Sync activated state for Active Directory.
                 if ( array_key_exists('useraccountcontrol', $results[$i]) ) {
                   $enabled_accounts = [
-                    '512', '544', '66048', '66080', '262656', '262688', '328192', '328224', '4260352'
+                    '512', '544', '66048', '66080', '262656', '262688', '328192', '328224', '1049088', '4260352'
                   ];
                   $user->activated = ( in_array($results[$i]['useraccountcontrol'][0], $enabled_accounts) ) ? 1 : 0;
                 }


### PR DESCRIPTION
We have a few accounts that we have marked as "Account is sensitive and cannot be delegated", and they were being marked as disabled as the useraccountcontrol value for a sensitive account was not considered an active value. This fixes that by considering those accounts as active.