### PR TITLE
Fixed extraneous asset search in depreciation report

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -102,11 +102,7 @@ class ReportsController extends Controller
     {
         $this->authorize('reports.view');
         $depreciations = Depreciation::get();
-        // Grab all the assets
-        $assets = Asset::with( 'assignedTo', 'assetstatus', 'defaultLoc', 'location', 'company', 'model.category', 'model.depreciation')
-                       ->orderBy('created_at', 'DESC')->get();
-
-        return view('reports/depreciation', compact('assets'))->with('depreciations',$depreciations);
+        return view('reports/depreciation')->with('depreciations',$depreciations);
     }
 
     /**


### PR DESCRIPTION
This fixes something I missed in #10034. In that PR, I made the depreciation report AJAXed in via bootstrap tables, but neglected to pull out the asset query that was so bulky to start with. This should hopefully make that depreciation report page load much faster for Snipe-IT users with hundreds of thousands of assets.