### PR TITLE
Fix for default parameters in JS functions IE

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -175,7 +175,9 @@
 
 
     // Make the edit/delete buttons
-    function genericActionsFormatter(owner_name, element_name = '') {
+    function genericActionsFormatter(owner_name, element_name) {
+        if(!element_name) element_name = ''
+
         return function (value,row) {
 
             var actions = '<nobr>';

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -176,7 +176,9 @@
 
     // Make the edit/delete buttons
     function genericActionsFormatter(owner_name, element_name) {
-        if(!element_name) element_name = ''
+        if (!element_name) {
+            element_name = '';
+        }
 
         return function (value,row) {
 


### PR DESCRIPTION
# Description
Internet Explorer's JavaScript engine doesn't support default parameters in the definition for functions. So I quit the assignation from the parameter list of the function definition and use an if to evaluate if the `element_name` is falsey (null, undefined) and assign the empty value as corresponds.

Fixes # (issue)

## Type of change
Fix

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Manually on a Windows machine with IE11 and Firefox 83 in Fedora Linux.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version: 7.4.13
* MySQL version: MariaDB 10.4
* Webserver version: NGINX 1.18
* OS version: Windows 10 and Fedora 33


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
