### PR TITLE
Added #8233: Use translated salutation from other notifications

### DIFF
--- a/resources/views/notifications/markdown/asset-requested.blade.php
+++ b/resources/views/notifications/markdown/asset-requested.blade.php
@@ -55,7 +55,7 @@
 @endif
 @endcomponent
 
-Thanks,
+{{ trans('mail.best_regards') }}
 
 {{ $snipeSettings->site_name }}
 

--- a/resources/views/notifications/markdown/checkin-accessory.blade.php
+++ b/resources/views/notifications/markdown/checkin-accessory.blade.php
@@ -26,7 +26,7 @@
 @endif
 @endcomponent
 
-Thanks,
+{{ trans('mail.best_regards') }}
 
 {{ $snipeSettings->site_name }}
 

--- a/resources/views/notifications/markdown/checkin-asset.blade.php
+++ b/resources/views/notifications/markdown/checkin-asset.blade.php
@@ -42,7 +42,7 @@
 @endif
 @endcomponent
 
-Thanks,
+{{ trans('mail.best_regards') }}
 
 {{ $snipeSettings->site_name }}
 

--- a/resources/views/notifications/markdown/checkin-license.blade.php
+++ b/resources/views/notifications/markdown/checkin-license.blade.php
@@ -24,7 +24,7 @@
 @endif
 @endcomponent
 
-Thanks,
+{{ trans('mail.best_regards') }}
 
 {{ $snipeSettings->site_name }}
 

--- a/resources/views/notifications/markdown/checkout-accessory.blade.php
+++ b/resources/views/notifications/markdown/checkout-accessory.blade.php
@@ -47,7 +47,7 @@
 @endif
 
 
-Thanks,
+{{ trans('mail.best_regards') }}
 
 {{ $snipeSettings->site_name }}
 

--- a/resources/views/notifications/markdown/checkout-asset.blade.php
+++ b/resources/views/notifications/markdown/checkout-asset.blade.php
@@ -64,7 +64,7 @@
 @endif
 
 
-Thanks,
+{{ trans('mail.best_regards') }}
 
 {{ $snipeSettings->site_name }}
 

--- a/resources/views/notifications/markdown/checkout-consumable.blade.php
+++ b/resources/views/notifications/markdown/checkout-consumable.blade.php
@@ -44,7 +44,7 @@
 @endif
 
 
-Thanks,
+{{ trans('mail.best_regards') }}
 
 {{ $snipeSettings->site_name }}
 

--- a/resources/views/notifications/markdown/checkout-license.blade.php
+++ b/resources/views/notifications/markdown/checkout-license.blade.php
@@ -47,7 +47,7 @@
 @endif
 
 
-Thanks,
+{{ trans('mail.best_regards') }}
 
 {{ $snipeSettings->site_name }}
 

--- a/resources/views/notifications/markdown/report-expected-checkins.blade.php
+++ b/resources/views/notifications/markdown/report-expected-checkins.blade.php
@@ -14,7 +14,7 @@ $checkin = \App\Helpers\Helper::getFormattedDateObject($asset->expected_checkin,
 @endforeach
 @endcomponent
 
-Thanks,
+{{ trans('mail.best_regards') }}
 
 {{ $snipeSettings->site_name }}
 


### PR DESCRIPTION
This Pull-Request changes the salutation in nine notification mails from a static ```Thanks,``` to the translated version ```best regards``` already used in other notification mails.
