### PR TITLE
Add variable declaration for $result

### DIFF
--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -285,6 +285,7 @@ class CustomField extends Model
      */
     public function formatFieldValuesAsArray()
     {
+        $result = [];
         $arr = preg_split("/\\r\\n|\\r|\\n/", $this->field_values);
 
         if (($this->element!='checkbox') && ($this->element!='radio')) {


### PR DESCRIPTION
It's always been sorta 'best-practice' to declare your variables before you actually use them. I suspect in some newer version of PHP, it changed from 'best-practice' to 'you have to.' Or maybe that's just in 'block-context'? Here, we're implicitly declaring `$result` within the 'then' part of an `if() {}` statement. And then we are maybe doing it again in the `for()` statement's scope? So maybe it's actually "falling out of scope?" Either way, the error I was getting on the `return $result` - 

```
Illuminate\View\ViewException: Undefined variable: result
```

Until I added the above line, I was getting 500-errors whenever this method was run. This fixes that and does not alter any functionality.