### PR TITLE
Added better visual cues for login

### DIFF
--- a/resources/lang/en/auth/general.php
+++ b/resources/lang/en/auth/general.php
@@ -9,5 +9,7 @@ return [
     'login_prompt'                  => 'Please Login',
     'forgot_password'               => 'I forgot my password',
     'remember_me'                   => 'Remember Me',
+    'username_help_top'                 => 'Enter your <strong>username</strong> to be emailed a password reset link.',
+    'username_help_bottom'          => 'Your username and email address <em>may</em> be the same, but may not be, depending on your configuration. If you cannot remember your username, contact your administrator. <br><br><strong>Usernames without an associated email address will not be emailed a password reset link.</strong> ',
     ];
 

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -243,5 +243,7 @@
     'i_accept'              => 'I accept',
     'i_decline'             => 'I decline',
     'sign_tos'              => 'Sign below to indicate that you agree to the terms of service:',
-    'clear_signature'       => 'Clear Signature'
+    'clear_signature'       => 'Clear Signature',
+    'show_help'             => 'Show help',
+    'hide_help'             => 'Hide help',
     ];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -53,8 +53,8 @@
                                             {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
                                         </div>
                                         <div class="checkbox">
-                                            <label>
-                                                <input name="remember" type="checkbox" value="1">{{ trans('auth/general.remember_me')  }}
+                                            <label style="margin-left: -20px;">
+                                                <input name="remember" type="checkbox" value="1" class="minimal"> {{ trans('auth/general.remember_me')  }}
                                             </label>
                                         </div>
                                     </fieldset>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -43,12 +43,12 @@
                                     <fieldset>
 
                                         <div class="form-group{{ $errors->has('username') ? ' has-error' : '' }}">
-                                            <label for="username">{{ trans('admin/users/table.username')  }}</label>
+                                            <label for="username"><i class="fa fa-user" aria-hidden="true"></i> {{ trans('admin/users/table.username')  }}</label>
                                             <input class="form-control" placeholder="{{ trans('admin/users/table.username')  }}" name="username" type="text" id="username" autocomplete="off" autofocus>
                                             {!! $errors->first('username', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
                                         </div>
                                         <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                                            <label for="password">{{ trans('admin/users/table.password')  }}</label>
+                                            <label for="password"><i class="fa fa-key" aria-hidden="true"></i> {{ trans('admin/users/table.password')  }}</label>
                                             <input class="form-control" placeholder="{{ trans('admin/users/table.password')  }}" name="password" type="password" id="password" autocomplete="off">
                                             {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
                                         </div>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -17,7 +17,7 @@
                 <div class="col-md-4 col-md-offset-4">
 
                     <div class="box login-box">
-                        <div class="box-header">
+                        <div class="box-header with-border">
                             <h1 class="box-title"> {{ trans('auth/general.login_prompt')  }}</h1>
                         </div>
 

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -5,7 +5,9 @@
 @section('content')
 
     @if ($snipeSettings->custom_forgot_pass_url)
-        <a href="{{ $snipeSettings->custom_forgot_pass_url  }}" rel="noopener">{{ trans('auth/general.forgot_password')  }}</a>
+        <a href="{{ $snipeSettings->custom_forgot_pass_url  }}" rel="noopener">
+            {{ trans('auth/general.forgot_password')  }}
+        </a>
     @else
 
     <form class="form" role="form" method="POST" action="{{ url('/password/email') }}">
@@ -13,18 +15,27 @@
     <div class="container">
         <div class="row">
 
-
-
             <div class="col-md-4 col-md-offset-4">
 
                 <div class="box login-box" style="width: 100%">
-                        <div class="box-header">
+                        <div class="box-header with-border">
                             <h2 class="box-title"> {{ trans('auth/general.send_password_link')  }}</h2>
                         </div>
 
 
                         <div class="login-box-body">
                             <div class="row">
+                                <div class="col-md-12">
+                                    <div class="alert alert-info">
+                                        <i class="fa fa-info-circle" aria-hidden="true"></i>
+                                        {!! trans('auth/general.username_help_top') !!}
+                                    </div>
+                                </div>
+
+
+                            </div>
+                            <div class="row">
+
 
                                 <!-- Notifications -->
                                 @include('notifications')
@@ -34,20 +45,41 @@
                                     <div class="form-group{{ $errors->has('username') ? ' has-error' : '' }}">
 
                                         <div class="col-md-12">
-                                            <label for="username">{{ trans('admin/users/table.username') }}: </label>
+                                            <label for="username"><i class="fa fa-user" aria-hidden="true"></i> {{ trans('admin/users/table.username') }} </label>
                                             <input type="text" class="form-control" name="username" value="{{ old('username') }}" placeholder="{{ trans('admin/users/table.username') }}" aria-label="username">
                                             {!! $errors->first('username', '<span class="alert-msg"><i class="fa fa-times"></i> :message</span>') !!}
                                         </div>
                                     </div>
+                            </div>
 
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <br>
+                                    <!-- show help text toggle -->
+                                    <a href="#" id="show">
+                                        <i class="fa fa-caret-right"></i>
+                                        {{ trans('general.show_help') }}
+                                    </a>
 
+                                    <!-- hide help text toggle -->
+                                    <a href="#" id="hide" style="display:none">
+                                        <i class="fa fa-caret-up"></i>
+                                        {{ trans('general.hide_help') }}
+                                    </a>
 
+                                    <!-- help text  -->
+                                    <p class="help-block" id="help-text" style="display:none">
+                                        {!! trans('auth/general.username_help_bottom') !!}
+                                    </p>
+
+                                </div>
                             </div>
                         </div>
+
                         <div class="box-footer">
                             <button type="submit" class="btn btn-lg btn-primary btn-block">
                                 {{ trans('auth/general.email_reset_password')  }}
-                                </button>
+                            </button>
                         </div>
 
                     </div>
@@ -59,4 +91,22 @@
 
     @endif
 @stop
+
+@push('js')
+    <script nonce="{{ csrf_token() }}">
+        $(document).ready(function () {
+            $("#show").click(function(){
+                $("#help-text").show();
+                $("#show").hide();
+                $("#hide").show();
+            });
+
+            $("#hide").click(function(){
+                $("#help-text").hide();
+                $("#show").show();
+                $("#hide").hide();
+            });
+        });
+    </script>
+@endpush
 

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -16,7 +16,7 @@
                 <div class="col-md-6 col-md-offset-3">
 
                     <div class="box login-box" style="width: 100%">
-                        <div class="box-header">
+                        <div class="box-header with-border">
                             <h2 class="box-title"> {{ trans('auth/general.reset_password')  }}</h2>
                         </div>
 
@@ -32,7 +32,7 @@
                                     <input type="hidden" name="token" value="{{ $token }}">
 
                                     <div class="form-group{{ $errors->has('username') ? ' has-error' : '' }}">
-                                        <label class="col-md-4 control-label">{{ trans('admin/users/table.username')  }}</label>
+                                        <label class="col-md-4 control-label"><i class="fa fa-user" aria-hidden="true"></i> {{ trans('admin/users/table.username')  }}</label>
 
                                         <div class="col-md-6">
                                             <input type="text" class="form-control" name="username" value="{{ old('username', $username) }}">
@@ -42,7 +42,7 @@
                         </div>
 
                         <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label" for="password">{{ trans('admin/users/table.password')  }}</label>
+                            <label class="col-md-4 control-label" for="password"><i class="fa fa-key" aria-hidden="true"></i> {{ trans('admin/users/table.password')  }}</label>
 
                             <div class="col-md-6">
                                 <input type="password" class="form-control" name="password" aria-label="password">
@@ -51,7 +51,7 @@
                         </div>
 
                         <div class="form-group{{ $errors->has('password_confirmation') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label" for="password_confirmation">{{ trans('admin/users/table.password_confirm')  }}</label>
+                            <label class="col-md-4 control-label" for="password_confirmation"><i class="fa fa-key" aria-hidden="true"></i> {{ trans('admin/users/table.password_confirm')  }}</label>
                             <div class="col-md-6">
                                 <input type="password" class="form-control" name="password_confirmation" aria-label="password_confirmation">
                                 {!! $errors->first('password_confirmation', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/layouts/basic.blade.php
+++ b/resources/views/layouts/basic.blade.php
@@ -11,10 +11,15 @@
     <link rel="shortcut icon" type="image/ico" href="{{ ($snipeSettings) && ($snipeSettings->favicon!='') ?  Storage::disk('public')->url('').e($snipeSettings->favicon) : 'favicon.ico' }} ">
     {{-- stylesheets --}}
     <link rel="stylesheet" href="{{ url(mix('css/dist/all.css')) }}">
-
-
-    <link rel="stylesheet" href="{{ url('css/dist/all.css') }}">
     <link rel="shortcut icon" type="image/ico" href="{{ url(asset('favicon.ico')) }}">
+
+    <script nonce="{{ csrf_token() }}">
+        window.snipeit = {
+            settings: {
+                "per_page": 50
+            }
+        };
+    </script>
 
 
     @if (($snipeSettings) && ($snipeSettings->header_color))
@@ -64,6 +69,11 @@
     @endif
     </div>
 
+    {{-- Javascript files --}}
+    <script src="{{ url(mix('js/dist/all.js')) }}" nonce="{{ csrf_token() }}"></script>
+
+
+    @stack('js')
 </body>
 
 </html>


### PR DESCRIPTION
This just adds a few icons and additional help text to prevent confusion where a user or customer incorrectly believes that forgotten password emails are not being sent when they are entering their *email* address instead of their *username*, and within the system, their username is not their email address.

For example:

My username in the system is `snipe`, my email address is `snipe@snipe.net`, but within Snipe-IT, I have no email address listed. I mistakenly use my *email address* to try to login (and subsequently reset my password when that invariably doesn't work), and no email is ever sent. Other system emails are being sent fine, but *some* users never get their password reset email. 

<img width="454" alt="Screen Shot 2021-01-26 at 7 48 21 PM" src="https://user-images.githubusercontent.com/197404/105940147-7cd45c00-600f-11eb-8b05-c72291785f25.png">

<img width="460" alt="Screen Shot 2021-01-26 at 7 34 16 PM" src="https://user-images.githubusercontent.com/197404/105939879-f15acb00-600e-11eb-9440-c885d31908d3.png">

<img width="456" alt="Screen Shot 2021-01-26 at 7 34 23 PM" src="https://user-images.githubusercontent.com/197404/105939880-f28bf800-600e-11eb-9efb-a6a21156e2fe.png">

<img width="444" alt="Screen Shot 2021-01-26 at 7 48 08 PM" src="https://user-images.githubusercontent.com/197404/105940161-8231a680-600f-11eb-9779-5ba934936965.png">


So this PR:

- adds icons in front of the username/password fields for a visual clue
- adds some more helpful text to remind people of what they should be entering
