### PR TITLE
Fixed #9904: Advanced search with serial and another field produce incorrect results

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1314,7 +1314,7 @@ class Asset extends Depreciable
                     $query->where('assets.name', 'LIKE', '%'.$search_val.'%');
                 }
 
-                if ($fieldname =='product_key') {
+                if ($fieldname =='serial') {
                     $query->where('assets.serial', 'LIKE', '%'.$search_val.'%');
                 }
 


### PR DESCRIPTION
# Description

The advanced search in /hardware produces incorrect results if the serial is combined with another field like category.
The query uses an OR-Clause to combine the fields.

This is because the filedname in Assets::scopeByFilter is incorrectly named as 'product_key', not serial.
The serial-field gets caught by the last generic If-Statement and the OR-Clause gets added:
	$query->orWhere('assets.'.$fieldname, 'LIKE', '%' . $search_val . '%');

Fix this by changing the fieldname to 'serial'.

Fixes #9904

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Steps to reproduce are in #9904, I verified that this is not reproducible after this change.


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
