### PR TITLE
Escape custom field values in API response

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -93,15 +93,15 @@ class AssetsTransformer
                     $value = (Gate::allows('superadmin')) ? $decrypted : strtoupper(trans('admin/custom_fields/general.encrypted'));
 
                     $fields_array[$field->name] = [
-                            'field' => $field->convertUnicodeDbSlug(),
-                            'value' => $value,
+                            'field' => e($field->convertUnicodeDbSlug()),
+                            'value' => e($value),
                             'field_format' => $field->format,
                         ];
 
                 } else {
                     $fields_array[$field->name] = [
-                        'field' => $field->convertUnicodeDbSlug(),
-                        'value' => $asset->{$field->convertUnicodeDbSlug()},
+                        'field' => e($field->convertUnicodeDbSlug()),
+                        'value' => e($asset->{$field->convertUnicodeDbSlug()}),
                         'field_format' => $field->format,
                     ];
 
@@ -134,7 +134,7 @@ class AssetsTransformer
                         
                             'id' => $component->id,
                             'pivot_id' => $component->pivot->id,
-                            'name' => $component->name,
+                            'name' => e($component->name),
                             'qty' => $component->pivot->assigned_qty,
                             'price_cost' => $component->purchase_cost,
                             'purchase_total' => $component->purchase_cost * $component->pivot->assigned_qty,


### PR DESCRIPTION
We were missing some escaping on custom field values in the API response - this should fix that.