### PR TITLE
Add new php extension dependencies for v6

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -25,6 +25,8 @@ RUN  apk add --no-cache \
         php7-session \
         php7-dom \
         php7-xmlwriter \
+        php7-xmlreader \
+        php7-sodium \
         curl \
         wget \
         vim \


### PR DESCRIPTION
# Description

`sudo docker-compose build` currently fails when running composer because of missing php extensions.
This PR adds them to the Dockerfile

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

run `sudo docker-compose build` and it succeeds

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings