### PR TITLE
Ensure misdefined active flags will not prevent user syncing

### DIFF
--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -237,8 +237,17 @@ class LdapAd extends LdapAdConfiguration
      */
     private function isLdapSync(AdldapUser $user): bool
     {
-        return (false == $this->ldapSettings['ldap_active_flag'])
-            || ('true' == strtolower($user->{$this->ldapSettings['ldap_active_flag']}[0]));
+        if ( !$this->ldapSettings['ldap_active_flag']) {
+            return true; // always sync if you didn't define an 'active' flag
+        }
+       
+        if ( $user->{$this->ldapSettings['ldap_active_flag']} &&                           // if your LDAP user has the aforementioned flag as an attribute *AND* 
+             count($user->{$this->ldapSettings['ldap_active_flag']}) == 1 &&               // if that attribute has exactly one value *AND* 
+             strtolower($user->{$this->ldapSettings['ldap_active_flag']}[0]) == 'false') { // that value is the string 'false' (regardless of case), 
+            return false;                                                                  // then your user is *INACTIVE* - return false
+        }
+        // otherwise, return true
+        return true;
     }
 
     /**


### PR DESCRIPTION
If an IT person were to inadvertently mis-define their `ldap_active_flag` flag in Snipe-IT, no LDAP users would've been able to log in. The `isLdapSync()` method would either return `false`, or raise an Exception.

Unfortunately, this is a very common misconfiguration, especially in Active Directory implementations. Previous Snipe-IT versions would loosely permit those misconfigurations and allow LDAP users to log in, regardless. Without fixing this, those misconfigured installations would suddenly stop permitting all LDAP logins.