### PR TITLE
Fixed ch17133 - Fixed sum total calculation on Bootstrap Table pages -

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -595,11 +595,23 @@
         }
     }
 
+    function cleanFloat(number) {
+        if ("{{$snipeSettings->digit_separator}}" == "1.234,56") {
+            // yank periods, change commas to periods
+            periodless = number.toString().replace("\.","");
+            decimalfixed = periodless.replace(",",".");
+        } else {
+            // yank commas, that's it.
+            decimalfixed = number.toString().replace(",","");
+        }
+        return parseFloat(decimalfixed);
+    }
+
     function sumFormatter(data) {
         if (Array.isArray(data)) {
             var field = this.field;
             var total_sum = data.reduce(function(sum, row) {
-                return (sum) + (parseFloat(row[field]) || 0);
+                return (sum) + (cleanFloat(row[field]) || 0);
             }, 0);
             return numberWithCommas(total_sum.toFixed(2));
         }


### PR DESCRIPTION
# Description

The calculation we perform to figure out the sum total on bootstrap-tables pages broke when we started to format currencies appropriately in the API. This small snippet of Bootstrap tables Javascript should work-around the issue - and even if we should decide to make the API not show internationalized currency values, this should still work.

Fixes # ch17133

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually added up the column in US-format to make sure it matched the calculated value
- [x] Manually added up the column in EU-format to make sure it still matched the calculated value