### PR TITLE
Improved Installer: Add Debian 11 (Bullseye) install script support

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -374,7 +374,39 @@ done
 
 case $distro in
   debian)
-  if [[ "$version" =~ ^10 ]]; then
+    if [[ "$version" =~ ^11 ]]; then
+    # Install for Debian 11.x
+    tzone=$(cat /etc/timezone)
+
+    echo "* Adding PHP repository."
+    log "apt-get install -y apt-transport-https lsb-release ca-certificates"
+    log "wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg"
+    echo "deb https://packages.sury.org/php/ $codename main" > /etc/apt/sources.list.d/php.list
+
+    echo -n "* Updating installed packages."
+    log "apt-get update && apt-get -y upgrade" & pid=$!
+    progress
+
+    echo "* Installing Apache httpd, PHP, MariaDB and other requirements."
+    PACKAGES="mariadb-server mariadb-client apache2 libapache2-mod-php7.4 php7.4 php7.4-mcrypt php7.4-curl php7.4-mysql php7.4-gd php7.4-ldap php7.4-zip php7.4-mbstring php7.4-xml php7.4-bcmath curl git unzip"
+    install_packages
+
+    echo "* Configuring Apache."
+    create_virtualhost
+    log "a2enmod rewrite"
+    log "a2ensite $APP_NAME.conf"
+	rename_default_vhost
+
+    set_hosts
+
+    echo "* Securing MariaDB."
+    /usr/bin/mysql_secure_installation
+
+    install_snipeit
+
+    echo "* Restarting Apache httpd."
+    log "service apache2 restart"
+  elif [[ "$version" =~ ^10 ]]; then
     # Install for Debian 10.x
     tzone=$(cat /etc/timezone)
 


### PR DESCRIPTION
# Description

Adds Debian 11.x (Bullseye) install script support.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on a fresh install of Debian 11, executed without issue.

**Test Configuration**:
* PHP version: 7.4.26
* MySQL version: 10.5.12-MariaDB-0+deb11u1
* Webserver version: Apache 2.4.51
* OS version: Debian 11.1


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
