### PR TITLE
Added termination date, depreciation in license column selection [ch14505]

### DIFF
--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -103,11 +103,32 @@ class LicensesController extends Controller
             case 'category':
                 $licenses = $licenses->leftJoin('categories', 'licenses.category_id', '=', 'categories.id')->orderBy('categories.name', $order);
                 break;
+            case 'depreciation':
+                $licenses = $licenses->leftJoin('depreciations', 'licenses.depreciation_id', '=', 'depreciations.id')->orderBy('depreciations.name', $order);
+                break;
             case 'company':
                 $licenses = $licenses->leftJoin('companies', 'licenses.company_id', '=', 'companies.id')->orderBy('companies.name', $order);
                 break;
             default:
-                $allowed_columns = ['id','name','purchase_cost','expiration_date','purchase_order','order_number','notes','purchase_date','serial','company','category','license_name','license_email','free_seats_count','seats'];
+                $allowed_columns =
+                    [
+                        'id',
+                        'name',
+                        'purchase_cost',
+                        'expiration_date',
+                        'purchase_order',
+                        'order_number',
+                        'notes',
+                        'purchase_date',
+                        'serial',
+                        'company',
+                        'category',
+                        'license_name',
+                        'license_email',
+                        'free_seats_count',
+                        'seats',
+                        'termination_date',
+                    ];
                 $sort = in_array($request->input('sort'), $allowed_columns) ? e($request->input('sort')) : 'created_at';
                 $licenses = $licenses->orderBy($sort, $order);
                 break;

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -29,6 +29,8 @@ class LicensesTransformer
             'order_number' => e($license->order_number),
             'purchase_order' => e($license->purchase_order),
             'purchase_date' => Helper::getFormattedDateObject($license->purchase_date, 'date'),
+            'termination_date' => Helper::getFormattedDateObject($license->termination_date, 'date'),
+            'depreciation' => ($license->depreciation) ? ['id' => (int) $license->depreciation->id,'name'=> e($license->depreciation->name)] : null,
             'purchase_cost' => e($license->purchase_cost),
             'notes' => e($license->notes),
             'expiration_date' => Helper::getFormattedDateObject($license->expiration_date, 'date'),

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -108,6 +108,7 @@ class License extends Depreciable
       'manufacturer' => ['name'],
       'company'      => ['name'],
       'category'     => ['name'],
+      'depreciation' => ['name'],
     ];
 
     /**

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -97,7 +97,26 @@ class LicensePresenter extends Presenter
                 "visible" => false,
                 "title" => trans('general.purchase_date'),
                 'formatter' => 'dateDisplayFormatter'
-            ], [
+            ],
+            [
+                "field" => "termination_date",
+                "searchable" => true,
+                "sortable" => true,
+                "visible" => false,
+                "title" => trans('admin/licenses/form.termination_date'),
+                'formatter' => 'dateDisplayFormatter'
+            ],
+            [
+                "field" => "depreciation",
+                "searchable" => true,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('admin/hardware/form.depreciation'),
+                "visible" => false,
+                "formatter" => "depreciationsLinkObjFormatter",
+            ],
+
+            [
                 "field" => "maintained",
                 "searchable" => false,
                 "sortable" => true,

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -167,9 +167,22 @@
                     </strong>
                   </div>
                   <div class="col-md-8">
-                    {{ $license->expiration_date }}
+                    {{ \App\Helpers\Helper::getFormattedDateObject($license->expiration_date, 'date', false) }}
                   </div>
                 </div>
+                @endif
+
+                @if ($license->termination_date)
+                  <div class="row">
+                    <div class="col-md-4">
+                      <strong>
+                        {{ trans('admin/licenses/form.termination_date') }}
+                      </strong>
+                    </div>
+                    <div class="col-md-8">
+                      {{ \App\Helpers\Helper::getFormattedDateObject($license->termination_date, 'date', false) }}
+                    </div>
+                  </div>
                 @endif
 
 
@@ -188,8 +201,6 @@
                   </div>
                 </div>
 
-
-
                 <div class="row">
                   <div class="col-md-4">
                     <strong>
@@ -197,7 +208,7 @@
                     </strong>
                   </div>
                   <div class="col-md-8">
-                    {{ $license->depreciated_date()->format("Y-m-d") }}
+                    {{ \App\Helpers\Helper::getFormattedDateObject($license->depreciated_date(), 'date', false) }}
                   </div>
                 </div>
 
@@ -233,13 +244,14 @@
                   @endif
 
 
-                  @if (isset($license->purchase_date))
+                @if (isset($license->purchase_date))
                 <div class="row">
                   <div class="col-md-4">
                     <strong>{{ trans('general.purchase_date') }}</strong>
                   </div>
                   <div class="col-md-8">
-                    {{ $license->purchase_date }}
+                    {{ \App\Helpers\Helper::getFormattedDateObject($license->purchase_date, 'date', false) }}
+
                   </div>
                 </div>
                   @endif


### PR DESCRIPTION
This PR adds `termination_date` and `depreciation` to the Licenses listing (and also therefore the API, in addition to fixing a bug on the license view page that didn't honor the date formatting in `Settings > Localization`.  (I know it's gauche to include a different fix in a feature PR, but it's just a few lines.)

The new `depreciation` field is set in the relational search array on the model, which sort of automagically makes it work when you're searching on the `name` field of the relation. 