### PR TITLE
Fixes donked layout required field error depreciation [sc-17111]

### DIFF
--- a/resources/views/depreciations/edit.blade.php
+++ b/resources/views/depreciations/edit.blade.php
@@ -17,7 +17,7 @@
     </label>
     <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'months')) ? ' required' : '' }}">
         <div class="col-md-7" style="padding-left:0px">
-            <input class="form-control" type="text" name="months" id="months" value="{{ Request::old('months', $item->months) }}" style="width: 80px;"{!!  (\App\Helpers\Helper::checkIfRequired($item, 'name')) ? ' data-validation="required" required' : '' !!} />
+            <input class="form-control" type="text" name="months" id="months" value="{{ Request::old('months', $item->months) }}" style="width: 80px;"{!!  (\App\Helpers\Helper::checkIfRequired($item, 'months')) ? ' data-validation="required" required' : '' !!} />
             {!! $errors->first('months', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>

--- a/resources/views/depreciations/edit.blade.php
+++ b/resources/views/depreciations/edit.blade.php
@@ -16,11 +16,12 @@
         {{ trans('admin/depreciations/general.number_of_months') }}
     </label>
     <div class="col-md-7{{  (\App\Helpers\Helper::checkIfRequired($item, 'months')) ? ' required' : '' }}">
-        <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="months" id="months" value="{{ Request::old('months', $item->months) }}" style="width: 80px;" />
+        <div class="col-md-7" style="padding-left:0px">
+            <input class="form-control" type="text" name="months" id="months" value="{{ Request::old('months', $item->months) }}" style="width: 80px;"{!!  (\App\Helpers\Helper::checkIfRequired($item, 'name')) ? ' data-validation="required" required' : '' !!} />
+            {!! $errors->first('months', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>
-    {!! $errors->first('months', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
+
 </div>
 <!-- Depreciation Minimum -->
 <div class="form-group {{ $errors->has('depreciation_min') ? ' has-error' : '' }}">


### PR DESCRIPTION
# Description
Makes a little prettier the error messages for when the user wants to create a new Depreciation.

Fixes internal shortcut 17111

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.23
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
