### PR TITLE
Add licenses api parameters and fix a missing variable in license view - V6

### DIFF
--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -78,10 +78,14 @@ class LicensesController extends Controller
 
         if (($request->filled('maintained')) && ($request->input('maintained')=='true')) {
             $licenses->where('maintained','=',1);
+        } elseif (($request->filled('maintained')) && ($request->input('maintained')=='false')) {
+            $licenses->where('maintained','=',0);
         }
 
         if (($request->filled('expires')) && ($request->input('expires')=='true')) {
             $licenses->whereNotNull('expiration_date');
+        } elseif (($request->filled('expires')) && ($request->input('expires')=='false')) {
+            $licenses->whereNull('expiration_date');
         }
 
         if ($request->filled('search')) {

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -76,6 +76,14 @@ class LicensesController extends Controller
             $licenses->where('supplier_id', '=', $request->input('supplier_id'));
         }
 
+        if (($request->filled('maintained')) && ($request->input('maintained')=='true')) {
+            $licenses->where('maintained','=',1);
+        }
+
+        if (($request->filled('expires')) && ($request->input('expires')=='true')) {
+            $licenses->whereNotNull('expiration_date');
+        }
+
         if ($request->filled('search')) {
             $licenses = $licenses->TextSearch($request->input('search'));
         }

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -285,6 +285,17 @@
                   </div>
                   @endif
 
+                  <div class="row">
+                    <div class="col-md-4">
+                      <strong>
+                        {{ trans('admin/licenses/form.maintained') }}
+                      </strong>
+                    </div>
+                    <div class="col-md-8">
+                      {{ $license->maintained ? 'Yes' : 'No' }}
+                    </div>
+                  </div>
+
                   @if (($license->seats) && ($license->seats) > 0)
                   <div class="row">
                     <div class="col-md-4">


### PR DESCRIPTION
# Description

Added 2 parameters in the license API in order to filter maintained licenses and licenses that expires or not. 

Also added a missing item that wasn't shown in the license view, the maintained field was not displayed.

I didn't find where i could change the API documentation in the repo. If you could point me in the right direction i'll make the necessary changes (add both `expires` and `maintained` parameters.)

As mentionned in #9834, this PR is for V6 integration.  I made changed to develop in #9889.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual test with docker

**Test Configuration**:
* Used the docker with default configuration. 


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
