### PR TITLE
Use the correct env variables in config/auth.php file.

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -189,8 +189,8 @@ class LoginController extends Controller
             return redirect()->back()->withInput()->withErrors($validator);
         }
 
-        $this->maxLoginAttempts = config('auth.throttle.max_attempts');
-        $this->lockoutTime = config('auth.throttle.lockout_duration');
+        $this->maxLoginAttempts = config('auth.passwords.users.throttle.max_attempts');
+        $this->lockoutTime = config('auth.passwords.users.throttle.lockout_duration');
 
         if ($lockedOut = $this->hasTooManyLoginAttempts($request)) {
             $this->fireLockoutEvent($request);
@@ -452,8 +452,8 @@ class LoginController extends Controller
      */
     protected function hasTooManyLoginAttempts(Request $request)
     {
-        $lockoutTime = config('auth.throttle.lockout_duration');
-        $maxLoginAttempts = config('auth.throttle.max_attempts');
+        $lockoutTime = config('auth.passwords.users.throttle.lockout_duration');
+        $maxLoginAttempts = config('auth.passwords.users.throttle.max_attempts');
 
         return $this->limiter()->tooManyAttempts(
             $this->throttleKey($request),

--- a/config/auth.php
+++ b/config/auth.php
@@ -103,7 +103,10 @@ return [
             'email' => 'auth.emails.password',
             'table' => 'password_resets',
             'expire' => env('RESET_PASSWORD_LINK_EXPIRES', 900),
-            'throttle' => env('LOGIN_MAX_ATTEMPTS', 60),
+            'throttle' => [
+                'max_attempts' => env('LOGIN_MAX_ATTEMPTS', 5),
+                'lockout_duration' => env('LOGIN_LOCKOUT_DURATION', 60)
+            ],
         ],
     ],
 


### PR DESCRIPTION
# Description
If password is wrong after just two attempts, it shows the  "Too many failed attempts" message. Reviewing the `config/auth.php` and the `LoginController` I added the (in my understanding) correct variables format in `auth.php` then put the correct route in the `LoginController`, also added a default so if there isn't a variable setted in the env file it functions correctly. For more insight review the file changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


**Test Configuration**: 
* PHP version: 7.4.14
* MySQL version: MariaDB Ver. 15.1 Distrib 10.4.17
* Webserver version: NGINX 1.18
* OS version: Fedora 33


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
