### PR TITLE
Fixes: Can't update departments if Full Company Support is activated

### DIFF
--- a/resources/views/departments/edit.blade.php
+++ b/resources/views/departments/edit.blade.php
@@ -12,6 +12,8 @@
     <!-- Company -->
     @if (\App\Models\Company::canManageUsersCompanies())
         @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
+    @else
+        <input id="hidden_company_id" type="hidden" name="company_id" value="{{ Auth::user()->company_id }}">
     @endif
 
 


### PR DESCRIPTION
# Description
When Full Company Support is enabled, a user with correct permissions is able to create new departments, but they can't assign a Company resulting in an issue because then the user can't view/edit it because the department doesn't belong to the same company as the user with the correct permisisons. 

To fix this I just added a hidden field with the `company_id` of the user creating the department, so the department is created inside the same user's company letting him later view/edit it as corresponds.

Fixes internal freshdesk ticket 18463

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
