### PR TITLE
Fix CORS requests on master (option *ONE*)

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -24,6 +24,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\SecurityHeaders::class,
         \App\Http\Middleware\PreventBackHistory::class,
+        \Barryvdh\Cors\HandleCors::class,
 
     ];
 
@@ -44,7 +45,6 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            \Barryvdh\Cors\HandleCors::class,
             'throttle:120,1',
             'auth:api',
         ],


### PR DESCRIPTION
CORS requests seem to not quite be working. It seems to be because we are invoking the `auth:api` middleware, which is a specific auth middleware, rather than the `auth` middleware group, which is a collection of a few middleware packages, one of which being the CORS one.

This fixes that in the dumbest way possible - by appending CORS headers to every response that can take them. It's not gonna kill us by any means, and it definitely solves the problem. But there are better ways to do it, IMHO, by striking at the root problem of having several different places to specify middleware - which I think can be dangerous, going forward.

Either way, this would fix it if we decided to go this way. I'll propose another option as well (but, tested, I promise).