### PR TITLE
Fix Dockerfile.alpine build error and snipeit runtime permission error

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -57,7 +57,7 @@ RUN \
     && mkdir -p "/var/lib/snipeit/dumps" && rm -r "/var/www/html/storage/app/backups" && ln -fs "/var/lib/snipeit/dumps" "/var/www/html/storage/app/backups" \
     && mkdir -p "/var/lib/snipeit/keys" && ln -fs "/var/lib/snipeit/keys/oauth-private.key" "/var/www/html/storage/oauth-private.key" \
     && ln -fs "/var/lib/snipeit/keys/oauth-public.key" "/var/www/html/storage/oauth-public.key" \
-    && chown -h "/var/www/html/storage/*.key"
+    && chown -hR apache "/var/www/html/storage/" \
     && chown -R apache "/var/lib/snipeit"
 
 # Install composer


### PR DESCRIPTION
# Description

Executing the docker-compose file leads to an error this pull requests fixes this error by adding the missing `\`.
After this fix snipeit still does not load because of permission errors, adding `-R` to chown fixes these errors.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Executing docker-compose file successfully builds and starts snipeit.
After the container started the page is reachable and no errors are repored in the laravel.log

**Test Configuration**:
* Docker: 20.10.5
* Docker-Compose: 1.29.1

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My changes generate no new warnings
