### PR TITLE
Fixes #9046, #9182 - Added saml custom setting retrieveParametersFromServer to allow fixing SLO issues with Azure AD

### DIFF
--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -128,7 +128,8 @@ class SamlController extends Controller
     public function sls(Request $request)
     {
         $auth = $this->saml->getAuth();
-        $sloUrl = $auth->processSLO(true, null, null, null, true);
+        $retrieveParametersFromServer = $this->saml->getSetting('retrieveParametersFromServer', false);
+        $sloUrl = $auth->processSLO(true, null, $retrieveParametersFromServer, null, true);
         $errors = $auth->getErrors();
         
         if (!empty($errors)) {

--- a/app/Services/Saml.php
+++ b/app/Services/Saml.php
@@ -325,6 +325,20 @@ class Saml
     }
 
     /**
+     * Get a setting.
+     * 
+     * @author Johnson Yi <jyi.dev@outlook.com>
+     * 
+     * @param string|array|int $key
+     * @param mixed $default
+     * 
+     * @return void
+     */
+    public function getSetting($key, $default = null) {
+        return data_get($this->_settings, $key, $default);
+    }
+
+    /**
      * Gets the SP metadata. The XML representation.
      *
      * @param bool $alwaysPublishEncryptionCert When 'true', the returned


### PR DESCRIPTION
# Description

This follows similarly how other projects that use onelogin/php-saml by providing the ability to set the retrieveParametersFromServer for processSLO. This setting is false by default.

What this setting does is tell onelogin/php-saml to use the original urlencoded parameters instead of reencoding it. This will allow signature validation for LogoutResponses sent from Azure AD to pass.

SAML documentation should be updated for Azure AD.

`retrieveParametersFromServer=true`

![image](https://user-images.githubusercontent.com/63399474/108837053-c4a5cd80-7625-11eb-8521-24468a980673.png)



Fixes #9046
Fixes #9182


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
