### PR TITLE
Added #2353: Add ability to tie locations to companies

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -44,7 +44,7 @@ class LocationsController extends Controller
             'ldap_ou',
             'company'];
 
-        $locations = Company::scopeCompanyables(Location::Select('locations.*'))
+        $locations = Company::scopeCompanyables(Location::Select('locations.*'), 'company_id', 'locations', true)
             ->with('parent', 'manager', 'children', 'company')
             ->withCount('assignedAssets as assigned_assets_count')
             ->withCount('assets as assets_count')

--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Helpers\Helper;
 use App\Http\Requests\ImageUploadRequest;
 use App\Http\Controllers\Controller;
+use App\Models\Company;
 use App\Http\Transformers\LocationsTransformer;
 use App\Http\Transformers\SelectlistTransformer;
 use App\Models\Location;
@@ -25,32 +26,36 @@ class LocationsController extends Controller
     {
         $this->authorize('view', Location::class);
         $allowed_columns = [
-            'id', 'name', 'address', 'address2', 'city', 'state', 'country', 'zip', 'created_at',
-            'updated_at', 'manager_id', 'image',
-            'assigned_assets_count', 'users_count', 'assets_count', 'currency', 'ldap_ou', ];
+            'id',
+            'name',
+            'address',
+            'address2',
+            'city',
+            'state',
+            'country',
+            'zip',
+            'created_at',
+            'updated_at',
+            'manager_id',
+            'image',
+            'assigned_assets_count',
+            'users_count','assets_count',
+            'currency',
+            'ldap_ou',
+            'company'];
 
-        $locations = Location::with('parent', 'manager', 'children')->select([
-            'locations.id',
-            'locations.name',
-            'locations.address',
-            'locations.address2',
-            'locations.city',
-            'locations.state',
-            'locations.zip',
-            'locations.country',
-            'locations.parent_id',
-            'locations.manager_id',
-            'locations.created_at',
-            'locations.updated_at',
-            'locations.image',
-            'locations.ldap_ou',
-            'locations.currency',
-        ])->withCount('assignedAssets as assigned_assets_count')
+        $locations = Company::scopeCompanyables(Location::Select('locations.*'))
+            ->with('parent', 'manager', 'children', 'company')
+            ->withCount('assignedAssets as assigned_assets_count')
             ->withCount('assets as assets_count')
             ->withCount('users as users_count');
 
         if ($request->filled('search')) {
             $locations = $locations->TextSearch($request->input('search'));
+        }
+
+        if ($request->filled('company_id')) {
+            $locations->where('locations.company_id', '=', $request->input('company_id'));
         }
 
         $offset = (($locations) && (request('offset') > $locations->count())) ? $locations->count() : request('offset', 0);
@@ -67,6 +72,9 @@ class LocationsController extends Controller
                 break;
             case 'manager':
                 $locations->OrderManager($order);
+                break;
+            case 'company':
+                $locations->OrderCompany($order);
                 break;
             default:
                 $locations->orderBy($sort, $order);
