### PR TITLE
Change the form input name for serials in the view

### DIFF
--- a/resources/views/partials/forms/edit/serial.blade.php
+++ b/resources/views/partials/forms/edit/serial.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('serial') ? ' has-error' : '' }}">
     <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ trans('admin/hardware/form.serial') }} </label>
     <div class="col-md-7 col-sm-12{{  (\App\Helpers\Helper::checkIfRequired($item, 'serial')) ? ' required' : '' }}">
-        <input class="form-control" type="text" name="serial" id="serial" value="{{ old('serial', $item->serial) }}" />
+        <input class="form-control" type="text" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old('serial', $item->serial) }}" />
         {!! $errors->first('serial', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>


### PR DESCRIPTION
I got to an error trying to edit an existing asset. It's probably caused by a PHP update (I'm using 7.4.7) since I can't find any other report about this behaviour. Since the code in the Controller looks to me pretty much like an intentional change (i.e. not a typo nor a non-setted variable) I change the name of the input in the view, where it looks more like an ommission since there is a variable called `$fieldname`.