### PR TITLE
Depreciation detail view fixes [ch15776]

### DIFF
--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -30,7 +30,20 @@ class AssetModelsController extends Controller
     public function index(Request $request)
     {
         $this->authorize('view', AssetModel::class);
-        $allowed_columns = ['id','image','name','model_number','eol','notes','created_at','manufacturer','requestable', 'assets_count'];
+        $allowed_columns =
+            [
+                'id',
+                'image',
+                'name',
+                'model_number',
+                'eol',
+                'notes',
+                'created_at',
+                'manufacturer',
+                'requestable',
+                'assets_count',
+                'category'
+            ];
 
         $assetmodels = AssetModel::select([
             'models.id',

--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -88,16 +88,16 @@ class AssetModelsController extends Controller
             case 'manufacturer':
                 $assetmodels->OrderManufacturer($order);
                 break;
+            case 'category':
+                $assetmodels->OrderCategory($order);
+                break;
             default:
                 $assetmodels->orderBy($sort, $order);
                 break;
         }
 
-
-
-        $total = $assetmodels->count();
         $assetmodels = $assetmodels->skip($offset)->take($limit)->get();
-        return (new AssetModelsTransformer)->transformAssetModels($assetmodels, $total);
+        return (new AssetModelsTransformer)->transformAssetModels($assetmodels, $assetmodels->count());
     }
 
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -141,8 +141,6 @@ class AssetsController extends Controller
         }
 
         $request->filled('order_number') ? $assets = $assets->where('assets.order_number', '=', e($request->get('order_number'))) : '';
-        $offset = (($assets) && (request('offset') > $assets->count())) ? 0 : request('offset', 0);
-
 
         // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
         // case we override with the actual count, so we should return 0 items.

--- a/app/Http/Controllers/Api/DepreciationsController.php
+++ b/app/Http/Controllers/Api/DepreciationsController.php
@@ -20,7 +20,7 @@ class DepreciationsController extends Controller
     public function index(Request $request)
     {
         $this->authorize('view', Depreciation::class);
-        $allowed_columns = ['id','name','created_at'];
+        $allowed_columns = ['id','name','months','created_at'];
 
         $depreciations = Depreciation::select('id','name','months','user_id','created_at','updated_at');
 

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -128,6 +128,7 @@ class LicensesController extends Controller
                         'free_seats_count',
                         'seats',
                         'termination_date',
+                        'depreciation_id'
                     ];
                 $sort = in_array($request->input('sort'), $allowed_columns) ? e($request->input('sort')) : 'created_at';
                 $licenses = $licenses->orderBy($sort, $order);

