### PR TITLE
Disable company select if full company support is activated

### DIFF
--- a/resources/views/partials/forms/edit/company-select.blade.php
+++ b/resources/views/partials/forms/edit/company-select.blade.php
@@ -4,7 +4,7 @@
     <div class="form-group">
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
         <div class="col-md-6">
-            <select class="js-data-ajax" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" id="company_select" aria-label="{{ $fieldname }}">
+            <select class="js-data-ajax"  disabled="true" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" id="company_select" aria-label="{{ $fieldname }}">
                 @if ($company_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                     <option value="{{ $company_id }}" selected="selected" role="option" aria-selected="true"  role="option">
                         {{ (\App\Models\Company::find($company_id)) ? \App\Models\Company::find($company_id)->name : '' }}


### PR DESCRIPTION
select should be disabled if full multiple companies is activated and the user isn't a superuser. otherwise the user get the ability to choose all companies.
