### PR TITLE
Fixed #8699: exclude blank LDAP attributes from searches

### DIFF
--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -398,7 +398,7 @@ class LdapAd extends LdapAdConfiguration
     {
         /** @var Schema $schema */
         $schema = new $this->ldapConfig['schema'];
-        return [
+        return array_values(array_filter([
             $this->ldapSettings['ldap_username_field'],
             $this->ldapSettings['ldap_fname_field'],
             $this->ldapSettings['ldap_lname_field'],
@@ -409,7 +409,7 @@ class LdapAd extends LdapAdConfiguration
             $schema->userAccountControl(),
             $schema->title(),
             $schema->telephone(),
-        ];
+        ]));
     }
 
     /**


### PR DESCRIPTION
Asking for '' attributes is an error for some LDAP servers.

# Description

Fixes #8699 

getSelectedFields() returns an array of LDAP attributes to request. This array must NOT contain empty values. Empty values will be passed on to the LDAP server, and some LDAP servers treat this as an error. (389-ds for one)
The proposed solution uses array_filter() to remove elements that are empty().

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
