### PR TITLE
No longer toggle the 'disabled' attribute for ldap_server based on is_ad

### DIFF
--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -355,7 +355,7 @@
             if( $('#is_ad').prop('checked') === false) {
                 $('#ad_domain').prop('disabled', 'disabled');
             } else {
-                $('#ldap_server').prop('disabled', 'disabled');
+                //$('#ldap_server').prop('disabled', 'disabled');
             }
         });
 
@@ -364,7 +364,7 @@
          */
         $('#is_ad').on('ifClicked', function(){
             $('#ad_domain').toggleDisabled();
-            $('#ldap_server').toggleDisabled();
+            //$('#ldap_server').toggleDisabled();
         });
 
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Fixes #8424 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I toggled the "This is an Active Directory Server" repeatedly and the ldap server field no longer toggled its 'disabled' attribute.

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
