### PR TITLE
Fixed #9928: update expected field name for response list

### DIFF
--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -296,11 +296,11 @@ $(document).ready(function () {
                 });
 				
 				// makes sure we're not selecting the same thing twice for multiples
-				var filteredResponse = response.items.filter(function(item) {
+				var filteredResponse = response.results.filter(function(item) {
 					return currentlySelected.indexOf(+item.id) < 0;
 				});
 
-				var first = (currentlySelected.length > 0) ? filteredResponse[0] : response.items[0];
+				var first = (currentlySelected.length > 0) ? filteredResponse[0] : response.results[0];
 				
 				if(first && first.id) {
 					first.selected = true;


### PR DESCRIPTION
# Description

The existing code to handle the "enter key" / auto selections in Select2s for assets broke at some point. It was expecting the results collection to be in an "items" field, not a "results" field. 

Fixes # (9928 )

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested locally by updating minified JavaScript file in version 5.1.5.

**Test Configuration**:
* PHP version: PHP 7.3
* MySQL version: 10.2
* Webserver version: Apache 2.4
* OS version: RHEL 7


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
