### PR TITLE
Fix #10552: Add checkin_at parameter to /hardware/:id/checkin API

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -860,8 +860,13 @@ class AssetsController extends Controller
             $asset->status_id =  $request->input('status_id');
         }
 
+        $checkin_at = null;
+        if ($request->filled('checkin_at')) {
+            $checkin_at = $request->input('checkin_at');
+        }
+
         if ($asset->save()) {
-            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note')));
+            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $checkin_at));
 
             return response()->json(Helper::formatStandardApiResponse('success', ['asset'=> e($asset->asset_tag)], trans('admin/hardware/message.checkin.success')));
         }


### PR DESCRIPTION
# Description
This adds the `checkin_at` parameter to the `/hardware/:id/checkin` API.

Fixes #10552

(Now that #10627 is fixed, I was able to test this.)

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

(somewhere in between; all of the plumbing was in place, it just needed hooked up)

# How Has This Been Tested?
Via API:
- Checkout with `checkout_at` parameter
- Checkin with `checkin_at` parameter

Then verify in the asset history that the dates are as expected:

![image](https://user-images.githubusercontent.com/1916566/153120487-240ade2d-5bf1-4d01-bf19-d752184e4cd4.png)

**Test Configuration**:
* PHP version: 7.4 (docker)
* MySQL version: 5.6 (docker)
* Webserver version: Apache/2.4.41 (Ubuntu)
* OS version: Ubuntu (docker)


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
  - Unnecessary here
- [ ] I have made corresponding changes to the documentation
  - See #10551
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

---

cc @inietov 