### PR TITLE
Fixed #8563 - Clean up AdLdap2 integration to better handle paged result-sets

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -221,12 +221,11 @@ class LdapSync extends Command
      *
      * @since 5.0.0
      *
-     * @param int $page The page to get the result set
      */
-    private function processLdapUsers(int $page=0): void
+    private function processLdapUsers(): void
     {
         try {
-            $ldapUsers = $this->ldap->getLdapUsers($page);
+            $ldapUsers = $this->ldap->getLdapUsers();
         } catch (Exception $e) {
             $this->outputError($e);
             exit($e->getMessage());
@@ -242,14 +241,8 @@ class LdapSync extends Command
         }
 
         // Process each individual users
-        foreach ($ldapUsers as $user) {
+        foreach ($ldapUsers->getResults() as $user) { // AdLdap2's paginate() method is weird, it gets *everything* and ->getResults() returns *everything*
             $this->updateCreateUser($user);
-        }
-
-        if ($ldapUsers->getCurrentPage() < $ldapUsers->getPages()-1) {
-            $current_page = $ldapUsers->getCurrentPage();
-            unset($ldapUsers); //deliberately unset the variable so we don't OOM
-            $this->processLdapUsers($current_page + 1); //this recursive call means that the $ldapUsers variable is not going to get GC'ed until everything returns. Blech.
         }
     }
 


### PR DESCRIPTION
# Description

The way AdLdap2 does paging is a little weird - it fetches the entire result-set, then jams it into an internal `$results` array. I can't really figure out why it does that or how it's intended to be used, and this solution will very likely blow up at or around 10k or more users, but this is at least better than our previous 500 user limit.

We can definitely look at some kind of more 'progressive' loading system in a minor release (probably not in a patch-release though).

Fixes #8563 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I added 1000 users to my test directory, and the LDAP sync code got stuck in an infinite loop
- [X] After this change, the script completed in a reasonable amount of time and all users were added succesfully 

**Test Configuration**:
* PHP version: 7.4.7
* MySQL version: 5.7.29
* Webserver version: nginx/1.19.0
* OS version: MacOS 10.15.7
