### PR TITLE
Change the `[END]` directive in `.htaccess` to `[L]`

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,7 +6,7 @@
     RewriteEngine On
 
     # Needed for https://letsencrypt.org/ certificates.
-    RewriteRule ^\.well-known/acme-challenge/ - [END]
+    RewriteRule ^\.well-known/acme-challenge/ - [L]
 
     # Uncomment these two lines to force SSL redirect in Apache
     # RewriteCond %{HTTPS} off


### PR DESCRIPTION
This allows backwards-compatibility with older Apache versions (which we _used_ to have), and should do the exact same thing.