### PR TITLE
Added consumables endpoint to user API

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\SaveUserRequest;
 use App\Http\Transformers\AccessoriesTransformer;
 use App\Http\Transformers\AssetsTransformer;
+use App\Http\Transformers\ConsumablesTransformer;
 use App\Http\Transformers\LicensesTransformer;
 use App\Http\Transformers\SelectlistTransformer;
 use App\Http\Transformers\UsersTransformer;
@@ -446,6 +447,24 @@ class UsersController extends Controller
         $this->authorize('view', Asset::class);
         $assets = Asset::where('assigned_to', '=', $id)->where('assigned_type', '=', User::class)->with('model')->get();
         return (new AssetsTransformer)->transformAssets($assets, $assets->count(), $request);
+    }
+
+
+    /**
+     * Return JSON containing a list of consumables assigned to a user.
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v3.0]
+     * @param $userId
+     * @return string JSON
+     */
+    public function consumables(Request $request, $id)
+    {
+        $this->authorize('view', User::class);
+        $this->authorize('view', Consumable::class);
+        $user = User::findOrFail($id);
+        $consumables = $user->consumables;
+        return (new ConsumablesTransformer)->transformConsumables($consumables, $consumables->count(), $request);
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -858,6 +858,13 @@ Route::group(['prefix' => 'v1','namespace' => 'Api', 'middleware' => 'auth:api']
             ]
         );
 
+        Route::get('{user}/consumables',
+            [
+                'as' => 'api.users.consumablelist',
+                'uses' => 'UsersController@consumables'
+            ]
+        );
+
 
         Route::get('{user}/accessories',
             [


### PR DESCRIPTION
I'm not entirely sure if this is the format that would be required for all use-cases. Some folks might need the actual join_id information. This at least lists the consumables that are currently checked out to a user, using the standard consumables transformer. I'd love if anyone with a use case that needs a list of consumables assigned to a user could give this a whirl and confirm that it meets your needs. (We literally didn't have an endpoint at all before, so I'd hope this is better than nothing, but if we're going to codify this, I'd prefer it's doing the right thing. Changing API specs can be treacherous water once people have built integrations around an expected payload.)

This adds the url endpoint of `/api/v1/users/{:id}/consumables` and the response would look something like this:

```json
{
    "total": 2,
    "rows": [
        {
            "id": 1,
            "name": "Cardstock (White)",
            "image": null,
            "category": {
                "id": 10,
                "name": "Printer Paper"
            },
            "company": {
                "id": 3,
                "name": "Hirthe-Pfannerstill"
            },
            "item_no": "49228112",
            "location": null,
            "manufacturer": {
                "id": 10,
                "name": "Avery"
            },
            "min_amt": 2,
            "model_number": null,
            "remaining": 9,
            "order_number": "24150202",
            "purchase_cost": "18.12",
            "purchase_date": {
                "date": "2021-05-14",
                "formatted": "Fri May 14, 2021"
            },
            "qty": 10,
            "created_at": {
                "datetime": "2021-12-24 13:38:25",
                "formatted": "Fri Dec 24, 2021 1:38PM"
            },
            "updated_at": {
                "datetime": "2021-12-24 13:38:25",
                "formatted": "Fri Dec 24, 2021 1:38PM"
            },
            "user_can_checkout": true,
            "available_actions": {
                "checkout": true,
                "checkin": true,
                "update": true,
                "delete": true
            }
        },
        {
            "id": 2,
            "name": "Laserjet Paper (Ream)",
            "image": null,
            "category": {
                "id": 10,
                "name": "Printer Paper"
            },
            "company": null,
            "item_no": "12845357",
            "location": null,
            "manufacturer": {
                "id": 10,
                "name": "Avery"
            },
            "min_amt": 2,
            "model_number": null,
            "remaining": 19,
            "order_number": "22588338",
            "purchase_cost": "18.87",
            "purchase_date": {
                "date": "2021-12-17",
                "formatted": "Fri Dec 17, 2021"
            },
            "qty": 20,
            "created_at": {
                "datetime": "2021-12-24 13:38:25",
                "formatted": "Fri Dec 24, 2021 1:38PM"
            },
            "updated_at": {
                "datetime": "2021-12-24 13:38:25",
                "formatted": "Fri Dec 24, 2021 1:38PM"
            },
            "user_can_checkout": true,
            "available_actions": {
                "checkout": true,
                "checkin": true,
                "update": true,
                "delete": true
            }
        }
    ]
}
```


Signed-off-by: snipe <snipe@snipe.net>