@@ -114,7 +122,7 @@ class LocationsController extends Controller
     public function show($id)
     {
         $this->authorize('view', Location::class);
-        $location = Location::with('parent', 'manager', 'children')
+        $location = Location::with('parent', 'manager', 'children', 'company')
             ->select([
                 'locations.id',
                 'locations.name',

--- a/app/Http/Controllers/BulkLocationsController.php
+++ b/app/Http/Controllers/BulkLocationsController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Location;
+use Illuminate\Http\Request;
+
+class BulkLocationsController extends Controller
+{
+    /**
+     * Display the bulk edit page.
+     *
+     * @author [T. Regnery] [<tobias.regnery@gmail.com>]
+     * @return View
+     * @internal param int $locationId
+     * @since [v6.0]
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function edit(Request $request)
+    {
+        $this->authorize('update', Location::class);
+
+        if (!$request->filled('ids')) {
+            return redirect()->back()->with('error', 'You must select at least one location to edit.');
+        }
+
+        $location_ids = array_values(array_unique($request->input('ids')));
+
+        if ($request->input('bulk_actions') == 'edit') {
+            return view('locations/bulk-edit')
+                ->with('locations', $location_ids);
+        }
+    }
+
+    /**
+     * Save bulk-edited locations
+     *
+     * @author [T.Regnery] [<tobias.regnery@gmail.com>]
+     * @since [v6.0]
+     * @param Request $request
+     * @return \Illuminate\Http\RedirectResponse
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function update(Request $request)
+    {
+        $this->authorize('update', Location::class);
+
+        if(!$request->filled('ids') || count($request->input('ids')) <= 0) {
+            return redirect()->route("locations.index")->with('warning', trans('No location selected, so nothing was updated.'));
+        }
+
+        $location_ids = array_keys($request->input('ids'));
+        $parent_conflict = false;
+
+        $return_array = [
+            'success' => trans('admin/locations/message.update.success')
+        ];
+
+        $this->conditionallyAddItem('manager_id')
+            ->conditionallyAddItem('company_id');
+
+        // If the parent_id is one of the locations being updated, generate a warning.
+        if (array_search($request->input('parent_id'), $location_ids)) {
+            $parent_conflict = true;
+            $return_array = [
+                'warning' => trans('admin/locations/message.bulk_parent_warn')
+            ];
+        }
+        if (!$parent_conflict) {
+            $this->conditionallyAddItem('parent_id');
+        }
+
+        // Save the updated info
+        Location::whereIn('id', $location_ids)->update($this->update_array);
+
+        return redirect()->route("locations.index")->with($return_array);
+    }
+
+    /**
+     * Array to store update data per item
+     * @var Array
+     */
+    private $update_array = [];
+
+    /**
+     * Adds parameter to update array for an item if it exists in request
+     * @param  String $field field name
+     * @return BulkUsersController Model for Chaining
+     */
+    protected function conditionallyAddItem($field)
+    {
+        if(request()->filled($field)) {
+            $this->update_array[$field] = request()->input($field);
+        }
+        return $this;
+    }
+}

--- a/app/Http/Controllers/LocationsController.php
+++ b/app/Http/Controllers/LocationsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\ImageUploadRequest;
 use App\Models\Asset;
+use App\Models\Company;
 use App\Models\Location;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
@@ -78,6 +79,7 @@ class LocationsController extends Controller
         $location->zip = $request->input('zip');
         $location->ldap_ou = $request->input('ldap_ou');
         $location->manager_id = $request->input('manager_id');
+        $location->company_id = Company::getIdForCurrentUser($request->input('company_id'));
         $location->user_id = Auth::id();
 
         $location = $request->handleImages($location);
@@ -141,6 +143,7 @@ class LocationsController extends Controller
         $location->zip = $request->input('zip');
         $location->ldap_ou = $request->input('ldap_ou');
         $location->manager_id = $request->input('manager_id');
+        $location->company_id = Company::getIdForCurrentUser($request->input('company_id'));
 
         $location = $request->handleImages($location);
 
@@ -214,10 +217,16 @@ class LocationsController extends Controller
         $location = Location::where('id', $id)->first();
         $parent = Location::where('id', $location->parent_id)->first();
         $manager = User::where('id', $location->manager_id)->first();
+        $company = Company::where('id', $location->company_id)->first();
         $users = User::where('location_id', $id)->with('company', 'department', 'location')->get();
         $assets = Asset::where('assigned_to', $id)->where('assigned_type', Location::class)->with('model', 'model.category')->get();
-
-        return view('locations/print')->with('assets', $assets)->with('users', $users)->with('location', $location)->with('parent', $parent)->with('manager', $manager);
+        return view('locations/print')
+            ->with('assets', $assets)
+            ->with('users',$users)
+            ->with('location', $location)
+            ->with('parent', $parent)
+            ->with('manager', $manager)
+            ->with('company', $company);
     }
 
     public function print_all_assigned($id)
@@ -225,9 +234,15 @@ class LocationsController extends Controller
         $location = Location::where('id', $id)->first();
         $parent = Location::where('id', $location->parent_id)->first();
         $manager = User::where('id', $location->manager_id)->first();
+        $company = Company::where('id', $location->company_id)->first();
         $users = User::where('location_id', $id)->with('company', 'department', 'location')->get();
         $assets = Asset::where('location_id', $id)->with('model', 'model.category')->get();
-
-        return view('locations/print')->with('assets', $assets)->with('users', $users)->with('location', $location)->with('parent', $parent)->with('manager', $manager);
+        return view('locations/print')
+            ->with('assets', $assets)
+            ->with('users',$users)
+            ->with('location', $location)
+            ->with('parent', $parent)
+            ->with('manager', $manager)
+            ->with('company', $company);
     }
 }

