### PR TITLE
Update AppServiceProvider.php

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -43,13 +43,13 @@ class AppServiceProvider extends ServiceProvider
                 \Log::warning("'APP_FORCE_TLS' is set to true, but 'APP_URL' does not start with 'https://'. Will not force TLS on connections.");
             }
         }
-
+        //Commenting out someones TODO because this would not let php artisan to generate a key, and therefore 500 Error on webiste for all users updating or installing snipe-it
         // TODO - isn't it somehow 'gauche' to check the environment directly; shouldn't we be using config() somehow?
-        if ( ! env('APP_ALLOW_INSECURE_HOSTS')) {  // unless you set APP_ALLOW_INSECURE_HOSTS, you should PROHIBIT forging domain parts of URL via Host: headers
-            $url_parts = parse_url(config('app.url'));
-            $root_url = $url_parts['scheme'].'://'.$url_parts['host'].( isset($url_parts['port']) ? ':'.$url_parts['port'] : '');
-            \URL::forceRootUrl($root_url);
-        }
+        //if ( ! env('APP_ALLOW_INSECURE_HOSTS')) {  // unless you set APP_ALLOW_INSECURE_HOSTS, you should PROHIBIT forging domain parts of URL via Host: headers
+          //  $url_parts = parse_url(config('app.url'));
+            //$root_url = $url_parts['scheme'].'://'.$url_parts['host'].( isset($url_parts['port']) ? ':'.$url_parts['port'] : '');
+            //\URL::forceRootUrl($root_url);
+        //}
 
         Schema::defaultStringLength(191);
         Asset::observe(AssetObserver::class);


### PR DESCRIPTION
Commenting out someones TODO near line 50, because this would not let php artisan to generate a key, and therefore 500 Error on webiste for all users updating or installing snipe-it

# Description

While installing/ updating snipe-it when we try to create key through php artisan, it immediately fails at line 50 calling out an invalid scheme. Therefore, I have commented out that part of the code until the TODO is done.  

Fixes # (issue)

## Type of change

Please delete options that are not relevant.


- [X ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: I was trying to create a clone of the asset management so we can just import the database. While installing it would fail at this point so I tried multiple times if something went wrong on my side. Later when digged deep into the code, it was an unattended TODO.
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
