### PR TITLE
Implement Checkout API for Consumables

### DIFF
--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Models\Company;
 use App\Models\Consumable;
+use App\Models\User;
 use App\Http\Transformers\ConsumablesTransformer;
 use App\Helpers\Helper;
 
@@ -157,7 +158,7 @@ class ConsumablesController extends Controller
         return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/consumables/message.delete.success')));
     }
 
-        /**
+    /**
     * Returns a JSON response containing details on the users associated with this consumable.
     *
     * @author [A. Gianotto] [<snipe@snipe.net>]
@@ -195,5 +196,56 @@ class ConsumablesController extends Controller
         $consumableCount = $consumable->users->count();
         $data = array('total' => $consumableCount, 'rows' => $rows);
         return $data;
+    }
+
+    /**
+     * Checkout a consumable
+     *
+     * @author [A. Gutierrez] [<andres@baller.tv>]
+     * @param int $id
+     * @since [v4.9.5]
+     * @return JsonResponse
+     */
+    public function checkout(Request $request, $id)
+    {
+        // Check if the consumable exists
+        if (is_null($consumable = Consumable::find($id))) { // TODO -> message
+            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/consumables/message.does_not_exist')));
+        }
+
+        $this->authorize('checkout', $consumable);
+
+        if ($consumable->qty > 0) {
+
+            // Check if the user exists
+            $assigned_to = $request->input('assigned_to');
+            if (is_null($user = User::find($assigned_to))) {
+                // Return error message
+                return response()->json(Helper::formatStandardApiResponse('error', null, 'No user found'));
+            }
+
+            // Update the consumable data
+            $consumable->assigned_to = e($assigned_to);
+
+            $consumable->users()->attach($consumable->id, [
+                'consumable_id' => $consumable->id,
+                'user_id' => $user->id,
+                'assigned_to' => $assigned_to
+            ]);
+
+            // Log checkout event
+            $logaction = $consumable->logCheckout(e($request->input('note')), $user);
+            $data['log_id'] = $logaction->id;
+            $data['eula'] = $consumable->getEula();
+            $data['first_name'] = $user->first_name;
+            $data['item_name'] = $consumable->name;
+            $data['checkout_date'] = $logaction->created_at;
+            $data['note'] = $logaction->note;
+            $data['require_acceptance'] = $consumable->requireAcceptance();
+
+            return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/consumables/message.checkout.success')));
+        }
+
+        return response()->json(Helper::formatStandardApiResponse('error', null, 'No consumables remaining'));
     }
 }

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -209,7 +209,7 @@ class ConsumablesController extends Controller
     public function checkout(Request $request, $id)
     {
         // Check if the consumable exists
-        if (is_null($consumable = Consumable::find($id))) { // TODO -> message
+        if (is_null($consumable = Consumable::find($id))) {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/consumables/message.does_not_exist')));
         }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -189,7 +189,6 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'api'], fun
 
 
     /*--- Consumables API ---*/
-
     Route::resource('consumables', 'ConsumablesController',
         [
             'names' =>
@@ -204,12 +203,22 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'api'], fun
             'parameters' => ['consumable' => 'consumable_id']
         ]
     ); // Consumables resource
-    Route::get('consumables/view/{id}/users',
-        [
-            'as' => 'api.consumables.showUsers',
-            'uses' => 'ConsumablesController@getDataView'
-        ]
-    );
+
+    Route::group(['prefix' => 'consumables'], function () {
+        Route::get('view/{id}/users',
+            [
+                'as' => 'api.consumables.showUsers',
+                'uses' => 'ConsumablesController@getDataView'
+            ]
+        );
+
+        Route::post('{consumable}/checkout',
+            [
+                'as' => 'api.consumables.checkout',
+                'uses' => 'ConsumablesController@checkout'
+            ]
+        );
+    });
 
     /*--- Depreciations API ---*/
 


### PR DESCRIPTION
This PR allows consumables to be checked out to a user at `POST .../api/v1/consumables/{id}/checkout`, based on the implementation for checking out accessories.

Fixes #7776 (at least for checking out to users).