### PR TITLE
Fixed #8561 - Add a new custom validator for Users

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -74,7 +74,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         'password'                => 'required|min:8',
         'locale'                  => 'max:10|nullable',
         'website'                 => 'url|nullable',
-        'manager_id'              => 'nullable|exists:users,id',
+        'manager_id'              => 'nullable|exists:users,id|cant_manage_self',
         'location_id'             => 'exists:locations,id|nullable',
     ];
 

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -107,6 +107,27 @@ class ValidationServiceProvider extends ServiceProvider
             return preg_match('/\p{Z}|\p{S}|\p{P}/', $value);
         });
 
+        Validator::extend('cant_manage_self', function ($attribute, $value, $parameters, $validator) {
+            // $value is the actual *value* of the thing that's being validated
+            // $attribute is the name of the field that the validation is running on - probably manager_id in our case
+            // $parameters are the optional parameters - an array for everything, split on commas. But we don't take any params here.
+            // $validator gives us proper access to the rest of the actual data
+            $data = $validator->getData();
+
+            if(array_key_exists("id", $data)) {
+                if ($value && $value == $data['id']) {
+                    // if you definitely have an ID - you're saving an existing user - and your ID matches your manager's ID - fail.
+                    return false;
+                } else {
+                    return true;
+                }
+            } else {
+                // no 'id' key to compare against (probably because this is a new user)
+                // so it automatically passes this validation
+                return true;
+            }
+        });
+
 
     }
 

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -117,6 +117,7 @@ return array(
         "hashed_pass"      => "Your current password is incorrect",
         "statuslabel_type" => "You must select a valid status label type",
     ],
+    'cant_manage_self'  => "A user cannot be their own manager",
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
To prevent someone from managing themselves.

We can run into all kinds of weird, bizarre problems when a user selects themselves as their own manager.

We tried to prevent this using the `different` validation from Laravel, but that failed when the thing it was comparing to happened to not exist. E.g. when you're comparing `manager_id` to `id` - but this a new user, so there *isn't* an `id` yet.

This PR adds a new custom validator, `cant_manage_self`, which prevents you from selecting yourself as a manager, if-and-only-if you already have an `id` set. Otherwise, it just passes.

I've tested it by doing the following:

- set self as manager on existing user - *FAILS*
- unset manager on existing user - *PASSES*
- set non-self as manager on existing user - *PASSES*
- set no manager on new user - *PASSES*
- set any manager on new user - *PASSES*
- (it's impossible to try to set yourself as your own manager on a new user, since your ID doesn't exist yet. Even if you mangled some kind of API request to do so, it still wouldn't work since the `exists` validation would fail.)

I felt a little weird about dropping a new translation string into the un-namespaced `lang/en/validation.php` - so I'm totally open to other ideas if it needs to get moved around.