### PR TITLE
Custom fields now allows Checkboxes and Radiobuttons

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -90,6 +90,10 @@ class CustomFieldsController extends Controller
             $field->format = e($request->get("format"));
         }
 
+        if($request->filled("element") == "checkbox"){
+            $field->format = 'boolean';
+        }
+
         if ($field->save()) {
 
             return redirect()->route("fields.index")->with("success", trans('admin/custom_fields/message.field.create.success'));

--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -90,7 +90,7 @@ class CustomFieldsController extends Controller
             $field->format = e($request->get("format"));
         }
 
-        if($request->filled("element") == "checkbox"){
+        if($request->get("element") == "checkbox"){
             $field->format = 'boolean';
         }
 

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -32,7 +32,6 @@ class CustomField extends Model
             'IPV4'          => 'ipv4',
             'IPV6'          => 'ipv6',
             'MAC'           => 'regex:/^[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}$/',
-            'BOOLEAN'       => 'boolean',
         ];
 
     public $guarded = [
@@ -286,8 +285,10 @@ class CustomField extends Model
     public function formatFieldValuesAsArray()
     {
         $arr = preg_split("/\\r\\n|\\r|\\n/", $this->field_values);
-
-        $result[''] = 'Select '.strtolower($this->format);
+        
+        if ($this->element != 'radio') {
+            $result[''] = 'Select ' . strtolower($this->format);
+        }
 
         for ($x = 0; $x < count($arr); $x++) {
             $arr_parts = explode('|', $arr[$x]);

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -70,7 +70,7 @@
           </div>
 
           <!-- Format -->
-          <div class="form-group {{ $errors->has('format') ? ' has-error' : '' }}">
+          <div class="form-group {{ $errors->has('format') ? ' has-error' : '' }}" id="format">
             <label for="format" class="col-md-4 control-label">
               {{ trans('admin/custom_fields/general.field_format') }}
             </label>
@@ -175,6 +175,19 @@
                     $("#field_values_text").show();
                 } else{
                     $("#field_values_text").hide();
+                }
+            });
+        }).change();
+
+        // Checkbox handling
+        $(".field_element").change(function(){
+            $(this).find("option:selected").each(function(){
+                if (($(this).attr("value")=="checkbox")){
+                    $("#field_values_text").hide();
+                    $("#format").hide();
+                } else{
+                    $("#field_values_text").show();
+                    $("#format").show();
                 }
             });
         }).change();

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -410,6 +410,8 @@
                                                         @can('superuser')
                                                             @if (($field->format=='URL') && ($asset->{$field->db_column_name()}!=''))
                                                                 <a href="{{ \App\Helpers\Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}" target="_new">{{ \App\Helpers\Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}</a>
+                                                            @elseif ($field->format == 'boolean')
+                                                                {{ \App\Helpers\Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) == 1 ? 'TRUE' : 'FALSE' }}
                                                             @else
                                                                 {{ \App\Helpers\Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}
                                                             @endif
@@ -420,6 +422,8 @@
                                                     @else
                                                         @if (($field->format=='URL') && ($asset->{$field->db_column_name()}!=''))
                                                             <a href="{{ $asset->{$field->db_column_name()} }}" target="_new">{{ $asset->{$field->db_column_name()} }}</a>
+                                                        @elseif ($field->format == 'boolean')
+                                                            {{ $asset->{$field->db_column_name()} == 1 ? 'TRUE' : 'FALSE' }}
                                                         @else
                                                             {!! nl2br(e($asset->{$field->db_column_name()})) !!}
                                                         @endif

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -19,7 +19,7 @@
                   <!-- Checkboxes -->
                   <div>
                     <label>
-                        <input type="checkbox" value="1" name="{{ $field->db_column_name() }}" class="minimal" {{ $item->{$field->db_column_name()} != '' ? ' checked="checked"' : '' }}>
+                        <input type="checkbox" value="1" name="{{ $field->db_column_name() }}" class="minimal" {{ $item->{$field->db_column_name()} ?? '' != '' ? ' checked="checked"' : '' }}>
                    </label>
                   </div>
 
@@ -28,7 +28,7 @@
               @foreach ($field->formatFieldValuesAsArray() as $key)
                   <div>
                       <label>
-                          <input type="radio" value="{{ $key }}" name="{{ $field->db_column_name() }}" class="minimal" {{ $item->{$field->db_column_name()} == $key ? ' checked="checked"' : '' }}> {{ $key }}
+                          <input type="radio" value="{{ $key }}" name="{{ $field->db_column_name() }}" class="minimal" {{ $item->{$field->db_column_name()} ?? '' == $key ? ' checked="checked"' : '' }}> {{ $key }}
                       </label>
                   </div>
               @endforeach

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -21,7 +21,7 @@
 
                       <div>
                           <label>
-                              <input type="checkbox" value="1" name="{{ $field->db_column_name() }}[]" class="minimal" {{ Request::old($field->db_column_name()) != '' ? ' checked="checked"' : '' }}> key: {{ $key }} value: {{ $value }}
+                              <input type="checkbox" value="1" name="{{ $field->db_column_name() }}" class="minimal" {{ $item->{$field->db_column_name()} != '' ? ' checked="checked"' : '' }}>
                           </label>
                       </div>
                   @endforeach

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -16,17 +16,24 @@
 
 
               @elseif ($field->element=='checkbox')
-                    <!-- Checkboxes -->
-                  @foreach ($field->formatFieldValuesAsArray() as $key => $value)
+                  <!-- Checkboxes -->
+                  <div>
+                    <label>
+                        <input type="checkbox" value="1" name="{{ $field->db_column_name() }}" class="minimal" {{ $item->{$field->db_column_name()} != '' ? ' checked="checked"' : '' }}>
+                   </label>
+                  </div>
 
-                      <div>
-                          <label>
-                              <input type="checkbox" value="1" name="{{ $field->db_column_name() }}" class="minimal" {{ $item->{$field->db_column_name()} != '' ? ' checked="checked"' : '' }}>
-                          </label>
-                      </div>
-                  @endforeach
+              @elseif ($field->element=='radio')
+              <!-- Radiobuttons -->
+              @foreach ($field->formatFieldValuesAsArray() as $key)
+                  <div>
+                      <label>
+                          <input type="radio" value="{{ $key }}" name="{{ $field->db_column_name() }}" class="minimal" {{ $item->{$field->db_column_name()} == $key ? ' checked="checked"' : '' }}> {{ $key }}
+                      </label>
+                  </div>
+              @endforeach
 
-              @endif
+          @endif
 
 
           @else


### PR DESCRIPTION
# Description
Added functionality for checkboxes and Radiobuttons in the Custom Fields. Radiobuttons where not implemented, now they appear correctly on the  form for create and edit assets that contains that Custom Fields.

Fixes # (issue)
N/A

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Manually.

**Test Configuration**:
* PHP version: 7.4.13
* MySQL version: MariaDB 10.4.17
* Webserver version: NGINX 1.18.0
* OS version: Fedora 33


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
