### PR TITLE
Added #8931: add health controller without session

### DIFF
--- a/app/Http/Controllers/HealthController.php
+++ b/app/Http/Controllers/HealthController.php
@@ -1,0 +1,23 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Controller as BaseController;
+
+
+/**
+ * This controller provide the healthz route  for
+ * the Snipe-IT Asset Management application.
+ *
+ * @version    v1.0
+ */
+class HealthController extends BaseController
+{
+    /**
+     * Returns a fixed JSON content ({ "status": "ok"}) which indicate the app is up and running
+     */
+    public function get() {
+        return response()->json([
+            "status" => "ok"
+        ]);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,7 +14,12 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
+        \App\Http\Middleware\NoSessionStore::class,
+        \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+        \Illuminate\Session\Middleware\StartSession::class,
+        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \Fideloper\Proxy\TrustProxies::class,
+        \App\Http\Middleware\CheckForSetup::class,
         \App\Http\Middleware\CheckForDebug::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\SecurityHeaders::class,
@@ -28,10 +33,6 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \Illuminate\Session\Middleware\StartSession::class,
-            \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
-            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            \App\Http\Middleware\CheckForSetup::class,
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
@@ -42,10 +43,6 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            \Illuminate\Session\Middleware\StartSession::class,
-            \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
-            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-            \App\Http\Middleware\CheckForSetup::class,
             \Barryvdh\Cors\HandleCors::class,
             'throttle:120,1',
             'auth:api',

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,11 +14,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
-        \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
-        \Illuminate\Session\Middleware\StartSession::class,
-        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \Fideloper\Proxy\TrustProxies::class,
-        \App\Http\Middleware\CheckForSetup::class,
         \App\Http\Middleware\CheckForDebug::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\SecurityHeaders::class,
@@ -32,6 +28,10 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \App\Http\Middleware\CheckForSetup::class,
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
@@ -42,6 +42,10 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \App\Http\Middleware\CheckForSetup::class,
             \Barryvdh\Cors\HandleCors::class,
             'throttle:120,1',
             'auth:api',

--- a/app/Http/Middleware/CheckForSetup.php
+++ b/app/Http/Middleware/CheckForSetup.php
@@ -27,7 +27,7 @@ class CheckForSetup
             }
 
         } else {
-            if (!($request->is('setup*')) && !($request->is('.env'))) {
+            if (!($request->is('setup*')) && !($request->is('.env')) && !($request->is('health'))) {
                 return redirect(url('/').'/setup');
             }
 

--- a/app/Http/Middleware/NoSessionStore.php
+++ b/app/Http/Middleware/NoSessionStore.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class NoSessionStore
+{
+    protected $except = [
+        'health'
+    ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        foreach ($this->except as $except) {
+            if ($request->is($except)) {
+                config()->set('session.driver', 'array');
+            }
+        }
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,5 +12,6 @@ class VerifyCsrfToken extends BaseVerifier
      * @var array
      */
     protected $except = [
+        'health'
     ];
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -464,4 +464,4 @@ Route::group(['middleware' => 'web'], function () {
 
 Auth::routes();
 
-Route::get('/healthz', [ 'as' => 'health', 'uses' => 'HealthController@get']);
+Route::get('/health', [ 'as' => 'health', 'uses' => 'HealthController@get']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -464,5 +464,4 @@ Route::group(['middleware' => 'web'], function () {
 
 Auth::routes();
 
-
-
+Route::get('/healthz', [ 'as' => 'health', 'uses' => 'HealthController@get']);


### PR DESCRIPTION
# Description

Added a `health` controller which doesn't start a new session to fix the session spam generated by load balancer health check.

Fixes #8931

## Type of change

- [X ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Make a HTTP call to the new endpoint (`/health`)
- [X] Check response is `200 OK` with the json `{ "status": "ok" }`
- [X] Check there is no session created by the app
- [X] Make a HTTP call to any other endpoint (like `/`) and check if a session is stored and the `snipeit*` cookie is present in HTTP response

**Test Configuration**:
* PHP version: 7.3
* MySQL version
* Webserver version: Apache
* OS version: Docker
