### PR TITLE
v6 Feature - Added backup restore from GUI

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -14,7 +14,7 @@ class RestoreFromBackup extends Command
      */
     protected $signature = 'snipeit:restore 
                                             {--force : Skip the danger prompt; assuming you hit "y"} 
-                                            {filename : The zip file to be migrated}
+                                            {filename : The full path of the .zip file to be migrated}
                                             {--no-progress : Don\'t show a progress bar}';
 
     /**
@@ -22,7 +22,7 @@ class RestoreFromBackup extends Command
      *
      * @var string
      */
-    protected $description = 'Restore from a previously created backup';
+    protected $description = 'Restore from a previously created Snipe-IT backup file';
 
     /**
      * Create a new command instance.
@@ -67,7 +67,7 @@ class RestoreFromBackup extends Command
                 ZipArchive::ER_INCONS => 'Zip archive inconsistent.',
                 ZipArchive::ER_INVAL => 'Invalid argument.',
                 ZipArchive::ER_MEMORY => 'Malloc failure.',
-                ZipArchive::ER_NOENT => 'No such file.',
+                ZipArchive::ER_NOENT => 'No such file ('.$filename.') in directory '.$dir.'.',
                 ZipArchive::ER_NOZIP => 'Not a zip archive.',
                 ZipArchive::ER_OPEN => "Can't open file.",
                 ZipArchive::ER_READ => 'Read error.',

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -899,7 +899,7 @@ class AssetsController extends Controller
             }
         }
 
-        return response()->json(Helper::formatStandardApiResponse('error', ['asset_tag'=> e($request->input('asset_tag'))], 'Asset with tag '.$request->input('asset_tag').' not found'));
+        return response()->json(Helper::formatStandardApiResponse('error', ['asset_tag'=> e($request->input('asset_tag'))], 'Asset with tag '.e($request->input('asset_tag')).' not found'));
 
 
 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1150,31 +1150,32 @@ class SettingsController extends Controller
 
     public function postUploadBackup(Request $request) {
 
-        $max_file_size = Helper::file_upload_max_size();
-
-        $rules = [
-            'file' => 'required|mimes:zip|max:'.$max_file_size,
-        ];
-
-        $validator = \Validator::make($request->all(), $rules);
-
-        if ($validator->passes()) {
-
-            if ($request->hasFile('file')) {
-
-                $upload_filename = 'uploaded-'.date('U').'-'.Str::slug(pathinfo($request->file('file')->getClientOriginalName(), PATHINFO_FILENAME)).'.zip';
-
-                Storage::putFileAs('app/backups', $request->file('file'), $upload_filename);
-    
-                return redirect()->route('settings.backups.index')->with('success', 'File uploaded');
-    
-            } else {
-                return redirect()->route('settings.backups.index')->with('error', 'No file uploaded');
-            }
-
+        if (!$request->hasFile('file')) {
+            return redirect()->route('settings.backups.index')->with('error', 'No file uploaded');
         } else {
-            return redirect()->route('settings.backups.index')->withErrors($request->getErrors());
+            $max_file_size = Helper::file_upload_max_size();
+
+            $rules = [
+                'file' => 'required|mimes:zip|max:'.$max_file_size,
+            ];
+
+            $validator = \Validator::make($request->all(), $rules);
+
+            if ($validator->passes()) {
+
+
+
+                    $upload_filename = 'uploaded-'.date('U').'-'.Str::slug(pathinfo($request->file('file')->getClientOriginalName(), PATHINFO_FILENAME)).'.zip';
+
+                    Storage::putFileAs('app/backups', $request->file('file'), $upload_filename);
+        
+                    return redirect()->route('settings.backups.index')->with('success', 'File uploaded');
+            } else {
+                return redirect()->route('settings.backups.index')->withErrors($request->getErrors());
+            }
         }
+
+        
         
     }
 
@@ -1198,29 +1199,41 @@ class SettingsController extends Controller
                 // grab the user's info so we can make sure they exist in the system
                 $user = User::find(Auth::user()->id);
 
+
+                // TODO: run a backup 
+
+                // TODO: add db:wipe 
+
+
                 // run the restore command
                 Artisan::call('snipeit:restore', 
-                    [
-                        '--force' => true, 
-                        '--no-progress' => true, 
-                        'filename' => storage_path($path).'/'.$filename
-                    ]);
+                [
+                    '--force' => true, 
+                    '--no-progress' => true, 
+                    'filename' => storage_path($path).'/'.$filename
+                ]);
 
                 $output = Artisan::output();
-
-
+                    
+            
                 // If it's greater than 300, it probably worked
                 if (strlen($output) > 300) {
                     return redirect()->route('settings.backups.index')->with('success', 'Your system has been restored.');
-
                 } else {
                     return redirect()->route('settings.backups.index')->with('error', $output);
 
                 }
                 //dd($output);
 
-                // insert the user if they are not there in the old one
+                // TODO: insert the user if they are not there in the old one
+                
+
+
+
                 // log the user out
+                // \Auth::logout();
+
+
             } else {
                 return redirect()->route('settings.backups.index')->with('error', trans('admin/settings/message.backup.file_not_found'));
             }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1018,17 +1018,25 @@ class SettingsController extends Controller
         $backup_files = Storage::files($path);
         $files_raw = [];
 
+
         if (count($backup_files) > 0) {
             for ($f = 0; $f < count($backup_files); $f++) {
 
                 // Skip dotfiles like .gitignore and .DS_STORE
                 if ((substr(basename($backup_files[$f]), 0, 1) != '.')) {
+                    //$lastmodified = Carbon::parse(Storage::lastModified($backup_files[$f]))->toDatetimeString();
+                    $file_timestamp = Storage::lastModified($backup_files[$f]);
+
+
                     $files_raw[] = [
                         'filename' => basename($backup_files[$f]),
                         'filesize' => Setting::fileSizeConvert(Storage::size($backup_files[$f])),
-                        'modified' => Storage::lastModified($backup_files[$f]),
+                        'modified_value' => $file_timestamp,
+                        'modified_display' => Helper::getFormattedDateObject($file_timestamp, $type = 'datetime', false),
+                        
                     ];
                 }
+               
             }
         }
 

--- a/app/Http/Requests/AssetFileRequest.php
+++ b/app/Http/Requests/AssetFileRequest.php
@@ -21,7 +21,7 @@ class AssetFileRequest extends Request
      */
     public function rules()
     {
-        $max_file_size = Helper::file_upload_max_size();
+        $max_file_size = \App\Helpers\Helper::file_upload_max_size();
 
         return [
           'file.*' => 'required|mimes:png,gif,jpg,svg,jpeg,doc,docx,pdf,txt,zip,rar,xls,xlsx,lic,xml,rtf,webp|max:'.$max_file_size,

--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -90,11 +90,6 @@ class ImageUploadRequest extends Request
             $use_db_field = $db_fieldname;
         }
 
-        \Log::info('Image path is: '.$path);
-        \Log::debug('Type is: '.$type);
-        \Log::debug('Form fieldname is: '.$form_fieldname);
-        \Log::debug('DB fieldname is: '.$use_db_field);
-        \Log::debug('Trying to upload to '. $path);
         
         // ConvertBase64ToFiles just changes object type, 
         // as it cannot currently insert files to $this->files

--- a/package-lock.json
+++ b/package-lock.json
@@ -15845,7 +15845,7 @@
     "jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+      "integrity": "sha1-xyoJ8Vwb3OFC9J2/EXC9+K2sJHA="
     },
     "jquery-form-validator": {
       "version": "2.3.79",

--- a/public/css/build/overrides.css
+++ b/public/css/build/overrides.css
@@ -554,7 +554,6 @@ th.css-accessory > .th-inner::before {
 .form-group.has-error label {
   color: #a94442;
 }
-
 .select2-container--default .select2-selection--multiple {
   border-radius: 0px;
 }

--- a/public/css/dist/all.css
+++ b/public/css/dist/all.css
@@ -20465,6 +20465,7 @@ th.css-accessory > .th-inner::before {
   border-radius: 0px;
 }
 
+
 .select2-container {
   box-sizing: border-box;
   display: inline-block;

--- a/public/js/build/app.js
+++ b/public/js/build/app.js
@@ -1695,7 +1695,36 @@ var baseUrl = $('meta[name="baseUrl"]').attr('content');
 
 (function ($, settings) {
   var Components = {};
-  Components.modals = {}; // confirm delete modal
+  Components.modals = {}; // confirm restore modal
+
+  Components.modals.confirmRestore = function () {
+    var $el = $('table');
+    var events = {
+      'click': function click(evnt) {
+        var $context = $(this);
+        var $restoreConfirmModal = $('#restoreConfirmModal');
+        var href = $context.attr('href');
+        var message = $context.attr('data-content');
+        var title = $context.attr('data-title');
+        $('#restoreConfirmModalLabel').text(title);
+        $restoreConfirmModal.find('.modal-body').text(message);
+        $('#restoreForm').attr('action', href);
+        $restoreConfirmModal.modal({
+          show: true
+        });
+        return false;
+      }
+    };
+
+    var render = function render() {
+      $el.on('click', '.restore-asset', events['click']);
+    };
+
+    return {
+      render: render
+    };
+  }; // confirm delete modal
+
 
   Components.modals.confirmDelete = function () {
     var $el = $('table');
@@ -1731,6 +1760,7 @@ var baseUrl = $('meta[name="baseUrl"]').attr('content');
 
 
   $(function () {
+    new Components.modals.confirmRestore().render();
     new Components.modals.confirmDelete().render();
   });
 })(jQuery, window.snipeit.settings);
@@ -1886,10 +1916,10 @@ $(document).ready(function () {
           return x !== 0;
         }); // makes sure we're not selecting the same thing twice for multiples
 
-        var filteredResponse = response.items.filter(function (item) {
+        var filteredResponse = response.results.filter(function (item) {
           return currentlySelected.indexOf(+item.id) < 0;
         });
-        var first = currentlySelected.length > 0 ? filteredResponse[0] : response.items[0];
+        var first = currentlySelected.length > 0 ? filteredResponse[0] : response.results[0];
 
         if (first && first.id) {
           first.selected = true;
@@ -2095,7 +2125,7 @@ $(document).ready(function () {
 
     for (var i = 0; i < this.files.length; i++) {
       total_size += this.files[i].size;
-      $(id + '-info').append('<span class="label label-default">' + this.files[i].name + ' (' + formatBytes(this.files[i].size) + ')</span> ');
+      $(id + '-info').append('<span class="label label-default">' + htmlEntities(this.files[i].name) + ' (' + formatBytes(this.files[i].size) + ')</span> ');
     }
 
     console.log('Max size is: ' + max_size);
@@ -2111,9 +2141,14 @@ $(document).ready(function () {
     }
   });
 });
+
+function htmlEntities(str) {
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
 /**
  * Toggle disabled
  */
+
 
 (function ($) {
   $.fn.toggleDisabled = function (callback) {

--- a/public/js/dist/all.js
+++ b/public/js/dist/all.js
@@ -60833,7 +60833,36 @@ var baseUrl = $('meta[name="baseUrl"]').attr('content');
 
 (function ($, settings) {
   var Components = {};
-  Components.modals = {}; // confirm delete modal
+  Components.modals = {}; // confirm restore modal
+
+  Components.modals.confirmRestore = function () {
+    var $el = $('table');
+    var events = {
+      'click': function click(evnt) {
+        var $context = $(this);
+        var $restoreConfirmModal = $('#restoreConfirmModal');
+        var href = $context.attr('href');
+        var message = $context.attr('data-content');
+        var title = $context.attr('data-title');
+        $('#restoreConfirmModalLabel').text(title);
+        $restoreConfirmModal.find('.modal-body').text(message);
+        $('#restoreForm').attr('action', href);
+        $restoreConfirmModal.modal({
+          show: true
+        });
+        return false;
+      }
+    };
+
+    var render = function render() {
+      $el.on('click', '.restore-asset', events['click']);
+    };
+
+    return {
+      render: render
+    };
+  }; // confirm delete modal
+
 
   Components.modals.confirmDelete = function () {
     var $el = $('table');
@@ -60869,6 +60898,7 @@ var baseUrl = $('meta[name="baseUrl"]').attr('content');
 
 
   $(function () {
+    new Components.modals.confirmRestore().render();
     new Components.modals.confirmDelete().render();
   });
 })(jQuery, window.snipeit.settings);
@@ -61024,10 +61054,10 @@ $(document).ready(function () {
           return x !== 0;
         }); // makes sure we're not selecting the same thing twice for multiples
 
-        var filteredResponse = response.items.filter(function (item) {
+        var filteredResponse = response.results.filter(function (item) {
           return currentlySelected.indexOf(+item.id) < 0;
         });
-        var first = currentlySelected.length > 0 ? filteredResponse[0] : response.items[0];
+        var first = currentlySelected.length > 0 ? filteredResponse[0] : response.results[0];
 
         if (first && first.id) {
           first.selected = true;
@@ -61233,7 +61263,7 @@ $(document).ready(function () {
 
     for (var i = 0; i < this.files.length; i++) {
       total_size += this.files[i].size;
-      $(id + '-info').append('<span class="label label-default">' + this.files[i].name + ' (' + formatBytes(this.files[i].size) + ')</span> ');
+      $(id + '-info').append('<span class="label label-default">' + htmlEntities(this.files[i].name) + ' (' + formatBytes(this.files[i].size) + ')</span> ');
     }
 
     console.log('Max size is: ' + max_size);
@@ -61249,9 +61279,14 @@ $(document).ready(function () {
     }
   });
 });
+
+function htmlEntities(str) {
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
 /**
  * Toggle disabled
  */
+
 
 (function ($) {
   $.fn.toggleDisabled = function (callback) {

--- a/public/js/snipeit.js
+++ b/public/js/snipeit.js
@@ -175,6 +175,36 @@ pieOptions = {
         return {
             render: render
         };
+
+    // confirm restore modal
+    Components.modals.confirmRestore = function () {
+        var $el = $('table');
+
+        var events = {
+            'click': function click(evnt) {
+                var $context = $(this);
+                var $dataConfirmModal = $('#restoreConfirmModal');
+                var href = $context.attr('href');
+                var message = $context.attr('data-content');
+                var title = $context.attr('data-title');
+
+                $('#myModalLabel').text(title);
+                $dataConfirmModal.find('.modal-body').text(message);
+                $('#confirmRestoreForm').attr('action', href);
+                $dataConfirmModal.modal({
+                    show: true
+                });
+                return false;
+            }
+        };
+
+        var render = function render() {
+            $el.on('click', '.restore-modal', events['click']);
+        };
+
+        return {
+            render: render
+        };
     };
 
     /**

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/js/build/app.js": "/js/build/app.js?id=c8a70594c0d99275266d",
+    "/js/build/app.js": "/js/build/app.js?id=202aad1c623e7f3c560c",
     "/css/dist/skins/skin-blue.css": "/css/dist/skins/skin-blue.css?id=83e39e254b7f9035eddc",
     "/css/build/overrides.css": "/css/build/overrides.css?id=b1866ec98d44c0a8ceea",
     "/css/build/app.css": "/css/build/app.css?id=61d5535cb27cce41d422",
@@ -26,7 +26,7 @@
     "/css/dist/bootstrap-table.css": "/css/dist/bootstrap-table.css?id=93c24b4c89490bbfd73e",
     "/js/build/vendor.js": "/js/build/vendor.js?id=651427cc4b45d8e68d0c",
     "/js/dist/bootstrap-table.js": "/js/dist/bootstrap-table.js?id=867755a1544f6c0ea828",
-    "/js/dist/all.js": "/js/dist/all.js?id=a233dcde4650f5d34491",
+    "/js/dist/all.js": "/js/dist/all.js?id=78b490e0623f67ef071d",
     "/css/dist/skins/skin-green.min.css": "/css/dist/skins/skin-green.min.css?id=efda2335fa5243175850",
     "/css/dist/skins/skin-green-dark.min.css": "/css/dist/skins/skin-green-dark.min.css?id=6e35fb4cb2f1063b3047",
     "/css/dist/skins/skin-black.min.css": "/css/dist/skins/skin-black.min.css?id=ec96c42439cdeb022133",

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -84,6 +84,37 @@ var baseUrl = $('meta[name="baseUrl"]').attr('content');
     var Components = {};
     Components.modals = {};
 
+    // confirm restore modal
+    Components.modals.confirmRestore = function() {
+        var $el = $('table');
+
+        var events = {
+            'click': function(evnt) {
+                var $context = $(this);
+                var $restoreConfirmModal = $('#restoreConfirmModal');
+                var href = $context.attr('href');
+                var message = $context.attr('data-content');
+                var title = $context.attr('data-title');
+
+                $('#restoreConfirmModalLabel').text(title);
+                $restoreConfirmModal.find('.modal-body').text(message);
+                $('#restoreForm').attr('action', href);
+                $restoreConfirmModal.modal({
+                    show: true
+                });
+                return false;
+            }
+        };
+
+        var render = function() {
+            $el.on('click', '.restore-asset', events['click']);
+        };
+
+        return {
+            render: render
+        };
+    };
+
     // confirm delete modal
     Components.modals.confirmDelete = function() {
         var $el = $('table');
@@ -121,6 +152,7 @@ var baseUrl = $('meta[name="baseUrl"]').attr('content');
      * Component definition stays out of load event, execution only happens.
      */
     $(function() {
+        new Components.modals.confirmRestore().render();
         new Components.modals.confirmDelete().render();
     });
 }(jQuery, window.snipeit.settings));

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -113,6 +113,8 @@
     'image'                 => 'Image',
     'image_delete'         	=> 'Delete Image',
     'image_upload'         	=> 'Upload Image',
+    'filetypes_accepted_help'    => 'Accepted filetype is :types. Max upload size allowed is :size.|Accepted filetypes are :types. Max upload size allowed is :size.',
+    'filetypes_size_help'   => 'Max upload size allowed is :size.',
     'image_filetypes_help'  => 'Accepted filetypes are jpg, webp, png, gif, and svg. Max upload size allowed is :size.',
     'import'         	    => 'Import',
     'importing'         	=> 'Importing',

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -853,12 +853,12 @@
     </div>
 
 
-    <div class="modal modal-warning fade" id="restoreConfirmModal" tabindex="-1" role="dialog" aria-labelledby="restoreConfirmModalLabel" aria-hidden="true">
+    <div class="modal modal-warning fade" id="restoreConfirmModal" tabindex="-1" role="dialog" aria-labelledby="confirmModalLabel" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="restoreConfirmModalLabel">&nbsp;</h4>
+                    <h4 class="modal-title" id="confirmModalLabel">&nbsp;</h4>
                 </div>
                 <div class="modal-body"></div>
                 <div class="modal-footer">

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -852,6 +852,28 @@
         </div>
     </div>
 
+
+    <div class="modal modal-warning fade" id="restoreConfirmModal" tabindex="-1" role="dialog" aria-labelledby="restoreConfirmModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="restoreConfirmModalLabel">&nbsp;</h4>
+                </div>
+                <div class="modal-body"></div>
+                <div class="modal-footer">
+                <form method="post" id="restoreForm" role="form">
+                    {{ csrf_field() }}
+                    {{ method_field('POST') }}
+
+                    <button type="button" class="btn btn-default pull-left" data-dismiss="modal">{{ trans('general.cancel') }}</button>
+                    <button type="submit" class="btn btn-outline" id="dataConfirmOK">{{ trans('general.yes') }}</button>
+                </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
     {{-- Javascript files --}}
     <script src="{{ url(mix('js/dist/all.js')) }}" nonce="{{ csrf_token() }}"></script>
 

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -47,7 +47,7 @@
               <i class="far fa-list-alt fa-2x" aria-hidden="true"></i>
               </span>
               <span class="hidden-xs hidden-sm">{{ trans('admin/licenses/form.seats') }}</span>
-              <badge class="badge badge-secondary">{{ $license->availCount()->count() }} / {{ $license->seats }}</badge>
+              <span class="badge badge-secondary">{{ $license->availCount()->count() }} / {{ $license->seats }}</span>
 
             </a>
         </li>

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -67,13 +67,12 @@
 
                   @can('superadmin')
                       <a data-html="false"
-                         class="btn delete-asset btn-danger btn-sm {{ (config('app.lock_passwords')) ? ' disabled': '' }}" data-toggle="modal" href=" {{ route('settings.backups.destroy', $file['filename']) }}" data-content="{{ trans('admin/settings/message.backup.delete_confirm') }}" data-title="{{ trans('general.delete') }}  {{ htmlspecialchars($file['filename']) }} ?" onClick="return false;">
+                         class="btn delete-asset btn-danger btn-sm {{ (config('app.lock_passwords')) ? ' disabled': '' }}" data-toggle="modal" href="{{ route('settings.backups.destroy', $file['filename']) }}" data-content="{{ trans('admin/settings/message.backup.delete_confirm') }}" data-title="{{ trans('general.delete') }}  {{ e($file['filename']) }} ?" onClick="return false;">
                           <i class="fas fa-trash icon-white" aria-hidden="true"></i>
                           <span class="sr-only">{{ trans('general.delete') }}</span>
                       </a>
 
-                     <a data-html="true" 
-                        href="{{ route('settings.backups.restore', $file['filename']) }}" class="btn btn-warning btn-sm restore-asset {{ (config('app.lock_passwords')) ? ' disabled': '' }}" data-toggle="modal" data-content="Yes, restore it. I acknowledge that this will overwrite any existing data currently in the database. This method does not currently support installations that use S3 for file storage. This will also log out all of your existing users (including you)." data-title="Are you sure you wish to restore your database from {{ $file['filename']}}?" onClick="return false;">
+                     <a data-html="true" href="{{ route('settings.backups.restore', $file['filename']) }}" class="btn btn-warning btn-sm restore-asset {{ (config('app.lock_passwords')) ? ' disabled': '' }}" data-toggle="modal" data-content="Yes, restore it. I acknowledge that this will overwrite any existing data currently in the database. This will also log out all of your existing users (including you)." data-title="Are you sure you wish to restore your database from {{ e($file['filename']) }}?" onClick="return false;">
                       <i class="fas fa-retweet" aria-hidden="true"></i>
                       <span class="sr-only">Restore</span>
                     </a>
@@ -175,17 +174,14 @@
     <script>
       $(document).ready(function() {
         
-        $('#uploadFile').on('keyup', function() {
-          let empty = false;
+        $("#uploadFile").on('change',function(event){
 
-          $('#uploadFile').each(function() {
-            empty = $(this).val().length == 0;
-          });
-
-          if (empty)
-            $('#uploadButton').attr('disabled', 'disabled');
-          else
-            $('#uploadButton').attr('disabled', false);
+            if ($('#uploadFile').val().length == 0) {
+              $("#uploadButton").attr("disabled", true);
+            } else {
+              $('#uploadButton').removeAttr('disabled');
+            }
+            
         });
       });
   </script>

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -1,6 +1,4 @@
-@extends('layouts/default', [
-  'helpText' => 'Backup files are located in: <code>'.$path.'</code>',
-])
+@extends('layouts/default')
 
 {{-- Page title --}}
 @section('title')
@@ -26,7 +24,7 @@
 
 <div class="row">
 
-  <div class="col-md-9">
+  <div class="col-md-8">
     
     <div class="box box-default">
       <div class="box-body">
@@ -92,7 +90,7 @@
 </div> <!-- end col-md div -->
 
    <!-- side address column -->
-  <div class="col-md-3">
+  <div class="col-md-4">
    <h2 style="margin-top: 0px">Upload Backup</h2>
 
       {{ Form::open([
@@ -100,7 +98,6 @@
         'route' => 'settings.backups.upload',
         'files' => true,
         'class' => 'form-horizontal' ]) }}
-
         @csrf
 
         
@@ -111,13 +108,14 @@
 
              <!-- displayed on screen -->
             <label class="btn btn-default col-md-12 col-xs-12" aria-hidden="true">
+              <i class="fas fa-paperclip" aria-hidden="true"></i>
                 {{ trans('button.select_file')  }}
                 <input type="file" name="file" class="js-uploadFile" id="uploadFile" data-maxsize="{{ Helper::file_upload_max_size() }}" accept="application/zip" style="display:none;" aria-label="file" aria-hidden="true">
             </label>   
 
         </div>
         <div class="col-md-4 col-xs-4">
-            <button class="btn btn-primary col-md-12 col-xs-12">Upload</button>
+            <button class="btn btn-primary col-md-12 col-xs-12" id="uploadButton" disabled>Upload</button>
         </div>
         <div class="col-md-12">
           
@@ -126,12 +124,39 @@
           <p class="help-block" style="margin-top: 10px; margin-bottom: 10px;" id="uploadFile-status">{{ trans_choice('general.filetypes_accepted_help', 3, ['size' => Helper::file_upload_max_size_readable(), 'types' => '.zip']) }}</p>     
           {!! $errors->first('image', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
 
-        </div>
-        
-        
+        </div>        
     </div>
     
     {{ Form::close() }}
+
+    <h3>Restoring from Backup</h3>
+
+    <div class="alert alert-warning fade in">
+      <p>You can use the restore (<i class="text-white fas fa-retweet" aria-hidden="true"></i>) button to restore from a previous backup, however there are a few things you should know: </p>
+    </div>
+
+
+      
+      <ul class="list-unstyled">
+        <li><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> 
+          Your entire database and any uploaded files will be completely replaced by what's in the backup file.
+          <br><br>
+        </li>
+        <li><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> 
+            Very large backups may time out on the restore attempt and may still need to be run via command line. 
+            <br><br>
+        </li>
+        <li><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> 
+          This does not currently work with S3 file storage.
+          <br><br>
+        </li>
+        <li><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> 
+          You will be logged out after your restore is complete.</li>
+      </ul>  
+      
+
+      <br><br>
+    <p>Backup files are located in: <code>{{ $path }}</code></p>
 
       
     
@@ -144,6 +169,25 @@
 @stop
 
 @section('moar_scripts')
+
     @include ('partials.bootstrap-table')
+
+    <script>
+      $(document).ready(function() {
+        
+        $('#uploadFile').on('keyup', function() {
+          let empty = false;
+
+          $('#uploadFile').each(function() {
+            empty = $(this).val().length == 0;
+          });
+
+          if (empty)
+            $('#uploadButton').attr('disabled', 'disabled');
+          else
+            $('#uploadButton').attr('disabled', false);
+        });
+      });
+  </script>
 @stop
 

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -152,12 +152,14 @@
       <div class="box-body">
         
       <p>
-        Use the restore (<i class="text-white fas fa-retweet" aria-hidden="true"></i>) button to 
-        restore from a previous backup. (This does not currently with with S3 file storage.)<br><br>Your <strong>entire {{ config('app.name') }} database and any uploaded files will be completely replaced</strong> by what's in the backup file.  
+        Use the restore button <small><span class="btn btn-xs btn-warning"><i class="text-white fas fa-retweet" aria-hidden="true"></i></span></small> to 
+        restore from a previous backup. (This does not currently with with S3 file storage.)</p>
+        
+      <p>Your <strong>entire {{ config('app.name') }} database and any uploaded files will be completely replaced</strong> by what's in the backup file.  
       </p>
         
-      <p class="text-danger" style="font-weight: bold">
-        You will be logged out after your restore is complete.
+      <p class="text-danger" style="font-weight: bold; font-size: 120%;">
+        You will be logged out once your restore is complete.
       </p>
 
       <p>

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -184,7 +184,7 @@
       /*
       * This just disables the upload button via JS unless they have actually selected a file.
       *
-      * Todo: - key off off of the javascript response for JS file upload info as well, so that if it fails that 
+      * Todo: - key off the javascript response for JS file upload info as well, so that if it fails that 
       * check (file size and type) we should also leave it disabled.
       */
 

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -90,8 +90,20 @@
 
    <!-- side address column -->
   <div class="col-md-4">
-   <h2 style="margin-top: 0px">Upload Backup</h2>
 
+    <div class="box box-default">
+      <div class="box-header with-border">
+        <h2 class="box-title">
+          <i class="far fa-file-archive" aria-hidden="true"></i>
+          Upload Backup</h2>
+        <div class="box-tools pull-right">
+        </div>
+      </div><!-- /.box-header -->
+
+      <div class="box-body">
+
+        <p>Backup files on the server are stored in: <code>{{ $path }}</code></p>
+        
       {{ Form::open([
         'method' => 'POST',
         'route' => 'settings.backups.upload',
@@ -100,7 +112,7 @@
         @csrf
 
         
-      <div class="form-group {{ $errors->has((isset($fieldname) ? $fieldname : 'image')) ? 'has-error' : '' }}">
+      <div class="form-group {{ $errors->has((isset($fieldname) ? $fieldname : 'image')) ? 'has-error' : '' }}" style="margin-bottom: 0px;">
         <div class="col-md-8 col-xs-8">
             <!-- screen reader only -->
             <input type="file" id="file" name="file" aria-label="file" class="sr-only">
@@ -120,44 +132,40 @@
           
           <p class="label label-default col-md-12" style="font-size: 120%!important; margin-top: 10px; margin-bottom: 10px;" id="uploadFile-info"></p>
           
-          <p class="help-block" style="margin-top: 10px; margin-bottom: 10px;" id="uploadFile-status">{{ trans_choice('general.filetypes_accepted_help', 3, ['size' => Helper::file_upload_max_size_readable(), 'types' => '.zip']) }}</p>     
+          <p class="help-block" style="margin-top: 10px;" id="uploadFile-status">{{ trans_choice('general.filetypes_accepted_help', 1, ['size' => Helper::file_upload_max_size_readable(), 'types' => '.zip']) }}</p>     
           {!! $errors->first('image', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
 
         </div>        
     </div>
     
     {{ Form::close() }}
-
-    <h3>Restoring from Backup</h3>
-
-    <div class="alert alert-warning fade in">
-      <p>You can use the restore (<i class="text-white fas fa-retweet" aria-hidden="true"></i>) button to restore from a previous backup, however there are a few things you should know: </p>
+      </div>
     </div>
 
+    <div class="box box-warning">
+      <div class="box-header with-border">
+        <h2 class="box-title">
+          <i class="fas fa-exclamation-triangle text-orange" aria-hidden="true"></i>  Restoring from Backup</h2>
+        <div class="box-tools pull-right">
+        </div>
+      </div><!-- /.box-header -->
+      <div class="box-body">
+        
+      <p>
+        Use the restore (<i class="text-white fas fa-retweet" aria-hidden="true"></i>) button to 
+        restore from a previous backup. (This does not currently with with S3 file storage.)<br><br>Your <strong>entire {{ config('app.name') }} database and any uploaded files will be completely replaced</strong> by what's in the backup file.  
+      </p>
+        
+      <p>
+        You will be logged out after your restore is complete.
+      </p>
 
+      <p>
+        Very large backups may time out on the restore attempt and may still need to be run via command line.  
+      </p>
       
-      <ul class="list-unstyled">
-        <li><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> 
-          Your entire database and any uploaded files will be completely replaced by what's in the backup file.
-          <br><br>
-        </li>
-        <li><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> 
-            Very large backups may time out on the restore attempt and may still need to be run via command line. 
-            <br><br>
-        </li>
-        <li><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> 
-          This does not currently work with S3 file storage.
-          <br><br>
-        </li>
-        <li><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> 
-          You will be logged out after your restore is complete.</li>
-      </ul>  
-      
-
-      <br><br>
-    <p>Backup files are located in: <code>{{ $path }}</code></p>
-
-      
+    </div>
+  </div>
     
         </div> <!-- end col-md-12 form div -->
    </div> <!-- end form group div -->

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -179,7 +179,15 @@
 
     @include ('partials.bootstrap-table')
 
+    
     <script>
+      /*
+      * This just disables the upload button via JS unless they have actually selected a file.
+      *
+      * Todo: - key off off of the javascript response for JS file upload info as well, so that if it fails that 
+      * check (file size and type) we should also leave it disabled.
+      */
+
       $(document).ready(function() {
         
         $("#uploadFile").on('change',function(event){

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -1,4 +1,6 @@
-@extends('layouts/default')
+@extends('layouts/default', [
+  'helpText' => 'Backup files are located in: <code>'.$path.'</code>',
+])
 
 {{-- Page title --}}
 @section('title')
@@ -72,8 +74,8 @@
                           <span class="sr-only">{{ trans('general.delete') }}</span>
                       </a>
 
-                     <a data-html="false" 
-                        href="{{ route('settings.backups.restore', $file['filename']) }}" class="btn btn-warning btn-sm restore-asset {{ (config('app.lock_passwords')) ? ' disabled': '' }}" data-toggle="modal" data-content="Yes, restore it. I acknowledge that this will overwrite any existing data currently in the database. This method does not currently support installations that use S3 for file storage." data-title="Are you sure you wish to restore your database from {{ $file['filename']}}?" onClick="return false;">
+                     <a data-html="true" 
+                        href="{{ route('settings.backups.restore', $file['filename']) }}" class="btn btn-warning btn-sm restore-asset {{ (config('app.lock_passwords')) ? ' disabled': '' }}" data-toggle="modal" data-content="Yes, restore it. I acknowledge that this will overwrite any existing data currently in the database. This method does not currently support installations that use S3 for file storage. This will also log out all of your existing users (including you)." data-title="Are you sure you wish to restore your database from {{ $file['filename']}}?" onClick="return false;">
                       <i class="fas fa-retweet" aria-hidden="true"></i>
                       <span class="sr-only">Restore</span>
                     </a>
@@ -91,37 +93,48 @@
 
    <!-- side address column -->
   <div class="col-md-3">
+   <h2 style="margin-top: 0px">Upload Backup</h2>
 
-     
-      <p>Backup files are located in: <code>{{ $path  }}</code></p>
+      {{ Form::open([
+        'method' => 'POST',
+        'route' => 'settings.backups.upload',
+        'files' => true,
+        'class' => 'form-horizontal' ]) }}
 
-      <h2>Upload Backup</h2>
+        @csrf
 
-      
-      <div class="form-group{{ $errors->has('file') ? ' has-error' : '' }}">
+        
+      <div class="form-group {{ $errors->has((isset($fieldname) ? $fieldname : 'image')) ? 'has-error' : '' }}">
+        <div class="col-md-8 col-xs-8">
+            <!-- screen reader only -->
+            <input type="file" id="file" name="file" aria-label="file" class="sr-only">
+
+             <!-- displayed on screen -->
+            <label class="btn btn-default col-md-12 col-xs-12" aria-hidden="true">
+                {{ trans('button.select_file')  }}
+                <input type="file" name="file" class="js-uploadFile" id="uploadFile" data-maxsize="{{ Helper::file_upload_max_size() }}" accept="application/zip" style="display:none;" aria-label="file" aria-hidden="true">
+            </label>   
+
+        </div>
+        <div class="col-md-4 col-xs-4">
+            <button class="btn btn-primary col-md-12 col-xs-12">Upload</button>
+        </div>
         <div class="col-md-12">
           
-          {{ Form::open([
-            'method' => 'POST',
-            'route' => 'settings.backups.upload',
-            'files' => true,
-            'class' => 'form-horizontal' ]) }}
-
-            @csrf
-
-            <input type="file" id="file" name="file" aria-label="file" class="sr-only">
-    
-            <label class="btn btn-default" aria-hidden="true">
-                {{ trans('button.select_file')  }}
-                <input type="file" name="file" class="js-uploadFile" data-maxsize="{{ Helper::file_upload_max_size() }}" accept="application/zip" style="display:none; max-width: 90%" aria-label="file" aria-hidden="true">
-            </label>
-    
-            <p class="help-block" id="uploadFile-status">{{ trans_choice('general.filetypes_accepted_help', 3, ['size' => Helper::file_upload_max_size_readable(), 'types' => '.zip']) }}</p>
-            {!! $errors->first('file', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-
-            <button>Submit</button>
-          {{ Form::close() }}
+          <p class="label label-default col-md-12" style="font-size: 120%!important; margin-top: 10px; margin-bottom: 10px;" id="uploadFile-info"></p>
           
+          <p class="help-block" style="margin-top: 10px; margin-bottom: 10px;" id="uploadFile-status">{{ trans_choice('general.filetypes_accepted_help', 3, ['size' => Helper::file_upload_max_size_readable(), 'types' => '.zip']) }}</p>     
+          {!! $errors->first('image', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+
+        </div>
+        
+        
+    </div>
+    
+    {{ Form::close() }}
+
+      
+    
         </div> <!-- end col-md-12 form div -->
    </div> <!-- end form group div -->
 

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -156,7 +156,7 @@
         restore from a previous backup. (This does not currently with with S3 file storage.)<br><br>Your <strong>entire {{ config('app.name') }} database and any uploaded files will be completely replaced</strong> by what's in the backup file.  
       </p>
         
-      <p>
+      <p class="text-danger" style="font-weight: bold">
         You will be logged out after your restore is complete.
       </p>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -189,6 +189,14 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth', 'authorize:superuser
             [SettingsController::class, 'postBackups']
         )->name('settings.backups.create');
 
+        Route::post('/restore/{filename}', 
+            [SettingsController::class, 'postRestore']
+        )->name('settings.backups.restore');
+
+        Route::post('/upload', 
+            [SettingsController::class, 'postUploadBackup']
+        )->name('settings.backups.upload');
+
         Route::get('/', [SettingsController::class, 'getBackups'])->name('settings.backups.index');
     });
 


### PR DESCRIPTION
This adds the ability to restore from a previous version of a Snipe-IT backup from the GUI, *and* to upload your own local backup to restore from. It invokes the `php artisan snipeit:restore` cli command, and does (or will do by the time it's not a draft) a few additional things:

- Grab the currently logged in user (in case they don't exist in the new backup) so we can insert them back in
- Do a `php artisan db:wipe` to clear out all old tables (though it may be better to just fix this migrations back in time)
- Potentially do a backup right before the restore in case all hell breaks loose
- Perform the restore (with as much debugging as possible - this can get tricky)
- Run migrations
- Insert the current admin user into the database
- log out the current user (in case their user ID is different than the user ID from the restore they just used)
- we'll be refining the restore script or adding a new console command for an "integrity check" on the restore zip file so we can confirm that the SQL file present looks like it's the right one to try to restore from
- add a log entry to note the upload and restore, and what user took that action

For the file upload, we check that it's a zip file and then rename it to start with `uploaded-unixtime` so we can tell the difference between a system-generated backup and an uploaded one.

This is still a WIP, but we're a lot of the way there. This should make it easier for superadmins who do not have cli access to the able to restore from a previous version. 

<img width="1292" alt="Screen Shot 2021-11-10 at 3 39 15 PM" src="https://user-images.githubusercontent.com/197404/141211745-81ede263-601e-4629-9ee1-b0807b4a9cf6.png">

<img width="1288" alt="Screen Shot 2021-11-10 at 3 42 00 PM" src="https://user-images.githubusercontent.com/197404/141211768-25435467-bbe1-4be6-b477-79db4c701649.png">

<img width="1296" alt="Screen Shot 2021-11-10 at 3 39 44 PM" src="https://user-images.githubusercontent.com/197404/141211787-2cf93413-2eb9-4a1f-95f1-e04767fdf84b.png">
