### PR TITLE
Set location_id to rtd_location_id on asset creation

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -453,6 +453,7 @@ class AssetsController extends Controller
         $asset->supplier_id             = $request->get('supplier_id', 0);
         $asset->requestable             = $request->get('requestable', 0);
         $asset->rtd_location_id         = $request->get('rtd_location_id', null);
+        $asset->location_id             = $request->get('rtd_location_id', null);
 
         // Update custom fields in the database.
         // Validation for these fields is handled through the AssetRequest form request

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -137,7 +137,7 @@ class AssetsController extends Controller
         $asset->supplier_id             = request('supplier_id', 0);
         $asset->requestable             = request('requestable', 0);
         $asset->rtd_location_id         = request('rtd_location_id', null);
-        $asset->location_id             = request('rtd_location_id', null);
+        
 
         if ($asset->assigned_to=='') {
             $asset->location_id = $request->input('rtd_location_id', null);

--- a/app/Http/Controllers/AssetsController.php
+++ b/app/Http/Controllers/AssetsController.php
@@ -137,6 +137,7 @@ class AssetsController extends Controller
         $asset->supplier_id             = request('supplier_id', 0);
         $asset->requestable             = request('requestable', 0);
         $asset->rtd_location_id         = request('rtd_location_id', null);
+        $asset->location_id             = request('rtd_location_id', null);
 
         if ($asset->assigned_to=='') {
             $asset->location_id = $request->input('rtd_location_id', null);


### PR DESCRIPTION
This PR sets the `location_id` of an asset to the `rtd_location_id` on asset creation. If the asset is being checked out on creation, the `location_id` should be overwritten by the 

```
if (($request->filled('assigned_user')) && ($target = User::find($request->get('assigned_user')))) {
```

statement that comes after.

If you need to update back-in-time assets, you can run this script: https://snipe-it.readme.io/docs/asset-location-sync