### PR TITLE
Fixes Quotations turn into HTML entity

### DIFF
--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -212,7 +212,7 @@ class AssetMaintenancesController extends Controller
         $assetMaintenance->supplier_id = e($request->input('supplier_id'));
         $assetMaintenance->is_warranty = e($request->input('is_warranty'));
         $assetMaintenance->cost =  Helper::ParseFloat(e($request->input('cost')));
-        $assetMaintenance->notes = e($request->input('notes'));
+        $assetMaintenance->notes = $request->input('notes');
 
         $asset = Asset::find(request('asset_id'));
 

--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -209,9 +209,9 @@ class AssetMaintenancesController extends Controller
             return static::getInsufficientPermissionsRedirect();
         }
 
-        $assetMaintenance->supplier_id = e($request->input('supplier_id'));
-        $assetMaintenance->is_warranty = e($request->input('is_warranty'));
-        $assetMaintenance->cost =  Helper::ParseFloat(e($request->input('cost')));
+        $assetMaintenance->supplier_id = $request->input('supplier_id');
+        $assetMaintenance->is_warranty = $request->input('is_warranty');
+        $assetMaintenance->cost =  Helper::ParseFloat($request->input('cost'));
         $assetMaintenance->notes = $request->input('notes');
 
         $asset = Asset::find(request('asset_id'));


### PR DESCRIPTION
# Description
When updating info on AssetsMaintenances, before we save the updated data the `notes` field is wrapped in the  `e()` function which converts the quotes and other special characters into the correspondent HTML entity. I think it makes so because of security reasons, to take the input data and sanitizes it before we save it in the database, but the same controller doesn't uses the `e()` function for the same `notes` field when first creating the maintenance, and also the AssetsController doesn't use this function before saving its notes so I remove it.

I have doubts because it's probably expected behaviour, but at the same time I also think the `e()` function is more used when showing data, like in a view or something. Please let me know if this is a correct approach to solve this, or if I have to rethink my solution.

Fixes interlan freshdesk 22149.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
