### PR TITLE
Better handle the logic to determine if we should display the license checkout blade [ch13792]

### DIFF
--- a/app/Http/Controllers/LicensesController.php
+++ b/app/Http/Controllers/LicensesController.php
@@ -246,17 +246,23 @@ class LicensesController extends Controller
      */
     public function getCheckout($licenceId)
     {
+
         // Check that the license is valid
         if ($license = License::where('id',$licenceId)->first()) {
+
+            $this->authorize('checkout', $license);
 
             // If the license is valid, check that there is an available seat
             if ($license->getAvailSeatsCountAttribute() < 1) {
                 return redirect()->route('licenses.index')->with('error', 'There are no available seats for this license');
             }
+            return view('licenses/checkout', compact('license'));
         }
 
-        $this->authorize('checkout', $license);
-        return view('licenses/checkout', compact('license'));
+        return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.does_not_exist'));
+
+
+
     }
 
 


### PR DESCRIPTION
In rare occasions, an admin would be trying to checkout a license that was simultaneously being deleted - or at least was deleted since the last time they refreshed the license index page. 

This fix just reorders some of the logic so that it:

1. Checks that the license exists
2. Then checks that the user is actually allowed to check it out
3. If the license exists and the user is allowed to check it out, display the checkout blade
4. If the license does not exist, redirect back to the licenses index with an error

(This relates to rb13799 and ch13792)