### PR TITLE
Re-add LDAP "test login" feature to LDAP settings (helps with #8751)

### DIFF
--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -446,7 +446,7 @@ class LdapAd extends LdapAdConfiguration
     public function testLdapAdUserConnection(): void
     {
         try {
-            $this->ldap->connect(); //uh, this doesn't seem to exist :/
+            $this->ldap->connect();
         } catch (\Adldap\Auth\BindException $e) {
             Log::error($e);
             throw new Exception('Unable to connect to LDAP directory!');

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -379,6 +379,38 @@
 
                             </div>
 
+                            <!-- LDAP Login test -->
+                            <div class="form-group">
+                                <div class="col-md-3">
+                                    {{ Form::label('test_ldap_login', 'Test LDAP Login') }}
+                                </div>
+                                <div class="col-md-9">
+                                    <div class="row">
+                                    <div class="col-md-4">
+                                        <input type="text" name="ldaptest_user" id="ldaptest_user"  class="form-control" placeholder="LDAP username">
+                                    </div>
+                                    <div class="col-md-4">
+                                    <input type="password" name="ldaptest_password" id="ldaptest_password" class="form-control" placeholder="LDAP password">
+                                    </div>
+                                    <div class="col-md-3">
+                                        <a class="btn btn-default btn-sm" id="ldaptestlogin" style="margin-right: 10px;">Test LDAP</a>
+                                    </div>
+
+
+                                </div>
+                                </div>
+                                <div class="col-md-9 col-md-offset-3">
+                                    <span id="ldaptestloginicon"></span>
+                                    <span id="ldaptestloginresult"></span>
+                                    <span id="ldaptestloginstatus"></span>
+                                </div>
+                                <div class="col-md-9 col-md-offset-3">
+                                    <p class="help-block">{{ trans('admin/settings/general.ldap_login_test_help') }}</p>
+                                </div>
+
+                        </div>
+
+
                        @endif
 
                         <!-- LDAP Forgotten password -->
@@ -527,5 +559,76 @@
             body += "</tbody>"
             return body;
         }
+
+        $("#ldaptestlogin").click(function(){
+            $("#ldaptestloginrow").removeClass('text-success');
+            $("#ldaptestloginrow").removeClass('text-danger');
+            $("#ldaptestloginstatus").removeClass('text-danger');
+            $("#ldaptestloginstatus").html('');
+            $("#ldaptestloginicon").html('<i class="fa fa-spinner spin"></i> Testing LDAP Authentication...');
+            $.ajax({
+                url: '{{ route('api.settings.ldaptestlogin') }}',
+                type: 'POST',
+                headers: {
+                    "X-Requested-With": 'XMLHttpRequest',
+                    "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr('content')
+                },
+                data: {
+                    'ldaptest_user': $('#ldaptest_user').val(),
+                    'ldaptest_password': $('#ldaptest_password').val()
+                },
+
+                dataType: 'json',
+
+                success: function (data) {
+                    $("#ldaptestloginicon").html('');
+                    $("#ldaptestloginrow").addClass('text-success');
+                    $("#ldaptestloginstatus").addClass('text-success');
+                    $("#ldaptestloginstatus").html('<i class="fa fa-check text-success"></i> User authenticated against LDAP successfully!');
+                },
+
+                error: function (data) {
+
+                    if (data.responseJSON) {
+                        var errors = data.responseJSON.message;
+                    } else {
+                        var errors;
+                    }
+
+                    var error_text = '';
+
+                    $("#ldaptestloginicon").html('');
+                    $("#ldaptestloginstatus").addClass('text-danger');
+                    $("#ldaptestloginicon").html('<i class="fa fa-exclamation-triangle text-danger"></i>');
+
+                    if (data.status == 500) {
+                        $('#ldaptestloginstatus').html('500 Server Error');
+                    } else if (data.status == 400) {
+
+                        if (typeof errors !='string') {
+
+                            for (i = 0; i < errors.length; i++) {
+                                if (errors[i]) {
+                                    error_text += '<li>Error: ' + errors[i];
+                                }
+
+                            }
+
+                        } else {
+                            error_text = errors;
+                        }
+
+                        $('#ldaptestloginstatus').html(error_text);
+
+                    } else {
+                        $('#ldaptestloginstatus').html(data.responseText.message);
+                    }
+                }
+
+
+
+
+            });
+        });
     </script>
 @endpush


### PR DESCRIPTION
# Description

We inadvertently did not include the test LDAP login feature into v5. This adds it back.

One of the approaches that we take here that feels...janky.... is that we actually begin a SQL transaction, then use the `LdapAd.php` service provider to attempt a real, live login. Then, whether that succeeds or fails, we fire a SQL rollback. This is weird, but I thought it would be even weirder if the Test LDAP login button created brand new users on success. So this is the best way to use the exact same code that we use for 'real' user logins, without inadvertently creating new users.

My logic as to why we don't want to create new users is that if you're still messing with LDAP settings and repeatedly testing, if you don't have them quite right, and then you try to test by logging in as someone who _shouldn't_ be able to log in, then we definitely don't want to make a User record for that person yet. Let them log in 'properly' (or be sync'ed) and then they will have their User record.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I tested logging in with invalid credentials
- [x] I tested logging in with valid credentials