### PR TITLE
Fix CSP Always being Enabled unless in debug mode.

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -99,7 +99,7 @@ class SecurityHeaders
         // We have to exclude debug mode here because debugbar pulls from a CDN or two
         // and it will break things.
 
-        if ((config('app.debug')!='true')  || (config('app.enable_csp')=='true')) {
+        if ((config('app.debug')!='true')  && (config('app.enable_csp')=='true')) {
             $csp_policy[] = "default-src 'self'";
             $csp_policy[] = "style-src 'self' 'unsafe-inline'";
             $csp_policy[] = "script-src 'self' 'unsafe-inline' 'unsafe-eval'";


### PR DESCRIPTION
# Description

CSP is always enabled unless debug is set to false.
Change: ```if ((config('app.debug')!='true')  || (config('app.enable_csp')=='true')) {```
to:
if ((config('app.debug')!='true')  && (config('app.enable_csp')=='true')) {

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Have debug = false and enable_csp = false, look for CSP Header in response from server (it will be there)
- [ ] Apply patch
- [ ] Have debug = false and enable_csp = false, look for CSP header in response (it won't be there)


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
