### PR TITLE
Fixes #10563 - Rework the LDAP sync command to better handle the active flag

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -213,25 +213,17 @@ class LdapSync extends Command
                 $user->country = $item["country"];
                 $user->department_id = $department->id;
 
-                if(@$results[$i][$ldap_result_active_flag][0]) {
-                    \Log::error("ldap_result_active_flag: $ldap_result_active_flag, value: ".@$results[$i][$ldap_result_active_flag][0]);
-                }
-
                 if ( !empty($ldap_result_active_flag)) { // IF we have an 'active' flag set....
-                    //\Log::error("WE HAVE AN ACTIVE FLAG! We are going to set activated TO: ".(@$results[$i][$ldap_result_active_flag][0] ? 1 : 0));
-                    // $parsed_active_flag = filter_var(@$results[$i][$ldap_result_active_flag][0], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-                    // $user->activated = $parsed_active_flag ?? true; // ....then anything truthy will activate the user, period. Anything falsey will deactivate them.
-                                                                    //     (and anything even weirder than that will process as 'true' I guess?)
+                    // ....then *most* things that are truthy will activate the user. Anything falsey will deactivate them.
+                    // (Specifically, we don't handle a value of '0.0' correctly)
                     $raw_value = @$results[$i][$ldap_result_active_flag][0];
                     $filter_var = filter_var($raw_value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
                     $boolean_cast = (bool)$raw_value;
-                    if(!is_null($raw_value)) {
-                        \Log::error("We have an active flag! filter_var for '$raw_value' says: ".(is_null($filter_var) ? 'NULL': ($filter_var ? 'true' : 'false'))." but boolean cast says: ".($boolean_cast ? 'true': 'false')." And string compare is: ".($raw_value > 0 ? 'true' : 'false'));
-                    }
-                    $user->activated = $filter_var ?? $boolean_cast; // this seems clever but it does pretty much exactly what I want. (I think?) No, it doesn't.
 
-                } elseif (array_key_exists('useraccountcontrol', $results[$i]) ) {
-                    // ....otherwise, (ie if no 'active' LDAP flag is defined), IF the UAC setting exists, 
+                    $user->activated = $filter_var ?? $boolean_cast; // if filter_var() was true or false, use that. If it's null, use the $boolean_cast
+
+                } elseif ( array_key_exists('useraccountcontrol', $results[$i]) ) {
+                    // ....otherwise, (ie if no 'active' LDAP flag is defined), IF the UAC setting exists,
                     // ....then use the UAC setting on the account to determine can-log-in vs. cannot-log-in
 
                     /* The following is _probably_ the correct logic, but we can't use it because
@@ -285,7 +277,6 @@ class LdapSync extends Command
                 $errors = '';
 
                 if ($user->save()) {
-                    //\Log::info("We have done a save, and it was succesful! Results: ".print_r($user,true));
                     $item["note"] = $item["createorupdate"];
                     $item["status"]='success';
                 } else {
@@ -297,7 +288,6 @@ class LdapSync extends Command
                 }
 
                 array_push($summary, $item);
-            
 
         }
 

--- a/database/migrations/2015_11_08_222305_add_ldap_fields_to_settings.php
+++ b/database/migrations/2015_11_08_222305_add_ldap_fields_to_settings.php
@@ -23,7 +23,7 @@ class AddLdapFieldsToSettings extends Migration {
 			$table->string('ldap_username_field')->nullable()->default('samaccountname');
 			$table->string('ldap_lname_field')->nullable()->default('sn');
 			$table->string('ldap_fname_field')->nullable()->default('givenname');
-			$table->string('ldap_auth_filter_query')->nullable()->default('uid=samaccountname');
+			$table->string('ldap_auth_filter_query')->nullable()->default('uid=');
 			$table->integer('ldap_version')->nullable()->default(3);
 			$table->string('ldap_active_flag')->nullable()->default(NULL);
 			$table->string('ldap_emp_num')->nullable()->default(NULL);

--- a/database/migrations/2022_02_03_214958_blank_out_ldap_active_flag.php
+++ b/database/migrations/2022_02_03_214958_blank_out_ldap_active_flag.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Setting;
+
+class BlankOutLdapActiveFlag extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $s = Setting::getSettings();
+        $s->ldap_active_flag = '';
+        $s->save();
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
The LDAP active flag code seems like it has never worked, or at least, hasn't worked at all throughout v5.

There were a lot of high-velocity, high-impact, ultra-scary changes that happened as we did our emergency rollback to our 'classic' LDAP system from v4 very early into the days of v5, and it looks like I made a few 'fixes' that didn't actually work very well, or at all. Whoops :(

This PR attempts to address some of that in the safest way possible.

Zeroth off, the default value that we insert into the "LDAP Auth Filter Query" doesn't work, so this change sneaks that fix into the old migration. I think that's *probably* fine, and relatively low impact - and at least means that new installations in the future won't have that incorrect default value anymore. Now, onto the real thing that we're doing here....

First off, the LDAP active flag had been completely ignored before. And just about every customer instance or self-hosted instance that I've encountered in the wild has the field misconfigured, if it's set. So that means that if we 'fix' the Active flag, we're going to suddenly batch-deactivate tons of users upon their next LDAP sync. So the safest way for us to go, then, is to blank this field once you update to this version of the software. That means the app behaves exactly as it did before. This is done in a migration.

Next, we have been bulk-reactivating all users whenever we do an LDAP sync. If an administrator marks a user as 'inactive', then upon LDAP sync, they would be marked as 'active' again. That's also not cool, so this change tries to not do that any more.

We have also been ignoring the LDAP Active field entirely for Active Directory users. Instead, the userAccountControl (UAC) attribute has been used - if it declares the user as a regular user who doesn't have a locked account, we let you log in. This has generally worked for our AD users and there hasn't been a lot of negative feedback for it. So with this change that continues to operate as it has. However, if, after the administrator updates to the latest version of Snipe-IT, and *then* they set an 'LDAP Active Flag' field, that will be respected instead of the UAC. This is a new feature for those folks.

So all of that being said, the main change that this introduces is that **IF** you set an "LDAP Active Flag" setting, **THEN** that alone will determine whether or not the user can log in. "Truthy" values (1, true, "active", "yes", "anything you want", 1.0) will mark the user as being able to log in. "Falsey" values (0, false, "", null, 0.0, attribute not even present) will mark the user as being **unable** to log in. This seems at least better.

One thing to note that this is *missing* is that AD folks who want to manually mark users as active or inactive have no way to do so - leaving the LDAP filter field blank means that UAC's are respected, and setting an actual LDAP filter means that that filter is respected. No manual approach remains to marking users as loginable or not-loginable. This is how the current system works, so while this definitely *does* suck, it sucks no worse than what we do today.

For testing, there are a lot of options I'm going to have to look at, I think I'll detail those in the comments as opposed to making this novel be any longer than it currently is, and that's why I'm marking this PR as WIP.