### PR TITLE
Added #8233: Enable translations of checkin notifications

### DIFF
--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -70,7 +70,7 @@ class CheckinAccessoryNotification extends Notification
         ];
 
         return (new SlackMessage)
-            ->content(':arrow_down: :keyboard: Accessory Checked In')
+            ->content(':arrow_down: :keyboard: '.trans('mail.Accessory_Checkin_Notification'))
             ->from($botname)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
@@ -93,7 +93,7 @@ class CheckinAccessoryNotification extends Notification
                 'note'          => $this->note,
                 'target'        => $this->target,
             ])
-            ->subject('Accessory checked in');
+            ->subject(trans('mail.Accessory_Checkin_Notification'));
 
     }
 }

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -79,7 +79,7 @@ class CheckinAssetNotification extends Notification
         ];
 
         return (new SlackMessage)
-            ->content(':arrow_down: :computer: Asset Checked In')
+            ->content(':arrow_down: :computer: '.trans('mail.Asset_Checkin_Notification'))
             ->from($botname)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
@@ -113,7 +113,7 @@ class CheckinAssetNotification extends Notification
                 'fields'        => $fields,
                 'expected_checkin'  => $this->expected_checkin,
             ])
-            ->subject('Asset checked in');
+            ->subject(trans('mail.Asset_Checkin_Notification'));
 
 
         return $message;

--- a/app/Notifications/CheckinLicenseSeatNotification.php
+++ b/app/Notifications/CheckinLicenseSeatNotification.php
@@ -75,7 +75,7 @@ class CheckinLicenseSeatNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_down: :floppy_disk: License  Checked In')
+            ->content(':arrow_down: :floppy_disk: '.trans('mail.License_Checkin_Notification'))
             ->from($botname)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
@@ -98,7 +98,7 @@ class CheckinLicenseSeatNotification extends Notification
                 'note'          => $this->note,
                 'target'        => $this->target,
             ])
-            ->subject('License checked in');
+            ->subject(trans('mail.License_Checkin_Notification'));
 
     }
 

--- a/app/Notifications/ExpectedCheckinAdminNotification.php
+++ b/app/Notifications/ExpectedCheckinAdminNotification.php
@@ -48,7 +48,7 @@ class ExpectedCheckinAdminNotification extends Notification
             [
                 'assets'  => $this->assets,
             ])
-            ->subject('Expected asset checkin report');
+            ->subject(trans('mail.Expected_Checkin_Report'));
 
         return $message;
 

--- a/resources/lang/en/mail.php
+++ b/resources/lang/en/mail.php
@@ -70,5 +70,8 @@ return array(
     'welcome' => 'Welcome :name',
     'welcome_to' => 'Welcome to :web!',
     'your_credentials' => 'Your Snipe-IT credentials',
-
+    'Accessory_Checkin_Notification' => 'Accessory checked in',
+    'Asset_Checkin_Notification' => 'Asset checked in',
+    'License_Checkin_Notification' => 'License checked in',
+    'Expected_Checkin_Report' => 'Expected asset checkin report'
 );


### PR DESCRIPTION
This Pull-Request allows translation of mail subjects for the three checkin notifications and the expected checking report.

It adds four new strings to the mail ressource