### PR TITLE
Added #5977: Add permission to view files attached to licenses

### DIFF
--- a/app/Policies/LicensePolicy.php
+++ b/app/Policies/LicensePolicy.php
@@ -35,4 +35,14 @@ class LicensePolicy extends CheckoutablePermissionsPolicy
         return false;
     }
 
+    /**
+     * Determine whether the user can access files associated with licenses.
+     *
+     * @param  \App\Models\User  $user
+     * @return mixed
+     */
+    public function files(User $user)
+    {
+        return $user->hasAccess($this->columnName().'.files');
+    }
 }

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -218,6 +218,12 @@ return array(
             'note'       => '',
             'display'    => true,
         ),
+        array(
+            'permission' => 'licenses.files',
+            'label'      => 'View and Modify License Files',
+            'note'       => '',
+            'display'    => true,
+        ),
     ),
 
 

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -31,7 +31,9 @@
       <ul class="nav nav-tabs">
         <li class="active"><a href="#details" data-toggle="tab">Details</a></li>
         <li><a href="#seats" data-toggle="tab">{{ trans('admin/licenses/form.seats') }}</a></li>
+        @can('files', $license)
         <li><a href="#uploads" data-toggle="tab">{{ trans('general.file_uploads') }}</a></li>
+        @endcan
         <li><a href="#history" data-toggle="tab">{{ trans('admin/licenses/general.checkout_history') }}</a></li>
         <li class="pull-right"><a href="#" data-toggle="modal" data-target="#uploadFileModal"><i class="fa fa-paperclip" aria-hidden="true"></i> {{ trans('button.upload') }}</a></li>
       </ul>
@@ -364,6 +366,7 @@
           </div> <!--/.row-->
         </div> <!-- /.tab-pane -->
 
+        @can('files', $license)
         <div class="tab-pane" id="uploads">
           <div class="table-responsive">
             <table
@@ -447,6 +450,7 @@
           </table>
           </div>
         </div> <!-- /.tab-pane -->
+        @endcan
 
         <div class="tab-pane" id="history">
           <div class="row">


### PR DESCRIPTION
# Description

Added #5977
Adds a small permission to remove access to files attached to licences.
Removes the 'File Upload' tab and content from the license view if the permission is missing.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested viewing a known license with files with accounts both with and without the permission

**Test Configuration**:
* PHP version: 7.4.3
* Database: 10.3.25-MariaDB
* Webserver version Apache 2.4.41
* OS version Ubuntu 20.04


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
