### PR TITLE
Fix for legacy location_id=0 issue that can cause failure to checkout/checkin

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -76,9 +76,32 @@ class AssetCheckinController extends Controller
             $asset->status_id =  e($request->get('status_id'));
         }
 
+        // This is just meant to correct legacy issues where some user data would have 0
+        // as a location ID, which isn't valid. Later versions of Snipe-IT have stricter validation
+        // rules, so it's necessary to fix this for long-time users. It's kinda gross, but will help
+        // people (and their data) in the long run
+
+        if ($asset->rtd_location_id=='0') {
+            \Log::debug('Manually override the RTD location IDs');
+            \Log::debug('Original RTD Location ID: '.$asset->rtd_location_id);
+            $asset->rtd_location_id = '';
+            \Log::debug('New RTD Location ID: '.$asset->rtd_location_id);
+        }
+
+        if ($asset->location_id=='0') {
+            \Log::debug('Manually override the location IDs');
+            \Log::debug('Original Location ID: '.$asset->location_id);
+            $asset->location_id = '';
+            \Log::debug('New RTD Location ID: '.$asset->location_id);
+        }
+
         $asset->location_id = $asset->rtd_location_id;
+        \Log::debug('After Location ID: '.$asset->location_id);
+        \Log::debug('After RTD Location ID: '.$asset->rtd_location_id);
+
 
         if ($request->filled('location_id')) {
+            \Log::debug('NEW Location ID: '.$request->get('location_id'));
             $asset->location_id =  e($request->get('location_id'));
         }
 
@@ -97,6 +120,6 @@ class AssetCheckinController extends Controller
             return redirect()->route("hardware.index")->with('success', trans('admin/hardware/message.checkin.success'));
         }
         // Redirect to the asset management page with error
-        return redirect()->route("hardware.index")->with('error', trans('admin/hardware/message.checkin.error'));
+        return redirect()->route("hardware.index")->with('error', trans('admin/hardware/message.checkin.error').$asset->getErrors());
     }
 }

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -80,7 +80,7 @@ class AssetCheckoutController extends Controller
             }
 
             // Redirect to the asset management page with error
-            return redirect()->to("hardware/$assetId/checkout")->with('error', trans('admin/hardware/message.checkout.error'))->withErrors($asset->getErrors());
+            return redirect()->to("hardware/$assetId/checkout")->with('error', trans('admin/hardware/message.checkout.error').$asset->getErrors());
         } catch (ModelNotFoundException $e) {
             return redirect()->back()->with('error', trans('admin/hardware/message.checkout.error'))->withErrors($asset->getErrors());
         } catch (CheckoutNotAllowed $e) {

--- a/database/migrations/2020_10_23_161736_fix_zero_values_for_locations.php
+++ b/database/migrations/2020_10_23_161736_fix_zero_values_for_locations.php
@@ -21,7 +21,7 @@ class FixZeroValuesForLocations extends Migration
         App\Models\Asset::where('rtd_location_id', '=', '0')
             ->update(['rtd_location_id' => null]);
 
-        App\Models\User::where('location_id', '0')
+        App\Models\User::where('location_id', '=', '0')
             ->update(['location_id' => null]);
 
     }

--- a/database/migrations/2020_10_23_161736_fix_zero_values_for_locations.php
+++ b/database/migrations/2020_10_23_161736_fix_zero_values_for_locations.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\User;
+use App\Models\Asset;
+
+class FixZeroValuesForLocations extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $assets = Asset::where('location_id', '=', '0')->orWhere('rtd_location_id', '=', '0')->get();
+        $users = User::where('location_id', '=', '0')->get();
+
+        foreach ($assets as $asset) {
+
+            if ($asset->location_id == '0') {
+                $asset->location_id = '';
+            }
+
+            if ($asset->rtd_location_id == '0') {
+                $asset->rtd_location_id = '';
+            }
+
+            $asset->save();
+
+        }
+
+        foreach ($users as $user) {
+            if ($user->location_id == '0') {
+                $user->location_id = '';
+            }
+
+            $user->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2020_10_23_161736_fix_zero_values_for_locations.php
+++ b/database/migrations/2020_10_23_161736_fix_zero_values_for_locations.php
@@ -15,30 +15,15 @@ class FixZeroValuesForLocations extends Migration
      */
     public function up()
     {
-        $assets = Asset::where('location_id', '=', '0')->orWhere('rtd_location_id', '=', '0')->get();
-        $users = User::where('location_id', '=', '0')->get();
+        App\Models\Asset::where('location_id', '=', '0')
+            ->update(['location_id' => null]);
 
-        foreach ($assets as $asset) {
+        App\Models\Asset::where('rtd_location_id', '=', '0')
+            ->update(['rtd_location_id' => null]);
 
-            if ($asset->location_id == '0') {
-                $asset->location_id = '';
-            }
+        App\Models\User::where('location_id', '0')
+            ->update(['location_id' => null]);
 
-            if ($asset->rtd_location_id == '0') {
-                $asset->rtd_location_id = '';
-            }
-
-            $asset->save();
-
-        }
-
-        foreach ($users as $user) {
-            if ($user->location_id == '0') {
-                $user->location_id = '';
-            }
-
-            $user->save();
-        }
     }
 
     /**


### PR DESCRIPTION
This is a smallish PR that tries to correct the issue of folks not being able to checkin/checkout because they have `0` as a value for either `location_id` or `rtd_location_id`. 

In previous versions of Snipe-IT, we weren't as strict about validating location selections, so it would allow you to save an asset or a user with an invalid `location_id`. This doesn't *exactly* fix that, but rather just tries to correct a zero value for `location_id`, since that would never be valid in our system. It doesn't try to check whether the location is actually valid (as in, there is a record for it in the database that's not been deleted/purged), but it at least tries to correct the 0 issue for legacy systems. 

It includes a migration to do a one-time sweep of the assets and users tables, and also adds a little bit of logic to override that at the checkout/checkin layer, and pass at least slightly more helpful error messages. (Before you would just get "Asset was not checked in", which doesn't really help anyone figure out what's happening.)

The migration is basically the equivalent of running:

```
UPDATE assets SET rtd_location_id = NULL WHERE rtd_location_id='0'; 
UPDATE assets SET location_id = NULL WHERE location_id='0';
UPDATE users SET location_id = NULL WHERE location_id='0';
```