### PR TITLE
WIP Feature - more strictly disallow non slack checkout hooks

### DIFF
--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -165,6 +165,14 @@ class SettingsController extends Controller
     public function slacktest(Request $request)
     {
 
+
+        $validatedData = $request->validate([
+            'slack_endpoint'     => 'url|required_with:slack_channel|nullable|starts_with:https://hooks.slack.com',
+            'slack_channel'      => 'starts_with:#|required_with:slack_endpoint|nullable',
+            'slack_botname'      => 'string|required_with:slack_endpoint|nullable',
+        ]);
+
+        
         $slack = new Client([
             'base_url' => e($request->input('slack_endpoint')),
             'defaults' => [

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -674,7 +674,9 @@ class SettingsController extends Controller
         }
 
         $validatedData = $request->validate([
-            'slack_channel'   => 'regex:/(?<!\w)#\w+/|required_with:slack_endpoint|nullable',
+            'slack_endpoint'     => 'url|required_with:slack_channel|nullable|starts_with:https://hooks.slack.com',
+            'slack_channel'      => 'starts_with:#|required_with:slack_endpoint|nullable',
+            'slack_botname'      => 'string|required_with:slack_endpoint|nullable',
         ]);
 
 

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -83,6 +83,7 @@ return array(
         'string'  => 'The :attribute must be :size characters.',
         'array'   => 'The :attribute must contain :size items.',
     ],
+    'starts_with' => 'The :attribute must start with one of the following: :values.',
     'string'               => 'The :attribute must be a string.',
     'timezone'             => 'The :attribute must be a valid zone.',
     'unique'               => 'The :attribute has already been taken.',

--- a/resources/views/settings/slack.blade.php
+++ b/resources/views/settings/slack.blade.php
@@ -146,7 +146,7 @@
                 $('#slacktestcontainer').fadeOut(500);
             }
 
-            if(event) { //on 'initial load' we don't *have* an 'event', but in the regular keyup callback, we *do*. So this only fires on 'real' callback events, not on first load
+            if (event) { //on 'initial load' we don't *have* an 'event', but in the regular keyup callback, we *do*. So this only fires on 'real' callback events, not on first load
                 if($('#slack_endpoint').val() == "" && $('#slack_channel').val() == "" && $('#slack_botname').val() == "") {
                     // if all three fields are blank, the user may want to disable Slack integration; enable the Save button
                     $('#save_slack').removeAttr('disabled');
@@ -183,15 +183,6 @@
                 dataType: 'json',
 
                 success: function (data) {
-                    $('#save_slack').removeAttr('disabled');
-                    $("#slacktesticon").html('');
-                    $("#slacktestrow").addClass('text-success');
-                    $("#slackteststatus").addClass('text-success');
-                    $("#slackteststatus").html('<i class="fa fa-check text-success"></i> Success! Check the ' + $('#slack_channel').val() + ' channel for your test message, and be sure to click SAVE below to store your settings.');
-                },
-
-                error: function (data) {
-
 
                     if (data.responseJSON) {
                         var errors = data.responseJSON.message;
@@ -201,10 +192,27 @@
 
                     var error_text = '';
 
-                    $('#save_slack').attr("disabled", true);
-                    $("#slacktesticon").html('');
-                    $("#slackteststatus").addClass('text-danger');
-                    $("#slacktesticon").html('<i class="fa fa-exclamation-triangle text-danger"></i>');
+
+                    if (data.status=="error") {
+
+                        $('#save_slack').attr("disabled", true);
+                        $("#slacktesticon").html('');
+                        $("#slacktestrow").addClass('text-danger');
+                        $("#slackteststatus").addClass('text-danger');
+                        $("#slacktesticon").html('<i class="fa fa-exclamation-triangle text-danger"></i> ');
+                        $("#slackteststatus").html('There was an error testing Slack. Please check that the Slack endpoint URL starts with https://hooks.slack.com, and that your channel name exists in your Slack workspace and starts with a #.');
+
+                    } else {
+                        $('#save_slack').removeAttr('disabled');
+                        $("#slacktesticon").html('');
+                        $("#slacktestrow").addClass('text-success');
+                        $("#slackteststatus").addClass('text-success');
+                        $("#slackteststatus").html('<i class="fa fa-check text-success"></i> Success! Check the ' + $('#slack_channel').val() + ' channel for your test message, and be sure to click SAVE below to store your settings.');
+                    }
+                                       
+                },
+
+                error: function (data) {
 
                     if (data.status == 500) {
                         $('#slackteststatus').html('500 Server Error');

--- a/resources/views/settings/slack.blade.php
+++ b/resources/views/settings/slack.blade.php
@@ -182,6 +182,8 @@
 
                 dataType: 'json',
 
+                // This part is a little confusing, since we return a 200 on failed validation, so we have to
+                // actually look at the contents of the response, where we have a "status" field in the JSON. 
                 success: function (data) {
 
                     if (data.responseJSON) {
@@ -193,6 +195,7 @@
                     var error_text = '';
 
 
+                    // The request responded with a 200, but we see an error as the "status"
                     if (data.status=="error") {
 
                         $('#save_slack').attr("disabled", true);


### PR DESCRIPTION
We have an issue where customers and sometimes users use a non-slack URL in the Slack section, which can cause a 500 error. For example, if they are trying to use Office 365 webhooks, that will always error, since the Laravel Slack driver only sends stuff to, well, Slack.

This introduces a little more strict validation, but for some reason the test button is showing as success even when the Slack webhook couldn't possibly pass, for example if I make up a bogus URL and channel name that fit the `starts_with` requirements, but they definitely don't exist. Not sure what's up with that, since I didn't change that part.

The API side of things isn't validating properly, partly because Laravel wants to send a 422 on AJAX responses, but IIRC we override that in the service provider and set it to a 200 (since the pipes are fine, the data is crappy), but at least now it won't let you *save* Office 365, etc webhooks, which should cut down on some of our rollbars eventually. 

<img width="818" alt="Screen Shot 2021-08-30 at 4 56 33 PM" src="https://user-images.githubusercontent.com/197404/131420660-cf001d9a-fbbc-4fe3-b50d-f195d57fc3d8.png">

<img width="821" alt="Screen Shot 2021-08-30 at 4 57 07 PM" src="https://user-images.githubusercontent.com/197404/131420661-dde7561c-4a38-4a7f-81a4-024572d974a5.png">


Still want to figure out why it's not failing on that test button tho. 

@inietov would love your laser eyeballs on this too when you get a second. This is largely mitigated with the v6 Livewire stuff, but I'd like to figure out why the stupid button isn't triggering an execption when it very clearly should.

