### PR TITLE
Fixed: double slashes in branding logo URL path

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -108,14 +108,14 @@
                  @if ($snipeSettings->brand == '3')
                       <a class="logo navbar-brand no-hover" href="{{ url('/') }}">
                           @if ($snipeSettings->logo!='')
-                          <img class="navbar-brand-img" src="{{ Storage::disk('public')->url('/').e($snipeSettings->logo) }}" alt="{{ $snipeSettings->site_name }} logo">
+                          <img class="navbar-brand-img" src="{{ Storage::disk('public')->url($snipeSettings->logo) }}" alt="{{ $snipeSettings->site_name }} logo">
                           @endif
                           {{ $snipeSettings->site_name }}
                       </a>
                   @elseif ($snipeSettings->brand == '2')
                       <a class="logo navbar-brand no-hover" href="{{ url('/') }}">
                           @if ($snipeSettings->logo!='')
-                            <img class="navbar-brand-img" src="{{ Storage::disk('public')->url('/').e($snipeSettings->logo) }}" alt="{{ $snipeSettings->site_name }} logo">
+                            <img class="navbar-brand-img" src="{{ Storage::disk('public')->url($snipeSettings->logo) }}" alt="{{ $snipeSettings->site_name }} logo">
                           @endif
                           <span class="sr-only">{{ $snipeSettings->site_name }}</span>
                       </a>


### PR DESCRIPTION
Thanks for your work on Snipe-It, seems like a good system so far!

# Description

The branding logo currently 404s when using cloud storage to store the logo, as the current template adds an additional slash to the URL. For Storage drivers like S3 and GCS that don't automatically collapse additional slashes into single slashes, the logo file can't be found.

E.g. with the current code my logo URL renders like `https://storage.googleapis.com/mybucketname/public//setting-logo-Al0aKMhmYz.svg` (note the double slash after "public") when instead it should render like `https://storage.googleapis.com/mybucketname/public/setting-logo-Al0aKMhmYz.svg`

For a local driver the existing behaviour should work fine since webservers handle the additional slashes case, but for key-based storage this 404s.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Setup up a public S3(-like) bucket for file storage in `.env`
2. Go to Admin > Branding and upload a logo
3. Go to Admin > Branding and set Web Branding Type to "Logo" or "Logo + Text"
4. Check if the logo appears on the page or not

**Test Configuration**:
* PHP version:  7.3.29-1~deb10u1 
* MySQL version: 5.7
* Webserver version: nginx 1.14.2-2+deb10u4
* OS version: Debian 10 (buster)


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
