### PR TITLE
Fixes bug where the depreciation report shows assets that not deprecate for master

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -55,7 +55,7 @@ class AssetsController extends Controller
     {
 
         \Log::debug(Route::currentRouteName());
-        
+        $filter_non_deprecable_assets = false;
 
         /**
          * This looks MAD janky (and it is), but the AssetsController@index does a LOT of heavy lifting throughout the 
@@ -69,6 +69,7 @@ class AssetsController extends Controller
          * which would have been far worse of a mess. *sad face*  - snipe (Sept 1, 2021)
          */
         if (Route::currentRouteName()=='api.depreciation-report.index') {
+            $filter_non_deprecable_assets = true;
             $transformer = 'App\Http\Transformers\DepreciationReportTransformer';
             $this->authorize('reports.view');
         } else {
@@ -118,6 +119,12 @@ class AssetsController extends Controller
             ->with('location', 'assetstatus', 'company', 'defaultLoc','assignedTo',
                 'model.category', 'model.manufacturer', 'model.fieldset','supplier'); //it might be tempting to add 'assetlog' here, but don't. It blows up update-heavy users.
 
+        
+        if($filter_non_deprecable_assets) {
+            $non_deprecable_models = AssetModel::select('id')->whereNotNull('depreciation_id')->get();
+        
+            $assets->InModelList($non_deprecable_models->toArray());
+        }
         
         // These are used by the API to query against specific ID numbers.
         // They are also used by the individual searches on detail pages like


### PR DESCRIPTION
# Description
Adds a query to filter assets that doesn't have a depreciation method set in the assigned model.

Fixes internal freshdesk 25413

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**: 
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
