### PR TITLE
Fixed #9680: Use Eloquent’s `withCount` method to count Statuslabel assets

### DIFF
--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -167,10 +167,7 @@ class StatuslabelsController extends Controller
     {
         $this->authorize('view', Statuslabel::class);
 
-        $statuslabels = Statuslabel::with('assets')
-            ->groupBy('id')
-            ->withCount('assets as assets_count')
-            ->get();
+        $statuslabels = Statuslabel::withCount('assets')->get();
 
         $labels=[];
         $points=[];


### PR DESCRIPTION
# Description

This PR uses Eloquent’s [`withCount`](https://laravel.com/docs/6.x/eloquent-relationships#counting-related-models) method to count related assets for status labels.

Fixes #9680 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Load ~160k assets
- Visit the dashboard
- See if the statuslabels/assets endpoint returns a 500 error or not

**Test Configuration**:
* PHP version: 7.4.20
* MySQL version: 5.7
* Webserver version: Docker (php:7.4.20-apache)
* OS version: Docker (php:7.4.20-apache)

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
