### PR TITLE
Fixes #9036 Issue when offset is greater than the number of locations.

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -54,7 +54,7 @@ class LocationsController extends Controller
 
 
 
-        $offset = (($locations) && (request('offset') > $locations->count())) ? 0 : request('offset', 0);
+        $offset = (($locations) && (request('offset') > $locations->count())) ? $locations->count() : request('offset', 0);
 
         // Check to make sure the limit is not higher than the max allowed
         ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');


### PR DESCRIPTION
# Description

Fixes ternary that sets the offset variable in the LocationsController to 0 when the offset passed to the API for the user is greater than total locations.

Fixes #9036

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.15
* MySQL version: mariadb  Ver 15.1 Distrib 10.4.17-MariaDB
* Webserver version nginx/1.18.0
* OS version: Fedora 33