### PR TITLE
WIP: Improve error-handling in case ldap_search() throws an Exception

### DIFF
--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -261,8 +261,12 @@ class Ldap extends Model
                 throw new Exception('Problem with your LDAP connection. Try checking the Use TLS setting in Admin > Settings. ');
             }
 
-
-            $search_results = ldap_search($ldapconn, $base_dn, '('.$filter.')');
+            try {
+                $search_results = ldap_search($ldapconn, $base_dn, '('.$filter.')');
+            } catch (Exception $e) {
+                \Log::error("Unable to perform LDAP search in: '".$base_dn."'");
+                $search_results = false;
+            }
 
             if (!$search_results) {
                 return redirect()->route('users.index')->with('error', trans('admin/users/message.error.ldap_could_not_search').ldap_error($ldapconn));


### PR DESCRIPTION
# Description

Right now the `ldap_search()` command may throw an Exception when run during ldap-sync, and we don't catch that or bubble it up to the user. So a user clicking the 'sync' command in the UI will get a Whoops page, and people running LDAP syncs via the CLI will get an error, aborting the sync run.

This change just catches the error, logs it, and lets the existing error-handling code run.

This is _not_ tested yet, though I've made a similar change elsewhere which _did_ work.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
