### PR TITLE
Adds audit dates in the asset importer

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -96,6 +96,14 @@ class AssetImporter extends ItemImporter
             $item['rtd_location_id'] = $this->item['location_id'];
         }
 
+        if (isset($this->item['last_audit_date'])) {
+            $item['last_audit_date'] = $this->item['last_audit_date'];
+        }
+
+        if (isset($this->item['next_audit_date'])) {
+            $item['next_audit_date'] = $this->item['next_audit_date'];
+        }
+
         if ($editingAsset) {
             $asset->update($item);
         } else {

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -76,6 +76,17 @@ class ItemImporter extends Importer
         if ($this->findCsvMatch($row, 'purchase_date') != '') {
             $this->item['purchase_date'] = date('Y-m-d 00:00:01', strtotime($this->findCsvMatch($row, 'purchase_date')));
         }
+
+        $this->item['last_audit_date'] = null;
+        if ($this->findCsvMatch($row, 'last_audit_date') != '') {
+            $this->item['last_audit_date'] = date('Y-m-d', strtotime($this->findCsvMatch($row, 'last_audit_date')));
+        }
+
+        $this->item['next_audit_date'] = null;
+        if ($this->findCsvMatch($row, 'next_audit_date') != '') {
+            $this->item['next_audit_date'] = date('Y-m-d', strtotime($this->findCsvMatch($row, 'next_audit_date')));
+        }
+
         $this->item['qty'] = $this->findCsvMatch($row, 'quantity');
         $this->item['requestable'] = $this->findCsvMatch($row, 'requestable');
         $this->item['user_id'] = $this->user_id;

--- a/resources/assets/js/components/importer/importer-file.vue
+++ b/resources/assets/js/components/importer/importer-file.vue
@@ -154,6 +154,8 @@
                         {id: 'full_name', text: 'Full Name' },
                         {id: 'status', text: 'Status' },
                         {id: 'warranty_months', text: 'Warranty Months' },
+                        {id: 'last_audit_date', text: 'Last Audit Date' },
+                        {id: 'next_audit_date', text: 'Audit Date' },
                     ],
                     consumables: [
                         {id: 'item_no', text: "Item Number"},


### PR DESCRIPTION
# Description
Adds the `next_audit_date` and `last_audit_date` to the importer. Not sure if the best approach since I skip the fillable columns... let me know if something is not ideal.

Feature request in internal freshdesk 24194

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
