### PR TITLE
Alert when invalid JSON is submitted to something that wants it

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use App\Helpers\Helper;
 use Illuminate\Validation\ValidationException;
 use Log;
+use JsonException;
 
 
 class Handler extends ExceptionHandler
@@ -26,6 +27,7 @@ class Handler extends ExceptionHandler
         \Illuminate\Validation\ValidationException::class,
         \Intervention\Image\Exception\NotSupportedException::class,
         \League\OAuth2\Server\Exception\OAuthServerException::class,
+        JsonException::class
     ];
 
     /**
@@ -58,6 +60,12 @@ class Handler extends ExceptionHandler
         // CSRF token mismatch error
         if ($e instanceof \Illuminate\Session\TokenMismatchException) {
             return redirect()->back()->with('error', trans('general.token_expired'));
+        }
+
+        // Invalid JSON exception
+        // TODO: don't understand why we have to do this when we have the invalidJson() method, below, but, well, whatever
+        if ($e instanceof JsonException) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, 'invalid JSON'), 422);
         }
 
 

--- a/app/Http/Requests/Request.php
+++ b/app/Http/Requests/Request.php
@@ -11,7 +11,7 @@ abstract class Request extends FormRequest
     public function json($key = null, $default = null)
     {
         if ($this->ajax() || $this->wantsJson()) {
-            json_decode($this->getContent(), false, 512, \JSON_THROW_ON_ERROR); // ignore output, just throw
+            json_decode($this->getContent(), false, 512, JSON_THROW_ON_ERROR); // ignore output, just throw
         }
         return parent::json($key, $default);
     }

--- a/app/Http/Requests/Request.php
+++ b/app/Http/Requests/Request.php
@@ -8,6 +8,14 @@ abstract class Request extends FormRequest
 {
     protected $rules = [];
 
+    public function json($key = null, $default = null)
+    {
+        if ($this->ajax() || $this->wantsJson()) {
+            json_decode($this->getContent(), false, 512, \JSON_THROW_ON_ERROR); // ignore output, just throw
+        }
+        return parent::json($key, $default);
+    }
+
     public function rules()
     {
         return $this->rules;


### PR DESCRIPTION
There's all kinds of stub logic in and around and even within the framework that seems like it *should* be alerting on invalid JSON, but apparently **we** don't, for reasons I do not yet fathom. I don't know why the framework wouldn't do a 'Throw; the moment the json decoding process breaks, I mean, it really seems like it should?

But regardless, this makes it so that if you submit grossly invalid JSON, an exception is raised. Then we make sure we don't crap all over the Laravel log (this is very much not log-worthy, and the stacktrace always looks the exact same and is not useful), and return a proper error with a 422 (Unprocessable Entity) message.

I think a large portion of Laravel changes around Exceptions and Requests in the v6 branch of Snipe-IT so I'm expecting that I'm going to have to substantially rework this for that. Not very excited about that.