### PR TITLE
Add migration for ldap_server URL's to ensure they are valid

### DIFF
--- a/database/migrations/2020_12_21_210105_fix_bad_ldap_server_url_for_v5.php
+++ b/database/migrations/2020_12_21_210105_fix_bad_ldap_server_url_for_v5.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class FixBadLdapServerUrlForV5 extends Migration
+{
+    /**
+     * Under v4 and previous versions of Snipe-IT, we permitted users to incorrectly specify LDAP URL's in their settings, and Snipe-IT 
+     * would silently permit that.
+     * 
+     * v5's LDAP system is not so lenient, and requires either ldap:// or ldaps:// in front of the server's URL. This migration tries
+     * to find misconfigured LDAP URL's and prepend 'ldap://' to them. (That's what we assumed if we *didn't* see ldaps://)
+     */
+    
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // UPDATE settings SET ldap_server = CONCAT('ldap://',ldap_server) WHERE ldap_server NOT LIKE 'ldap://%' AND ldap_server NOT LIKE 'ldaps://%'
+        $settings = App\Models\Setting::where("ldap_server","not like","ldap://%")->where("ldap_server","not like","ldaps://%");
+        foreach($settings->get() AS $setting) { // we don't formally support having multiple settings records, but just in case they come up...
+            $setting->ldap_server = "ldap://".$setting->ldap_server;
+            $setting->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Since previous versions supported ldap:// URL's just fine, we don't need to migrate these changes back out on rollback.
+    }
+}


### PR DESCRIPTION
Meaning, specifically, that they start with `ldap://` or `ldaps://`

I could've done this with some SQL cleverness but I thought being a little more verbose and un-clever might be easier to troubleshoot and understand.

We grab all the settings records that **don't** start with either `ldap://` or `ldaps://`, and we prepend `ldap://` to them. I decided to hit all settings records (not just the first) because some users might do the same trick that we do where we have multiple settings files and shift them around sometimes.

I tested this by migrating back and forth for three cases:

1. If you have `ldap://` starting your URL, the migration shouldn't change it.
2. If you have `ldaps://` starting your URL, the migration shouldn't change that either.
3. If you don't have either of those, the migration should prepend `ldap://` to it.