### PR TITLE
Added ldap_import and assets_count to user api

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -132,6 +132,14 @@ class UsersController extends Controller
             $users = $users->where('users.manager_id','=',$request->input('manager_id'));
         }
 
+        if ($request->filled('ldap_import')) {
+            $users = $users->where('users.ldap_import', '=', $request->input('ldap_import'));
+        }
+
+        if ($request->filled('assets_count')) {
+           $users->has('assets', '=', $request->input('assets_count'));
+        }
+
         if ($request->filled('search')) {
             $users = $users->TextSearch($request->input('search'));
         }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -133,7 +133,7 @@ class UsersController extends Controller
         }
 
         if ($request->filled('ldap_import')) {
-            $users = $users->where('users.ldap_import', '=', $request->input('ldap_import'));
+            $users = $users->where('ldap_import', '=', $request->input('ldap_import'));
         }
 
         if ($request->filled('assets_count')) {

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -140,6 +140,18 @@ class UsersController extends Controller
            $users->has('assets', '=', $request->input('assets_count'));
         }
 
+        if ($request->filled('consumables_count')) {
+            $users->has('consumables', '=', $request->input('consumables_count'));
+        }
+
+        if ($request->filled('licenses_count')) {
+            $users->has('licenses', '=', $request->input('licenses_count'));
+        }
+
+        if ($request->filled('accessories_count')) {
+            $users->has('accessories', '=', $request->input('accessories_count'));
+        }
+
         if ($request->filled('search')) {
             $users = $users->TextSearch($request->input('search'));
         }


### PR DESCRIPTION
This adds the `ldap_import` flag to the user's search endpoint, as well as a way to return users with x number of assets, consumables, licenses and accessories by passing `assets_count=1` as a parameter. Will hopefully help the bird people and anyone else doing custom dashboard stuff who might want to query on ONLY users who have x assets (etc) and/or only users who were imported from LDAP.