### PR TITLE
Update supervisor-exit-event-listener

### DIFF
--- a/docker/supervisor-exit-event-listener
+++ b/docker/supervisor-exit-event-listener
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # A supervisor event listener which terminates supervisord if any of its child
 # processes enter the FATAL state.
 # https://stackoverflow.com/a/37527488/119527


### PR DESCRIPTION
This is a stab at fixing the docker issue with the deprecation of python2