### PR TITLE
Fixed #8486: Add index for asset serial number

### DIFF
--- a/database/migrations/2021_06_07_155421_add_serial_number_indexes.php
+++ b/database/migrations/2021_06_07_155421_add_serial_number_indexes.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSerialNumberIndexes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->index(['serial']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->dropIndex(['serial']);
+        });
+    }
+}


### PR DESCRIPTION
# Description

This PR adds a migration for adding a non-unique index on the serial column of the assets table.

- Improves performance, particularly when importing large asset files with serial numbers.

Fixes #8486

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Import an asset file with many thousands of rows that include a serial number using `artisan snipeit:import`. Compare the time it takes.

**Test Configuration**:
* PHP version: 7.4.20 
* MySQL version: 5.7
* Webserver version: Docker (php:7.4.20-apache)
* OS version: Docker (php:7.4.20-apache)

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
