### PR TITLE
Improved upgrade.php script to check for PHP extensions

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -48,7 +48,10 @@ if (version_compare(PHP_VERSION, $required_version, '<')) {
 
 echo "Checking Required PHP extensions... \n\n";
 
+// Get the list of installed extensions
 $loaded_exts_array = get_loaded_extensions();
+
+// The PHP extensions PHP is *required* to have enabled in order to run
 $required_exts_array =
     [
         'bcmath',
@@ -68,6 +71,8 @@ $required_exts_array =
 
 $ext_missing = '';
 $ext_installed = '';
+
+// Loop through the required extensions 
 foreach ($required_exts_array as $rkey => $required_ext) {
 
     // If we don't find the string in the array....

--- a/upgrade.php
+++ b/upgrade.php
@@ -88,6 +88,7 @@ foreach ($required_exts_array as $required_ext) {
             foreach ($require_either as $require_either_value) {
 
                 if (in_array($require_either_value, $loaded_exts_array)) {
+                    $ext_installed .=  '√ '.$require_either_value." is installed!\n";
                     break;
                 // If no match, add it to the string for errors
                 } else {

--- a/upgrade.php
+++ b/upgrade.php
@@ -37,7 +37,7 @@ if (version_compare(PHP_VERSION, $required_version, '<')) {
     echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ERROR !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
     echo "This version of PHP (".PHP_VERSION.") is not compatible with Snipe-IT.\n";
     echo "Snipe-IT requires PHP version ".$required_version." or greater. Please upgrade \n";
-    echo "your server's version of PHP (mod and cli) and try running this script again.\n\n\n";
+    echo "your version of PHP (web/php-fcgi and cli) and try running this script again.\n\n\n";
     exit;
 
 } else {

--- a/upgrade.php
+++ b/upgrade.php
@@ -111,7 +111,7 @@ foreach ($required_exts_array as $rkey => $required_ext) {
 // Print out a useful error message and abort the install
 if ($ext_missing!='') {
     echo "--------------------------------------------------------\n";
-    echo $ext_missing."\n";
+    echo $ext_missing;
     echo "--------------------------------------------------------\n\n";
     echo "You have the following extensions installed: \n\n";
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -217,8 +217,8 @@ if (file_exists('composer.phar')) {
     $composer = shell_exec('composer install --no-dev --prefer-source');
 }
 
-echo $composer_dump."\n\n";
-echo $composer."\n\n";
+echo $composer_dump."\n";
+echo $composer."\n";
 
 
 echo "--------------------------------------------------------\n";

--- a/upgrade.php
+++ b/upgrade.php
@@ -262,7 +262,7 @@ echo "Step 10: Taking application out of maintenance mode:\n";
 echo "--------------------------------------------------------\n\n";
 
 $up = shell_exec('php artisan up');
-echo '-- '.$up."\n\n";
+echo '-- '.$up."\n";
 
 
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -46,7 +46,7 @@ if (version_compare(PHP_VERSION, $required_version, '<')) {
 }
 
 
-echo "Checking PHP extensions: \n\n";
+echo "Checking Required PHP extensions... \n\n";
 
 $loaded_exts_array = get_loaded_extensions();
 $required_exts_array =

--- a/upgrade.php
+++ b/upgrade.php
@@ -56,6 +56,7 @@ $required_exts_array =
     [
         'bcmath',
         'curl',
+        'farts',
         'fileinfo',
 		'gd|imagick',
         'json',
@@ -72,7 +73,7 @@ $required_exts_array =
 $ext_missing = '';
 $ext_installed = '';
 
-// Loop through the required extensions 
+// Loop through the required extensions
 foreach ($required_exts_array as $rkey => $required_ext) {
 
     // If we don't find the string in the array....

--- a/upgrade.php
+++ b/upgrade.php
@@ -121,7 +121,7 @@ if ($ext_missing!='') {
 
     echo "------------------------- :( ---------------------------\n";
     echo "ABORTING THE INSTALLER  \n";
-    echo "Please install the extensions above and re-run this script.\n\n";
+    echo "Please install the extensions above and re-run this script.\n";
     echo "------------------------- :( ---------------------------\n";
     exit;
 } else {

--- a/upgrade.php
+++ b/upgrade.php
@@ -184,7 +184,7 @@ $unused_files = [
 foreach ($unused_files as $unused_file) {
     if (file_exists($unused_file)) {
         echo "√ Deleting ".$unused_file.". It is no longer used.\n";
-        @unlink('bootstrap/cache/compiled.php');
+        @unlink($unused_file);
     } else {
         echo "√ No ".$unused_file.", so nothing to delete.\n";
     }

--- a/upgrade.php
+++ b/upgrade.php
@@ -266,9 +266,9 @@ echo '-- '.$up."\n";
 
 
 
-echo "--------------------------------------------------------\n";
-echo "FINISHED! Clear your browser cookies and re-login to use :\n";
-echo "your upgraded Snipe-IT.\n";
+echo "---------------------- FINISHED! -----------------------\n";
+echo "All done! Clear your browser cookies and re-login to use \n";
+echo "your upgraded Snipe-IT!\n";
 echo "--------------------------------------------------------\n\n";
 
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -50,7 +50,7 @@ if (version_compare(PHP_VERSION, $required_version, '<')) {
 }
 
 $ext_check = '';
-if ((!extension_loaded('gd')) || (!extension_loaded('imagick'))) {
+if ((!extension_loaded('php-gd')) || (!extension_loaded('imagick'))) {
     $ext_check .= "PHP extension MISSING: gd or imagick \n";
 }
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -110,7 +110,7 @@ foreach ($required_exts_array as $rkey => $required_ext) {
 
 // Print out a useful error message and abort the install
 if ($ext_missing!='') {
-    echo "--------------------------------------------------------\n";
+    echo "--------------------- !! ERROR !! ----------------------\n";
     echo $ext_missing;
     echo "--------------------------------------------------------\n\n";
     echo "You have the following extensions installed: \n\n";

--- a/upgrade.php
+++ b/upgrade.php
@@ -20,7 +20,7 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 (array_key_exists('1', $argv)) ? $branch = $argv[1] : $branch = 'master';
 
 echo "--------------------------------------------------------\n";
-echo "Welcome to the Snipe-IT upgrader! \n";
+echo "WELCOME TO THE SNIPE-IT UPGRADER! \n";
 echo "--------------------------------------------------------\n\n";
 echo "This script will attempt to: \n\n";
 echo "- check your PHP version and extension requirements \n";
@@ -46,6 +46,7 @@ if (version_compare(PHP_VERSION, $required_version, '<')) {
 }
 
 
+echo "Checking PHP extensions: \n\n";
 
 $loaded_exts_array = get_loaded_extensions();
 $required_exts_array =

--- a/upgrade.php
+++ b/upgrade.php
@@ -19,7 +19,10 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 // otherwise just use master
 (array_key_exists('1', $argv)) ? $branch = $argv[1] : $branch = 'master';
 
-echo "\nWelcome to the Snipe-IT upgrader. This script will attempt to: \n\n";
+echo "--------------------------------------------------------\n";
+echo "\nWelcome to the Snipe-IT upgrader! \n\n";
+echo "--------------------------------------------------------\n\n";
+echo "This script will attempt to: \n\n";
 echo "- check your PHP version and extension requirements \n";
 echo "- do a git pull to bring you to the latest version \n";
 echo "- run composer install to get your vendors up to date \n";

--- a/upgrade.php
+++ b/upgrade.php
@@ -229,7 +229,7 @@ echo "Step 7: Migrating database:\n";
 echo "--------------------------------------------------------\n\n";
 
 $migrations = shell_exec('php artisan migrate --force');
-echo '-- '.$migrations."\n\n";
+echo '-- '.$migrations."\n";
 
 
 echo "--------------------------------------------------------\n";
@@ -247,18 +247,7 @@ if ((!file_exists('storage/oauth-public.key')) || (!file_exists('storage/oauth-p
 
 
 echo "--------------------------------------------------------\n";
-echo "Step 9: Caching routes and config:\n";
-echo "--------------------------------------------------------\n\n";
-$config_cache = shell_exec('php artisan config:cache');
-$route_cache = shell_exec('php artisan route:cache');
-echo '-- '.$config_cache;
-echo '-- '.$route_cache;
-echo "\n";
-
-
-
-echo "--------------------------------------------------------\n";
-echo "Step 10: Taking application out of maintenance mode:\n";
+echo "Step 9: Taking application out of maintenance mode:\n";
 echo "--------------------------------------------------------\n\n";
 
 $up = shell_exec('php artisan up');

--- a/upgrade.php
+++ b/upgrade.php
@@ -20,7 +20,7 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 (array_key_exists('1', $argv)) ? $branch = $argv[1] : $branch = 'master';
 
 echo "--------------------------------------------------------\n";
-echo "\nWelcome to the Snipe-IT upgrader! \n\n";
+echo "Welcome to the Snipe-IT upgrader! \n";
 echo "--------------------------------------------------------\n\n";
 echo "This script will attempt to: \n\n";
 echo "- check your PHP version and extension requirements \n";

--- a/upgrade.php
+++ b/upgrade.php
@@ -73,7 +73,7 @@ $ext_missing = '';
 $ext_installed = '';
 
 // Loop through the required extensions
-foreach ($required_exts_array as $rkey => $required_ext) {
+foreach ($required_exts_array as $required_ext) {
 
     // If we don't find the string in the array....
     if (!in_array($required_ext, $loaded_exts_array)) {
@@ -85,7 +85,7 @@ foreach ($required_exts_array as $rkey => $required_ext) {
             $require_either = explode("|", $required_ext);
 
             // Now loop through the either/or array and see whether any of the options match
-            foreach ($require_either as $rqkey => $require_either_value) {
+            foreach ($require_either as $require_either_value) {
 
                 if (in_array($require_either_value, $loaded_exts_array)) {
                     break;
@@ -114,7 +114,7 @@ if ($ext_missing!='') {
     echo "--------------------------------------------------------\n\n";
     echo "You have the following extensions installed: \n\n";
 
-    foreach ($loaded_exts_array as $lkey => $loaded_ext) {
+    foreach ($loaded_exts_array as $loaded_ext) {
        echo "- ".$loaded_ext."\n";
     }
 
@@ -172,27 +172,23 @@ echo "--------------------------------------------------------\n";
 echo "Step 5: Cleaning up old cached files:\n";
 echo "--------------------------------------------------------\n\n";
 
+// Build an array of the files we generally want to delete because they
+// can cause issues with funky caching
+$unused_files = [
+    "bootstrap/cache/compiled.php",
+    "bootsrap/cache/services.php",
+    "bootstrap/cache/config.php",
+];
 
-if (file_exists('bootstrap/cache/compiled.php')) {
-    echo "√ Deleting bootstrap/cache/compiled.php. It is no longer used.\n";
-    @unlink('bootstrap/cache/compiled.php');
-} else {
-    echo "√ No bootstrap/cache/compiled.php, so nothing to delete.\n";
+foreach ($unused_files as $unused_file) {
+    if (file_exists($unused_file)) {
+        echo "√ Deleting ".$unused_file.". It is no longer used.\n";
+        @unlink('bootstrap/cache/compiled.php');
+    } else {
+        echo "√ No ".$unused_file.", so nothing to delete.\n";
+    }
 }
 
-if (file_exists('bootstrap/cache/services.php')) {
-    echo "√ Deleting bootstrap/cache/services.php. It it no longer used.\n";
-    @unlink('bootstrap/cache/services.php');
-} else {
-    echo "√ No bootstrap/cache/services.php, so nothing to delete.\n";
-}
-
-if (file_exists('bootstrap/cache/config.php')) {
-    echo "√ Deleting bootstrap/cache/config.php. It it no longer used.\n";
-    @unlink('bootstrap/cache/config.php');
-} else {
-    echo "√ No bootstrap/cache/config.php, so nothing to delete.\n";
-}
 
 $config_clear = shell_exec('php artisan config:clear');
 $cache_clear = shell_exec('php artisan cache:clear');

--- a/upgrade.php
+++ b/upgrade.php
@@ -140,7 +140,7 @@ echo "--------------------------------------------------------\n";
 echo "STEP 3: Putting application into maintenance mode: \n";
 echo "--------------------------------------------------------\n\n";
 $down = shell_exec('php artisan down');
-echo '-- '.$down."\n\n";
+echo '-- '.$down."\n";
 
 
 echo "--------------------------------------------------------\n";
@@ -218,13 +218,13 @@ if (file_exists('composer.phar')) {
     $composer = shell_exec('php composer.phar install --no-dev --prefer-source');
 
 } else {
-    echo "-- We couldn't find a local composer.phar - trying globally.\n\n";
+    echo "-- We couldn't find a local composer.phar. No worries, trying globally.\n\n";
     $composer_dump = shell_exec('composer dump');
     $composer = shell_exec('composer install --no-dev --prefer-source');
 }
 
 echo $composer_dump."\n";
-echo $composer."\n";
+echo $composer;
 
 
 echo "--------------------------------------------------------\n";
@@ -232,7 +232,7 @@ echo "Step 7: Migrating database:\n";
 echo "--------------------------------------------------------\n\n";
 
 $migrations = shell_exec('php artisan migrate --force');
-echo '-- '.$migrations."\n";
+echo $migrations."\n";
 
 
 echo "--------------------------------------------------------\n";

--- a/upgrade.php
+++ b/upgrade.php
@@ -50,7 +50,7 @@ if (version_compare(PHP_VERSION, $required_version, '<')) {
 }
 
 $ext_check = '';
-if ((!extension_loaded('php-gd')) || (!extension_loaded('imagick'))) {
+if ((!extension_loaded('gd')) || (!extension_loaded('imagick'))) {
     $ext_check .= "PHP extension MISSING: gd or imagick \n";
 }
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -57,7 +57,7 @@ $required_exts_array =
         'bcmath',
         'curl',
         'fileinfo',
-		'gd|imagick',
+        'gd|imagick',
         'json',
         'ldap',
         'mbstring',

--- a/upgrade.php
+++ b/upgrade.php
@@ -92,14 +92,14 @@ foreach ($required_exts_array as $rkey => $required_ext) {
                     break;
                 // If no match, add it to the string for errors
                 } else {
-                    $ext_missing .=  'MISSING PHP EXTENSION: '.str_replace("|", " OR ", $required_ext)."\n";
+                    $ext_missing .=  '✘ MISSING PHP EXTENSION: '.str_replace("|", " OR ", $required_ext)."\n";
                     break;
                 }
             }
 
         // If this isn't an either/or option, just add it to the string of errors conventionally
         } else {
-            $ext_missing .=  'MISSING PHP EXTENSION: '.$required_ext."\n";
+            $ext_missing .=  '✘ MISSING PHP EXTENSION: '.$required_ext."\n";
         }
 
     // The required extension string was found in the array of installed extensions - yay!
@@ -111,7 +111,8 @@ foreach ($required_exts_array as $rkey => $required_ext) {
 // Print out a useful error message and abort the install
 if ($ext_missing!='') {
     echo "--------------------------------------------------------\n";
-    echo $ext_missing."\n\n";
+    echo $ext_missing."\n";
+    echo "--------------------------------------------------------\n\n";
     echo "You have the following extensions installed: \n\n";
 
     foreach ($loaded_exts_array as $lkey => $loaded_ext) {

--- a/upgrade.php
+++ b/upgrade.php
@@ -118,7 +118,7 @@ if ($ext_missing!='') {
     echo "------------------------- :( ---------------------------\n";
     exit;
 } else {
-    echo $ext_installed;
+    echo $ext_installed."\n";
 
 }
 
@@ -150,7 +150,7 @@ if ((strpos('git version', $git_version)) === false) {
     echo '-- '.$git_fetch;
     echo '-- '.$git_stash;
     echo '-- '.$git_checkout;
-    echo '-- '.$git_pull;
+    echo '-- '.$git_pull."\n";
 } else {
     echo "Git is NOT installed. You can still use this upgrade script to run common \n";
     echo "migration commands, but you will have to manually download the updated files. \n\n";
@@ -162,31 +162,30 @@ if ((strpos('git version', $git_version)) === false) {
 }
 
 
-
 echo "--------------------------------------------------------\n";
 echo "Step 5: Cleaning up old cached files:\n";
 echo "--------------------------------------------------------\n\n";
 
 
 if (file_exists('bootstrap/cache/compiled.php')) {
-    echo "-- Deleting bootstrap/cache/compiled.php. It is no longer used.\n";
+    echo "√ Deleting bootstrap/cache/compiled.php. It is no longer used.\n";
     @unlink('bootstrap/cache/compiled.php');
 } else {
-    echo "-- No bootstrap/cache/compiled.php, so nothing to delete.\n";
+    echo "√ No bootstrap/cache/compiled.php, so nothing to delete.\n";
 }
 
 if (file_exists('bootstrap/cache/services.php')) {
-    echo "-- Deleting bootstrap/cache/services.php. It it no longer used.\n";
+    echo "√ Deleting bootstrap/cache/services.php. It it no longer used.\n";
     @unlink('bootstrap/cache/services.php');
 } else {
-    echo "-- No bootstrap/cache/services.php, so nothing to delete.\n";
+    echo "√ No bootstrap/cache/services.php, so nothing to delete.\n";
 }
 
 if (file_exists('bootstrap/cache/config.php')) {
-    echo "-- Deleting bootstrap/cache/config.php. It it no longer used.\n";
+    echo "√ Deleting bootstrap/cache/config.php. It it no longer used.\n";
     @unlink('bootstrap/cache/config.php');
 } else {
-    echo "-- No bootstrap/cache/config.php, so nothing to delete.\n";
+    echo "√ No bootstrap/cache/config.php, so nothing to delete.\n";
 }
 
 $config_clear = shell_exec('php artisan config:clear');
@@ -207,7 +206,7 @@ echo "--------------------------------------------------------\n\n";
 
 // Composer install
 if (file_exists('composer.phar')) {
-    echo "-- Local composer.phar detected, so we'll use that.\n\n";
+    echo "√ Local composer.phar detected, so we'll use that.\n\n";
     echo "-- Updating local composer.phar\n\n";
     $composer_update = shell_exec('php composer.phar self-update');
     echo $composer_update."\n\n";
@@ -243,7 +242,7 @@ if ((!file_exists('storage/oauth-public.key')) || (!file_exists('storage/oauth-p
     $passport = shell_exec('php artisan passport:install');
     echo $passport;
 } else {
-    echo "- OAuth keys detected. Skipping passport install.\n\n";
+    echo "√ OAuth keys detected. Skipping passport install.\n\n";
 }
 
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -56,7 +56,6 @@ $required_exts_array =
     [
         'bcmath',
         'curl',
-        'farts',
         'fileinfo',
 		'gd|imagick',
         'json',

--- a/upgrade.php
+++ b/upgrade.php
@@ -153,7 +153,7 @@ if ((strpos('git version', $git_version)) === false) {
     $git_checkout = shell_exec('git checkout '.$branch);
     $git_stash = shell_exec('git stash');
     $git_pull = shell_exec('git pull');
-    echo '-- '.$git_fetch;
+    echo $git_fetch;
     echo '-- '.$git_stash;
     echo '-- '.$git_checkout;
     echo '-- '.$git_pull."\n";
@@ -188,7 +188,7 @@ foreach ($unused_files as $unused_file) {
         echo "√ No ".$unused_file.", so nothing to delete.\n";
     }
 }
-
+echo "\n";
 
 $config_clear = shell_exec('php artisan config:clear');
 $cache_clear = shell_exec('php artisan cache:clear');


### PR DESCRIPTION
First off, I apologize for all the pushes/commits to the branch. By its very nature, the only way I could test some of the improvements/spacing/etc was to commit and push.

This PR introduces a few *hopefully* helpful additions to the `upgrade.php` script. Specifically, we're now checking for required extensions.

If the script finds a missing extension, the output looks like this:

<details>

```
✨snipe@deepthought✨ snipe-it  $ php upgrade.php features/check_extensions_in_upgrade_script
--------------------------------------------------------
WELCOME TO THE SNIPE-IT UPGRADER!
--------------------------------------------------------

This script will attempt to:

- check your PHP version and extension requirements
- do a git pull to bring you to the latest version
- run composer install to get your vendors up to date
- run migrations to get your schema up to date
- clear out old cache settings

--------------------------------------------------------
STEP 1: Checking PHP requirements:
--------------------------------------------------------

Current PHP version: (7.2.8) is at least 7.2.0 - continuing...
FYI: The php.ini used by this PHP is: /Library/Application Support/appsolute/MAMP PRO/conf/php7.2.8.ini

Checking Required PHP extensions...

--------------------- !! ERROR !! ----------------------
✘ MISSING PHP EXTENSION: farts
--------------------------------------------------------

You have the following extensions installed:

- Core
- date
- libxml
- openssl
- pcre
- sqlite3
- zlib
- bcmath
- bz2
- calendar
- ctype
- curl
- dom
- hash
- fileinfo
- filter
- ftp
- gd
- SPL
- iconv
- intl
- json
- ldap
- mbstring
- session
- standard
- mysqlnd
- PDO
- pdo_mysql
- pdo_sqlite
- Phar
- posix
- readline
- Reflection
- mysqli
- SimpleXML
- soap
- sockets
- sodium
- exif
- tokenizer
- wddx
- xml
- xmlreader
- xmlwriter
- xsl
- zip
- imap
- gettext
- pgsql
- pdo_pgsql
------------------------- :( ---------------------------
ABORTING THE INSTALLER
Please install the extensions above and re-run this script.
------------------------- :( ---------------------------
```
</details>

And a successful output would look like this: 

<details>

```
✨snipe@deepthought✨ snipe-it $ php upgrade.php features/check_extensions_in_upgrade_script
--------------------------------------------------------
WELCOME TO THE SNIPE-IT UPGRADER!
--------------------------------------------------------

This script will attempt to:

- check your PHP version and extension requirements
- do a git pull to bring you to the latest version
- run composer install to get your vendors up to date
- run migrations to get your schema up to date
- clear out old cache settings

--------------------------------------------------------
STEP 1: Checking PHP requirements:
--------------------------------------------------------

Current PHP version: (7.2.8) is at least 7.2.0 - continuing...
FYI: The php.ini used by this PHP is: /Library/Application Support/appsolute/MAMP PRO/conf/php7.2.8.ini

Checking Required PHP extensions...

√ bcmath is installed!
√ curl is installed!
√ fileinfo is installed!
√ json is installed!
√ ldap is installed!
√ mbstring is installed!
√ openssl is installed!
√ PDO is installed!
√ tokenizer is installed!
√ xml is installed!
√ zip is installed!

--------------------------------------------------------
STEP 2: Backing up database:
--------------------------------------------------------

-- Starting backup...
Dumping database snipeit-local...
Determining files to backup...
Zipping 202 files and directories...
Created zip containing 202 files and directories. Size is 8.85 MB
Copying zip to disk named backup...
Successfully copied zip to disk named backup.
Backup completed!


--------------------------------------------------------
STEP 3: Putting application into maintenance mode:
--------------------------------------------------------

-- Application is now in maintenance mode.


--------------------------------------------------------
STEP 4: Pulling latest from Git (features/check_extensions_in_upgrade_script branch):
--------------------------------------------------------

Git is installed.
Already on 'features/check_extensions_in_upgrade_script'
-- -- No local changes to save
-- Your branch is up to date with 'origin/features/check_extensions_in_upgrade_script'.
-- Already up to date.

--------------------------------------------------------
Step 5: Cleaning up old cached files:
--------------------------------------------------------

√ No bootstrap/cache/compiled.php, so nothing to delete.
√ Deleting bootstrap/cache/services.php. It it no longer used.
√ No bootstrap/cache/config.php, so nothing to delete.
-- Configuration cache cleared!
-- Application cache cleared!
-- Route cache cleared!
-- Compiled views cleared!

--------------------------------------------------------
Step 6: Updating composer dependencies:
(This may take a moment.)
--------------------------------------------------------

-- We couldn't find a local composer.phar - trying globally.

> Illuminate\Foundation\ComposerScripts::postAutoloadDump
Loading composer repositories with package information
Installing dependencies from lock file
Nothing to install or update
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
11 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Generating optimized autoload files
Generated optimized autoload files containing 5498 classes


--------------------------------------------------------
Step 7: Migrating database:
--------------------------------------------------------

-- Nothing to migrate.

--------------------------------------------------------
Step 8: Checking for OAuth keys:
--------------------------------------------------------

√ OAuth keys detected. Skipping passport install.

--------------------------------------------------------
Step 9: Taking application out of maintenance mode:
--------------------------------------------------------

-- Application is now live.

---------------------- FINISHED! -----------------------
All done! Clear your browser cookies and re-login to use
your upgraded Snipe-IT!
--------------------------------------------------------
```
</details>

This will helpfully assist with those folks who have been running Snipe-IT this whole time without all of the required PHP extensions enabled, at least making it clearer what's breaking, since the framework isn't doing a baller job of explaining why it's not working when they're missing extensions.

### Testing

To test this script, checkout this `features/check_extensions_in_upgrade_script`, and then run:

```
php upgrade.php features/check_extensions_in_upgrade_script
```