### PR TITLE
Turn custom fields required/optional/remove into POST requests

### DIFF
--- a/resources/views/custom_fields/fieldsets/view.blade.php
+++ b/resources/views/custom_fields/fieldsets/view.blade.php
@@ -57,21 +57,28 @@
               <td>{{$field->element}}</td>
               <td>{{ $field->field_encrypted=='1' ?  trans('general.yes') : trans('general.no') }}</td>
                 <td>
+                  
                     @if ($field->pivot->required)
-                        <a href="{{ route('fields.optional', [$custom_fieldset->id, $field->id]) }}">
-                            <i class="fa fa-check text-success" aria-hidden="true"></i>
-                            <span class="sr-only">Required - click to make optional</span>
-                        </a>
+                    <form method="post" action="{{ route('fields.optional', [$custom_fieldset->id, $field->id]) }}">
+                      @csrf 
+                      <button type="submit" class="btn btn-link"><i class="fa fa-check text-success" aria-hidden="true"></i></button>
+                      </form>
+
                     @else
-                        <a href="{{ route('fields.required', [$custom_fieldset->id, $field->id]) }}">
-                            <i class="fa fa-times text-danger" aria-hidden="true"></i>
-                            <span class="sr-only">Optional - click to make required</span>
-                        </a>
+
+                      <form method="post" action="{{ route('fields.required', [$custom_fieldset->id, $field->id]) }}">
+                      @csrf 
+                      <button type="submit" class="btn btn-link"><i class="fa fa-times text-danger" aria-hidden="true"></i></button>
+                      </form>
                     @endif
+                    
                 </td>
               <td>
                 @can('update', $custom_fieldset)
-                <a href="{{ route('fields.disassociate', [$field, $custom_fieldset->id]) }}" class="btn btn-sm btn-danger">Remove</a>
+                <form method="post" action="{{ route('fields.disassociate', [$field, $custom_fieldset->id]) }}">
+                  @csrf 
+                  <button type="submit" class="btn btn-sm btn-danger">Remove</button>
+                </form>
                 @endcan
               </td>
             </tr>

--- a/routes/web/fields.php
+++ b/routes/web/fields.php
@@ -7,17 +7,17 @@
 
 Route::group([ 'prefix' => 'fields','middleware' => ['auth'] ], function () {
 
-    Route::get('required/{fieldset_id}/{field_id}',
+    Route::post('required/{fieldset_id}/{field_id}',
         ['uses' => 'CustomFieldsetsController@makeFieldRequired',
             'as' => 'fields.required']
     );
 
-    Route::get('optional/{fieldset_id}/{field_id}',
+    Route::post('optional/{fieldset_id}/{field_id}',
         ['uses' => 'CustomFieldsetsController@makeFieldOptional',
             'as' => 'fields.optional']
     );
 
-    Route::get('{field_id}/fieldset/{fieldset_id}/disassociate',
+    Route::post('{field_id}/fieldset/{fieldset_id}/disassociate',
         ['uses' => 'CustomFieldsController@deleteFieldFromFieldset',
         'as' => 'fields.disassociate']
     );


### PR DESCRIPTION
This resolves the [low-level CSRF vulnerability](https://huntr.dev/bounties/03b21d69-3bf5-4b2f-a2cf-872dd677a68f/) reported by haxatron on huntr.dev. 

```
<img src="http://<SNIPE_IT_APP>/fields/1/fieldset/1/disassociate">
<img src="http://<SNIPE_IT_APP>/fields/required/3/3">
<img src="http://<SNIPE_IT_APP>/fields/optional/3/3">
``` 

The impact level here is not really higher than "nuisance", since the user loading the image would have to be a currently logged in admin that has custom fields editing abilities - and the end result not data destructive, but we always try to fix even small vulnerabilities.