### PR TITLE
Fixes Integrity constraint violation when emailing password reset.

### DIFF
--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -83,7 +83,7 @@ class ForgotPasswordController extends Controller
                 )
             );
         } catch(\Exception $e) {
-            \Log::info('Password reset attempt: User '.$request->input('username').' doesnt have email setted' );
+            \Log::info('Password reset attempt: User '.$request->input('username').'failed with exception: '.$e );
         }
 
 

--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -61,7 +61,7 @@ class ForgotPasswordController extends Controller
         $request->validate([
             'username' => ['required', 'max:255'],
         ]);
-        
+
 
 
         /**
@@ -71,13 +71,21 @@ class ForgotPasswordController extends Controller
          * Once we have attempted to send the link, we will examine the response
          * then see the message we need to show to the user. Finally, we'll send out a proper response.
          */
-        $response = $this->broker()->sendResetLink(
-            array_merge(
-                $request->only('username'),
-                ['activated' => '1'],
-                ['ldap_import' => '0']
-            )
-        );
+
+        $response = null;
+
+        try {
+            $response = $this->broker()->sendResetLink(
+                array_merge(
+                    $request->only('username'),
+                    ['activated' => '1'],
+                    ['ldap_import' => '0']
+                )
+            );
+        } catch(\Exception $e) {
+            \Log::info('Password reset attempt: User '.$request->input('username').' doesnt have email setted' );
+        }
+
 
         if ($response === \Password::RESET_LINK_SENT) {
             \Log::info('Password reset attempt: User '.$request->input('username').' WAS found, password reset sent');


### PR DESCRIPTION
# Description
When the user wants to reset their password if the user doesn't have an email assigned, the system hard-fail. I know in the past I tried to fix another issue adding a try/catch and I got my ass handled (that code looked very weird, to be honest...) but I couldn't think of a better solution here. Probably returning an error with the message that "the user doesn't have an email assigned" is not problematic security-wise, but anyways I don't added that (most for avoid the trouble of create a new translate line) let me know if it's needed so I can add it.

(Also if my try/catch solution is bad and I should feel bad, let me know so I can handle it differently).

Fixes internal rollbar 15442

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
