### PR TITLE
Fixed #8580: ReportsController called method on NULL Object

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -682,7 +682,7 @@ class ReportsController extends Controller
                             $diff = ($asset->purchase_cost - $depreciation);
                             $row[]        = Helper::formatCurrencyOutput($depreciation);
                             $row[]        = Helper::formatCurrencyOutput($diff);
-                            $row[]        = ($asset->depreciation ? $asset->depreciated_date()->format('Y-m-d') : '';
+                            $row[]        = ($asset->depreciation) ? $asset->depreciated_date()->format('Y-m-d') : '';
                     }
 
                     if ($request->filled('checkout_date')) {

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -682,7 +682,7 @@ class ReportsController extends Controller
                             $diff = ($asset->purchase_cost - $depreciation);
                             $row[]        = Helper::formatCurrencyOutput($depreciation);
                             $row[]        = Helper::formatCurrencyOutput($diff);
-                            $row[]        = ($asset->depreciated_date()!='') ? $asset->depreciated_date()->format('Y-m-d') : '';
+                            $row[]        = ($asset->depreciation ? $asset->depreciated_date()->format('Y-m-d') : '';
                     }
 
                     if ($request->filled('checkout_date')) {


### PR DESCRIPTION
# Description

Having Assets based on a model with no Depreciation results in Depreciable.php: this->get_depreciation() == NULL 
(app/Models/Depreciable.php:155)

So ```$asset->depreciated_date()``` MUST not be called if there is no depreciation set

But ReporsController checked ```$asset->depreciated_date()!=''``` but this requires $asset->depreciated_date() to be evaluated and inside this function error 500 occurs.

Now i'm checking ```$asset->depreciation``` as in resources\views\hardware\view.blade.php and resources\views\hardware\qr-view.blade.php 

Fixes #8580 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Docker build from own repo
