### PR TITLE
Fixed #8125: Multiple company support, restricted user can choose other companies

### DIFF
--- a/resources/views/partials/forms/edit/company-select.blade.php
+++ b/resources/views/partials/forms/edit/company-select.blade.php
@@ -1,23 +1,20 @@
 <!-- Company -->
+    <!-- full company support is enabled and this user is not a superadmin -->
 @if (($snipeSettings->full_multiple_companies_support=='1') && (!Auth::user()->isSuperUser()))
     <!-- full company support is enabled and this user isn't a superadmin -->
     <div class="form-group">
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
         <div class="col-md-6">
-            <select class="js-data-ajax" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" id="company_select" aria-label="{{ $fieldname }}">
-                @if ($company_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
-                    <option value="{{ $company_id }}" selected="selected" role="option" aria-selected="true"  role="option">
-                        {{ (\App\Models\Company::find($company_id)) ? \App\Models\Company::find($company_id)->name : '' }}
+             <select class="js-data-ajax" data-endpoint="companies" disabled="true" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" id="company_select" aria-label="{{ $fieldname }}">
+                               <option selected="selected"  role="option" aria-selected="true">
+                        {{ (\App\Models\Company::find($user->company_id)) ? \App\Models\Company::find($user->company_id)->name : '' }}
                     </option>
-                @else
-                    <option value="" role="option">{{ trans('general.select_company') }}</option>
-                @endif
-            </select>
+             </select>
         </div>
     </div>
 
 @else
-    <!-- full company support is enabled or this user is a superadmin -->
+    <!-- full company support is disabled or this user is a superadmin -->
     <div id="{{ $fieldname }}" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}">
         {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
         <div class="col-md-6">


### PR DESCRIPTION
New asset should get users company_id if multiple companies is enabled and user not superuser.
And select should be disabled. Maybe also it should be hidden?

Not tested when fcs are disabled.
