### PR TITLE
Fixes an issue that causes Custom Reports to sometimes duplicate items. [ch14587]

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -641,7 +641,7 @@ class ReportsController extends Controller
                 $assets->whereBetween('assets.next_audit_date', [$request->input('next_audit_start'), $request->input('next_audit_end')]);
             }
             
-            $assets->orderBy('assets.created_at', 'ASC')->chunk(20, function($assets) use($handle, $customfields, $request) {
+            $assets->orderBy('assets.id', 'ASC')->chunk(20, function($assets) use($handle, $customfields, $request) {
 
                 $executionTime = microtime(true) - $_SERVER["REQUEST_TIME_FLOAT"];
                 \Log::debug('Walking results: '.$executionTime);


### PR DESCRIPTION
# Description
Custom Reports had a problem that makes some assets to appear duplicated in the CSV that the report generates. 

This was caused because the function that appends data to the CSV used the 'chunk' method in case the user had millions of registers. But if the order column we passed to that 'chunk' method is not unique, the database could sometimes get back records that already was appended to the CSV, the column used by the order was `created_at` but if the assets where imported from a file, that date could appear repeated causing this error. This was fixed making the ordering by a really unique column in our assets database: `id`.

Fixes [ch14587]

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version:  nginx/1.19.8
* OS version. Debian 10