### PR TITLE
Fixed rb445 and rb446 - the unlink calls for the client-side certs...

### DIFF
--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -380,16 +380,20 @@ class Setting extends Model
          * one place where we will do that, so I'll just explicitly call
          * this method at that spot instead. It'll be easier to debug and understand.
          */
-        if($this->ldap_client_tls_cert) {
+        if ($this->ldap_client_tls_cert) {
             file_put_contents(self::get_client_side_cert_path(), $this->ldap_client_tls_cert);
         } else {
-            unlink(self::get_client_side_cert_path());
+            if (file_exists(self::get_client_side_cert_path())) {
+                unlink(self::get_client_side_cert_path());
+            }
         }
 
-        if($this->ldap_client_tls_key) {
+        if ($this->ldap_client_tls_key) {
             file_put_contents(self::get_client_side_key_path(), $this->ldap_client_tls_key);
         } else {
-            unlink(self::get_client_side_key_path());
+            if (file_exists(self::get_client_side_key_path())) {
+                unlink(self::get_client_side_key_path());
+            }
         }
     }
 


### PR DESCRIPTION
...need to be wrapped around by a file-existence check

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Fixes rb445 and rb446

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I tried saving empty textareas for the client-side LDAP cert fields
- [x] I also tried saving ones that were populated, and the behavior seemed to work out OK.