### PR TITLE
Fixes #10627 Inconsistencies between checkout/checkin dates on asset history and activity log  

### DIFF
--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -112,6 +112,7 @@ trait Loggable
 
         $log->location_id = null;
         $log->note = $note;
+        $log->action_date= $action_date;
 
         if (Auth::user()) {
             $log->user_id = Auth::user()->id;

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1083,7 +1083,7 @@
                 <thead>
                 <tr>
                   <th data-visible="true" style="width: 40px;" class="hidden-xs">{{ trans('admin/hardware/table.icon') }}</th>
-                  <th class="col-sm-2" data-visible="true" data-field="created_at" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
+                  <th class="col-sm-2" data-visible="true" data-field="action_date" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
                   <th class="col-sm-1" data-visible="true" data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
                   <th class="col-sm-1" data-visible="true" data-field="action_type">{{ trans('general.action') }}</th>
                   <th class="col-sm-2" data-visible="true" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>


### PR DESCRIPTION
# Description

Some time ago I add custom checkin dates to the checkin assets form, and the world were a happier place. Until  users figure out that I made a mistake :(.

This PR builds over https://github.com/snipe/snipe-it/pull/6733 and finish the implementation of custom checkins, all was more or less ok, but I forgot to actually add the `checkin_at` to the logger, so every checkin found that their `action_date` unpopulate, making that the Activity report show the date in which it was checked in, not the custom date the user set.

Also, in the history tab of every asset details, the Bootstrap Table was using the `created_at` column, instead of the `action_date` one.

Fixes #10627

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
