### PR TITLE
Fixed #10062: Added Support for Heroku Deployments

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: php heroku/startup.php && heroku-php-apache2 public/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ For instructions on installing and configuring Snipe-IT on your server, check ou
 
 If you're having trouble with the installation, please check the [Common Issues](https://snipe-it.readme.io/docs/common-issues) and [Getting Help](https://snipe-it.readme.io/docs/getting-help) documentation, and search this repository's open *and* closed issues for help.
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 -----
 ### User's Manual
 For help using Snipe-IT, check out the [user's manual](https://snipe-it.readme.io/docs/overview).

--- a/app.json
+++ b/app.json
@@ -148,6 +148,7 @@
     "image": "heroku/php",
     "addons": [
       "cleardb:ignite",
-      "heroku-redis:hobby-dev"
+      "heroku-redis:hobby-dev",
+      "papertrail:choklad"
     ]
   }

--- a/app.json
+++ b/app.json
@@ -7,15 +7,19 @@
     ],
     "website": "https://snipeitapp.com/",
     "repository": "https://github.com/snipe/snipe-it",
-    "logo": "https://snipeitapp.com/img/logos/snipe-it-logo-xs.png",
+    "logo": "https://pbs.twimg.com/profile_images/976748875733020672/K-HnZCCK_400x400.jpg",
     "success_url": "/setup",
     "env": {
       "APP_ENV": {
-        "description": "Symfony environment mode.",
+        "description": "Symfony environment mode. Unless developing the application, this should be production.",
         "value": "production"
       },
+      "APP_DEBUG": {
+        "description": "Symfony debug mode. Unless developing the application or actively debugging a problem, this should be set to false.",
+        "value": "false"
+      },
       "APP_KEY": {
-        "description": "A secret key for verifying the integrity of signed cookies. (https://coderstoolbox.online/toolbox/generate-symfony-secret)",
+        "description": "A secret key for verifying the integrity of signed cookies. (See either https://snipe-it.readme.io/docs/install-dependencies or generate at https://coderstoolbox.online/toolbox/generate-symfony-secret)",
         "value": ""
       },
       "APP_URL": {
@@ -30,84 +34,88 @@
         "description": "Which language do you want to use for your install? (https://snipe-it.readme.io/docs/configuration#setting-a-language)",
         "value": "en"
       },
+      "MAX_RESULTS": {
+        "description": "The maximum number of search results that can be returned at one time.",
+        "value": "500"
+      },
       "MAIL_DRIVER": {
-        "description": "",
+        "description": "Mail driver - Generally SMTP on Heroku - https://snipe-it.readme.io/docs/configuration#required-outgoing-mail-settings",
         "value": "smtp"
       },
       "MAIL_HOST": {
-        "description": "",
+        "description": "SMTP Server Hostname",
         "value": "smtp.your.domain.name"
       },
       "MAIL_PORT": {
-        "description": "",
+        "description": "SMTP Server Port",
         "value": "25"
       },
       "MAIL_USERNAME": {
-        "description": "",
+        "description": "SMTP Server Username",
         "value": "YOURUSERNAME"
       },
       "MAIL_PASSWORD": {
-        "description": "",
+        "description": "SMTP Server Password",
         "value": "YOURPASSWORD"
       },
       "MAIL_ENCRYPTION": {
-        "description": "",
+        "description": "Encryption protocol for email sending.",
         "value": "null"
       },
       "MAIL_FROM_ADDR": {
-        "description": "",
-        "value": "your@domain.name"
+        "description": "Email from address",
+        "value": "no-reply@domain.name"
       },
       "MAIL_FROM_NAME": {
-        "description": "",
+        "description": "Email from Name",
         "value": "Snipe-IT"
       },
       "MAIL_REPLYTO_ADDR": {
-        "description": "",
+        "description": "Email Reply-To address",
         "value": "your@domain.name"
       },
       "MAIL_REPLYTO_NAME": {
-        "description": "",
+        "description": "Email Reply-To Name",
         "value": "Snipe-IT"
       },
       "MAIL_AUTO_EMBED": {
-        "description": "",
+        "description": "Whether or not to embed images in emails (via CID or base64) versus linking to them.",
         "value": "true"
       },
       "MAIL_AUTO_EMBED_METHOD": {
-        "description": "",
+        "description": "Method that should be used for attaching inline images.",
         "value": "base64"
       },
       "SESSION_LIFETIME": {
-        "description": "",
+        "description": "Specify the time in minutes that the session should remain valid.",
         "value": "12000"
       },
       "EXPIRE_ON_CLOSE": {
-        "description": "",
+        "description": "Specify whether or not the logged in session should be expired when the user closes their browser window.",
         "value": "false"
       },
       "ENCRYPT": {
-        "description": "",
-        "value": "false"
+        "description": "Specify whether you wish to use encrypted cookies for your Snipe-IT sessions.",
+        "value": "true"
       },
       "COOKIE_NAME": {
-        "description": "",
+        "description": "The name of the cookie set by Snipe-IT for session management.",
         "value": "snipeit_session"
       },
       "COOKIE_DOMAIN": {
-        "description": "",
+        "description": "The domain name that the session cookie should be sent for.",
         "value": "your-app-name.herokuapp.com"
       },
       "SECURE_COOKIES": {
-        "description": "",
-        "value": "false"
+        "description": "Should cookies only be sent for HTTPS connections? Generally true on Heroku.",
+        "value": "true"
       },
       "LOGIN_MAX_ATTEMPTS": {
-        "description": "",
+        "description": "The maximum number of failed attempts allowed before the user is throttled.",
         "value": "5"
       },
       "LOGIN_LOCKOUT_DURATION": {
-        "description": "",
+        "description": "The duration (in seconds) that the user should be blocked from attempting to authenticate again.",
         "value": "60"
       },
       "APP_LOG": {
@@ -115,19 +123,19 @@
         "value": "errorlog"
       },
       "ALLOW_IFRAMING": {
-        "description": "",
+        "description": "Allow Snipe-IT to be loaded using an iFrame?",
         "value": "false"
       },
       "GOOGLE_MAPS_API": {
-        "description": "",
-        "value": ""
+        "description": "Include your Google Maps API key here if you'd like Snipe-IT to load maps from Google on your locations and suppliers pages.",
+        "required": false
       },
       "BACKUP_ENV": {
-        "description": "",
+        "description": "Set this to true if you wish to backup your .env file in your Admin > Backups process.",
         "value": "true"
       },
       "ENABLE_HSTS": {
-        "description": "",
+        "description": "Whether or not to send the HSTS security policy header.",
         "value": "false"
       }
     },

