### PR TITLE
Fixed #9607: Sessions expire for SAML/RemoteUser/LDAP

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -108,7 +108,7 @@ class LoginController extends Controller
                 Log::debug("Attempting to log user in by SAML authentication.");
                 $user = $saml->samlLogin($samlData);
                 if(!is_null($user)) {
-                    Auth::login($user, true);
+                    Auth::login($user);
                 } else {
                     $username = $saml->getUsername();
                     \Log::warning("SAML user '$username' could not be found in database.");
@@ -183,7 +183,7 @@ class LoginController extends Controller
             try {
                 $user = User::where('username', '=', $remote_user)->whereNull('deleted_at')->where('activated', '=', '1')->first();
                 Log::debug("Remote user auth lookup complete");
-                if(!is_null($user)) Auth::login($user, true);
+                if(!is_null($user)) Auth::login($user, $request->input('remember'));
             } catch(Exception $e) {
                 Log::debug("There was an error authenticating the Remote user: " . $e->getMessage());
             }
@@ -223,7 +223,7 @@ class LoginController extends Controller
             try {
                 LOG::debug("Attempting to log user in by LDAP authentication.");
                 $user = $this->loginViaLdap($request);
-                Auth::login($user, true);
+                Auth::login($user, $request->input('remember'));
 
             // If the user was unable to login via LDAP, log the error and let them fall through to
             // local authentication.


### PR DESCRIPTION
Fixed #9607 - Sessions expire for SAML/RemoteUser/LDAP

# Description

Fixes issue with sessions not expiring. Remember me token was hardcoded as TRUE for SAML, RemoteUser, & LDAP auths. Discussed the issue with johnson-yi https://github.com/snipe/snipe-it/issues/9607#issuecomment-847539762.

Fixes # 9607

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Yes, tested on our own DEV and PROD instances. The remember cookie is no longer present for our SSO instance.

**Test Configuration**:
* PHP version:  v7.4.3
* MySQL version
* Webserver version
* OS version: Ubuntu Server 20.04 LTS 


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
