### PR TITLE
Remove 'actionlog' from the ::with() clause in the asset query API

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -115,8 +115,8 @@ class AssetsController extends Controller
         }
 
         $assets = Company::scopeCompanyables(Asset::select('assets.*'),"company_id","assets")
-            ->with('location', 'assetstatus', 'assetlog', 'company', 'defaultLoc','assignedTo',
-                'model.category', 'model.manufacturer', 'model.fieldset','supplier');
+            ->with('location', 'assetstatus', 'company', 'defaultLoc','assignedTo',
+                'model.category', 'model.manufacturer', 'model.fieldset','supplier'); //it might be tempting to add 'assetlog' here, but don't. It blows up update-heavy users.
 
         
         // These are used by the API to query against specific ID numbers.


### PR DESCRIPTION
A user noted that they got timeouts when looking at their asset listings sometimes [fd24811]. I determined that they had large number of updates to their assets (via API) and this was adding up to nearly a thousand updates on an asset in some cases. The error seemed to be memory exhaustion, but seemed to fire intermittently.

Weirdly, you could set it to do 10 assets per page and you could literally page through all of them. So it couldn't have been bad data. It must've been real memory exhaustion.

I noticed on my local development environment that I saw Laravel's version of a `JOIN` (a big giant `IN()` query) was firing to grab all of the `action_logs` for the listed assets. I could imagine that at 200 or so records each with 1000 or so action_logs could definitely start to cause problems, and it didn't seem like we actually *used* those records anywhere in the API - we already denormed counters for checkin, checkout, and request.

So this PR just removes the `assetlog` element out of the `::with()` clause near the beginning of that API.