### PR TITLE
Checkin license from all users cli tool

### DIFF
--- a/app/Console/Commands/CheckinLicensesFromAllUsers.php
+++ b/app/Console/Commands/CheckinLicensesFromAllUsers.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\LicenseSeat;
+use Illuminate\Console\Command;
+use App\Models\User;
+use App\Models\License;
+use Illuminate\Database\Eloquent\Model;
+
+class CheckinLicensesFromAllUsers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:checkin-from-all {--license_id=} {--notify}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Checks in licenses from all users';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+
+        $license_id = $this->option('license_id');
+        $notify = $this->option('notify');
+
+        if (!$license_id) {
+            $this->error('ERROR: License ID is required.');
+            return false;
+        }
+
+
+        if (!$license = License::where('id','=',$license_id)->first()) {
+            $this->error('Invalid license ID');
+            return false;
+        }
+
+        $this->info('Checking in ALL seats for '.$license->name);
+
+
+        $licenseSeats = LicenseSeat::where('license_id', '=', $license_id)
+            ->whereNotNull('assigned_to')
+            ->with('user')
+            ->get();
+
+        $this->info(' There are ' .$licenseSeats->count(). ' seats checked out: ');
+
+        if (!$notify) {
+            $this->info('No mail will be sent.');
+        }
+
+        foreach ($licenseSeats as $seat) {
+            $this->info($seat->user->username .' has a license seat for '.$license->name);
+
+            if (!$notify) {
+                $seat->user->email = null;
+            }
+
+            $seat->assigned_to = null;
+
+            if ($seat->save()) {
+                // Log the checkin
+                $seat->logCheckin($license, 'Checked in via cli tool');
+            }
+
+
+
+
+        }
+        
+
+    }
+}

--- a/app/Console/Commands/CheckinLicensesFromAllUsers.php
+++ b/app/Console/Commands/CheckinLicensesFromAllUsers.php
@@ -72,14 +72,15 @@ class CheckinLicensesFromAllUsers extends Command
 
         foreach ($licenseSeats as $seat) {
             $this->info($seat->user->username .' has a license seat for '.$license->name);
-
-            if (!$notify) {
-                $seat->user->email = null;
-            }
-
             $seat->assigned_to = null;
 
             if ($seat->save()) {
+
+                // Override the email address so we don't notify on checkin
+                if (!$notify) {
+                    $seat->user->email = null;
+                }
+
                 // Log the checkin
                 $seat->logCheckin($seat->user, 'Checked in via cli tool');
             }

--- a/app/Console/Commands/CheckinLicensesFromAllUsers.php
+++ b/app/Console/Commands/CheckinLicensesFromAllUsers.php
@@ -81,7 +81,7 @@ class CheckinLicensesFromAllUsers extends Command
 
             if ($seat->save()) {
                 // Log the checkin
-                $seat->logCheckin($license, 'Checked in via cli tool');
+                $seat->logCheckin($seat->user, 'Checked in via cli tool');
             }
 
 

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -41,8 +41,9 @@ trait Loggable
         $settings = Setting::getSettings();
         $log = new Actionlog;
         $log = $this->determineLogItemType($log);
-        if(Auth::user())
+        if (Auth::user()) {
             $log->user_id = Auth::user()->id;
+        }
 
         if (!isset($target)) {
             throw new \Exception('All checkout logs require a target.');
@@ -144,9 +145,11 @@ trait Loggable
 
         $log->location_id = null;
         $log->note = $note;
-        if(Auth::user())
-            $log->user_id = Auth::user()->id;
 
+        if (Auth::user()) {
+            $log->user_id = Auth::user()->id;
+        }
+        
         $log->logaction('checkin from');
 
         $params = [

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -144,7 +144,9 @@ trait Loggable
 
         $log->location_id = null;
         $log->note = $note;
-        $log->user_id = Auth::user()->id;
+        if(Auth::user())
+            $log->user_id = Auth::user()->id;
+
         $log->logaction('checkin from');
 
         $params = [


### PR DESCRIPTION
This is... not my finest work, and could definitely be optimized, but this should allow us to checkin a single license from all users. We'll want to integrate this into the UI once v5 is out. 

The use case here would be, for example, as a company policy you've decided to stop using a particular piece of software (GSuite, for example).

### Usage:

`php artisan snipeit:checkin-from-all --license_id=<license_id>`

First time running it:

<img width="1144" alt="Screen Shot 2020-08-14 at 2 46 59 PM" src="https://user-images.githubusercontent.com/197404/90295158-0f57b900-de3d-11ea-9865-de17951cd2e4.png">

Second time running it:

<img width="1144" alt="Screen Shot 2020-08-14 at 2 47 10 PM" src="https://user-images.githubusercontent.com/197404/90295179-17175d80-de3d-11ea-807f-b5f21ae8fdc5.png">

In working on this, I think I see an issue with the way we (normally) log license checkins where we're setting the target as the license ID instead of the user/asset/whatever. This leads the checkin to be disconnected from the checkin. 

Here you can see two checkouts, but the checkin is no longer connected.

<img width="1380" alt="Screen Shot 2020-08-14 at 2 48 20 PM" src="https://user-images.githubusercontent.com/197404/90295338-96a52c80-de3d-11ea-9e68-32d0f84f6058.png">

<img width="1376" alt="Screen Shot 2020-08-14 at 2 53 29 PM" src="https://user-images.githubusercontent.com/197404/90295465-f0a5f200-de3d-11ea-9dc3-9476a7215b2c.png">

This would also explain why license checkin notifications don't work as expected. We can't send a notification email to a license. 

I'll see if it can fix that in another PR.
