### PR TITLE
Fixed #10690 - Initial audit date fix

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -24,7 +24,6 @@ use Redirect;
 use Response;
 use App\Helpers\StorageHelper;
 use App\Http\Requests\SlackSettingsRequest;
-use Carbon\Carbon;
 
 /**
  * This controller handles all actions related to Settings for

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -656,7 +656,6 @@ class SettingsController extends Controller
         $setting->audit_warning_days  = $request->input('audit_warning_days');
         $setting->show_alerts_in_menu = $request->input('show_alerts_in_menu', '0');
 
-        
         if ($setting->save()) {
             return redirect()->route('settings.index')
                 ->with('success', trans('admin/settings/message.update.success'));

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -627,23 +627,16 @@ class SettingsController extends Controller
 
             // Be careful - this could be a negative number
             $audit_diff_months = ((int)$request->input('audit_interval') - (int)($setting->audit_interval));
-
-            \Log::debug('We need to update audit dates. Interval is changing from '.$setting->audit_interval.' to '.$request->input('audit_interval'));
-            \Log::debug('Audit difference: '.$audit_diff_months);
-
+            
+            // Grab all of the assets that have an existing next_audit_date
             $assets = Asset::whereNotNull('next_audit_date')->get();
 
+            // Update all of the assets' next_audit_date values
             foreach ($assets as $asset) {
 
                 if ($asset->next_audit_date != '') {
-
                     $old_next_audit = new \DateTime($asset->next_audit_date);
-                    \Log::debug('Old audit date: '.$old_next_audit->format('Y-m-d'));
-                    \Log::debug('Adding '.$audit_diff_months.' months');
-
                     $asset->next_audit_date = $old_next_audit->modify($audit_diff_months.' month')->format('Y-m-d');
-                    
-                    \Log::debug('New audit date: '.$asset->next_audit_date->format('Y-m-d'));
                     $asset->forceSave();
                 }
                 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -639,12 +639,8 @@ class SettingsController extends Controller
                     $asset->next_audit_date = $old_next_audit->modify($audit_diff_months.' month')->format('Y-m-d');
                     $asset->forceSave();
                 }
-                
             }
-
         } 
-
-
 
         $alert_email    = rtrim($request->input('alert_email'), ',');
         $alert_email    = trim($alert_email);

--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -2,7 +2,6 @@
 
 return [
     'ad'				        => 'Active Directory',
-    'update_null_audits'        => 'Also update audit dates on assets without a current next audit date set based on purchase date (if present)',
     'ad_domain'				    => 'Active Directory domain',
     'ad_domain_help'			=> 'This is sometimes the same as your email domain, but not always.',
     'ad_append_domain_label'    => 'Append domain name',

--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -2,6 +2,7 @@
 
 return [
     'ad'				        => 'Active Directory',
+    'update_null_audits'        => 'Also update audit dates on assets without a current next audit date set based on purchase date (if present)',
     'ad_domain'				    => 'Active Directory domain',
     'ad_domain_help'			=> 'This is sometimes the same as your email domain, but not always.',
     'ad_append_domain_label'    => 'Append domain name',
@@ -21,7 +22,7 @@ return [
     'allow_user_skin_help_text' => 'Checking this box will allow a user to override the UI skin with a different one.',
     'asset_ids'					=> 'Asset IDs',
     'audit_interval'            => 'Audit Interval',
-    'audit_interval_help'       => 'If you are required to regularly physically audit your assets, enter the interval in months.',
+    'audit_interval_help'       => 'If you are required to regularly physically audit your assets, enter the interval in months that you use. If you update this value, all of the "next audit dates" for assets with an upcoming audit date.',
     'audit_warning_days'        => 'Audit Warning Threshold',
     'audit_warning_days_help'   => 'How many days in advance should we warn you when assets are due for auditing?',
     'auto_increment_assets'		=> 'Generate auto-incrementing asset tags',


### PR DESCRIPTION
<del>This is will a WIP, as I need to account for the fact that assets without a `next_audit_date` might not be supposed to have one, so I need to add a checkbox or *something* to account for that - and I need to make sure this change is actually logged in the action logs table. we're close, but not there just yet.</del>

Okay, I think I have this working. For now in this PR, changing the Audit Interval in `Admin Settings > Alerts` will:

- check to see if the value for that field has changed
- if it has, update the `next_audit_date` for all assets that currently have a value for `next_audit_date`. 

We should probably add some logging in here as well, so you can see who changed these values, but that's part of a much bigger PR.

With debugging turned on, I see this in my console:

```
[2022-02-17 17:17:07] local.ERROR: We need to update audit dates. Interval is changing from 15 to 8
[2022-02-17 17:17:07] local.ERROR: Audit difference: -7
[2022-02-17 17:17:07] local.ERROR: Old audit date: 2020-10-11
[2022-02-17 17:17:07] local.ERROR: Adding -7 months
[2022-02-17 17:17:07] local.ERROR: New audit date: 2020-03-11


[2022-02-17 17:17:28] local.ERROR: We need to update audit dates. Interval is changing from 8 to 10
[2022-02-17 17:17:28] local.ERROR: Audit difference: 2
[2022-02-17 17:17:28] local.ERROR: Old audit date: 2020-03-11
[2022-02-17 17:17:28] local.ERROR: Adding 2 months
[2022-02-17 17:17:28] local.ERROR: New audit date: 2020-05-11
```

