### PR TITLE
Adds delete endpoint for licenses

### DIFF
--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -82,6 +82,10 @@ class LicensesController extends Controller
             $licenses = $licenses->TextSearch($request->input('search'));
         }
 
+        if ($request->filled('deleted')) {
+            $licenses->onlyTrashed();
+        }
+
 
         // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
         // case we override with the actual count, so we should return 0 items.


### PR DESCRIPTION
This adds a deleted endpoint to the API to be able to view deleted licenses. `/api/v1/licenses?deleted=true` will return only deleted licenses. 

Signed-off-by: snipe <snipe@snipe.net>