### PR TITLE
Fixed #8661 - Added feature to disallow password equal to username, email, etc

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -165,13 +165,18 @@ class ProfileController extends Controller
 
             // There may be a more elegant way to do this in the future.
 
-            if (($request->input('password') == $user->username) ||
-                ($request->input('password') == $user->email) ||
-                ($request->input('password') == $user->first_name) ||
-                ($request->input('password') == $user->last_name))
-            {
-                $validator->errors()->add('password', trans('validation.disallow_same_pwd_as_user_fields'));
+            // First let's see if that option is enabled in the settings
+            if (strpos(Setting::passwordComplexityRulesSaving('store'), 'disallow_same_pwd_as_user_fields')) {
+                \Log::debug('disallow_same_pwd_as_user_fields is ON');
+                if (($request->input('password') == $user->username) ||
+                    ($request->input('password') == $user->email) ||
+                    ($request->input('password') == $user->first_name) ||
+                    ($request->input('password') == $user->last_name))
+                {
+                    $validator->errors()->add('password', trans('validation.disallow_same_pwd_as_user_fields'));
+                }
             }
+
 
 
             

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -156,6 +156,16 @@ class ProfileController extends Controller
             if (!Hash::check($request->input('current_password'), $user->password)) {
                 $validator->errors()->add('current_password', trans('validation.hashed_pass'));
             }
+
+            if (($request->input('password') == $user->username) ||
+                ($request->input('password') == $user->email) ||
+                ($request->input('password') == $user->first_name) ||
+                ($request->input('password') == $user->last_name))
+            {
+                $validator->errors()->add('password', trans('validation.disallow_same_pwd_as_user_fields'));
+            }
+
+
             
         });
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -157,6 +157,14 @@ class ProfileController extends Controller
                 $validator->errors()->add('current_password', trans('validation.hashed_pass'));
             }
 
