### PR TITLE
Fixes #9415 Cannot set regex for Custom Field via API.

### DIFF
--- a/app/Http/Controllers/Api/CustomFieldsController.php
+++ b/app/Http/Controllers/Api/CustomFieldsController.php
@@ -95,7 +95,14 @@ class CustomFieldsController extends Controller
         $field = new CustomField;
 
         $data = $request->all();
-        $validator = Validator::make($data, $field->validationRules());
+        $regex_format = null;
+        
+        if (str_contains($data["format"], "regex:")){
+            $regex_format = $data["format"];
+        }
+
+        $validator = Validator::make($data, $field->validationRules($regex_format));
+
         if ($validator->fails()) {
             return response()->json(Helper::formatStandardApiResponse('error', null, $validator->errors()));
         }

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -353,7 +353,7 @@ class CustomField extends Model
     * @since [v4.1.10]
     * @return array
     */
-    public function validationRules()
+    public function validationRules($regex_format = null)
     {
         return [
             "name" => "required|unique:custom_fields",
@@ -362,7 +362,7 @@ class CustomField extends Model
                 Rule::in(['text', 'listbox',  'textarea', 'checkbox', 'radio'])
             ],
             'format' => [
-                Rule::in(array_merge(array_keys(CustomField::PREDEFINED_FORMATS), CustomField::PREDEFINED_FORMATS))
+                Rule::in(array_merge(array_keys(CustomField::PREDEFINED_FORMATS), CustomField::PREDEFINED_FORMATS, [$regex_format]))
             ],
             'field_encrypted' => "nullable|boolean"
         ];


### PR DESCRIPTION
# Description

The validator in the CustomFieldsController reached when a Custom Field is intended to be created via API has a fixed set of formats that ignores custom regexed ones. This change handle those use cases, I think like is a little bit 'clever' and I know how @uberbrady feels about those changes, but I couldn't find another way without change the behaviour of the existing API.

Other fix I though was that if the user needs a Custom Regex format, they probably could add an aditional parameter to the API  call `custom_format` or something like that. But let me know what you think, if this works to keep it simpler, if is better to implement the extra parameter, or if you think of another better way. Cheers! 

Fixes  #9415 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
