### PR TITLE
Fixes: When using API CheckIn assets, there will be two CheckIn records in the Activity Report log for each asset.

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -798,7 +798,6 @@ class AssetsController extends Controller
         }
 
         if ($asset->save()) {
-            $asset->logCheckin($target, e($request->input('note')));
             event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note')));
 
             return response()->json(Helper::formatStandardApiResponse('success', ['asset'=> e($asset->asset_tag)], trans('admin/hardware/message.checkin.success')));


### PR DESCRIPTION
Fix：When using API CheckIn assets, there will be two CheckIn records in the Activity Report log for each asset.

# Description

The logCheckin in this module is the same as the LogListener in Laravel.

So, when using API CheckIn assets, there will be two CheckIn records in the Activity Report log for each asset.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version: PHP 7.4.15
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
