### PR TITLE
Fixed - v6 migration licenses table issue

### DIFF
--- a/database/migrations/2013_11_15_190357_create_temp_licenses_table.php
+++ b/database/migrations/2013_11_15_190357_create_temp_licenses_table.php
@@ -6,30 +6,15 @@ class CreateTempLicensesTable extends Migration
 {
     /**
      * Run the migrations.
+     * 
+     * This migration is overwritten by a later migration - 2013_11_25_recreate_licenses_table.php
      *
      * @return void
      */
     public function up()
     {
         
-        if (!Schema::hasTable('licenses')) {
-            Schema::create('licenses', function ($table) {
-                $table->increments('id');
-                $table->string('name');
-                $table->integer('model_id');
-                $table->text('serial');
-                $table->string('license_email');
-                $table->string('license_name');
-                $table->date('purchase_date')->nullable();
-                $table->decimal('purchase_cost', 8, 2)->nullable();
-                $table->string('order_number');
-                $table->integer('assigned_to');
-                $table->text('notes');
-                $table->integer('user_id')->nullable();
-                $table->timestamps();
-                $table->engine = 'InnoDB';
-            });
-        }
+        //
 
        
     }
@@ -41,6 +26,6 @@ class CreateTempLicensesTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('licenses');
+        // Schema::dropIfExists('licenses');
     }
 }

--- a/database/migrations/2013_11_25_013244_recreate_licenses_table.php
+++ b/database/migrations/2013_11_25_013244_recreate_licenses_table.php
@@ -11,22 +11,23 @@ class ReCreateLicensesTable extends Migration
      */
     public function up()
     {
-        //
-        Schema::create('licenses', function ($table) {
-            $table->increments('id');
-            $table->string('name');
-            $table->string('serial');
-            $table->date('purchase_date')->nullable();
-            $table->decimal('purchase_cost', 8, 2)->nullable();
-            $table->string('order_number');
-            $table->integer('seats');
-            $table->text('notes');
-            $table->integer('user_id')->nullable();
-            $table->integer('depreciation_id');
-            $table->timestamps();
-            $table->softDeletes();
-            $table->engine = 'InnoDB';
-        });
+        if (!Schema::hasTable('licenses')) {
+            Schema::create('licenses', function ($table) {
+                $table->increments('id');
+                $table->string('name');
+                $table->string('serial');
+                $table->date('purchase_date')->nullable();
+                $table->decimal('purchase_cost', 8, 2)->nullable();
+                $table->string('order_number');
+                $table->integer('seats');
+                $table->text('notes');
+                $table->integer('user_id')->nullable();
+                $table->integer('depreciation_id');
+                $table->timestamps();
+                $table->softDeletes();
+                $table->engine = 'InnoDB';
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Because in the very early days, we created the licenses table, then dropped it, then re-created it, this was causing some errors in the develop build when running migrations. This attempts to fix that.

Internal [sc-17655]