### PR TITLE
Fixes #8834 - Added support for radio buttons in Custom Fields.

### DIFF
--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -287,7 +287,7 @@ class CustomField extends Model
     {
         $arr = preg_split("/\\r\\n|\\r|\\n/", $this->field_values);
 
-        if (($this->element!='checkbox') && ($this->element!='checkbox')) {
+        if (($this->element!='checkbox') && ($this->element!='radio')) {
             $result[''] = 'Select '.strtolower($this->format);
         }
 

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -70,7 +70,7 @@
           </div>
 
           <!-- Format -->
-          <div class="form-group {{ $errors->has('format') ? ' has-error' : '' }}">
+          <div class="form-group {{ $errors->has('format') ? ' has-error' : '' }}" id="format_values">
             <label for="format" class="col-md-4 control-label">
               {{ trans('admin/custom_fields/general.field_format') }}
             </label>
@@ -164,6 +164,17 @@
                     $("#custom_regex").show();
                 } else{
                     $("#custom_regex").hide();
+                }
+            });
+        }).change();
+
+        // If the element is a radiobutton, doesn't show the format input box
+        $(".field_element").change(function(){
+            $(this).find("option:selected").each(function(){
+                if (($(this).attr("value") != "radio")){
+                    $("#format_values").show();
+                } else{
+                    $("#format_values").hide();
                 }
             });
         }).change();

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -27,6 +27,17 @@
                       </div>
                   @endforeach
 
+              @elseif ($field->element=='radio')
+              @foreach ($field->formatFieldValuesAsArray() as $value)
+
+              <div>
+                  <label>
+                      <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" class="minimal" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : '') }}>
+                      {{ $value }}
+                  </label>
+              </div>
+          @endforeach
+
               @endif
 
 


### PR DESCRIPTION
# Description
Radio Buttons now work when selected in Custom Fields. 

- Remove the 'Format' input field in the form when Radio buttons element are created as is not necessary (user sets the fixed values each radio button have)
- Add the logic to the view that actually renders the Radio buttons
- Add the logic to the model that converts the values showed in the view, so it doesn't paint the 'Select any' option as is not needed.

Fixes #8834 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 

**Test Configuration**:
* PHP version: 7.4.14
* MySQL version: MariaDB Ver 15.1 Distrib 10.4.17
* Webserver version: NGINX 1.18.0
* OS version: Fedora 33
