### PR TITLE
Adding .my.cnf to disable column-statistics backup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,8 @@ COPY . /var/www/html
 
 RUN a2enmod rewrite
 
+COPY docker/.my.cnf /root/.my.cnf
+
 ############ INITIAL APPLICATION SETUP #####################
 
 WORKDIR /var/www/html

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -34,6 +34,8 @@ RUN  apk add --no-cache \
         mysql-client \
         tini
 
+COPY docker/.my.cnf /root/.my.cnf
+
 # Where apache's PID lives
 RUN mkdir -p /run/apache2 && chown apache:apache /run/apache2
 

--- a/Dockerfile.fpm-alpine
+++ b/Dockerfile.fpm-alpine
@@ -98,5 +98,6 @@ VOLUME [ "/var/lib/snipeit" ]
 
 COPY --chown=www-data:www-data docker/docker-secrets.env /var/www/html/.env
 COPY --chmod=655 docker/docker-entrypoint.sh /usr/local/bin/docker-snipeit-entrypoint
+COPY docker/.my.cnf /root/.my.cnf
 ENTRYPOINT [ "/usr/local/bin/docker-snipeit-entrypoint" ]
 CMD [ "/usr/local/bin/docker-php-entrypoint", "php-fpm" ]

--- a/docker/.my.cnf
+++ b/docker/.my.cnf
@@ -1,0 +1,2 @@
+[mysqldump]
+column-statistics=0


### PR DESCRIPTION
Fixes #10176

The ```.my.cnf``` file is copied to ```/root/.my.cnf``` for each
Dockerfile that exists

# Description

Adds a mysql configuration file that disables column-statistics for mysqldump, which allows the snipe-it backup to run as expected.

Fixes # 10176

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Try running backup from existing container, to a mysql 5.x database server. It fails. Add the `.my.cnf` to /root with the following contents:
```
[mysqldump]
column-statistics=0
```

Run `docker-compose exec snipe-it sh -c 'php artisan snipeit:backup'`, backup succeeds. 

# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
