### PR TITLE
Fixes #9666 Asset checkin via api doesn't send notification.

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Http\Controllers\Api;
 
+use App\Events\CheckoutableCheckedIn;
 use Illuminate\Support\Facades\Gate;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
@@ -782,6 +783,8 @@ class AssetsController extends Controller
 
         if ($asset->save()) {
             $asset->logCheckin($target, e($request->input('note')));
+            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note')));
+
             return response()->json(Helper::formatStandardApiResponse('success', ['asset'=> e($asset->asset_tag)], trans('admin/hardware/message.checkin.success')));
         }
 


### PR DESCRIPTION
# Description
The AssetsController.php class used when querying the API doesn't throws the CheckoutableCheckedIn() event, meaning notifications where not send. I noted the `$asset->logCheckin()` function used to send notifications, but the code is now commented, so I think the preferred way in Snipe-It to send notifications is via events now, but as always, every insight is welcome.

Fixes #9666 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10