### PR TITLE
Fixes #9216 - Deleting users affects locations with the same ID

### DIFF
--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -174,7 +174,7 @@ class BulkUsersController extends Controller
         }
 
         $users = User::whereIn('id', $user_raw_array)->get();
-        $assets = Asset::whereIn('assigned_to', $user_raw_array)->get();
+        $assets = Asset::whereIn('assigned_to', $user_raw_array)->where('assigned_type', 'App\Models\User')->get();
         $accessories = DB::table('accessories_users')->whereIn('assigned_to', $user_raw_array)->get();
         $licenses = DB::table('license_seats')->whereIn('assigned_to', $user_raw_array)->get();
 


### PR DESCRIPTION
# Description

Added a condition to ensure that only assets checked out to an user that is being deleted are updating their status

Fixes #9216 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.15
* MySQL version:  Ver 15.1 Distrib 10.4.17-MariaDB
* Webserver version: nginx/1.18.0
* OS version: Fedora 33


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
