### PR TITLE
Fixed #8828: Can't search by checked out user in advanced search

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1357,8 +1357,8 @@ class Asset extends Depreciable
                     });
                 }
 
-                if ($fieldname == 'checkedout_to') {
-                    $query->whereHas('assigneduser', function ($query) use ($search_val) {
+                if ($fieldname =='assigned_to') {
+                    $query->whereHasMorph('assignedTo', [User::class], function ($query) use ($search_val) {
                         $query->where(function ($query) use ($search_val) {
                             $query->where('users.first_name', 'LIKE', '%'.$search_val.'%')
                                 ->orWhere('users.last_name', 'LIKE', '%'.$search_val.'%');
@@ -1421,7 +1421,7 @@ class Asset extends Depreciable
                         });
                     });
                 }
-            }
+            
 
             /**
              * THIS CLUNKY BIT IS VERY IMPORTANT
@@ -1447,11 +1447,11 @@ class Asset extends Depreciable
              */
 
             if (($fieldname!='category') && ($fieldname!='model_number') && ($fieldname!='rtd_location') && ($fieldname!='location') && ($fieldname!='supplier')
-                && ($fieldname!='status_label') && ($fieldname!='model') && ($fieldname!='company') && ($fieldname!='manufacturer')) {
+                && ($fieldname!='status_label') && ($fieldname!='assigned_to') && ($fieldname!='model') && ($fieldname!='company') && ($fieldname!='manufacturer')) {
                     $query->where('assets.'.$fieldname, 'LIKE', '%' . $search_val . '%');
             }
 
-
+            }
 
 
         });


### PR DESCRIPTION
# Description

When using the Advanced Search in the Assets table users are unable to search by "Checked Out To". 

Also fixed not being able to search for both custom and built in fields at the same time as described in #10233 (I don't think the merged PR addressed that issue). Moved closing bracket for FOREACH loop below the additional filters. I would have indented lines 1426-1452, but I didn't want to mess up the diff

Cause:
Incorrect field name 'checkedout_to' used. Changed to correct fieldname of 'assigned_to'

'assigneduser' was also not a defined function, used 'assignedTo' with 'whereHasMorph'

Fixes # (8828)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I reproduced the issue in #8828 on both my local environment, as well as the demo online. After making the fix the issue was no longer there

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version: 7.4.3
* MySQL version: Ver 8.0.27-0ubuntu0.20.04.1 for Linux on x86_64 ((Ubuntu))
* Webserver version: Apache/2.4.41 (Ubuntu)
* OS version: Chrome 94.0.4606.81


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
