### PR TITLE
Fixed #9973 - add use_default_eula to category endpoint

### DIFF
--- a/app/Http/Transformers/CategoriesTransformer.php
+++ b/app/Http/Transformers/CategoriesTransformer.php
@@ -29,6 +29,7 @@ class CategoriesTransformer
                 'image' =>   ($category->image) ? Storage::disk('public')->url('categories/'.e($category->image)) : null,
                 'category_type' => ucwords(e($category->category_type)),
                 'has_eula' => ($category->getEula() ? true : false),
+                'use_default_eula' => ($category->use_default_eula=='1' ? true : false),
                 'eula' => ($category->getEula()),
                 'checkin_email' => ($category->checkin_email =='1'),
                 'require_acceptance' => ($category->require_acceptance == '1'),

--- a/app/Presenters/CategoryPresenter.php
+++ b/app/Presenters/CategoryPresenter.php
@@ -57,6 +57,13 @@ class CategoryPresenter extends Presenter
                 "visible" => false,
                 "formatter" => 'trueFalseFormatter',
             ],[
+                "field" => "use_default_eula",
+                "searchable" => false,
+                "sortable" => true,
+                "title" => trans('admin/categories/general.use_default_eula_column'),
+                "visible" => false,
+                "formatter" => 'trueFalseFormatter',
+            ],[
                 "field" => "checkin_email",
                 "searchable" => false,
                 "sortable" => true,

--- a/resources/lang/en/admin/categories/general.php
+++ b/resources/lang/en/admin/categories/general.php
@@ -17,6 +17,7 @@ return array(
     'no_default_eula'					=> 'No primary default EULA found. Add one in Settings.',
     'update'  							=> 'Update Category',
     'use_default_eula'					=> 'Use the <a href="#" data-toggle="modal" data-target="#eulaModal">primary default EULA</a> instead.',
+    'use_default_eula_column'			=> 'Use default EULA',
     'use_default_eula_disabled'			=> '<del>Use the primary default EULA instead.</del> No primary default EULA is set. Please add one in Settings.',
 
 );


### PR DESCRIPTION
```json
{
    "id": 1,
    "name": "Laptops",
    "image": null,
    "category_type": "Asset",
    "has_eula": true,
    "use_default_eula": true,
    "eula": "<p>Sunt distinctio quo eum reiciendis. Quidem qui totam et dolorem sequi maiores sunt. Quo ut nihil ut fuga. Quo non ipsam autem.</p>",
    "checkin_email": false,
    "require_acceptance": true,
    "item_count": 1173,
    "assets_count": 0,
    "accessories_count": 0,
    "consumables_count": 0,
    "components_count": 0,
    "licenses_count": 0,
    "created_at": {
        "datetime": "2021-06-11 22:39:33",
        "formatted": "Fri Jun 11, 2021 10:39PM"
    },
    "updated_at": {
        "datetime": "2021-06-11 22:39:33",
        "formatted": "Fri Jun 11, 2021 10:39PM"
    },
    "available_actions": {
        "update": true,
        "delete": false
    }
}
```