### PR TITLE
Added CLI tool to checkout license to all users

### DIFF
--- a/app/Console/Commands/CheckoutLicenseToAllUsers.php
+++ b/app/Console/Commands/CheckoutLicenseToAllUsers.php
@@ -75,11 +75,8 @@ class CheckoutLicenseToAllUsers extends Command
             }
 
             // Get the seat ID
-            $next = $license->freeSeat();
-            if (!$licenseSeat = LicenseSeat::where('id', '=', $next->id)->first()) {
-                $this->error('ERROR: No available seats');
-                return false;
-            }
+            $licenseSeat = $license->freeSeat();
+
 
             // Update the seat with checkout info,
            $licenseSeat->assigned_to = $user->id;

--- a/app/Console/Commands/CheckoutLicenseToAllUsers.php
+++ b/app/Console/Commands/CheckoutLicenseToAllUsers.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\LicenseSeat;
+use Illuminate\Console\Command;
+use App\Models\User;
+use App\Models\License;
+use Illuminate\Database\Eloquent\Model;
+
+class CheckoutLicenseToAllUsers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:checkout-to-all {--license_id=} {--notify}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+
+        $license_id = $this->option('license_id');
+        $notify = $this->option('notify');
+
+        if (!$license_id) {
+             $this->error('ERROR: License ID is required.');
+             return false;
+        }
+
+
+        if (!$license = License::find($license_id)->first()) {
+            $this->error('Invalid license ID');
+            return false;
+        }
+        $users = User::whereNull('deleted_at')->get();
+
+        if ($users->count() > $license->getAvailSeatsCountAttribute()) {
+            $this->info('You do not have enough free seats to complete this task, so we will check out as many as we can. ');
+        }
+
+        $this->info('Checking out '.$users->count().' of '.$license->getAvailSeatsCountAttribute().' seats for '.$license->name);
+
+        if (!$notify) {
+            $this->info('No mail will be sent.');
+        }
+
+        foreach ($users as $user) {
+            // If the license is valid, check that there is an available seat
+            if ($license->getAvailSeatsCountAttribute() < 1) {
+                $this->error('ERROR: No available seats');
+                return false;
+            }
+
+            // Get the seat ID
+            $next = $license->freeSeat();
+            if (!$licenseSeat = LicenseSeat::where('id', '=', $next->id)->first()) {
+                $this->error('ERROR: No available seats');
+                return false;
+            }
+
+            // Update the seat with checkout info,
+           $licenseSeat->assigned_to = $user->id;
+            if ($licenseSeat->save()) {
+
+                // Temporarily null the user's email address so we don't send mail if we're not supposed to
+                if (!$notify) {
+                    $user->email = null;
+                }
+
+                // Log the checkout
+                $licenseSeat->logCheckout('Checked out via cli tool', $user);
+                $this->info('License '.$license_id.' checked out to '.$user->username);
+            }
+
+        }
+
+
+
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -128,9 +128,12 @@ final class Company extends SnipeModel
         } elseif (!static::isFullMultipleCompanySupportEnabled()) {
             return true;
         } else {
-            $current_user_company_id = Auth::user()->company_id;
-            $companyable_company_id = $companyable->company_id;
-            return ($current_user_company_id == null || $current_user_company_id == $companyable_company_id || Auth::user()->isSuperUser());
+            if (Auth::user()) {
+                $current_user_company_id = Auth::user()->company_id;
+                $companyable_company_id = $companyable->company_id;
+                return ($current_user_company_id == null || $current_user_company_id == $companyable_company_id || Auth::user()->isSuperUser());
+            }
+
         }
     }
 


### PR DESCRIPTION
This is pretty straightforward, I think. It takes two options, the first being license ID and then an optional `--notify` flag that sends the checkout email. I had to do this in kind of a gross way because the notifications happen in the `logCheckout()` method, but it seems to work.


`php artisan snipeit:checkout-to-all --license_id=1`
`php artisan snipeit:checkout-to-all --license_id=1 --notify`