### PR TITLE
Check if table exists before trying to create in migrations

### DIFF
--- a/database/migrations/2018_07_28_023826_create_checkout_acceptances_table.php
+++ b/database/migrations/2018_07_28_023826_create_checkout_acceptances_table.php
@@ -13,20 +13,22 @@ class CreateCheckoutAcceptancesTable extends Migration
      */
     public function up()
     {
-        Schema::create('checkout_acceptances', function (Blueprint $table) {
-            $table->increments('id');
+        if (!Schema::hasTable('checkout_acceptances')) {
+            Schema::create('checkout_acceptances', function (Blueprint $table) {
+                $table->increments('id');
 
-            $table->morphs('checkoutable');
-            $table->integer('assigned_to_id')->nullable();
+                $table->morphs('checkoutable');
+                $table->integer('assigned_to_id')->nullable();
 
-            $table->string('signature_filename')->nullable();
+                $table->string('signature_filename')->nullable();
 
-            $table->timestamp('accepted_at')->nullable();
-            $table->timestamp('declined_at')->nullable();
+                $table->timestamp('accepted_at')->nullable();
+                $table->timestamp('declined_at')->nullable();
 
-            $table->timestamps();
-            $table->softDeletes();
-        });
+                $table->timestamps();
+                $table->softDeletes();
+            });
+        }
     }
 
     /**
@@ -36,6 +38,8 @@ class CreateCheckoutAcceptancesTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('checkout_acceptances');
+        if (Schema::hasTable('checkout_acceptances')) {
+            Schema::dropIfExists('checkout_acceptances');
+        }
     }
 }

--- a/database/migrations/2018_10_18_191228_add_kits_licenses_table.php
+++ b/database/migrations/2018_10_18_191228_add_kits_licenses_table.php
@@ -12,14 +12,15 @@ class AddKitsLicensesTable extends Migration {
 	 */
 	public function up()
 	{
-		//
-		Schema::create('kits_licenses', function ($table) {
-            $table->increments('id');
-            $table->integer('kit_id')->nullable()->default(NULL); 
-            $table->integer('license_id')->nullable()->default(NULL);    
-            $table->integer('quantity')->default(1);
-            $table->timestamps();
-        });
+		if (!Schema::hasTable('kits_licenses')) {
+			Schema::create('kits_licenses', function ($table) {
+				$table->increments('id');
+				$table->integer('kit_id')->nullable()->default(NULL); 
+				$table->integer('license_id')->nullable()->default(NULL);    
+				$table->integer('quantity')->default(1);
+				$table->timestamps();
+			});
+		}
 	}
 
 	/**
@@ -29,8 +30,9 @@ class AddKitsLicensesTable extends Migration {
 	 */
 	public function down()
 	{
-		//
-		Schema::drop('kits_licenses');
+		if (Schema::hasTable('kits_licenses')) {
+			Schema::drop('kits_licenses');
+		}
 	}
 
 }

