### PR TITLE
Manually re-add support for Label Logos in Labels

### DIFF
--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -56,6 +56,13 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='')
         padding-top: .11in;
         width: 100%;
     }
+    div.label-logo {
+        float: right;
+        display: inline-block;
+    }
+    img.label-logo {
+        height: 0.5in;
+    }
     .qr_text {
         width: {{ $settings->labels_width }}in;
         height: {{ $settings->labels_height }}in;
@@ -111,6 +118,11 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='')
         @endif
 
         <div class="qr_text">
+            @if ($settings->label_logo)
+                <div class="label-logo">
+                    <img class="label-logo" src="{{ Storage::disk('public')->url('').e($snipeSettings->label_logo) }}">
+                </div>
+            @endif
             @if ($settings->qr_text!='')
                 <div class="pull-left">
                     <strong>{{ $settings->qr_text }}</strong>


### PR DESCRIPTION
# Description

A customer reported an issue where the "label logos" were not showing up in their labels. I confirmed that we didn't seem to reference them anywhere other than in the settings. Some `git bisect` magic showed that one of our integration branches (with a ton of conflict resolution) must have inadvertently "merged out" the label logo support. The differences between the files were so great that I wasn't able to do any kind of automated fix, I just did some manual copy-paste into the same relative positions in the file.

One of the nice things about how this was originally implemented is that if you don't set a label logo, the HTML doesn't change at all, so it feels relatively additive and somewhat safe.

Another item to note is that this has probably been broken since the release of v5, which was quite a while ago. So I imagine it must not be used very often.

Fixes # (ticket 17550 in internal helpdesk)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I made some really obnoxiously busy labels and it all seemed to work OK. If I set enough text, I was able to force the 1D barcode to flow off the label, which is not good. But It seems like it has always been that way and this doesn't seem any worse.