### PR TITLE
Fixed issue when creating a status label via API - default_label and show_in_nav being not nullable

### DIFF
--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -73,7 +73,7 @@ class StatuslabelsController extends Controller
         $statuslabel->archived          =  $statusType['archived'];
         $statuslabel->color             =  $request->input('color');
         $statuslabel->show_in_nav       =  $request->input('show_in_nav', 0);
-        $statuslabel->default_label     =  $request->input('default_label');
+        $statuslabel->default_label     =  $request->input('default_label', 0);
 
 
         if ($statuslabel->save()) {
@@ -124,8 +124,8 @@ class StatuslabelsController extends Controller
         $statuslabel->pending           =  $statusType['pending'];
         $statuslabel->archived          =  $statusType['archived'];
         $statuslabel->color             =  $request->input('color');
-        $statuslabel->show_in_nav       =  $request->input('show_in_nav');
-        $statuslabel->default_label     =  $request->input('default_label');
+        $statuslabel->show_in_nav       =  $request->input('show_in_nav', 0);
+        $statuslabel->default_label     =  $request->input('default_label', 0);
 
         if ($statuslabel->save()) {
             return response()->json(Helper::formatStandardApiResponse('success', $statuslabel, trans('admin/statuslabels/message.update.success')));

--- a/database/migrations/2016_08_23_145619_add_show_in_nav_to_status_labels.php
+++ b/database/migrations/2016_08_23_145619_add_show_in_nav_to_status_labels.php
@@ -13,7 +13,7 @@ class AddShowInNavToStatusLabels extends Migration
     public function up()
     {
         Schema::table('status_labels', function (Blueprint $table) {
-            $table->boolean('show_in_nav')->default(0);
+            $table->boolean('show_in_nav')->nullable()->default(0);
         });
     }
 

--- a/database/migrations/2018_03_06_054937_add_default_flag_on_statuslabels.php
+++ b/database/migrations/2018_03_06_054937_add_default_flag_on_statuslabels.php
@@ -14,7 +14,7 @@ class AddDefaultFlagOnStatuslabels extends Migration
     public function up()
     {
         Schema::table('status_labels', function (Blueprint $table) {
-            $table->boolean('default_label')->default(0);
+            $table->boolean('default_label')->nullable()->default(0);
         });
     }
 

--- a/database/migrations/2021_09_20_183216_change_default_label_to_nullable.php
+++ b/database/migrations/2021_09_20_183216_change_default_label_to_nullable.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeDefaultLabelToNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     * 
+     * This is stupid because it has a default valuye of 0 so it *should* 
+     * default to 0, but it doesn't on some versions of MySQL. 
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('nullable', function (Blueprint $table) {
+            Schema::table('status_labels', function (Blueprint $table) {
+                $table->boolean('default_label')->nullable()->default(0);
+                $table->boolean('show_in_nav')->nullable()->default(0);
+            });
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('nullable', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2021_09_20_183216_change_default_label_to_nullable.php
+++ b/database/migrations/2021_09_20_183216_change_default_label_to_nullable.php
@@ -16,12 +16,12 @@ class ChangeDefaultLabelToNullable extends Migration
      */
     public function up()
     {
-        Schema::table('nullable', function (Blueprint $table) {
-            Schema::table('status_labels', function (Blueprint $table) {
-                $table->boolean('default_label')->nullable()->default(0);
-                $table->boolean('show_in_nav')->nullable()->default(0);
-            });
+
+        Schema::table('status_labels', function (Blueprint $table) {
+            $table->boolean('default_label')->nullable()->default(0)->change();
+            $table->boolean('show_in_nav')->nullable()->default(0)->change();
         });
+
     }
 
     /**
@@ -31,8 +31,6 @@ class ChangeDefaultLabelToNullable extends Migration
      */
     public function down()
     {
-        Schema::table('nullable', function (Blueprint $table) {
-            //
-        });
+        //
     }
 }

--- a/database/migrations/2021_09_20_183216_change_default_label_to_nullable.php
+++ b/database/migrations/2021_09_20_183216_change_default_label_to_nullable.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use App\Models\Statuslabel;
 
 class ChangeDefaultLabelToNullable extends Migration
 {
@@ -17,10 +18,19 @@ class ChangeDefaultLabelToNullable extends Migration
     public function up()
     {
 
+
+        Statuslabel::whereNull('default_label')
+        ->update(['default_label' => 0]);
+
+        Statuslabel::whereNull('show_in_nav')
+        ->update(['show_in_nav' => 0]);
+
+
         Schema::table('status_labels', function (Blueprint $table) {
             $table->boolean('default_label')->nullable()->default(0)->change();
             $table->boolean('show_in_nav')->nullable()->default(0)->change();
         });
+
 
     }
 


### PR DESCRIPTION
This just sets some defaults in the code and updates the field to be nullable so it at least won't throw an error. Fixes RB#15683 