### PR TITLE
Added restore functionality to user API

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -474,4 +474,26 @@ class UsersController extends Controller
     {
         return (new UsersTransformer)->transformUser($request->user());
     }
+
+    /**
+     * Restore a soft-deleted user.
+     *
+     * @author [E. Taylor] [<dev@evantaylor.name>]
+     * @param int $userId
+     * @since [v6.0.0]
+     * @return JsonResponse
+     */
+    public function restore($userId = null)
+    {
+        // Get asset information
+        $user = User::withTrashed()->find($userId);
+        $this->authorize('delete', $user);
+        if (isset($user->id)) {
+            // Restore the user
+            User::withTrashed()->where('id', $userId)->restore();
+
+            return response()->json(Helper::formatStandardApiResponse('success', null, trans('admin/users/message.success.restored')));
+        }
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/users/message.user_exists')), 200);
+    }
 }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -474,4 +474,28 @@ class UsersController extends Controller
     {
         return (new UsersTransformer)->transformUser($request->user());
     }
+
+    /**
+     * Restore a soft-deleted user.
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @param int $userId
+     * @since [v6.0.0]
+     * @return JsonResponse
+     */
+    public function restore($userId = null)
+    {
+        // Get asset information
+        $user = User::withTrashed()->find($userId);
+        $this->authorize('delete', $user);
+        if (isset($user->id)) {
+            // Restore the user
+            User::withTrashed()->where('id', $userId)->restore();
+
+            return response()->json(Helper::formatStandardApiResponse('success', null, trans('admin/users/message.success.restored')));
+        
+
+        }
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/users/message.user_exists')), 200);
+    }
 }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -494,6 +494,8 @@ class UsersController extends Controller
 
             return response()->json(Helper::formatStandardApiResponse('success', null, trans('admin/users/message.success.restored')));
         }
-        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/users/message.user_exists')), 200);
+        
+        $id = $userId;
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/users/message.user_not_found', compact('id'))), 200);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -896,6 +896,13 @@ Route::group(['prefix' => 'v1', 'middleware' => 'api'], function () {
             ]
             )->name('api.users.uploads');
 
+            Route::post('{user}/restore',
+                [
+                    Api\UsersController::class,
+                    'restore'
+                ]
+            )->name('api.users.restore');
+
         }); 
     
         Route::resource('users', 


### PR DESCRIPTION
# Description

Code adds the ability to restore a deleted user through the API. This supports a use-case where we delete users when they are no longer active but would like to restore them if they return to the organization. Code was copied from the asset restore API endpoint and modified for the user controller.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tests were run on the API endpoint within the dev environment using Postman to make the necessary API calls.

- [x] Create a user and delete it through web UI. Restore the user via the API and verify the user is no longer marked as deleted
- [x] Create a user and delete it through the API. Restore the user via the API and verify the user is no longer marked as deleted

**Test Configuration**:
* PHP version: 7.4
* MySQL version: 8.0.26
* Webserver version: Apache 2.4.41
* OS version: Ubuntu 20.04.3


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
