### PR TITLE
Update upgrade.php with newer requires

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -1,7 +1,7 @@
 <?php
 (PHP_SAPI !== 'cli' || isset($_SERVER['HTTP_USER_AGENT'])) && die('Access denied.');
 
-$required_version = '7.2.5';
+$required_version = '7.4.0';
 
 if ((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') || (!function_exists('posix_getpwuid'))) {
 	echo "Skipping user check as it is not supported on Windows or Posix is not installed on this server. \n";
@@ -64,6 +64,7 @@ $required_exts_array =
         'mysqli|pgsql',
         'openssl',
         'PDO',
+        'sodium',
         'tokenizer',
         'xml',
         'zip',


### PR DESCRIPTION
Changes to PHP and the JWT library specifically require the sodium extension - we should check for this to enable better troubleshooting for users.