### PR TITLE
Fixed missing index for fieldsets

### DIFF
--- a/app/Http/Controllers/CustomFieldsetsController.php
+++ b/app/Http/Controllers/CustomFieldsetsController.php
@@ -23,6 +23,12 @@ use Redirect;
 class CustomFieldsetsController extends Controller
 {
 
+    public function index() 
+    {
+        return redirect()->route("fields.index")
+        ->with("error", trans('admin/custom_fields/message.fieldset.does_not_exist'));
+    }
+
     /**
      * Validates and stores a new custom field.
      *


### PR DESCRIPTION
This really shouldn't even be necessary, since we don't call `CustomFieldsets@index` literally anywhere in the code, but it's been shitting up our logs, since some folks want to be clever and fuzz urls. It now returns a redirect.