### PR TITLE
Added #9745 - adds searchable, sortable notes to statuslabels index

### DIFF
--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -22,7 +22,7 @@ class StatuslabelsController extends Controller
     public function index(Request $request)
     {
         $this->authorize('view', Statuslabel::class);
-        $allowed_columns = ['id','name','created_at', 'assets_count','color','default_label'];
+        $allowed_columns = ['id','name','created_at', 'assets_count','color', 'notes','default_label'];
 
         $statuslabels = Statuslabel::withCount('assets as assets_count');
 

--- a/app/Models/Statuslabel.php
+++ b/app/Models/Statuslabel.php
@@ -41,7 +41,7 @@ class Statuslabel extends SnipeModel
      * 
      * @var array
      */
-    protected $searchableAttributes = ['name'];
+    protected $searchableAttributes = ['name', 'notes'];
 
     /**
      * The relations and their attributes that should be included when searching the model.

--- a/resources/views/statuslabels/index.blade.php
+++ b/resources/views/statuslabels/index.blade.php
@@ -53,6 +53,7 @@
                 <th data-sortable="true" data-field="color" data-formatter="colorSqFormatter">{{ trans('admin/statuslabels/table.color') }}</th>
                 <th class="text-center" data-sortable="true" data-field="show_in_nav" data-formatter="trueFalseFormatter">{{ trans('admin/statuslabels/table.show_in_nav') }}</th>
                   <th class="text-center" data-sortable="true" data-field="default_label" data-formatter="trueFalseFormatter">{{ trans('admin/statuslabels/table.default_label') }}</th>
+                  <th data-sortable="true" data-field="notes">{{ trans('general.notes') }}</th>
                 <th data-formatter="statuslabelsActionsFormatter" data-searchable="false" data-sortable="false" data-field="actions">{{ trans('table.actions') }}</th>
               </tr>
             </thead>

--- a/resources/views/statuslabels/index.blade.php
+++ b/resources/views/statuslabels/index.blade.php
@@ -53,7 +53,7 @@
                 <th data-sortable="true" data-field="color" data-formatter="colorSqFormatter">{{ trans('admin/statuslabels/table.color') }}</th>
                 <th class="text-center" data-sortable="true" data-field="show_in_nav" data-formatter="trueFalseFormatter">{{ trans('admin/statuslabels/table.show_in_nav') }}</th>
                   <th class="text-center" data-sortable="true" data-field="default_label" data-formatter="trueFalseFormatter">{{ trans('admin/statuslabels/table.default_label') }}</th>
-                  <th data-sortable="true" data-field="notes">{{ trans('general.notes') }}</th>
+                  <th data-sortable="true" data-field="notes" data-visible="false">{{ trans('general.notes') }}</th>
                 <th data-formatter="statuslabelsActionsFormatter" data-searchable="false" data-sortable="false" data-field="actions">{{ trans('table.actions') }}</th>
               </tr>
             </thead>


### PR DESCRIPTION
<img width="1030" alt="Screen Shot 2021-06-28 at 11 55 25 AM" src="https://user-images.githubusercontent.com/197404/123689169-c7007a00-d807-11eb-8c60-b6118f34fe3c.png">

What it says on the tin :)