### PR TITLE
Fixed: #10311: Docker: ldap_client_tls.{key,cert} are located in /var/www/html/storage instead of /var/lib/snipeit/keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,8 @@ RUN \
       && rm -r "/var/www/html/storage/app/backups" && ln -fs "/var/lib/snipeit/dumps" "/var/www/html/storage/app/backups" \
       && mkdir -p "/var/lib/snipeit/keys" && ln -fs "/var/lib/snipeit/keys/oauth-private.key" "/var/www/html/storage/oauth-private.key" \
       && ln -fs "/var/lib/snipeit/keys/oauth-public.key" "/var/www/html/storage/oauth-public.key" \
+      && ln -fs "/var/lib/snipeit/keys/ldap_client_tls.cert" "/var/www/html/storage/ldap_client_tls.cert" \
+      && ln -fs "/var/lib/snipeit/keys/ldap_client_tls.key" "/var/www/html/storage/ldap_client_tls.key" \
       && chown docker "/var/lib/snipeit/keys/" \
       && chown -h docker "/var/www/html/storage/" \
       && chmod +x /var/www/html/artisan \


### PR DESCRIPTION
# Description

Added symlinks for `ldap_client_tls.{key,cert}` files in the same manner as done for `oauth-private.key` & `oauth-public.key`.

Fixes #10311 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual testing

**Test Configuration**:
* PHP version: 7.4.3
* MySQL version: 8.0.27
* Webserver version: Apache/2.4.41 (Ubuntu)
* OS version: Ubuntu 20.04


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
