### PR TITLE
Fixes an issue where importer is creating duplicate asset models

### DIFF
--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -178,6 +178,7 @@ class ItemImporter extends Importer
      */
     public function createOrFetchAssetModel(array $row)
     {
+        $condition = array();
         $asset_model_name = $this->findCsvMatch($row, 'asset_model');
         $asset_modelNumber = $this->findCsvMatch($row, 'model_number');
         // TODO: At the moment, this means  we can't update the model number if the model name stays the same.
@@ -189,8 +190,16 @@ class ItemImporter extends Importer
         } elseif ((empty($asset_model_name)) && (empty($asset_modelNumber))) {
             $asset_model_name = 'Unknown';
         }
+
+        if ((!empty($asset_model_name)) && (empty($asset_modelNumber))) {
+            $condition[] = ['name', '=', $asset_model_name];
+        } elseif ((!empty($asset_model_name)) && (!empty($asset_modelNumber))) {
+            $condition[] = ['name', '=', $asset_model_name];
+            $condition[] = ['model_number', '=', $asset_modelNumber];
+        }
+
         $editingModel = $this->updating;
-        $asset_model = AssetModel::where(['name' => $asset_model_name, 'model_number' => $asset_modelNumber])->first();
+        $asset_model = AssetModel::where($condition)->first();
 
         if ($asset_model) {
             if (! $this->updating) {
@@ -201,7 +210,6 @@ class ItemImporter extends Importer
             $this->log('Matching Model found, updating it.');
             $item = $this->sanitizeItemForStoring($asset_model, $editingModel);
             $item['name'] = $asset_model_name;
-            $item['model_number'] = $asset_modelNumber;
             $asset_model->update($item);
             $asset_model->save();
             $this->log('Asset Model Updated');

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -210,6 +210,11 @@ class ItemImporter extends Importer
             $this->log('Matching Model found, updating it.');
             $item = $this->sanitizeItemForStoring($asset_model, $editingModel);
             $item['name'] = $asset_model_name;
+            
+            if(!empty($asset_modelNumber)){
+                $item['model_number'] = $asset_modelNumber;
+            }
+            
             $asset_model->update($item);
             $asset_model->save();
             $this->log('Asset Model Updated');

--- a/routes/api.php
+++ b/routes/api.php
@@ -368,18 +368,18 @@ Route::group(['prefix' => 'v1', 'middleware' => 'api'], function () {
     
         });
 
-        Route::resource('fields', 
+        Route::resource('fieldsets', 
         Api\CustomFieldsetsController::class,
             ['names' => 
                 [
-                    'index' => 'api.customfields.index',
-                    'show' => 'api.customfields.show',
-                    'update' => 'api.customfields.update',
-                    'store' => 'api.customfields.store',
-                    'destroy' => 'api.customfields.destroy',
+                    'index' => 'api.fieldsets.index',
+                    'show' => 'api.fieldsets.show',
+                    'update' => 'api.fieldsets.update',
+                    'store' => 'api.fieldsets.store',
+                    'destroy' => 'api.fieldsets.destroy',
                 ],
             'except' => ['create', 'edit'],
-            'parameters' => ['field' => 'field_id'],
+            'parameters' => ['fieldset' => 'fieldset_id'],
             ]
         ); // end custom fieldsets API routes
 


### PR DESCRIPTION
# Description
User reports that adding only Model Name to their importing file ended up duplicating existing models, which causes issues specially with Custom Fields, issue that is non-existent if the import file adds the Model Number, but as the Model Number is not an obligatory field, this behavior is not expected. These changes take care of that issue giving the Importer capacity to search existing models only by Model Name.

Also, I found an error in an API definition which makes that the select lists in the importer were filled with with bad fields, making Custom Fields unable to got imported because were impossible to map.

Fixes internal ShortCut ticket 14356

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
