### PR TITLE
Add primary keys to tables that don't have them

### DIFF
--- a/database/migrations/2021_03_29_120402_add_custom_field_custom_fieldset_pk.php
+++ b/database/migrations/2021_03_29_120402_add_custom_field_custom_fieldset_pk.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCustomFieldCustomFieldsetPk extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('custom_field_custom_fieldset', function (Blueprint $table) {
+            $table->primary(['custom_field_id', 'custom_fieldset_id'], 'custom_field_custom_fieldset_primary');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('custom_field_custom_fieldset', function (Blueprint $table) {
+            $table->dropPrimary('custom_field_custom_fieldset_primary');
+        });
+    }
+}

--- a/database/migrations/2021_03_29_124623_add_migrations_pk.php
+++ b/database/migrations/2021_03_29_124623_add_migrations_pk.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMigrationsPk extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('migrations', function (Blueprint $table) {
+            // Add the new id and batch columns to the migrations table if they
+            // don't exist yet
+            if (!Schema::hasColumn('migrations', 'id')) {
+                $table->increments('id');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/database/migrations/2021_03_29_124623_add_migrations_pk.php
+++ b/database/migrations/2021_03_29_124623_add_migrations_pk.php
@@ -14,8 +14,7 @@ class AddMigrationsPk extends Migration
     public function up()
     {
         Schema::table('migrations', function (Blueprint $table) {
-            // Add the new id and batch columns to the migrations table if they
-            // don't exist yet
+            // Add the id column to the migrations table if it doesn't yet.
             if (!Schema::hasColumn('migrations', 'id')) {
                 $table->increments('id');
             }

--- a/database/migrations/2021_03_30_094127_add_password_resets_pk.php
+++ b/database/migrations/2021_03_30_094127_add_password_resets_pk.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPasswordResetsPk extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('password_resets', function (Blueprint $table) {
+            $table->increments('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('password_resets', function (Blueprint $table) {
+            $table->dropColumn('id');
+        });
+    }
+}


### PR DESCRIPTION
# Description

Adds primary keys to tables where they are missing.

In short: Some database systems (like XtraDB cluster) require explicit primary keys for _all_ tables, so this PR adds them to those that are missing them.
See laravel/framework#15770 for a thorough explanation and more context. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on our environment where the migrations table was missing the `id` column (shows you we've been using this since at least 2016 :sweat_smile: ) and with the default database you get when installing snipe it


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
