### PR TITLE
Fixes API Issue when checking out a component 

### DIFF
--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -220,7 +220,7 @@ class ComponentsController extends Controller
         $this->authorize('checkout', $component);
 
 
-        if ($component->numRemaining() > $request->get('assigned_qty')) {
+        if ($component->numRemaining() >= $request->get('assigned_qty')) {
 
             if (!$asset = Asset::find($request->input('assigned_to'))) {
                 return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/hardware/message.does_not_exist')));


### PR DESCRIPTION
# Description
When trying to checking out a component that has only one item remaining via API, the system doesn't let to do it because the condition says `$component->numRemaining() > $request->get('assigned_qty')` and 1 is not higher than 1.

Fixes internal freshdesk #22199


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
