### PR TITLE
Fixes #10299 Default Values do not allow Checkbox/Radio Buttons

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -155,7 +155,6 @@ class AssetModelsController extends Controller
         $model->requestable         = $request->input('requestable', '0');
 
 
-
         $this->removeCustomFieldsDefaultValues($model);
 
         if ($request->input('custom_fieldset')=='') {
@@ -464,8 +463,7 @@ class AssetModelsController extends Controller
         foreach ($defaultValues as $customFieldId => $defaultValue) {
             if(is_array($defaultValue)){
                 $model->defaultValues()->attach($customFieldId, ['default_value' => implode(',', $defaultValue)]);
-            }
-            if ($defaultValue) {
+            }elseif ($defaultValue) {
                 $model->defaultValues()->attach($customFieldId, ['default_value' => $defaultValue]);
             }
         }

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -462,7 +462,7 @@ class AssetModelsController extends Controller
     {
         foreach ($defaultValues as $customFieldId => $defaultValue) {
             if(is_array($defaultValue)){
-                $model->defaultValues()->attach($customFieldId, ['default_value' => implode(',', $defaultValue)]);
+                $model->defaultValues()->attach($customFieldId, ['default_value' => implode(', ', $defaultValue)]);
             }elseif ($defaultValue) {
                 $model->defaultValues()->attach($customFieldId, ['default_value' => $defaultValue]);
             }

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -168,7 +168,6 @@ class AssetModelsController extends Controller
             }
         }
 
-
         if ($model->save()) {
             return redirect()->route("models.index")->with('success', trans('admin/models/message.update.success'));
         }
@@ -463,6 +462,9 @@ class AssetModelsController extends Controller
     private function assignCustomFieldsDefaultValues(AssetModel $model, array $defaultValues)
     {
         foreach ($defaultValues as $customFieldId => $defaultValue) {
+            if(is_array($defaultValue)){
+                $model->defaultValues()->attach($customFieldId, ['default_value' => implode(',', $defaultValue)]);
+            }
             if ($defaultValue) {
                 $model->defaultValues()->attach($customFieldId, ['default_value' => $defaultValue]);
             }

--- a/resources/assets/js/components/forms/asset-models/fieldset-default-values.vue
+++ b/resources/assets/js/components/forms/asset-models/fieldset-default-values.vue
@@ -47,7 +47,7 @@
                                 <textarea v-if="field.type == 'textarea'" class="form-control" :value="getValue(field)" :id="'default-value' + field.id" :name="'default_values[' + field.id + ']'"></textarea><br>
 
                               <div v-for="field_value in field.field_values_array">
-                                <input v-if="field.type == 'checkbox'" class="" type="checkbox" :name="'default_values[' + field.id + '][]'" :value="field_value"> <label>{{ field_value }}</label>
+                                <input v-if="field.type == 'checkbox'" class="" type="checkbox" :name="'default_values[' + field.id + '][]'" :value="field_value" :checked="getValue(field).split(',').includes(field_value)"> <label>{{ field_value }}</label>
                               </div>
 
                                 <select v-if="field.type == 'listbox'" class="form-control m-b-xs" :name="'default_values[' + field.id + ']'">

--- a/resources/assets/js/components/forms/asset-models/fieldset-default-values.vue
+++ b/resources/assets/js/components/forms/asset-models/fieldset-default-values.vue
@@ -46,8 +46,12 @@
                                 <input v-if="field.type == 'text'" class="form-control m-b-xs" type="text" :value="getValue(field)" :id="'default-value' + field.id" :name="'default_values[' + field.id + ']'">
                                 <textarea v-if="field.type == 'textarea'" class="form-control" :value="getValue(field)" :id="'default-value' + field.id" :name="'default_values[' + field.id + ']'"></textarea><br>
 
-                              <div v-for="field_value in field.field_values_array">
-                                <input v-if="field.type == 'checkbox'" class="" type="checkbox" :name="'default_values[' + field.id + '][]'" :value="field_value" :checked="getValue(field).split(',').includes(field_value)"> <label>{{ field_value }}</label>
+                              <div v-if="field.type == 'checkbox'" v-for="field_value in field.field_values_array">
+                                <input v-if="field.type == 'checkbox'" class="" type="checkbox" :name="'default_values[' + field.id + '][]'" :value="field_value" :checked="getValue(field).split(', ').includes(field_value)"> <label>{{ field_value }}</label>
+                              </div>
+
+                              <div v-if="field.type == 'radio'" v-for="field_value in field.field_values_array">
+                                <input v-if="field.type == 'radio'" class="" type="radio" :name="'default_values[' + field.id + ']'" :value="field_value" :checked="getValue(field).split(', ').includes(field_value)"> <label>{{ field_value }}</label>
                               </div>
 
                                 <select v-if="field.type == 'listbox'" class="form-control m-b-xs" :name="'default_values[' + field.id + ']'">

--- a/resources/assets/js/components/forms/asset-models/fieldset-default-values.vue
+++ b/resources/assets/js/components/forms/asset-models/fieldset-default-values.vue
@@ -45,6 +45,7 @@
                             <div class="col-sm-12 col-lg-6">
                                 <input v-if="field.type == 'text'" class="form-control m-b-xs" type="text" :value="getValue(field)" :id="'default-value' + field.id" :name="'default_values[' + field.id + ']'">
                                 <textarea v-if="field.type == 'textarea'" class="form-control" :value="getValue(field)" :id="'default-value' + field.id" :name="'default_values[' + field.id + ']'"></textarea><br>
+                                <input v-if="field.type == 'checkbox'" v-for="field_value in field.field_values_array" class="" type="checkbox" :value="field_value">
 
                                 <select v-if="field.type == 'listbox'" class="form-control m-b-xs" :name="'default_values[' + field.id + ']'">
                                     <option value=""></option>

--- a/resources/assets/js/components/forms/asset-models/fieldset-default-values.vue
+++ b/resources/assets/js/components/forms/asset-models/fieldset-default-values.vue
@@ -45,7 +45,10 @@
                             <div class="col-sm-12 col-lg-6">
                                 <input v-if="field.type == 'text'" class="form-control m-b-xs" type="text" :value="getValue(field)" :id="'default-value' + field.id" :name="'default_values[' + field.id + ']'">
                                 <textarea v-if="field.type == 'textarea'" class="form-control" :value="getValue(field)" :id="'default-value' + field.id" :name="'default_values[' + field.id + ']'"></textarea><br>
-                                <input v-if="field.type == 'checkbox'" v-for="field_value in field.field_values_array" class="" type="checkbox" :value="field_value">
+
+                              <div v-for="field_value in field.field_values_array">
+                                <input v-if="field.type == 'checkbox'" class="" type="checkbox" :name="'default_values[' + field.id + '][]'" :value="field_value"> <label>{{ field_value }}</label>
+                              </div>
 
                                 <select v-if="field.type == 'listbox'" class="form-control m-b-xs" :name="'default_values[' + field.id + ']'">
                                     <option value=""></option>

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -20,7 +20,7 @@
                   @foreach ($field->formatFieldValuesAsArray() as $key => $value)
                       <div>
                           <label>
-                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" class="minimal" {{  isset($item) ? (in_array($key, explode(',', $item->{$field->db_column_name()})) ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, explode(',', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
+                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" class="minimal" {{  isset($item) ? (in_array($value, explode(', ', $item->{$field->db_column_name()})) ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, explode(', ', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
                               {{ $value }}
                           </label>
                       </div>
@@ -31,7 +31,7 @@
 
               <div>
                   <label>
-                      <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" class="minimal" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : '') }}>
+                      <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" class="minimal" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($value, explode(', ', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
                       {{ $value }}
                   </label>
               </div>

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -18,10 +18,9 @@
               @elseif ($field->element=='checkbox')
                     <!-- Checkboxes -->
                   @foreach ($field->formatFieldValuesAsArray() as $key => $value)
-
                       <div>
                           <label>
-                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" class="minimal" {{  isset($item) ? (in_array($key, explode(', ', $item->{$field->db_column_name()})) ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : '') }}>
+                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" class="minimal" {{  isset($item) ? (in_array($key, explode(',', $item->{$field->db_column_name()})) ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, explode(',', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
                               {{ $value }}
                           </label>
                       </div>


### PR DESCRIPTION
# Description
Add support for default values in checkboxes and RadioButtons customfields. Phew! That was a long time!! Sorry, I do have to test not only that the default values save and show as expected. I also need that those reflected fine in the New and Update Asset screens.

Fixes #10299 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
