### PR TITLE
Fix [ch945] Status colors are not displaying correctly in the dashboard chart

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -67,7 +67,7 @@ class Helper
     {
         $colors = [
             "#008941",
-            "#FF4A46",
+            "#FF851B",
             "#006FA6",
             "#A30059",
             "#1CE6FF",

--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -176,17 +176,15 @@ class StatuslabelsController extends Controller
 
         foreach ($statuslabels as $statuslabel) {
             if ($statuslabel->assets_count > 0) {
-
                 $labels[]=$statuslabel->name. ' ('.number_format($statuslabel->assets_count).')';
                 $points[]=$statuslabel->assets_count;
 
                 if ($statuslabel->color!='') {
                     $colors_array[] = $statuslabel->color;
-                    $default_color_count++;
                 } else {
                     $colors_array[] = Helper::defaultChartColors($default_color_count);
-                    $default_color_count++;
                 }
+                $default_color_count++;
             }
         }
 

--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -182,6 +182,7 @@ class StatuslabelsController extends Controller
 
                 if ($statuslabel->color!='') {
                     $colors_array[] = $statuslabel->color;
+                    $default_color_count++;
                 } else {
                     $colors_array[] = Helper::defaultChartColors($default_color_count);
                     $default_color_count++;


### PR DESCRIPTION
Also edit the default color for assets with the Pending label, so it match the color in the docs

# Description
When an Status Label has a custom color there was a counter that wasn't updated making that the index of the colors array defined in the `Helper@defaultChartColors()` isn't selected correctly. This PR introduces a counter increment in the  `StatuslabelsController@getAssetsCountByStatuslabel()` function allowing to keep the index updated.

Also edit the default color for assets with the Pending label, so it match the color in the docs. Right now looks like this in the chart:
![image](https://user-images.githubusercontent.com/653557/129961081-d49b416d-69a4-48be-b60a-cef4c3cb9110.png)

And this in the About Status Labels:
![image](https://user-images.githubusercontent.com/653557/129961242-d7d3fdd6-a008-4492-8382-cddb7d788e02.png)

Now it match.

Fixes internal clubhouse [ch945]

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
**Test Configuration**: 
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx:1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