--- a/database/migrations/2018_10_19_153910_add_kits_table.php
+++ b/database/migrations/2018_10_19_153910_add_kits_table.php
@@ -12,13 +12,14 @@ class AddKitsTable extends Migration {
 	 */
 	public function up()
 	{
-		//
-		 Schema::create('kits', function ($table) {
-            $table->increments('id');
-            $table->string('name')->nullable()->default(NULL);
-            $table->timestamps();
-            $table->engine = 'InnoDB';
-        });
+		if (!Schema::hasTable('kits')) {
+			Schema::create('kits', function ($table) {
+				$table->increments('id');
+				$table->string('name')->nullable()->default(NULL);
+				$table->timestamps();
+				$table->engine = 'InnoDB';
+			});
+		}
 
 	}
 
@@ -29,8 +30,9 @@ class AddKitsTable extends Migration {
 	 */
 	public function down()
 	{
-		//
-		Schema::drop('kits');
+		if (Schema::hasTable('kits')) {
+			Schema::drop('kits');
+		}
 
 	}
 

--- a/database/migrations/2018_10_19_154013_add_kits_models_table.php
+++ b/database/migrations/2018_10_19_154013_add_kits_models_table.php
@@ -12,14 +12,15 @@ class AddKitsModelsTable extends Migration {
 	 */
 	public function up()
 	{
-		//
-		Schema::create('kits_models', function ($table) {
-            $table->increments('id');
-            $table->integer('kit_id')->nullable()->default(NULL); 
-            $table->integer('model_id')->nullable()->default(NULL);    
-            $table->integer('quantity')->default(1);
-            $table->timestamps();
-        });
+		if (!Schema::hasTable('kits_models')) {
+			Schema::create('kits_models', function ($table) {
+				$table->increments('id');
+				$table->integer('kit_id')->nullable()->default(NULL); 
+				$table->integer('model_id')->nullable()->default(NULL);    
+				$table->integer('quantity')->default(1);
+				$table->timestamps();
+			});
+		}
 	}
 
 	/**
@@ -29,8 +30,9 @@ class AddKitsModelsTable extends Migration {
 	 */
 	public function down()
 	{
-		//
-		Schema::drop('kits_models');
+		if (Schema::hasTable('kits_models')) {
+			Schema::drop('kits_models');
+		}
 	}
 
 }

--- a/database/migrations/2019_02_07_185953_add_kits_consumables_table.php
+++ b/database/migrations/2019_02_07_185953_add_kits_consumables_table.php
@@ -13,14 +13,15 @@ class AddKitsConsumablesTable extends Migration
      */
     public function up()
     {
-        //
-        Schema::create('kits_consumables', function ($table) {
-            $table->increments('id');
-            $table->integer('kit_id')->nullable()->default(NULL); 
-            $table->integer('consumable_id')->nullable()->default(NULL);    
-            $table->integer('quantity')->default(1);
-            $table->timestamps();
-        });
+        if (!Schema::hasTable('kits_consumables')) {
+            Schema::create('kits_consumables', function ($table) {
+                $table->increments('id');
+                $table->integer('kit_id')->nullable()->default(NULL); 
+                $table->integer('consumable_id')->nullable()->default(NULL);    
+                $table->integer('quantity')->default(1);
+                $table->timestamps();
+            });
+        }
     }
 
     /**
@@ -30,7 +31,8 @@ class AddKitsConsumablesTable extends Migration
      */
     public function down()
     {
-        //
-		Schema::drop('kits_consumables');
+        if (Schema::hasTable('kits_consumables')) {
+		    Schema::drop('kits_consumables');
+        }
     }
 }

--- a/database/migrations/2019_02_07_190030_add_kits_accessories_table.php
+++ b/database/migrations/2019_02_07_190030_add_kits_accessories_table.php
@@ -13,14 +13,15 @@ class AddKitsAccessoriesTable extends Migration
      */
     public function up()
     {
-        //
-        Schema::create('kits_accessories', function ($table) {
-            $table->increments('id');
-            $table->integer('kit_id')->nullable()->default(NULL); 
-            $table->integer('accessory_id')->nullable()->default(NULL);    
-            $table->integer('quantity')->default(1);
-            $table->timestamps();
-        });
+        if (!Schema::hasTable('kits_accessories')) {
+            Schema::create('kits_accessories', function ($table) {
+                $table->increments('id');
+                $table->integer('kit_id')->nullable()->default(NULL); 
+                $table->integer('accessory_id')->nullable()->default(NULL);    
+                $table->integer('quantity')->default(1);
+                $table->timestamps();
+            });
+        }
     }
 
     /**
@@ -30,7 +31,8 @@ class AddKitsAccessoriesTable extends Migration
      */
     public function down()
     {
-        //
-		Schema::drop('kits_accessories');
+        if (Schema::hasTable('kits_accessories')) {
+		    Schema::drop('kits_accessories');
+        }
     }
 }


### PR DESCRIPTION
This is a fringe case, and I'm still not 100% sure why it happens sometimes but not all the time, usually with customers who have given us a backup and they wish to migrate to hosted. Somehow the migration tables get mangled where they don't actually register a few of the migrations, so they keep trying to re-run them, which means the migrations never complete. 

This change targets those specific files that seem to fail in these circumstances and checks to make sure the table doesn't already exist before trying to create it. 

You're welcome, @uberbrady :)

Signed-off-by: snipe <snipe@snipe.net>
