### PR TITLE
adds info on how to nullify reorder alerts for consumables, component…

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -146,7 +146,7 @@
     'manufacturers'			=> 'Manufacturers',
     'markdown'				=> 'This field allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'min_amt'				=> 'Min. QTY',
-    'min_amt_help'	=> 'Minimum number of items that should be available before an alert gets triggered.',
+    'min_amt_help'          => 'Minimum number of items that should be available before an alert gets triggered. Set Min. QTY to Null if you do not want to get alerts for low inventory.',
     'model_no'				=> 'Model No.',
     'months'				=> 'months',
     'moreinfo'				=> 'More Info',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -146,7 +146,7 @@
     'manufacturers'			=> 'Manufacturers',
     'markdown'				=> 'This field allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'min_amt'				=> 'Min. QTY',
-    'min_amt_help'          => 'Minimum number of items that should be available before an alert gets triggered. Set Min. QTY to Null if you do not want to receive alerts for low inventory.',
+    'min_amt_help'          => 'Minimum number of items that should be available before an alert gets triggered. Leave Min. QTY blank if you do not want to receive alerts for low inventory.',
     'model_no'				=> 'Model No.',
     'months'				=> 'months',
     'moreinfo'				=> 'More Info',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -146,7 +146,7 @@
     'manufacturers'			=> 'Manufacturers',
     'markdown'				=> 'This field allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
     'min_amt'				=> 'Min. QTY',
-    'min_amt_help'          => 'Minimum number of items that should be available before an alert gets triggered. Set Min. QTY to Null if you do not want to get alerts for low inventory.',
+    'min_amt_help'          => 'Minimum number of items that should be available before an alert gets triggered. Set Min. QTY to Null if you do not want to receive alerts for low inventory.',
     'model_no'				=> 'Model No.',
     'months'				=> 'months',
     'moreinfo'				=> 'More Info',


### PR DESCRIPTION
# Description
There was no clear description of how to nullify reorder alerts. I've updated the `min_amt_help` to convey that information on the edit screens for consumables, components and accessories.
![image](https://user-images.githubusercontent.com/47435081/139162811-ccd3df77-5ac3-4091-92e9-08b49e6dc8b4.png)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
