### PR TITLE
Fixes #10577 - Fix "secure hostnames" feature for subdirectory-based Snipe-IT installs

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -47,9 +47,8 @@ class AppServiceProvider extends ServiceProvider
         // TODO - isn't it somehow 'gauche' to check the environment directly; shouldn't we be using config() somehow?
         if ( ! env('APP_ALLOW_INSECURE_HOSTS')) {  // unless you set APP_ALLOW_INSECURE_HOSTS, you should PROHIBIT forging domain parts of URL via Host: headers
             $url_parts = parse_url(config('app.url'));
-            if ($url_parts && array_key_exists('scheme', $url_parts) && array_key_exists('host', $url_parts)) {
-                $root_url = $url_parts['scheme'].'://'.$url_parts['host'].(isset($url_parts['port']) ? ':'.$url_parts['port'] : '');
-                \URL::forceRootUrl($root_url);
+            if ($url_parts && array_key_exists('scheme', $url_parts) && array_key_exists('host', $url_parts)) { // check for the *required* parts of a bare-minimum URL
+                \URL::forceRootUrl(config('app.url'));
             } else {
                 \Log::error("Your APP_URL in your .env is misconfigured - it is: ".config('app.url').". Many things will work strangely unless you fix it.");
             }


### PR DESCRIPTION
The new "Secure Hostnames" feature added in 5.3.8 seems to have broken subdirectory installs. I've modified the logic so that it just takes the entire `config('app.url')` as the forced root URL - only if it meets the bare minimums of what an `APP_URL` should look like, e.g. having a scheme and a hostname.

@savornicesei was able to confirm that it works with subdirectory installs, and I was able to confirm that it doesn't break 'normal' root-level URL installs, so this should hopefully fix #10577 

I'll cherry-pick and apply to develop in a separate PR. 