### PR TITLE
Fixes Importing licenses without product key duplicates the license

### DIFF
--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -32,7 +32,6 @@ class LicenseImporter extends ItemImporter
     {
         $editingLicense = false;
         $license = License::where('name', $this->item['name'])
-                    ->where('serial', $this->item['serial'])
                     ->first();
         if ($license) {
             if (!$this->updating) {


### PR DESCRIPTION
# Description
If the user tries to import licenses without the correct Product Key (Serial Number in the Importer), the system creates a new one even if another with the same name already exists.

Fixes Internal freshdesk 23689

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.23
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