--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -8,7 +8,125 @@ namespace App\Presenters;
  */
 class AssetModelPresenter extends Presenter
 {
-    
+    public static function dataTableLayout() {
+
+        $layout = [
+            [
+                "field" => "id",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.id'),
+                "visible" => false
+            ], [
+                "field" => "company",
+                "searchable" => true,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('admin/companies/table.title'),
+                "visible" => false,
+                "formatter" => "companiesLinkObjFormatter"
+            ], [
+                "field" => "name",
+                "searchable" => true,
+                "sortable" => true,
+                "visible" => true,
+                "title" => trans('general.name'),
+                "formatter" => "modelsLinkFormatter"
+            ],
+            [
+                "field" => "image",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.image'),
+                "visible" => true,
+                "formatter" => 'imageFormatter',
+            ],
+            [
+                "field" => "manufacturer",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.manufacturer'),
+                "visible" => false,
+                "formatter" => 'manufacturersLinkObjFormatter',
+            ],
+            [
+                "field" => "model_number",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('admin/models/table.modelnumber'),
+                "visible" => true,
+            ],
+            [
+                "field" => "assets_count",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('admin/models/table.numassets'),
+                "visible" => true,
+            ],
+            [
+                "field" => "depreciation",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.depreciation'),
+                "visible" => false,
+                "formatter" => "depreciationsLinkObjFormatter",
+            ],
+            [
+                "field" => "category",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.category'),
+                "visible" => false,
+                "formatter" => "categoriesLinkObjFormatter",
+            ],
+            [
+                "field" => "eol",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.eol'),
+                "visible" => true,
+            ],
+            [
+                "field" => "fieldset",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('admin/models/general.fieldset'),
+                "visible" => true,
+                "formatter" => "fieldsetsLinkObjFormatter",
+            ],
+            [
+                "field" => "notes",
+                "searchable" => true,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.notes'),
+                "visible" => false,
+            ],
+        ];
+
+
+        $layout[] = [
+            "field" => "actions",
+            "searchable" => false,
+            "sortable" => false,
+            "switchable" => false,
+            "title" => trans('table.actions'),
+            "formatter" => "licensesActionsFormatter",
+        ];
+
+
+        return json_encode($layout);
+
+    }
     /**
      * Formatted note for this model
      * @return string

--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -12,6 +12,10 @@ class AssetModelPresenter extends Presenter
 
         $layout = [
             [
+                "field" => "checkbox",
+                "checkbox" => true
+            ],
+            [
                 "field" => "id",
                 "searchable" => false,
                 "sortable" => true,

--- a/app/Presenters/DepreciationPresenter.php
+++ b/app/Presenters/DepreciationPresenter.php
@@ -8,5 +8,49 @@ namespace App\Presenters;
  */
 class DepreciationPresenter extends Presenter
 {
+    /**
+     * Json Column Layout for bootstrap table
+     * @return string
+     */
+    public static function dataTableLayout()
+    {
+        $layout = [
+            [
+                "field" => "id",
+                "searchable" => false,
+                "sortable" => true,
+                "switchable" => true,
+                "title" => trans('general.id'),
+                "visible" => false
+            ], [
+                "field" => "name",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('general.name'),
+                "visible" => true,
+                "formatter" => 'depreciationsLinkFormatter',
+            ],
+
+            [
+                "field" => "months",
+                "searchable" => true,
+                "sortable" => true,
+                "title" =>  trans('admin/depreciations/table.term'),
+                "visible" => true,
+            ],
+
+            [
+                "field" => "actions",
+                "searchable" => false,
+                "sortable" => false,
+                "switchable" => false,
+                "title" => trans('table.actions'),
+                "visible" => true,
+                "formatter" => "depreciationsActionsFormatter",
+            ]
+        ];
+
+        return json_encode($layout);
+    }
 
 }

--- a/resources/views/depreciations/index.blade.php
+++ b/resources/views/depreciations/index.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Page title --}}
 @section('title')
-Asset Depreciations
+  Depreciations
 @parent
 @stop
 
@@ -22,6 +22,7 @@ Asset Depreciations
         <div class="table-responsive">
 
           <table
+                  data-columns="{{ \App\Presenters\DepreciationPresenter::dataTableLayout() }}"
                   data-cookie-id-table="depreciationsTable"
                   data-pagination="true"
                   data-id-table="depreciationsTable"
@@ -39,14 +40,6 @@ Asset Depreciations
                     "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                     }'>
 
-            <thead>
-              <tr>
-                <th data-sortable="true" data-field="id" data-visible="false">{{ trans('general.id') }}</th>
-                <th data-sortable="true" data-field="name">{{ trans('admin/depreciations/table.title') }}</th>
-                <th data-sortable="false" data-field="months">{{ trans('admin/depreciations/table.term') }}</th>
-                <th data-switchable="false" data-searchable="false" data-sortable="false" data-field="actions"  data-formatter="depreciationsActionsFormatter">{{ trans('table.actions') }}</th>
-              </tr>
-            </thead>
           </table>
         </div>
       </div>

--- a/resources/views/depreciations/view.blade.php
+++ b/resources/views/depreciations/view.blade.php
@@ -32,6 +32,7 @@
                 <ul class="nav nav-tabs">
                     <li class="active"><a href="#assets" data-toggle="tab">{{ trans('general.assets') }}</a></li>
                     <li><a href="#licenses" data-toggle="tab">{{ trans('general.licenses') }}</a></li>
+                    <li><a href="#models" data-toggle="tab">{{ trans('general.asset_models') }}</a></li>
                     </ul>
 
                 <div class="tab-content">
@@ -97,7 +98,46 @@
                         </div> <!--/.row-->
                     </div> <!-- /.tab-pane -->
 
