### PR TITLE
Added #9716: Allow to bulk update accessories min_amt

### DIFF
--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -91,6 +91,7 @@ class Accessory extends SnipeModel
         'supplier_id',
         'image',
         'qty',
+        'min_amt',
         'requestable'
     ];
 


### PR DESCRIPTION
# Description
Fixes  #9716: Allow to bulk update accessories min_amt

Currently its not possible bulk update accessories  min_amt or update it via api.


## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested on latest snipeit version git master. After this addition it was possible to set min_amt via snipe it api.

# Checklist:

- [ X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation (no need)
- [ X] My changes generate no new warnings
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
