### PR TITLE
Fixed #10365: Snipe-IT has a wrong total purchase cost when reaches m…

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -637,7 +637,7 @@
             decimalfixed = periodless.replace(/,/g,".");
         } else {
             // yank commas, that's it.
-            decimalfixed = number.toString().replace(",","");
+            decimalfixed = number.toString().replace(/\,/g,"");
         }
         return parseFloat(decimalfixed);
     }
@@ -646,8 +646,10 @@
         if (Array.isArray(data)) {
             var field = this.field;
             var total_sum = data.reduce(function(sum, row) {
+                
                 return (sum) + (cleanFloat(row[field]) || 0);
             }, 0);
+            
             return numberWithCommas(total_sum.toFixed(2));
         }
         return 'not an array';
@@ -679,6 +681,7 @@
     }
 
     function numberWithCommas(value) {
+        
         if ((value) && ("{{$snipeSettings->digit_separator}}" == "1.234,56")){
             var parts = value.toString().split(".");
              parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ".");


### PR DESCRIPTION
…illion.  Fixed to remove multiple commas in +1M per item.

# Description

display error due to string formatting.  conditional for format (1.234,00) already removed multiple separators with /g option.  This fix simply implements /g for multiple comma separators (e.g. 1,040,000.00).

Fixed #10365

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] My changes generate no new warnings