--- a/app.json
+++ b/app.json
@@ -1,0 +1,145 @@
+{
+    "name": "Snipe-IT",
+    "description": "Open source asset management.",
+    "keywords": [
+      "asset management",
+      "it asset"
+    ],
+    "website": "https://snipeitapp.com/",
+    "repository": "https://github.com/snipe/snipe-it",
+    "logo": "https://snipeitapp.com/img/logos/snipe-it-logo-xs.png",
+    "success_url": "/setup",
+    "env": {
+      "APP_ENV": {
+        "description": "Symfony environment mode.",
+        "value": "production"
+      },
+      "APP_KEY": {
+        "description": "A secret key for verifying the integrity of signed cookies. (https://coderstoolbox.online/toolbox/generate-symfony-secret)",
+        "value": ""
+      },
+      "APP_URL": {
+        "description": "URL where your Snipe-IT install will be available at.",
+        "value": "https://your-app-name.herokuapp.com"
+      },
+      "APP_TIMEZONE": {
+        "description": "Which timezone do you want to use for your install? (http://php.net/manual/en/timezones.php)",
+        "value": "UTC"
+      },
+      "APP_LOCALE": {
+        "description": "Which language do you want to use for your install? (https://snipe-it.readme.io/docs/configuration#setting-a-language)",
+        "value": "en"
+      },
+      "MAIL_DRIVER": {
+        "description": "",
+        "value": "smtp"
+      },
+      "MAIL_HOST": {
+        "description": "",
+        "value": "smtp.your.domain.name"
+      },
+      "MAIL_PORT": {
+        "description": "",
+        "value": "25"
+      },
+      "MAIL_USERNAME": {
+        "description": "",
+        "value": "YOURUSERNAME"
+      },
+      "MAIL_PASSWORD": {
+        "description": "",
+        "value": "YOURPASSWORD"
+      },
+      "MAIL_ENCRYPTION": {
+        "description": "",
+        "value": "null"
+      },
+      "MAIL_FROM_ADDR": {
+        "description": "",
+        "value": "your@domain.name"
+      },
+      "MAIL_FROM_NAME": {
+        "description": "",
+        "value": "Snipe-IT"
+      },
+      "MAIL_REPLYTO_ADDR": {
+        "description": "",
+        "value": "your@domain.name"
+      },
+      "MAIL_REPLYTO_NAME": {
+        "description": "",
+        "value": "Snipe-IT"
+      },
+      "MAIL_AUTO_EMBED": {
+        "description": "",
+        "value": "true"
+      },
+      "MAIL_AUTO_EMBED_METHOD": {
+        "description": "",
+        "value": "base64"
+      },
+      "SESSION_LIFETIME": {
+        "description": "",
+        "value": "12000"
+      },
+      "EXPIRE_ON_CLOSE": {
+        "description": "",
+        "value": "false"
+      },
+      "ENCRYPT": {
+        "description": "",
+        "value": "false"
+      },
+      "COOKIE_NAME": {
+        "description": "",
+        "value": "snipeit_session"
+      },
+      "COOKIE_DOMAIN": {
+        "description": "",
+        "value": "your-app-name.herokuapp.com"
+      },
+      "SECURE_COOKIES": {
+        "description": "",
+        "value": "false"
+      },
+      "LOGIN_MAX_ATTEMPTS": {
+        "description": "",
+        "value": "5"
+      },
+      "LOGIN_LOCKOUT_DURATION": {
+        "description": "",
+        "value": "60"
+      },
+      "APP_LOG": {
+        "description": "Driver to send logs to. (errorlog for stderr)",
+        "value": "errorlog"
+      },
+      "ALLOW_IFRAMING": {
+        "description": "",
+        "value": "false"
+      },
+      "GOOGLE_MAPS_API": {
+        "description": "",
+        "value": ""
+      },
+      "BACKUP_ENV": {
+        "description": "",
+        "value": "true"
+      },
+      "ENABLE_HSTS": {
+        "description": "",
+        "value": "false"
+      }
+    },
+    "formation": {
+      "web": {
+        "quantity": 1,
+        "size": "free"
+      }
+    },
+    "image": "heroku/php",
+    "addons": [
+      "cleardb:ignite",
+      "heroku-redis:hobby-dev"
+    ]
+  }

