### PR TITLE
Escape asset_tag attribute at controller level for bulk checkout

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -910,7 +910,7 @@ class AssetsController extends Controller
             }
         }
 
-        return response()->json(Helper::formatStandardApiResponse('error', ['asset_tag'=> e($request->input('asset_tag'))], 'Asset with tag '.$request->input('asset_tag').' not found'));
+        return response()->json(Helper::formatStandardApiResponse('error', ['asset_tag'=> e($request->input('asset_tag'))], 'Asset with tag '.e($request->input('asset_tag')).' not found'));
 
 
 


### PR DESCRIPTION
If someone injects a nasty XSS payload into the asset_tag in the bulk checkout, it will execute whatever payload you put in via Javascript.

Solves a https://huntr.dev vulnerability reported to us.