### PR TITLE
Restore the LDAP_TIME_LIM .env var

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -108,7 +108,7 @@ class LdapSync extends Command
      */
     public function handle()
     {
-        ini_set('max_execution_time', '600'); //600 seconds = 10 minutes
+        ini_set('max_execution_time', env('LDAP_TIME_LIM', 600)); //600 seconds = 10 minutes
         ini_set('memory_limit', '500M');
         $old_error_reporting = error_reporting(); // grab old error_reporting .ini setting, for later re-enablement
         error_reporting($old_error_reporting & ~E_DEPRECATED); // disable deprecation warnings, for LDAP in PHP 7.4 (and greater)


### PR DESCRIPTION
Specifically, for LDAP sync of very large directories.

It looks like we inadvertently blew out the change on the LdapSync Command when we did the big merge for v5. Not shocking, as the entire script had been completely rewritten for the new LDAP system that we use in v5, so it was going to conflict everywhere. In fact, I think it was *me* that broke this, as I was the one who had re-merged the original version of the LdapSync script to shore up v5's LDAP support.

I wish it were called `LDAP_TIME_LIMIT` instead of `LDAP_TIME_LIM`, but especially for upgraders from v4, I'd rather keep the variable name consistent with older versions rather than change it now. And it's already documented as `..._LIM` in our `.env.example` file anyways.