### PR TITLE
WIP - Minor normalization of consumables API endpoints

### DIFF
--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -68,8 +68,7 @@ class AccessoriesTransformer
         $array = [];
 
         foreach ($accessory_users as $user) {
-            \Log::debug(print_r($user->pivot, true));
-            \Log::debug(print_r($user->pivot, true));
+
             $array[] = [
 
                 'assigned_pivot_id' => $user->pivot->id,

--- a/app/Http/Transformers/ConsumablesTransformer.php
+++ b/app/Http/Transformers/ConsumablesTransformer.php
@@ -69,4 +69,29 @@ class ConsumablesTransformer
 
         return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
+
+    public function transformCheckedoutConsumable($consumable, $consumable_users, $total)
+    {
+        $array = [];
+
+        foreach ($consumable_users as $user) {
+
+            $array[] = [
+
+                'assigned_pivot_id' => $user->pivot->id,
+                'id' => (int) $user->id,
+                'assigned_qty' => (int) $user->pivot->assigned_qty,
+                'username' => e($user->username),
+                'name' => e($user->getFullNameAttribute()),
+                'first_name'=> e($user->first_name),
+                'last_name'=> e($user->last_name),
+                'employee_number' =>  e($user->employee_num),
+                'checkout_notes' => ($user->pivot->note!='') ? e($user->pivot->note) : null,
+                'last_checkout' => Helper::getFormattedDateObject($user->pivot->created_at, 'datetime'),
+                'type' => 'user',
+            ];
+        }
+
+        return (new DatatablesTransformer)->transformDatatables($array, $total);
+    }
 }

--- a/database/migrations/2022_03_04_171150_add_assigned_qty_to_consumables.php
+++ b/database/migrations/2022_03_04_171150_add_assigned_qty_to_consumables.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAssignedQtyToConsumables extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('consumables_users', function (Blueprint $table) {
+            $table->integer('assigned_qty')->nullable()->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('consumables_users', function (Blueprint $table) {
+            if (Schema::hasColumn('consumables_users', 'assigned_qty')) {
+                $table->dropColumn('assigned_qty');
+            }
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -244,12 +244,24 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:'.config('app.
             ]
         )->name('api.consumables.selectlist');
 
+
+        // DEPRICATE IN NEXT MAJOR RELEASE - /checkedout should be used instead
         Route::get('view/{id}/users',
             [
                 Api\ConsumablesController::class, 
                 'getDataView'
             ]
         )->name('api.consumables.showUsers');
+        
+
+
+        Route::get('{id}/checkedout',
+            [
+                Api\ConsumablesController::class, 
+                'checkedout'
+            ]
+        )->name('api.consumables.checkedout');
+
 
         Route::get('{consumable}/checkout',
             [


### PR DESCRIPTION
So, this is my bike-shedding moment for the week. 

There is - and has been - a very long-standing discussion about how to best handle 1) API endpoints and 2) the logical flow (including UI) of the different types of objects we have in Snipe-IT. There is certainly the discussion about One Table to Rule Them All, and this is profoundly NOT trying to tackle that problem, it's just normalizing consumables to behave a little more like accessories with respect to the endpoints we offer and the format we offer them in.

~It would also (shit my MBP battery is dying, I'll pick this back up on my iPad to finish this draft PR.~

One of the challenges we’ve always had has been that the API endpoints for different types of targets can return slightly differently formatted results, and that’s because have a few different behaviors in the schema/database.

As I’ve mentioned on discord and certainly here, the end goal here is to do a series of very big but important migrations in the data to normalize this a little bit. This ties directly into the “licenses, consumables, accessories will act more like asset models do” thing I talk about. (Don’t worry, end users - you likely won’t notice anything other than expanded capabilities like custom fields, and hopefully faster response times i large lists.)

Right now we have ~3 behaviors across the various items:

### Licenses/Seats: 

“licenses” largely act like asset models but are less flexible and very noisy. Each license *seat* checkout is effectively the same as an asset record, while the overall license container is much like an asset mode. Licenses are fully-formed models, and each license can have one or more license seats associated with it. The seats table effectively acts like a pivot table (which we have almost everywhere else, so it’s not weird, but we do weird things here that I want us to stop doing.

Each time a license seat is checked out, a row gets added to the license_seats_users table and that behaves as the pivot. This was a mistake, IMHO, when I wrote it 125 years ago when 11 people were using this software, and it’s been on my shortlist of things to fix for quite a long time now. Really, the seats table itself should be the pivot. This will be a hideous migration, especially for users with hundreds of thousands of license seats, but I think we can do it. (Not to mention changing history in the `action_logs` table, so we don’t lose any data.)

### Assets/Asset Models: 

This was the flagship item-type within Snipe-IT, and for the most part is still the most popular, which is why it’s so fully-featured, with things like custom fields, etc. 

Asset models can have 0 or many assets within them, and the assets table itself behaves as the join.

### Accessories

Accessories largely work similarly to Licenses, with the `accessories_users` join table handling what accessories are checked out to whom. This one is largely straightforward, I think, and turning Accessories into a sort of Accessory Models behavior more similar to Assets and Asset Models isn’t that much of a stretch.

### Consumables

Similar to accessories, but you never check them in because they are consumed. If they are consumed, we should probably handle that via some kind of filter so we’re not looking at every paper ream someone ever had checked out to them.

### Components

Again, similar to accessories, but can only be checked out to assets - which makes a ton of sense in most cases, except for things like electronics labs and hackerspaces. A Component Models could work here too. 

I think you can see where I’m going with this. So far in this PR, I’m just trying to make the API response look more consistent with the rest of our API responses - but the goal here, had my laptop not punked out, would be to start to move us in the above direction. 

The migrations involved in the Final Form of this will be horrific, but this normalizing of endpoints should put us in a much better spot for the Custom Fields (Mostly) ALL the Things stuff that @uberbrady has been working on. 

At the end of the day, these pivots are extra weight. The licenses in particular, but all of them. This is the first step, because at the end of the day, we want people using the API, regardless of what’s happening on the backend.


Signed-off-by: snipe <snipe@snipe.net>
