### PR TITLE
Added assigned components to assets API

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -325,7 +325,7 @@ class AssetsController extends Controller
          * Include additional associated relationships
          */  
         if ($request->input('components')) {
-            $assets->load(['components' => function ($query) {
+            $assets->loadMissing(['components' => function ($query) {
                 $query->orderBy('created_at', 'desc');
             }]);
         }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -440,12 +440,12 @@ class UsersController extends Controller
      * @param $userId
      * @return string JSON
      */
-    public function assets($id)
+    public function assets(Request $request, $id)
     {
         $this->authorize('view', User::class);
         $this->authorize('view', Asset::class);
         $assets = Asset::where('assigned_to', '=', $id)->where('assigned_type', '=', User::class)->with('model')->get();
-        return (new AssetsTransformer)->transformAssets($assets, $assets->count());
+        return (new AssetsTransformer)->transformAssets($assets, $assets->count(), $request);
     }
 
     /**

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -134,6 +134,28 @@ class AssetsTransformer
         }
 
 
+
+        if (request('components')=='true') {
+        
+            if ($asset->components) {
+                $array['components'] = [];
+    
+                foreach ($asset->components as $component) {
+                    $array['components'][] = [
+                        [
+                            'id' => $component->id,
+                            'name' => $component->name,
+                            'qty' => $component->pivot->assigned_qty,
+                            'price_cost' => $component->purchase_cost,
+                            'purchase_total' => $component->purchase_cost * $component->pivot->assigned_qty,
+                            'checkout_date' => Helper::getFormattedDateObject($component->pivot->created_at, 'datetime') ,
+                        ]
+                    ];
+                }
+            }
+
+        }
+        
         $array += $permissions_array;
         return $array;
     }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -376,7 +376,7 @@ class Asset extends Depreciable
      */
     public function components()
     {
-        return $this->belongsToMany('\App\Models\Component', 'components_assets', 'asset_id', 'component_id')->withPivot('id', 'assigned_qty')->withTrashed();
+        return $this->belongsToMany('\App\Models\Component', 'components_assets', 'asset_id', 'component_id')->withPivot('id', 'assigned_qty', 'created_at')->withTrashed();
     }
 
 


### PR DESCRIPTION
By including `components=true` to the API request, we can now load the associated components. I'm not 100% sure here whether `load()`, `loadMissing(), or `with()` will be more performative, but the resulting JSON looks like this:

```json
{
    "id": 1358,
    "name": "",
    "asset_tag": "148671489",
    "serial": "d52c24bd-e6eb-30e5-804f-935d28a304b7",
    "model": {
        "id": 17,
        "name": "Ultrafine 4k"
    },
    "model_number": "341423500614500",
    "eol": {
        "date": "2021-10-09",
        "formatted": "Sat Oct 09, 2021"
    },
    "status_label": {
        "id": 1,
        "name": "Ready to Deploy",
        "status_type": "deployable",
        "status_meta": "deployed"
    },
    "category": {
        "id": 5,
        "name": "Displays"
    },
    "manufacturer": {
        "id": 7,
        "name": "LG"
    },
    "supplier": {
        "id": 1,
        "name": "Cummings-Satterfield"
    },
    "notes": "Created by DB seeder",
    "order_number": "44946029",
    "company": null,
    "location": {
        "id": 5,
        "name": "East Ineston"
    },
    "rtd_location": {
        "id": 8,
        "name": "South Margaritafort"
    },
    "image": "https://snipe-it.local:8890/uploads/models/ultrafine.jpg",
    "assigned_to": {
        "id": 4,
        "username": "okon.jaiden",
        "name": "Serena Cruickshank",
        "first_name": "Serena",
        "last_name": "Cruickshank",
        "employee_number": "30291",
        "type": "user"
    },
    "warranty_months": null,
    "warranty_expires": null,
    "created_at": {
        "datetime": "2021-09-20 21:25:04",
        "formatted": "Mon Sep 20, 2021 9:25PM"
    },
    "updated_at": {
        "datetime": "2021-09-20 21:25:20",
        "formatted": "Mon Sep 20, 2021 9:25PM"
    },
    "last_audit_date": null,
    "next_audit_date": null,
    "deleted_at": null,
    "purchase_date": {
        "date": "2020-10-09",
        "formatted": "Fri Oct 09, 2020"
    },
    "last_checkout": null,
    "expected_checkin": null,
    "purchase_cost": "906.37",
    "checkin_counter": 0,
    "checkout_counter": 0,
    "requests_counter": 0,
    "user_can_checkout": false,
    "custom_fields": [],
    "components": [
        [
            {
                "id": 2,
                "name": "Crucial 8GB DDR3L-1600 SODIMM Memory for Mac",
                "qty": 1,
                "price_cost": "48.35",
                "purchase_total": 48.35,
                "checkout_date": {
                    "datetime": "2021-09-23 19:04:10",
                    "formatted": "Thu Sep 23, 2021 7:04PM"
                }
            }
        ],
        [
            {
                "id": 2,
                "name": "Crucial 8GB DDR3L-1600 SODIMM Memory for Mac",
                "qty": 1,
                "price_cost": "48.35",
                "purchase_total": 48.35,
                "checkout_date": {
                    "datetime": "2021-09-23 19:09:06",
                    "formatted": "Thu Sep 23, 2021 7:09PM"
                }
            }
        ],
        [
            {
                "id": 3,
                "name": "Crucial BX300 120GB SATA Internal SSD",
                "qty": 4,
                "price_cost": "13.21",
                "purchase_total": 52.84,
                "checkout_date": {
                    "datetime": "2021-09-23 19:09:16",
                    "formatted": "Thu Sep 23, 2021 7:09PM"
                }
            }
        ]
    ],
    "available_actions": {
        "checkout": true,
        "checkin": true,
        "clone": true,
        "restore": false,
        "update": true,
        "delete": false
    }
}
```

By only requesting this on demand, it allows us to exclude it from the regular API calls (and therefore not bog down the queries, which are already doing a LOT of relationship loading.)