### PR TITLE
Fixes #9041 - Instead of return a JSON response, redirect back to the previous screen. [ch15737]

### DIFF
--- a/app/Http/Controllers/Users/UserFilesController.php
+++ b/app/Http/Controllers/Users/UserFilesController.php
@@ -38,7 +38,7 @@ class UserFilesController extends Controller
                 $filename = 'user-' . $user->id . '-' . str_random(8);
                 $filename .= '-' . str_slug($file->getClientOriginalName()) . '.' . $extension;
                 if (!$file->move($destinationPath, $filename)) {
-                    return JsonResponse::create(["error" => "Unabled to move file"], 500);
+                    return redirect()->back()->with('error', trans('admin/users/message.upload.invalidfiles'));
                 }
                 //Log the uploaded file to the log
                 $logAction = new Actionlog();
@@ -57,10 +57,10 @@ class UserFilesController extends Controller
                 }
                 $logActions[] = $logAction;
             }
-//            dd($logActions);
-            return JsonResponse::create($logActions);
+            // dd($logActions);
+            return redirect()->back()->with('success', trans('admin/users/message.upload.success'));
         }
-        return JsonResponse::create(["error" => "No User associated with this request"], 500);
+        return redirect()->back()->with('error', trans('admin/users/message.upload.nofiles'));
 
     }
 


### PR DESCRIPTION
# Description
The `UserFilesController.php` file returned a JSON response, that's why the browser displays it. Instead, I'm redirecting back to the screen that trigger the action. In this case, the User index view.

Fixes #9041 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* PHP version: 7.4.14
* MySQL version: mariadb  Ver 15.1 Distrib 10.4.17-MariaDB
* Webserver version. NGINX 1.18.0
* OS version: Fedora 33
