### PR TITLE
Fixed format property on invalid custom field object when trying to edit a field that doesn't exist

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -178,20 +178,25 @@ class CustomFieldsController extends Controller
      */
     public function edit($id)
     {
-        $field = CustomField::find($id);
+        if ($field = CustomField::find($id)) {
 
-        $this->authorize('update', $field);
+            $this->authorize('update', $field);
 
-        $customFormat = '';
-        if((stripos($field->format, 'regex') === 0) && ($field->format !== CustomField::PREDEFINED_FORMATS['MAC'])) {
-            $customFormat = $field->format;
-        }
+            $customFormat = '';
+            if((stripos($field->format, 'regex') === 0) && ($field->format !== CustomField::PREDEFINED_FORMATS['MAC'])) {
+                $customFormat = $field->format;
+            }
 
-        return view("custom_fields.fields.edit",[
-            'field'             => $field,
-            'customFormat'      => $customFormat,
-            'predefinedFormats' => Helper::predefined_formats()
-        ]);
+            return view("custom_fields.fields.edit",[
+                'field'             => $field,
+                'customFormat'      => $customFormat,
+                'predefinedFormats' => Helper::predefined_formats()
+            ]);
+        } 
+
+        return redirect()->route("fields.index")
+            ->with("error", trans('admin/custom_fields/message.field.invalid'));
+        
     }
 
 


### PR DESCRIPTION
Like some of the other recent PRs, this one really only helps us and doesn't really solve real-world problems, but I'm tired of seeing them show up in Rollbar. They're mostly triggered (I assume) by the reset of the demo data. Someone is in the middle of a session, they click on a custom field (say, ID `666`), but the demo data has been reset between page loads, and that field doesn't exist anymore. 

Previously, we were assuming that the field exists (which we shouldn't have), and behaving accordingly, which would trigger a "Trying to get property 'format' of non-object" 500 error if the object doesn't exist. Now we check that the field is valid before we try to present you with an edit screen, and if it's not valid, we kick you back to the fields/fieldsets page with an error that the field doesn't exist. 

Fixes RB#1160