### PR TITLE
Localization digit separator feature.

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -577,6 +577,7 @@ class SettingsController extends Controller
         $setting->default_currency    = $request->input('default_currency', '$');
         $setting->date_display_format = $request->input('date_display_format');
         $setting->time_display_format = $request->input('time_display_format');
+        $setting->digit_separator = $request->input('digit_separator');
 
         if ($setting->save()) {
             return redirect()->route('settings.index')

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -146,6 +146,7 @@ class AssetPresenter extends Presenter
                 "searchable" => true,
                 "sortable" => true,
                 "title" => trans('general.purchase_cost'),
+                "formatter" => 'numberWithCommas',
                 "footerFormatter" => 'sumFormatter',
             ], [
                 "field" => "order_number",

--- a/database/migrations/2020_12_14_233815_add_digit_separator_to_settings.php
+++ b/database/migrations/2020_12_14_233815_add_digit_separator_to_settings.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDigitSeparatorToSettings extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->char('digit_separator')->nullable()->default('1234.56');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('digit_separator');
+        });
+    }
+}

--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -411,6 +411,25 @@ Form::macro('time_display_format', function ($name = "time_display_format", $sel
 
 });
 
+Form::macro('digit_separator', function ($name = "digit_separator", $selected = null, $class = null) {
+
+    $formats = [
+        '1234.56',
+        '1.234,56',
+    ];
+
+    foreach ($formats as $format) {
+    }
+    $select = '<select name="'.$name.'" class="'.$class.'" style="min-width:120px">';
+    foreach ($formats as $format_inner ) {
+        $select .= '<option value="'.$format_inner.'"'.($selected == $format_inner ? ' selected="selected"' : '').'>'.$format_inner.'</option> ';
+    }
+
+    $select .= '</select>';
+    return $select;
+
+});
+
 /**
 * Barcode macro
 * Generates the dropdown menu of available 1D barcodes

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -592,11 +592,19 @@
             var total_sum = data.reduce(function(sum, row) {
                 return (sum) + (parseFloat(row[field]) || 0);
             }, 0);
-            return total_sum.toFixed(2);
+            return numberWithCommas(total_sum.toFixed(2));
         }
         return 'not an array';
     }
 
+    function numberWithCommas(value) {
+        if ((value) && ("{{$snipeSettings->digit_separator}}" == "1.234,56")){
+        var parts = value.toString().split(".");
+        parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+        return parts.join(",");
+        }
+        return value
+    }
 
     $(function () {
         $('#bulkEdit').click(function () {

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -72,7 +72,10 @@
                                 {{ Form::label('default_currency', trans('admin/settings/general.default_currency')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('default_currency', old('default_currency', $setting->default_currency), array('class' => 'form-control','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                                {{ Form::text('default_currency', old('default_currency', $setting->default_currency), array('class' => 'form-control select2-container','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px; display: inline-block; ')) }}
+
+                                {!! Form::digit_separator('digit_separator', old('digit_separator', $setting->digit_separator), 'select2') !!}
+
                                 {!! $errors->first('default_currency', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
                         </div>


### PR DESCRIPTION
Provides an ability to localize the purchase_cost field in front-end hardware index table.
Has two formats of digit separator tuned in admin localization page - comma and dot separators.

# Description

Fixes #8896

![Video_2020-12-16_151337](https://user-images.githubusercontent.com/6271335/102347613-af6f4b80-3fb1-11eb-91be-2cee22bb4612.gif)


## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Try to change digit separator formats in admin "Localization" page and check what will change in "All Asset" page.

**Test Configuration**:
* PHP version: 7.2.24
* MySQL version: 10.1.47-MariaDB-0ubuntu0.18.04.1 Ubuntu 18.04
* Webserver version: Server version: Apache/2.4.29 (Ubuntu) Server built:   2020-08-12T21:33:25
* OS version: Ubuntu 18.04

# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
