### PR TITLE
Fix Accepted Assets still showing on Unaccepted Asset Report 

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -71,20 +71,27 @@ class CheckoutableListener
         /**
          * Send the appropriate notification
          */
+        $acceptances = CheckoutAcceptance::where('checkoutable_id', $event->checkoutable->id)
+                                        ->where('assigned_to_id', $event->checkedOutTo->id)
+                                        ->get();
 
-
+        foreach($acceptances as $acceptance){
+            if($acceptance->isPending()){
+                $acceptance->delete();
+            }
+        }
         \Log::debug('checked out to a user');
         if(!$event->checkedOutTo->locale){
             \Log::debug('Use default settings locale');
             Notification::locale(Setting::getSettings()->locale)->send(
-                $this->getNotifiables($event), 
+                $this->getNotifiables($event),
                 $this->getCheckinNotification($event)
             );
         } else {
             \Log::debug('Use user locale? I do not think this works as expected yet');
             // \Log::debug(print_r($this->getNotifiables($event), true));
             Notification::send(
-                $this->getNotifiables($event), 
+                $this->getNotifiables($event),
                 $this->getCheckinNotification($event)
             );
         }


### PR DESCRIPTION
# Description
When the assets are configured to be accepted, at the moment of the checkout a register for `checkout_acceptances` is created to see if an asset is pending of acceptance. The issue is that if the acceptance is pending, and we checkin that asset, the checkout acceptance gets 'orphan'. If then that asset is checked out to another user, now two `checkout_acceptances` are pending and when the user accepts or rejects it, only one acceptance is updated meaning that for the system that asset is accepted/rejected and pending at the same time. Making the Unaccepted Asset Report unreliable.

Fixes internal freshdesk 23006

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
