### PR TITLE
Fixed #8772 - initial LDAP import of users are deactivated

### DIFF
--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -229,6 +229,8 @@ class LdapAd extends LdapAdConfiguration
         $user->phone        = trim($userInfo['telephonenumber']);
         if(array_key_exists('activated',$userInfo)) {
             $user->activated    = $userInfo['activated'];
+        } else if ( !$user->exists ) { // no 'activated' flag was set or unset, *AND* this user is new - activate by default.
+            $user->activated = 1;
         }
         if(array_key_exists('location_id',$userInfo)) {
             $user->location_id  = $userInfo['location_id'];
@@ -322,19 +324,30 @@ class LdapAd extends LdapAdConfiguration
             $activeStatus = (in_array($user->getUserAccountControl(), self::AD_USER_ACCOUNT_CONTROL_FLAGS)) ? 1 : 0;
         } else {
 
-            \Log::debug('This looks like LDAP (or an AD where the UAC is disabled)');
             // If there is no activated flag, then we can't make any determination about activated/deactivated
             if (false == $this->ldapSettings['ldap_active_flag']) {
                 \Log::debug('ldap_active_flag is false - no ldap_active_flag is set');
                 return null;
             }
 
-            // If there *is* an activated flag, then respect it *only* if it is actually present. If it's not there, ignore it. <-- NOT SURE IF RIGHT?
+            // If there *is* an activated flag, then respect it *only* if it is actually present. If it's not there, ignore it.
             if (!$user->hasAttribute($this->ldapSettings['ldap_active_flag'])) {
                 return null; // 'active' flag is defined, but does not exist on returned user record. So we don't know if they're active or not.
             }
 
-            $activeStatus = $user->{$this->ldapSettings['ldap_active_flag']} ? 1 : 0 ;
+            // if $user has the flag *AND* that flag has exactly one value -
+            if ( $user->{$this->ldapSettings['ldap_active_flag']} && count($user->{$this->ldapSettings['ldap_active_flag']}) == 1 ) {
+
+                $active_flag_value = $user->{$this->ldapSettings['ldap_active_flag']}[0];
+
+                // if the value of that flag is case-insensitively the string 'false' or boolean false
+                if ( strcasecmp($active_flag_value, "false") == 0 || $active_flag_value === false ) {
+                    return 0; // then make them INACTIVE
+                } else {
+                    return 1; // otherwise active
+                }
+            }
+            return 1; // fail 'open' (active) if we have the attribute and it's multivalued or empty; that's weird
         }
 
         return $activeStatus;


### PR DESCRIPTION
The new fixes to the LDAP activation system were missing parts about how to handle the `activated` flag on users.

This means a lot of initial LDAP imports (usually non-Active Directory) marked all the new users as unable-to-login.

This PR explicitly handles both: 
- New-user activation when imported from LDAP
- Using the LDAP active flag. It uses as a much more conservative way of handling activation. It tries to fail open.

Fixes #8772

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Repeatedly deleted a user out of the database and then forced a re-sync via LDAP, making sure the users showed up 'active'.
- [x] Declared an unused LDAP attribute as the 'active flag' and toggled it on and off after repeated syncs, ensuring that the user was activated and deactivated appropriately.