### PR TITLE
fix css when not running from webroot directory

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -28,7 +28,7 @@
     </script>
 
     {{-- stylesheets --}}
-    <link rel="stylesheet" href="{{ mix('css/dist/all.css') }}">
+    <link rel="stylesheet" href="{{ url(mix('css/dist/all.css')) }}">
     @if (($snipeSettings) && ($snipeSettings->allow_user_skin==1) && Auth::check() && Auth::user()->present()->skin != '')
         <link rel="stylesheet" href="{{ mix('css/dist/skins/skin-'.Auth::user()->present()->skin.'.min.css') }}">
     @else


### PR DESCRIPTION
# Description
Fix css when Snipe-IT is not running in the root of the webserver but in a subdirectory


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Install Snipe-IT to be served eg. below https://example.org/snipe-it/

Without fix it tries to lod the all.css file from `https://example.org/css/dist/all.css?id=xxxxxx`

With fix the all.css file is loaded from `https://example.org/snipe-it/css/dist/all.css?id=xxxxxx`

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
