### PR TITLE
[Docker] Fix ownership of cache directory in startup script

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -40,6 +40,7 @@ done
 chown -R docker:root /var/lib/snipeit/data/*
 chown -R docker:root /var/lib/snipeit/dumps
 chown -R docker:root /var/lib/snipeit/keys
+chown -R docker:root /var/www/html/storage/framework/cache
 
 # Fix php settings
 if [ -v "PHP_UPLOAD_LIMIT" ]


### PR DESCRIPTION
# Description

In the latest Docker container, Snipe-IT was failing to load because
/var/www/html/storage/framework/cache/ and its contents were owned by
root:root, but docker needed to be able to write to them

This change recursively chowns that path to docker:root, and now it
loads.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Built container locally and it worked, vs the one i downloaded that
didn't