### PR TITLE
Check that the field exists before trying to detach it from the fieldset

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -133,12 +133,19 @@ class CustomFieldsController extends Controller
 
         $this->authorize('update', $field);
 
-        if ($field->fieldset()->detach($fieldset_id)) {
-            return redirect()->route('fieldsets.show', ['fieldset' => $fieldset_id])
-                ->with("success", trans('admin/custom_fields/message.field.delete.success'));
-        }
+        // Check that the field exists - this is mostly related to the demo, where we 
+        // rewrite the data every x minutes, so it's possible someone might be disassociating 
+        // a field from a fieldset just as we're wiping the database
+        if (($field) && ($fieldset_id)) {
 
-        return redirect()->back()->withErrors(['message' => "Field is in-use"]);
+            if ($field->fieldset()->detach($fieldset_id)) {
+                return redirect()->route('fieldsets.show', ['fieldset' => $fieldset_id])
+                    ->with("success", trans('admin/custom_fields/message.field.delete.success'));
+            }   
+             
+        }
+       
+        return redirect()->back()->withErrors(['message' => "Error deleting field from fieldset"]);
     }
 
     /**

--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -141,11 +141,15 @@ class CustomFieldsController extends Controller
             if ($field->fieldset()->detach($fieldset_id)) {
                 return redirect()->route('fieldsets.show', ['fieldset' => $fieldset_id])
                     ->with("success", trans('admin/custom_fields/message.field.delete.success'));
-            }   
-             
+            } else {
+                return redirect()->back()->withErrors(['message' => "Field is in use and cannot be deleted."]);
+            }  
+
         }
-       
+
         return redirect()->back()->withErrors(['message' => "Error deleting field from fieldset"]);
+
+       
     }
 
     /**


### PR DESCRIPTION
Kinda what it says on the tin. This just checks that the field actually exists before trying to `->detach()` it from the fieldset. This would likely only come up on the demo, where someone could be in the middle of detaching a field from a fieldset just as we're wiping the database so the field or fieldset doesn't exist anymore. 

(Basically I just got tired of the Rollbars pooping up Shortcut. Which I realize sounds like gibberish, but welcome to tech in 2022 😁 ... I've never seen this issue in production.)

Fixes `Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function fieldset() on null`

Fixes Rollbar 1175 and SC-18710

Signed-off-by: snipe <snipe@snipe.net>
