### PR TITLE
Fixes #9063 Added sanity check to determine if a bind user account is set.

### DIFF
--- a/app/Services/LdapAd.php
+++ b/app/Services/LdapAd.php
@@ -129,7 +129,13 @@ class LdapAd extends LdapAdConfiguration
             $login_username = $username;
         }
 
-        if ($this->ldap->auth()->attempt($login_username, $password, true) === false) {
+        if ($this->ldapConfig['username'] && $this->ldapConfig['password']) {
+            $bind_as_user = false;
+        } else {
+            $bind_as_user = true;
+        }
+
+        if ($this->ldap->auth()->attempt($login_username, $password, $bind_as_user) === false) {
             throw new Exception('Unable to validate user credentials!');
         }    
 


### PR DESCRIPTION
# Description

This bug was introduced in this commit: https://github.com/snipe/snipe-it/pull/7919

The adlap2 module binds to the AD/LDAP server using $username and $password because the third parameter in $this->ldap->auth()->attempt($username, $password, true) is set to true. When the third parameter is set to false, it allows the adldap2 module to bind to the AD/LDAP server using AD/LDAP Bind Username and Password from app/Services/LdapAdConfiguration.php. Then, It will authenticate the $username and $password against the AD/LDAP server. This change fixes issue #9063.

The original rewrite of this code accounted for this by omitting the third parameter. 
https://github.com/snipe/snipe-it/pull/6352

Reference: Adldap2 setup documentation -- https://github.com/Adldap2/Adldap2/blob/master/docs/setup.md

Fixes #9063

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] I've tested this against my JumpCloud LDAP as a service, and it allows for login for the correct passwords and disallows login for the incorrect ones.
- [x] I disabled LDAP Password Sync during testing to prevent the passwords from being synchronized 
- [x] Also, I deleted the user accounts and resync LDAP to ensure the LDAP password wasn't synchronized and user accounts are authenticated against the LDAP server.

**Test Configuration**:
* PHP version: PHP 7.3.19-1
* MySQL version: Ver 15.1 Distrib 10.5.8-MariaDB
* Webserver version: Apache/2.4.38 (Debian)
* OS version: Debian GNU/Linux 10 (buster)


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
