### PR TITLE
Fixes/cli importer issue

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -120,6 +120,8 @@ class AssetImporter extends ItemImporter
             $this->log('Asset ' . $this->item["name"] . ' with serial number ' . $this->item['serial'] . ' was created');
 
             // If we have a target to checkout to, lets do so.
+            //-- user_id is a property of the abstract class Importer, which this class inherits from and it's setted by
+            //-- the class that needs to use it (command importer or GUI importer inside the project).
             if(isset($target)) {
                 $asset->fresh()->checkOut($target, $this->user_id);
             }

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -121,7 +121,7 @@ class AssetImporter extends ItemImporter
 
             // If we have a target to checkout to, lets do so.
             if(isset($target)) {
-                $asset->fresh()->checkOut($target);
+                $asset->fresh()->checkOut($target, $this->user_id);
             }
             return;
         }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -279,7 +279,7 @@ class Asset extends Depreciable
      * @since [v3.0]
      * @return boolean
      */
-    public function checkOut($target, $admin = null, $checkout_at = null, $expected_checkin = null, $note = null, $name = null, $location = null)
+    public function checkOut($target, $admin_id = null, $checkout_at = null, $expected_checkin = null, $note = null, $name = null, $location = null)
     {
         if (!$target) {
             return false;
@@ -313,9 +313,14 @@ class Asset extends Depreciable
         }
 
         if ($this->save()) {
+            if(isset($admin_id)){
+                $checkedOutBy = User::find($admin_id);
 
-            event(new CheckoutableCheckedOut($this, $target, Auth::user(), $note));
-
+                event(new CheckoutableCheckedOut($this, $target, $checkedOutBy, $note));
+            } else {
+                event(new CheckoutableCheckedOut($this, $target, Auth::user(), $note));
+            }
+            
             $this->increment('checkout_counter', 1);
             return true;
         }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -279,7 +279,7 @@ class Asset extends Depreciable
      * @since [v3.0]
      * @return boolean
      */
-    public function checkOut($target, $admin_id = null, $checkout_at = null, $expected_checkin = null, $note = null, $name = null, $location = null)
+    public function checkOut($target, $admin = null, $checkout_at = null, $expected_checkin = null, $note = null, $name = null, $location = null)
     {
         if (!$target) {
             return false;
@@ -313,8 +313,8 @@ class Asset extends Depreciable
         }
 
         if ($this->save()) {
-            if(isset($admin_id)){
-                $checkedOutBy = User::find($admin_id);
+            if (is_integer($admin)){
+                $checkedOutBy = User::findOrFail($admin);
 
                 event(new CheckoutableCheckedOut($this, $target, $checkedOutBy, $note));
             } else {

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -315,10 +315,11 @@ class Asset extends Depreciable
         if ($this->save()) {
             if (is_integer($admin)){
                 $checkedOutBy = User::findOrFail($admin);
+            } elseif (get_class($admin) === 'App\Models\User') {
+                $checkedOutBy = $admin;
             } else {
                 $checkedOutBy = Auth::user();
             }
-
             event(new CheckoutableCheckedOut($this, $target, $checkedOutBy, $note));
 
             $this->increment('checkout_counter', 1);

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -315,12 +315,12 @@ class Asset extends Depreciable
         if ($this->save()) {
             if (is_integer($admin)){
                 $checkedOutBy = User::findOrFail($admin);
-
-                event(new CheckoutableCheckedOut($this, $target, $checkedOutBy, $note));
             } else {
-                event(new CheckoutableCheckedOut($this, $target, Auth::user(), $note));
+                $checkedOutBy = Auth::user();
             }
-            
+
+            event(new CheckoutableCheckedOut($this, $target, $checkedOutBy, $note));
+
             $this->increment('checkout_counter', 1);
             return true;
         }


### PR DESCRIPTION
# Description
If the importer is launched from the CLI, no user was passed to the CheckoutableCheckedOut.php event. 

In the Models/Asset.php@checkout() function I saw an unused variable called $admin that I thought I can use for this because ObjectImportCommand.php already set an user_id that I pass to that unused variable. Then I search for that user and pass it to the event, so it doesn't crash.

See the changes for more info. Thanks to @uberbrady for the insight!! 

Fixes #8837

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.15
* MySQL version: mariadb  Ver 15.1 Distrib 10.4.17-MariaDB, for Linux
* Webserver version: nginx/1.18.0
* OS version: Fedora 33


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
