### PR TITLE
Allow setting the Monolog channel with the LOG_CHANNEL environment variable.

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -14,8 +14,7 @@ $config = [
     | one of the channels defined in the "channels" configuration array.
     |
     */
-
-    'default' => 'stack',
+    'default' => env('LOG_CHANNEL', 'stack'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This restores functionality inadvertently removed last month by e9ee9ea2e9c8eb8185b8fd5dbe2f74d4da90ab33. This is helpful for containerized deployments, where sending logs to stdout or stderr is standard practice.