### PR TITLE
Added escape to assigned_to API response

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -170,7 +170,7 @@ class AssetsTransformer
         }
         return $asset->assigned ? [
             'id' => $asset->assigned->id,
-            'name' => $asset->assigned->display_name,
+            'name' => e($asset->assigned->display_name),
             'type' => $asset->assignedType()
         ] : null;
     }


### PR DESCRIPTION
If an asset is assigned to another asset and the asset model had an XSS payload, this could trigger an XSS attack. This escaping mitigates this issue.