--- a/app.json
+++ b/app.json
@@ -11,15 +11,15 @@
     "success_url": "/setup",
     "env": {
       "APP_ENV": {
-        "description": "Symfony environment mode. Unless developing the application, this should be production.",
+        "description": "Laravel environment mode. Unless developing the application, this should be production.",
         "value": "production"
       },
       "APP_DEBUG": {
-        "description": "Symfony debug mode. Unless developing the application or actively debugging a problem, this should be set to false.",
+        "description": "Laravel debug mode. Unless developing the application or actively debugging a problem, this should be set to false.",
         "value": "false"
       },
       "APP_KEY": {
-        "description": "A secret key for verifying the integrity of signed cookies. (See either https://snipe-it.readme.io/docs/install-dependencies or generate at https://coderstoolbox.online/toolbox/generate-symfony-secret)",
+        "description": "A secret key for verifying the integrity of signed cookies. (See either https://snipe-it.readme.io/docs/generate-your-app-key or generate at https://coderstoolbox.online/toolbox/generate-symfony-secret)",
         "value": ""
       },
       "APP_URL": {

--- a/heroku/startup.php
+++ b/heroku/startup.php
@@ -1,0 +1,47 @@
+<?php
+// Snipe-IT Heroku Startup Script
+
+// If DB_<value> values are set, ignore parser.
+if (getenv("DB_DATABASE") || getenv("DB_HOST") || getenv("DB_USERNAME")) {
+  echo "Database Environment variables are manually set. Ignoring add-ins.";
+} else if (getenv("CLEARDB_DATABASE_URL")) {  // ClearDB Add-in
+  echo "Using ClearDB Heroku add-in." . PHP_EOL;
+  set_db(getenv('CLEARDB_DATABASE_URL'));
+} else if (getenv("JAWSDB_MARIA_URL")) {      // JawsDB Maria Add-in
+  echo "Using JawsDB Maria Heroku add-in." . PHP_EOL;
+  set_db(getenv("JAWSDB_MARIA_URL"));
+} else if (getenv("JAWSDB_MYSQL_URL")) {      // JawsDB MySQL Add-in
+  echo "Using JawsDB MySQL Heroku add-in." . PHP_EOL;
+  set_db(getenv("JAWSDB_MYSQL_URL"));
+}
+
+function set_db($uri) {
+  file_put_contents('./.env', 'DB_HOST='     . parse_url($uri, PHP_URL_HOST). PHP_EOL, FILE_APPEND);
+  file_put_contents('./.env', 'DB_USERNAME=' . parse_url($uri, PHP_URL_USER). PHP_EOL, FILE_APPEND);
+  file_put_contents('./.env', 'DB_PASSWORD=' . parse_url($uri, PHP_URL_PASS). PHP_EOL, FILE_APPEND);
+  file_put_contents('./.env', 'DB_DATABASE=' . ltrim(parse_url($uri, PHP_URL_PATH), '/'). PHP_EOL, FILE_APPEND);
+}
+
+// If Heroku Redis is setup, let's get it working.
+if (getenv("REDIS_URL")) {                    // Heroku Redis
+  echo "Setting up Heroku Redis." . PHP_EOL;
+  $url = getenv("REDIS_URL");
+  file_put_contents('./.env', 'REDIS_HOST='     . parse_url($url, PHP_URL_HOST). PHP_EOL, FILE_APPEND);
+  file_put_contents('./.env', 'REDIS_PASSWORD=' . parse_url($url, PHP_URL_PASS). PHP_EOL, FILE_APPEND);
+  file_put_contents('./.env', 'REDIS_PORT='     . parse_url($url, PHP_URL_PORT). PHP_EOL, FILE_APPEND);
+}
+
+// Set up APP_TRUSTED_PROXIES to allow for the Heroku Router
+// https://devcenter.heroku.com/articles/deploying-symfony4#trusting-the-heroku-router
+file_put_contents('./.env', 'APP_TRUSTED_PROXIES=10.0.0.0/8' . PHP_EOL, FILE_APPEND); 
+
+// Set up GD
+file_put_contents('./.env', 'IMAGE_LIB=gd' . PHP_EOL, FILE_APPEND); 
+
+// Set local FILESYSTEM_DISK
+file_put_contents('./.env', 'FILESYSTEM_DISK=local' . PHP_EOL, FILE_APPEND); 
+
+// Set APP_CIPHER
+file_put_contents('./.env', 'APP_CIPHER=AES-256-CBC' . PHP_EOL, FILE_APPEND); 
+
+?>

--- a/heroku/startup.php
+++ b/heroku/startup.php
@@ -20,6 +20,9 @@ function set_db($uri) {
   file_put_contents('./.env', 'DB_USERNAME=' . parse_url($uri, PHP_URL_USER). PHP_EOL, FILE_APPEND);
   file_put_contents('./.env', 'DB_PASSWORD=' . parse_url($uri, PHP_URL_PASS). PHP_EOL, FILE_APPEND);
   file_put_contents('./.env', 'DB_DATABASE=' . ltrim(parse_url($uri, PHP_URL_PATH), '/'). PHP_EOL, FILE_APPEND);
+  file_put_contents('./.env', 'DB_PREFIX=' . 'null' . PHP_EOL, FILE_APPEND);
+  file_put_contents('./.env', 'DB_DUMP_PATH=' . 'null' . PHP_EOL, FILE_APPEND);
+
 }
 
 // If Heroku Redis is setup, let's get it working.

--- a/heroku/startup.php
+++ b/heroku/startup.php
@@ -38,8 +38,9 @@ file_put_contents('./.env', 'APP_TRUSTED_PROXIES=10.0.0.0/8' . PHP_EOL, FILE_APP
 // Set up GD
 file_put_contents('./.env', 'IMAGE_LIB=gd' . PHP_EOL, FILE_APPEND); 
 
-// Set local FILESYSTEM_DISK
+// Set local FILESYSTEM_DISK and PUBLIC_FILESYSTEM_DISK
 file_put_contents('./.env', 'FILESYSTEM_DISK=local' . PHP_EOL, FILE_APPEND); 
+file_put_contents('./.env', 'PUBLIC_FILESYSTEM_DISK=local_public' . PHP_EOL, FILE_APPEND);
 
 // Set APP_CIPHER
 file_put_contents('./.env', 'APP_CIPHER=AES-256-CBC' . PHP_EOL, FILE_APPEND); 


### PR DESCRIPTION
# Description

This PR adds support for Heroku one-click deployments directly from the GitHub Readme page of the application. This also unlocks the ability for developers to test changes inside of Heroku using automatic deploys of their own fork, allowing for faster iteration of a production like containerized environment. This PR only focuses on the core functionality of the application deployment and has not been fully tested to ensure point-for-point compatibility with all functionality of a standard installation of Snipe-IT.

This PR does make use of a number of Heroku add-ons, all with Free tiers to help offload some of the background processes:
* ClearDB for MySQL DB Hosting
* Heroku Redis for Redis Session Management Hosting
* Papertrail Logs for Log Aggregation and Analytics

The defaults for each of these add-ons are set to use the Free tier available. Upgrades may be necessary to enable functionality available for making the application production-ready. My intention would be to include a guide of this in the documentation once this PR is accepted.

I've similarly added in support for JawsDB MySQL + Maria DB Hosting as well for users that may wish to use that provider.

The files added at the root of the repo are app.json (a file describing all of the environment variables, add-ons, and other various application settings that are needed to get everything going), a Procfile (the command run to start and run the container), and the heroku/startup.php file (used to populate/parse out some environment variables that are necessary to run the application).

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

The Deploy to Heroku button located on [my develop branch's README.md](https://github.com/jasonspriggs/snipe-it/tree/develop) prompts the user for the most common environment variables and stands up a working copy of Snipe-IT once those variables are filled in.

**Test Configuration**:
* PHP version: 7.4.23
* MySQL version: (depends on upstream add-on provider)
* Webserver version: 2.4.48
* OS version: Heroku-20 PHP Buildpack


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
