### PR TITLE
Fix AD Accounts with delegation disabled

### DIFF
--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -23,10 +23,33 @@ use Illuminate\Support\Facades\Log;
  */
 class LdapAd extends LdapAdConfiguration
 {
-    /**
-     * @see https://wdmsb.wordpress.com/2014/12/03/descriptions-of-active-directory-useraccountcontrol-value/
-     */
-    const AD_USER_ACCOUNT_CONTROL_FLAGS = ['512', '544', '66048', '66080', '262656', '262688', '328192', '328224', '1049088'];
+    /* The following is _probably_ the correct logic, but we can't use it because
+       some users may have been dependent upon the previous behavior, and this
+       could cause additional access to be available to users they don't want
+       to allow to log in.
+    $useraccountcontrol = $results[$i]['useraccountcontrol'][0];
+    if(
+        // based on MS docs at: https://support.microsoft.com/en-us/help/305144/how-to-use-useraccountcontrol-to-manipulate-user-account-properties
+        ($useraccountcontrol & 0x200) && // is a NORMAL_ACCOUNT
+        !($useraccountcontrol & 0x02) && // *and* _not_ ACCOUNTDISABLE
+        !($useraccountcontrol & 0x10)    // *and* _not_ LOCKOUT
+    ) {
+        $user->activated = 1;
+    } else {
+        $user->activated = 0;
+    } */
+    const AD_USER_ACCOUNT_CONTROL_FLAGS = [
+      '512',    // 0x200    NORMAL_ACCOUNT
+      '544',    // 0x220    NORMAL_ACCOUNT, PASSWD_NOTREQD
+      '66048',  // 0x10200  NORMAL_ACCOUNT, DONT_EXPIRE_PASSWORD
+      '66080',  // 0x10220  NORMAL_ACCOUNT, PASSWD_NOTREQD, DONT_EXPIRE_PASSWORD
+      '262656', // 0x40200  NORMAL_ACCOUNT, SMARTCARD_REQUIRED
+      '262688', // 0x40220  NORMAL_ACCOUNT, PASSWD_NOTREQD, SMARTCARD_REQUIRED
+      '328192', // 0x50200  NORMAL_ACCOUNT, SMARTCARD_REQUIRED, DONT_EXPIRE_PASSWORD
+      '328224', // 0x50220  NORMAL_ACCOUNT, PASSWD_NOT_REQD, SMARTCARD_REQUIRED, DONT_EXPIRE_PASSWORD
+      '4260352',// 0x410200 NORMAL_ACCOUNT, DONT_EXPIRE_PASSWORD, DONT_REQ_PREAUTH
+      '1049088',// 0x100200 NORMAL_ACCOUNT, NOT_DELEGATED
+    ];
 
     /**
      * The LDAP results per page.

--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -26,7 +26,7 @@ class LdapAd extends LdapAdConfiguration
     /**
      * @see https://wdmsb.wordpress.com/2014/12/03/descriptions-of-active-directory-useraccountcontrol-value/
      */
-    const AD_USER_ACCOUNT_CONTROL_FLAGS = ['512', '544', '66048', '66080', '262656', '262688', '328192', '328224'];
+    const AD_USER_ACCOUNT_CONTROL_FLAGS = ['512', '544', '66048', '66080', '262656', '262688', '328192', '328224', '1049088'];
 
     /**
      * The LDAP results per page.


### PR DESCRIPTION
# Description

I have some AD accounts that have delegation disabled, and they are then marked as login disabled. This fixes that issue. This was fixed on v4, but the problem has come back on v5 as the fix was not implemented again

The pull requests that fixed this problem on v4
https://github.com/snipe/snipe-it/pull/8111
https://github.com/snipe/snipe-it/pull/8270

## Type of change
[x] Bug fix (non-breaking change which fixes an issue)

