### PR TITLE
Fixing #9224 - database prefix issue

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -78,7 +78,7 @@ final class Company extends SnipeModel
             $company_id = null;
         }
 
-        $table = ($table_name) ? DB::getTablePrefix().$table_name."." : '';
+        $table = ($table_name) ? $table_name."." : '';
 
         if(\Schema::hasColumn($query->getModel()->getTable(), $column)){
              return $query->where($table.$column, '=', $company_id); 


### PR DESCRIPTION
# Description

We found out that the 'where' in line 84 already adds the database prefix; thus while trying to view the assets in a multi company environment the actual table called was 'snipeit_snipeit_assets' instead of 'snipeit_assets'. This was different when using 'whereRaw', but we found deleting the database prefix adding to be the better fix.

Fixes #9224

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Done in a test environment with v5.1.3.

**Test Configuration**:
* PHP version: 7.3.23-1+020201008.68+debian91.gbp30f6c3
* MySQL version: 5.8+1.0.2
* Webserver version: nginx 1.10.3-1+deb9u3
* OS version: Debian 9


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
