### PR TITLE
Fixes an issue with the Settings Seeder and the artisan snipe:demo-settings command that not copies example logos for demo purposes. [ch16422]

### DIFF
--- a/app/Console/Commands/ResetDemoSettings.php
+++ b/app/Console/Commands/ResetDemoSettings.php
@@ -81,6 +81,8 @@ class ResetDemoSettings extends Command
             $user->save();
         }
 
+        \Storage::disk('local_public')->put('snipe-logo.png', file_get_contents(public_path('img/demo/snipe-logo.png')));
+        \Storage::disk('local_public')->put('snipe-logo-lg.png', file_get_contents(public_path('img/demo/snipe-logo-lg.png')));
 
     }
 

--- a/database/seeds/SettingsSeeder.php
+++ b/database/seeds/SettingsSeeder.php
@@ -42,8 +42,8 @@ class SettingsSeeder extends Seeder
 
 
         // Copy the logos from the img/demo directory
-        Storage::disk('public')->put(public_path('uploads/snipe-logo.png'), file_get_contents(public_path('img/demo/snipe-logo.png')));
-        Storage::disk('public')->put(public_path('uploads/snipe-logo-lg.png'), file_get_contents(public_path('img/demo/snipe-logo-lg.png')));
+        Storage::disk('local_public')->put('snipe-logo.png', file_get_contents(public_path('img/demo/snipe-logo.png')));
+        Storage::disk('local_public')->put('snipe-logo-lg.png', file_get_contents(public_path('img/demo/snipe-logo-lg.png')));
 
     }
 }


### PR DESCRIPTION

# Description

Fix the correct disk to use for the `Storage::` facade and in doing so, the target path to copy the demo logos in the `database\seeds\SettingsSeeder.php` file. Also added the code that copies the demo logos to `app\Console\Commands\ResetDemoSettings.php`, for when a previous settings record exist, and the seeder doesn't run the Settings Seeder.

Fixes # [ch16422]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx:1.19.8
* OS version: Debian 10
