### PR TITLE
Fixed #9355: include Accessories and Consumables on the location reports

### DIFF
--- a/resources/views/locations/view.blade.php
+++ b/resources/views/locations/view.blade.php
@@ -86,6 +86,71 @@
             </div><!-- /.box-body -->
           </div> <!--/.box-->
 
+      <div class="box box-default">
+        <div class="box-header with-border">
+          <div class="box-heading">
+            <h2 class="box-title">{{ trans('general.accessories') }}</h2>
+          </div>
+        </div>
+        <div class="box-body">
+              <div class="table table-responsive">
+
+                  <table
+                          data-columns="{{ \App\Presenters\AccessoryPresenter::dataTableLayout() }}"
+                          data-cookie-id-table="accessoriesListingTable"
+                          data-pagination="true"
+                          data-id-table="accessoriesListingTable"
+                          data-search="true"
+                          data-side-pagination="server"
+                          data-show-columns="true"
+                          data-show-export="true"
+                          data-show-refresh="true"
+                          data-sort-order="asc"
+                          id="accessoriesListingTable"
+                          class="table table-striped snipe-table"
+                          data-url="{{route('api.accessories.index', ['location_id' => $location->id]) }}"
+                          data-export-options='{
+                              "fileName": "export-locations-{{ str_slug($location->name) }}-accessories-{{ date('Y-m-d') }}",
+                              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                              }'>
+                  </table>
+
+              </div><!-- /.table-responsive -->
+            </div><!-- /.box-body -->
+          </div> <!--/.box-->
+
+      <div class="box box-default">
+        <div class="box-header with-border">
+          <div class="box-heading">
+            <h2 class="box-title">{{ trans('general.consumables') }}</h2>
+          </div>
+        </div>
+        <div class="box-body">
+              <div class="table table-responsive">
+
+                  <table
+                          data-columns="{{ \App\Presenters\ConsumablePresenter::dataTableLayout() }}"
+                          data-cookie-id-table="consumablesListingTable"
+                          data-pagination="true"
+                          data-id-table="consumablesListingTable"
+                          data-search="true"
+                          data-side-pagination="server"
+                          data-show-columns="true"
+                          data-show-export="true"
+                          data-show-refresh="true"
+                          data-sort-order="asc"
+                          id="consumablesListingTable"
+                          class="table table-striped snipe-table"
+                          data-url="{{route('api.consumables.index', ['location_id' => $location->id]) }}"
+                          data-export-options='{
+                              "fileName": "export-locations-{{ str_slug($location->name) }}-consumables-{{ date('Y-m-d') }}",
+                              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                              }'>
+                  </table>
+
+              </div><!-- /.table-responsive -->
+            </div><!-- /.box-body -->
+          </div> <!--/.box-->
 
       <div class="box box-default">
           <div class="box-header with-border">


### PR DESCRIPTION
# Description

Consumables and Accessories allow setting a Location (I view this as inventory location, and location checkout is not allowed) so to keep track of what is at a location, these can have a Location ID set, but when clicking on it the location presenter does only includes Users/Assets/Components, and there's no way to view Accessories and Consumables.

This change adds the missing tables reusing the existing presenter code.

Fixes #9355 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Deployed the static template change to a a live instance with accessories and consumables
- [x] Validated that the tables render as expected

**Test Configuration**:
Snipe-IT Version: v5.1.3
OS: Ubuntu Kubernetes v1.19.6
Web Server: nginx
PHP Version: PHP 7.3.27



# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
