### PR TITLE
Fixes PDO exeception syntax error when Expiring Alerts Threshold is not set

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -665,13 +665,15 @@ class Asset extends Depreciable
      */
     public static function getExpiringWarrantee($days = 30)
     {
+        $days = (is_null($days)) ? 30 : $days;
+        
         return Asset::where('archived', '=', '0')
             ->whereNotNull('warranty_months')
             ->whereNotNull('purchase_date')
             ->whereNull('deleted_at')
             ->whereRaw(\DB::raw('DATE_ADD(`purchase_date`,INTERVAL `warranty_months` MONTH) <= DATE(NOW() + INTERVAL '
                                  . $days
-                                 . ' DAY) AND DATE_ADD(`purchase_date`,INTERVAL `warranty_months` MONTH) > NOW()'))
+                                 . ' DAY) AND DATE_ADD(`purchase_date`, INTERVAL `warranty_months` MONTH) > NOW()'))
             ->orderBy('purchase_date', 'ASC')
             ->get();
     }

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -627,8 +627,8 @@ class License extends Depreciable
      */
     public static function getExpiringLicenses($days = 60)
     {
-        $days = (is_null($days)) ? 30 : $days;
-        
+        $days = (is_null($days)) ? 60 : $days;
+
         return License::whereNotNull('expiration_date')
         ->whereNull('deleted_at')
         ->whereRaw(DB::raw('DATE_SUB(`expiration_date`,INTERVAL '.$days.' DAY) <= DATE(NOW()) '))

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -627,7 +627,8 @@ class License extends Depreciable
      */
     public static function getExpiringLicenses($days = 60)
     {
-
+        $days = (is_null($days)) ? 30 : $days;
+        
         return License::whereNotNull('expiration_date')
         ->whereNull('deleted_at')
         ->whereRaw(DB::raw('DATE_SUB(`expiration_date`,INTERVAL '.$days.' DAY) <= DATE(NOW()) '))


### PR DESCRIPTION
# Description
I was hunting a [bug ](https://rollbar.com/Grokability/Snipe-IT-Customers/items/15768/ )in rollbar, but it's not clear when is triggered, so in trying to replicate it I found that we admit null values in this Settings form:

![image](https://user-images.githubusercontent.com/653557/150014518-49eca678-c677-4f08-a61a-e8b9e4cfef38.png)

But in the Asset model (that is `app\Models\Asset.php`) even when we have a default value for a variable called `$days` if the value is null, the default is not setted. I imagine is because it takes that days is setted as a NULL value instead of taking it as not passed at all... Also I'm not sure if this fixes the original rollbar problem, I think we need to patch this and wait, maybe?

Fixes internal rollbar 15768

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.23
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
