### PR TITLE
Nicer formatting of the page if custom logout [ch15660]

### DIFF
--- a/resources/lang/en/auth/general.php
+++ b/resources/lang/en/auth/general.php
@@ -3,6 +3,7 @@
 return [
     'send_password_link'	        => 'Send Password Reset Link',
     'email_reset_password'			=> 'Email Password Reset',
+    'ldap_reset_password'           => 'Please click here to reset your password',
     'reset_password'			    => 'Reset Password',
     'saml_login'                    => 'Login via SAML',
     'login'                         => 'Login',

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -5,7 +5,12 @@
 @section('content')
 
     @if ($snipeSettings->custom_forgot_pass_url)
-        <a href="{{ $snipeSettings->custom_forgot_pass_url  }}" rel="noopener">{{ trans('auth/general.forgot_password')  }}</a>
+        <div class="col-md-4 col-md-offset-4">
+            <div class="box box-header text-center">
+       <h2 class="box-title"> <a href="{{ $snipeSettings->custom_forgot_pass_url  }}" rel="noopener">{{ trans('auth/general.ldap_reset_password')  }}</a>
+       </h2>
+            </div>
+        </div>
     @else
 
     <form class="form" role="form" method="POST" action="{{ url('/password/email') }}">


### PR DESCRIPTION
centered and increased the font of the ldap password reset link
[](url)
<img width="987" alt="Screen Shot 2021-02-01 at 4 52 12 PM" src="https://user-images.githubusercontent.com/47435081/106537068-73833d80-64ae-11eb-8823-7eaa51e1d48e.png">

Could be more shiny? Thoughts?
