### PR TITLE
Fixed #9299: Use correct SVG MIME type for uploads

### DIFF
--- a/resources/views/partials/forms/edit/image-upload.blade.php
+++ b/resources/views/partials/forms/edit/image-upload.blade.php
@@ -6,7 +6,7 @@
 
         <label class="btn btn-default" aria-hidden="true">
             {{ trans('button.select_file')  }}
-            <input type="file" name="{{ (isset($fieldname) ? $fieldname : 'image') }}" class="js-uploadFile" id="uploadFile" data-maxsize="{{ \App\Helpers\Helper::file_upload_max_size() }}" accept="image/gif,image/jpeg,image/webp,image/png,image/svg" style="display:none; max-width: 90%" aria-label="image" aria-hidden="true">
+            <input type="file" name="{{ (isset($fieldname) ? $fieldname : 'image') }}" class="js-uploadFile" id="uploadFile" data-maxsize="{{ \App\Helpers\Helper::file_upload_max_size() }}" accept="image/gif,image/jpeg,image/webp,image/png,image/svg,image/svg+xml" style="display:none; max-width: 90%" aria-label="image" aria-hidden="true">
         </label>
         <span class='label label-default' id="uploadFile-info"></span>
 

--- a/resources/views/partials/forms/edit/uploadLogo.blade.php
+++ b/resources/views/partials/forms/edit/uploadLogo.blade.php
@@ -35,7 +35,7 @@
             {{ trans('button.select_file')  }}
             <input type="file" name="{{ $logoVariable }}" class="js-uploadFile" id="{{ $logoId }}"
                 data-maxsize="{{ $maxSize ?? \App\Helpers\Helper::file_upload_max_size() }}"
-                accept="{{ $allowedTypes ?? 'image/gif,image/jpeg,image/png,image/svg'}}" style="display:none; max-width: 90%">
+                accept="{{ $allowedTypes ?? 'image/gif,image/jpeg,image/png,image/svg,image/svg+xml'}}" style="display:none; max-width: 90%">
         </label>
         <span class='label label-default' id="{{ $logoId }}-info"></span>
 

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -105,7 +105,7 @@
                         "logoLabel" => trans('admin/settings/general.favicon'),
                         "logoClearVariable" => "clear_favicon",
                         "helpBlock" => trans('admin/settings/general.favicon_size') .' '. trans('admin/settings/general.favicon_format'),
-                        "allowedTypes" => "image/x-icon,image/gif,image/jpeg,image/png,image/svg,image/vnd.microsoft.icon",
+                        "allowedTypes" => "image/x-icon,image/gif,image/jpeg,image/png,image/svg,image/svg+xml,image/vnd.microsoft.icon",
                         "maxSize" => 20000
                     ])
 


### PR DESCRIPTION
The correct MIME type of SVG is `image/svg+xml`. Out of an abundance of caution, I am leaving in `image/svg` to avoid potentially causing issues on very old browsers, but this can likely be removed without issue.

# Description

When given an `<input>` tag of type `file`, browsers limit which files you can upload based on a list of MIME types provided in the `accept` attribute. We currently specify `image/svg` instead of `image/svg+xml` and, as a result, current browsers will not allow users to upload SVG files to Snipe-IT. This resolves that by adding `image/svg+xml` to the list of accepted MIME types.

Fixes #9299

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Attempt to upload an SVG image without this patch
- [ ] Attempt to upload an SVG image with this patch

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes