### PR TITLE
Fixed #8884: Fixed alpine image build

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -47,8 +47,7 @@ WORKDIR /var/www/html
 
 COPY docker/docker.env /var/www/html/.env
 
-RUN mkdir -p "/var/www/html/vendor" \
-    && chown -R apache:apache /var/www/html
+RUN chown -R apache:apache /var/www/html
 
 RUN \
 	rm -r "/var/www/html/storage/private_uploads" \
@@ -74,7 +73,7 @@ VOLUME ["/var/lib/snipeit"]
 
 # Entrypoints
 COPY docker/entrypoint_alpine.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.shf
 
 ENTRYPOINT ["/sbin/tini", "--"]
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.12
 # Apache + PHP
 RUN  apk add --update --no-cache \
         apache2 \
@@ -23,6 +23,8 @@ RUN  apk add --update --no-cache \
         php7-fileinfo \
         php7-simplexml \
         php7-session \
+        php7-dom \
+        php7-xmlwriter \
         curl \
         wget \
         vim \
@@ -45,7 +47,8 @@ WORKDIR /var/www/html
 
 COPY docker/docker.env /var/www/html/.env
 
-RUN chown -R apache:apache /var/www/html
+RUN mkdir -p "/var/www/html/vendor" \
+    && chown -R apache:apache /var/www/html
 
 RUN \
 	rm -r "/var/www/html/storage/private_uploads" \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -73,7 +73,7 @@ VOLUME ["/var/lib/snipeit"]
 
 # Entrypoints
 COPY docker/entrypoint_alpine.sh /entrypoint.sh
-RUN chmod +x /entrypoint.shf
+RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/sbin/tini", "--"]
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -47,8 +47,7 @@ WORKDIR /var/www/html
 
 COPY docker/docker.env /var/www/html/.env
 
-RUN mkdir -p "/var/www/html/vendor" \
-    && chown -R apache:apache /var/www/html
+RUN chown -R apache:apache /var/www/html
 
 RUN \
 	rm -r "/var/www/html/storage/private_uploads" \

--- a/docker/entrypoint_alpine.sh
+++ b/docker/entrypoint_alpine.sh
@@ -49,5 +49,7 @@ php artisan migrate --force
 php artisan config:clear
 php artisan config:cache
 
+chown -R apache:root /var/www/html/storage/logs/laravel.log
+
 export APACHE_LOG_DIR=/var/log/apache2
 exec httpd -DNO_DETACH < /dev/null


### PR DESCRIPTION
# Description

The Alpine docker image build was broken. This PR aims to reestablish this build so that it is possible to use a reduced size Docker image and based on a distribution focused on security

Fixes #8884

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The image was built and deployed in a complete production environment

**Test Configuration**:
* PHP version: 7
* MySQL version: 8.0.22
* Webserver version: Apache/2.4.46
* OS version: Alpine 3.12

# Checklist:

- [*] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [*] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [*] My code follows the style guidelines of this project
- [*] My changes generate no new warnings
- [*] I have added tests that prove my fix is effective or that my feature works
- [*] New and existing unit tests pass locally with my changes
