### PR TITLE
Fixes donked layout required field error depreciation in develop[sc-17111]

### DIFF
--- a/resources/views/depreciations/edit.blade.php
+++ b/resources/views/depreciations/edit.blade.php
@@ -16,21 +16,11 @@
         {{ trans('admin/depreciations/general.number_of_months') }}
     </label>
     <div class="col-md-7 col-sm-12 {{  (Helper::checkIfRequired($item, 'months')) ? ' required' : '' }}">
-            <input class="form-control" type="text" name="months" aria-label="months" id="months" value="{{ Request::old('months', $item->months) }}" style="width: 80px;" />
+            <input class="form-control" type="text" name="months" aria-label="months" id="months" value="{{ Request::old('months', $item->months) }}" style="width: 80px;"{!!  (Helper::checkIfRequired($item, 'months')) ? ' data-validation="required" required' : '' !!} />
             {!! $errors->first('months', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
 </div>
 
-<!-- Depreciation Minimum -->
-<div class="form-group {{ $errors->has('depreciation_min') ? ' has-error' : '' }}">
-    <label for="depreciation_min" class="col-md-3 control-label">
-        {{ trans('admin/depreciations/general.depreciation_min') }}
-    </label>
-    <div class="col-md-2" style="padding-left:0px">
-        <input class="form-control"  name="depreciation_min" id="depreciation_min" value="{{ Request::old('depreciation_min', $item->depreciation_min) }}" style="width: 80px; margin-left:15px" />
-    </div>
-    {!! $errors->first('depreciation_min', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-</div>
 <!-- Depreciation Minimum -->
 <div class="form-group {{ $errors->has('depreciation_min') ? ' has-error' : '' }}">
     <label for="depreciation_min" class="col-md-3 control-label">


### PR DESCRIPTION
# Description
Makes a little prettier the error messages for when the user wants to create a new Depreciation. Also deletes a duplicate form entry present in the develop branch.

Fixes internal shortcut 17111

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.23
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
