### PR TITLE
Fixes: UserImporter error. [ch15613]

### DIFF
--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -125,7 +125,10 @@ class UserImporter extends ItemImporter
         if ($department) {
             $this->log('A matching department ' . $department_name . ' already exists');
             return $department->id;
+        } else {
+            return null;
         }
+
         $department = new department();
         $department->name = $department_name;
         $department->user_id = $this->user_id;
@@ -134,7 +137,8 @@ class UserImporter extends ItemImporter
             $this->log('department ' . $department_name . ' was created');
             return $department->id;
         }
-        $this->logError($department, 'Company');
+
+        $this->logError($department, 'Department');
         return null;
     }
 


### PR DESCRIPTION
# Description
The Importer was returning an error when importing Users saying the 'Company name is required' even if the Company name field is present in the Importer. In reality we were logging the incorrect thing, it was the department the thing that's not present in the CSV. So first I fix the log to report the actual error for Department field, then added a clause that lets the function that updates the department to fail gracefully if no dept. name is provided in the CSV passed to the Importer.

Fixes # (issue)
[ch15613]

## Type of change
- [*] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* PHP version: 7.4.14
* MySQL version: mariadb  Ver 15.1 Distrib 10.4.17-MariaDB
* Webserver version: nginx/1.18.0
* OS version: Fedora 33
