### PR TITLE
Added usleep random to forgotten password method to mitigate timing attacks 

### DIFF
--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -87,6 +87,8 @@ class ForgotPasswordController extends Controller
             \Log::info('Password reset attempt: User '.$request->input('username').'failed with exception: '.$e );
         }
 
+        // Prevent timing attack to enumerate users.
+        usleep(500000 + random_int(0, 1500000));
 
         if ($response === \Password::RESET_LINK_SENT) {
             \Log::info('Password reset attempt: User '.$request->input('username').' WAS found, password reset sent');


### PR DESCRIPTION
This is kind of a shit solution, but it mitigates the issue *now*. Longer term, we probably want to fix this by setting an env var to set a limit on how long any request should take for that, whether there is a valid email address/account to not, should take to execute. I hate these kinds of solutions, since they sacrifice user experience for security, but the time limits we have here should be low enough to not be too noticeable. 

Signed-off-by: snipe <snipe@snipe.net>