### PR TITLE
Fixed non-superadmin gate permissions for kits

### DIFF
--- a/app/Policies/PredefinedKitPolicy.php
+++ b/app/Policies/PredefinedKitPolicy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Policies;
+
+class PredefinedKitPolicy extends SnipePermissionsPolicy
+{
+    protected function columnName()
+    {
+        return 'kits';
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,6 +16,7 @@ use App\Models\Depreciation;
 use App\Models\License;
 use App\Models\Location;
 use App\Models\Manufacturer;
+use App\Models\PredefinedKit;
 use App\Models\Statuslabel;
 use App\Models\Supplier;
 use App\Models\User;
@@ -33,6 +34,7 @@ use App\Policies\DepreciationPolicy;
 use App\Policies\LicensePolicy;
 use App\Policies\LocationPolicy;
 use App\Policies\ManufacturerPolicy;
+use App\Policies\PredefinedKitPolicy;
 use App\Policies\StatuslabelPolicy;
 use App\Policies\SupplierPolicy;
 use App\Policies\UserPolicy;
@@ -63,6 +65,7 @@ class AuthServiceProvider extends ServiceProvider
         Depreciation::class => DepreciationPolicy::class,
         License::class => LicensePolicy::class,
         Location::class => LocationPolicy::class,
+        PredefinedKit::class => PredefinedKitPolicy::class,
         Statuslabel::class => StatuslabelPolicy::class,
         Supplier::class => SupplierPolicy::class,
         User::class => UserPolicy::class,


### PR DESCRIPTION
This should fix the permissions for Predefined Kits for non-admins.

### How to Test - User Permissions

- Create a non-superadmin user and grant them kit access to the *user* to view, edit, etc
- Try to create, edit, etc a predefined kit
- Confirm that any kit permissions that are denied to that user prevent the user from doing that action

### How to Test - Group  Permissions

- Create a non-superadmin user *group* and grant it kit access to view, edit, etc
- Create a user with no specific permissions granted and assign them to only the group you created above (the one with kits permissions)
- Try to create, edit, etc a predefined kit as that user
- Confirm that any kit permissions that are denied to that user prevent the user from doing that action

