### PR TITLE
Fix for #8746 - missing comma in a translation file

### DIFF
--- a/resources/lang/en/mail.php
+++ b/resources/lang/en/mail.php
@@ -73,7 +73,7 @@ return array(
     'Accessory_Checkin_Notification' => 'Accessory checked in',
     'Asset_Checkin_Notification' => 'Asset checked in',
     'License_Checkin_Notification' => 'License checked in',
-    'Expected_Checkin_Report' => 'Expected asset checkin report'
+    'Expected_Checkin_Report' => 'Expected asset checkin report',
     'Expected_Checkin_Notification' => 'Reminder: :name checkin deadline approaching',
     'Expected_Checkin_Date' => 'An asset checked out to you is due to be checked back in on :date',
     'your_assets' => 'View Your Assets'


### PR DESCRIPTION
# Description

It looks like we missed a comma in the English translation file for mail, causing users email-sending issues and other bugs due to the syntax error.

Fixes #8746 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

My code editor showed a squiggly red line (syntax error) at the point of the error, and after this it doesn't?