--- a/app/Http/Transformers/LocationsTransformer.php
+++ b/app/Http/Transformers/LocationsTransformer.php
@@ -55,6 +55,10 @@ class LocationsTransformer
                     'name'=> e($location->parent->name),
                 ] : null,
                 'manager' => ($location->manager) ? (new UsersTransformer)->transformUser($location->manager) : null,
+                'company' => ($location->company) ? [
+                    'id' => (int) $location->company->id,
+                    'name'=> e($location->company->name)
+                ] : null,
 
                 'children' => $children_arr,
             ];

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -33,11 +33,13 @@ class Location extends SnipeModel
         'zip'           => 'min:3|max:10|nullable',
         'manager_id'    => 'exists:users,id|nullable',
         'parent_id'     => 'non_circular:locations,id',
+        'company_id'    => 'integer|nullable'
     ];
 
     protected $casts = [
         'parent_id'     => 'integer',
         'manager_id'    => 'integer',
+        'company_id'    => 'integer',
     ];
 
     /**
@@ -69,6 +71,7 @@ class Location extends SnipeModel
         'currency',
         'manager_id',
         'image',
+        'company_id',
     ];
     protected $hidden = ['user_id'];
 
@@ -87,7 +90,8 @@ class Location extends SnipeModel
      * @var array
      */
     protected $searchableRelations = [
-      'parent' => ['name'],
+      'parent'  => ['name'],
+      'company' => ['name']
     ];
 
     public function isDeletable()
@@ -127,6 +131,18 @@ class Location extends SnipeModel
            into Assets to make this slightly less miserable.
         */
         return $this->hasMany(\App\Models\Asset::class, 'rtd_location_id');
+    }
+
+    /**
+     * Establishes the locations -> company relationship
+     *
+     * @author [T. Regnery] [<tobias.regnery@gmail.com>]
+     * @since [v6.0]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function company()
+    {
+        return $this->belongsTo('\App\Models\Company', 'company_id');
     }
 
     public function parent()
@@ -211,5 +227,18 @@ class Location extends SnipeModel
     public function scopeOrderManager($query, $order)
     {
         return $query->leftJoin('users as location_user', 'locations.manager_id', '=', 'location_user.id')->orderBy('location_user.first_name', $order)->orderBy('location_user.last_name', $order);
+    }
+
+   /**
+    * Query builder scope to order on company
+    *
+    * @param  \Illuminate\Database\Query\Builder  $query  Query builder instance
+    * @param  text                              $order       Order
+    *
+    * @return \Illuminate\Database\Query\Builder          Modified query builder
+    */
+    public function scopeOrderCompany($query, $order)
+    {
+        return $query->leftJoin('companies as company_sort', 'locations.company_id', '=', 'company_sort.id')->orderBy('company_sort.name', $order);
     }
 }

