### PR TITLE
Fixed - Check for valid user before trying to present the auditor name

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -281,7 +281,10 @@
                                             </div>
                                             <div class="col-md-6">
                                                 {{ \App\Helpers\Helper::getFormattedDateObject($audit_log->created_at, 'date', false) }} 
-                                                (by {{ link_to_route('users.show', $audit_log->user->present()->fullname(), [$audit_log->user->id]) }})
+                                                @if ($audit_log->user) 
+                                                    (by {{ link_to_route('users.show', $audit_log->user->present()->fullname(), [$audit_log->user->id]) }})
+                                                @endif 
+                                                
                                             </div>
                                         </div>
                                     @endif


### PR DESCRIPTION
This would only come up if the user ID that was recorded during an audit was force-deleted (deleted+purged). 