### PR TITLE
Feature: adds current and default locations to bulk audit screen

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -895,6 +895,8 @@ class AssetsController extends Controller
                     'asset_tag'=> e($asset->asset_tag),
                     'note'=> e($request->input('note')),
                     'next_audit_date' => Helper::getFormattedDateObject($asset->next_audit_date),
+                    'default_location' =>e($asset->defaultLoc->name),
+                    'current_location' =>e($asset->location->name),
                 ], trans('admin/hardware/message.audit.success')));
             }
         }

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -69,6 +69,7 @@
     'date'					=> 'Date',
     'debug_warning'         => 'Warning!',
     'debug_warning_text'    => 'This application is running in production mode with debugging enabled. This can expose sensitive data if your application is accessible to the outside world. Disable debug mode by setting the <code>APP_DEBUG</code> value in your <code>.env</code> file to <code>false</code>.',
+    'default_location'      => 'Default Location',
     'delete'  				=> 'Delete',
     'delete_confirm'  		=> 'Are you sure you wish to delete :item?',
     'deleted'  				=> 'Deleted',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -69,7 +69,6 @@
     'date'					=> 'Date',
     'debug_warning'         => 'Warning!',
     'debug_warning_text'    => 'This application is running in production mode with debugging enabled. This can expose sensitive data if your application is accessible to the outside world. Disable debug mode by setting the <code>APP_DEBUG</code> value in your <code>.env</code> file to <code>false</code>.',
-    'default_location'      => 'Default Location',
     'delete'  				=> 'Delete',
     'delete_confirm'  		=> 'Are you sure you wish to delete :item?',
     'deleted'  				=> 'Deleted',

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -108,7 +108,8 @@
                         <tr>
                             <th>{{ trans('general.asset_tag') }}</th>
                             <th>{{ trans('general.bulkaudit_status') }}</th>
-                            <th></th>
+                            <th>{{ trans('general.location') }}</th>
+                            <th>{{ trans('general.default_location') }}</th>
                         </tr>
                         <tr id="audit-loader" style="display: none;">
                             <td colspan="3">
@@ -152,8 +153,7 @@
                 data : formData,
                 success : function (data) {
                     if (data.status == 'success') {
-                        $('#audited tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.messages + "</td><td><i class='fas fa-check text-success'></i></td></tr>");
-                        incrementOnSuccess();
+                        $('#audited tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.messages + "</td><td>" + data.payload.current_location + "</td><td>" + data.payload.default_location + "</td><td><i class='fas fa-check text-success'></i></td></tr>");                        incrementOnSuccess();
                     } else {
                         handleAuditFail(data);
                     }

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -109,7 +109,7 @@
                             <th>{{ trans('general.asset_tag') }}</th>
                             <th>{{ trans('general.bulkaudit_status') }}</th>
                             <th>{{ trans('general.location') }}</th>
-                            <th>{{ trans('general.default_location') }}</th>
+                            <th>{{ trans('admin/hardware/form.default_location') }}</th>
                         </tr>
                         <tr id="audit-loader" style="display: none;">
                             <td colspan="3">


### PR DESCRIPTION
# Description

adds default location and current location of assets to the bulk audit page:
![image](https://user-images.githubusercontent.com/47435081/138198057-45f5fb17-a36b-4bcb-93d0-51199b91748e.png)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
