### PR TITLE
Fixes #10015. Archived Assets Showing Under Locations/'Print All Assigned' Feature

### DIFF
--- a/resources/views/locations/print.blade.php
+++ b/resources/views/locations/print.blade.php
@@ -122,7 +122,7 @@
             </tr>
         </thead>
 		@php
-        	$counter = 1;;
+        	$counter = 1;
     	@endphp
     	
     	@foreach ($assets as $asset)

--- a/resources/views/locations/print.blade.php
+++ b/resources/views/locations/print.blade.php
@@ -122,11 +122,15 @@
             </tr>
         </thead>
 		@php
-        	$counter = 1;
+        	$counter = 1;;
     	@endphp
     	
     	@foreach ($assets as $asset)
-
+            @php
+                if($snipeSettings->show_archived_in_list != 1 && $asset->assetstatus->name === 'Archived'){
+                    continue;
+                }
+            @endphp
         <tr>
         <td>{{ $counter }}</td>
         <td>{{ $asset->asset_tag }}</td>

--- a/resources/views/locations/print.blade.php
+++ b/resources/views/locations/print.blade.php
@@ -127,7 +127,7 @@
     	
     	@foreach ($assets as $asset)
             @php
-                if($snipeSettings->show_archived_in_list != 1 && $asset->assetstatus->name === 'Archived'){
+                if($snipeSettings->show_archived_in_list != 1 && $asset->assetstatus->archived == 1){
                     continue;
                 }
             @endphp


### PR DESCRIPTION

# Description
When viewing a Location we can print all assets assigned to that location, but the report to print shows the Archived ones even if the option to do that is not activated. This is not my finest solution performance-wise but let me know what you think.

I added a condition for when the asset is marked as 'Archived' and the option in settings is not activated, in the report I just skip that asset and continue the loop that prints' em, as I was unable to filter' em from the query, :man_shrugging: 

Fixes #10015

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
