### PR TITLE
Fixes New department error importing users.

### DIFF
--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -118,6 +118,10 @@ class UserImporter extends ItemImporter
      */
     public function createOrFetchDepartment($department_name)
     {
+        if(is_null($department_name)){
+            return null;
+        }
+
         $department = Department::where(['name' => $department_name])->first();
         if ($department) {
             $this->log('A matching department '.$department_name.' already exists');

--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -118,10 +118,10 @@ class UserImporter extends ItemImporter
      */
     public function createOrFetchDepartment($department_name)
     {
-        if(is_null($department_name)){
+        if(is_null($department_name) || $department_name == ''){
             return null;
         }
-
+        
         $department = Department::where(['name' => $department_name])->first();
         if ($department) {
             $this->log('A matching department '.$department_name.' already exists');


### PR DESCRIPTION
# Description
When importing users, if the department is not setted or it hasn't any value, the import fails. I added a condition to check this and return early without error, as the Department value is not required for import Users.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Fixes internal freshdesk 23458

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
