### PR TITLE
Fixed #9875: Make locations deletable for non Superuser-Accounts with FullMultipleCompanySupport

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -125,6 +125,11 @@ final class Company extends SnipeModel
             return false;
         } elseif (!static::isFullMultipleCompanySupportEnabled()) {
             return true;
+        } elseif (!$companyable instanceof Company && !\Schema::hasColumn($companyable->getModel()->getTable(), 'company_id')) {
+            // This is primary for the gate:allows-check in location->isDeletable()
+            // Locations don't have a company_id so without this it isn't possible to delete locations with FullMultipleCompanySupport enabled
+            // because this function is called by SnipePermissionsPolicy->before()
+            return true;
         } else {
             if (Auth::user()) {
                 $current_user_company_id = Auth::user()->company_id;


### PR DESCRIPTION
# Description

It isn't possible for non Superuser-Accounts to delete locations with FullMultipleCompanySupport enabled.

locations->isDeletable() checks via gate::allows if a location is deletable.
This calls SnipePermissionsPolicy->before() and checks for !Company::isCurrentUserHasAccess($item).
This returns false because locations don't have a company_id.

Check for this and return true if the item don't have a company_id.

Fixes #9875

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Steps to reproduce are in #9875.


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
