### PR TITLE
Added QR and alt barcode urls to asset transformer

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -3,6 +3,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Asset;
+use App\Models\Setting;
 use Gate;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -20,6 +21,8 @@ class AssetsTransformer
 
     public function transformAsset(Asset $asset)
     {
+        $setting = Setting::getSettings();
+
         $array = [
             'id' => (int) $asset->id,
             'name' => e($asset->name),
@@ -64,6 +67,8 @@ class AssetsTransformer
                 'name'=> e($asset->defaultLoc->name)
             ]  : null,
             'image' => ($asset->getImageUrl()) ? $asset->getImageUrl() : null,
+            'qr' => ($setting->qr_code=='1') ? config('app.url').'/uploads/barcodes/qr-'.str_slug($asset->asset_tag).'-'.str_slug($asset->id).'.png' : null,
+            'alt_barcode' => ($setting->alt_barcode_enabled=='1') ? config('app.url').'/uploads/barcodes/'.str_slug($setting->alt_barcode).'-'.str_slug($asset->asset_tag).'.png' : null,
             'assigned_to' => $this->transformAssignedTo($asset),
             'warranty_months' =>  ($asset->warranty_months > 0) ? e($asset->warranty_months . ' ' . trans('admin/hardware/form.months')) : null,
             'warranty_expires' => ($asset->warranty_months > 0) ?  Helper::getFormattedDateObject($asset->warranty_expires, 'date') : null,

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -21,6 +21,7 @@ class AssetsTransformer
 
     public function transformAsset(Asset $asset)
     {
+        // This uses the getSettings() method so we're pulling from the cache versus querying the settings on single asset
         $setting = Setting::getSettings();
 
         $array = [


### PR DESCRIPTION
This just adds two new fields to the JSON payload for assets  - the URL of the QR code image and the URL of the barcode image.

This *could* get a little confusing, since it's not actually checking to see if that barcode exists (it would exist in the cache IF it's been accessed before), but this is better than nothing. 

Example payload:

```json
{
    "id": 1,
    "name": "",
    "asset_tag": "914739550",
    "serial": "24c93083-c3fe-3f9e-8f90-173f6065d49d",
    "model": {
        "id": 1,
        "name": "Macbook Pro 13&quot;"
    },
    "model_number": "4024007105643679",
    "eol": {
        "date": "2024-05-11",
        "formatted": "Sat May 11, 2024"
    },
    "status_label": {
        "id": 4,
        "name": "Out for Diagnostics",
        "status_type": "undeployable",
        "status_meta": "undeployable"
    },
    "category": {
        "id": 1,
        "name": "Laptops"
    },
    "manufacturer": null,
    "supplier": null,
    "notes": "Created by DB seeder",
    "order_number": "49349524",
    "company": null,
    "location": {
        "id": 11,
        "name": "Lindchester"
    },
    "rtd_location": {
        "id": 11,
        "name": "Lindchester"
    },
    "image": "https://snipe-it.local:8890/uploads/models/mbp.jpg",
    "qr": "https://snipe-it.local:8890/uploads/barcodes/qr-914739550-1.png",
    "alt_barcode": "https://snipe-it.local:8890/uploads/barcodes/c128-914739550.png",
    "assigned_to": null,
    "warranty_months": null,
    "warranty_expires": null,
    "created_at": {
        "datetime": "2021-12-24 13:37:47",
        "formatted": "Fri Dec 24, 2021 1:37PM"
    },
    "updated_at": {
        "datetime": "2022-02-17 17:33:29",
        "formatted": "Thu Feb 17, 2022 5:33PM"
    },
    "last_audit_date": null,
    "next_audit_date": {
        "date": "2019-10-11",
        "formatted": "Fri Oct 11, 2019"
    },
    "deleted_at": null,
    "purchase_date": {
        "date": "2021-05-11",
        "formatted": "Tue May 11, 2021"
    },
    "last_checkout": null,
    "expected_checkin": null,
    "purchase_cost": "855.83",
    "checkin_counter": 0,
    "checkout_counter": 0,
    "requests_counter": 0,
    "user_can_checkout": false,
    "custom_fields": {
        "RAM": {
            "field": "_snipeit_ram_3",
            "value": "",
            "field_format": "ANY"
        },
        "CPU": {
            "field": "_snipeit_cpu_4",
            "value": "",
            "field_format": "ANY"
        },
        "MAC Address": {
            "field": "_snipeit_mac_address_5",
            "value": "",
            "field_format": "regex:/^([0-9a-fA-F]{2}[:-]){5}[0-9a-fA-F]{2}$/"
        },
        "test date": {
            "field": "_snipeit_test_date_6",
            "value": "",
            "field_format": "DATE"
        }
    },
    "available_actions": {
        "checkout": true,
        "checkin": true,
        "clone": true,
        "restore": false,
        "update": true,
        "delete": true
    }
}
```

Signed-off-by: snipe <snipe@snipe.net>