### PR TITLE
FIxes Sum of purchase cost of components not taking quantity into account in Asset View > Components tab

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -856,8 +856,7 @@
                                                     </td>
                                                     <td>{{ $component->pivot->assigned_qty }}</td>
                                                     <td>{{ $component->purchase_cost }}</td>
-                                                    <?php $totalCost = $totalCost + $component->purchase_cost ;?>
-
+                                                    <?php $totalCost = $totalCost + ($component->purchase_cost *$component->pivot->assigned_qty) ?>
                                                 </tr>
                                             @endif
                                         @endforeach

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -855,7 +855,7 @@
                                                         <a href="{{ route('components.show', $component->id) }}">{{ $component->name }}</a>
                                                     </td>
                                                     <td>{{ $component->pivot->assigned_qty }}</td>
-                                                    <td>{{ $component->purchase_cost }}</td>
+                                                    <td>{{ $component->purchase_cost }} each</td>
                                                     <?php $totalCost = $totalCost + ($component->purchase_cost *$component->pivot->assigned_qty) ?>
                                                 </tr>
                                             @endif


### PR DESCRIPTION
# Description

Multiple duplicate components that were added to an asset at once would not total correctly on the components tab. This change fixes that.

![image](https://user-images.githubusercontent.com/47435081/114484252-b6ecdd00-9bbe-11eb-80dd-9bf18e6afa1e.png)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

