### PR TITLE
Tweak v5 ldap migration for backwards-compatibility with working pre-v5 Active Directory setups

### DIFF
--- a/database/migrations/2020_02_04_172100_add_ad_append_domain_settings.php
+++ b/database/migrations/2020_02_04_172100_add_ad_append_domain_settings.php
@@ -17,8 +17,8 @@ class AddAdAppendDomainSettings extends Migration
         Schema::table('settings', function (Blueprint $table) {
             $table->boolean('ad_append_domain')->nullable(false)->default('0');
         });
+
         $s = Setting::first(); // we are deliberately *not* using the ::getSettings() method, as it caches things, and our Settings table is being migrated right now
-        \Log::info("is ad? ".($s->is_ad)." is enabled? ".($s->ldap_enabled)." ad_domain? ".($s->ad_domain));
         if($s->is_ad && $s->ldap_enabled && $s->ad_domain) { //backwards-compatibility setting; < v5 always appended AD Domains
             $s->ad_append_domain = 1;
             $s->save();

--- a/database/migrations/2020_02_04_172100_add_ad_append_domain_settings.php
+++ b/database/migrations/2020_02_04_172100_add_ad_append_domain_settings.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Models\Setting;
 
 class AddAdAppendDomainSettings extends Migration
 {
@@ -16,7 +17,13 @@ class AddAdAppendDomainSettings extends Migration
         Schema::table('settings', function (Blueprint $table) {
             $table->boolean('ad_append_domain')->nullable(false)->default('0');
         });
-    }
+        $s = Setting::first(); // we are deliberately *not* using the ::getSettings() method, as it caches things, and our Settings table is being migrated right now
+        \Log::info("is ad? ".($s->is_ad)." is enabled? ".($s->ldap_enabled)." ad_domain? ".($s->ad_domain));
+        if($s->is_ad && $s->ldap_enabled && $s->ad_domain) { //backwards-compatibility setting; < v5 always appended AD Domains
+            $s->ad_append_domain = 1;
+            $s->save();
+        }
+}
 
     /**
      * Reverse the migrations.


### PR DESCRIPTION
# Description

A new setting is introduced with v5 - `ad_append_domain`. The DB default is to have it disabled, which seems fine. But for people who had working LDAP configurations in v4 and earlier, that's not how Snipe-IT's LDAP integration worked. The new LDAP code would've generated different-looking usernames.

This modifies the migration back-in-time (which is definitely a little weird!) to force-enable `ad_append_domain` IF you have LDAP enabled, are *already* using AD, *and* have an `ad_domain` already set.

If we've got it right, that means that people with working AD setups in v4 should have it "just work" in v5.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I ran the migration back and forth repeatedly with and without those values being set, and the new field toggled on or stayed off apppropriately.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
