### PR TITLE
Feature: Prevent showing of double values in a checkin or checkout email

### DIFF
--- a/resources/views/notifications/markdown/checkin-asset.blade.php
+++ b/resources/views/notifications/markdown/checkin-asset.blade.php
@@ -13,14 +13,16 @@
 @if ((isset($item->name)) && ($item->name!=''))
 | **{{ trans('mail.asset_name') }}** | {{ $item->name }} |
 @endif
+@if (($item->name!=$item->asset_tag))
 | **{{ trans('mail.asset_tag') }}** | {{ $item->asset_tag }} |
+@endif
 @if (isset($item->manufacturer))
 | **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
 @endif
 @if (isset($item->model))
 | **{{ trans('general.asset_model') }}** | {{ $item->model->name }} |
 @endif
-@if (isset($item->model->model_number))
+@if ((isset($item->model->model_number)) && ($item->model->name!=$item->model->model_number))
 | **{{ trans('general.model_no') }}** | {{ $item->model->model_number }} |
 @endif
 @if (isset($item->serial))

--- a/resources/views/notifications/markdown/checkout-asset.blade.php
+++ b/resources/views/notifications/markdown/checkout-asset.blade.php
@@ -13,14 +13,16 @@
 @if ((isset($item->name)) && ($item->name!=''))
 | **{{ trans('mail.asset_name') }}** | {{ $item->name }} |
 @endif
+@if (($item->name!=$item->asset_tag))
 | **{{ trans('mail.asset_tag') }}** | {{ $item->asset_tag }} |
+@endif
 @if (isset($item->manufacturer))
 | **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
 @endif
 @if (isset($item->model))
 | **{{ trans('general.asset_model') }}** | {{ $item->model->name }} |
 @endif
-@if (isset($item->model->model_number))
+@if ((isset($item->model->model_number)) && ($item->model->name!=$item->model->model_number))
 | **{{ trans('general.model_no') }}** | {{ $item->model->model_number }} |
 @endif
 @if (isset($item->serial))


### PR DESCRIPTION
# Description

In my case, our company asset tag is the same as the asset name. Therefor it might be handy to prevent showing double values whenever an email is sent for checkin or checkout. When importing from a CSV out of Lansweeper, the model name and number are the same. The check is also made for this.

- If the asset name and tag are the same, the tag does not get shown in an email.
- If the model name is the same as the model number (when importing from LanSweeper for example), do not show the model number.

Some things redacted :)
![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/9415391/155673020-1e3f40dc-2237-4ce4-ab2f-61a44c9cb964.png)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: email sent :), not a breaking change
- [ ] Test B

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
