### PR TITLE
Remove unnecessary apt-get clean in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu:bionic
 LABEL maintainer Brady Wetherington <uberbrady@gmail.com>
 
+# No need to add `apt-get clean` here, reference:
+# - https://github.com/snipe/snipe-it/pull/9201
+# - https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
+
 RUN export DEBIAN_FRONTEND=noninteractive; \
     export DEBCONF_NONINTERACTIVE_SEEN=true; \
     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections; \
@@ -37,7 +41,6 @@ libmcrypt-dev \
 php7.2-dev \
 ca-certificates \
 unzip \
-&& apt-get clean \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 


### PR DESCRIPTION
# Description

This image is built from the official Debian image as upstream, so there
is no need to do apt-get clean manually.

Ref:
- docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get

> Official Debian and Ubuntu images automatically run apt-get clean, so
> explicit invocation is not required.


## Type of change

Please delete options that are not relevant.

- [x] Refactor

# How Has This Been Tested?

`docker build -t snipe-it:temp .`

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
