### PR TITLE
Convert value of column 'checkout type' in CSV file to lowercase

### DIFF
--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -100,7 +100,7 @@ class ItemImporter extends Importer
             return $this->createOrFetchUser($row);
         }
 
-        if ($this->item['checkout_class'] === 'location') {
+        if (strtolower($this->item['checkout_class']) === 'location') {
             return Location::findOrFail($this->createOrFetchLocation($this->findCsvMatch($row, 'checkout_location')));
         }
 


### PR DESCRIPTION
# Description
When a user needs to import assets and checkout them ot location, if the `checkout type` column has some letter in uppercase, then the checkout is not executed, because it expects the checkout type as 'location' all lowercase (for example Location doesn't work). As it's an honest error to make I think that case needs to be addressed in code (also is a diminute change). 

Fixes internal freshdesk 22704

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
