### PR TITLE
Remove extra / from Logo url when using S3 Bucket Storage

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -108,14 +108,14 @@
                  @if ($snipeSettings->brand == '3')
                       <a class="logo navbar-brand no-hover" href="{{ url('/') }}">
                           @if ($snipeSettings->logo!='')
-                          <img class="navbar-brand-img" src="{{ Storage::disk('public')->url('/').e($snipeSettings->logo) }}" alt="{{ $snipeSettings->site_name }} logo">
+                          <img class="navbar-brand-img" src="{{ Storage::disk('public')->url('').e($snipeSettings->logo) }}" alt="{{ $snipeSettings->site_name }} logo">
                           @endif
                           {{ $snipeSettings->site_name }}
                       </a>
                   @elseif ($snipeSettings->brand == '2')
                       <a class="logo navbar-brand no-hover" href="{{ url('/') }}">
                           @if ($snipeSettings->logo!='')
-                            <img class="navbar-brand-img" src="{{ Storage::disk('public')->url('/').e($snipeSettings->logo) }}" alt="{{ $snipeSettings->site_name }} logo">
+                            <img class="navbar-brand-img" src="{{ Storage::disk('public')->url('').e($snipeSettings->logo) }}" alt="{{ $snipeSettings->site_name }} logo">
                           @endif
                           <span class="sr-only">{{ $snipeSettings->site_name }}</span>
                       </a>


### PR DESCRIPTION
By having the extra / and using an external storage service makes the logo not load due to the extra /.
This was tested with S3 and local storage and both continued to work afterwards

# Description

By having the extra ```/``` in the code URL's are generated like https://bucket.s3.amazonaws.com/<root>//setting-logo-zSdoVnTFSz.jpg and S3 will not serve it. By removing the extra ```/``` the URL is generated as https://bucket.s3.amazonaws.com/<root>/setting-logo-zSdoVnTFSz.jpg and displays as expected

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Test A
- [ ] Enable storage on S3
- [ ] Upload Logo
- [ ] See logo does not display
- [ ] Apply Patch
- [ ] php artisan config:cache
- [ ] php artisan cache:clear
- [ ] Refresh Page, see logo

Test B (Local storage)
- [ ] Upload Logo
- [ ] See logo there
- [ ] Apply Patch
- [ ] php artisan config:cache
- [ ] php artisan cache:clear
- [ ] Refresh page, logo is still there

# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
