### PR TITLE
Fixes #10536 Unable to add asset model (v6.0.0-RC-1)

### DIFF
--- a/app/Http/Livewire/CustomFieldSetDefaultValuesForModel.php
+++ b/app/Http/Livewire/CustomFieldSetDefaultValuesForModel.php
@@ -17,6 +17,10 @@ class CustomFieldSetDefaultValuesForModel extends Component
 
     public function mount()
     {
+        if(is_null($this->model_id)){
+            return;
+        }
+            
         $this->model = AssetModel::find($this->model_id); // It's possible to do some clever route-model binding here, but let's keep it simple, shall we?
         $this->fieldset_id = $this->model->fieldset_id;
 

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -34,9 +34,7 @@
 </div>
 
 <!-- Custom Fieldset -->
-@if (isset($item->id))
-    @livewire('custom-field-set-default-values-for-model',["model_id" => $item->id])
-@endif
+@livewire('custom-field-set-default-values-for-model',["model_id" => $item->id])
 
 @include ('partials.forms.edit.notes')
 @include ('partials.forms.edit.requestable', ['requestable_text' => trans('admin/models/general.requestable')])


### PR DESCRIPTION
# Description
Add a return early clause to `CustomFieldSetDefaultValuesForModel` class for the case when the user needs to create a new Asset Model. Also, removed an if that I stupidly added in a previous PR that deactivate that option for new Asset Models.

The current mount function only contemplate when an ID is present, as in we are editing an existing Asset Model.

Fixes #10536 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.23
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
