### PR TITLE
Fix LicenseSeatsController method documentation

### DIFF
--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -17,6 +17,8 @@ class LicenseSeatsController extends Controller
     /**
      * Display a listing of the resource.
      *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $licenseId
      * @return \Illuminate\Http\Response
      */
     public function index(Request $request, $licenseId)
@@ -53,7 +55,8 @@ class LicenseSeatsController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  int  $id
+     * @param  int  $licenseId
+     * @param  int  $seatId
      * @return \Illuminate\Http\Response
      */
     public function show($licenseId, $seatId)


### PR DESCRIPTION
Doing this in an attempt to get the automatic API reference generation to work

# Description

The automatic API reference generation does not pick up the new /licenses/:id/seats endpoint. Attempting to fix it by properly documenting parameters. Also see https://github.com/snipe/snipe-it/issues/6696 for the motivation to do this

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This is purely a documentation-related change. No explicit testing was done.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
