### PR TITLE
add rewrite rule for Let's Encrypt certificates

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,6 +5,9 @@
 
     RewriteEngine On
 
+    # Needed for https://letsencrypt.org/ certificates.
+    RewriteRule ^\.well-known/acme-challenge/ - [END]
+
     # Uncomment these two lines to force SSL redirect in Apache
     # RewriteCond %{HTTPS} off
     # RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]


### PR DESCRIPTION
The LE tools need access to a stable path to automatically obtain
certificates, so add a rewrite rule to allow it.
