### PR TITLE
Fixes [ch15453] Maintenance/History columns not remembered.

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -991,7 +991,8 @@
                            "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                          }'
                                         data-url="{{ route('api.maintenances.index', array('asset_id' => $asset->id)) }}"
-                                        data-cookie-id-table="assetMaintenancesTable">
+                                        data-cookie-id-table="assetMaintenancesTable"
+                                        data-cookie="true">
                                 </table>
                             </div> <!-- /.col-md-12 -->
                         </div> <!-- /.row -->
@@ -1019,7 +1020,8 @@
                        }'
 
                       data-url="{{ route('api.activity.index', ['item_id' => $asset->id, 'item_type' => 'asset']) }}"
-                      data-cookie-id-table="assetHistory">
+                      data-cookie-id-table="assetHistory"
+                      data-cookie="true">
                 <thead>
                 <tr>
                   <th data-visible="true" style="width: 40px;" class="hidden-xs">Icon</th>


### PR DESCRIPTION
# Description
Per the Bootstrap Tables [docs](https://bootstrap-table.com/docs/extensions/cookie/), the `data-cookie` attribute needs to be setted to `true` to save the state of a table (its paging position, ordering state, records per page). So I added that attribute to the Maintenances and History tables of the Assets' view.

Fixes [ch15453]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10
