### PR TITLE
[WIP] Added #3520: Add ability to map users to multiple companies with FullMultipleCompanySupport

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -336,6 +336,12 @@ class UsersController extends Controller
                 $user->groups()->sync(array());
             }
 
+            // Remove the new company from the fmcs mapping table
+            if ($request->filled('company_id')
+                && Company::isFullMultipleCompanySupportEnabled()
+                && $user->companies()->get()->contains($request->input('company_id'))) {
+                    $user->companies()->detach($request->input('company_id'));
+                }
 
             return response()->json(Helper::formatStandardApiResponse('success', (new UsersTransformer)->transformUser($user), trans('admin/users/message.success.update')));
         }

--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Accessory;
 use App\Models\Actionlog;
 use App\Models\Asset;
+use App\Models\Company;
 use App\Models\Group;
 use App\Models\LicenseSeat;
 use App\Models\User;
@@ -118,6 +119,13 @@ class BulkUsersController extends Controller
         if ($request->filled('groups')) {
             foreach ($users as $user) {
                 $user->groups()->sync($request->input('groups'));
+            }
+        }
+
+        // Remove the new company from the fmcs mapping table
+        if ($request->filled('company_id') && Company::isFullMultipleCompanySupportEnabled()) {
+            foreach ($users as $user) {
+                $user->companies()->detach($request->input('company_id'));
             }
         }
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -90,7 +90,7 @@ class Asset extends Depreciable
         'name'            => 'max:255|nullable',
         'model_id'        => 'required|integer|exists:models,id',
         'status_id'       => 'required|integer|exists:status_labels,id',
