### PR TITLE
Change license serial type to TEXT for longer license files

### DIFF
--- a/database/migrations/2020_11_18_214827_widen_license_serial_field.php
+++ b/database/migrations/2020_11_18_214827_widen_license_serial_field.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class WidenLicenseSerialField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->text('serial')->nullable()->default(null)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->string('serial', 2048)->nullable()->default(null)->change();
+        });
+    }
+}


### PR DESCRIPTION
# Description

License Serial numbers for some pieces of software can exceed even our 2048 maximum character limit. But we need to be wary of hitting MySQL's row-size limitation (64k), and the math gets even weirder with Unicode (especially MySQL's weird `utf8mb4`, which is 4 bytes). So I've changed the license serial ("Product Key") to be a `TEXT` field, which means it will only contribute a few bytes (less than 10) to the row-max, and allow Product Keys up to 64k.

Much bigger than that and we're becoming a file storage platform, and that's just too weird.

Fixes # (Customer-Reported Issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] I ran the migrations and inspected the DB; the field changed accordingly
- [x] The already-existing license keys were unaffected
- [x] I inserted a randomly-generated 4196 byte string into the field via the app. It showed up in the DB, in full.
- [x] I ran a rollback. It truncated my overly-long license key, which is expected. The rest of the license keys were fine.