### PR TITLE
Fixes #9229 #9227 - Fixes a couple of links on View Models page

### DIFF
--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -124,7 +124,7 @@ class AssetModelPresenter extends Presenter
             "sortable" => false,
             "switchable" => false,
             "title" => trans('table.actions'),
-            "formatter" => "licensesActionsFormatter",
+            "formatter" => "modelsActionsFormatter",
         ];
 
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -160,11 +160,12 @@
 
                 // Add some overrides for any funny urls we have
                 var dest = destination;
+                var dpolymorphicItemFormatterest = '';
                 if (destination=='fieldsets') {
-                    var dpolymorphicItemFormatterest = 'fields/fieldsets';
+                    var dpolymorphicItemFormatterest = 'fields/';
                 }
 
-                return '<nobr><a href="{{ url('/') }}/' + dest + '/' + value.id + '"> ' + value.name + '</a></span>';
+                return '<nobr><a href="{{ url('/') }}/' + dpolymorphicItemFormatterest + dest + '/' + value.id + '"> ' + value.name + '</a></span>';
             }
         };
     }


### PR DESCRIPTION
# Description
`AssetModelPresenter.php` had a link pointing to licenses actions (clone, edit, delete) instead of models actions. Also  fix the link in `bootstrap-table.blade` view adding the `dpolymorphicItemFormatterest` variable to the generated link when destination is `fieldsets`.

Fixes #9229 #9227

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**: 
* PHP version: 7.4.15
* MySQL version. mariadb  Ver 15.1 Distrib 10.4.17-MariaDB,
* Webserver version : nginx 1.18.0
* OS version: Fedora 33


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
