### PR TITLE
Fixes #10614 Checkin/Checkout API route's broken

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -460,7 +460,7 @@ Route::group(['prefix' => 'v1', 'middleware' => 'api'], function () {
         ]
         )->name('api.asset.audit');
 
-        Route::post('checkin',
+        Route::post('{id}/checkin',
         [
             Api\AssetsController::class, 
             'checkin'
@@ -474,7 +474,7 @@ Route::group(['prefix' => 'v1', 'middleware' => 'api'], function () {
             ]
         )->name('api.asset.checkinbytag');
 
-        Route::post('checkout',
+        Route::post('{id}/checkout',
         [
             Api\AssetsController::class, 
             'checkout'


### PR DESCRIPTION
# Description
The routes to checkin/checkout assets via API are incorrect, I just add the ID of the checkin/checkout asset to the API call.

Fixes #10614

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
