### PR TITLE
Fixes an issue when licenses without enough seats are imported.

### DIFF
--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -73,12 +73,21 @@ class LicenseImporter extends ItemImporter
                 $asset = Asset::where('asset_tag', $asset_tag)->first();
                 $targetLicense = $license->freeSeat();
                 if ($checkout_target) {
-                    $targetLicense->assigned_to = $checkout_target->id;
-                    $targetLicense->user_id = Auth::id();
-                    if ($asset) {
-                        $targetLicense->asset_id = $asset->id;
+                    try{
+                        $targetLicense->assigned_to = $checkout_target->id;
+                        $targetLicense->user_id = Auth::id();
+                        if ($asset) {
+                            $targetLicense->asset_id = $asset->id;
+                        }
+                        $targetLicense->save();
+                    } catch (\Exception $ex){
+                        if($ex->getMessage() === "Creating default object from empty value"){
+                            return back()->withError(trans("admin/licenses/message.not_found"));
+                        } else {
+                            return back()->withError($ex->getMessage());
+                        }
+
                     }
-                    $targetLicense->save();
                 } elseif ($asset) {
                     $targetLicense->user_id = Auth::id();
                     $targetLicense->asset_id = $asset->id;

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -71,27 +71,20 @@ class LicenseImporter extends ItemImporter
             if ($license->seats > 0) {
                 $checkout_target = $this->item['checkout_target'];
                 $asset = Asset::where('asset_tag', $asset_tag)->first();
-                $targetLicense = $license->freeSeat();
+                $targetSeat = $license->freeSeat();
                 if ($checkout_target) {
-                    try{
-                        $targetLicense->assigned_to = $checkout_target->id;
-                        $targetLicense->user_id = Auth::id();
-                        if ($asset) {
-                            $targetLicense->asset_id = $asset->id;
-                        }
-                        $targetLicense->save();
-                    } catch (\Exception $ex){
-                        if($ex->getMessage() === "Creating default object from empty value"){
-                            return back()->withError(trans("admin/licenses/message.not_enough_seats"));
-                        } else {
-                            return back()->withError($ex->getMessage());
-                        }
+                    if ($targetSeat){
+                        $targetSeat->assigned_to = $checkout_target->id;
+                        $targetSeat->user_id = Auth::id();
 
+                        $targetSeat->save();
+                    } else {
+                        return back()->withError(trans("admin/licenses/message.not_enough_seats"));
                     }
                 } elseif ($asset) {
-                    $targetLicense->user_id = Auth::id();
-                    $targetLicense->asset_id = $asset->id;
-                    $targetLicense->save();
+                    $targetSeat->user_id = Auth::id();
+                    $targetSeat->asset_id = $asset->id;
+                    $targetSeat->save();
                 }
             }
             return;

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -82,7 +82,7 @@ class LicenseImporter extends ItemImporter
                         $targetLicense->save();
                     } catch (\Exception $ex){
                         if($ex->getMessage() === "Creating default object from empty value"){
-                            return back()->withError(trans("admin/licenses/message.not_found"));
+                            return back()->withError(trans("admin/licenses/message.not_enough_seats"));
                         } else {
                             return back()->withError($ex->getMessage());
                         }

--- a/resources/lang/en/admin/licenses/message.php
+++ b/resources/lang/en/admin/licenses/message.php
@@ -9,6 +9,7 @@ return array(
     'assoc_users'	 => 'This license is currently checked out to a user and cannot be deleted. Please check the license in first, and then try deleting again. ',
     'select_asset_or_person' => 'You must select an asset or a user, but not both.',
     'not_found' => 'License not found',
+    'not_enough_seats' => 'Some licenses may not be imported, not enough seats created.',
 
 
     'create' => array(


### PR DESCRIPTION
# Description
If Licenses imported via CSV doesn't have enough seats enabled for the people in the file to be checked out, the system fails with an exception and doesn't import anything. This changes let the system to import what it can, ie. if the licenses have one seat and 4 people assigned it only assigns 1 person to 1 license and the other 3 aren't imported. It also shows an error telling that they aren't enough seats and not every license is imported.

Fixes # FD-19913 and FD-20057

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: MySQL 5.7
* Webserver version:  nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
