### PR TITLE
Fix docker/startup.sh to run migrations before supervisord

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -55,11 +55,9 @@ then
   cp -ax /var/www/html/vendor/laravel/passport/database/migrations/* /var/www/html/database/migrations/
 fi
 
-exec supervisord -c /supervisord.conf
-
+# Perform migration actions before starting the webserver
 php artisan migrate --force
 php artisan config:clear
 php artisan config:cache
 
-. /etc/apache2/envvars
-exec apache2 -DNO_DETACH < /dev/null
+exec supervisord -c /supervisord.conf


### PR DESCRIPTION
# Description

This restores the intended behavior of the docker image, whereby migrations are run automatically at startup. See the history of this defect here: https://github.com/snipe/snipe-it/issues/8953#issuecomment-753247027

Fixes #8953

To support the correctness of this code, please review the changes to `docker/startup.sh` in these PRs:
- #6606
- #6680

Somewhere along the way, those changes were incorrectly merged, and this PR fixes that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Simply running the docker image and observing the output -- necessary migrations will run prior to starting Apache.
# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas