### PR TITLE
Fixes an issue when tried to upload a file to an user without actually selecting a file. [ch16471]

### DIFF
--- a/app/Http/Controllers/Users/UserFilesController.php
+++ b/app/Http/Controllers/Users/UserFilesController.php
@@ -33,6 +33,10 @@ class UserFilesController extends Controller
 
             $logActions = [];
             $files = $request->file('file');
+
+            if (is_null($files)){
+                return redirect()->back()->with('error', trans('admin/users/message.upload.nofiles'));
+            }
             foreach($files as $file) {
                 $extension = $file->getClientOriginalExtension();
                 $filename = 'user-' . $user->id . '-' . str_random(8);

--- a/resources/views/modals/upload-file.blade.php
+++ b/resources/views/modals/upload-file.blade.php
@@ -19,7 +19,7 @@
 
                         <label class="btn btn-default">
                             {{ trans('button.select_file')  }}
-                            <input type="file" name="file[]" multiple="true" class="js-uploadFile" id="uploadFile" data-maxsize="{{ \App\Helpers\Helper::file_upload_max_size() }}" accept="image/*,.csv,.zip,.rar,.doc,.docx,.xls,.xlsx,.xml,.lic,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/plain,.pdf,application/rtf" style="display:none">
+                            <input type="file" name="file[]" multiple="true" class="js-uploadFile" id="uploadFile" data-maxsize="{{ \App\Helpers\Helper::file_upload_max_size() }}" accept="image/*,.csv,.zip,.rar,.doc,.docx,.xls,.xlsx,.xml,.lic,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/plain,.pdf,application/rtf" style="display:none" required>
                         </label>
 
                     </div>


### PR DESCRIPTION
# Description
When someone tries to upload a file to an user and forgot to select a file to upload, a state of exception is reached. I added the attribute 'required' to the upload file modal, and to be sure it doesn't happen again also added a validation to the UserFilesController, to check that the files field isn't setted. 

Fixes # [ch16471]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10