### PR TITLE
Fix cors develop

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -24,6 +24,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\SecurityHeaders::class,
         \App\Http\Middleware\PreventBackHistory::class,
+        \Fruitcake\Cors\HandleCors::class,
 
     ];
 
@@ -44,7 +45,6 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            \Fruitcake\Cors\HandleCors::class,
             'throttle:120,1',
             'auth:api',
         ],

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,10 +1,14 @@
 <?php
 
+$allowed_origins = env('CORS_ALLOWED_ORIGINS') !== null ?
+    explode(',', env('CORS_ALLOWED_ORIGINS')) : [];
+
+
 return [
 
     'supportsCredentials' => false,
 
-    'allowedOrigins' => ['*'],
+    'allowedOrigins' => $allowed_origins,
 
     'allowedHeaders' => ['*'],
 


### PR DESCRIPTION
CORS hasn't been working for a little bit - and, it turns out, the newer version that we use in later Laravel versions has some incompatible changes in there.

The biggest and most obvious of which is that the new `HandleCors` class no longer works as a 'group middleware' - only as 'global middleware'. It instead prefers that you use the paths argument to limit where it can be used.

So this (somewhat bedgrudingly) does exactly that.