### PR TITLE
Fixed #7919 - LDAP Logins + query filters

### DIFF
--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -63,7 +63,7 @@ class LdapAd extends LdapAdConfiguration
 
         parent::init();
         if($this->isLdapEnabled()) {
-            $this->ldapConfig['account_prefix'] = 'uid=';
+            $this->ldapConfig['account_prefix'] = $this->ldapSettings['ldap_auth_filter_query'];
             $this->ldapConfig['account_suffix'] = ','.$this->ldapConfig['base_dn'];
             $this->ldap = new Adldap();
             $this->ldap->addProvider($this->ldapConfig);

--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -63,6 +63,8 @@ class LdapAd extends LdapAdConfiguration
 
         parent::init();
         if($this->isLdapEnabled()) {
+            $this->ldapConfig['account_prefix'] = 'uid=';
+            $this->ldapConfig['account_suffix'] = ','.$this->ldapConfig['base_dn'];
             $this->ldap = new Adldap();
             $this->ldap->addProvider($this->ldapConfig);
             return true;
@@ -90,12 +92,9 @@ class LdapAd extends LdapAdConfiguration
             $username .= '@' . $this->ldapSettings['ad_domain'];
         }
 
-        try {
-            $this->ldap->auth()->attempt($username, $password);
-        } catch (Exception $e) {
-            Log::error($e->getMessage());
+        if ($this->ldap->auth()->attempt($username, $password, true) === false) {
             throw new Exception('Unable to validate user credentials!');
-        }
+        }    
 
         // Should we sync the logged in user
         Log::debug('Attempting to find user in LDAP directory');


### PR DESCRIPTION
# Description

This helps with LDAP login for v5, just a small enhancement against #7919 . The code had originally assumed that all login queries were going to be of the form `uid=`, but our settings permit the user to specify any auth query they wish (though it defaults to `uid=`) 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've tested this against my JumpCloud setup, and it allows for login for correct passwords and disallows login for incorrect ones.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
