### PR TITLE
Fixes cloning a user that's managed via LDAP throws a password error. [ch15711]

### DIFF
--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -106,7 +106,7 @@
                 <div class="form-group {{ $errors->has('username') ? 'has-error' : '' }}">
                   <label class="col-md-3 control-label" for="username">{{ trans('admin/users/table.username') }}</label>
                   <div class="col-md-6{{  (\App\Helpers\Helper::checkIfRequired($user, 'username')) ? ' required' : '' }}">
-                    @if ($user->ldap_import!='1')
+                    @if ($user->ldap_import!='1' || str_contains(Route::currentRouteName(), 'clone'))
                       <input
                         class="form-control"
                         type="text"
@@ -137,7 +137,7 @@
                     {{ trans('admin/users/table.password') }}
                   </label>
                   <div class="col-md-6{{  (\App\Helpers\Helper::checkIfRequired($user, 'password')) ? ' required' : '' }}">
-                    @if ($user->ldap_import!='1')
+                    @if ($user->ldap_import!='1' || str_contains(Route::currentRouteName(), 'clone') )
                       <input
                         type="password"
                         name="password"
@@ -161,7 +161,7 @@
                   </div>
                 </div>
 
-                @if ($user->ldap_import!='1')
+                @if ($user->ldap_import!='1' || str_contains(Route::currentRouteName(), 'clone'))
                 <!-- Password Confirm -->
                 <div class="form-group {{ $errors->has('password_confirmation') ? 'has-error' : '' }}">
                   <label class="col-md-3 control-label" for="password_confirmation">


### PR DESCRIPTION
# Description

When we try to clone a user that's imported via LDAP, the password is required but the form field doesn't appears. Also as the username is copied, it doesn't let the cloned user gets created as the field is not editable. This fixes both scenarios.

Fixes # ch15711

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
