### PR TITLE
Added feature: Checkbox Custom Fields as list of values. 

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -165,8 +165,11 @@ class AssetsController extends Controller
                 foreach ($model->fieldset->fields as $field) {
                     if ($field->field_encrypted=='1') {
                         if (Gate::allows('admin')) {
-                            $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt($request->input($field->convertUnicodeDbSlug()));
-                        }
+                            if(is_array($request->input($field->convertUnicodeDbSlug()))){
+                                $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt(e(implode(', ', $request->input($field->convertUnicodeDbSlug()))));
+                            }else{
+                                $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt(e($request->input($field->convertUnicodeDbSlug())));
+                            }                        }
                     } else {
                         if(is_array($request->input($field->convertUnicodeDbSlug()))){
                             $asset->{$field->convertUnicodeDbSlug()} = implode(', ', $request->input($field->convertUnicodeDbSlug()));
@@ -346,14 +349,19 @@ class AssetsController extends Controller
             foreach ($model->fieldset->fields as $field) {
                 if ($field->field_encrypted=='1') {
                     if (Gate::allows('admin')) {
-                        $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt(e($request->input($field->convertUnicodeDbSlug())));
+                        if(is_array($request->input($field->convertUnicodeDbSlug()))){
+                            $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt(e(implode(', ', $request->input($field->convertUnicodeDbSlug()))));
+                        }else{
+                            $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt(e($request->input($field->convertUnicodeDbSlug())));
+                        }
                     }
                 } else {
                     if(is_array($request->input($field->convertUnicodeDbSlug()))){
                         $asset->{$field->convertUnicodeDbSlug()} = implode(', ', $request->input($field->convertUnicodeDbSlug()));
                     }else{
                         $asset->{$field->convertUnicodeDbSlug()} = $request->input($field->convertUnicodeDbSlug());
-                    }                }
+                    }
+                }
             }
         }
 

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -168,7 +168,11 @@ class AssetsController extends Controller
                             $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt($request->input($field->convertUnicodeDbSlug()));
                         }
                     } else {
-                        $asset->{$field->convertUnicodeDbSlug()} = $request->input($field->convertUnicodeDbSlug());
+                        if(is_array($request->input($field->convertUnicodeDbSlug()))){
+                            $asset->{$field->convertUnicodeDbSlug()} = implode(', ', $request->input($field->convertUnicodeDbSlug()));
+                        }else{
+                            $asset->{$field->convertUnicodeDbSlug()} = $request->input($field->convertUnicodeDbSlug());
+                        }
                     }
                 }
             }
@@ -345,8 +349,11 @@ class AssetsController extends Controller
                         $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt(e($request->input($field->convertUnicodeDbSlug())));
                     }
                 } else {
-                    $asset->{$field->convertUnicodeDbSlug()} = $request->input($field->convertUnicodeDbSlug());
-                }
+                    if(is_array($request->input($field->convertUnicodeDbSlug()))){
+                        $asset->{$field->convertUnicodeDbSlug()} = implode(', ', $request->input($field->convertUnicodeDbSlug()));
+                    }else{
+                        $asset->{$field->convertUnicodeDbSlug()} = $request->input($field->convertUnicodeDbSlug());
+                    }                }
             }
         }
 

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -168,10 +168,10 @@
             });
         }).change();
 
-        // If the element is a radiobutton, doesn't show the format input box
+        // If the element is a radiobutton/checkbox, doesn't show the format input box
         $(".field_element").change(function(){
             $(this).find("option:selected").each(function(){
-                if (($(this).attr("value") != "radio")){
+                if (($(this).attr("value") != "radio") && ($(this).attr("value") != "checkbox")){
                     $("#format_values").show();
                 } else{
                     $("#format_values").hide();

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -21,7 +21,7 @@
 
                       <div>
                           <label>
-                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" class="minimal" {{ Request::old($field->db_column_name()) != '' ? ' checked="checked"' : '' }}>
+                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" class="minimal" {{  isset($item) ? (in_array($key, explode(', ', $item->{$field->db_column_name()})) ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : '') }}>
                               {{ $value }}
                           </label>
                       </div>

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -21,7 +21,7 @@
 
                       <div>
                           <label>
-                              <input type="checkbox" value="1" name="{{ $field->db_column_name() }}[]" class="minimal" {{ Request::old($field->db_column_name()) != '' ? ' checked="checked"' : '' }}>
+                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" class="minimal" {{ Request::old($field->db_column_name()) != '' ? ' checked="checked"' : '' }}>
                               {{ $value }}
                           </label>
                       </div>


### PR DESCRIPTION
# Description

In `AssetsController.php` for some reason, when I tried to save an asset with a custom field in form of array, if the asset is new it throws an error but when updating an existing asset the error state is not reached. I fix it in the new asset using the  `implode()` function, and while the update function doesn't need it I used it there too, because I wanted the list of values to be saved in the same format. 

Also I fixed the `custom_field_form.blade` view, to actually send the value selected in the checkbox, and to show the values already stored in the database.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

**Test Configuration**:
* PHP version: 7.4.15
* MySQL version: mariadb  Ver 15.1 Distrib 10.4.17-MariaDB
* Webserver version: nginx/1.18.0
* OS version: Fedora 33