### PR TITLE
Fixed #8772, #8689 -  500 error on deactivated LDAP user trying to login

### DIFF
--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -145,9 +145,17 @@ class LdapAd extends LdapAdConfiguration
             throw new Exception('Unable to find user in LDAP directory!');
         }
 
-        return User::where('username', $username)
+        $user = User::where('username', $username)
                 ->whereNull('deleted_at')->where('ldap_import', '=', 1)
                 ->where('activated', '=', '1')->first();
+        /* Above, I could've just done ->firstOrFail() which would've been cleaner, but it would've been miserable to
+           troubleshoot if it ever came up (giving a really generic and untraceable error message)
+        */
+        if (!$user) {
+            throw new Exception("User is either deleted, not activated (can't log in), not from LDAP, or can't be found in database");
+        }
+
+        return $user;
     }
 
     /**


### PR DESCRIPTION
If a user is deactivated in the database, but there's no active flag defined to reactivate them via LDAP, then when they try to log in they will generate a 500-page. Not a huge deal, in that they weren't allowed to log in in the first place, but still we try not to throw 500's around.

I had a simple one-liner to fix this but I realized that it was going to be impossible to troubleshoot if it ever managed to come up - it would end up saying: `No query results for model [App\Models\User]` - which isn't going to help much. So instead I threw my own verbose `Exception` which should make this easier to track down should it come up later.

Fixes #8772 and #8689

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tried to log in to an LDAP user with Deactivated Login - got generic "The username or password is incorrect" message 
- [x] Re-enabled login for that user and was able to log in OK.