### PR TITLE
Basic fixes to at least get the dashboard up

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -630,12 +630,12 @@ Route::group(['prefix' => 'v1', 'middleware' => 'auth:api'], function () {
     Route::group(['prefix' => 'statuslabels'], function () {
 
         // Pie chart for dashboard
-        Route::get('assets',
-            [
-                'as' => 'api.statuslabels.assets.bytype',
-                'uses' => [Api\StatuslabelsController::class, 'getAssetCountByStatuslabel'],
-            ]
-        );
+        Route::get('assets', [Api\StatuslabelsController::class, 'getAssetCountByStatuslabel']
+            // [
+            //     'as' => 'api.statuslabels.assets.bytype',
+            //     'uses' => [Api\StatuslabelsController::class, 'getAssetCountByStatuslabel'],
+            // ]
+        )->name('api.statuslabels.assets.bytype');
 
         Route::get('{statuslabel}/assetlist',
             [
@@ -774,9 +774,10 @@ Route::group(['prefix' => 'v1', 'middleware' => 'auth:api'], function () {
     ); // Users resource
 
     Route::get(
-        'reports/activity',
-        ['as' => 'api.activity.index', 'uses' => [Api\ReportsController::class, 'index']]
-    );
+        'reports/activity', 
+        [Api\ReportsController::class, 'index']
+        // ['as' => 'api.activity.index', 'uses' => [Api\ReportsController::class, 'index']]
+    )->name('api.activity.index');
 
     /*--- Kits API ---*/
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\StatuslabelsController;
 use App\Http\Controllers\SuppliersController;
 use App\Http\Controllers\ViewAssetsController;
+use App\Http\Controllers\Auth\LoginController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Auth;
 
@@ -339,7 +340,7 @@ Route::group(['middleware' => ['auth']], function () {
 
 Route::get(
     'auth/signin',
-    ['uses' => [Auth\LoginController::class, 'legacyAuthRedirect']]
+    ['uses' => [LoginController::class, 'legacyAuthRedirect']]
 );
 
 /*
@@ -399,7 +400,7 @@ Route::get(
     [
         'as' => 'two-factor-enroll',
         'middleware' => ['web'],
-        'uses' => [Auth\LoginController::class, 'getTwoFactorEnroll'], ]
+        'uses' => [LoginController::class, 'getTwoFactorEnroll'], ]
 );
 
 Route::get(
@@ -407,7 +408,7 @@ Route::get(
     [
         'as' => 'two-factor',
         'middleware' => ['web'],
-        'uses' => [Auth\LoginController::class, 'getTwoFactorAuth'], ]
+        'uses' => [LoginController::class, 'getTwoFactorAuth'], ]
 );
 
 Route::post(
@@ -415,7 +416,7 @@ Route::post(
     [
         'as' => 'two-factor',
         'middleware' => ['web'],
-        'uses' => [Auth\LoginController::class, 'postTwoFactorAuth'], ]
+        'uses' => [LoginController::class, 'postTwoFactorAuth'], ]
 );
 
 
@@ -423,25 +424,27 @@ Route::post(
 Route::group(['middleware' => 'web'], function () {
     Route::get(
         'login',
-        [
-            'as' => 'login',
-            'middleware' => ['web'],
-            'uses' => [Auth\LoginController::class, 'showLoginForm'], ]
-    );
+        [LoginController::class, 'showLoginForm']
+        // [
+        //     'as' => 'login',
+        //     'middleware' => ['web'],
+        //     'uses' => [LoginController::class, 'showLoginForm'], ]
+    )->name("login");
 
     Route::post(
         'login',
-        [
-            'as' => 'login',
-            'middleware' => ['web'],
-            'uses' => [Auth\LoginController::class, 'login'], ]
+        [LoginController::class, 'login']
+        // [
+        //     'as' => 'login',
+        //     'middleware' => ['web'],
+        //     'uses' => [LoginController::class, 'login'], ]
     );
 
     Route::get(
         'logout',
         [
             'as' => 'logout',
-            'uses' => [Auth\LoginController::class, 'logout'], ]
+            'uses' => [LoginController::class, 'logout'], ]
     );
 });
 
@@ -454,10 +457,11 @@ Route::get(
     'uses' => [HealthController::class, 'get'],]
 );
 
-Route::get(
+Route::middleware(['auth'])->get(
     '/',
-    [
-    'as' => 'home',
-    'middleware' => ['auth'],
-    'uses' => [DashboardController::class, 'index'], ]
-);
+    [DashboardController::class, 'index']
+    // [
+    // 'as' => 'home',
+    // 'middleware' => ['auth'],
+    // 'uses' => [DashboardController::class, 'index'], ]
+)->name('home');


### PR DESCRIPTION
I made a few small changes that seem to at least get the basic dashboard working, and let me log in.

For some reason the "style" of routes that we use - 

```php
    Route::post(
        'login',
        [
            'as' => 'login',
            'middleware' => ['web'],
            'uses' => [LoginController::class, 'login'], ]
    );
```

seems to really make Laravel 8 *angry*. I've gone through and replaced a few of the key routes (there are absolutely going to be way, way more) with the style that seems to make Laravel slightly _less_ angry:

```php
    Route::middleware(['web'])->post(
        'login',
        [LoginController::class, 'login']
    )->name('login');
```

There were also some places where we had a route group that declared middleware, and then we additionally declared it within a particular route - I skipped those redundant declarations. Laravel also says that all route names *must* be unique, and I've definitely seen a few duplicates around, so that could potentially get us into trouble as well.

Before I got too deep into this refactoring, I wanted to check with you @snipe and see what your thoughts were. It's certainly also possible that the previous routing syntax was deprecated at some point - but I never saw anything that said that anywhere.