### PR TITLE
Apply trim() function when storing Custom Fields names

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -92,7 +92,7 @@ class CustomFieldsController extends Controller
         $this->authorize('create', CustomField::class);
 
         $field = new CustomField([
-            "name" => $request->get("name"),
+            "name" => trim($request->get("name")),
             "element" => $request->get("element"),
             "help_text" => $request->get("help_text"),
             "field_values" => $request->get("field_values"),
@@ -212,7 +212,7 @@ class CustomFieldsController extends Controller
  
         $this->authorize('update', $field);
 
-        $field->name          = e($request->get("name"));
+        $field->name          = trim(e($request->get("name")));
         $field->element       = e($request->get("element"));
         $field->field_values  = e($request->get("field_values"));
         $field->user_id       = Auth::id();


### PR DESCRIPTION
# Description

When importing Custom fields, if the field name doesn't match the header on the CSV file, the data is not imported. An issue arose where a customer couldn't import their data because their Custom Field name had an extra whitespace in the end of the name (something like "My Customfield " instead of "My Customfield"). So I applied a trim() function to the name of Custom Fields when storing in the Database, so this doesn't happen again. 🤞 

Fixes internal helpdesk #24377

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
