### PR TITLE
Fixes #8584, #8654, #8727 - fixes and improvements for saml

### DIFF
--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -53,8 +53,10 @@ class SamlController extends Controller
         if (empty($metadata)) {
             return response()->view('errors.403', [], 403);
         }
-
-        return response($metadata)->header('Content-Type', 'text/xml');
+    
+        return response()->streamDownload(function () use ($metadata) {
+            echo $metadata;
+        }, 'snipe-it-metadata.xml', ['Content-Type' => 'text/xml']);
     }
 
     /**

--- a/app/Http/Requests/SettingsSamlRequest.php
+++ b/app/Http/Requests/SettingsSamlRequest.php
@@ -70,22 +70,27 @@ class SettingsSamlRequest extends FormRequest
                 ]);
                 
                 $csr = openssl_csr_new($dn, $pkey, ['digest_alg' => 'sha256']);
-                
-                $x509 = openssl_csr_sign($csr, null, $pkey, 3650, ['digest_alg' => 'sha256']);
 
-                openssl_x509_export($x509, $x509cert);
-                openssl_pkey_export($pkey, $privateKey);
+                if ($csr) {
 
-                $errors = [];
-                while (($error = openssl_error_string() !== false)) {
-                    $errors[] = $error;
-                }
-    
-                if (!(empty($x509cert) && empty($privateKey))) {
-                    $this->merge([
-                        'saml_sp_x509cert' => $x509cert,
-                        'saml_sp_privatekey' => $privateKey,
-                    ]);
+                    $x509 = openssl_csr_sign($csr, null, $pkey, 3650, ['digest_alg' => 'sha256']);
+
+                    openssl_x509_export($x509, $x509cert);
+                    openssl_pkey_export($pkey, $privateKey);
+
+                    $errors = [];
+                    while (($error = openssl_error_string() !== false)) {
+                        $errors[] = $error;
+                    }
+        
+                    if (!(empty($x509cert) && empty($privateKey))) {
+                        $this->merge([
+                            'saml_sp_x509cert' => $x509cert,
+                            'saml_sp_privatekey' => $privateKey,
+                        ]);
+                    }
+                } else {
+                    $validator->errors()->add('saml_integration', 'openssl.cnf is missing/invalid');
                 }
             }
 

--- a/app/Services/Saml.php
+++ b/app/Services/Saml.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
 use OneLogin\Saml2\IdPMetadataParser as OneLogin_Saml2_IdPMetadataParser;
 use OneLogin\Saml2\Settings as OneLogin_Saml2_Settings;
+use OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
 use App\Models\Setting;
 use App\Models\User;
 use Exception;
@@ -153,6 +154,9 @@ class Saml
         $this->_enabled = $setting->saml_enabled == '1';
 
         if ($this->isEnabled()) {
+            //Let onelogin/php-saml know to use 'X-Forwarded-*' headers if it is from a trusted proxy
+            OneLogin_Saml2_Utils::setProxyVars(request()->isFromTrustedProxy());
+
             data_set($settings, 'sp.entityId', url('/'));
             data_set($settings, 'sp.assertionConsumerService.url', route('saml.acs'));
             data_set($settings, 'sp.singleLogoutService.url', route('saml.sls'));

--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -125,6 +125,7 @@ return array(
     'saml_sp_acs_url'           => 'Assertion Consumer Service (ACS) URL',
     'saml_sp_sls_url'           => 'Single Logout Service (SLS) URL',
     'saml_sp_x509cert'          => 'Public Certificate',
+    'saml_sp_metadata_url'      => 'Metadata URL',
     'saml_idp_metadata'         => 'SAML IdP Metadata',
     'saml_idp_metadata_help'    => 'You can specify the IdP metadata using a URL or XML file.',
     'saml_attr_mapping_username' => 'Attribute Mapping - Username',

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -83,8 +83,12 @@
                                         {{ Form::textarea('saml_sp_x509cert', $setting->saml_sp_x509cert, ['class' => 'form-control', 'wrap' => 'off', 'readonly']) }}
                                         <br>
                                     @endif
+                                    <!-- SAML SP Metadata URL -->
+                                    {{ Form::label('saml_sp_metadata_url', trans('admin/settings/general.saml_sp_metadata_url')) }}
+                                    {{ Form::text('saml_sp_metadata_url', route('saml.metadata'), ['class' => 'form-control', 'readonly']) }}
+                                    <br>
                                     <p class="help-block">
-                                        <a href="{{ route('saml.metadata') }}" target="_blank" class="btn btn-default" style="margin-right: 5px;">View Metadata</a>
+                                        <a href="{{ route('saml.metadata') }}" target="_blank" class="btn btn-default" style="margin-right: 5px;">Download Metadata</a>
                                     </p>
                                 @endif
                                 {!! $errors->first('saml_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -55,6 +55,7 @@
 
                                 {{ Form::checkbox('saml_enabled', '1', Request::old('saml_enabled', $setting->saml_enabled), [((config('app.lock_passwords')===true)) ? 'disabled ': '', 'class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('admin/settings/general.saml_enabled') }}
+                                {!! $errors->first('saml_integration', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}<br>
                                 @if (config('app.lock_passwords')===true)
                                 <p class="text-warning"><i class="fa fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                 @endif


### PR DESCRIPTION
# Description

These are simple fixes/improvements for SAML in Snipe-IT.
- Gracefully handle the case where openssl_csr_new fails when [openssl.cnf](https://www.php.net/manual/en/openssl.installation.php) is invalid/missing on enabling SAML. The users will now see an error instead of getting http 500.
![image](https://user-images.githubusercontent.com/63399474/99863705-8dbdb700-2bf3-11eb-9c41-60862f583014.png)
- Letting onelogin/php-saml know to use 'X-Forwarded-*' headers if it is from a trusted proxy
- Improve UI of SAML SP metadata by displaying it's URL and a download button
![image](https://user-images.githubusercontent.com/63399474/99862989-2a7e5580-2bf0-11eb-95dd-dffea9a4c779.png)

Fixes #8584
Fixes #8654, #8727 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested saml with snipe-it behind a reverse proxy and onelogin/php-saml now correctly picks up the right protocol
- [x] Deleted the openssl.cnf file and set saml_sp_x509cert to NULL in db  to replicate the case of it being missing and trying to enable saml. No longer returns http 500 error.

**Test Configuration**:
* PHP version: 7.4.4
* MySQL version:  MariaDB 10.4
* Webserver version: Apache 2.4.43
* OS version: Window Server 2019


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
