### PR TITLE
Potential fix for empty-page problem in Assets view

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -17,6 +17,16 @@
             stickyHeaderOffsetY += +$('.navbar-fixed-top').css('margin-bottom').replace('px','');
         }
 
+        var blockedFields = "searchable,sortable,switchable,title,visible,formatter,class".split(",");
+
+        var keyBlocked = function(key) {
+            for(var j in blockedFields) {
+                if(key === blockedFields[j]) {
+                    return true;
+                }
+            }
+            return false;
+        }
 
         $('.snipe-table').bootstrapTable('destroy').bootstrapTable({
             classes: 'table table-responsive table-no-bordered',
@@ -42,6 +52,15 @@
             pageList: ['10','20', '30','50','100','150','200', '500'],
             pageSize: {{  (($snipeSettings->per_page!='') && ($snipeSettings->per_page > 0)) ? $snipeSettings->per_page : 20 }},
             paginationVAlign: 'both',
+            queryParams: function (params) {
+                var newParams = {};
+                for(var i in params) {
+                    if(!keyBlocked(i)) { // only send the field if it's not in blockedFields
+                        newParams[i] = params[i];
+                    }
+                }
+                return newParams;
+            },
             formatLoadingMessage: function () {
                 return '<h2><i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Loading... please wait.... </h4>';
             },


### PR DESCRIPTION
# Description

This *may* fix the problems we've seen with extremely-long URL's, such as in #8604 

The problem is this - the system we use to render table-views in Snipe-IT - bootstrap-tables - seems like they might have changed how data gets sent to AJAX back-ends. Specifically, it sends a bunch of fields we don't really care about (`searchable[]` being most common). For customers who are on IIS (which has a very tiny default query-parameter space), or who have a very large number of custom fields, the URL that gets sent via `GET` can grow far too large, causing it to get rejected by the web server (and thus, presenting an empty screen).

This change uses the bootstrap-tables `queryParams` feature to filter out any parameters that we add to a blocklist; and not send those parameters to the back-end. The resulting URL's are far more manageable, and should mostly prevent those web server errors.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I tested all kinds of different sorts and searches to make sure they still worked; they seemed to
- [x] The default view, with no sort or search selected, still seems to work

**Test Configuration**:
* PHP version: 7.4
* MySQL version: 5.7
* Webserver version: nginx/1.19.0
* OS version: macOS Catalina 10.15.7 w/supplemental security update


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes