### PR TITLE
Fix route to checkout components from the details page

### DIFF
--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -16,8 +16,9 @@
         {{ trans('button.actions') }}
           <span class="caret"></span>
       </button>
+      
       <ul class="dropdown-menu pull-right" role="menu22">
-        @if ($component->assigned_to != '')
+        @if ($component->assigned_to != ''))
           @can('checkin', $component)
           <li role="menuitem">
             <a href="{{ route('checkin/component', $component->id) }}">

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -18,7 +18,7 @@
       </button>
       
       <ul class="dropdown-menu pull-right" role="menu22">
-        @if ($component->assigned_to != ''))
+        @if ($component->assigned_to != '')
           @can('checkin', $component)
           <li role="menuitem">
             <a href="{{ route('checkin/component', $component->id) }}">

--- a/routes/web/components.php
+++ b/routes/web/components.php
@@ -18,7 +18,7 @@ Route::group(['prefix' => 'components', 'middleware' => ['auth']], function () {
     Route::get(
         '{componentID}/checkin/{backto?}',
         [Components\ComponentCheckinController::class, 'create']
-    )->name('checkout/component');
+    )->name('checkin/component');
 
     Route::post(
         '{componentID}/checkin/{backto?}',


### PR DESCRIPTION
# Description
The route inside components' detailed page to checkout was pointing to make a checkin instead, if the component was not assigned an error occurs.

Fixes internal [sc17714]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10