### PR TITLE
Fixed markdown upcoming audits email table

### DIFF
--- a/resources/views/notifications/markdown/upcoming-audits.blade.php
+++ b/resources/views/notifications/markdown/upcoming-audits.blade.php
@@ -4,7 +4,7 @@
 
 @component('mail::table')
 | |{{ trans('mail.name') }}|{{ trans('general.last_audit') }}|{{ trans('general.next_audit_date') }}|{{ trans('mail.Days') }}|{{ trans('mail.supplier') }} | {{ trans('mail.assigned_to') }}
-| |:------------- |:-------------|:---------|:---------|:---------|:---------|
+|-|:------------- |:-------------|:---------|:---------|:---------|:---------|
 @foreach ($assets as $asset)
 @php
 $next_audit_date = Helper::getFormattedDateObject($asset->next_audit_date, 'date', false);


### PR DESCRIPTION
It’s just a missing dash. Just pushing this to develop; we haven’t had any complaints about this for v5 so that ought to be enough.