### PR TITLE
Fixed #9682: Add indexes for company_id

### DIFF
--- a/database/migrations/2021_06_07_155436_add_company_id_indexes.php
+++ b/database/migrations/2021_06_07_155436_add_company_id_indexes.php
@@ -1,0 +1,88 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCompanyIdIndexes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('accessories', function (Blueprint $table) {
+            $table->index(['company_id']);
+        });
+
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->index(['company_id']);
+        });
+
+        Schema::table('assets', function (Blueprint $table) {
+            $table->index(['company_id']);
+        });
+
+        Schema::table('components', function (Blueprint $table) {
+            $table->index(['company_id']);
+        });
+
+        Schema::table('consumables', function (Blueprint $table) {
+            $table->index(['company_id']);
+        });
+
+        Schema::table('departments', function (Blueprint $table) {
+            $table->index(['company_id']);
+        });
+
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->index(['company_id']);
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->index(['company_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['company_id']);
+        });
+
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->dropIndex(['company_id']);
+        });
+
+        Schema::table('departments', function (Blueprint $table) {
+            $table->dropIndex(['company_id']);
+        });
+
+        Schema::table('consumables', function (Blueprint $table) {
+            $table->dropIndex(['company_id']);
+        });
+
+        Schema::table('components', function (Blueprint $table) {
+            $table->dropIndex(['company_id']);
+        });
+
+        Schema::table('assets', function (Blueprint $table) {
+            $table->dropIndex(['company_id']);
+        });
+
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->dropIndex(['company_id']);
+        });
+
+        Schema::table('accessories', function (Blueprint $table) {
+            $table->dropIndex(['company_id']);
+        });
+    }
+}


### PR DESCRIPTION
# Description

This PR adds a migration for adding non-unique indexes for company_id on the assets and other tables.

Fixes #9682

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visit the companies page with many assets associated with many companies and compare the performance difference with and without the index.

**Test Configuration**:
* PHP version: 7.4.20 
* MySQL version: 5.7
* Webserver version: Docker (php:7.4.20-apache)
* OS version: Docker (php:7.4.20-apache)


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
