### PR TITLE
Duplicate route meant overwrite of route-name

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -275,7 +275,7 @@ Route::group(['prefix' => 'account', 'middleware' => ['auth']], function () {
     Route::get('accept', [Account\AcceptanceController::class, 'index'])
         ->name('account.accept');
 
-    Route::post('accept/{id}', [Account\AcceptanceController::class, 'create'])
+    Route::get('accept/{id}', [Account\AcceptanceController::class, 'create'])
         ->name('account.accept.item');
 
     Route::post('accept/{id}', [Account\AcceptanceController::class, 'store']);


### PR DESCRIPTION
Fixes [ch18484]

I think during the Great Route Renaming that got us onto the later version of Laravel's routing system, we inadvertently specified the wrong HTTP method in one of our routes. This meant that the second route would overwrite the first one, blanking out the name.

We should take a **very** close look at this one, though, in case we had changed route verbs to remediate some kind of CSRF attack. As far as *I* can see, the `account.accept.item` `GET` route is harmless - it shows whether or not a thing can be accepted. If it's already accepted it says 'has already been accepted'.

Actually accepting (or rejecting) the asset requires a `POST`, as it should.