-        'company_id'      => 'integer|nullable',
+        'company_id'      => 'integer|nullable|fmcs_validator',
         'warranty_months' => 'numeric|nullable|digits_between:0,240',
         'physical'        => 'numeric|max:1|nullable',
         'checkout_date'   => 'date|max:10|min:10|nullable',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -401,6 +401,32 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     }
 
     /**
+     * Establishes the user -> companies relationship for FullMultipleCompanySupport
+     *
+     * @author T. Regnery <tobias.regnery@gmail.com>
+     * @since [vX.X]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function companies()
+    {
+        return $this->belongsToMany('\App\Models\Company', 'companies_users_fmcs');
+    }
+
+    /**
+     * Returns the combined company_ids from the users "primary" company and the FullMultipleCompanySupport mapping table
+     *
+     * @author T. Regnery <tobias.regnery@gmail.com>
+     * @since [vX.X]
+     * @return Illuminate\Support\Collection
+     */
+    public function company_ids()
+    {
+        $company_ids = $this->companies()->pluck('company_id');
+        $company_ids->push($this->company_id);
+        return $company_ids;
+    }
+
+    /**
      * Establishes the user -> assets relationship
      *
      * @author A. Gianotto <snipe@snipe.net>

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -1,6 +1,8 @@
 <?php
 namespace App\Providers;
 
+use App\Models\Company;
+use Auth;
 use DB;
 use Illuminate\Support\ServiceProvider;
 use Validator;
@@ -210,7 +212,19 @@ class ValidationServiceProvider extends ServiceProvider
             }
         });
 
+        // Validates if the user has the permission to choose the specified company in case of FullMultipleCompanySupport
+        Validator::extendImplicit('fmcs_validator', function ($attribute, $value, $parameters, $validator) {
+            $current_user = Auth::user();
+            if (!Company::isFullMultipleCompanySupportEnabled() || $current_user->isSuperUser() || $current_user->company_id == null) {
+                return true;
+            }
 
+            if ($value != null && $current_user->company_ids()->contains($value)) {
+                return true;
+            } else {
+                return false;
+            }
+        });
     }
 
     /**

--- a/database/migrations/2021_06_11_135748_create_companies_users_fmcs_table.php
+++ b/database/migrations/2021_06_11_135748_create_companies_users_fmcs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCompaniesUsersFmcsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('companies_users_fmcs', function (Blueprint $table) {
+            $table->integer('company_id')->unsigned();
+            $table->integer('user_id')->unsigned();
+            $table->primary(['company_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('companies_users_fmcs');
+    }
+}

--- a/resources/views/departments/edit.blade.php
+++ b/resources/views/departments/edit.blade.php
@@ -14,7 +14,6 @@
         @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
     @endif
 
-
     <!-- Manager -->
     @include ('partials.forms.edit.user-select', ['translated_name' => trans('admin/users/table.manager'), 'fieldname' => 'manager_id'])
 

--- a/resources/views/partials/forms/edit/company-mappings-fmcs.blade.php
+++ b/resources/views/partials/forms/edit/company-mappings-fmcs.blade.php
@@ -1,0 +1,12 @@
+<tbody class="fmcs_mappings">
+  @foreach ($companies as $id => $company)
+    <tr class="fmcs_mappings-row">
+      <td class="col-md-8 company-name"> {{ $company }}</td>
+      <td class="col-md-1 company-checkbox">
+        <input class="form-check-input" type="checkbox" id="checkboxNoLabel" value={{$id}} name=companyMappings[]
+          @if($user->company_id == $id) disabled title="Own Company is always mapped" @endif
+          @if($companyMappings->contains($id)) checked @endif>
+      </td>
+    </tr>
+  @endforeach
+</tbody>

--- a/resources/views/partials/forms/edit/company-select.blade.php
+++ b/resources/views/partials/forms/edit/company-select.blade.php
@@ -1,6 +1,6 @@
 <!-- Company -->
-@if (($snipeSettings->full_multiple_companies_support=='1') && (!Auth::user()->isSuperUser()))
-    <!-- full company support is enabled and this user isn't a superadmin -->
+@if(!\App\Models\Company::canManageUsersCompanies())
+    <!-- full company support is enabled, this user isn't a superadmin and has no mapped companies -->
     <div class="form-group">
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
         <div class="col-md-6">
@@ -15,9 +15,8 @@
             </select>
         </div>
     </div>
-
 @else
-    <!-- full company support is enabled or this user is a superadmin -->
+    <!-- full company support is disabled or this user is a superadmin or has mapped companies -->
     <div id="{{ $fieldname }}" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}">
         {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
         <div class="col-md-6">
@@ -35,5 +34,4 @@
 
     {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span></div>') !!}
     </div>
-
 @endif

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -78,6 +78,9 @@
         <ul class="nav nav-tabs">
           <li class="active"><a href="#tab_1" data-toggle="tab">Information</a></li>
           <li><a href="#tab_2" data-toggle="tab">Permissions</a></li>
+          @if($fmcs)
+            <li><a href="#tab_3" data-toggle="tab">Company Mappings</a></li>
+          @endif
         </ul>
 
         <div class="tab-content">
@@ -273,7 +276,6 @@
                 @if (\App\Models\Company::canManageUsersCompanies())
                     @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.select_company'), 'fieldname' => 'company_id'])
                 @endif
-
 
               <!-- Image -->
                   @if ($user->avatar)
@@ -523,6 +525,22 @@
                 @include('partials.forms.edit.permissions-base')
             </table>
           </div><!-- /.tab-pane -->
+
+          <!-- Company Mappings Tab-->
+          @if($fmcs)
+          <div class="tab-pane" id="tab_3">
+            <table class="table table-striped company-mappings-fmcs">
+              <thead>
+                <tr class="company-mappings-fmcs-row">
+                  <th class="col-md-8">Company</th>
+                  <th class="col-md-1">Mapped</th>
+                </tr>
+              </thead>
+                @include('partials.forms.edit.company-mappings-fmcs')
+            </table>
+          </div><!-- /.tab-pane -->
+          @endif
+
         </div><!-- /.tab-content -->
         <div class="box-footer text-right">
           <button type="submit" class="btn btn-primary"><i class="fa fa-check icon-white" aria-hidden="true"></i> {{ trans('general.save') }}</button>


### PR DESCRIPTION
# Description

We have a hierarchical set of companies grouped in multiple layers:
 a) the upper layer must have access to all companies
 b) the lowest layer must be scoped to only one company
 c) the middle layer must have access to multiple companies of the lowest layer, but not all of them

a) and b) is possible with FullMultipleCompanySupport and super user, but c) is currently not supported.

To accomplish this, I propose the concept of "mapped" companies.
Users with a mapped company can see and update all resources of the mapped company according to the users permissions, just like the "primary" company.

A new mapping table is created and linked to users and companies and the company scoping function is updated accordingly.
The mapping table only contains additional mappings, not the "primary" company of the user.
In the user edit view a new tab is created to map users to companies:
![comopany_mappings](https://user-images.githubusercontent.com/84392209/125451890-3fa904b0-f802-442f-9ca2-6683215ae43f.png)

The validation logic must be changed for this. Currently a scoped user can't change the company.
Now it must be possible for users with mapped companies to choose between companies.
To do this, two changes are needed:
 - the company selectlist gets scoped to the primary and the mapped companies
 - a new validator is introduced to validate if the user is allowed to choose a company or if a company is required. This validator handles input through the UI and the API

The logic if a user is edited must be changed accordingly:
- If a different "primary" company is assigned to a user, the mapping table must be updated.
- Bulk editing this must also be supported.
- If a user gets cloned, the mappings must be cloned.

I implemented this feature with performance and backward compatibility in mind. There is no overhead if FullMultipleCompanySupport is disabled.
The feature is fully optional, there is only minimal overhead if FullMultipleCompanySupport is enabled and no mappings are used.

This is WIP for now, there are several areas that needs further work:

- There are no permission checks for updating the mappings. My plan is to go with the solution for groups: only super users should be permitted to update the mappings
- There is no localization for the new UI elements and the validator
- I focused on assets for now. The validator must be applied to every other part of the system
- There is no documentation update for now

Fixes #3520 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I ran the following tests manually for the 5 different cases: FullMultipleCompanySupport disabled, super user, user with no mappings, user with mappings, user with no company

- show companies (UI and API)
- show assets (UI and API)
- create assets (UI and API)
- edit assets (UI and API)
- show users (UI and API)
- create users and mappings
- edit users (change company, change mappings)
- clone user
- bulk edit users

I found a few existing inconsistencies here:
- Scoped users can see all companies and get 403 errors if they try to view another company
- Scoped users can see all departments and get 403 errors if they try to view departments from other companies -> see #9798
- It is possible for a scoped user with permissions to create or edit a user to set the company_id to an arbitrary value

I will address these separately later.

**Test Configuration**:
* PHP version: 7.4
* MySQL version: mariadb 10.4
* Webserver version: apache 2.4.47
* OS version: Windows 10


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
