### PR TITLE
Fix regression for NULL valued numbers in the summary calculation

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -596,6 +596,9 @@
     }
 
     function cleanFloat(number) {
+        if(!number) { // in a JavaScript context, meaning, if it's null or zero or unset
+            return 0.0;
+        }
         if ("{{$snipeSettings->digit_separator}}" == "1.234,56") {
             // yank periods, change commas to periods
             periodless = number.toString().replace("\.","");


### PR DESCRIPTION
I caused a regression when I fixed the summary math, for people who don't *have* price values - the nulls would crash the javascript. This small change treats nulls as 0.0, so if you have a page of all-nulls, you should result in a summary of 0.0.

I tested this by nulling out one of my assets and replicating the problem, then noting that my fix made the problem go away?