### PR TITLE
The custom settings section of SAML sometimes has bad linefeeds

### DIFF
--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -157,9 +157,7 @@
                             {{ Form::label('saml_custom_settings', trans('admin/settings/general.saml_custom_settings')) }}
                         </div>
                         <div class="col-md-9">
-                            {{ Form::textarea('saml_custom_settings', old('saml_custom_settings', $setting->saml_custom_settings), ['class' => 'form-control','placeholder' => 'example.option=false
-sp_x509cert=file:///...
-sp_private_key=file:///', 'wrap' => 'off', $setting->demoMode]) }}
+                            {{ Form::textarea('saml_custom_settings', old('saml_custom_settings', $setting->saml_custom_settings), ['class' => 'form-control','placeholder' => 'example.option=false&#13;&#10;sp_x509cert=file:///...&#13;&#10;sp_private_key=file:///', 'wrap' => 'off', $setting->demoMode]) }}
                             <p class="help-block">{{ trans('admin/settings/general.saml_custom_settings_help') }}</p>
                             {!! $errors->first('saml_custom_settings', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                         </div>


### PR DESCRIPTION
I've noticed whenever I go into the Advanced SAML settings on our hosted platform that the placeholder-text seems to be all jammed-together. But when I look at it on my local machine, it isn't. So it turns out you need to do `\r\n` for your linefeeds, so I did that via HTML escapes. I think we may have been just doing `\n`'s before?