### PR TITLE
Fix #10629: Fix /hardware/{id}/checkin API response on error

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -866,7 +866,7 @@ class AssetsController extends Controller
             return response()->json(Helper::formatStandardApiResponse('success', ['asset'=> e($asset->asset_tag)], trans('admin/hardware/message.checkin.success')));
         }
 
-        return response()->json(Helper::formatStandardApiResponse('success', ['asset'=> e($asset->asset_tag)], trans('admin/hardware/message.checkin.error')));
+        return response()->json(Helper::formatStandardApiResponse('error', ['asset'=> e($asset->asset_tag)], trans('admin/hardware/message.checkin.error')));
     }
 
 


### PR DESCRIPTION
# Description

This fixes the status returned by `/hardware/{id}/checkin ` when there is an error. Specifically the `status` field now says `error` instead of `success`.
```json
{"status": "error", "messages": "Asset was not checked in, please try again", "payload": {"asset": "TEST-00001"}}
```

Fixes #10629

## Type of change
Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I repeated the `POST` indicated in #10629 and observed the above correct JSON response.


**Test Configuration**:
* Docker `snipe/snipe-it:v5.3.8` w/ this patch


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
