### PR TITLE
Feature Save logged in user data and re-add them after restore if they don't exist [ch-17664]

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1224,7 +1224,14 @@ class SettingsController extends Controller
                         $new_user = $user->replicate();
                         $new_user->push();
                     }
+
+                    $session_files = glob(storage_path("framework/sessions/*"));
+                    foreach ($session_files as $file) {
+                        if (is_file($file))
+                            unlink($file);
+                    }
                     \Auth::logout();
+
                     return redirect()->route('login')->with('success', 'Your system has been restored. Please login again.');
                 } else {
                     return redirect()->route('settings.backups.index')->with('error', $output);

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1238,16 +1238,6 @@ class SettingsController extends Controller
                     return redirect()->route('settings.backups.index')->with('error', $output);
 
                 }
-                //dd($output);
-
-                // TODO: insert the user if they are not there in the old one
-                
-
-
-
-                // log the user out
-                
-
 
             } else {
                 return redirect()->route('settings.backups.index')->with('error', trans('admin/settings/message.backup.file_not_found'));

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1202,11 +1202,10 @@ class SettingsController extends Controller
                 // grab the user's info so we can make sure they exist in the system
                 $user = User::find(Auth::user()->id);
 
+                // TODO: run a backup
 
-                // TODO: run a backup 
 
-                // TODO: add db:wipe 
-
+                Artisan::call('db:wipe');
 
                 // run the restore command
                 Artisan::call('snipeit:restore', 
@@ -1216,10 +1215,8 @@ class SettingsController extends Controller
                     'filename' => storage_path($path).'/'.$filename
                 ]);
 
-                $output = Artisan::output();
-                    
-            
                 // If it's greater than 300, it probably worked
+                $output = Artisan::output();
                 if (strlen($output) > 300) {
                     \Auth::logout();
                     return redirect()->route('login')->with('success', 'Your system has been restored. Please login again.');

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1218,6 +1218,12 @@ class SettingsController extends Controller
                 // If it's greater than 300, it probably worked
                 $output = Artisan::output();
                 if (strlen($output) > 300) {
+                    $find_user = DB::table('users')->where('first_name', $user->first_name)->where('last_name', $user->last_name)->exists();
+                    if(!$find_user){
+                        \Log::warning('Attempting to restore user: ' . $user->first_name . ' ' . $user->last_name);
+                        $new_user = $user->replicate();
+                        $new_user->push();
+                    }
                     \Auth::logout();
                     return redirect()->route('login')->with('success', 'Your system has been restored. Please login again.');
                 } else {

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1230,6 +1230,7 @@ class SettingsController extends Controller
                         if (is_file($file))
                             unlink($file);
                     }
+                    DB::table('users')->update(['remember_token' => null]);
                     \Auth::logout();
 
                     return redirect()->route('login')->with('success', 'Your system has been restored. Please login again.');

--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -32,7 +32,7 @@ return [
     'backups_upload'            => 'Upload Backup',
     'backups_path'              => 'Backups on the server are stored in <code>:path</code>',
     'backups_restore_warning'   => 'Use the restore button <small><span class="btn btn-xs btn-warning"><i class="text-white fas fa-retweet" aria-hidden="true"></i></span></small> to restore from a previous backup. (This does not currently work with S3 file storage or Docker.<br><br>Your <strong>entire :app_name database and any uploaded files will be completely replaced</strong> by what\'s in the backup file.  ',
-    'backups_logged_out'         => 'You will be logged out once your restore is complete.',
+    'backups_logged_out'         => 'All existing users, including you, will be logged out once your restore is complete.',
     'backups_large'             => 'Very large backups may time out on the restore attempt and may still need to be run via command line. ',
     'barcode_settings'			=> 'Barcode Settings',
     'confirm_purge'			    => 'Confirm Purge',


### PR DESCRIPTION
# Description
Added some steps in the `Backups > Restore` process:

Wipe the database before the restore.
After the restore is made, look if the user that triggers the restore exist (created after the restore file used was, for example).
Logout every user that is logged in at the time of the restoration.

Fixes [ch-17664]

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
