### PR TITLE
Fixes #9985. Error 500 when using the asset search - blank results for non super-admins

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -78,12 +78,12 @@ final class Company extends SnipeModel
             $company_id = null;
         }
 
-        $table = ($table_name) ? $table_name."." : '';
+        $table = ($table_name) ? $table_name."." : $query->getModel()->getTable().".";
 
         if(\Schema::hasColumn($query->getModel()->getTable(), $column)){
-             return $query->where($table.$column, '=', $company_id); 
+             return $query->where($table.$column, '=', $company_id);
         } else {
-            return $query->join('users as users_comp', 'users_comp.id', 'user_id')->where('users_comp.company_id', '=', $company_id); 
+            return $query->join('users as users_comp', 'users_comp.id', 'user_id')->where('users_comp.company_id', '=', $company_id);
         }
     }
 


### PR DESCRIPTION
# Description
When Full Company Support is activated, the query of the search bar adds the column `company_id`, but in doing so it doesn't specifies from what table it's taking the column and as the query has a couple more tables with a column called like that, the query fails because the comparison is ambiguous. 

Fixes #9985 #9917 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
