### PR TITLE
Fixed #7674: Deletes file from assets folder, not just the database reference.

### DIFF
--- a/app/Http/Controllers/Assets/AssetFilesController.php
+++ b/app/Http/Controllers/Assets/AssetFilesController.php
@@ -110,15 +110,15 @@ class AssetFilesController extends Controller
     {
         $asset = Asset::find($assetId);
         $this->authorize('update', $asset);
-        $rel_path = 'storage/private_uploads/assets';
+        $rel_path = 'private_uploads/assets';
 
         // the asset is valid
         if (isset($asset->id)) {
             $this->authorize('update', $asset);
             $log = Actionlog::find($fileId);
             if ($log) {
-            if (file_exists(base_path().'/'.$rel_path.'/'.$log->filename)) {
-                Storage::disk('public')->delete($rel_path.'/'.$log->filename);
+            if (Storage::exists($rel_path.'/'.$log->filename)) {
+                Storage::delete($rel_path.'/'.$log->filename);
                 }
                 $log->delete();
                 return redirect()->back()->with('success', trans('admin/hardware/message.deletefile.success'));


### PR DESCRIPTION
# Description

The function ```destroy``` in the AssetFilesController.php only removes the link in the database, but does not clean up the actual file
Fixes #7674 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Upload File under the Asset -> Files tab
- [ ] Try Deleting file
- [ ] Check private_uploads/assets/ -- file will still be there.
- [ ] Remove file
- [ ] Apply patch
- [ ] Upload file under assets -> files tab
- [ ] Try deleting file
- [ ] Check private_uploads/assets/ -- file will be removed

**Test Configuration**:
* PHP version: 7.2.24
* MySQL version: MySQL 5.7
* Webserver version - Apache 2.4.29
* OS version - ubuntu 18.04


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
