### PR TITLE
Better debugging output, and remove non-PHP-7.3-compatible option

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -61,7 +61,7 @@ class RestoreFromBackup extends Command
 
         $za = new ZipArchive();
 
-        $errcode = $za->open($filename, ZipArchive::RDONLY);
+        $errcode = $za->open($filename/* , ZipArchive::RDONLY */); // that constant only exists in PHP 7.4 and higher
         if ($errcode !== true) {
             $errors = [
                 ZipArchive::ER_EXISTS => "File already exists.",
@@ -248,8 +248,13 @@ class RestoreFromBackup extends Command
         }
         fclose($pipes[0]);
         fclose($sql_contents);
+        
+        $this->line(stream_get_contents($pipes[1]));
         fclose($pipes[1]);
+
+        $this->error(stream_get_contents($pipes[2]));
         fclose($pipes[2]);
+
         //wait, have to do fclose() on all pipes first?
         $close_results = proc_close($proc_results);
         if($close_results != 0) {


### PR DESCRIPTION
The `ZipArchive::RDONLY` option was not compatible with PHP 7.3, so I removed it. We don't end up even attempting to write to the Zip archive anyways, so it shouldn't matter.

In troubleshooting some other issues I was having I wasn't getting very good output from stdout or stderr on the call to the `mysql` binary, so I added a little more verbose output there.