### PR TITLE
Fixed sorting on non-asset relations in API (FD#23117)

### DIFF
--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -97,14 +97,11 @@ class AccessoriesController extends Controller
                 $accessories = $accessories->OrderSupplier($order);
                 break;       
             default:
-                \Log::error('switch: order by default');
                 $accessories = $accessories->orderBy($column_sort, $order);
                 break;
         }
 
-        
-        //$accessories->orderBy($sort, $order);
-
+    
         $total = $accessories->count();
         $accessories = $accessories->skip($offset)->take($limit)->get();
         return (new AccessoriesTransformer)->transformAccessories($accessories, $total);

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -27,9 +27,23 @@ class AccessoriesController extends Controller
     public function index(Request $request)
     {
         $this->authorize('view', Accessory::class);
-        $allowed_columns = ['id','name','model_number','eol','notes','created_at','min_amt','company_id'];
+        
+        // This array is what determines which fields should be allowed to be sorted on ON the table itself, no relations
+        // Relations will be handled in query scopes a little further down.
+        $allowed_columns = 
+            [
+                'id',
+                'name',
+                'model_number',
+                'eol',
+                'notes',
+                'created_at',
+                'min_amt',
+                'company_id'
+            ];
 
-        $accessories = Accessory::with('category', 'company', 'manufacturer', 'users', 'location');
+
+        $accessories = Accessory::with('category', 'company', 'manufacturer', 'users', 'location', 'supplier');
 
         if ($request->filled('search')) {
             $accessories = $accessories->TextSearch($request->input('search'));
@@ -62,23 +76,34 @@ class AccessoriesController extends Controller
         // Check to make sure the limit is not higher than the max allowed
         ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
 
-
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
-        $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
+        $sort_override =  $request->input('sort');
+        $column_sort = in_array($sort_override, $allowed_columns) ? $sort_override : 'created_at';
 
-        switch ($sort) {
+        switch ($sort_override) {
             case 'category':
                 $accessories = $accessories->OrderCategory($order);
                 break;
             case 'company':
                 $accessories = $accessories->OrderCompany($order);
                 break;
+            case 'location':
+                $accessories = $accessories->OrderLocation($order);
+                break;
+            case 'manufacturer':
+                $accessories = $accessories->OrderManufacturer($order);
+                break;    
+            case 'supplier':
+                $accessories = $accessories->OrderSupplier($order);
+                break;       
             default:
-                $accessories = $accessories->orderBy($sort, $order);
+                \Log::error('switch: order by default');
+                $accessories = $accessories->orderBy($column_sort, $order);
                 break;
         }
 
-        $accessories->orderBy($sort, $order);
+        
+        //$accessories->orderBy($sort, $order);
 
         $total = $accessories->count();
         $accessories = $accessories->skip($offset)->take($limit)->get();

--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -26,8 +26,25 @@ class ComponentsController extends Controller
     public function index(Request $request)
     {
         $this->authorize('view', Component::class);
+
+        // This array is what determines which fields should be allowed to be sorted on ON the table itself, no relations
+        // Relations will be handled in query scopes a little further down.
+        $allowed_columns = 
+            [
+                'id',
+                'name',
+                'min_amt',
+                'order_number',
+                'serial',
+                'purchase_date',
+                'purchase_cost',
+                'qty',
+                'image',
+            ];
+
+
         $components = Company::scopeCompanyables(Component::select('components.*')
-            ->with('company', 'location', 'category'));
+            ->with('company', 'location', 'category', 'assets'));
 
         if ($request->filled('search')) {
             $components = $components->TextSearch($request->input('search'));
@@ -52,11 +69,12 @@ class ComponentsController extends Controller
         // Check to make sure the limit is not higher than the max allowed
         ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
 
-        $allowed_columns = ['id','name','min_amt','order_number','serial','purchase_date','purchase_cost','company','category','qty','location','image'];
+        
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
-        $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
+        $sort_override =  $request->input('sort');
+        $column_sort = in_array($sort_override, $allowed_columns) ? $sort_override : 'created_at';
 
-        switch ($sort) {
+        switch ($sort_override) {
             case 'category':
                 $components = $components->OrderCategory($order);
                 break;
@@ -67,7 +85,7 @@ class ComponentsController extends Controller
                 $components = $components->OrderCompany($order);
                 break;
             default:
-                $components = $components->orderBy($sort, $order);
+                $components = $components->orderBy($column_sort, $order);
                 break;
         }
 

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -378,4 +378,17 @@ class Accessory extends SnipeModel
     {
         return $query->leftJoin('manufacturers', 'accessories.manufacturer_id', '=', 'manufacturers.id')->orderBy('manufacturers.name', $order);
     }
+
+    /**
+    * Query builder scope to order on supplier
+    *
+    * @param  \Illuminate\Database\Query\Builder  $query  Query builder instance
+    * @param  text                              $order       Order
+    *
+    * @return \Illuminate\Database\Query\Builder          Modified query builder
+    */
+    public function scopeOrderSupplier($query, $order)
+    {
+        return $query->leftJoin('suppliers', 'accessories.supplier_id', '=', 'suppliers.id')->orderBy('suppliers.name', $order);
+    }
 }


### PR DESCRIPTION
This fixes an issue where some items (non-assets) were not sorting properly on relations via their query scopes. 

It also addresses a few places where we were not eager loading relations, causing an n+1 query issue, and adds Supplier as a sortable column via query scope for Accessories. 