### PR TITLE
Fixes BadMethodCallException Call to undefined method App\Models\Asset::unaccepted() [ch-17636]

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -985,7 +985,7 @@ class ReportsController extends Controller
         ];
 
         $header = array_map('trim', $header);
-        $rows[] = implode($header, ',');
+        $rows[] = implode(',', $header);
 
         foreach ($assetsForReport as $assetItem) {
             $row    = [ ];
@@ -994,11 +994,11 @@ class ReportsController extends Controller
             $row[]  = str_replace(',', '', e($assetItem->assetlog->present()->name()));
             $row[]  = str_replace(',', '', e($assetItem->assetlog->asset_tag));
             $row[]  = str_replace(',', '', e($assetItem->assetlog->assignedTo->present()->name()));
-            $rows[] = implode($row, ',');
+            $rows[] = implode(',' ,$row);
         }
 
         // spit out a csv
-        $csv      = implode($rows, "\n");
+        $csv      = implode("\n", $rows);
         $response = Response::make($csv, 200);
         $response->header('Content-Type', 'text/csv');
         $response->header('Content-disposition', 'attachment;filename=report.csv');
@@ -1086,6 +1086,6 @@ class ReportsController extends Controller
     protected function getAssetsNotAcceptedYet()
     {
         $this->authorize('reports.view');
-        return Asset::unaccepted();
+        return CheckoutAcceptance::pending()->get('id');
     }
 }


### PR DESCRIPTION
# Description
A call to a method that don't longer exist is sometimes triggered, these changes fix that cases.

Fixes rollbar #529 and [ch-17636]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
