### PR TITLE
[FIX] Lite test email won't use the mail component

### DIFF
--- a/resources/views/notifications/Test.blade.php
+++ b/resources/views/notifications/Test.blade.php
@@ -1,7 +1,11 @@
+@if ($setupCompleted = \App\Models\Setting::setupCompleted())
 @component('mail::message')
+@endif
 
 {{ trans('mail.test_mail_text') }}
 
 Thanks,
 Snipe-IT
+@if ($setupCompleted)
 @endcomponent
+@endif

--- a/resources/views/notifications/Test.blade.php
+++ b/resources/views/notifications/Test.blade.php
@@ -1,4 +1,7 @@
+@component('mail::message')
+
 {{ trans('mail.test_mail_text') }}
 
 Thanks,
 Snipe-IT
+@endcomponent

--- a/resources/views/notifications/Test.blade.php
+++ b/resources/views/notifications/Test.blade.php
@@ -1,7 +1,4 @@
-@component('mail::message')
-
 {{ trans('mail.test_mail_text') }}
 
 Thanks,
 Snipe-IT
-@endcomponent

--- a/resources/views/vendor/mail/markdown/message.blade.php
+++ b/resources/views/vendor/mail/markdown/message.blade.php
@@ -2,7 +2,7 @@
 {{-- Header --}}
 @slot('header')
 @component('mail::header', ['url' => config('app.url')])
-@if (($snipeSettings->show_images_in_email=='1' ) && ($snipeSettings::setupCompleted()))
+@if (($snipeSettings !== null) && ($snipeSettings->show_images_in_email=='1' ) && ($snipeSettings::setupCompleted()))
 
 @if ($snipeSettings->brand == '3')
 @if ($snipeSettings->logo!='')
@@ -38,13 +38,13 @@ Snipe-IT
 {{-- Footer --}}
 @slot('footer')
 @component('mail::footer')
-@if($snipeSettings::setupCompleted())
+@if($snipeSettings !== null && $snipeSettings::setupCompleted())
 © {{ date('Y') }} {{ $snipeSettings->site_name }}. All rights reserved.
 @else
 © {{ date('Y') }} Snipe-it. All rights reserved.
 @endif
 
-@if ($snipeSettings->privacy_policy_link!='')
+@if ($snipeSettings !== null && $snipeSettings->privacy_policy_link!='')
 <a href="{{ $snipeSettings->privacy_policy_link }}">{{ trans('admin/settings/general.privacy_policy') }}</a>ldfkgjg
 @endif
 

--- a/resources/views/vendor/mail/markdown/message.blade.php
+++ b/resources/views/vendor/mail/markdown/message.blade.php
@@ -2,7 +2,7 @@
 {{-- Header --}}
 @slot('header')
 @component('mail::header', ['url' => config('app.url')])
-@if (($snipeSettings !== null) && ($snipeSettings->show_images_in_email=='1' ) && ($snipeSettings::setupCompleted()))
+@if (($snipeSettings->show_images_in_email=='1' ) && ($snipeSettings::setupCompleted()))
 
 @if ($snipeSettings->brand == '3')
 @if ($snipeSettings->logo!='')
@@ -38,13 +38,13 @@ Snipe-IT
 {{-- Footer --}}
 @slot('footer')
 @component('mail::footer')
-@if($snipeSettings !== null && $snipeSettings::setupCompleted())
+@if($snipeSettings::setupCompleted())
 © {{ date('Y') }} {{ $snipeSettings->site_name }}. All rights reserved.
 @else
 © {{ date('Y') }} Snipe-it. All rights reserved.
 @endif
 
-@if ($snipeSettings !== null && $snipeSettings->privacy_policy_link!='')
+@if ($snipeSettings->privacy_policy_link!='')
 <a href="{{ $snipeSettings->privacy_policy_link }}">{{ trans('admin/settings/general.privacy_policy') }}</a>
 @endif
 

--- a/resources/views/vendor/mail/markdown/message.blade.php
+++ b/resources/views/vendor/mail/markdown/message.blade.php
@@ -45,7 +45,7 @@ Snipe-IT
 @endif
 
 @if ($snipeSettings !== null && $snipeSettings->privacy_policy_link!='')
-<a href="{{ $snipeSettings->privacy_policy_link }}">{{ trans('admin/settings/general.privacy_policy') }}</a>ldfkgjg
+<a href="{{ $snipeSettings->privacy_policy_link }}">{{ trans('admin/settings/general.privacy_policy') }}</a>
 @endif
 
 @endcomponent


### PR DESCRIPTION
# Description

The test email that is sent when using the installer should not depend on the main mail component because that component assumes a fully-installed system.

Rather than maintaining a separate agnostic template or touching the logic of the main email template, I made the Test notification simpler because that serves the purpose just fine of verifying the mail-sending configuration is successful.

Fixes # (issue)
#9087 
#9066 
#9057 
#9026 
#8987 
#8868 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Go through manual setup setting up database and running `composer install`. Try to send test email, it fails.
- [X] Go through manual set up and run `composer install`. Try to send test email, it will succeed.

**Test Configuration**:
* PHP version: PHP 7.3.26
* MySQL version: mysql  Ver 8.0.22
* Webserver version: nginx/1.17.10
* OS version: Mac OS Big Sur
