### PR TITLE
Fixes #8918 The validation rules on Manufacturer Model 'name' attribute are malformed.

### DIFF
--- a/app/Http/Controllers/ManufacturersController.php
+++ b/app/Http/Controllers/ManufacturersController.php
@@ -158,7 +158,7 @@ class ManufacturersController extends Controller
     public function destroy($manufacturerId)
     {
         $this->authorize('delete', Manufacturer::class);
-        if (is_null($manufacturer = Manufacturer::withCount('models as models_count')->find($manufacturerId))) {
+        if (is_null($manufacturer = Manufacturer::withTrashed()->withCount('models as models_count')->find($manufacturerId))) {
             return redirect()->route('manufacturers.index')->with('error', trans('admin/manufacturers/message.not_found'));
         }
 
@@ -174,8 +174,12 @@ class ManufacturersController extends Controller
             }
         }
 
-        // Delete the manufacturer
-        $manufacturer->delete();
+        // Soft delete the manufacturer if active, permanent delete if is already deleted
+        if($manufacturer->deleted_at === NULL) {
+            $manufacturer->delete();
+        } else {
+            $manufacturer->forceDelete();
+        }
         // Redirect to the manufacturers management page
         return redirect()->route('manufacturers.index')->with('success', trans('admin/manufacturers/message.delete.success'));
     }

--- a/app/Models/Manufacturer.php
+++ b/app/Models/Manufacturer.php
@@ -17,7 +17,7 @@ class Manufacturer extends SnipeModel
 
     // Declare the rules for the form validation
     protected $rules = array(
-        'name'   => 'required|min:2|max:255|unique:manufacturers,name,NULL,deleted_at',
+        'name'   => 'required|min:2|max:255|unique:manufacturers,name,NULL,id,deleted_at,NULL',
         'url'   => 'url|nullable',
         'support_url'   => 'url|nullable',
         'support_email'   => 'email|nullable'


### PR DESCRIPTION
# Description
The validation rules on Manufacturer Model generate a malformed query that fails in some MySQL versions. Current rule is that the name of new or updated Manufacturers can't be repeated in active Manufacturers but if is a name of a deleted Manufacturer it can be setted.

Also fixed a little issue when the user tries to permanently delete a manufacturer that has already soft deleted.

Fixes #8918 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* PHP version: 7.4.15
* MySQL version: MySQL 8.0.21
* Webserver version: nginx/1.18.0
* OS version: Fedora 33

