### PR TITLE
Improved Category API for category_type with strtolower() to make it case insensitive

### DIFF
--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -63,6 +63,7 @@ class CategoriesController extends Controller
         $this->authorize('create', Category::class);
         $category = new Category;
         $category->fill($request->all());
+        $category->category_type = strtolower($request->input('category_type'));
         $category = $request->handleImages($category);
 
         if ($category->save()) {
@@ -103,6 +104,7 @@ class CategoriesController extends Controller
         $this->authorize('update', Category::class);
         $category = Category::findOrFail($id);
         $category->fill($request->all());
+        $category->category_type = strtolower($request->input('category_type'));
         $category = $request->handleImages($category);
 
         if ($category->save()) {


### PR DESCRIPTION
Previous API calls would reject "Component" vs "component". While the documentation does state that the accepted types are "asset, accessory, consumable, component", this does a `strtolower()` to make the type case insensitive.

Fixed FD#22172 and CH#17189
