### PR TITLE
Fix APP_ENV/APP_DEBUG typo overwriting the APP_ENV in Vagrant Playbook

### DIFF
--- a/ansible/ubuntu/vagrant_playbook.yml
+++ b/ansible/ubuntu/vagrant_playbook.yml
@@ -199,7 +199,7 @@
         - { regexp: '^DB_PASSWORD=', line: 'DB_PASSWORD=vagrant' }
         - { regexp: '^APP_URL=', line: "APP_URL=http://{{ fqdn }}" }
         - { regexp: '^APP_ENV=', line: "APP_ENV=development" }
-        - { regexp: '^APP_DEBUG=', line: "APP_ENV=true" }
+        - { regexp: '^APP_DEBUG=', line: "APP_DEBUG=true" }
     - name: Generate application key
       shell: "php {{ app_path }}/artisan key:generate --force"
     - name: Artisan Migrate


### PR DESCRIPTION
Guidance requested: My commit message is not semantic as required because there is no corresponding issue. I'm happy to amend the message to whatever is favorable. If I need to create an issue to address in the commit message I'm happy to do that to help.


# Description

[A user commented](https://github.com/snipe/snipe-it/pull/6909#issuecomment-870478980) they noticed a typo in the `vagrant_playbook.yml`. I've updated the typo which fixes the `APP_ENV` and `APP_DEBUG`  regex replacements from clobbering each other. (`APP_ENV` was getting set to `true` instead of `APP_DEBUG` and `APP_ENV` was incorrectly set to `true` instead of `development`.

Fixes # (issue) - did not find relevant issues when searching.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] [Ansible Lint](https://ansible-lint.readthedocs.io/en/latest/) output does not differ before or after the change. [Gist of ansible-lint output](https://gist.github.com/svpernova09/a425b385e37634e9bd339dec5da60c6c). (Ansible Lint version `ansible-lint 5.0.10 using ansible 2.10.9`)
- [ ] Attempt to Vagrant up + Provision a VM (I haven't done this yet as I couldn't find the Vagrant docs in a 30-second search)

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
