### PR TITLE
v6 bug - Error when editing model with no custom

### DIFF
--- a/app/Http/Livewire/CustomFieldSetDefaultValuesForModel.php
+++ b/app/Http/Livewire/CustomFieldSetDefaultValuesForModel.php
@@ -19,13 +19,22 @@ class CustomFieldSetDefaultValuesForModel extends Component
     {
         $this->model = AssetModel::find($this->model_id); // It's possible to do some clever route-model binding here, but let's keep it simple, shall we?
         $this->fieldset_id = $this->model->fieldset_id;
-        $this->fields = CustomFieldset::find($this->fieldset_id)->fields;
-        $this->add_default_values = ( $this->model->defaultValues->count() > 0);
+
+        $this->fields = null;
+
+        if ($fieldset = CustomFieldset::find($this->fieldset_id)) {
+            $this->fields = CustomFieldset::find($this->fieldset_id)->fields;
+        } 
+
+        $this->add_default_values = ($this->model->defaultValues->count() > 0);
     }
 
     public function updatedFieldsetId()
     {
-        $this->fields = CustomFieldset::find($this->fieldset_id)->fields;
+        if (CustomFieldset::find($this->fieldset_id)) {
+            $this->fields = CustomFieldset::find($this->fieldset_id)->fields;
+        }
+        
     }
 
     public function render()

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -12,9 +12,10 @@
                 </span>
             </div>
     </div>
-    @if( $this->add_default_values ) {{-- 'if the checkbox is enabled *AND* there are more than 0 fields in the fieldsset' --}}
+    @if ($this->add_default_values ) {{-- 'if the checkbox is enabled *AND* there are more than 0 fields in the fieldsset' --}}
     <div>
         <div class="form-group">
+            @if ($fields)
                 @foreach ($fields as $field)
                     <div class="form-group">
                     
@@ -49,6 +50,7 @@
                         </div>
 
                 @endforeach
+                @endif
 
         </div>
     </div>


### PR DESCRIPTION
This is an attempt to fix [sc17684] on v6. I don't know if this is the right way to do it, and @uberbrady you know LW better than I do, so take a look and let me know if you think this is sufficient.

Ideally, we should probably make that checkbox ONLY appear if an actual fieldset is selected, versus this workaround - it would just be a better UX imho. But this at least in my testing fixes the error. 