### PR TITLE
Fixes #8462 - move accessory notes into pivot table

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -75,7 +75,8 @@ class AccessoryCheckoutController extends Controller
             'accessory_id' => $accessory->id,
             'created_at' => Carbon::now(),
             'user_id' => Auth::id(),
-            'assigned_to' => $request->get('assigned_to')
+            'assigned_to' => $request->get('assigned_to'),
+            'note' => $request->input('note')
         ]);
 
         DB::table('accessories_users')->where('assigned_to', '=', $accessory->assigned_to)->where('accessory_id', '=', $accessory->id)->first();

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -154,7 +154,6 @@ class AccessoriesController extends Controller
         $offset = request('offset', 0);
         $limit = request('limit', 50);
 
-        $accessory->lastCheckoutArray = $accessory->lastCheckout->toArray();
         $accessory_users = $accessory->users;
         $total = $accessory_users->count();
 

--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -68,8 +68,13 @@ class AccessoriesTransformer
 
 
         $array = array();
+
+
         foreach ($accessory_users as $user) {
+            \Log::debug(print_r($user->pivot, true));
+            \Log::debug(print_r($user->pivot, true));
             $array[] = [
+
                 'assigned_pivot_id' => $user->pivot->id,
                 'id' => (int) $user->id,
                 'username' => e($user->username),
@@ -77,7 +82,8 @@ class AccessoriesTransformer
                 'first_name'=> e($user->first_name),
                 'last_name'=> e($user->last_name),
                 'employee_number' =>  e($user->employee_num),
-                'checkout_notes' => $accessory->lastCheckoutArray[0]['note'],
+                'checkout_notes' => $user->pivot->note,
+                'last_checkout' => Helper::getFormattedDateObject($user->pivot->created_at, 'datetime'),
                 'type' => 'user',
                 'available_actions' => ['checkin' => true]
             ];

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -234,7 +234,7 @@ class Accessory extends SnipeModel
 
     public function users()
     {
-        return $this->belongsToMany('\App\Models\User', 'accessories_users', 'accessory_id', 'assigned_to')->withPivot('id')->withTrashed();
+        return $this->belongsToMany('\App\Models\User', 'accessories_users', 'accessory_id', 'assigned_to')->withPivot('id', 'created_at', 'note')->withTrashed();
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -295,7 +295,8 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function accessories()
     {
-        return $this->belongsToMany('\App\Models\Accessory', 'accessories_users', 'assigned_to', 'accessory_id')->withPivot('id')->withTrashed();
+        return $this->belongsToMany('\App\Models\Accessory', 'accessories_users', 'assigned_to', 'accessory_id')
+            ->withPivot('id', 'created_at', 'note')->withTrashed();
     }
 
     /**

--- a/database/migrations/2020_10_22_233743_move_accessory_checkout_note_to_join_table.php
+++ b/database/migrations/2020_10_22_233743_move_accessory_checkout_note_to_join_table.php
@@ -1,0 +1,84 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Accessory;
+
+class MoveAccessoryCheckoutNoteToJoinTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+//        Schema::table('accessory_checkout', function (Blueprint $table) {
+//            $table->string('note')->nullable(true)->default(null);
+//        });
+
+        // Loop through the checked out accessories, find their related action_log entry, and copy over the note
+        // to the newly created note field
+
+
+        $accessories = Accessory::get();
+        $count = 0;
+
+        foreach ($accessories as $accessory) {
+            $count++;
+
+            foreach ($accessory->users as $join_log) {
+
+                \Log::debug('Looking for accessories_users that match '. $join_log->created_at);
+
+                $log_entries = $accessory
+                    ->assetlog()
+                    ->whereNotNull('note')
+                    ->where('created_at', '=',$join_log->created_at)
+                    ->where('action_type', '=', 'checkout')
+                    ->orderBy('created_at', 'DESC')
+                    ->take('1');
+
+
+                \Log::debug($accessory->toSql());
+
+                $log_entries->get();
+
+                \Log::debug($count. '. Looking for action_logs that match '. $join_log->created_at);
+
+                foreach ($log_entries as $log_entry) {
+                    \Log::debug($log_entries->count().' action_logs that match');
+
+                    \Log::debug($count. '. Checkout date in asset log: '.$log_entry->created_at.' against accessories_users: '.$join_log->created_at);
+
+                    if ($log_entry->created_at == $join_log->created_at) {
+                        \Log::debug($count. '. Note for '.$accessory->name.' checked out on '.$log_entry->created_at.' to '.$log_entry->target_id.' is '.$log_entry->note);
+                    } else {
+                        \Log::debug('No match');
+
+                    }
+                }
+
+            }
+
+
+
+        }
+
+        die();
+
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('accessory_checkout', function (Blueprint $table) {
+            $table->dropColumn('note');
+        });
+    }
+}

--- a/database/migrations/2020_10_22_233743_move_accessory_checkout_note_to_join_table.php
+++ b/database/migrations/2020_10_22_233743_move_accessory_checkout_note_to_join_table.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use App\Models\Accessory;
+use App\Models\Actionlog;
 
 class MoveAccessoryCheckoutNoteToJoinTable extends Migration
 {
@@ -14,49 +15,54 @@ class MoveAccessoryCheckoutNoteToJoinTable extends Migration
      */
     public function up()
     {
-//        Schema::table('accessory_checkout', function (Blueprint $table) {
-//            $table->string('note')->nullable(true)->default(null);
-//        });
+        Schema::table('accessories_users', function (Blueprint $table) {
+            $table->string('note')->nullable(true)->default(null);
+        });
 
         // Loop through the checked out accessories, find their related action_log entry, and copy over the note
         // to the newly created note field
 
-
         $accessories = Accessory::get();
         $count = 0;
+        \Log::debug('Accessory Count:  '. $accessories->count());
 
+
+        // Loop through all of the accessories
         foreach ($accessories as $accessory) {
             $count++;
 
-            foreach ($accessory->users as $join_log) {
+            \Log::debug('Querying join logs');
+            $join_logs = DB::table('accessories_users')->get();
 
+            // Loop through the accessories_users records
+            foreach ($join_logs as $join_log) {
+                \Log::debug($join_logs->count().' join log records');
                 \Log::debug('Looking for accessories_users that match '. $join_log->created_at);
 
-                $log_entries = $accessory
-                    ->assetlog()
-                    ->whereNotNull('note')
-                    ->where('created_at', '=',$join_log->created_at)
+                // Get the records from action_logs so we can copy the notes over to the new notes field
+                // on the accessories_users table
+                $action_log_entries = Actionlog::where('created_at', '=',$join_log->created_at)
+                    ->where('target_id', '=',$join_log->assigned_to)
+                    ->where('item_id', '=',$accessory->id)
+                    ->where('target_type', '=','App\\Models\\User')
                     ->where('action_type', '=', 'checkout')
-                    ->orderBy('created_at', 'DESC')
-                    ->take('1');
+                    ->orderBy('created_at', 'DESC')->get();
 
+                \Log::debug($action_log_entries->count().' matching entries in the action_logs table');
+                \Log::debug('Looking for action_logs that match '. $join_log->created_at);
 
-                \Log::debug($accessory->toSql());
+                foreach ($action_log_entries as $action_log_entry) {
 
-                $log_entries->get();
+                    \Log::debug('Checkout date in asset log: '.$action_log_entry->created_at.' against accessories_users: '.$join_log->created_at);
+                    \Log::debug('Action log: '.$action_log_entry->created_at);
+                    \Log::debug('Join log: '.$join_log->created_at);
 
-                \Log::debug($count. '. Looking for action_logs that match '. $join_log->created_at);
-
-                foreach ($log_entries as $log_entry) {
-                    \Log::debug($log_entries->count().' action_logs that match');
-
-                    \Log::debug($count. '. Checkout date in asset log: '.$log_entry->created_at.' against accessories_users: '.$join_log->created_at);
-
-                    if ($log_entry->created_at == $join_log->created_at) {
-                        \Log::debug($count. '. Note for '.$accessory->name.' checked out on '.$log_entry->created_at.' to '.$log_entry->target_id.' is '.$log_entry->note);
+                    if ($action_log_entry->created_at == $join_log->created_at) {
+                        DB::table('accessories_users')
+                            ->where('id', $join_log->id)
+                            ->update(['note' => $action_log_entry->note]);
                     } else {
                         \Log::debug('No match');
-
                     }
                 }
 
@@ -66,7 +72,6 @@ class MoveAccessoryCheckoutNoteToJoinTable extends Migration
 
         }
 
-        die();
 
     }
 
@@ -77,7 +82,7 @@ class MoveAccessoryCheckoutNoteToJoinTable extends Migration
      */
     public function down()
     {
-        Schema::table('accessory_checkout', function (Blueprint $table) {
+        Schema::table('accessories_users', function (Blueprint $table) {
             $table->dropColumn('note');
         });
     }

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -76,6 +76,7 @@
                 <tr>
                     <th data-searchable="false" data-formatter="usersLinkFormatter" data-sortable="false" data-field="name">{{ trans('general.user') }}</th>
                     <th data-searchable="false" data-sortable="false" data-field="checkout_notes">{{ trans('general.notes') }}</th>
+                    <th data-searchable="false" data-formatter="dateDisplayFormatter" data-sortable="false" data-field="last_checkout">{{ trans('admin/hardware/table.checkout_date') }}</th>
                     <th data-searchable="false" data-sortable="false" data-field="actions" data-formatter="accessoriesInOutFormatter">{{ trans('table.actions') }}</th>
                 </tr>
                 </thead>


### PR DESCRIPTION
This should fix the notes issue reported in #8462, and adds a check-out date for the listings.

The migration is a little gross, as we have to find the matching rows from the `action_logs` table and copy them over into the `accessories_users` table, but it seems to get the job done without having us consistently hammering the `action_logs` table, which can get kinda big over time. 

@uberbrady I'd love your eyes on this, if you can pull down this branch. To test this, check out a few accessories to a few different users before pulling the branch, then pull the branch down, and run migrations. 