### PR TITLE
Possible fix to #8563 - unset $ldapUsers to avoid OOM'ing

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -117,7 +117,7 @@ class LdapSync extends Command
             $this->dryrun = true;
         }
         $this->checkIfLdapIsEnabled();
-        $this->checkLdapConnetion();
+        $this->checkLdapConnection();
         $this->setBaseDn();
         $this->getUserDefaultLocation();
         /*
@@ -247,7 +247,9 @@ class LdapSync extends Command
         }
 
         if ($ldapUsers->getCurrentPage() < $ldapUsers->getPages()-1) {
-            $this->processLdapUsers($ldapUsers->getCurrentPage() + 1);
+            $current_page = $ldapUsers->getCurrentPage();
+            unset($ldapUsers); //deliberately unset the variable so we don't OOM
+            $this->processLdapUsers($current_page + 1); //this recursive call means that the $ldapUsers variable is not going to get GC'ed until everything returns. Blech.
         }
     }
 
@@ -355,7 +357,7 @@ class LdapSync extends Command
      *
      * @since 5.0.0
      */
-    private function checkLdapConnetion(): void
+    private function checkLdapConnection(): void
     {
         try {
             $this->ldap->testLdapAdUserConnection();


### PR DESCRIPTION
There was also a typo which I fixed - `checkLdapConnetion` instead of `checkLdapConnection`

We deliberately unset `$ldapUsers` because it's going to be a chunk of 500 or so LDAP users, (and some paging information). We recursively call `processLdapUsers()` over and over to page through the entire directory, but `$ldapUsers` won't get Garbage-Collected until the entire recursive function series completes.

So I temporarily store the current page from the result set, then I deliberately `unset()` the `$ldapUsers` variable before the recursive call is made.

I can't replicate the bug locally, unfortunately, so I can't be certain that this will help, but this seems like it at least won't hurt.