### PR TITLE
Fixed #8781 - added asset count by status type

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,6 +38,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\CheckLocale::class,
             \App\Http\Middleware\CheckForTwoFactor::class,
             \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
+            \App\Http\Middleware\AssetCountForSidebar::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/AssetCountForSidebar.php
+++ b/app/Http/Middleware/AssetCountForSidebar.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Auth;
+use App\Models\Asset;
+use Closure;
+
+class AssetCountForSidebar
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $total_rtd_sidebar = Asset::RTD()->count();
+        $total_deployed_sidebar = Asset::Deployed()->count();
+        $total_archived_sidebar = Asset::Archived()->count();
+        $total_pending_sidebar = Asset::Pending()->count();
+        $total_undeployable_sidebar = Asset::Undeployable()->count();
+        view()->share('total_rtd_sidebar', $total_rtd_sidebar);
+        view()->share('total_deployed_sidebar', $total_deployed_sidebar);
+        view()->share('total_archived_sidebar', $total_archived_sidebar);
+        view()->share('total_pending_sidebar', $total_pending_sidebar);
+        view()->share('total_undeployable_sidebar', $total_undeployable_sidebar);
+
+        return $next($request);
+    }
+}

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -403,24 +403,26 @@
                 </a>
                 <ul class="treeview-menu">
                   <li>
-                    <a href="{{ url('hardware') }}">
+                      <a href="{{ url('hardware') }}">
+                          <i class="fa fa-circle-o text-grey" aria-hidden="true"></i>
                         {{ trans('general.list_all') }}
                     </a>
                   </li>
 
-                    <?php $status_navs = \App\Models\Statuslabel::where('show_in_nav', '=', 1)->get(); ?>
+                    <?php $status_navs = \App\Models\Statuslabel::where('show_in_nav', '=', 1)->withCount('assets as asset_count')->get(); ?>
                     @if (count($status_navs) > 0)
-                        <li class="divider">&nbsp;</li>
                         @foreach ($status_navs as $status_nav)
-                            <li><a href="{{ route('statuslabels.show', ['statuslabel' => $status_nav->id]) }}"}> {{ $status_nav->name }}</a></li>
+                            <li><a href="{{ route('statuslabels.show', ['statuslabel' => $status_nav->id]) }}"><i class="fa fa-circle text-grey" aria-hidden="true"></i> {{ $status_nav->name }} ({{ $status_nav->asset_count }})</a></li>
                         @endforeach
                     @endif
 
 
                   <li{!! (Request::query('status') == 'Deployed' ? ' class="active"' : '') !!}>
-                    <a href="{{ url('hardware?status=Deployed') }}"><i class="fa fa-circle-o text-blue"></i>
+                    <a href="{{ url('hardware?status=Deployed') }}">
+                        <i class="fa fa-circle-o text-blue"></i>
                         {{ trans('general.all') }}
                         {{ trans('general.deployed') }}
+                        ({{ ($total_deployed_sidebar) ? $total_deployed_sidebar : '' }})
                     </a>
                   </li>
                   <li{!! (Request::query('status') == 'RTD' ? ' class="active"' : '') !!}>
@@ -428,21 +430,25 @@
                         <i class="fa fa-circle-o text-green"></i>
                         {{ trans('general.all') }}
                         {{ trans('general.ready_to_deploy') }}
+                        ({{ ($total_rtd_sidebar) ? $total_rtd_sidebar : '' }})
                     </a>
                   </li>
                   <li{!! (Request::query('status') == 'Pending' ? ' class="active"' : '') !!}><a href="{{ url('hardware?status=Pending') }}"><i class="fa fa-circle-o text-orange"></i>
                           {{ trans('general.all') }}
                           {{ trans('general.pending') }}
+                          ({{ ($total_pending_sidebar) ? $total_pending_sidebar : '' }})
                       </a>
                   </li>
                   <li{!! (Request::query('status') == 'Undeployable' ? ' class="active"' : '') !!} ><a href="{{ url('hardware?status=Undeployable') }}"><i class="fa fa-times text-red"></i>
                           {{ trans('general.all') }}
                           {{ trans('general.undeployable') }}
+                          ({{ ($total_undeployable_sidebar) ? $total_undeployable_sidebar : '' }})
                       </a>
                   </li>
                   <li{!! (Request::query('status') == 'Archived' ? ' class="active"' : '') !!}><a href="{{ url('hardware?status=Archived') }}"><i class="fa fa-times text-red"></i>
                           {{ trans('general.all') }}
                           {{ trans('admin/hardware/general.archived') }}
+                          ({{ ($total_archived_sidebar) ? $total_archived_sidebar : '' }})
                           </a>
                   </li>
                     <li{!! (Request::query('status') == 'Requestable' ? ' class="active"' : '') !!}><a href="{{ url('hardware?status=Requestable') }}"><i class="fa fa-check text-blue"></i>


### PR DESCRIPTION
We may want to work out some sort of caching, or optional on/off in the DB or env. I could see this getting slow if people have tons and tons of asset statuses. 

<img width="500" alt="Screen Shot 2020-11-24 at 11 52 46 AM" src="https://user-images.githubusercontent.com/197404/100144434-a0cac400-2e4b-11eb-9467-00f36b2cc84a.png">
<img width="630" alt="Screen Shot 2020-11-24 at 11 52 53 AM" src="https://user-images.githubusercontent.com/197404/100144438-a1635a80-2e4b-11eb-8c13-0536a05cb469.png">
