### PR TITLE
Fix [ch15188] 500 error

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -186,7 +186,7 @@ class SettingsController extends Controller
             Auth::login($user, true);
             $settings->save();
 
-            if ('1' == get('email_creds')) {
+            if ($request->input('email_creds') == '1') {
                 $data               = [];
                 $data['email']      = $user->email;
                 $data['username']   = $user->username;
@@ -347,7 +347,7 @@ class SettingsController extends Controller
 
         $setting->depreciation_method = $request->input('depreciation_method');
 
-        if ('' != get('per_page')) {
+        if ($request->input('per_page') != '') {
             $setting->per_page = $request->input('per_page');
         } else {
             $setting->per_page = 200;
@@ -1149,7 +1149,7 @@ class SettingsController extends Controller
     public function postPurge(Request $request)
     {
         if (! config('app.lock_passwords')) {
-            if ('DELETE' == $request->get('confirm_purge')) {
+            if ('DELETE' == $request->input('confirm_purge')) {
                 // Run a backup immediately before processing
                 Artisan::call('backup:run');
                 Artisan::call('snipeit:purge', ['--force' => 'true', '--no-interaction' => true]);


### PR DESCRIPTION
# Description
In the SettingsController.php there was a comparison like `if('' != get('per_page))` where the `get()` function wasn't unable to get resolved to a valid function. I explicitly changed the call to that function so the expression knows the scope where the function exists.

Fixes # (issue)
Related to [ch15188]

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)