### PR TITLE
Fixed #9422: pivot ID was being used as a user_id

### DIFF
--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -287,7 +287,7 @@ class AccessoriesController extends Controller
         $accessory = Accessory::find($accessory_user->accessory_id);
         $this->authorize('checkin', $accessory);
 
-        $logaction = $accessory->logCheckin(User::find($accessoryUserId), $request->input('note'));
+        $logaction = $accessory->logCheckin(User::find($accessory_user->user_id), $request->input('note'));
 
         // Was the accessory updated?
         if (DB::table('accessories_users')->where('id', '=', $accessory_user->id)->delete()) {


### PR DESCRIPTION
# Description

In the API call for an Accessory checkin, the User table is queried but it was passed the accessory_user_id - which is the pivot ID of the accessory_user table, and not a user ID.

Fixes # 9422

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

On a linux shell, this can be tested by finding an accessory in the database and doing the following. 
% export token="enter-an-API-token"

-- in the following curl command, put a valid accessory ID in the URL .../accessories/1/checkout
-- in the following curl command, put a valid user ID in for "1" in the assigned_to body
-- do this several times to see multiple checkout records

% curl --request POST http://localhost/api/v1/accessories/1/checkout --data '{"assigned_to": 1}' --header "Authorization: Bearer $token" --header "Accept: application/json" --header "Content-Type: application/json"

-- in the following curl command, use the same accessory ID in the URL as above
-- you should see the different checkout records for this accessory
-- note the different "assigned_pivot_id" values in the records

% curl --request GET http://localhost/api/v1/accessories/1/checkedout --header "Authorization: Bearer $token" --header "Accept: application/json" --header "Content-Type: application/json"

-- in the following curl command, put one of the assigned_pivot_id's in the checkout records above in the url for the "6" as .../accessories/6/checkin

% curl --request POST http://localhost/api/v1/accessories/6/checkin --header "Authorization: Bearer $token" --header "Accept: application/json" --header "Content-Type: application/json"

You should now see the records checked in the UI; re-run the checkedout curl command above to also verify they have been checked in. Check the activity report in the UI to see the records checked in. If you happen to have users in your database with User::id matching the assigned_pivot_id you should note that user in the checkin record is the correct user.

**Test Configuration**:
* PHP version: 7.4.3
* MySQL version: 8.0.23-0ubuntu0.20.04.1
* Webserver version: apache2
* OS version: ubuntu 20.04


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
