### PR TITLE
Fix for #8890: The last audit is not recorded correctly. (12/24hours ambiguity fix)

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -812,7 +812,7 @@ class AssetsController extends Controller
                 $asset->location_id = $request->input('location_id');
             }
 
-            $asset->last_audit_date = date('Y-m-d h:i:s');
+            $asset->last_audit_date = date('Y-m-d H:i:s');
 
             if ($asset->save()) {
                 $log = $asset->logAudit(request('note'),request('location_id'));


### PR DESCRIPTION
To eliminate 12/24hours ambiguity fix. This fix prevents loss of time accuracy.

# Description
Bug description see #8890 
Fixes #8890

``Its a tiny fix to eliminate 12/24hours ambiguity. Fix prevents time accuracy loss in field "last_audit_date" for assets.
(Minor fix)``

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
Fixes #8890

# How Has This Been Tested?

``After this fix You will be able to know when was the last audit (in the early morning or evening).``
``Before the fix it is unclear.``

**Test Configuration**:
* PHP version:  - Does Not Depend (DND)
* MySQL version -  DND
* Webserver version - DND
* OS version  - DND


# Checklist: ALL PASSED
