### PR TITLE
Fixes #8472 (again) - LDAP sync was assigning a bad default location

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -84,7 +84,7 @@ class LdapSync extends Command
         }
 
         /* Determine which location to assign users to by default. */
-        $location = NULL;
+        $location = NULL; // FIXME - this would be better called "$default_location", which is more explicit about its purpose
 
         if ($this->option('location')!='') {
             $location = Location::where('name', '=', $this->option('location'))->first();
@@ -106,8 +106,8 @@ class LdapSync extends Command
             $ldap_ou_locations = Location::where('ldap_ou', '!=', '')->get()->toArray();
             $ldap_ou_lengths = array();
 
-            foreach ($ldap_ou_locations as $location) {
-                $ldap_ou_lengths[] = strlen($location["ldap_ou"]);
+            foreach ($ldap_ou_locations as $ou_loc) {
+                $ldap_ou_lengths[] = strlen($ou_loc["ldap_ou"]);
             }
 
             array_multisort($ldap_ou_lengths, SORT_ASC, $ldap_ou_locations);


### PR DESCRIPTION
# Description

If you had per-OU locations set up, and you had a user that was not in one of those OU's, it would automatically be assigned to the last location in the per-OU list, instead of correctly not being touched at all (or, on a brand new sync, being set to no location).

Fixes #8472 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran a sync using the current system and it moved my test user incorrectly to the wrong location. Made a fix, and after manually fixing the user (ugh), subsequent syncs did not move the user any more.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
