### PR TITLE
Escape notes in transformCheckedOutAccessory

### DIFF
--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -82,7 +82,7 @@ class AccessoriesTransformer
                 'first_name'=> e($user->first_name),
                 'last_name'=> e($user->last_name),
                 'employee_number' =>  e($user->employee_num),
-                'checkout_notes' => $user->pivot->note,
+                'checkout_notes' => e($user->pivot->note),
                 'last_checkout' => Helper::getFormattedDateObject($user->pivot->created_at, 'datetime'),
                 'type' => 'user',
                 'available_actions' => ['checkin' => true]


### PR DESCRIPTION
Per the report on [huntr.dev](https://huntr.dev/bounties/c14395f6-bf0d-4b06-b4d1-b509d8a99b54/). This was exploitable if an accessory was checked out with notes with an XSS payload and then you view the details of the checkout. 