### PR TITLE
Feature #3088 Print labels from asset detail page

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -722,7 +722,28 @@
                                             {{ ($asset->userRequests) ? (int) $asset->userRequests->count() : '0' }}
                                         </div>
                                     </div>
+                                    <div class="row">
+                                        <div class="col-md-2">
+                                            <strong>
+                                               Labels
+                                            </strong>
+                                        </div>
+                                        <div class="col-md-6">
+                                            {{ Form::open([
+                                                      'method' => 'POST',
+                                                      'route' => ['hardware/bulkedit'],
+                                                      'class' => 'form-inline',
+                                                       'id' => 'bulkForm']) }}
+                                            <div id="toolbar">
+                                                <input type="hidden" name="bulk_actions" value="labels" />
+                                                <input type="hidden" name="ids[{{$asset->id}}]" value="{{ $asset->id }}" />
+                                                <button class="btn btn-primary" id="bulkEdit" >{{ trans_choice('button.generate_labels', 1) }}</button>
+                                            </div>
 
+                                            {{ Form::close() }}
+
+                                        </div>
+                                    </div>
                                 </div> <!-- end row-striped -->
 
                             </div><!-- /col-md-8 -->


### PR DESCRIPTION
# Description

This PR adds a "Generate Label" button to the detail asset page as described in #3088.

The change is summarized quite well in the the feature request mentioned above. After receiving an asset, it takes quite a lot of clicks to print a label, including finding it. This makes it simpler.

![image](https://user-images.githubusercontent.com/11973217/117790812-9ce7fe00-b241-11eb-846e-4378c34108c7.png)

Fixes #3088

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I am running this change locally in production having printed 100s of labels.

**Test Configuration**:
* PHP version: PHP 7.3.27-1~deb10u1
* MySQL version: mariadb Ver 15.1
* Webserver version: nginx/1.14.2
* OS version: Debian 10

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
