### PR TITLE
Checkout/checkin of multiple licenses

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -375,7 +375,21 @@ class AssetsController extends Controller
      */
     public function selectlist(Request $request)
     {
+        $assets = self::getAssetSelectList($request);
+ 
+        $assets = self::prepareForSelectList($assets);
 
+        return (new SelectlistTransformer)->transformSelectlist($assets);
+    }
+
+    /**
+     * Gets a prepared list for users to use in select2 menus
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v5.0]
+     */
+    public static function getAssetSelectList(Request $request)
+    {
         $assets = Company::scopeCompanyables(Asset::select([
             'assets.id',
             'assets.name',
@@ -393,8 +407,11 @@ class AssetsController extends Controller
         if ($request->filled('search')) {
             $assets = $assets->AssignedSearch($request->input('search'));
         }
+        return $assets;
+    }
 
-
+    public static function prepareForSelectList($assets)
+    {
         $assets = $assets->paginate(50);
 
         // Loop through and set some custom properties for the transformer to use.
@@ -417,8 +434,7 @@ class AssetsController extends Controller
             $asset->use_image = ($asset->getImageUrl()) ? $asset->getImageUrl() : null;
         }
 
-        return (new SelectlistTransformer)->transformSelectlist($assets);
-
+        return $assets;
     }
 
 

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -157,9 +157,7 @@ class UsersController extends Controller
     public function selectlist(Request $request)
     {
         $users = self::getUserSelectList($request);
-
         $users = self::prepareForSelectList($users);
-
         return (new SelectlistTransformer)->transformSelectlist($users);
 
     }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -156,7 +156,22 @@ class UsersController extends Controller
      */
     public function selectlist(Request $request)
     {
+        $users = self::getUserSelectList($request);
 
+        $users = self::prepareForSelectList($users);
+
+        return (new SelectlistTransformer)->transformSelectlist($users);
+
+    }
+
+    /**
+     * Gets a prepared list for users to use in select2 menus
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v5.0]
+     */
+    public static function getUserSelectList(Request $request)
+    {
         $users = User::select(
             [
                 'users.id',
@@ -177,7 +192,11 @@ class UsersController extends Controller
                 ->orWhere('username', 'LIKE', '%'.$request->get('search').'%')
                 ->orWhere('employee_num', 'LIKE', '%'.$request->get('search').'%');
         }
+        return $users;
+    }
 
+    public static function prepareForSelectList($users)
+    {
         $users = $users->orderBy('last_name', 'asc')->orderBy('first_name', 'asc');
         $users = $users->paginate(50);
 
@@ -200,8 +219,7 @@ class UsersController extends Controller
             $user->use_image = ($user->present()->gravatar) ? $user->present()->gravatar : null;
         }
 
-        return (new SelectlistTransformer)->transformSelectlist($users);
-
+        return $users;
     }
 
 

--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Models\License;
 use App\Models\LicenseSeat;
 use App\Models\User;
+use App\Models\Asset;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Input;
@@ -38,6 +39,12 @@ class LicenseCheckinController extends Controller
         return view('licenses/checkin', compact('licenseSeat'))->with('backto', $backTo);
     }
 
+    public function bulkcreate($licenseId, $asset = null, $user = null, $backTo = null)
+    {
+        $license = License::find($licenseId);
+        $this->authorize('checkout', $license);
+        return view('licenses/bulkcheckin', compact('license', 'asset', 'user'))->with('backto', $backTo);
+    }
 
     /**
      * Validates and stores the license checkin action.
@@ -59,6 +66,103 @@ class LicenseCheckinController extends Controller
         }
 
         $license = License::find($licenseSeat->license_id);
+
+        // Declare the rules for the form validation
+        $rules = [
+            'note'   => 'string|nullable',
+        ];
+
+        $requestValid = $this->validateStoreRequest($request, $license, $rules);
+        if ($requestValid !== true) {
+            return $requestValid;
+        }
+
+        $return_to = User::find($licenseSeat->assigned_to);
+
+        $licenseUnassign = $this->unassignLicenseSeat($licenseSeat, $return_to, $request->input('note'));
+        if ($licenseUnassign === true) {
+            if ($backTo=='user') {
+                return redirect()->route("users.show", $return_to->id)->with('success', trans('admin/licenses/message.checkin.success'));
+            }
+            return redirect()->route("licenses.show", $licenseSeat->license_id)->with('success', trans('admin/licenses/message.checkin.success'));
+        }
+        return $licenseUnassign;
+    }
+
+    /**
+     * Validates and stores the license bulk checkin action.
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @author [Michael Pietsch] [<skywalker-11@mi-pietsch.de>]
+     * @see LicenseCheckinController::bulkcreate() method that provides the form view
+     * @since [v5.0]
+     * @param int $licenseId
+     * @param string $backTo
+     * @return \Illuminate\Http\RedirectResponse
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function bulkstore(Request $request, $licenseId = null, $backTo = null)
+    {
+        $license = License::find($licenseId);
+
+        // Declare the rules for the form validation
+        $rules = [
+            'checkout_to_type' => 'in:asset,user',
+            'note'             => 'string|nullable',
+            'qty'              => 'int',
+            'asset_id'         => 'required_if:checkout_to_type,==,asset|nullable',
+            'assigned_to'      => 'required_if:checkout_to_type,==,user|nullable',
+        ];
+
+        if (($request->checkout_to_type == 'asset' && empty($request->asset_id)) ||
+            ($request->checkout_to_type == 'user'  && empty($request->assigned_to)) ||
+            ($request->checkout_to_type != 'asset' && $request->checkout_to_type != 'user')) {
+
+            return redirect()->back()->withInput()->with('error', 'Invalid formular');
+        }
+
+        $requestValid = $this->validateStoreRequest($request, $license, $rules);
+        if ($requestValid !== true) {
+            return $requestValid;
+        }
+
+        //get license seats matching requested license and user/asset
+        $return_from = null;
+        $licenseSeatsToCheckin = LicenseSeat::where('license_id', $license->id);
+        if (!empty($request->assigned_to)) {
+            $return_from = User::find($request->assigned_to);
+            $licenseSeatsToCheckin = $licenseSeatsToCheckin->where('assigned_to', $request->assigned_to);
+        } elseif (!empty($request->asset_id)) {
+            $return_from = Asset::find($request->asset_id);
+            $licenseSeatsToCheckin = $licenseSeatsToCheckin->where('asset_id', $request->asset_id);
+        }
+
+        //check if the number of license seats we found matches the requested number
+        $licenseSeatsToCheckin = $licenseSeatsToCheckin->take($request->qty)->get();
+        if ($licenseSeatsToCheckin->count() != $request->qty) {
+            return redirect()->route('licenses.show', $license->id)->with('error', 'Not enough license seat assigned to be checked in: only ' . $licenseSeatsToCheckin->count() .'/' . $request->qty);
+        }
+
+        //unassign the license seats
+        foreach($licenseSeatsToCheckin as $licenseSeat) {
+            $licenseUnassign = $this->unassignLicenseSeat($licenseSeat, $return_from, $request->input('note'));
+            if($licenseUnassign !== true) {
+                return $licenseUnassign;
+            }
+        }
+
+        if ($backTo=='user') {
+            return redirect()->route("users.show", $return_to->id)->with('success', trans('admin/licenses/message.checkin.success'));
+        }
+
+        return redirect()->route("licenses.show", $licenseSeat->license_id)->with('success', trans('admin/licenses/message.checkin.success'));
+    }
+
+    protected function validateStoreRequest($request, $license, $rules) {
+        if (is_null($license)) {
+            // Redirect to the asset management page with error
+            return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.not_found'));
+        }
         $this->authorize('checkout', $license);
 
         if (!$license->reassignable) {
@@ -67,38 +171,30 @@ class LicenseCheckinController extends Controller
             return redirect()->back()->withInput();
         }
 
-        // Declare the rules for the form validation
-        $rules = [
-            'note'   => 'string|nullable',
-        ];
-
         // Create a new validator instance from our validation rules
         $validator = Validator::make($request->all(), $rules);
-
         // If validation fails, we'll exit the operation now.
         if ($validator->fails()) {
             // Ooops.. something went wrong
             return redirect()->back()->withInput()->withErrors($validator);
         }
-        $return_to = User::find($licenseSeat->assigned_to);
+        return true;
+    }
 
+    protected function unassignLicenseSeat($licenseSeat, $return_from, $note)
+    {
         // Update the asset data
         $licenseSeat->assigned_to                   = null;
         $licenseSeat->asset_id                      = null;
 
         // Was the asset updated?
         if ($licenseSeat->save()) {
+            event(new CheckoutableCheckedIn($licenseSeat, $return_from, Auth::user(), $note));
 
-            event(new CheckoutableCheckedIn($licenseSeat, $return_to, Auth::user(), $request->input('note')));
-
-            if ($backTo=='user') {
-                return redirect()->route("users.show", $return_to->id)->with('success', trans('admin/licenses/message.checkin.success'));
-            }
-            return redirect()->route("licenses.show", $licenseSeat->license_id)->with('success', trans('admin/licenses/message.checkin.success'));
+            return true;
         }
 
         // Redirect to the license page with error
         return redirect()->route("licenses.index")->with('error', trans('admin/licenses/message.checkin.error'));
     }
-
 }

--- a/app/Http/Requests/LicenseCheckoutRequest.php
+++ b/app/Http/Requests/LicenseCheckoutRequest.php
@@ -25,6 +25,7 @@ class LicenseCheckoutRequest extends FormRequest
     {
         return [
             'note'   => 'string|nullable',
+            'qty'   => 'int',
             'asset_id'  => 'required_without:assigned_to',
         ];
     }

--- a/resources/views/licenses/bulkcheckin.blade.php
+++ b/resources/views/licenses/bulkcheckin.blade.php
@@ -1,0 +1,88 @@
+@extends('layouts/default')
+
+{{-- Page title --}}
+@section('title')
+     {{ trans('admin/licenses/general.checkin') }}
+@parent
+@stop
+
+
+@section('header_right')
+    <a href="{{ URL::previous() }}" class="btn btn-primary pull-right">
+        {{ trans('general.back') }}</a>
+@stop
+
+{{-- Page content --}}
+@section('content')
+    <div class="row">
+        <!-- left column -->
+        <div class="col-md-7">
+            <form class="form-horizontal" method="post" action="{{ route('licenses.bulkcheckin.save', ['licenseId'=>$license->id, 'backTo'=>$backto] ) }}" autocomplete="off">
+                {{csrf_field()}}
+
+                <div class="box box-default">
+                    <div class="box-header with-border">
+                        <h2 class="box-title"> {{ $license->name }}</h2>
+                    </div>
+                    <div class="box-body">
+
+            <!-- license name -->
+            <div class="form-group">
+                <label class="col-sm-2 control-label">{{ trans('admin/hardware/form.name') }}</label>
+                <div class="col-md-6">
+                    <p class="form-control-static">{{ $license->name }}</p>
+                </div>
+            </div>
+
+            <!-- Serial -->
+            <div class="form-group">
+                <label class="col-sm-2 control-label">{{ trans('admin/hardware/form.serial') }}</label>
+                <div class="col-md-6">
+                    <p class="form-control-static">
+                        @can('viewKeys', $license)
+                            {{ $license->serial }}
+                        @else
+                            ------------
+                        @endcan
+                        </p>
+                </div>
+            </div>
+            @if ($user == null && $asset == null)
+                @include ('partials.forms.checkout-selector', ['user_select' => 'true','asset_select' => 'true', 'location_select' => 'false'])
+
+                @include ('partials.forms.edit.user-select-custom-endpoint', ['translated_name' => trans('general.user'), 'fieldname' => 'assigned_to', 'user_select_data_endpoint' => 'licenses/assignedUsers/' . $license->id ])
+
+                @include ('partials.forms.edit.asset-select-custom-endpoint', ['translated_name' => trans('admin/licenses/form.asset'), 'fieldname' => 'asset_id', 'style' => 'display:none;', 'asset_select_data_endpoint' => 'licenses/assignedAssets/' . $license->id])
+            @endif
+
+            <!-- QTY -->
+            <div class="form-group {{ $errors->has('qty') ? ' has-error' : '' }}">
+                <label for="qty" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
+                <div class="col-md-7">
+                   <div class="col-md-2" style="padding-left:0px">
+                       <input class="form-control" type="number" name="qty" aria-label="qty" id="qty" value="{{ old('qty', 1) }}" min="1" step="1" />
+                   </div>
+                   {!! $errors->first('qty', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
+                </div>
+            </div>
+
+
+            <!-- Note -->
+            <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
+                <label for="note" class="col-md-2 control-label">{{ trans('admin/hardware/form.notes') }}</label>
+                <div class="col-md-7">
+                    <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
+                    {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
+                </div>
+            </div>
+                        <div class="box-footer">
+                            <a class="btn btn-link" href="{{ route('licenses.index') }}">{{ trans('button.cancel') }}</a>
+                            <button type="submit" class="btn btn-primary pull-right"><i class="fa fa-check icon-white" aria-hidden="true"></i> {{ trans('general.checkin') }}</button>
+                        </div>
+                    </div> <!-- /.box-->
+            </form>
+        </div> <!-- /.col-md-7-->
+    </div>
+
+
+@stop

--- a/resources/views/licenses/checkout.blade.php
+++ b/resources/views/licenses/checkout.blade.php
@@ -53,6 +53,18 @@
 
                     @include ('partials.forms.edit.asset-select', ['translated_name' => trans('admin/licenses/form.asset'), 'fieldname' => 'asset_id', 'style' => 'display:none;'])
 
+                    @if (request('seatId') == null)
+                    <!-- QTY -->
+                    <div class="form-group {{ $errors->has('qty') ? ' has-error' : '' }}">
+                         <label for="qty" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
+                         <div class="col-md-7">
+                           <div class="col-md-2" style="padding-left:0px">
+                               <input class="form-control" type="number" name="qty" aria-label="qty" id="qty" value="{{ old('qty', 1) }}" min="1" step="1" />
+                           </div>
+                           {!! $errors->first('qty', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
+                       </div>
+                    </div>
+                    @endif
 
                     <!-- Note -->
                     <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -17,6 +17,7 @@
     <ul class="dropdown-menu" role="menu">
         <li role="menuitem"><a href="{{ route('licenses.edit', ['license' => $license->id]) }}">{{ trans('admin/licenses/general.edit') }}</a></li>
         <li role="menuitem"><a href="{{ route('clone/license', $license->id) }}">{{ trans('admin/licenses/general.clone') }}</a></li>
+        <li role="menuitem"><a href="{{ route('licenses.bulkcheckin', $license->id) }}">{{ trans('admin/licenses/general.checkin') }}</a></li>
     </ul>
    @endcan
 </div>

--- a/resources/views/partials/forms/edit/asset-select-custom-endpoint.blade.php
+++ b/resources/views/partials/forms/edit/asset-select-custom-endpoint.blade.php
@@ -1,0 +1,20 @@
+<!-- Asset -->
+<div id="assigned_asset" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
+    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
+        <select class="js-data-ajax select2" data-endpoint="{{ $asset_select_data_endpoint }}" data-placeholder="{{ trans('general.select_asset') }}" aria-label="{{ $fieldname }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_asset_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}{!! (!empty($asset_status_type)) ? ' data-asset-status-type="' . $asset_status_type . '"' : '' !!}>
+
+            @if ((!isset($unselect)) && ($asset_id = old($fieldname, (isset($asset) ? $asset->id  : (isset($item) ? $item->{$fieldname} : '')))))
+                <option value="{{ $asset_id }}" selected="selected" role="option" aria-selected="true"  role="option">
+                    {{ (\App\Models\Asset::find($asset_id)) ? \App\Models\Asset::find($asset_id)->present()->fullName : '' }}
+                </option>
+            @else
+                @if(!isset($multiple))
+                    <option value=""  role="option">{{ trans('general.select_asset') }}</option>
+                @endif
+            @endif
+        </select>
+    </div>
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+
+</div>

--- a/resources/views/partials/forms/edit/user-select-custom-endpoint.blade.php
+++ b/resources/views/partials/forms/edit/user-select-custom-endpoint.blade.php
@@ -1,0 +1,27 @@
+<div id="assigned_user" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
+
+    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+
+    <div class="col-md-6{{  ((isset($required)) && ($required=='true')) ? ' required' : '' }}">
+        <select class="js-data-ajax" data-endpoint="{{ $user_select_data_endpoint }}" data-placeholder="{{ trans('general.select_user') }}" name="{{ $fieldname }}" style="width: 100%" id="assigned_user_select" aria-label="{{ $fieldname }}">
+            @if ($user_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
+                <option value="{{ $user_id }}" selected="selected" role="option" aria-selected="true"  role="option">
+                    {{ (\App\Models\User::find($user_id)) ? \App\Models\User::find($user_id)->present()->fullName : '' }}
+                </option>
+            @else
+                <option value=""  role="option">{{ trans('general.select_user') }}</option>
+            @endif
+        </select>
+    </div>
+
+    <div class="col-md-1 col-sm-1 text-left">
+        @can('create', \App\Models\User::class)
+            @if ((!isset($hide_new)) || ($hide_new!='true'))
+                <a href='{{ route('modal.show', 'user') }}' data-toggle="modal"  data-target="#createModal" data-select='assigned_user_select' class="btn btn-sm btn-primary">New</a>
+            @endif
+        @endcan
+    </div>
+
+    {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -493,6 +493,18 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
                 'uses'=> 'LicensesController@selectlist'
             ]
         );
+        Route::get('assignedUsers/{licenseId}/selectlist',
+            [
+                'as' => 'api.license.assignedusers',
+                'uses' => 'LicensesController@assignedusers'
+            ]
+        );
+        Route::get('assignedAssets/{licenseId}/selectlist',
+            [
+                'as' => 'api.license.assignedassets',
+                'uses' => 'LicensesController@assignedassets'
+            ]
+        );
 
     }); // Licenses group
 

--- a/routes/web/licenses.php
+++ b/routes/web/licenses.php
@@ -28,6 +28,15 @@ Route::group([ 'prefix' => 'licenses', 'middleware' => ['auth'] ], function () {
     'uses' => 'Licenses\LicenseCheckinController@store'
     ]);
 
+    Route::get('{licenseId}/bulkcheckin/{backto?}', [
+    'as' => 'licenses.bulkcheckin',
+    'uses' => 'Licenses\LicenseCheckinController@bulkcreate'
+    ]);
+    Route::post('{licenseId}/bulkcheckin/{backto?}', [
+    'as' => 'licenses.bulkcheckin.save',
+    'uses' => 'Licenses\LicenseCheckinController@bulkstore'
+    ]);
+
     Route::post(
     '{licenseId}/upload',
     [ 'as' => 'upload/license', 'uses' => 'Licenses\LicenseFilesController@store' ]


### PR DESCRIPTION
# Description

Enables checkout/checkin of multiple license per asset/user

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Checkout multiple licenses via Checkout button on license overview
- Checkin multiple licenses via License View "Checkin License Seat" action (only user/assets with checkout seats shown)
- Checkin/checkout single specific license seat via License Seats overview

**Test Configuration**:
* PHP version:7.4
* MySQL version: MariaDB 10.4
* Webserver version: Apache2.4
* OS version: Debian 10


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
