### PR TITLE
Added #5762 Modify expected checkin dates

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -186,7 +186,7 @@ class AssetsController extends Controller
                 }
 
                 if (isset($target)) {
-                    $asset->checkOut($target, Auth::user(), date('Y-m-d H:i:s'), '', 'Checked out on asset creation', e($request->get('name')), $location);
+                    $asset->checkOut($target, Auth::user(), date('Y-m-d H:i:s'), $request->input('expected_checkin', null), 'Checked out on asset creation', e($request->get('name')), $location);
                 }
 
                 $success = true;
@@ -295,6 +295,7 @@ class AssetsController extends Controller
         $asset->purchase_cost = Helper::ParseFloat($request->input('purchase_cost', null));
         $asset->purchase_date = $request->input('purchase_date', null);
         $asset->supplier_id = $request->input('supplier_id', null);
+        $asset->expected_checkin = $request->input('expected_checkin', null);
 
         // If the box isn't checked, it's not in the request at all.
         $asset->requestable = $request->filled('requestable');

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -78,6 +78,7 @@ class BulkAssetsController extends Controller
         $assets = array_keys($request->input('ids'));
 
         if (($request->filled('purchase_date'))
+            || ($request->filled('expected_checkin'))
             || ($request->filled('purchase_cost'))
             || ($request->filled('supplier_id'))
             || ($request->filled('order_number'))
@@ -92,6 +93,7 @@ class BulkAssetsController extends Controller
                 $this->update_array = [];
 
                 $this->conditionallyAddItem('purchase_date')
+                    ->conditionallyAddItem('expected_checkin')
                     ->conditionallyAddItem('model_id')
                     ->conditionallyAddItem('order_number')
                     ->conditionallyAddItem('requestable')

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -39,6 +39,18 @@
               {!! $errors->first('purchase_date', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
           </div>
+          <!-- Expected Checkin Date -->
+          <div class="form-group {{ $errors->has('expected_checkin') ? ' has-error' : '' }}">
+             <label for="expected_checkin" class="col-md-3 control-label">{{ trans('admin/hardware/form.expected_checkin') }}</label>
+             <div class="input-group col-md-3">
+                  <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
+                      <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ Input::old('expected_checkin') }}">
+                      <span class="input-group-addon"><i class="fa fa-calendar" aria-hidden="true"></i></span>
+                 </div>
+                 {!! $errors->first('expected_checkin', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
+             </div>
+          </div>
+
 
           <!-- Status -->
           <div class="form-group {{ $errors->has('status_id') ? ' has-error' : '' }}">

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -32,9 +32,11 @@
           <div class="form-group {{ $errors->has('purchase_date') ? ' has-error' : '' }}">
             <label for="purchase_date" class="col-md-3 control-label">{{ trans('admin/hardware/form.date') }}</label>
             <div class="input-group col-md-3">
-              <input type="date" class="datepicker form-control" data-date-format="yyyy-mm-dd" placeholder="Select Date" name="purchase_date" id="purchase_date" value="{{ old('purchase_date') }}" arial-label="purchase_date">
-              <span class="input-group-addon"><i class="fa fa-calendar" aria-hidden="true"></i></span>
-              {!! $errors->first('purchase_date', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
+              <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
+                <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="purchase_date" id="purchase_date" value="{{ Input::old('purchase_date') }}">
+                <span class="input-group-addon"><i class="fa fa-calendar" aria-hidden="true"></i></span>
+              </div>
+              {!! $errors->first('purchase_date', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
             </div>
           </div>
 


### PR DESCRIPTION
Initial commit 0f899bc Directly addresses #5762 by adding the ability to edit expected checkin dates at Actions > Edit Asset.

Second commit cd112a2 Brings the date picker in bulk edit inline with other date pickers I saw. Happy to drop this commit and submit as a separate pull request if requested.

Third commit 0edb25d Allows expected checkin dates to be bulk edited, I believed this would be a useful addition as people are experiencing 500+ devices that need the expected checkin date updated

I haven't spent a huge amount of time in snipe-it so apologies if I missed something obvious I will do my best to fix any mistakes pointed out :)

I have looked at the unit test but I am unsure at the level the unit tests are at if it would provide any utility. Happy to have another look or implement any suggestions
