### PR TITLE
Fixed #10639 - incorrect linear depreciation calculation

### DIFF
--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -79,7 +79,7 @@ class Depreciable extends SnipeModel
 
         if($this->get_depreciation()->depreciation_min > $current_value) {
 
-            $current_value=$this->get_depreciation()->depreciation_min;
+            $current_value=round($this->get_depreciation()->depreciation_min,2);
         }
         if ($current_value < 0) {
             $current_value = 0;

--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -73,10 +73,9 @@ class Depreciable extends SnipeModel
         $deprecation_per_year= $numerator/$denominator;
         $deprecation_per_month= $deprecation_per_year/12;
 
-//      fraction of value left
         $months_remaining = $this->time_until_depreciated()->m + 12 * $this->time_until_depreciated()->y; //UGlY
-//        formula for current value is correct now. $months_remaining is not giving me the same value as expected. Considering how to fix this. -Godfrey M.
-        $current_value = $deprecation_per_month*27;
+        $months_depreciated=$this->get_depreciation()->months-$months_remaining;
+        $current_value = $deprecation_per_month*$months_depreciated;
 
         if($this->get_depreciation()->depreciation_min > $current_value) {
 

--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -75,7 +75,7 @@ class Depreciable extends SnipeModel
 
         $months_remaining = $this->time_until_depreciated()->m + 12 * $this->time_until_depreciated()->y; //UGlY
         $months_depreciated=$this->get_depreciation()->months-$months_remaining;
-        $current_value = $deprecation_per_month*$months_depreciated;
+        $current_value = $this->purchase_cost-($deprecation_per_month*$months_depreciated);
 
         if($this->get_depreciation()->depreciation_min > $current_value) {
 

--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -68,9 +68,15 @@ class Depreciable extends SnipeModel
      */
     public function getLinearDepreciatedValue()
     {
-        // fraction of value left
+        $numerator= (($this->purchase_cost-($this->purchase_cost*12/($this->get_depreciation()->months))));
+        $denominator=$this->get_depreciation()->months/12;
+        $deprecation_per_year= $numerator/$denominator;
+        $deprecation_per_month= $deprecation_per_year/12;
+
+//      fraction of value left
         $months_remaining = $this->time_until_depreciated()->m + 12 * $this->time_until_depreciated()->y; //UGlY
-        $current_value = round(($months_remaining / $this->get_depreciation()->months) * $this->purchase_cost, 2);
+//        formula for current value is correct now. $months_remaining is not giving me the same value as expected. Considering how to fix this. -Godfrey M.
+        $current_value = $deprecation_per_month*27;
 
         if($this->get_depreciation()->depreciation_min > $current_value) {
 


### PR DESCRIPTION
…iable left to fix.

# Description
fixes the linear depreciation formula. 
<img width="1345" alt="image" src="https://user-images.githubusercontent.com/47435081/153915637-c61f1687-7f7e-43bf-98bb-9f6376a5fde4.png">


Fixes # 10639

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
