### PR TITLE
Fixes #9592 - Added unique option to custom fields

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -92,6 +92,7 @@ class CustomFieldsController extends Controller
             "field_values" => $request->get("field_values"),
             "field_encrypted" => $request->get("field_encrypted", 0),
             "show_in_email" => $request->get("show_in_email", 0),
+            "is_unique" => $request->get("is_unique", 0),
             "user_id" => Auth::id()
         ]);
 
@@ -211,6 +212,7 @@ class CustomFieldsController extends Controller
         $field->user_id       = Auth::id();
         $field->help_text     = $request->get("help_text");
         $field->show_in_email = $request->get("show_in_email", 0);
+        $field->is_unique     = $request->get("is_unique", 0);
 
         if ($request->get('format') == 'CUSTOM REGEX') {
             $field->format = e($request->get('custom_format'));

--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -161,7 +161,6 @@ class ImageUploadRequest extends Request
 
         // If the user isn't uploading anything new but wants to delete their old image, do so
         } else {
-            \Log::debug('No file passed for '.$form_fieldname);
             if ($this->input('image_delete') == '1') {
                 \Log::debug('Deleting image');
                 try {

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -63,6 +63,7 @@ class CustomField extends Model
         'field_encrypted',
         'help_text',
         'show_in_email',
+        'is_unique',
     ];
 
     /**

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -83,7 +83,11 @@ class CustomFieldset extends Model
 
             if (($field->field_encrypted != '1') ||
                   (($field->field_encrypted == '1') && (Gate::allows('admin')))) {
-                $rule[] = ($field->pivot->required == '1') ? 'required' : 'nullable';
+                    $rule[] = ($field->pivot->required == '1') ? 'required' : 'nullable';
+            }
+
+            if ($field->is_unique == '1') {
+                    $rule[] = 'unique';
             }
 
             array_push($rule, $field->attributes['format']);

--- a/database/migrations/2022_02_16_152431_add_unique_constraint_to_custom_field.php
+++ b/database/migrations/2022_02_16_152431_add_unique_constraint_to_custom_field.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUniqueConstraintToCustomField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('custom_fields', function (Blueprint $table) {
+            $table->boolean('is_unique')->nullable()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('custom_fields', function (Blueprint $table) {
+            $table->dropColumn('is_unique');
+        });
+    }
+}

--- a/resources/lang/en/admin/custom_fields/general.php
+++ b/resources/lang/en/admin/custom_fields/general.php
@@ -41,5 +41,7 @@ return [
     'make_required' => 'Optional - click to make required',
     'reorder' => 'Reorder',
     'db_field' => 'DB Field',
-    'db_convert_warning' => 'WARNING. This field is in the custom fields table as <code> :db_column </code> but should be :expected </code>.'
+    'db_convert_warning' => 'WARNING. This field is in the custom fields table as <code> :db_column </code> but should be :expected </code>.',
+    'is_unique' => 'This value must be unique across all assets',
+    'unique' => 'Unique',
 ];

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -116,6 +116,17 @@
 
           </div>
 
+          <!-- Value Must be Unique -->
+          <div class="form-group {{ $errors->has('is_unique') ? ' has-error' : '' }}"  id="is_unique">
+            <div class="col-md-8 col-md-offset-4">
+                <label for="is_unique">
+                    <input type="checkbox" name="is_unique" aria-label="is_unique" value="1" class="minimal"{{ (old('is_unique') || $field->is_unique) ? ' checked="checked"' : '' }}>
+                    {{ trans('admin/custom_fields/general.is_unique') }}
+                </label>
+            </div>
+
+        </div>
+
 
       @if (!$field->id)
         <!-- Encrypted  -->

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -129,6 +129,7 @@
               <th data-searchable="true">{{ trans('general.name') }}</th>
               <th data-searchable="true">{{ trans('admin/custom_fields/general.help_text')}}</th>
               <th data-searchable="true">{{ trans('general.email') }}</th>
+              <th data-searchable="true">{{ trans('admin/custom_fields/general.unique') }}</th>
               <th data-visible="false">{{ trans('admin/custom_fields/general.db_field') }}</th>
               <th data-searchable="true">{{ trans('admin/custom_fields/general.field_format') }}</th>
               <th data-searchable="true">{{ trans('admin/custom_fields/general.field_element_short') }}</th>
@@ -142,6 +143,7 @@
               <td>{{ $field->name }}</td>
               <td>{{ $field->help_text }}</td>
               <td class='text-center'>{!! ($field->show_in_email=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"><span class="sr-only">'.trans('general.yes').'</span></i>' : '<i class="fas fa-times text-danger" aria-hidden="true"><span class="sr-only">'.trans('general.no').'</span></i>'  !!}</td>
+              <td class='text-center'>{!! ($field->is_unique=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"><span class="sr-only">'.trans('general.yes').'</span></i>' : '<i class="fas fa-times text-danger" aria-hidden="true"><span class="sr-only">'.trans('general.no').'</span></i>'  !!}</td>
               <td>
                  <code>{{ $field->convertUnicodeDbSlug() }}</code>
                 @if ($field->convertUnicodeDbSlug()!=$field->db_column)


### PR DESCRIPTION
This should allow you to set a custom field to be unique, fixing #9592. Although I have tested this (obviously), I'd appreciate it if some other folks can test this out as well.

<img width="996" alt="Screen Shot 2022-02-16 at 1 55 30 PM" src="https://user-images.githubusercontent.com/197404/154363936-ff036ab9-5f6c-4691-9d7b-44b739ac0e34.png">

<img width="1334" alt="Screen Shot 2022-02-16 at 1 54 46 PM" src="https://user-images.githubusercontent.com/197404/154363888-9e2aae3a-d17d-4530-ba60-86141ca11704.png">

<img width="672" alt="Screen Shot 2022-02-16 at 1 49 33 PM" src="https://user-images.githubusercontent.com/197404/154363698-4d5e3304-d149-4f38-bc27-eabc8548d894.png">

I have an internal ticket for trying to make those error messages a little less weird (by dropping the number from the error message, but that's always been there so is outside the scope of this PR.