### PR TITLE
Fix incorrect case of ldap sync status string

### DIFF
--- a/resources/views/users/ldap.blade.php
+++ b/resources/views/users/ldap.blade.php
@@ -75,7 +75,7 @@ LDAP User Sync
           </tr>
 
           @foreach (Session::get('summary') as $entry)
-          <tr {!! ($entry['status']=='SUCCESS') ? 'class="success"' : 'class="danger"' !!}>
+          <tr {!! ($entry['status']=='success') ? 'class="success"' : 'class="danger"' !!}>
               <td>{{ $entry['username'] }}</td>
               <td>{{ $entry['employee_number'] }}</td>
               <td>{{ $entry['firstname'] }}</td>


### PR DESCRIPTION
Here's a quick bug-fix.

Fixes #9562

The case of the LDAP sync status string was incorrect, causing all rows to use class "danger" and appear pink.

With this fix, successful imports now use class "success" and show up green, while failed import rows use "danger":

```html
                    <tr class="success">
              <td>jsmith</td>
              <td></td>
              <td>John</td>
              <td>Smith</td>
              <td>jsmith@example.com</td>
              <td>
                                  <i class="fa fa-check"></i> updated
                
                </td>
              </tr>
                    <tr class="danger">
              <td>jdoe</td>
              <td></td>
              <td>Jane</td>
              <td>Doe</td>
              <td>jdoe@example.com</td>
              <td>
                                  <span class="alert-msg" aria-hidden="true">The selected manager id is invalid.</span>
                
                </td>
              </tr>
```