### PR TITLE
Set headers in a different manner in the middleware [sc-17520]

### DIFF
--- a/app/Http/Middleware/PreventBackHistory.php
+++ b/app/Http/Middleware/PreventBackHistory.php
@@ -15,9 +15,16 @@ class PreventBackHistory
      */
     public function handle($request, Closure $next)
     {
+        $headers = [
+            'Cache-Control'      => 'nocache, no-store, max-age=0, must-revalidate',
+            'Pragma'     => 'no-cache',
+            'Expires' => 'Sun, 02 Jan 1990 00:00:00 GMT'
+        ];
         $response = $next($request);
-        return $response->header('Cache-Control','no-cache, no-store, max-age=0, must-revalidate')
-            ->header('Pragma','no-cache')
-            ->header('Expires','Sun, 02 Jan 1990 00:00:00 GMT');
+        foreach($headers as $key => $value) {
+            $response->headers->set($key, $value);
+        }
+
+        return $response;
     }
 }


### PR DESCRIPTION
# Description
A middleware was added to force revalidation in commit https://github.com/snipe/snipe-it/commit/9b48732cd21f8245a510cadc4e1ddf247cfca55c, but it breaks the qr code request because of the way it sets headers. Without much investigation, I think that Laravel changes the way to define those, so now the method `header` can't be directly called from the `$response` object so I changed it to the recommended (?) way.

Fixes internal shortcut #17520

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
