### PR TITLE
Fixed #8942: Include quantity in totalCost calculation

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -856,7 +856,7 @@
                                                     </td>
                                                     <td>{{ $component->pivot->assigned_qty }}</td>
                                                     <td>{{ $component->purchase_cost }}</td>
-                                                    <?php $totalCost = $totalCost + $component->purchase_cost ;?>
+                                                    <?php $totalCost = $totalCost + $component->purchase_cost * $component->pivot->assigned_qty ;?>
 
                                                 </tr>
                                             @endif


### PR DESCRIPTION
# Description

The totalCost calculation didn't include the quantity.

Before:
![grafik](https://user-images.githubusercontent.com/2892832/103159263-92175a00-47c7-11eb-9408-d666b73fd2e4.png)

After:
![grafik](https://user-images.githubusercontent.com/2892832/103159271-bb37ea80-47c7-11eb-934f-ff8f31899cc3.png)

Fixes #8942

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added multiple components to an asset with quantities larger than one, as seen on the previous screenshots.

**Test Configuration**:
* PHP version: PHP Version 7.4.3
* MySQL version 10.3.25-MariaDB
* Webserver version Apache/2.4.41
* OS version Ubuntu Server 20.04 LTS


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
