### PR TITLE
Fixes #9463 - re-enable LDAP Logins via deferred LdapAd provider

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -140,8 +140,9 @@ class LoginController extends Controller
      * 
      * @throws \Exception
      */
-    private function loginViaLdap(LdapAd $ldap, Request $request): User
+    private function loginViaLdap(Request $request): User
     {
+        $ldap = \App::make( LdapAd::class);
         try {
             return $ldap->ldapLogin($request->input('username'), $request->input('password'));
         } catch (\Exception $ex) {


### PR DESCRIPTION
# Description

In the process of trying to make it so that users can use Snipe-IT without having the LDAP module installed, I misunderstood how Service Providers work in Laravel and messed up the signature to the `loginViaLdap()` method. Service provider injection only happpens on `__construct()`, you can't just go an dinject service providers whereever you want, which is what I did.

To keep the fix rolling forward, I replaced it with the manual resolution of the Service Provider dependency.

Fixes #9463 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Made sure that I could reproduce the bug without the fix; I was able to.
- [x] Made sure that once the fix was in place, the bug no longer showed up.