### PR TITLE
Fixes an issue with CSS when the 'skin' value in settings table is empty.

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -31,7 +31,7 @@
     <link rel="stylesheet" href="{{ mix('css/dist/all.css') }}">
     @if (($snipeSettings) && ($snipeSettings->allow_user_skin==1) && Auth::check() && Auth::user()->present()->skin != '')
         <link rel="stylesheet" href="{{ mix('css/dist/skins/skin-'.Auth::user()->present()->skin.'.min.css') }}">
-    @elseif (($snipeSettings) && ($snipeSettings->skin!=''))
+    @else
     <link rel="stylesheet" href="{{ url(mix('css/dist/skins/skin-'.($snipeSettings->skin!='' ? $snipeSettings->skin : 'blue').'.css')) }}">
     @endif
     {{-- page level css --}}


### PR DESCRIPTION
# Description

With a fresh install the setting in the Branding menu that let's you choose a skin for your Snipe-It install is blank, making the default CSS stylesheet `skin-blue.css`unreachable because some conditions. I delete those conditions because I understand that the ternary condition used to check the skin setted inline is enough to handle the possibilities. 

Fixes # N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx:1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
