### PR TITLE
Barcode DPI 

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -484,7 +484,7 @@ class AssetsController extends Controller
                 return response()->file($barcode_file, $header);
             } else {
                 // Calculate barcode width in pixel based on label width (inch)
-                $barcode_width = ($settings->labels_width - $settings->labels_display_sgutter) * 96.000000000001;
+                $barcode_width = ($settings->labels_width - $settings->labels_display_sgutter) * 200.000000000001;
 
                 $barcode = new \Com\Tecnick\Barcode\Barcode();
                 try {


### PR DESCRIPTION
# Description
Hi this is the correct commit instead #9343

Motivation-> Issue #9293
CSS used to fit the barcode, qr code and Text tighter together
[Custom CSS (Branding).txt](https://github.com/snipe/snipe-it/files/6203126/Custom.CSS.Branding.txt)
![image](https://user-images.githubusercontent.com/80526133/112442888-9c0c1300-8d4c-11eb-8c9d-2c24c1c4f739.png)
![image](https://user-images.githubusercontent.com/80526133/112443131-dfff1800-8d4c-11eb-8a16-f7ec3f7810b2.png)


Fixes #9293

Type of change:
Adjusted multiplier so barcode is readable even with low "label width"
snipeit\app\Http\Controllers\Assets\AssetsController.php
changed 96.000000000001 to 200.000000000001
`                // Calculate barcode width in pixel based on label width (inch)` 
`                 $barcode_width = ($settings->labels_width - $settings->labels_display_sgutter) * 200.000000000001;` 


- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Printed lables out with 1.6 inch width and they are scannable as the generated Barcode PNG has enough resolution for the saved barcode data.

Lables look the same so no formatation issue with the additional width of the barcode, just better DPI.

This is not a real fix but an optimization as the dpi should be relative to the encoded data and not to the width of the lable, but it allows to use smaller lables without any deficits (minimaly more diskspace per barcode image but if you'd print 2" lables it would be anyways that big)

**Test Configuration**: ^above
* PHP version: 7.4.16
* Webserver version Apache
* OS version: ubuntu 18.04.5 LTS
* SnipeIT: v5.1.4 build 5886 (g9f3a8a43c)


# Checklist:
Basically 'just' changed a multiplyer so no logical change
- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
