### PR TITLE
Fixed #9115: Duplicate column name 'provider'

### DIFF
--- a/database/migrations/2021_02_05_172502_add_provider_to_oauth_table.php
+++ b/database/migrations/2021_02_05_172502_add_provider_to_oauth_table.php
@@ -14,9 +14,16 @@ class AddProviderToOauthTable extends Migration
      */
     public function up()
     {
-        Schema::table('oauth_clients', function (Blueprint $table) {
-            $table->string('provider')->after('secret')->nullable();
-        });
+        // Add a 'provider' column if not existing or else modify it
+        if (!Schema::hasColumn('oauth_clients', 'provider')) {
+            Schema::table('oauth_clients', function (Blueprint $table) {
+                $table->string('provider')->after('secret')->nullable();
+            });
+        } else {
+            Schema::table('oauth_clients', function (Blueprint $table) {
+                $table->string('provider')->after('secret')->nullable()->change();
+            });
+        }
     }
 
     /**
@@ -26,9 +33,10 @@ class AddProviderToOauthTable extends Migration
      */
     public function down()
     {
-        Schema::table('oauth_clients', function (Blueprint $table) {
-            $table->dropColumn('provider');
-        });
-
+        if (Schema::hasColumn('oauth_clients', 'provider')) {
+            Schema::table('oauth_clients', function (Blueprint $table) {
+                $table->dropColumn('provider');
+            });
+        }
     }
 }


### PR DESCRIPTION
# Description

The migration from [February 5th 2021](https://github.com/snipe/snipe-it/blob/master/database/migrations/2021_02_05_172502_add_provider_to_oauth_table.php) does collide with an earlier migration from [June 1st 2016](https://github.com/snipe/snipe-it/blob/master/database/migrations/2016_06_01_000004_create_oauth_clients_table.php).
This prevents at least new setups (see issue #9115) - maybe also upgrades but I did not check this.

To circumvent this I did a check if the column already exists. If yes, the column is modified (`...->change()`) else it is created as normally.

Fixes #9115 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Set up fresh instance -> Enable Debug mode -> Go through setup wizard/pre-flight -> Fails at step "/setup/migrate" with error `Column already exists: 1060 Duplicate column name 'provider'`
- [x] Clean Database -> Apply this fix -> Run "/setup/migrate" again -> OK

**Test Configuration**:
* PHP version: 7.3.27
* MySQL version: 10.4.17-MariaDB-1:10.4.17+maria~bionic-log
* Webserver version: nginx/1.18.0
* OS version: Alpine 3.12 (Docker-Image [linuxserver/snipe-it](https://docs.linuxserver.io/images/docker-snipe-it))


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes