### PR TITLE
Fixed ch15966 - attempts to download extremely large files (Backups) exhausts all memory

### DIFF
--- a/app/Helpers/StorageHelper.php
+++ b/app/Helpers/StorageHelper.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Helpers;
+use Illuminate\Support\Facades\Storage;
+
+class StorageHelper
+{
+    static function downloader($filename, $disk = 'default') {
+        if($disk == 'default') {
+            $disk = config('filesystems.default');
+        }
+        switch(config("filesystems.disks.$disk.driver")) {
+            case 'local':
+                return response()->download(Storage::disk($disk)->path($filename)); //works for PRIVATE or public?!
+
+            case 's3':
+                return redirect()->away(Storage::disk($disk)->temporaryUrl($filename, now()->addMinutes(5))); //works for private or public, I guess?
+
+            default:
+                return Storage::disk($disk)->download($filename);
+        }
+    }
+}

--- a/app/Http/Controllers/Assets/AssetFilesController.php
+++ b/app/Http/Controllers/Assets/AssetFilesController.php
@@ -9,6 +9,7 @@ use App\Models\Actionlog;
 use App\Models\Asset;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Storage;
+use App\Helpers\StorageHelper;
 
 class AssetFilesController extends Controller
 {
@@ -86,7 +87,7 @@ class AssetFilesController extends Controller
                   }
                 return JsonResponse::create(["error" => "Failed validation: "], 500);
             }
-            return Storage::download($file);
+            return StorageHelper::downloader($file);
         }
         // Prepare the error message
         $error = trans('admin/hardware/message.does_not_exist', ['id' => $fileId]);

--- a/app/Http/Controllers/Licenses/LicenseFilesController.php
+++ b/app/Http/Controllers/Licenses/LicenseFilesController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use App\Helpers\StorageHelper;
 
 class LicenseFilesController extends Controller
 {
@@ -143,18 +144,18 @@ class LicenseFilesController extends Controller
 
                 // We have to override the URL stuff here, since local defaults in Laravel's Flysystem
                 // won't work, as they're not accessible via the web
-                if (config('filesystems.default') == 'local') {
-                    return Storage::download($file);
+                if (config('filesystems.default') == 'local') { // TODO - is there any way to fix this at the StorageHelper layer?
+                    return StorageHelper::downloader($file);
                 } else {
                     if ($download != 'true') {
                         \Log::debug('display the file');
-                        if ($contents = file_get_contents(Storage::url($file))) {
+                        if ($contents = file_get_contents(Storage::url($file))) { // TODO - this will fail on private S3 files or large public ones
                             return Response::make(Storage::url($file)->header('Content-Type', mime_content_type($file)));
                         }
                         return JsonResponse::create(["error" => "Failed validation: "], 500);
                     }
 
-                    return Storage::download($file);
+                    return StorageHelper::downloader($file);
                 }
 
             }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -21,6 +21,7 @@ use Image;
 use Input;
 use Redirect;
 use Response;
+use App\Helpers\StorageHelper;
 
 /**
  * This controller handles all actions related to Settings for
@@ -1091,7 +1092,7 @@ class SettingsController extends Controller
 
         if (! config('app.lock_passwords')) {
             if (Storage::exists($path . '/' . $filename)) {
-                return Storage::download($path . '/' . $filename);
+                return StorageHelper::downloader($path . '/' . $filename);
             } else {
                 // Redirect to the backup page
                 return redirect()->route('settings.backups.index')->with('error', trans('admin/settings/message.backup.file_not_found'));

--- a/app/Http/Controllers/Users/UserFilesController.php
+++ b/app/Http/Controllers/Users/UserFilesController.php
@@ -117,7 +117,7 @@ class UserFilesController extends Controller
 
             $log = Actionlog::find($fileId);
             $file = $log->get_src('users');
-            return Response::download($file);
+            return Response::download($file); //FIXME this doesn't use the new StorageHelper yet, but it's complicated...
         }
         // Prepare the error message
         $error = trans('admin/users/message.user_not_found', ['id' => $userId]);


### PR DESCRIPTION
Laravel has a `Storage::download()` method which we use, but that breaks pretty hard on large enough files (basically, anything bigger than the memory limit, or so). Backups in particular, for customers who have lots of images, can easily exceed that.

This adds a new `StorageHelper` Helper class (just a single static method right now) and uses it where it makes sense. Though, see caveats below. I called my method `downloader` rather than `download` to make sure we can easily visually distinguish between `Storage::download()` and `StorageHelper::downloader()`.

I tested it against local storage **and** against S3, and it was able to download my 1GB file with ease in all the sections where I made modifications.

Some caveats:
 - S3 storage doesn't show image previews properly, because our MIME-type-determining code is tied to local storage. I figure that's okay, because it was already like this.
 - There are a few remaining places where we have hardcoded references to the local filesystem's `storage/private_uploads` - most frequently using `config('app.private_uploads')`. Again, it was already like this already so I figured this isn't any worse.
 - Spatie Backup running under S3 local 'private' storage seemed to get _very_ confused, but my stuff didn't mess with any of that (just the 'download' side) so I don't think that's on me; I think it was already that way. Spatie Backup **is** disk-aware (a.k.a. Flysystem-aware) with the version we're using now, so this could potentially be fixable in the future.