### PR TITLE
Fix CORS requests on master (option *TWO*)

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -78,7 +78,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapApiRoutes()
     {
         Route::group([
-            'middleware' => 'auth:api',
+            'middleware' => 'api', //this will load the *ENTIRE* middleware group called 'api' - which should include auth:api, as well as others
             'namespace' => $this->namespace,
             'prefix' => 'api',
         ], function ($router) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,7 +14,7 @@ use Illuminate\Http\Request;
 */
 
 
-Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api'], function () {
+Route::group(['prefix' => 'v1','namespace' => 'Api'], function () { //we don't explicitly mention middleware here, because that is quite well-defined under the RouteServiceProvider - unless we need to override, of course
 
 
     Route::get('/', function() {


### PR DESCRIPTION
As mentioned in #10718 - CORS has been not working for a little bit. This is option TWO for how to fix it. We should only take one of these, IMHO (though, weirdly enough, I think both would actually work? Though it'd be even more confusing).

This is a slightly smarter, but also a little bit scarier, fix. This one works under the assumption that the "api" middleware group should be specified at the `RouteServiceProvider` level - and any other middleware mentions should only be additions - via `->middleware($blah)` - or removals - via `->withoutMiddleware($blah)`. Of which there do not seem to be any.

This has been tested by me doing CORS requests and them working - and when I change:

https://github.com/snipe/snipe-it/compare/master...uberbrady:fix_cors_option_2_master?expand=1#diff-846ccd1dd2844a1dab103a38b7919ae15e1d9cde8fae8507369b324ea1718689L81

to instead say `auth:api` then those CORS requests fail again.