+            // This checks to make sure that the user's password isn't the same as their username,
+            // email address, first name or last name (see https://github.com/snipe/snipe-it/issues/8661)
+            // While this is handled via SaveUserRequest form request in other places, we have to do this manually
+            // here because we don't have the username, etc form fields available in the profile password change
+            // form.
+
+            // There may be a more elegant way to do this in the future.
+
             if (($request->input('password') == $user->username) ||
                 ($request->input('password') == $user->email) ||
                 ($request->input('password') == $user->first_name) ||

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -94,14 +94,8 @@ class ValidationServiceProvider extends ServiceProvider
         // This ONLY works for create/update user forms, since the Update Profile Password form doesn't
         // include any of these additional validator fields
         Validator::extend('disallow_same_pwd_as_user_fields', function ($attribute, $value, $parameters, $validator) {
-
-
+            
             $data = $validator->getData();
-            \Log::debug('Attribute: '.$attribute);
-            \Log::debug('Value: '. $value);
-            \Log::debug('Parameters: '.print_r($parameters, true));
-            \Log::debug('Data: '.print_r($data, true));
-
 
             if (array_key_exists("username", $data)) {
                 if ($data['username'] == $data['password']) {

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -91,6 +91,48 @@ class ValidationServiceProvider extends ServiceProvider
         });
 
 
+        // This ONLY works for create/update user forms, since the Update Profile Password form doesn't
+        // include any of these additional validator fields
+        Validator::extend('disallow_same_pwd_as_user_fields', function ($attribute, $value, $parameters, $validator) {
+
+
+            $data = $validator->getData();
+            \Log::debug('Attribute: '.$attribute);
+            \Log::debug('Value: '. $value);
+            \Log::debug('Parameters: '.print_r($parameters, true));
+            \Log::debug('Data: '.print_r($data, true));
+
+
+            if (array_key_exists("username", $data)) {
+                if ($data['username'] == $data['password']) {
+                    return false;
+                }
+            }
+
+            if (array_key_exists("email", $data)) {
+                if ($data['email'] == $data['password']) {
+                    return false;
+                }
+            }
+
+            if (array_key_exists("first_name", $data)) {
+                if ($data['first_name'] == $data['password']) {
+                    return false;
+                }
+            }
+
+            if (array_key_exists("last_name", $data)) {
+                if ($data['last_name'] == $data['password']) {
+                    return false;
+                }
+            }
+
+
+           return true;
+
+
+        });
+
         Validator::extend('letters', function ($attribute, $value, $parameters) {
             return preg_match('/\pL/', $value);
         });

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -99,7 +99,7 @@ return array(
     'url'                  => 'The :attribute format is invalid.',
     "unique_undeleted"     => "The :attribute must be unique.",
     "import_field_empty"   => "The value of the Import Field shouldn't be empty",
-    "same_pwd_as_user_fields" => 'The password cannot be the same as the username, email address, or first or last name.',
+    "disallow_same_pwd_as_user_fields" => 'The password cannot be the same as the username, email address, or first or last name.',
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -99,7 +99,7 @@
                             </div>
                             <div class="col-md-9">
 
-                                {{ Form::checkbox("pwd_secure_complexity['same_pwd_as_user_fields']", 'same_pwd_as_user_fields', old('same_pwd_as_user_fields', strpos($setting->pwd_secure_complexity, 'same_pwd_as_user_fields')!==false), array('class' => 'minimal', 'aria-label'=>'pwd_secure_complexity')) }}
+                                {{ Form::checkbox("pwd_secure_complexity['disallow_same_pwd_as_user_fields']", 'disallow_same_pwd_as_user_fields', old('disallow_same_pwd_as_user_fields', strpos($setting->pwd_secure_complexity, 'disallow_same_pwd_as_user_fields')!==false), array('class' => 'minimal', 'aria-label'=>'pwd_secure_complexity')) }}
                                 Password cannot be the same as first name, last name, email, or username<br>
 
 


### PR DESCRIPTION
This should create a setting in the `Admin > Security` section that offers the option to disallow users from using their username, email address, first name or last name as their password. 

Additional info inline in the comments.

There may be a way to handle this more elegantly, i.e. passing the User model to a validator if it exists, but this seemed the most straightforward way to handle it for now. 

### Testing

#### Saving the Settings
1. . Go to `Admin > Security` and click SAVE
2. Confirm the new "Password cannot be the same as first name, last name, email, or username" option remains unchecked
3. Change `Admin > Security` settings to enable the "Password cannot be the same as first name, last name, email, or username" option in Password Complexity
4. Click SAVE
5. Go back to `Admin > Security` settings and confirm it's still checked.

#### Testing Password Validation on Create/Edit
1. Go through creating a new user that would otherwise pass validation but enter their username as their password. (This user will need to have a username, email address, first name and last name that meet your minimum password length requirements)
2. Confirm it fails validation with an error message under the `password` field
3. Try creating that user again with their email address, first name and last name as their password (separate times)
4. Confirm it fails validation with an error message under the `password` field
5. Edit an existing user (with a long enough username), attempting to use their username, email, first name, and last name. (This user will need to have a username, email address, first name and last name that meet your minimum password length requirements)
6. Go back into the `Admin > Security` settings, uncheck the "Password cannot be the same as first name, last name, email, or username" box
7. Click SAVE
8. Confirm that steps 1-5 do *not* fail validation

#### Testing Password Validation on Profile > Edit Password
1. Click on the `Change Password` link under your name in the top right
2. Attempt to change your password to the email address, username, etc of the account you're currently logged in as
3. Confirm it fails validation with an error message under the `password` field
4. Go back into the `Admin > Security` settings, uncheck the "Password cannot be the same as first name, last name, email, or username" box
5. Click SAVE
6. Confirm that steps 1-2 do *not* fail validation

#### Testing Password Validation on Forgotten Password Reset
1. Logout, making a note of the email address, username, etc of the account you want to test this on
2. Click on the "I forgot my password" link and fill it out
3. Click on the reset password link in the email
4. Attempt to change your password to the email address, username, etc of the account you're testing
5. Confirm it fails validation with an error message under the `password` field
5. Go back into the `Admin > Security` settings, uncheck the "Password cannot be the same as first name, last name, email, or username" box
6. Click SAVE
7. Confirm that steps 1-4 do *not* fail validation



