### PR TITLE
Automatic Building of Docker Images and Pushing to DockerHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,82 @@
+# Snipe-IT Docker image build for hub.docker.com
+name: Docker images
+
+# Run this Build for all pushes to 'master' or develop branch, or tagged releases.
+# Also run for PRs to ensure PR doesn't break Docker build process
+on:
+  push:
+    branches:
+      - master
+      - develop
+    tags:
+      - 'v**'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  pull_request:
+
+jobs:
+  docker:
+    # Ensure this job never runs on forked repos. It's only executed for 'snipe/snipe-it'
+    if: github.repository == 'snipe/snipe-it'
+    runs-on: ubuntu-latest
+    env:
+      # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)
+      # For a new commit on default branch (master), use the literal tag 'latest' on Docker image.
+      # For a new commit on other branches, use the branch name as the tag for Docker image.
+      # For a new tag, copy that tag name as the tag for Docker image.
+      IMAGE_TAGS: |
+        type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+        type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
+        type=ref,event=tag
+      # Define default tag "flavor" for docker/metadata-action per
+      # https://github.com/docker/metadata-action#flavor-input
+      # We turn off 'latest' tag by default.
+      TAGS_FLAVOR: |
+        latest=false
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout codebase
+        uses: actions/checkout@v2
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # https://github.com/docker/login-action
+      - name: Login to DockerHub
+        # Only login if not a PR, as PRs only trigger a Docker build and not a push
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      ###############################################
+      # Build/Push the 'snipe/snipe-it' image
+      ###############################################
+      # https://github.com/docker/metadata-action
+      # Get Metadata for docker_build step below
+      - name: Sync metadata (tags, labels) from GitHub to Docker for 'snipe-it' image
+        id: meta_build
+        uses: docker/metadata-action@v3
+        with:
+          images: snipe/snipe-it
+          tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push 'snipe-it' image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
+          # but we ONLY do an image push to DockerHub if it's NOT a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          # Use tags / labels provided by 'docker/metadata-action' above
+          tags: ${{ steps.meta_build.outputs.tags }}
+          labels: ${{ steps.meta_build.outputs.labels }}


### PR DESCRIPTION
# Description

This allows for building and pushing of the Snipe-IT docker images
directly from GitHub to DockerHub.

This will push a "latest" based on the master branch, a
"develop" based on the develop branch, and a v##.##.##
image based on any released version.

`DOCKER_USERNAME` and `DOCKER_ACCESS_TOKEN` do both need
to be added to the repository as secrets.


This would also allow for easy building of arm64 images. I can submit that PR if this gets approved and merged.

Fixes #10065 (does not require a subscription to Docker to utilize)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I tested this on my fork of the project and was able to have it automatically build and deploy the different images to DockerHub successfully. I than tested the Alpine version locally on my deployment of Snipe-IT and was functioning as expected. 


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
