### PR TITLE
Fixed #10461: Groups management page did not paginate correctly

### DIFF
--- a/app/Http/Transformers/GroupsTransformer.php
+++ b/app/Http/Transformers/GroupsTransformer.php
@@ -9,13 +9,13 @@ use Illuminate\Database\Eloquent\Collection;
 class GroupsTransformer
 {
 
-    public function transformGroups (Collection $groups)
+    public function transformGroups (Collection $groups, $total = null)
     {
         $array = array();
         foreach ($groups as $group) {
             $array[] = self::transformGroup($group);
         }
-        return (new DatatablesTransformer)->transformDatatables($array);
+        return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
     public function transformGroup (Group $group)


### PR DESCRIPTION
# Description

Fixed the collection of the groups total to GroupsTransformer.php. Groups page should now paginate correctly.

![image](https://user-images.githubusercontent.com/38761237/147306367-9fded9af-770a-4d6b-9017-c78145729eca.png)

Fixes #10461 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [x] Able to access multiple pages of groups
- [x] Able to change number of rows per page

**Test Configuration**:
* PHP version: 7.4.26
* MySQL version: 5.7.36
* Webserver version: PHPStorm Internal Web Server
* OS version: Windows 10 WSL


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
