### PR TITLE
Typo found in snipeit/routes/api.php @ line 391

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -389,7 +389,7 @@ Route::group(['prefix' => 'v1', 'middleware' => 'api'], function () {
          * Groups API routes
         */
         Route::resource('groups', 
-        Api\GroupsCOntroller::class,
+        Api\GroupsController::class,
             ['names' => 
                 [
                     'index' => 'api.groups.index',


### PR DESCRIPTION
# Description

I'm using a forked branch for a feature, but I traced the issue as part of the snipe:snipeit/develop branch. When I went to look at my groups and their permissions I couldn't see any groups, but the groups were still in affect(super admins, admins, and building techs). I tried clearing the view cache just in case this was the issue and verified permissions on the files too. Nothing happened. I could create new groups too and they wouldn't show up. I looked at this Laravel log and noticed the typo. I began to grep to see where this mispelling came up and found it in snipeit/routes/api.php

./storage/logs/laravel.log:[2022-01-31 13:57:25] production.ERROR: Target class [App\Http\Controllers\Api\GroupsCOntroller] does not exist. {"userId":2125,"exception":"[object] (Illuminate\Contracts\Container\BindingResolutionException(code: 0): Target class [App\Http\Controllers\Api\GroupsCOntroller] does not exist. at /var/www/html/snipeit/vendor/laravel/framework/src/Illuminate/Container/Container.php:879)

Fixes # (problem I ran into during normal use no issue created that I could find)

## Type of change

edited the code for snipeit/routes/api.php @ line 391

<img width="481" alt="Screen Shot 2022-02-01 at 8 59 00 AM" src="https://user-images.githubusercontent.com/48162670/151992699-ba1f091b-611f-4005-b2a0-78e7b5ef10fc.png">

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I went to the groups page after applying change and the groups I made loaded as they did before switching to the Develop branch.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
