### PR TITLE
Add some guardrails around very-badly formatted APP_URL settings

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -47,8 +47,12 @@ class AppServiceProvider extends ServiceProvider
         // TODO - isn't it somehow 'gauche' to check the environment directly; shouldn't we be using config() somehow?
         if ( ! env('APP_ALLOW_INSECURE_HOSTS')) {  // unless you set APP_ALLOW_INSECURE_HOSTS, you should PROHIBIT forging domain parts of URL via Host: headers
             $url_parts = parse_url(config('app.url'));
-            $root_url = $url_parts['scheme'].'://'.$url_parts['host'].( isset($url_parts['port']) ? ':'.$url_parts['port'] : '');
-            \URL::forceRootUrl($root_url);
+            if($url_parts && array_key_exists('scheme', $url_parts) && array_key_exists('host', $url_parts)) {
+                $root_url = $url_parts['scheme'].'://'.$url_parts['host'].( isset($url_parts['port']) ? ':'.$url_parts['port'] : '');
+                \URL::forceRootUrl($root_url);
+            } else {
+                \Log::error("Your APP_URL in your .env is misconfigured - it is: ".config('app.url').". Many things will work strangely unless you fix it.");
+            }
         }
 
         Schema::defaultStringLength(191);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -47,8 +47,8 @@ class AppServiceProvider extends ServiceProvider
         // TODO - isn't it somehow 'gauche' to check the environment directly; shouldn't we be using config() somehow?
         if ( ! env('APP_ALLOW_INSECURE_HOSTS')) {  // unless you set APP_ALLOW_INSECURE_HOSTS, you should PROHIBIT forging domain parts of URL via Host: headers
             $url_parts = parse_url(config('app.url'));
-            if($url_parts && array_key_exists('scheme', $url_parts) && array_key_exists('host', $url_parts)) {
-                $root_url = $url_parts['scheme'].'://'.$url_parts['host'].( isset($url_parts['port']) ? ':'.$url_parts['port'] : '');
+            if ($url_parts && array_key_exists('scheme', $url_parts) && array_key_exists('host', $url_parts)) {
+                $root_url = $url_parts['scheme'].'://'.$url_parts['host'].(isset($url_parts['port']) ? ':'.$url_parts['port'] : '');
                 \URL::forceRootUrl($root_url);
             } else {
                 \Log::error("Your APP_URL in your .env is misconfigured - it is: ".config('app.url').". Many things will work strangely unless you fix it.");


### PR DESCRIPTION
Putting just the tiniest touch of tooling in place in case someone has a really ridiculously incorrect APP_URL. We've seen one PR and one issue about this already, so it's probably worth addressing now.

This PR is against master, another I will make for Develop.