### PR TITLE
One attempt to fix the 'datatable double-request' problem.

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -31,7 +31,7 @@
             return false;
         }
 
-        $('.snipe-table').bootstrapTable('destroy').bootstrapTable({
+        $('.snipe-table').bootstrapTable({
             classes: 'table table-responsive table-no-bordered',
             ajaxOptions: {
                 headers: {

--- a/resources/views/reports/activity.blade.php
+++ b/resources/views/reports/activity.blade.php
@@ -35,7 +35,7 @@
                         id="activityReport"
                         data-url="{{ route('api.activity.index') }}"
                         data-mobile-responsive="true"
-                        data-toggle="table"
+                        {{-- data-toggle="table" --}}
                         class="table table-striped snipe-table"
                         data-export-options='{
                         "fileName": "activity-report-{{ date('Y-m-d') }}",

--- a/resources/views/reports/depreciation.blade.php
+++ b/resources/views/reports/depreciation.blade.php
@@ -33,7 +33,7 @@
                         id="depreciationReport"
                         data-url="{{ route('api.depreciation-report.index') }}"
                         data-mobile-responsive="true"
-                        data-toggle="table"
+                        {{-- data-toggle="table" --}}
                         class="table table-striped snipe-table"
                         data-columns="{{ \App\Presenters\DepreciationReportPresenter::dataTableLayout() }}"
                         data-export-options='{


### PR DESCRIPTION
We have a problem where a lot of bootstrapTables will AJAX request their data twice - once, that results in a 500. And once that actually works, and populates the table.

This is one example of fixing that for the Activity Report, which, if it works, we can take across to any other table that uses the bootstrap-table partial blade system.

It works by disabling the automatic enabling of the bootstrap table, waiting instead to allow the blade partial to do it instead.

This seems to work. Maybe? But we'll test before we get there.