+                    <!-- tab-pane -->
+                    <div class="tab-pane" id="models">
+                        <div class="row">
+                            <div class="col-md-12">
+
+                                <div class="table-responsive">
+
+                                    <table
+                                            data-columns="{{ \App\Presenters\AssetModelPresenter::dataTableLayout() }}"
+                                            data-cookie-id-table="depreciationsModelsTable"
+                                            data-id-table="depreciationsModelsTable"
+                                            id="depreciationsModelsTable"
+                                            data-pagination="true"
+                                            data-search="true"
+                                            data-side-pagination="server"
+                                            data-show-columns="true"
+                                            data-show-export="true"
+                                            data-show-refresh="true"
+                                            data-sort-order="asc"
+                                            data-sort-name="name"
+                                            class="table table-striped snipe-table"
+                                            data-url="{{ route('api.models.index',['depreciation_id'=> $depreciation->id]) }}"
+                                            data-export-options='{
+                        "fileName": "export-depreciations-bymodel-{{ date('Y-m-d') }}",
+                        "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                        }'>
+                                    </table>
+
+                                </div>
+
+                            </div>
+
+                        </div> <!--/.row-->
+                    </div> <!-- /.tab-pane -->
+
                 </div> <!-- /.tab-content -->
+
+
+
+            </div> <!-- /.tab-content -->
             </div> <!-- nav-tabs-custom -->
 
 

--- a/resources/views/depreciations/view.blade.php
+++ b/resources/views/depreciations/view.blade.php
@@ -3,7 +3,7 @@
 {{-- Page title --}}
 @section('title')
 
-    {{ trans('general.depreciation') }}: {{ $depreciation->name }}
+    {{ trans('general.depreciation') }}: {{ $depreciation->name }} ({{ $depreciation->months }} {{ trans('general.months') }})
 
     @parent
 @stop
@@ -24,7 +24,7 @@
 @section('content')
 
     <div class="row">
-        <div class="col-md-9">
+        <div class="col-md-12">
 
 
             <!-- Custom Tabs -->
@@ -39,7 +39,27 @@
                     <div class="tab-pane active" id="assets">
 
 
-                               sldkgjlksgj
+                        <table
+                                data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
+                                data-cookie-id-table="depreciationsAssetTable"
+                                data-id-table="depreciationsAssetTable"
+                                id="depreciationsAssetTable"
+                                data-pagination="true"
+                                data-search="true"
+                                data-side-pagination="server"
+                                data-show-columns="true"
+                                data-show-export="true"
+                                data-show-refresh="true"
+                                data-sort-order="asc"
+                                data-sort-name="name"
+                                class="table table-striped snipe-table"
+                                data-url="{{ route('api.assets.index',['depreciation_id'=> $depreciation->id]) }}"
+                                data-export-options='{
+                        "fileName": "export-depreciations-{{ date('Y-m-d') }}",
+                        "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                        }'>
+                        </table>
+
                     </div> <!-- end tab-pane -->
 
                     <!-- tab-pane -->
@@ -50,12 +70,12 @@
                                 <div class="table-responsive">
 
                                     <table
-                                            data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayoutSeats() }}"
-                                            data-cookie-id-table="seatsTable"
-                                            data-id-table="seatsTable"
-                                            id="seatsTable"
+                                            data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayout() }}"
+                                            data-cookie-id-table="depreciationsLicenseTable"
+                                            data-id-table="depreciationsLicenseTable"
+                                            id="depreciationsLicenseTable"
                                             data-pagination="true"
-                                            data-search="false"
+                                            data-search="true"
                                             data-side-pagination="server"
                                             data-show-columns="true"
                                             data-show-export="true"
@@ -63,7 +83,7 @@
                                             data-sort-order="asc"
                                             data-sort-name="name"
                                             class="table table-striped snipe-table"
-                                            data-url="{{ route('api.assets.index',['depreciation'=> $depreciation->id]) }}"
+                                            data-url="{{ route('api.licenses.index',['depreciation_id'=> $depreciation->id]) }}"
                                             data-export-options='{
                         "fileName": "export-depreciations-{{ date('Y-m-d') }}",
                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
@@ -82,18 +102,12 @@
 
 
         </div>
-        <div class="col-md-3">
-            <h2>Depreciation info:</h2>
-        </div>
+
     </div>
 
 @stop
 
 @section('moar_scripts')
-    @include ('partials.bootstrap-table', [
-        'exportFile' => 'assets-export',
-        'search' => true,
-        'columns' => \App\Presenters\AssetPresenter::dataTableLayout()
-    ])
+    @include ('partials.bootstrap-table')
 
 @stop

