### PR TITLE
Make the LDAP Client-side certificate fields Nullable

### DIFF
--- a/database/migrations/2021_07_28_031345_add_client_side_l_d_a_p_cert_to_settings.php
+++ b/database/migrations/2021_07_28_031345_add_client_side_l_d_a_p_cert_to_settings.php
@@ -14,7 +14,7 @@ class AddClientSideLDAPCertToSettings extends Migration
     public function up()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->text('ldap_client_tls_cert')->nullable();
+            $table->text('ldap_client_tls_cert')->nullable()->default(null);
         });
     }
 
@@ -26,7 +26,7 @@ class AddClientSideLDAPCertToSettings extends Migration
     public function down()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->dropColumn('ldap_client_tls_cert')->nullable();
+            $table->dropColumn('ldap_client_tls_cert');
         });
     }
 }

--- a/database/migrations/2021_07_28_040554_add_client_side_l_d_a_p_key_to_settings.php
+++ b/database/migrations/2021_07_28_040554_add_client_side_l_d_a_p_key_to_settings.php
@@ -14,7 +14,7 @@ class AddClientSideLDAPKeyToSettings extends Migration
     public function up()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->text("ldap_client_tls_key")->nullable();
+            $table->text("ldap_client_tls_key")->nullable()->default(null);
         });
     }
 
@@ -26,7 +26,7 @@ class AddClientSideLDAPKeyToSettings extends Migration
     public function down()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->dropColumn("ldap_client_tls_key")->nullable();
+            $table->dropColumn("ldap_client_tls_key");
         });
     }
 }

--- a/database/migrations/2021_07_28_040554_add_client_side_l_d_a_p_key_to_settings.php
+++ b/database/migrations/2021_07_28_040554_add_client_side_l_d_a_p_key_to_settings.php
@@ -14,7 +14,7 @@ class AddClientSideLDAPKeyToSettings extends Migration
     public function up()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->text("ldap_client_tls_key");
+            $table->text("ldap_client_tls_key")->nullable();
         });
     }
 
@@ -26,7 +26,7 @@ class AddClientSideLDAPKeyToSettings extends Migration
     public function down()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->dropColumn("ldap_client_tls_key");
+            $table->dropColumn("ldap_client_tls_key")->nullable();
         });
     }
 }

--- a/database/migrations/2021_08_24_124354_make_ldap_client_certs_nullable.php
+++ b/database/migrations/2021_08_24_124354_make_ldap_client_certs_nullable.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddClientSideLDAPCertToSettings extends Migration
+class MakeLdapClientCertsNullable extends Migration
 {
     /**
      * Run the migrations.
@@ -14,7 +14,9 @@ class AddClientSideLDAPCertToSettings extends Migration
     public function up()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->text('ldap_client_tls_cert')->nullable();
+            //
+            $table->text('ldap_client_tls_cert')->nullable()->change();
+            $table->text('ldap_client_tls_key')->nullable()->change();
         });
     }
 
@@ -26,7 +28,7 @@ class AddClientSideLDAPCertToSettings extends Migration
     public function down()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->dropColumn('ldap_client_tls_cert')->nullable();
+            //
         });
     }
 }


### PR DESCRIPTION
I inadvertently made the new client-side LDAP certificate fields not-nullable, when I intended for them to be Nullable. This PR fixes that.

There are a few things I do here that are weird - 

1. Doing a back-in-time migration is always weird, but this feature just came out, so we think it's okay.
2. There's no `down()` migration for the new switch-to-nullable migration. This is because we've edited the original migrations to always be nullable, and trying to make an already-nullable field nullable again doesn't hurt.

I feel like these justifications are OK. Let me know if you think otherwise.