### PR TITLE
Fix issue where users with edit permission cannot invoke LDAP sync

### DIFF
--- a/app/Http/Controllers/Users/LDAPImportController.php
+++ b/app/Http/Controllers/Users/LDAPImportController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Services\LdapAd;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
+use App\Models\User as UserModel; // to more-clearly distinguish between the Users *controller* Namespace, at the top. (it's *not* a conflict, it's Users vs. User)
 
 class LDAPImportController extends Controller
 {
@@ -42,7 +43,7 @@ class LDAPImportController extends Controller
      */
     public function create()
     {
-        $this->authorize('update', User::class);
+        $this->authorize('update', UserModel::class);
         try {
             //$this->ldap->connect(); I don't think this actually exists in LdapAd.php, and we don't really 'persist' LDAP connections anyways...right?
         } catch (\Exception $e) {
@@ -65,6 +66,7 @@ class LDAPImportController extends Controller
      */
     public function store(Request $request)
     {
+        $this->authorize('update', UserModel::class);
         // Call Artisan LDAP import command.
         $location_id = $request->input('location_id');
         Artisan::call('snipeit:ldap-sync', ['--location_id' => $location_id, '--json_summary' => true]);

--- a/app/Http/Controllers/Users/LDAPImportController.php
+++ b/app/Http/Controllers/Users/LDAPImportController.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Services\LdapAd;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
-use App\Models\User as UserModel; // to more-clearly distinguish between the Users *controller* Namespace, at the top. (it's *not* a conflict, it's Users vs. User)
+use App\Models\User; // Note that this is awful close to 'Users' the namespace above; be careful
 
 class LDAPImportController extends Controller
 {
@@ -43,7 +43,7 @@ class LDAPImportController extends Controller
      */
     public function create()
     {
-        $this->authorize('update', UserModel::class);
+        $this->authorize('update', User::class);
         try {
             //$this->ldap->connect(); I don't think this actually exists in LdapAd.php, and we don't really 'persist' LDAP connections anyways...right?
         } catch (\Exception $e) {
@@ -66,7 +66,7 @@ class LDAPImportController extends Controller
      */
     public function store(Request $request)
     {
-        $this->authorize('update', UserModel::class);
+        $this->authorize('update', User::class);
         // Call Artisan LDAP import command.
         $location_id = $request->input('location_id');
         Artisan::call('snipeit:ldap-sync', ['--location_id' => $location_id, '--json_summary' => true]);


### PR DESCRIPTION
# Description

A customer reported that they could not invoke LDAP sync, even if they had user-edit permissions. There was a bug in the code where we were checking their permission against the Users *namespace* (that all our User controllers live in), rather than the User Model.

Additionally, the 'store' method that fires when someone invokes an LDAP sync was not re-checking the authorization.

Bizarre side note - look at the changes, and you'll see that we specifically were saying `User::class` - when there was nothing that imported any such class. However, there was a `Users::class` (e.g. the namespace itself, which must exist as a first-class object somewhere). Perhaps there is some kind of strange pluralization thing that Laravel is doing to automatically make the singular version of the namespace, for closer-to-English readability somewhere? No idea.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I replicated the bug by revoking my super-user status, but giving myself everything else
- [x] I fixed the bug and then I could no longer replicate it
- [x] I then changed the text of the `authorize()` check in the `store()` method, and clicked on the LDAP sync button, and correctly got a 403 error - permission denied. When I changed the text back, an LDAP sync fired correctly.