### PR TITLE
Fixed weird JSON-handling on log_meta updates

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -19,6 +19,14 @@ class ActionlogsTransformer
         return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
+    private function clean_field($value)
+    {
+        if(is_object($value) && isset($value->value)) {
+            return clean_field($value->value);
+        }
+        return is_scalar($value) || is_null($value) ? e($value) : e(json_encode($value));
+    }
+
     public function transformActionlog (Actionlog $actionlog, $settings = null)
     {
         $icon = $actionlog->present()->icon();
@@ -31,49 +39,9 @@ class ActionlogsTransformer
             $meta_array = json_decode($actionlog->log_meta);
 
             if ($meta_array) {
-                foreach ($meta_array as $key => $value) {
-                    foreach ($value as $meta_key => $meta_value) {
-
-                        if (is_array($meta_value)) {
-                            foreach ($meta_value as $meta_value_key => $meta_value_value) {
-                                if (is_scalar($meta_value_value)) {
-                                    $clean_meta[$key][$meta_value_key] = e($meta_value_value);
-                                } else {
-                                    $clean_meta[$key][$meta_value_key] = 'invalid scalar: '.print_r($meta_value_value, true);
-                                }
-                            }
-                        } else {
-
-                            // This object stuff is weird, and is used to make up for the fact that
-                            // older data can get strangely formatted if an asset existed,
-                            // then a new custom field is added, and the asset is saved again.
-                            // It can result in funnily-formatted strings like:
-                            //
-                            // {"_snipeit_right_sized_fault_tolerant_localareanetwo_1":
-                            // {"old":null,"new":{"value":"1579490695972","_snipeit_new_field_2":2,"_snipeit_new_field_3":"Monday, 20 January 2020 2:24:55 PM"}}
-                            // so we have to walk down that next level
-
-                            if (is_object($meta_value)) {
-
-                                foreach ($meta_value as $meta_value_key => $meta_value_value) {
-
-                                    if ($meta_value_key == 'value') {
-                                        $clean_meta[$key]['old'] = null;
-                                        $clean_meta[$key]['new'] = e($meta_value->value);
-                                    } else {
-                                        $clean_meta[$meta_value_key]['old'] = null;
-                                        $clean_meta[$meta_value_key]['new'] = e($meta_value_value);
-                                    }
-                                }
-
-
-
-                            } else {
-                                $clean_meta[$key][$meta_key] = e($meta_value);
-                            }
-                        }
-
-                    }
+                foreach ($meta_array as $fieldname => $fieldata) {
+                    $clean_meta[$fieldname]['old'] = $this->clean_field($fieldata['old']);
+                    $clean_meta[$fieldname]['new'] = $this->clean_field($fieldata['new']);
                 }
 
             }
@@ -122,6 +90,7 @@ class ActionlogsTransformer
             'action_date'   => ($actionlog->action_date) ? Helper::getFormattedDateObject($actionlog->action_date, 'datetime'): Helper::getFormattedDateObject($actionlog->created_at, 'datetime'),
 
         ];
+        //\Log::info("Clean Meta is: ".print_r($clean_meta,true));
 
         return $array;
     }


### PR DESCRIPTION
Instead of treating the `log_meta` field as truly arbitrary random JSON data, which it absolutely is not, let's stop the charade - knowing that it's going to look like a particular 'shape'.

This code does that and shaves off a few lines of code, for some stuff that's a little bit more tight, in terms of output. And will prevent the previous issue we had where there was an HTTP 500-status page for not being able to parse some JSON funkery.