### PR TITLE
Fixes: Column activated cannot be null [sc-18528]

### DIFF
--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -484,7 +484,6 @@ class UsersController extends Controller
             $user->first_name = '';
             $user->last_name = '';
             $user->email = substr($user->email, ($pos = strpos($user->email, '@')) !== false ? $pos : 0);
-
             $user->id = null;
 
             // Get this user groups

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -200,7 +200,7 @@
                                   <div class="icheckbox disabled" style="padding-left: 10px;">
                                       <input type="checkbox" value="1" name="activated" class="minimal disabled" {{ (old('activated', $user->activated)) == '1' ? ' checked="checked"' : '' }} disabled="disabled" aria-label="activated">
                                       <!-- this is necessary because the field is disabled and will reset -->
-                                      <input type="hidden" name="activated" value="{{ $user->activated }}">
+                                      <input type="hidden" name="activated" value="{{ (int)$user->activated }}">
                                       {{ trans('admin/users/general.activated_help_text') }}
                                       <p class="help-block">{{ trans('general.feature_disabled') }}</p>
 


### PR DESCRIPTION
# Description
This was a hard one to debug... that's why I'm putting this PR. because to be honest I don't think it could happen in a self-hosted or with a customer. It just happens when the .env var `APP_LOCKED` have assigned a true value (which is only used in our demo I believe) and if we try to clone a User that has the login deactivated. 

Because of PHP reasons (interpreted language, truthy/falsy, etc) when the user has the login deactivated `$user->activated` is read as `true` and `false` inside a hidden field, making the system fails as if the column was sent as `null`.

As I said, I don't think this error have a lot of impact in users, but it took me some time to figure out, so I just put the fix out anyways. :P

Fixes internal Shortcut 18528

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
