### PR TITLE
Make 'pending' assets properly requestable; use requestable scope

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -937,7 +937,7 @@ class AssetsController extends Controller
 
         $assets = Company::scopeCompanyables(Asset::select('assets.*'), 'company_id', 'assets')
             ->with('location', 'assetstatus', 'assetlog', 'company', 'defaultLoc','assignedTo',
-                'model.category', 'model.manufacturer', 'model.fieldset', 'supplier')->where('assets.requestable', '=', '1');
+                'model.category', 'model.manufacturer', 'model.fieldset', 'supplier')->requestableAssets();
 
         $offset = request('offset', 0);
         $limit = $request->input('limit', 50);

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1167,9 +1167,10 @@ class Asset extends Depreciable
     {
         return Company::scopeCompanyables($query->where('requestable', '=', 1))
         ->whereHas('assetstatus', function ($query) {
-            $query->where('deployable', '=', 1)
-                 ->where('pending', '=', 0)
-                 ->where('archived', '=', 0);
+            $query->where(function ($query) {
+                $query->where('deployable', '=', 1)
+                      ->where('archived', '=', 0); // you definitely can't request something that's archived
+            })->orWhere('pending', '=', 1); // we've decided that even though an asset may be 'pending', you can still request it
         });
     }
 


### PR DESCRIPTION
Fixes [ch18479]

If you requested a pending asset, you would get an error message saying that the asset either doesn't exist, or is not requestable. We figured that either we ought to not show you the asset, or we ought to let you request it.

After some discussion, we decided that in the same way that you can request an asset that's currently deployed to another person, you also ought to be able to request an asset that is currently pending. You still can't request an archived asset though.

In the process of troubleshooting this, it turned out we weren't using the `requestableAssets()` scope properly the the `requestable` method of the Api\AssetsController.

So this change makes us use the correct `requestableAssets()` scope, and modifies that scope to allow pending assets.

I don't like the nested `where()` business, and we could easily argue that simply `->where('archived','!=',1)` would be sufficient, but I slightly preferred the more explicit way of stating things so we could explain our logic. I'm happy to switch to the much shorter `->where('archived','!=',1)` (or `->where('archived','=',0)`, either is fine) if @snipe prefers.