### PR TITLE
Use the max_results env value in the paginator

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -51,7 +51,7 @@
             paginationLastText: "{{ trans('general.last') }}",
             paginationPreText: "{{ trans('general.previous') }}",
             paginationNextText: "{{ trans('general.next') }}",
-            pageList: ['10','20', '30','50','100','150','200', '500', '1000'],
+            pageList: ['10','20', '30','50','100','150','200', '500'{!! ((config('app.max_results') > 500) ? ",'".config('app.max_results')."'" : '') !!}],
             pageSize: {{  (($snipeSettings->per_page!='') && ($snipeSettings->per_page > 0)) ? $snipeSettings->per_page : 20 }},
             paginationVAlign: 'both',
             queryParams: function (params) {

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -51,7 +51,7 @@
             paginationLastText: "{{ trans('general.last') }}",
             paginationPreText: "{{ trans('general.previous') }}",
             paginationNextText: "{{ trans('general.next') }}",
-            pageList: ['10','20', '30','50','100','150','200', '500'{!! ((config('app.max_results') > 500) ? ",'".config('app.max_results')."'" : '') !!}],
+            pageList: ['10','20', '30','50','100','150','200'{!! ((config('app.max_results') > 200) ? ",'500'" : '') !!}{!! ((config('app.max_results') > 500) ? ",'".config('app.max_results')."'" : '') !!}],
             pageSize: {{  (($snipeSettings->per_page!='') && ($snipeSettings->per_page > 0)) ? $snipeSettings->per_page : 20 }},
             paginationVAlign: 'both',
             queryParams: function (params) {


### PR DESCRIPTION
This is a small change, and while it's gross to mix PHP and javascript, it was previously setup a little confusing. If you don't have this set, it will default to 500 - but the bootstrap-tables results list (10, 20, 50, 100, 200, etc) would go up to 1000 - but since this setting exists, it wouldn't actually return 1000, and the export wouldn't actually export higher than 500 rows at a time. 

This isn't a flawless solution - **and generally speaking if you're returning over 500, you're gonna have a bad time - not because Snipe-IT can't handle it, but because jamming that much stuff into any browser's DOM is going to be sloooooow** - but at least now it doesn't show an option that shouldn't be shown. 

https://github.com/snipe/snipe-it/blob/3e2fe1048076eb0c768a5e529a074d3adbafd611/config/app.php#L40-L50

<img width="503" alt="Screen Shot 2022-03-07 at 6 50 01 PM" src="https://user-images.githubusercontent.com/197404/157156820-192cadc9-37ff-4ea2-83d4-7ab49d7f9c5b.png">

<img width="459" alt="Screen Shot 2022-03-07 at 6 50 44 PM" src="https://user-images.githubusercontent.com/197404/157156831-7f093c5a-ed3e-4e79-bcdf-3b5760f31974.png">

Down the line, we probably want to create a helper method that sanely walks through increments a little better and just use that to determine what the page amounts should be, but this fixes the issue for the vast majority of use cases. 

Fixes SC-17768 and FD-24875.

Signed-off-by: snipe <snipe@snipe.net>