### PR TITLE
Fixes an issue that allows duplicate asset tags when the Asset is created via API.

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -180,11 +180,6 @@ class Asset extends Depreciable
      */
     public function save(array $params = [])
     {
-        $settings = \App\Models\Setting::getSettings();
-
-        // I don't remember why we have this here? Asset tag would always be required, even if auto increment is on...
-        $this->rules['asset_tag'] = ($settings->auto_increment_assets == '1') ? 'max:255' : 'required';
-
         if($this->model_id != '') {
             $model = AssetModel::find($this->model_id);
 


### PR DESCRIPTION
# Description
For some reason if the auto increment asset tags are enabled in the settings, we rewrite the `save()` method in the `Asset` model to allow a maximum lenght of 255 characters and if not, the validation rule is setted as required. But to me this doesn't have any sense because those rules are already part of the validation of the model, we don't care if the auto increment is enabled or not, the limit always must be 255 characters for the asset tag and it's always required. So I decided to get rid of those lines. Now the API also doesn't allow repeated asset tags.

Fixes internal Helpdesk 20678 and probably Helpdesk 20548

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10
