### PR TITLE
Upgrade Docker to PHP 7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:bionic
-LABEL maintainer Brady Wetherington <uberbrady@gmail.com>
+FROM ubuntu:focal
+LABEL maintainer Brady Wetherington <bwetherington@grokability.com>
 
 # No need to add `apt-get clean` here, reference:
 # - https://github.com/snipe/snipe-it/pull/9201
@@ -14,15 +14,15 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
 apt-utils \
 apache2 \
 apache2-bin \
-libapache2-mod-php7.2 \
-php7.2-curl \
-php7.2-ldap \
-php7.2-mysql \
-php7.2-gd \
-php7.2-xml \
-php7.2-mbstring \
-php7.2-zip \
-php7.2-bcmath \
+libapache2-mod-php7.4 \
+php7.4-curl \
+php7.4-ldap \
+php7.4-mysql \
+php7.4-gd \
+php7.4-xml \
+php7.4-mbstring \
+php7.4-zip \
+php7.4-bcmath \
 patch \
 curl \
 wget  \
@@ -38,7 +38,7 @@ autoconf \
 libc-dev \
 pkg-config \
 libmcrypt-dev \
-php7.2-dev \
+php7.4-dev \
 ca-certificates \
 unzip \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -47,16 +47,16 @@ unzip \
 RUN curl -L -O https://github.com/pear/pearweb_phars/raw/master/go-pear.phar
 RUN php go-pear.phar
 
-RUN pecl install mcrypt-1.0.2
+RUN pecl install mcrypt-1.0.3
 
-RUN bash -c "echo extension=/usr/lib/php/20170718/mcrypt.so > /etc/php/7.2/mods-available/mcrypt.ini"
+RUN bash -c "echo extension=/usr/lib/php/20190902/mcrypt.so > /etc/php/7.4/mods-available/mcrypt.ini"
 
 RUN phpenmod mcrypt
 RUN phpenmod gd
 RUN phpenmod bcmath
 
-RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/7.2/apache2/php.ini
-RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/7.2/cli/php.ini
+RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/7.4/apache2/php.ini
+RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/7.4/cli/php.ini
 
 RUN useradd -m --uid 1000 --gid 50 docker
 


### PR DESCRIPTION
Moving our Docker environment to a later version of PHP is going to be a requirement for Snipe-IT v6. The current v5 uses PHP 7.2, which is too old for Snipe-IT v6. I could've put this change on our v6 integration branch, but I feel like the benefits to the v5 users are too great to make our current v5 users wait for it. So hopefully, when we do implement the Great and Final merge from v6 to develop, we don't accidentally step on this change. I guess we'll see :/

We do have other Dockerfiles for Alpine, but I don't know which versions of PHP those use, as I'm not particularly familiar with them.