### PR TITLE
Fixes pave command to persist api keys and first few test users

### DIFF
--- a/app/Console/Commands/PaveIt.php
+++ b/app/Console/Commands/PaveIt.php
@@ -79,7 +79,10 @@ class PaveIt extends Command
                     }
                     
                 }   
-                \DB::statement('delete from users WHERE id!=1' 
+                \DB::statement('delete from users WHERE id > 2');
+                \DB::statement('delete from oauth_clients WHERE id > 2');
+                \DB::statement('delete from oauth_access_tokens WHERE id > 2');
+                
         }
     }
 }

--- a/app/Console/Commands/PaveIt.php
+++ b/app/Console/Commands/PaveIt.php
@@ -29,15 +29,14 @@ class PaveIt extends Command
      *
      * @var string
      */
-    protected $signature = 'snipeit:pave
-              {--soft : Perform a "Soft" Delete, leaving all migrations, table structure, and the first user in place.}';
+    protected $signature = 'snipeit:pave';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Pave the database to start over. This should ALMOST NEVER BE USED. (It is primarily a quick tool for developers.)';
+    protected $description = 'Clear the database tables, leaving all migrations, table structure, and the first user in place. (It is primarily a quick tool for developers.) If you want to destroy all tables as well, use php artisan db:wipe.';
 
     /**
      * Create a new command instance.
@@ -57,105 +56,30 @@ class PaveIt extends Command
     public function handle()
     {
         if ($this->confirm("\n****************************************************\nTHIS WILL DELETE ALL OF THE DATA IN YOUR DATABASE. \nThere is NO undo. This WILL destroy ALL of your data. \n****************************************************\n\nDo you wish to continue? No backsies! [y|N]")) {
-            if ($this->option('soft')) {
-                Accessory::getQuery()->delete();
-                Asset::getQuery()->delete();
-                Category::getQuery()->delete();
-                Company::getQuery()->delete();
-                Component::getQuery()->delete();
-                Consumable::getQuery()->delete();
-                Department::getQuery()->delete();
-                Depreciation::getQuery()->delete();
-                License::getQuery()->delete();
-                LicenseSeat::getQuery()->delete();
-                Location::getQuery()->delete();
-                Manufacturer::getQuery()->delete();
-                AssetModel::getQuery()->delete();
-                Statuslabel::getQuery()->delete();
-                Supplier::getQuery()->delete();
-                Group::getQuery()->delete();
-                Import::getQuery()->delete();
 
-                DB::statement('delete from accessories_users');
-                DB::statement('delete from asset_logs');
-                DB::statement('delete from asset_maintenances');
-                DB::statement('delete from login_attempts');
-                DB::statement('delete from asset_uploads');
-                DB::statement('delete from action_logs');
-                DB::statement('delete from checkout_requests');
-                DB::statement('delete from checkout_acceptances');
-                DB::statement('delete from consumables_users');
-                DB::statement('delete from custom_field_custom_fieldset');
-                DB::statement('delete from custom_fields');
-                DB::statement('delete from custom_fieldsets');
-                DB::statement('delete from components_assets');
-                DB::statement('delete from kits');
-                DB::statement('delete from kits_accessories');
-                DB::statement('delete from kits_consumables');
-                DB::statement('delete from kits_licenses');
-                DB::statement('delete from kits_models');
-                DB::statement('delete from login_attempts');
-                DB::statement('delete from models_custom_fields');
-                DB::statement('delete from permission_groups');
-                DB::statement('delete from password_resets');
-                DB::statement('delete from requested_assets');
-                DB::statement('delete from requests');
-                DB::statement('delete from throttle');
-                DB::statement('delete from users_groups');
-                DB::statement('delete from users WHERE id!=1');
-            } else {
-                \DB::statement('drop table IF EXISTS accessories_users');
-                \DB::statement('drop table IF EXISTS accessories');
-                \DB::statement('drop table IF EXISTS asset_logs');
-                \DB::statement('drop table IF EXISTS action_logs');
-                \DB::statement('drop table IF EXISTS asset_maintenances');
-                \DB::statement('drop table IF EXISTS asset_uploads');
-                \DB::statement('drop table IF EXISTS assets');
-                \DB::statement('drop table IF EXISTS categories');
-                \DB::statement('drop table IF EXISTS checkout_requests');
-                \DB::statement('drop table IF EXISTS checkout_acceptances');
-                \DB::statement('drop table IF EXISTS companies');
-                \DB::statement('drop table IF EXISTS components');
-                \DB::statement('drop table IF EXISTS components_assets');
-                \DB::statement('drop table IF EXISTS consumables_users');
-                \DB::statement('drop table IF EXISTS consumables');
-                \DB::statement('drop table IF EXISTS custom_field_custom_fieldset');
-                \DB::statement('drop table IF EXISTS custom_fields');
-                \DB::statement('drop table IF EXISTS custom_fieldsets');
-                \DB::statement('drop table IF EXISTS depreciations');
-                \DB::statement('drop table IF EXISTS departments');
-                \DB::statement('drop table IF EXISTS groups');
-                \DB::statement('drop table IF EXISTS history');
-                \DB::statement('drop table IF EXISTS kits');
-                \DB::statement('drop table IF EXISTS kits_accessories');
-                \DB::statement('drop table IF EXISTS kits_consumables');
-                \DB::statement('drop table IF EXISTS kits_licenses');
-                \DB::statement('drop table IF EXISTS kits_models');
-                \DB::statement('drop table IF EXISTS models_custom_fields');
-                \DB::statement('drop table IF EXISTS permission_groups');
-                \DB::statement('drop table IF EXISTS license_seats');
-                \DB::statement('drop table IF EXISTS licenses');
-                \DB::statement('drop table IF EXISTS locations');
-                \DB::statement('drop table IF EXISTS login_attempts');
-                \DB::statement('drop table IF EXISTS manufacturers');
-                \DB::statement('drop table IF EXISTS models');
-                \DB::statement('drop table IF EXISTS migrations');
-                \DB::statement('drop table IF EXISTS oauth_access_tokens');
-                \DB::statement('drop table IF EXISTS oauth_auth_codes');
-                \DB::statement('drop table IF EXISTS oauth_clients');
-                \DB::statement('drop table IF EXISTS oauth_personal_access_clients');
-                \DB::statement('drop table IF EXISTS oauth_refresh_tokens');
-                \DB::statement('drop table IF EXISTS password_resets');
-                \DB::statement('drop table IF EXISTS requested_assets');
-                \DB::statement('drop table IF EXISTS requests');
-                \DB::statement('drop table IF EXISTS settings');
-                \DB::statement('drop table IF EXISTS status_labels');
-                \DB::statement('drop table IF EXISTS suppliers');
-                \DB::statement('drop table IF EXISTS throttle');
-                \DB::statement('drop table IF EXISTS users_groups');
-                \DB::statement('drop table IF EXISTS users');
-                \DB::statement('drop table IF EXISTS imports');
-            }
+            $tables = DB::connection()->getDoctrineSchemaManager()->listTableNames();
+
+                $except_tables = [
+                    'oauth_access_tokens',
+                    'oauth_clients',
+                    'oauth_personal_access_clients',
+                    'migrations',
+                    'settings',
+                    'users',
+                ];
+
+                foreach ($tables as $table) {
+
+                    $this->info($table);
+                    
+                    if (in_array($table, $except_tables)) {
+                        $this->info('Table '. $table. ' will be skipped');
+                    } else {
+                        \DB::statement('delete from '.$table);
+                    }
+                    
+                }   
+                \DB::statement('delete from users WHERE id!=1' 
         }
     }
 }

--- a/app/Console/Commands/PaveIt.php
+++ b/app/Console/Commands/PaveIt.php
@@ -2,23 +2,9 @@
 
 namespace App\Console\Commands;
 
-use App\Models\Accessory;
 use App\Models\Asset;
-use App\Models\AssetModel;
-use App\Models\Category;
-use App\Models\Company;
-use App\Models\Component;
-use App\Models\Consumable;
-use App\Models\Department;
-use App\Models\Depreciation;
-use App\Models\Group;
-use App\Models\Import;
-use App\Models\License;
-use App\Models\LicenseSeat;
-use App\Models\Location;
-use App\Models\Manufacturer;
-use App\Models\Statuslabel;
-use App\Models\Supplier;
+use App\Models\CustomField;
+use Schema;
 use DB;
 use Illuminate\Console\Command;
 
@@ -57,32 +43,43 @@ class PaveIt extends Command
     {
         if ($this->confirm("\n****************************************************\nTHIS WILL DELETE ALL OF THE DATA IN YOUR DATABASE. \nThere is NO undo. This WILL destroy ALL of your data. \n****************************************************\n\nDo you wish to continue? No backsies! [y|N]")) {
 
+            // List all the tables in the database so we don't have to worry about missing some as the app grows
             $tables = DB::connection()->getDoctrineSchemaManager()->listTableNames();
 
-                $except_tables = [
-                    'oauth_access_tokens',
-                    'oauth_clients',
-                    'oauth_personal_access_clients',
-                    'migrations',
-                    'settings',
-                    'users',
-                ];
+            $except_tables = [
+                'oauth_access_tokens',
+                'oauth_clients',
+                'oauth_personal_access_clients',
+                'migrations',
+                'settings',
+                'users',
+            ];
 
-                foreach ($tables as $table) {
+            // We only need to find out what these are so we can nuke these columns on the assets table.
+            $custom_fields = CustomField::get();
+            foreach ($custom_fields as $custom_field) {
+                $this->info('Drop the '.$custom_field->db_column.' column from assets as well.');
 
-                    $this->info($table);
-                    
-                    if (in_array($table, $except_tables)) {
-                        $this->info('Table '. $table. ' will be skipped');
-                    } else {
-                        \DB::statement('delete from '.$table);
-                    }
-                    
-                }   
-                \DB::statement('delete from users WHERE id > 2');
-                \DB::statement('delete from oauth_clients WHERE id > 2');
-                \DB::statement('delete from oauth_access_tokens WHERE id > 2');
-                
+                if (\Schema::hasColumn('assets', $custom_field->db_column)) {
+                    \Schema::table('assets', function ($table) use ($custom_field) {
+                        $table->dropColumn($custom_field->db_column);
+                    });
+                }
+            }
+
+            foreach ($tables as $table) {
+                if (in_array($table, $except_tables)) {
+                    $this->info('Table '. $table. ' is skipped');
+                } else {
+                    \DB::statement('truncate '.$table);
+                    $this->info('Table '. $table. ' is truncated');
+                }
+            }
+
+            // Leave in the demo oauth keys so we don't have to reset them every day in the demos
+            //\DB::statement('delete from users WHERE id > 2');
+            \DB::statement('delete from oauth_clients WHERE id > 2');
+            \DB::statement('delete from oauth_access_tokens WHERE id > 2');
         }
     }
 }


### PR DESCRIPTION
This PR hopes to handle our demo a little better (as well as other people developing on the platform that want to start *kind of* from scratch, without wiping the entire DB). 

In the before times, we used this `php artisan snipeit:pave` method to blow out the contents of the demo tables, which we would then reseed with dummy data to make the demo easy to understand using "real world" assets like iPhones, etc. 

Then, we switched to `php artisan db:wipe` in an effort to better handle leftover custom field columns that were hangers-on in the assets table, since those columns get created on the fly, but seeding would clear out the custom fields table without handling those extra custom field asset columns. This means that while the demo would get re-seeded properly most of the time, once a few hundred custom fields had been created, I'd have to go in and manually remove those (now) extraneous fields on the assets table, which was, as you can imagine, very time consuming and terrible. 

`php artisan db:wipe` is SUPER HANDY in development, except when you've got a public API. 

What we hadn't realized was happening tho is that the `db:wipe` was clearing out the two users we create and that are used by the public API explorer, which basically meant that every day, the API key would have to be recreated and re-added to the public demo at https://snipe-it.readme.io/reference/api-overview, since we re-seed data daily. 

```
✨snipe@deepthought✨ snipe-it  (fixes/revamp_pave_command_to_persist_api_keys) $ php artisan snipeit:pave


****************************************************
THIS WILL DELETE ALL OF THE DATA IN YOUR DATABASE.
There is NO undo. This WILL destroy ALL of your data.
****************************************************

Do you wish to continue? No backsies! [y|N] (yes/no) [no]:
 > yes

Drop the _snipeit_imei_1 column from assets as well.
Drop the _snipeit_phone_number_2 column from assets as well.
Drop the _snipeit_ram_3 column from assets as well.
Drop the _snipeit_cpu_4 column from assets as well.
Drop the _snipeit_mac_address_5 column from assets as well.
Table accessories is truncated
Table accessories_users is truncated
Table action_logs is truncated
Table asset_logs is truncated
Table asset_maintenances is truncated
Table asset_uploads is truncated
Table assets is truncated
Table categories is truncated
Table checkout_acceptances is truncated
Table checkout_requests is truncated
Table companies is truncated
Table components is truncated
Table components_assets is truncated
Table consumables is truncated
Table consumables_users is truncated
Table custom_field_custom_fieldset is truncated
Table custom_fields is truncated
Table custom_fieldsets is truncated
Table departments is truncated
Table depreciations is truncated
Table imports is truncated
Table kits is truncated
Table kits_accessories is truncated
Table kits_consumables is truncated
Table kits_licenses is truncated
Table kits_models is truncated
Table license_seats is truncated
Table licenses is truncated
Table locations is truncated
Table login_attempts is truncated
Table manufacturers is truncated
Table migrations is skipped
Table models is truncated
Table models_custom_fields is truncated
Table oauth_access_tokens is skipped
Table oauth_auth_codes is truncated
Table oauth_clients is skipped
Table oauth_personal_access_clients is skipped
Table oauth_refresh_tokens is truncated
Table password_resets is truncated
Table permission_groups is truncated
Table requested_assets is truncated
Table requests is truncated
Table settings is skipped
Table status_labels is truncated
Table suppliers is truncated
Table throttle is truncated
Table users is skipped
Table users_groups is truncated
```

I've also pulled the drop tables stuff, since if that's the world you want, it's best to just use the built-in laravel `php artisan db:wipe` command.

### Testing

The easiest way I have been testing this is by running it in a local dev environment, re-seeding the database using `php artisan db:seed`, re-running the `php artisan snipeit:pave` command, making sure that all checks out, then re-seeding. 

TYVM for the confirm workaround, @uberbrady - I'm massively annoyed that Laravel doesn't have a better way to handle it, but I guess this is fine for now.