### PR TITLE
Optimize target type + ID index for more realistic use cases

### DIFF
--- a/database/migrations/2020_12_18_090026_swap_target_type_index_order.php
+++ b/database/migrations/2020_12_18_090026_swap_target_type_index_order.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class SwapTargetTypeIndexOrder extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->dropIndex(['target_id', 'target_type']);
+        });
+
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->index(['target_type', 'target_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->dropIndex(['target_type', 'target_id']);
+        });
+
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->index(['target_id', 'target_type']);
+        });
+    }
+}


### PR DESCRIPTION
Per https://youtu.be/EOXgHH4-WX4?t=1378 or thereabouts

# Description

This swaps column order on a multi-column index to allow for indexed queries on target type alone (which makes sense) in addition to target type + target ID, versus target ID alone (which, since we're talking about a polymorphic relationship here, doesn't make any sense).

That, or I wasn't listening closely enough to the sweary database talk ;)

I'll re-roll the commit message here if @uberbrady gives me an issue # to tag this with.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Pulled down the project under PHP 7.4.13 (Homebrew/Big Sur), installed deps, pointed it at a MySQL DB, and ran migrations prior to making code changes. Made changes, ran migrations again. Then rolled back to ensure the down migration wasn't broken. Noting caught on fire.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [?] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [?] I have commented my code, particularly in hard-to-understand areas
- n/a I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
