### PR TITLE
Added utility to delete barcode cache from labels/barcodes setting

### DIFF
--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -9,10 +9,12 @@ use App\Notifications\MailTest;
 use App\Services\LdapAd;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
 use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Storage;
 
 class SettingsController extends Controller
 {
@@ -142,6 +144,51 @@ class SettingsController extends Controller
         return response()->json(['message' => 'Mail would have been sent, but this application is in demo mode! '], 200);
 
     }
+
+
+    /**
+     * Delete server-cached barcodes
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v5.0.0]
+     * @return Response
+     */
+    public function purgeBarcodes()
+    {
+
+        $file_count = 0;
+        $files = Storage::disk('public')->files('barcodes');
+
+        foreach ($files as $file) { // iterate files
+
+            $file_parts = explode(".", $file);
+            $extension = end($file_parts);
+            \Log::debug($extension);
+
+            // Only generated barcodes would have a .png file extension
+            if ($extension =='png') {
+
+                \Log::debug('Deleting: '.$file);
+
+
+                try  {
+                    Storage::disk('public')->delete($file);
+                    \Log::debug('Deleting: '.$file);
+                    $file_count++;
+                } catch (\Exception $e) {
+                    \Log::debug($e);
+                }
+            }
+
+        }
+
+        return response()->json(['message' => 'Deleted '.$file_count.' barcodes'], 200);
+
+    }
+
+
+
+
 
     /**
      * Get a list of login attempts

--- a/resources/views/settings/barcodes.blade.php
+++ b/resources/views/settings/barcodes.blade.php
@@ -112,7 +112,7 @@
                             </div>
                         </div>
 
-                        <!-- Nule barcodes -->
+                        <!-- Nuke barcode cache -->
                         <div class="form-group">
                             <div class="col-md-3">
                                 {{ Form::label('purge_barcodes', 'Purge Barcodes') }}

--- a/resources/views/settings/barcodes.blade.php
+++ b/resources/views/settings/barcodes.blade.php
@@ -157,14 +157,14 @@
 @push('js')
 
     <script nonce="{{ csrf_token() }}">
-        // Test Mail
+        // Delete barcodes
         $("#purgebarcodes").click(function(){
             $("#purgebarcodesrow").removeClass('text-success');
             $("#purgebarcodesrow").removeClass('text-danger');
             $("#purgebarcodesicon").html('');
             $("#purgebarcodesstatus").html('');
             $('#purgebarcodesstatus-error').html('');
-            $("#purgebarcodesicon").html('<i class="fa fa-spinner spin"></i> Sending Test Email...');
+            $("#purgebarcodesicon").html('<i class="fa fa-spinner spin"></i> Attempting to delete files...');
             $.ajax({
                 url: '{{ route('api.settings.purgebarcodes') }}',
                 type: 'POST',

--- a/resources/views/settings/barcodes.blade.php
+++ b/resources/views/settings/barcodes.blade.php
@@ -58,7 +58,7 @@
                                     {{ Form::label('barcode_type', trans('admin/settings/general.barcode_type')) }}
                                 </div>
                                 <div class="col-md-9">
-                                    {!! Form::barcode_types('barcode_type', old('barcode_type', $setting->barcode_type), 'select2') !!}
+                                    {!! Form::barcode_types('barcode_type', old('barcode_type', $setting->barcode_type), 'select2 col-md-4') !!}
                                     {!! $errors->first('barcode_type', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
                                 </div>
                             </div>
@@ -80,13 +80,13 @@
                                     {{ Form::label('alt_barcode', trans('admin/settings/general.alt_barcode_type')) }}
                                 </div>
                                 <div class="col-md-9">
-                                    {!! Form::alt_barcode_types('alt_barcode', old('alt_barcode', $setting->alt_barcode), 'select2') !!}
+                                    {!! Form::alt_barcode_types('alt_barcode', old('alt_barcode', $setting->alt_barcode), 'select2 col-md-4') !!}
                                     {!! $errors->first('barcode_type', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
                                 </div>
                             </div>
                         @else
                             <span class="help-block col-md-offset-3 col-md-12">
-                    {{ trans('admin/settings/general.php_gd_warning') }}
+                                {{ trans('admin/settings/general.php_gd_warning') }}
                                 <br>
                                 {{ trans('admin/settings/general.php_gd_info') }}
                   </span>
@@ -112,6 +112,27 @@
                             </div>
                         </div>
 
+                        <!-- Nule barcodes -->
+                        <div class="form-group">
+                            <div class="col-md-3">
+                                {{ Form::label('purge_barcodes', 'Purge Barcodes') }}
+                            </div>
+                            <div class="col-md-9" id="purgebarcodesrow">
+                                <a class="btn btn-default btn-sm pull-left" id="purgebarcodes" style="margin-right: 10px;">
+                                    Delete Barcode Cache</a>
+                                <span id="purgebarcodesicon"></span>
+                                <span id="purgebarcodesresult"></span>
+                                <span id="purgebarcodesstatus"></span>
+                            </div>
+                            <div class="col-md-9 col-md-offset-3">
+                                <div id="purgebarcodesstatus-error" class="text-danger"></div>
+                            </div>
+                            <div class="col-md-9 col-md-offset-3">
+                                <p class="help-block">This will attempt to delete cached barcodes. This would typically only be used if your barcode dettings have changed, or if your Snipe-IT URL has changed. Barcodes will be re-generated when accessed next.</p>
+                            </div>
+
+                        </div>
+
 
                     </div>
 
@@ -132,3 +153,61 @@
     {{Form::close()}}
 
 @stop
+
+@push('js')
+
+    <script nonce="{{ csrf_token() }}">
+        // Test Mail
+        $("#purgebarcodes").click(function(){
+            $("#purgebarcodesrow").removeClass('text-success');
+            $("#purgebarcodesrow").removeClass('text-danger');
+            $("#purgebarcodesicon").html('');
+            $("#purgebarcodesstatus").html('');
+            $('#purgebarcodesstatus-error').html('');
+            $("#purgebarcodesicon").html('<i class="fa fa-spinner spin"></i> Sending Test Email...');
+            $.ajax({
+                url: '{{ route('api.settings.purgebarcodes') }}',
+                type: 'POST',
+                headers: {
+                    "X-Requested-With": 'XMLHttpRequest',
+                    "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr('content')
+                },
+                data: {},
+                dataType: 'json',
+
+                success: function (data) {
+                    console.dir(data);
+                    $("#purgebarcodesicon").html('');
+                    $("#purgebarcodesstatus").html('');
+                    $('#purgebarcodesstatus-error').html('');
+                    $("#purgebarcodesstatus").removeClass('text-danger');
+                    $("#purgebarcodesstatus").addClass('text-success');
+                    if (data.message) {
+                        $("#purgebarcodesstatus").html('<i class="fa fa-check text-success"></i> ' + data.message);
+                    }
+                },
+
+                error: function (data) {
+
+                    $("#purgebarcodesicon").html('');
+                    $("#purgebarcodesstatus").html('');
+                    $('#purgebarcodesstatus-error').html('');
+                    $("#purgebarcodesstatus").removeClass('text-success');
+                    $("#purgebarcodesstatus").addClass('text-danger');
+                    $("#purgebarcodesicon").html('<i class="fa fa-exclamation-triangle text-danger"></i>');
+                    $('#purgebarcodesstatus').html('Files could not be deleted.');
+                    if (data.responseJSON) {
+                        $('#purgebarcodesstatus-error').html('Error: ' + data.responseJSON.messages);
+                    } else {
+                        console.dir(data);
+                    }
+
+                }
+
+
+            });
+        });
+
+    </script>
+
+@endpush

--- a/routes/api.php
+++ b/routes/api.php
@@ -635,6 +635,11 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
         'uses' => 'SettingsController@ldapAdSettingsTest'
     ]);
 
+    Route::post('settings/purge_barcodes', [
+        'as' => 'api.settings.purgebarcodes',
+        'uses' => 'SettingsController@purgeBarcodes'
+    ]);
+
     Route::get('settings/login-attempts', [
         'middleware' => ['auth', 'authorize:superuser'],
         'as' => 'api.settings.login_attempts',


### PR DESCRIPTION
This is for-sure not the more elegant way to handle this - lots of jquery style nesting that we could probably skip, and after v5, we'll hopefully be finding another way to generate barcodes that doesn't require them to be cached on the server, but this fits a need for now at least.

Similar to the mail "test" button in the General Settings, this simply calls an Ajax command that walks the barcode directory and deletes anything that ends in png. 