### PR TITLE
Fixes typo that doesn't accepts 'textarea' as custom field type element.

### DIFF
--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -359,7 +359,7 @@ class CustomField extends Model
             "name" => "required|unique:custom_fields",
             "element" => [
                 "required",
-                Rule::in(['text', 'listbox',  'textara', 'checkbox', 'radio'])
+                Rule::in(['text', 'listbox',  'textarea', 'checkbox', 'radio'])
             ],
             'format' => [
                 Rule::in(array_merge(array_keys(CustomField::PREDEFINED_FORMATS), CustomField::PREDEFINED_FORMATS))


### PR DESCRIPTION
# Description
In app\Models\CustomField.php the function `validation_rules()` had a typo that doesn't accept 'textarea' as a valid form element to create custom fields from the API 

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
PHP version: 7.4.16
MySQL version: 8.0.23
Webserver version: nginx 1.19.8
OS version: Debian 10
