### PR TITLE
Force revalidation headers when user logs out

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -23,6 +23,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\CheckForDebug::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\SecurityHeaders::class,
+        \App\Http\Middleware\PreventBackHistory::class,
 
     ];
 

--- a/app/Http/Middleware/PreventBackHistory.php
+++ b/app/Http/Middleware/PreventBackHistory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class PreventBackHistory
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+        return $response->header('Cache-Control','no-cache, no-store, max-age=0, must-revalidate')
+            ->header('Pragma','no-cache')
+            ->header('Expires','Sun, 02 Jan 1990 00:00:00 GMT');
+    }
+}


### PR DESCRIPTION
This middleware forces a re-validation when the user logs out. While this is normal browser behavior, there is the possibility of a user logging out and a different user using the back button to view what could be sensitive information. (This would not the malicious user modify any data, since they do not currently have an active session, and reloading or clicking on anything would previously send them to a login page.)

https://huntr.dev/bounties/ba86f7fe-7ac7-45ce-83e3-4dc61550b0dc/