### PR TITLE
Auditing feature improvement Better mobile [ch14328]

### DIFF
--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -16,6 +16,34 @@
         }
     </style>
 
+    <div class="col-md-6">
+        <div class="box box-default" id="audited-div" style="display: none">
+            <div class="box-header with-border">
+                <h2 class="box-title"> {{ trans('general.bulkaudit_status') }} (<span id="audit-counter">0</span> assets audited) </h2>
+            </div>
+            <div class="box-body">
+
+                <table id="audited" class="table table-striped snipe-table">
+                    <thead>
+                    <tr>
+                        <th>{{ trans('general.asset_tag') }}</th>
+                        <th>{{ trans('general.bulkaudit_status') }}</th>
+                        <th></th>
+                    </tr>
+                    <tr id="audit-loader" style="display: none;">
+                        <td colspan="3">
+                            <i class="fa fa-spinner spin" aria-hidden="true"></i> Processing...
+                        </td>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    </tbody>
+                </table>
+            </div><
+        </div>
+    </div>
+
+    <div>
 
     <div class="row">
     {{ Form::open(['method' => 'POST', 'class' => 'form-horizontal', 'role' => 'form', 'id' => 'audit-form' ]) }}


### PR DESCRIPTION
the Audit status for Bulk audit now logs at the top of the screen.
![image](https://user-images.githubusercontent.com/47435081/108756183-0850e800-74fd-11eb-83cb-70a598799461.png)
