### PR TITLE
Added additional gate for selectlists

### DIFF
--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -234,6 +234,7 @@ class AssetModelsController extends Controller
     public function selectlist(Request $request)
     {
 
+        $this->authorize('view.selectlists');
         $assetmodels = AssetModel::select([
             'models.id',
             'models.name',

--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -148,7 +148,7 @@ class CategoriesController extends Controller
      */
     public function selectlist(Request $request, $category_type = 'asset')
     {
-
+        $this->authorize('view.selectlists');
         $categories = Category::select([
             'id',
             'name',

--- a/app/Http/Controllers/Api/CompaniesController.php
+++ b/app/Http/Controllers/Api/CompaniesController.php
@@ -159,7 +159,7 @@ class CompaniesController extends Controller
      */
     public function selectlist(Request $request)
     {
-
+        $this->authorize('view.selectlists');
         $companies = Company::select([
             'companies.id',
             'companies.name',

--- a/app/Http/Controllers/Api/DepartmentsController.php
+++ b/app/Http/Controllers/Api/DepartmentsController.php
@@ -168,6 +168,7 @@ class DepartmentsController extends Controller
     public function selectlist(Request $request)
     {
 
+        $this->authorize('view.selectlists');
         $departments = Department::select([
             'id',
             'name',

--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -223,6 +223,8 @@ class LocationsController extends Controller
     public function selectlist(Request $request)
     {
 
+        $this->authorize('view.selectlists');
+
         $locations = Location::select([
             'locations.id',
             'locations.name',

--- a/app/Http/Controllers/Api/ManufacturersController.php
+++ b/app/Http/Controllers/Api/ManufacturersController.php
@@ -155,6 +155,7 @@ class ManufacturersController extends Controller
     public function selectlist(Request $request)
     {
 
+        $this->authorize('view.selectlists');
         $manufacturers = Manufacturer::select([
             'id',
             'name',

--- a/app/Http/Controllers/Api/SuppliersController.php
+++ b/app/Http/Controllers/Api/SuppliersController.php
@@ -155,6 +155,8 @@ class SuppliersController extends Controller
     public function selectlist(Request $request)
     {
 
+        $this->authorize('view.selectlists');
+
         $suppliers = Supplier::select([
             'id',
             'name',

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -180,7 +180,7 @@ class AuthServiceProvider extends ServiceProvider
         // if the user can't view and interact with the select lists.
         Gate::define('view.selectlists', function ($user) {
             return $user->can('update', Asset::class) 
-                || $user->can('create', License::class)    
+                || $user->can('create', Asset::class)    
                 || $user->can('update', License::class)   
                 || $user->can('create', License::class)   
                 || $user->can('update', Component::class)

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -179,18 +179,12 @@ class AuthServiceProvider extends ServiceProvider
         // to the logged in API user, but creating assets, licenses, etc won't work 
         // if the user can't view and interact with the select lists.
         Gate::define('view.selectlists', function ($user) {
-            return $user->can('update', Asset::class) 
-                || $user->can('create', Asset::class)    
-                || $user->can('update', License::class)   
-                || $user->can('create', License::class)   
-                || $user->can('update', Component::class)
-                || $user->can('create', Component::class)   
-                || $user->can('update', Consumable::class)   
-                || $user->can('create', Consumable::class)   
-                || $user->can('update', Accessory::class)
-                || $user->can('create', Accessory::class)   
-                || $user->can('update', User::class)
-                || $user->can('create', User::class);   
+            return $user->can(['create','update'], Asset::class) 
+                || $user->can(['create','update'], License::class)   
+                || $user->can(['create','update'], Component::class)
+                || $user->can(['create','update'], Consumable::class)   
+                || $user->can(['create','update'], Accessory::class)   
+                || $user->can(['create','update'], User::class);   
         });
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -174,9 +174,8 @@ class AuthServiceProvider extends ServiceProvider
         });
 
 
-        // This largely echoes the above backend.interact gate, but also determins 
-        // whether or not an API user should be able tp get the selectlists.
-        // This can seema a little confusing, since view properties may not have been granted
+        // This  determines whether or not an API user should be able to get the selectlists.
+        // This can seem a little confusing, since view properties may not have been granted
         // to the logged in API user, but creating assets, licenses, etc won't work 
         // if the user can't view and interact with the select lists.
         Gate::define('view.selectlists', function ($user) {

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -179,12 +179,18 @@ class AuthServiceProvider extends ServiceProvider
         // to the logged in API user, but creating assets, licenses, etc won't work 
         // if the user can't view and interact with the select lists.
         Gate::define('view.selectlists', function ($user) {
-            return $user->can('view', Asset::class)   
-                || $user->can('view', License::class)   
-                || $user->can('view', Component::class)   
-                || $user->can('view', Consumable::class)   
-                || $user->can('view', Accessory::class)   
-                || $user->can('view', User::class);   
+            return $user->can('update', Asset::class) 
+                || $user->can('create', License::class)    
+                || $user->can('update', License::class)   
+                || $user->can('create', License::class)   
+                || $user->can('update', Component::class)
+                || $user->can('create', Component::class)   
+                || $user->can('update', Consumable::class)   
+                || $user->can('create', Consumable::class)   
+                || $user->can('update', Accessory::class)
+                || $user->can('create', Accessory::class)   
+                || $user->can('update', User::class)
+                || $user->can('create', User::class);   
         });
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -180,8 +180,7 @@ class AuthServiceProvider extends ServiceProvider
         // to the logged in API user, but creating assets, licenses, etc won't work 
         // if the user can't view and interact with the select lists.
         Gate::define('view.selectlists', function ($user) {
-            return $user->can('view', Statuslabel::class)
-                || $user->can('view', Asset::class)   
+            return $user->can('view', Asset::class)   
                 || $user->can('view', License::class)   
                 || $user->can('view', Consumable::class)   
                 || $user->can('view', Accessory::class)   

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -156,6 +156,8 @@ class AuthServiceProvider extends ServiceProvider
             return $user->hasAccess('self.checkout_assets');
         });
 
+        // This is largely used to determine whether to display the gear icon sidenav 
+        // in the left-side navigation
         Gate::define('backend.interact', function ($user) {
             return $user->can('view', Statuslabel::class)
                 || $user->can('view', AssetModel::class)
@@ -168,7 +170,22 @@ class AuthServiceProvider extends ServiceProvider
                 || $user->can('view', Manufacturer::class)
                 || $user->can('view', CustomField::class)
                 || $user->can('view', CustomFieldset::class)                
-                || $user->can('view', Depreciation::class);
+                || $user->can('view', Depreciation::class); 
+        });
+
+
+        // This largely echoes the above backend.interact gate, but also determins 
+        // whether or not an API user should be able tp get the selectlists.
+        // This can seema a little confusing, since view properties may not have been granted
+        // to the logged in API user, but creating assets, licenses, etc won't work 
+        // if the user can't view and interact with the select lists.
+        Gate::define('view.selectlists', function ($user) {
+            return $user->can('view', Statuslabel::class)
+                || $user->can('view', Asset::class)   
+                || $user->can('view', License::class)   
+                || $user->can('view', Consumable::class)   
+                || $user->can('view', Accessory::class)   
+                || $user->can('view', User::class);   
         });
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -182,6 +182,7 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('view.selectlists', function ($user) {
             return $user->can('view', Asset::class)   
                 || $user->can('view', License::class)   
+                || $user->can('view', Component::class)   
                 || $user->can('view', Consumable::class)   
                 || $user->can('view', Accessory::class)   
                 || $user->can('view', User::class);   


### PR DESCRIPTION
This one is a little fraught, since if something was missed here, it could break all kinds of things - BUT it should at least be pretty straightforward.

Right now, we have a Gate that determine whether you should see the gear icon in the right side. This logic makes sense, because if you have the ability to edit ANY of those things, you need to be able to see the gear icon in order to get the dropdown options in the nav item. 

https://github.com/snipe/snipe-it/blob/f5ffda8053ba1350c216f851cdae378d0296acdc/app/Providers/AuthServiceProvider.php#L159-L172

This PR introduces a new permission that determines whether you should be able to see the contents of a select list like locations, etc.

The reason for this change is that it comes up occasionally on huntr.dev reports, and while it would be difficult to execute AND you'd have to be a valid user with login privileges on the system, it seems fair enough I suppose to lock that down a little further. 

If you can edit assets, for example, even if you're not allowed to view *details* of a location, you still need to be able to see the select list for it, otherwise you cannot complete the task of creating the asset. 

I've tested this locally, but would love additional eyes on it. 