### PR TITLE
ES_ES double UserUser String in the login form

### DIFF
--- a/resources/lang/es-ES/admin/users/table.php
+++ b/resources/lang/es-ES/admin/users/table.php
@@ -30,7 +30,7 @@ return array(
     'title' 				=> 'Puesto',
 	'to_restore_them'		=> 'para restaurarlos.',
     'updateuser' 			=> 'Actualizar Usuario',
-    'username' 				=> 'UsuarioUsuario',
+    'username' 				=> 'Usuario',
 	'user_deleted_text' 	=> 'Este usuario ha sido marcado como eliminado.',
     'username_note' 		=> '(Esto se usa solo para la conexión con Active Directory, no para el inicio de sesión.)',
     'cloneuser'             => 'Clonar Usuario',


### PR DESCRIPTION
in the login form in spanish langs, show 2 times "UserUser" in spanish "UsuarioUsuario"

# Description

Double username on Spanish Lang login Screen

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Fixes # (7558)

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:

Snipe-IT Version 4.7.6 to 4.9.0
OS: [Zorin OS 15.3 (Ubuntu 18.04)]
Web Server: [Apache]
PHP Version 7.2


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
