### PR TITLE
Fixes #9730. Remove an else statement that doesn't allow to continue the importer flow.

### DIFF
--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -125,8 +125,6 @@ class UserImporter extends ItemImporter
         if ($department) {
             $this->log('A matching department ' . $department_name . ' already exists');
             return $department->id;
-        } else {
-            return null;
         }
 
         $department = new department();

--- a/resources/assets/js/components/importer/importer-file.vue
+++ b/resources/assets/js/components/importer/importer-file.vue
@@ -300,7 +300,7 @@
             }
         },
         components: {
-            select2: require('../select2.vue')
+            select2: require('../select2.vue').default
         }
     }
 </script>

--- a/resources/assets/js/components/importer/importer.vue
+++ b/resources/assets/js/components/importer/importer.vue
@@ -120,9 +120,9 @@
         },
 
         components: {
-            alert: require('../alert.vue'),
-            errors: require('./importer-errors.vue'),
-            importFile: require('./importer-file.vue'),
+            alert: require('../alert.vue').default,
+            errors: require('./importer-errors.vue').default,
+            importFile: require('./importer-file.vue').default,
         }
     }
 


### PR DESCRIPTION
# Description
When importing users with Departments that doesn't exist, there's an else statement that instead of continue creating the department and assigning it to the user, returns `null` and exits. That part is now removed, allowing the Importer to continue it's flow and creating new departments assigned in the import file if needed. 

Also fixes some Vuejs issues with the importer: nothing happens after upload the import file and hit the 'Process' button.

Fixes #9730 
Fixes #9788
Fixes #9780 (some comments mention the importer issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx:1.19.8
* OS version: Debian 10
