### PR TITLE
Allow invalid app urls develop

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -46,8 +46,12 @@ class AppServiceProvider extends ServiceProvider
         // TODO - isn't it somehow 'gauche' to check the environment directly; shouldn't we be using config() somehow?
         if ( ! env('APP_ALLOW_INSECURE_HOSTS')) {  // unless you set APP_ALLOW_INSECURE_HOSTS, you should PROHIBIT forging domain parts of URL via Host: headers
             $url_parts = parse_url(config('app.url'));
-            $root_url = $url_parts['scheme'].'://'.$url_parts['host'].( isset($url_parts['port']) ? ':'.$url_parts['port'] : '');
-            \URL::forceRootUrl($root_url);
+            if($url_parts && array_key_exists('scheme', $url_parts) && array_key_exists('host', $url_parts)) {
+                $root_url = $url_parts['scheme'].'://'.$url_parts['host'].( isset($url_parts['port']) ? ':'.$url_parts['port'] : '');
+                \URL::forceRootUrl($root_url);
+            } else {
+                \Log::error("Your APP_URL in your .env is misconfigured - it is: ".config('app.url').". Many things will work strangely unless you fix it.");
+            }
         }
 
         \Illuminate\Pagination\Paginator::useBootstrap();


### PR DESCRIPTION
This is the same fix that we executed on v5 - allowing grossly misformatted APP_URL values to limp on, as best as possible.