--- a/resources/views/depreciations/view.blade.php
+++ b/resources/views/depreciations/view.blade.php
@@ -3,8 +3,7 @@
 {{-- Page title --}}
 @section('title')
 
-    {{ trans('general.depreciation') }}
-    : {{ $depreciation->name }}
+    {{ trans('general.depreciation') }}: {{ $depreciation->name }}
 
     @parent
 @stop
@@ -25,28 +24,66 @@
 @section('content')
 
     <div class="row">
-        <div class="col-md-12">
-            <div class="box box-default">
-                <div class="box-body">
-                    <div class="row">
-                        <div class="col-md-12">
-                            <div class="table table-responsive">
-                                <table
-                                        name="location_users"
-                                        id="table-users"
-                                        class="table table-striped snipe-table"
-                                        data-url="{{ route('api.assets.index',['depreciation'=> $depreciation->id]) }}"
-                                        data-cookie="true"
-                                        data-click-to-select="true"
-                                        data-cookie-id-table="department_usersDetailTable">
-                                    <thead>
+        <div class="col-md-9">
 
-                                </table>
+
+            <!-- Custom Tabs -->
+            <div class="nav-tabs-custom">
+                <ul class="nav nav-tabs">
+                    <li class="active"><a href="#assets" data-toggle="tab">{{ trans('general.assets') }}</a></li>
+                    <li><a href="#licenses" data-toggle="tab">{{ trans('general.licenses') }}</a></li>
+                    </ul>
+
+                <div class="tab-content">
+
+                    <div class="tab-pane active" id="assets">
+
+
+                               sldkgjlksgj
+                    </div> <!-- end tab-pane -->
+
+                    <!-- tab-pane -->
+                    <div class="tab-pane" id="licenses">
+                        <div class="row">
+                            <div class="col-md-12">
+
+                                <div class="table-responsive">
+
+                                    <table
+                                            data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayoutSeats() }}"
+                                            data-cookie-id-table="seatsTable"
+                                            data-id-table="seatsTable"
+                                            id="seatsTable"
+                                            data-pagination="true"
+                                            data-search="false"
+                                            data-side-pagination="server"
+                                            data-show-columns="true"
+                                            data-show-export="true"
+                                            data-show-refresh="true"
+                                            data-sort-order="asc"
+                                            data-sort-name="name"
+                                            class="table table-striped snipe-table"
+                                            data-url="{{ route('api.assets.index',['depreciation'=> $depreciation->id]) }}"
+                                            data-export-options='{
+                        "fileName": "export-depreciations-{{ date('Y-m-d') }}",
+                        "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                        }'>
+                                    </table>
+
+                                </div>
+
                             </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+
+                        </div> <!--/.row-->
+                    </div> <!-- /.tab-pane -->
+
+                </div> <!-- /.tab-content -->
+            </div> <!-- nav-tabs-custom -->
+
+
+        </div>
+        <div class="col-md-3">
+            <h2>Depreciation info:</h2>
         </div>
     </div>
 

--- a/resources/views/depreciations/view.blade.php
+++ b/resources/views/depreciations/view.blade.php
@@ -100,11 +100,26 @@
 
                     <!-- tab-pane -->
                     <div class="tab-pane" id="models">
+
                         <div class="row">
+                            {{ Form::open(
+                                      [
+                                     'method' => 'POST',
+                                     'route' => ['models.bulkedit.index'],
+                                     'class' => 'form-inline',
+                                      'id' => 'bulkForm']
+                                      ) }}
                             <div class="col-md-12">
+                                <div id="toolbar">
+                                    <label for="bulk_actions" class="sr-only">Bulk Actions</label>
+                                    <select name="bulk_actions" class="form-control select2" aria-label="bulk_actions" style="width: 300px;">
+                                        <option value="edit">Bulk Edit</option>
+                                        <option value="delete">Bulk Delete</option>
+                                    </select>
+                                    <button class="btn btn-primary" id="bulkEdit" disabled>Go</button>
+                                </div>
 
                                 <div class="table-responsive">
-
                                     <table
                                             data-columns="{{ \App\Presenters\AssetModelPresenter::dataTableLayout() }}"
                                             data-cookie-id-table="depreciationsModelsTable"
@@ -112,6 +127,7 @@
                                             id="depreciationsModelsTable"
                                             data-pagination="true"
                                             data-search="true"
