### PR TITLE
Added allow list to modal view options

### DIFF
--- a/app/Http/Controllers/ModalController.php
+++ b/app/Http/Controllers/ModalController.php
@@ -6,15 +6,43 @@ use App\Helpers\Helper;
 
 class ModalController extends Controller
 {
-    function show($type, $itemId = null) {
-        $view = view("modals.${type}");
 
-        if($type == "statuslabel") {
-            $view->with('statuslabel_types', Helper::statusTypeList());
+    /** 
+     * Load the modal views after confirming they are in the allowed_types array.
+     * The allowed types away just prevents shithead skiddies from fuzzing the urls 
+     * with automated scripts and junking up the logs. - snipe
+     */
+    function show ($type, $itemId = null) {
+
+        $allowed_types = [
+            'category',
+            'kit-model', 
+            'kit-license', 
+            'kit-consumable', 
+            'kit-accessory',
+            'location',
+            'manufacturer',
+            'model',
+            'statuslabel',
+            'supplier',
+            'upload-file',
+            'user',         
+        ];
+
+
+        if (in_array($type, $allowed_types)) {
+            $view = view("modals.${type}");
+
+            if ($type == "statuslabel") {
+                $view->with('statuslabel_types', Helper::statusTypeList());
+            }
+            if (in_array($type, ['kit-model', 'kit-license', 'kit-consumable', 'kit-accessory'])) {
+                $view->with('kitId', $itemId);
+            }
+            return $view;
         }
-        if(in_array($type, ['kit-model', 'kit-license', 'kit-consumable', 'kit-accessory'])) {
-            $view->with('kitId', $itemId);
-        }
-        return $view;
+        
+        abort(404,'Page not found');
+        
     }
 }


### PR DESCRIPTION
This doesn't solve any real-world problems here, but I noticed some skiddies attempting to fuzz modal URLs on the demo, like: `https://demo.snipeitapp.com/modals/farts.tar.gz`

This isn't so much a security issue as it is an annoyance for us in the demo, as 500 errors get shipped to our internal team via Rollbar, Slack *and* Shortcut, so it really just very noisy. I woke up to 600 Rollbar notifications this morning and the dev channel in Slack is still a mess. 👎 

It's not a security issue, since the modals cannot load a view that doesn't exist, and - at least for now - the file `resources/views/modals/farts.tar.gz.blade.php` does not exist. 

Before this change, it throws an exception like:

`InvalidArgumentException: View [modals.website.zip] not found. in /home/serverpilot/apps/demo.snipeitapp.com/snipe-it/vendor/laravel/framework/src/Illuminate/View/FileViewFinder.php:137`

in the logs (or on the screen if you're in develop mode with debugging turned on.)

@uberbrady - since you wrote a lot of the modal interactions, I'd love your eyeholes on this when you get a moment. Sorry to bug you during our holiday break. ☹️❤️‍🩹

Signed-off-by: snipe <snipe@snipe.net> 
Internal ID: Allow list for modal URLs [sc-18424] (and about 600 others)
