### PR TITLE
 Fixes #8853 - allow saml to be more easily debugged

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -105,13 +105,13 @@ class LoginController extends Controller
         $samlData = $request->session()->get('saml_login');
         if ($saml->isEnabled() && !empty($samlData)) {
             try {
-                LOG::debug("Attempting to log user in by SAML authentication.");
+                Log::debug("Attempting to log user in by SAML authentication.");
                 $user = $saml->samlLogin($samlData);
                 if(!is_null($user)) {
                     Auth::login($user, true);
                 } else {
                     $username = $saml->getUsername();
-                    LOG::debug("SAML user '$username' could not be found in database.");
+                    Log::error("SAML user '$username' could not be found in database.");
                     $request->session()->flash('error', trans('auth/message.signin.error'));
                     $saml->clearData();
                 }
@@ -121,7 +121,7 @@ class LoginController extends Controller
                     $user->save();
                 }
             } catch (\Exception $e) {
-                LOG::debug("There was an error authenticating the SAML user: " . $e->getMessage());
+                Log::error("There was an error authenticating the SAML user: " . $e->getMessage());
                 throw new \Exception($e->getMessage());
             }
         }

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -101,8 +101,8 @@ class SamlController extends Controller
         $errors = $auth->getErrors();
 
         if (!empty($errors)) {
-            Log::debug("There was an error with SAML ACS: " . implode(', ', $errors));
-            Log::debug("Reason: " . $auth->getLastErrorReason());
+            Log::error("There was an error with SAML ACS: " . implode(', ', $errors));
+            Log::error("Reason: " . $auth->getLastErrorReason());
             return redirect()->route('login')->with('error', trans('auth/message.signin.error'));
         }
 
@@ -115,7 +115,7 @@ class SamlController extends Controller
      * Receives LogoutRequest/LogoutResponse from IdP and flashes
      * back to the LoginController for logging out.
      * 
-     * /saml/slo
+     * /saml/sls
      * 
      * @author Johnson Yi <jyi.dev@outlook.com>
      * 
@@ -132,8 +132,8 @@ class SamlController extends Controller
         $errors = $auth->getErrors();
         
         if (!empty($errors)) {
-            Log::debug("There was an error with SAML SLS: " . implode(', ', $errors));
-            Log::debug("Reason: " . $auth->getLastErrorReason());
+            Log::error("There was an error with SAML SLS: " . implode(', ', $errors));
+            Log::error("Reason: " . $auth->getLastErrorReason());
             return view('errors.403');
         }
 


### PR DESCRIPTION
# Description

All SAML errors were originally being sent to `Log::debug` but now has been changed to use `Log::error` instead. This change allows you to easily see these errors without having to enable `APP_DEBUG` since they will now be visible in laravel.log.

Fixes #8853

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested SAML on snipe-it with a non existing user and the error shows up in laravel.log as
`[2020-12-04 21:53:21] development.ERROR: SAML user 'missing@example.com' could not be found in database.`


**Test Configuration**:
* PHP version: 7.4.4
* MySQL version:  MariaDB 10.4
* Webserver version: Apache 2.4.43
* OS version: Window Server 2019


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