+                                            data-toolbar="#toolbar"
                                             data-side-pagination="server"
                                             data-show-columns="true"
                                             data-show-export="true"
@@ -126,9 +142,11 @@
                         }'>
                                     </table>
 
+
                                 </div>
 
                             </div>
+                            {{ Form::close() }}
 
                         </div> <!--/.row-->
                     </div> <!-- /.tab-pane -->

--- a/resources/views/models/bulk-edit.blade.php
+++ b/resources/views/models/bulk-edit.blade.php
@@ -22,43 +22,60 @@
 
                 <div class="box box-default">
                     <div class="box-header with-border">
-                        @foreach ($models as $model)
-                            <span class="box-title"><strong>{{ $model->display_name }}</strong> ({{ $model->model_number }})</span><br />
-                        @endforeach
+                        <div class="box-title"><i class="fa fa-warning"></i> You are about to edit the following: </div>
                     </div>
                     <div class="box-body">
-                        <!-- manufacturer -->
-                        @include ('partials.forms.edit.manufacturer-select', ['translated_name' => trans('general.manufacturer'), 'fieldname' => 'manufacturer_id'])
 
-                        <!-- category -->
-                        @include ('partials.forms.edit.category-select', ['translated_name' => trans('admin/categories/general.category_name'), 'fieldname' => 'category_id', 'required' => 'true', 'category_type' => 'asset'])
-
-                        <!-- custom fields -->
-                        <div class="form-group {{ $errors->has('fieldset_id') ? ' has-error' : '' }}">
-                            <label for="category_id" class="col-md-3 control-label">
-                                {{ trans('admin/models/general.fieldset') }}
-                            </label>
-                            <div class="col-md-7">
-                                {{ Form::select('fieldset_id', $fieldset_list , old('fieldset_id', 'NC'), array('class'=>'select2 js-fieldset-field', 'style'=>'width:350px')) }}
-                                {!! $errors->first('fieldset_id', '<span class="alert-msg" aria-hidden="true"><br><i class="fa fa-times"></i> :message</span>') !!}
-                            </div>
-                        </div>
-
-                        <!-- depreciation -->
-
-                        <div class="form-group {{ $errors->has('depreciation_id') ? ' has-error' : '' }}">
-                            <label for="category_id" class="col-md-3 control-label">
-                                {{ trans('general.depreciation') }}
-                            </label>
-                            <div class="col-md-7">
-                                {{ Form::select('depreciation_id', $depreciation_list , old('depreciation_id', 'NC'), array('class'=>'select2', 'style'=>'width:350px')) }}
-                                {!! $errors->first('depreciation_id', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
-                            </div>
-                        </div>
-
+                        <table class="table">
+                            <tbody>
                         @foreach ($models as $model)
-                            <input type="hidden" name="ids[{{ $model->id }}]" value="{{ $model->id }}">
+
+                            <tr{!!  (($model->assets_count > 0 ) ? ' class="warning"' : ' class="success"') !!}>
+                                    <td>
+                                        <i class="fa {!!  (($model->assets_count > 0 ) ? 'fa-warning info' : 'fa-check success') !!}"></i>
+                                        {{ $model->display_name }}  ({{ $model->model_number }})
+                                        </td>
+                                        <td>{{ $model->assets_count }} assets
+                                    </td>
+                            </tr>
+
                         @endforeach
+                        </table>
+
+                        <div class="col-md-12" style="padding-top: 20px;">
+                            <!-- manufacturer -->
+                            @include ('partials.forms.edit.manufacturer-select', ['translated_name' => trans('general.manufacturer'), 'fieldname' => 'manufacturer_id'])
+
+                            <!-- category -->
+                            @include ('partials.forms.edit.category-select', ['translated_name' => trans('admin/categories/general.category_name'), 'fieldname' => 'category_id', 'required' => 'true', 'category_type' => 'asset'])
+
+                            <!-- custom fields -->
+                            <div class="form-group {{ $errors->has('fieldset_id') ? ' has-error' : '' }}">
+                                <label for="category_id" class="col-md-3 control-label">
+                                    {{ trans('admin/models/general.fieldset') }}
+                                </label>
+                                <div class="col-md-7">
+                                    {{ Form::select('fieldset_id', $fieldset_list , old('fieldset_id', 'NC'), array('class'=>'select2 js-fieldset-field', 'style'=>'width:350px')) }}
+                                    {!! $errors->first('fieldset_id', '<span class="alert-msg" aria-hidden="true"><br><i class="fa fa-times"></i> :message</span>') !!}
+                                </div>
+                            </div>
+
+                            <!-- depreciation -->
+
+                            <div class="form-group {{ $errors->has('depreciation_id') ? ' has-error' : '' }}">
+                                <label for="category_id" class="col-md-3 control-label">
+                                    {{ trans('general.depreciation') }}
+                                </label>
+                                <div class="col-md-7">
+                                    {{ Form::select('depreciation_id', $depreciation_list , old('depreciation_id', 'NC'), array('class'=>'select2', 'style'=>'width:350px')) }}
+                                    {!! $errors->first('depreciation_id', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                </div>
+                            </div>
+
+                            @foreach ($models as $model)
+                                <input type="hidden" name="ids[{{ $model->id }}]" value="{{ $model->id }}">
+                            @endforeach
+                        </div>
                     </div> <!--/.box-body-->
 
                     <div class="box-footer text-right">

--- a/resources/views/models/index.blade.php
+++ b/resources/views/models/index.blade.php
@@ -83,7 +83,7 @@
               <th data-sortable="true" data-field="model_number">{{ trans('admin/models/table.modelnumber') }}</th>
               <th data-sortable="true" data-field="assets_count">{{ trans('admin/models/table.numassets') }}</th>
               <th data-sortable="false" data-field="depreciation" data-formatter="depreciationsLinkObjFormatter">{{ trans('general.depreciation') }}</th>
-              <th data-sortable="false" data-field="category" data-formatter="categoriesLinkObjFormatter">{{ trans('general.category') }}</th>
+              <th data-sortable="true" data-field="category" data-formatter="categoriesLinkObjFormatter">{{ trans('general.category') }}</th>
               <th data-sortable="true" data-field="eol">{{ trans('general.eol') }}</th>
               <th data-sortable="false" data-field="fieldset" data-formatter="fieldsetsLinkObjFormatter">{{ trans('admin/models/general.fieldset') }}</th>
               <th data-sortable="true" data-field="notes">{{ trans('general.notes') }}</th>


### PR DESCRIPTION
I only noticed this bug recently as I was adding a few things to the licenses API endpoint to display `termination_date` (#9052) - I believe it's been happening on the models page this whole time, and it's just that nobody noticed because nobody was clicking on that particular link. 

<img width="672" alt="Software_Licenses____Snipe-IT_Asset_Management_Demo" src="https://user-images.githubusercontent.com/197404/106068886-3554db00-60b6-11eb-9814-13c2d4e9d759.png">

<img width="674" alt="View_Models____Snipe-IT_Asset_Management_Demo" src="https://user-images.githubusercontent.com/197404/106068998-7baa3a00-60b6-11eb-88cf-4a52221b330a.png">

brought you to `/depreciations/:id`, which... 

<img width="674" alt="Depreciation___Display_Depreciation____Snipe-IT_Asset_Management_Demo" src="https://user-images.githubusercontent.com/197404/106068895-3a198f00-60b6-11eb-82ee-84e3e3763115.png">

That page would never have worked the way it was (it was literally pointing to the wrong endpoints and using the wrong data url), so I updated the depreciation view blade to be split into two tabs - assets and licenses. While I was in there, I added the ability to sort on depreciations by months, and included the months in the title/headline for clarity, and switched us over to using a presenter (versus embedded HTML) in the Depreciations listing data table. 

What we *now* see the we click on `/depreciations/:id` is:

<img width="1355" alt="Screen Shot 2021-01-27 at 4 13 03 PM" src="https://user-images.githubusercontent.com/197404/106071274-e78ea180-60ba-11eb-82aa-8f2b24c56e84.png">

<img width="1355" alt="Screen Shot 2021-01-27 at 4 13 21 PM" src="https://user-images.githubusercontent.com/197404/106071276-e8bfce80-60ba-11eb-97eb-d3d6880f653f.png">

<img width="1352" alt="Screen Shot 2021-01-27 at 4 13 34 PM" src="https://user-images.githubusercontent.com/197404/106071278-e9586500-60ba-11eb-905f-423c8e42d7de.png">


This fixes [ch15776].
