### PR TITLE
Fixed assets_count doesnt exist as a column on kits

### DIFF
--- a/app/Http/Controllers/Api/PredefinedKitsController.php
+++ b/app/Http/Controllers/Api/PredefinedKitsController.php
@@ -31,8 +31,8 @@ class PredefinedKitsController extends Controller
 
         $offset = $request->input('offset', 0);
         $limit = $request->input('limit', 50);
-        $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
-        $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'assets_count';
+        $order = $request->input('order') === 'desc' ? 'desc' : 'asc';
+        $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'name';
         $kits->orderBy($sort, $order);
 
         $total = $kits->count();


### PR DESCRIPTION
Fixed internal RB#561, SC#915, SC#17819, and SC#17820 - we were sorting by default on a column that didn't exist. Most likely a copypasta error from the original PR that we didn't catch.