--- a/app/Presenters/LocationPresenter.php
+++ b/app/Presenters/LocationPresenter.php
@@ -24,6 +24,15 @@ class LocationPresenter extends Presenter
                 'visible' => false,
             ],
             [
+                'field' => 'company',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('general.company'),
+                'visible' => false,
+                'formatter' => 'locationCompanyObjFilterFormatter'
+            ],
+            [
                 'field' => 'name',
                 'searchable' => true,
                 'sortable' => true,

--- a/app/Presenters/LocationPresenter.php
+++ b/app/Presenters/LocationPresenter.php
@@ -14,7 +14,10 @@ class LocationPresenter extends Presenter
     public static function dataTableLayout()
     {
         $layout = [
-
+            [
+                "field" => "checkbox",
+                "checkbox" => true
+            ],
             [
                 'field' => 'id',
                 'searchable' => false,

--- a/database/migrations/2022_02_10_110210_add_company_id_to_locations.php
+++ b/database/migrations/2022_02_10_110210_add_company_id_to_locations.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCompanyIdToLocations extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->integer('company_id')->unsigned()->nullable();
+            $table->index(['company_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->dropIndex(['company_id']);
+            $table->dropColumn('company_id');
+        });
+    }
+}
+

--- a/resources/lang/en/admin/locations/general.php
+++ b/resources/lang/en/admin/locations/general.php
@@ -4,6 +4,8 @@ return array(
     'assigned_location' 	                => 'Assigned to :location Location',
     'asset_management_system' => 'Asset Management System',
     'assigned_to' => 'Assigned To:',
+    'bulk_update_warn'	=> 'You are about to edit the properties of :location_count locations.',
+    'bulk_update_help'	=> 'This form allows you to update multiple locations at once. Only fill in the fields you need to change. Any fields left blank will remain unchanged.',
     'manager' => 'Manager',
     'date' => 'Current Date:',
 );

--- a/resources/lang/en/admin/locations/message.php
+++ b/resources/lang/en/admin/locations/message.php
@@ -8,6 +8,7 @@ return array(
     'assoc_child_loc'	 => 'This location is currently the parent of at least one child location and cannot be deleted. Please update your locations to no longer reference this location and try again. ',
 
     'create' => [
+        'bulk_parent_warn'  => 'Your locations have been successfully updated, however your parent entry was not saved because the parent you selected was also in the location list to be edited, and locations may not be their own parent. Please select your locations again, excluding the parent.',
         'error'   => 'Location was not created, please try again.',
         'success' => 'Location created successfully.',
     ],

--- a/resources/views/locations/bulk-edit.blade.php
+++ b/resources/views/locations/bulk-edit.blade.php
@@ -1,0 +1,56 @@
+@extends('layouts/default')
+
+{{-- Page title --}}
+@section('title')
+    Bulk Edit
+    @parent
+@stop
+
+
+@section('header_right')
+    <a href="{{ URL::previous() }}" class="btn btn-sm btn-primary pull-right">
+        {{ trans('general.back') }}</a>
+@stop
+
+{{-- Page content --}}
+@section('content')
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+
+            <p>{{ trans('admin/locations/general.bulk_update_help') }}</p>
+
+            <div class="callout callout-warning">
+                <i class="fa fa-warning"></i> {{ trans('admin/locations/general.bulk_update_warn', ['location_count' => count($locations)]) }}
+            </div>
+
+            <form class="form-horizontal" method="post" action="{{ route('locations/bulkeditsave') }}" autocomplete="off" role="form">
+                {{ csrf_field() }}
+
+                <div class="box box-default">
+                    <div class="box-body">
+
+                        <!-- Parent -->
+                        @include ('partials.forms.edit.location-select', ['translated_name' => trans('admin/locations/table.parent'), 'fieldname' => 'parent_id'])
+
+                        <!-- Company -->
+                        @if (\App\Models\Company::canManageUsersCompanies())
+                            @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.select_company'), 'fieldname' => 'company_id'])
+                        @endif
+
+                        <!-- Manager -->
+                        @include ('partials.forms.edit.user-select', ['translated_name' => trans('admin/users/table.manager'), 'fieldname' => 'manager_id'])
+
+                        @foreach ($locations as $key => $value)
+                            <input type="hidden" name="ids[{{ $value }}]" value="1">
+                        @endforeach
+
+                    </div> <!--/.box-body-->
+
+                    <div class="box-footer text-right">
+                        <button type="submit" class="btn btn-success"><i class="fa fa-check icon-white" aria-hidden="true"></i> {{ trans('general.save') }}</button>
+                    </div>
+                </div> <!--/.box.box-default-->
+            </form>
+        </div> <!--/.col-md-8-->
+    </div>
+@stop

--- a/resources/views/locations/edit.blade.php
+++ b/resources/views/locations/edit.blade.php
@@ -17,6 +17,9 @@
 <!-- Manager-->
 @include ('partials.forms.edit.user-select', ['translated_name' => trans('admin/users/table.manager'), 'fieldname' => 'manager_id'])
 
+<!-- Company -->
+@include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
+
 <!-- Currency -->
 <div class="form-group {{ $errors->has('currency') ? ' has-error' : '' }}">
     <label for="currency" class="col-md-3 control-label">

--- a/resources/views/locations/index.blade.php
+++ b/resources/views/locations/index.blade.php
@@ -18,9 +18,24 @@
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-body">
-        <div class="table-responsive">
+        {{ Form::open([
+          'method' => 'POST',
+          'route' => ['locations/bulkedit'],
+          'class' => 'form-inline',
+          'id' => 'bulkForm']) }}
+
+          @if (Request::get('status')!='Deleted')
+            <div id="toolbar">
+              <label for="bulk_actions"><span class="sr-only">Bulk Actions</span></label>
+              <select name="bulk_actions" class="form-control select2" style="width: 200px;" aria-label="bulk_actions">
+                <option value="edit">{{ trans('button.edit') }}</option>
+              </select>
+              <button class="btn btn-primary" id="bulkEdit" disabled>Go</button>
+            </div>
+          @endif
 
           <table
+                  data-click-to-select="true"
                   data-columns="{{ \App\Presenters\LocationPresenter::dataTableLayout() }}"
                   data-cookie-id-table="locationTable"
                   data-pagination="true"
@@ -32,6 +47,7 @@
                   data-show-export="true"
                   data-show-refresh="true"
                   data-sort-order="asc"
+                  data-toolbar="#toolbar"
                   id="locationTable"
                   class="table table-striped snipe-table"
                   data-url="{{ route('api.locations.index', array('company_id'=>e(Request::get('company_id')))) }}"
@@ -40,7 +56,7 @@
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
               }'>
           </table>
-        </div>
+        {{ Form::close() }}
       </div>
     </div>
   </div>

--- a/resources/views/locations/index.blade.php
+++ b/resources/views/locations/index.blade.php
@@ -34,7 +34,7 @@
                   data-sort-order="asc"
                   id="locationTable"
                   class="table table-striped snipe-table"
-                  data-url="{{ route('api.locations.index') }}"
+                  data-url="{{ route('api.locations.index', array('company_id'=>e(Request::get('company_id')))) }}"
                   data-export-options='{
               "fileName": "export-locations-{{ date('Y-m-d') }}",
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]

--- a/resources/views/locations/print.blade.php
+++ b/resources/views/locations/print.blade.php
@@ -55,6 +55,10 @@
         {{ $parent->present()->fullName() }}
     @endif
 <br>
+@if ($company)
+    <b>{{ trans('admin/companies/table.name') }}:</b> {{ $company->present()->Name() }}</b>
+<br>
+@endif
 @if ($manager)
     <b>{{ trans('admin/locations/general.manager') }}</b> {{ $manager->present()->fullName() }}<br>
 @endif

--- a/resources/views/locations/view.blade.php
+++ b/resources/views/locations/view.blade.php
@@ -205,6 +205,9 @@
             @if ($location->manager)
               <li>{{ trans('admin/users/table.manager') }}: {!! $location->manager->present()->nameUrl() !!}</li>
             @endif
+            @if ($location->company)
+              <li>{{ trans('admin/companies/table.name') }}: {!! $location->company->present()->nameUrl() !!}</li>
+            @endif
             @if ($location->parent)
               <li>{{ trans('admin/locations/table.parent') }}: {!! $location->parent->present()->nameUrl() !!}</li>
             @endif

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -584,6 +584,14 @@
         }
     }
 
