### PR TITLE
Fixed #10564: Edit the route to associate custom fields with fieldsets

### DIFF
--- a/routes/web/fields.php
+++ b/routes/web/fields.php
@@ -29,7 +29,7 @@ Route::group([ 'prefix' => 'fields','middleware' => ['auth'] ], function () {
 
     Route::post(
         'fieldsets/{id}/associate',
-        [CustomFieldsController::class, 'associate']
+        [CustomFieldsetsController::class, 'associate']
     )->name('fieldsets.associate');
 
     Route::resource('fieldsets', CustomFieldsetsController::class, [


### PR DESCRIPTION
# Description
When trying to add a custom field to an existing fieldset, the system throws an error that the method doesn't exist because it was pointing to an erroneus controller.

Fixes #10564

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.23
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
