### PR TITLE
Modify Snipe-IT v5 AD handling to use the same ldap_host as for LDAP

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -197,14 +197,14 @@ class LdapSync extends Command
             } else {
                 $errors = '';
                 foreach ($user->getErrors()->getMessages() as  $error) {
-                    $errors .= $error[0];
+                    $errors .= implode(", ",$error);
                 }
-                $summary['note']   = $userMsg.' was not imported. REASON: '.$errors;
+                $summary['note']   = $snipeUser->getDN().' was not imported. REASON: '.$errors;
                 $summary['status'] = 'ERROR';
             }
         }
 
-        $summary['note'] = ($user->getOriginal('username') ? 'UPDATED' : 'CREATED');
+        // $summary['note'] = ($user->getOriginal('username') ? 'UPDATED' : 'CREATED'); // this seems, kinda, like, superfluous, relative to the $summary['note'] thing above, yeah?
         $this->summary->push($summary);
     }
 
@@ -265,7 +265,7 @@ class LdapSync extends Command
                 $this->info($msg);
             }
 
-            $this->mappedLocations = $locations->pluck('ldap_ou', 'id');
+            $this->mappedLocations = $locations->pluck('ldap_ou', 'id'); // TODO: this seems ok-ish, but the key-> value is going location_id -> OU name, and the primary action here is the opposite of that - going from OU's to location ID's.
         }
     }
 

--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -286,13 +286,15 @@ class LdapAd extends LdapAdConfiguration
         // Check to see if the user is in a mapped location
         if ($mappedLocations) {
             $location = $mappedLocations->filter(function ($value, $key) use ($user) {
-                if ($user->inOu($value)) {
-                    return $key;
+                //if ($user->inOu($value)) { // <----- *THIS* seems not to be working, and it seems more 'intelligent' - but it's literally just a strpos() call, and it doesn't work quite right against plain strings
+                $user_ou = substr($user->getDn(), -strlen($value)); // get the LAST chars of the user's DN, the count of those chars being the length of the thing we're checking against
+                if(strcasecmp($user_ou, $value) === 0) { // case *IN*sensitive comparision - some people say OU=blah, some say ou=blah. returns 0 when strings are identical (which is a little odd, yeah)
+                    return $key; // WARNING: we are doing a 'filter' - not a regular for-loop. So the answer(s) get "return"ed into the $location array
                 }
             });
 
             if ($location->count() > 0) {
-                $locationId = $location->keys()->first();
+                $locationId = $location->keys()->first(); // from the returned $location array from the ->filter() method above, we return the first match - there should be only one
             }
         }
 

--- a/app/Services/LdapAdConfiguration.php
+++ b/app/Services/LdapAdConfiguration.php
@@ -248,11 +248,14 @@ class LdapAdConfiguration
      */
     private function getServerUrlBase(): array
     {
-        if ($this->ldapSettings['is_ad']) {
+        /* if ($this->ldapSettings['is_ad']) {
             return collect(explode(',', $this->ldapSettings['ad_domain']))->map(function ($item) {
                 return trim($item);
             })->toArray();
-        }
+        } */ // <- this was the *original* intent of the PR for AdLdap2, but we've been moving away from having
+             // two separate fields - one for "ldap_host" and one for "ad_domain" - towards just using "ldap_host"
+             // ad_domain for us just means "append this domain to your usernames for login, if you click that checkbox"
+             // that's all, nothing more (I hope).
 
         $url = $this->getLdapServerData('host');
         return $url ? [$url] : [];


### PR DESCRIPTION
It should also improve OU handling.

# Description

Snipe-IT v5 latest release candidates have had several reports of problems with AD's version of LDAP, and I think this solves most of them. There're also some comments that clarifiy some code that I found a little confusing on the first few read-throughs. 

I should note that I've changed some of the original _intent_ of the original PR. Originally, it the author wanted to have completely separate fields for your AD server, versus your LDAP servers. Since AD is simply just a particulary 'flavor' of LDAP, I decided to not go that way, because:

a) It makes the upgrade process smoother
b) It's more consistent with our v4 and v5 documentation
c) It fits with some of our customer use-cases a little better (some customers may have an AD domain of "blah.whatever.thing" but that particular name may not be able to be directly resolved by Snipe-IT. For example, our own internal AD server is set up that way.).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested against a working v.4.x config, and then upgraded to v5. I got it to the point where the code worked with the same config as that worked against v4.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