+    function locationCompanyObjFilterFormatter(value, row) {
+        if (value) {
+            return '<a href="{{ url('/') }}/locations/?company_id=' + row.company.id + '">' + row.company.name + '</a>';
+        } else {
+            return value;
+        }
+    }
+
     function employeeNumFormatter(value, row) {
 
         if ((row) && (row.assigned_to) && ((row.assigned_to.employee_number))) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Account;
 use App\Http\Controllers\ActionlogController;
+use App\Http\Controllers\BulkLocationsController;
 use App\Http\Controllers\CategoriesController;
 use App\Http\Controllers\CompaniesController;
 use App\Http\Controllers\DashboardController;
@@ -54,6 +55,16 @@ Route::group(['middleware' => 'auth'], function () {
         'locations/{locationId}/printallassigned',
         [LocationsController::class, 'print_all_assigned']
     )->name('locations.print_all_assigned');
+
+    Route::post(
+        'locations/bulkedit',
+        [BulkLocationsController::class, 'edit']
+    )->name('locations/bulkedit');
+
+    Route::post(
+        'locations/bulkeditsave',
+        [BulkLocationsController::class, 'update']
+    )->name('locations/bulkeditsave');
 
     /*
     * Manufacturers


### PR DESCRIPTION
# Description

Locations are the last big part of the application that can't be tied to companies.
This can be a problem with FullMultipleCompanySupport, because you can't restrict the visibility of locations to the company of the users.

The first commit wires everything up so that locations have a company_id and are properly scoped with FullMultipleCompanySupport.

The second commit preserve backward compatibility with the existing behaviour, as locations with company_id = null are shown regardless of the users company. I'm not sure if this is worth it and personally I don't need this for my organisation, but I included this just to show how it could be made possible.

The third commit introduces bulk operations for locations to ease transition for this new feature.

Fixes #2353

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I developed and tested this feature with V5 and rebased it later to V6. All tests passed on this version either.
I checked that the correct locations are shown as SuperUser and scoped user with FullMultipleCompanySupport.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
