### PR TITLE
Adds a check to know if the asset is checked out to the logged in user to allow check the state in the view

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -185,12 +185,12 @@ class AssetsTransformer
             'expected_checkin' => Helper::getFormattedDateObject($asset->expected_checkin, 'date'),
             'location' => ($asset->location) ? e($asset->location->name) : null,
             'status'=> ($asset->assetstatus) ? $asset->present()->statusMeta : null,
+            'assigned_to_self' => ($asset->assigned_to == \Auth::user()->id),
         ];
 
         $permissions_array['available_actions'] = [
             'cancel' => ($asset->isRequestedBy(\Auth::user())) ? true : false,
             'request' => ($asset->isRequestedBy(\Auth::user())) ? false : true,
-
         ];
 
          $array += $permissions_array;

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -333,7 +333,9 @@
 
     // This is only used by the requestable assets section
     function assetRequestActionsFormatter (row, value) {
-        if (value.available_actions.cancel == true)  {
+        if (value.assigned_to_self == true){
+            return '<button class="btn btn-danger btn-sm disabled" data-toggle="tooltip" title="Cancel this item request">{{ trans('button.cancel') }}</button>';
+        } else if (value.available_actions.cancel == true)  {
             return '<form action="{{ url('/') }}/account/request-asset/'+ value.id + '" method="GET"><button class="btn btn-danger btn-sm" data-toggle="tooltip" title="Cancel this item request">{{ trans('button.cancel') }}</button></form>';
         } else if (value.available_actions.request == true)  {
             return '<form action="{{ url('/') }}/account/request-asset/'+ value.id + '" method="GET"><button class="btn btn-primary btn-sm" data-toggle="tooltip" title="Request this item">{{ trans('button.request') }}</button></form>';


### PR DESCRIPTION
# Description
Requested assets should not still allow a user to "cancel" request if it's been checked out to them. So I added a validation and if the asset is already deployed to the logged in user the button appears deactivated. Not sure if this is correct or if it's best to put a label indicating that 'the asset is already deployed to you (logged user)'. Please tell me if you think there's a better approach.

Fixes internal clubhouse [ch15357]

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version:  5.7
* Webserver version: nginx 1.21.1
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
