### PR TITLE
Update labels.blade.php

### DIFF
--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -11,7 +11,7 @@
 $settings->labels_width = $settings->labels_width - $settings->labels_display_sgutter;
 $settings->labels_height = $settings->labels_height - $settings->labels_display_bgutter;
 // Leave space on bottom for 1D barcode if necessary
-$qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='') ? $settings->labels_height - .3 : $settings->labels_height - .3;
+$qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='') ? $settings->labels_height - .3 : $settings->labels_height - 0.1;
 ?>
 
 <style>
@@ -61,8 +61,8 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='')
         height: {{ $settings->labels_height }}in;
         padding-top: {{$settings->labels_display_bgutter}}in;
         font-family: arial, helvetica, sans-serif;
-        font-size: {{$settings->labels_fontsize}};
-        padding-right: .01in;
+        font-size: {{$settings->labels_fontsize}}pt;
+        padding-right: .0001in;
         overflow: hidden !important;
         display: inline;
         word-wrap: break-word;


### PR DESCRIPTION
- Make the qr_size bigger when no barcode printed.
- BUG: Missing unit of font size for .qr-text class.
- Reduce padding-right to remove the additional space above text when print from Google Chrome. (I do not know the cause. I tried "box-sizing: border-box" without success.)

# Description

A few bug fixes. Tested on Google Chrome 85.0.4183.102 (Official Build) (64-bit) to print on Brother P-touch 2730.