### PR TITLE
(Maybe?) Fixes the problem where we always need LDAP enabled

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -58,12 +58,12 @@ class LoginController extends Controller
      *
      * @return void
      */
-    public function __construct(LdapAd $ldap, Saml $saml)
+    public function __construct(/*LdapAd $ldap, */ Saml $saml)
     {
         parent::__construct();
         $this->middleware('guest', ['except' => ['logout','postTwoFactorAuth','getTwoFactorAuth','getTwoFactorEnroll']]);
         Session::put('backUrl', \URL::previous());
-        $this->ldap = $ldap;
+        // $this->ldap = $ldap;
         $this->saml = $saml;
     }
 
@@ -140,10 +140,10 @@ class LoginController extends Controller
      * 
      * @throws \Exception
      */
-    private function loginViaLdap(Request $request): User
+    private function loginViaLdap(LdapAd $ldap, Request $request): User
     {
         try {
-            return $this->ldap->ldapLogin($request->input('username'), $request->input('password'));
+            return $ldap->ldapLogin($request->input('username'), $request->input('password'));
         } catch (\Exception $ex) {
             LOG::debug("LDAP user login: " . $ex->getMessage());
             throw new \Exception($ex->getMessage());
@@ -217,7 +217,7 @@ class LoginController extends Controller
         $user = null;
 
         // Should we even check for LDAP users?
-        if ($this->ldap->init()) {
+        if (Setting::getSettings()->ldap_enabled) { // avoid hitting the $this->ldap
             LOG::debug("LDAP is enabled.");
             try {
                 LOG::debug("Attempting to log user in by LDAP authentication.");

--- a/app/Providers/LdapServiceProvider.php
+++ b/app/Providers/LdapServiceProvider.php
@@ -2,8 +2,9 @@
 
 use App\Services\LdapAd;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Support\DeferrableProvider;
 
-class LdapServiceProvider extends ServiceProvider
+class LdapServiceProvider extends ServiceProvider implements DeferrableProvider
 {
 
     /**
@@ -25,5 +26,15 @@ class LdapServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(LdapAd::class, LdapAd::class);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [LdapAd::class];
     }
 }


### PR DESCRIPTION
We needed it always enabled, even if we weren't using it. This is because it was implemented as a Service Provider. I'm not sure though that this is enough to render it unnecessary (if you aren't using LDAP). Unfortunately, the constructor for the LoginController gets the LdapAd object injected into it, so it may always get loaded, no matter what.

I've tested that this does work fine on my machine for when LDAP is actually enabled in PHP, but I think we need to test with one of the people who does *not* have LDAP enabled in PHP to see if this helps them, too. I'm not sure whether or not it will.