### PR TITLE
Fixes integrity constraint violation when reordering columns 'model' or 'asset model' in Requestable Assets report

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1172,7 +1172,9 @@ class Asset extends Depreciable
 
     public function scopeRequestableAssets($query)
     {
-        return Company::scopeCompanyables($query->where('requestable', '=', 1))
+        $table = $query->getModel()->getTable();
+        
+        return Company::scopeCompanyables($query->where($table.'.requestable', '=', 1))
         ->whereHas('assetstatus', function ($query) {
             $query->where(function ($query) {
                 $query->where('deployable', '=', 1)

--- a/resources/views/hardware/requested.blade.php
+++ b/resources/views/hardware/requested.blade.php
@@ -48,11 +48,10 @@
                         <th class="col-md-1">Image</th>
                         <th class="col-md-2">Item Name</th>
                         <th class="col-md-2" data-sortable="true">{{ trans('admin/hardware/table.location') }}</th>
-                        <th class="col-md-2" data-sortable="true">{{ trans('admin/hardware/form.expected_checkin') }}</th>
-                        <th class="col-md-3" data-sortable="true">{{ trans('admin/hardware/form.requesting_user') }}</th>
-                        <th class="col-md-2">{{ trans('admin/hardware/form.requested_date') }}</th>
-                        <th class="col-md-1"></th>
-                        <th class="col-md-1"></th>
+                        <th class="col-md-2" data-sortable="true">{{ trans('general.expected_checkin') }}</th>
+                        <th class="col-md-3" data-sortable="true">{{ trans('admin/hardware/table.requesting_user') }}</th>
+                        <th class="col-md-2">{{ trans('admin/hardware/table.requested_date') }}</th>
+                        <th class="col-md-1">{{ trans('general.checkin').'/'.trans('general.checkout') }}</th>
                     </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
# Description
Fix some translations that are wrongly called in Assets `requested.blade` view
Fix the table headers that are appearing extra in the same report
Fix integrity constraint violation when reordering columns 'model' or 'asset model' in Requestable Assets report
![image](https://user-images.githubusercontent.com/653557/156469585-d7ac469c-98d9-4eda-8c33-b8f7101b467f.png)


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version:nginx/1.19.8
* OS version: Debian 10