### PR TITLE
Fixes auth controls on api key creation

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -113,6 +113,12 @@ class ProfileController extends Controller
      */
     public function api()
     {
+
+        // Make sure the self.api permission has been granted
+        if (!Gate::allows('self.api')) {
+            abort(403);
+        }
+
         return view('account/api');
     }
 


### PR DESCRIPTION
This is a very small fix that handles a missing authentication gate for the account API creation page. It's a pretty low level security fix, since API key tokens, which are used to utilize the API, are not exposed after they are created, and users can only create their own API tokens, which means if their user couldn't do any authorized actions in the system, the API token wouldn't be able to either - but [it was reported](https://huntr.dev/bounties/81c6b974-d0b3-410b-a902-8324a55b1368/) and makes sense for us to fix.

Signed-off-by: snipe <snipe@snipe.net>
