### PR TITLE
Example: dompdf implementation

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -129,11 +129,11 @@ class AcceptanceController extends Controller
         $data = [
             'item' => $item,
             'eula' => $item->getEula(),
-            'signature' => app_path().'/private_uploads/signatures/'.$sig_filename,
+            'signature' => storage_path().'/private_uploads/signatures/'.$sig_filename,
             'logo' => public_path().'/uploads/snipe-logo.png',
         ];
 
-        \Log::error(storage_path().'/pdfs/'.$sig_filename);
+        \Log::error(storage_path().'/eula-pdfs/'.$sig_filename);
 
         $pdf = Pdf::loadView('account.accept-eula', $data);
         Storage::put('private_uploads/eula-pdfs/accepted-eula-'.date('Y-m-d-h-i-s').'.pdf', $pdf->output());

--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Barryvdh\DomPDF\Facade\Pdf;
 
 class AcceptanceController extends Controller
 {
@@ -38,6 +39,7 @@ class AcceptanceController extends Controller
     public function create($id)
     {
         $acceptance = CheckoutAcceptance::find($id);
+
 
         if (is_null($acceptance)) {
             return redirect()->route('account.accept')->with('error', trans('admin/hardware/message.does_not_exist'));
@@ -97,12 +99,13 @@ class AcceptanceController extends Controller
         }
 
         $sig_filename = '';
+
         if ($request->filled('signature_output')) {
             $sig_filename = 'siglog-'.Str::uuid().'-'.date('Y-m-d-his').'.png';
             $data_uri = e($request->input('signature_output'));
             $encoded_image = explode(',', $data_uri);
             $decoded_image = base64_decode($encoded_image[1]);
-            Storage::put('private_uploads/signatures/'.$sig_filename, (string) $decoded_image);
+            $path = Storage::put('private_uploads/signatures/'.$sig_filename, (string) $decoded_image);
         }
 
         if ($request->input('asset_acceptance') == 'accepted') {
@@ -111,6 +114,8 @@ class AcceptanceController extends Controller
             event(new CheckoutAccepted($acceptance));
 
             $return_msg = trans('admin/users/message.accepted');
+            
+
         } else {
             $acceptance->decline($sig_filename);
 
@@ -119,6 +124,21 @@ class AcceptanceController extends Controller
             $return_msg = trans('admin/users/message.declined');
         }
 
+        $item = $acceptance->checkoutable_type::find($acceptance->checkoutable_id);
+
+        $data = [
+            'item' => $item,
+            'eula' => $item->getEula(),
+            'signature' => app_path().'/private_uploads/signatures/'.$sig_filename,
+            'logo' => public_path().'/uploads/snipe-logo.png',
+        ];
+
+        \Log::error(storage_path().'/pdfs/'.$sig_filename);
+
+        $pdf = Pdf::loadView('account.accept-eula', $data);
+        Storage::put('private_uploads/eula-pdfs/accepted-eula-'.date('Y-m-d-h-i-s').'.pdf', $pdf->output());
+
+    
         return redirect()->to('account/accept')->with('success', $return_msg);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "alek13/slack": "^2.0",
     "bacon/bacon-qr-code": "^2.0",
     "barryvdh/laravel-debugbar": "^3.6",
+    "barryvdh/laravel-dompdf": "^1.0",
     "doctrine/cache": "^1.10",
     "doctrine/common": "^2.12",
     "doctrine/dbal": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1c8533013db55e3b5f154e2a9464239",
+    "content-hash": "6d51656455202d9ee74c659267ad69f4",
     "packages": [
         {
             "name": "alek13/slack",
@@ -407,6 +407,82 @@
                 }
             ],
             "time": "2022-02-09T07:52:32+00:00"
+        },
+        {
+            "name": "barryvdh/laravel-dompdf",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-dompdf.git",
+                "reference": "e3f429e97087b2ef19b83e5ed313f080f2477685"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/e3f429e97087b2ef19b83e5ed313f080f2477685",
+                "reference": "e3f429e97087b2ef19b83e5ed313f080f2477685",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/dompdf": "^1",
+                "illuminate/support": "^6|^7|^8|^9",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "nunomaduro/larastan": "^1|^2",
+                "orchestra/testbench": "^4|^5|^6|^7",
+                "phpro/grumphp": "^1",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\DomPDF\\ServiceProvider"
+                    ],
+                    "aliases": {
+                        "PDF": "Barryvdh\\DomPDF\\Facade\\Pdf"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\DomPDF\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "A DOMPDF Wrapper for Laravel",
+            "keywords": [
+                "dompdf",
+                "laravel",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-dompdf/issues",
+                "source": "https://github.com/barryvdh/laravel-dompdf/tree/v1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-01-29T08:02:59+00:00"
         },
         {
             "name": "brick/math",
@@ -1671,6 +1747,73 @@
             },
             "abandoned": "roave/better-reflection",
             "time": "2020-10-27T21:46:55+00:00"
+        },
+        {
+            "name": "dompdf/dompdf",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "60b704331479a69e9bcdb3496da2315b5c4f94fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/60b704331479a69e9bcdb3496da2315b5c4f94fd",
+                "reference": "60b704331479a69e9bcdb3496da2315b5c4f94fd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "phenx/php-font-lib": "^0.5.4",
+                "phenx/php-svg-lib": "^0.3.3 || ^0.4.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Ménager",
+                    "email": "fabien.menager@gmail.com"
+                },
+                {
+                    "name": "Brian Sweeney",
+                    "email": "eclecticgeek@gmail.com"
+                },
+                {
+                    "name": "Gabriel Bull",
+                    "email": "me@gabrielbull.com"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v1.2.0"
+            },
+            "time": "2022-02-07T13:02:10+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -5965,6 +6108,96 @@
             "time": "2021-01-07T16:38:58+00:00"
         },
         {
+            "name": "phenx/php-font-lib",
+            "version": "0.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "dd448ad1ce34c63d09baccd05415e361300c35b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/dd448ad1ce34c63d09baccd05415e361300c35b4",
+                "reference": "dd448ad1ce34c63d09baccd05415e361300c35b4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3 || ^4 || ^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Ménager",
+                    "email": "fabien.menager@gmail.com"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/PhenX/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/0.5.4"
+            },
+            "time": "2021-12-17T19:44:54+00:00"
+        },
+        {
+            "name": "phenx/php-svg-lib",
+            "version": "0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "4498b5df7b08e8469f0f8279651ea5de9626ed02"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/4498b5df7b08e8469f0f8279651ea5de9626ed02",
+                "reference": "4498b5df7b08e8469f0f8279651ea5de9626ed02",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^7.2 || ^7.3 || ^7.4 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Ménager",
+                    "email": "fabien.menager@gmail.com"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/PhenX/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/0.4.1"
+            },
+            "time": "2022-03-07T12:52:04+00:00"
+        },
+        {
             "name": "php-http/message-factory",
             "version": "v1.0.2",
             "source": {
@@ -7604,6 +7837,59 @@
                 "source": "https://github.com/rollbar/rollbar-php-laravel/tree/v7.1.0"
             },
             "time": "2022-02-21T21:48:29+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "8.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabberworm/PHP-CSS-Parser.git",
+                "reference": "e41d2140031d533348b2192a83f02d8dd8a71d30"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabberworm/PHP-CSS-Parser/zipball/e41d2140031d533348b2192a83f02d8dd8a71d30",
+                "reference": "e41d2140031d533348b2192a83f02d8dd8a71d30",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=5.6.20"
+            },
+            "require-dev": {
+                "codacy/coverage": "^1.4",
+                "phpunit/phpunit": "^4.8.36"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/sabberworm/PHP-CSS-Parser/issues",
+                "source": "https://github.com/sabberworm/PHP-CSS-Parser/tree/8.4.0"
+            },
+            "time": "2021-12-11T13:40:54+00:00"
         },
         {
             "name": "sebastian/comparator",

--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -1,0 +1,248 @@
+<?php
+
+return array(
+
+    /*
+    |--------------------------------------------------------------------------
+    | Settings
+    |--------------------------------------------------------------------------
+    |
+    | Set some default values. It is possible to add all defines that can be set
+    | in dompdf_config.inc.php. You can also override the entire config file.
+    |
+    */
+    'show_warnings' => false,   // Throw an Exception on warnings from dompdf
+    'orientation' => 'portrait',
+    /*
+     * Dejavu Sans font is missing glyphs for converted entities, turn it off if you need to show € and £.
+     */
+    'convert_entities' => true,
+    'defines' => array(
+        /**
+         * The location of the DOMPDF font directory
+         *
+         * The location of the directory where DOMPDF will store fonts and font metrics
+         * Note: This directory must exist and be writable by the webserver process.
+         * *Please note the trailing slash.*
+         *
+         * Notes regarding fonts:
+         * Additional .afm font metrics can be added by executing load_font.php from command line.
+         *
+         * Only the original "Base 14 fonts" are present on all pdf viewers. Additional fonts must
+         * be embedded in the pdf file or the PDF may not display correctly. This can significantly
+         * increase file size unless font subsetting is enabled. Before embedding a font please
+         * review your rights under the font license.
+         *
+         * Any font specification in the source HTML is translated to the closest font available
+         * in the font directory.
+         *
+         * The pdf standard "Base 14 fonts" are:
+         * Courier, Courier-Bold, Courier-BoldOblique, Courier-Oblique,
+         * Helvetica, Helvetica-Bold, Helvetica-BoldOblique, Helvetica-Oblique,
+         * Times-Roman, Times-Bold, Times-BoldItalic, Times-Italic,
+         * Symbol, ZapfDingbats.
+         */
+        "font_dir" => storage_path('fonts'), // advised by dompdf (https://github.com/dompdf/dompdf/pull/782)
+
+        /**
+         * The location of the DOMPDF font cache directory
+         *
+         * This directory contains the cached font metrics for the fonts used by DOMPDF.
+         * This directory can be the same as DOMPDF_FONT_DIR
+         *
+         * Note: This directory must exist and be writable by the webserver process.
+         */
+        "font_cache" => storage_path('fonts'),
+
+        /**
+         * The location of a temporary directory.
+         *
+         * The directory specified must be writeable by the webserver process.
+         * The temporary directory is required to download remote images and when
+         * using the PFDLib back end.
+         */
+        "temp_dir" => sys_get_temp_dir(),
+
+        /**
+         * ==== IMPORTANT ====
+         *
+         * dompdf's "chroot": Prevents dompdf from accessing system files or other
+         * files on the webserver.  All local files opened by dompdf must be in a
+         * subdirectory of this directory.  DO NOT set it to '/' since this could
+         * allow an attacker to use dompdf to read any files on the server.  This
+         * should be an absolute path.
+         * This is only checked on command line call by dompdf.php, but not by
+         * direct class use like:
+         * $dompdf = new DOMPDF();	$dompdf->load_html($htmldata); $dompdf->render(); $pdfdata = $dompdf->output();
+         */
+        "chroot" => realpath(base_path()),
+
+        /**
+         * Whether to enable font subsetting or not.
+         */
+        "enable_font_subsetting" => false,
+
+        /**
+         * The PDF rendering backend to use
+         *
+         * Valid settings are 'PDFLib', 'CPDF' (the bundled R&OS PDF class), 'GD' and
+         * 'auto'. 'auto' will look for PDFLib and use it if found, or if not it will
+         * fall back on CPDF. 'GD' renders PDFs to graphic files. {@link
+         * Canvas_Factory} ultimately determines which rendering class to instantiate
+         * based on this setting.
+         *
+         * Both PDFLib & CPDF rendering backends provide sufficient rendering
+         * capabilities for dompdf, however additional features (e.g. object,
+         * image and font support, etc.) differ between backends.  Please see
+         * {@link PDFLib_Adapter} for more information on the PDFLib backend
+         * and {@link CPDF_Adapter} and lib/class.pdf.php for more information
+         * on CPDF. Also see the documentation for each backend at the links
+         * below.
+         *
+         * The GD rendering backend is a little different than PDFLib and
+         * CPDF. Several features of CPDF and PDFLib are not supported or do
+         * not make any sense when creating image files.  For example,
+         * multiple pages are not supported, nor are PDF 'objects'.  Have a
+         * look at {@link GD_Adapter} for more information.  GD support is
+         * experimental, so use it at your own risk.
+         *
+         * @link http://www.pdflib.com
+         * @link http://www.ros.co.nz/pdf
+         * @link http://www.php.net/image
+         */
+        "pdf_backend" => "CPDF",
+
+        /**
+         * PDFlib license key
+         *
+         * If you are using a licensed, commercial version of PDFlib, specify
+         * your license key here.  If you are using PDFlib-Lite or are evaluating
+         * the commercial version of PDFlib, comment out this setting.
+         *
+         * @link http://www.pdflib.com
+         *
+         * If pdflib present in web server and auto or selected explicitely above,
+         * a real license code must exist!
+         */
+        //"DOMPDF_PDFLIB_LICENSE" => "your license key here",
+
+        /**
+         * html target media view which should be rendered into pdf.
+         * List of types and parsing rules for future extensions:
+         * http://www.w3.org/TR/REC-html40/types.html
+         *   screen, tty, tv, projection, handheld, print, braille, aural, all
+         * Note: aural is deprecated in CSS 2.1 because it is replaced by speech in CSS 3.
+         * Note, even though the generated pdf file is intended for print output,
+         * the desired content might be different (e.g. screen or projection view of html file).
+         * Therefore allow specification of content here.
+         */
+        "default_media_type" => "screen",
+
+        /**
+         * The default paper size.
+         *
+         * North America standard is "letter"; other countries generally "a4"
+         *
+         * @see CPDF_Adapter::PAPER_SIZES for valid sizes ('letter', 'legal', 'A4', etc.)
+         */
+        "default_paper_size" => "a4",
+
+        /**
+         * The default font family
+         *
+         * Used if no suitable fonts can be found. This must exist in the font folder.
+         * @var string
+         */
+        "default_font" => "serif",
+
+        /**
+         * Image DPI setting
+         *
+         * This setting determines the default DPI setting for images and fonts.  The
+         * DPI may be overridden for inline images by explictly setting the
+         * image's width & height style attributes (i.e. if the image's native
+         * width is 600 pixels and you specify the image's width as 72 points,
+         * the image will have a DPI of 600 in the rendered PDF.  The DPI of
+         * background images can not be overridden and is controlled entirely
+         * via this parameter.
+         *
+         * For the purposes of DOMPDF, pixels per inch (PPI) = dots per inch (DPI).
+         * If a size in html is given as px (or without unit as image size),
+         * this tells the corresponding size in pt.
+         * This adjusts the relative sizes to be similar to the rendering of the
+         * html page in a reference browser.
+         *
+         * In pdf, always 1 pt = 1/72 inch
+         *
+         * Rendering resolution of various browsers in px per inch:
+         * Windows Firefox and Internet Explorer:
+         *   SystemControl->Display properties->FontResolution: Default:96, largefonts:120, custom:?
+         * Linux Firefox:
+         *   about:config *resolution: Default:96
+         *   (xorg screen dimension in mm and Desktop font dpi settings are ignored)
+         *
+         * Take care about extra font/image zoom factor of browser.
+         *
+         * In images, <img> size in pixel attribute, img css style, are overriding
+         * the real image dimension in px for rendering.
+         *
+         * @var int
+         */
+        "dpi" => 96,
+
+        /**
+         * Enable inline PHP
+         *
+         * If this setting is set to true then DOMPDF will automatically evaluate
+         * inline PHP contained within <script type="text/php"> ... </script> tags.
+         *
+         * Enabling this for documents you do not trust (e.g. arbitrary remote html
+         * pages) is a security risk.  Set this option to false if you wish to process
+         * untrusted documents.
+         *
+         * @var bool
+         */
+        "enable_php" => false,
+
+        /**
+         * Enable inline Javascript
+         *
+         * If this setting is set to true then DOMPDF will automatically insert
+         * JavaScript code contained within <script type="text/javascript"> ... </script> tags.
+         *
+         * @var bool
+         */
+        "enable_javascript" => true,
+
+        /**
+         * Enable remote file access
+         *
+         * If this setting is set to true, DOMPDF will access remote sites for
+         * images and CSS files as required.
+         * This is required for part of test case www/test/image_variants.html through www/examples.php
+         *
+         * Attention!
+         * This can be a security risk, in particular in combination with DOMPDF_ENABLE_PHP and
+         * allowing remote access to dompdf.php or on allowing remote html code to be passed to
+         * $dompdf = new DOMPDF(, $dompdf->load_html(...,
+         * This allows anonymous users to download legally doubtful internet content which on
+         * tracing back appears to being downloaded by your server, or allows malicious php code
+         * in remote html pages to be executed by your server with your account privileges.
+         *
+         * @var bool
+         */
+        "enable_remote" => true,
+
+        /**
+         * A ratio applied to the fonts height to be more like browsers' line height
+         */
+        "font_height_ratio" => 1.1,
+
+        /**
+         * Use the more-than-experimental HTML5 Lib parser
+         */
+        "enable_html5_parser" => false,
+    ),
+
+
+);

--- a/database/migrations/2022_03_08_122942_add_eula_to_checkout_acceptance.php
+++ b/database/migrations/2022_03_08_122942_add_eula_to_checkout_acceptance.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddEulaToCheckoutAcceptance extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('checkout_acceptances', function (Blueprint $table) {
+            $table->text('stored_eula')->nullable()->default(null);
+            $table->string('stored_eula_file')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('checkout_acceptances', function (Blueprint $table) {
+            if (Schema::hasColumn('checkout_acceptances', 'stored_eula')) {
+                $table->dropColumn('stored_eula');
+            }
+            if (Schema::hasColumn('checkout_acceptances', 'stored_eula_file')) {
+                $table->dropColumn('stored_eula_file');
+            }
+        });
+    }
+}

--- a/resources/views/account/accept-eula.blade.php
+++ b/resources/views/account/accept-eula.blade.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>HTML 5 Boilerplate</title>
+    <link rel="stylesheet" href="style.css">
+  </head>
+  <body>
+
+    @if ($signature)
+        <center>
+            <img src="{{ $logo }}">
+        </center>
+    @endif
+    <br>
+    
+    <h2>{{ $item->name }}</h2>
+    
+    @if ($eula)
+        {!!  $eula !!}
+    @endif
+
+    <br><br>
+    @if ($signature)
+    <center>
+        <img src="{{ $signature }}">
+    </center>
+    @endif
+  </body>
+</html>

--- a/resources/views/account/accept-eula.blade.php
+++ b/resources/views/account/accept-eula.blade.php
@@ -17,7 +17,7 @@
     <br>
     
     <h2>{{ $item->name }}</h2>
-    
+    <p>Date: {{ date('Y-m-d h:i') }} </p>
     @if ($eula)
         {!!  $eula !!}
     @endif
@@ -25,7 +25,7 @@
     <br><br>
     @if ($signature)
     <center>
-        <img src="{{ $signature }}">
+        <img src="{{ $signature }}" style="max-width: 50%">
     </center>
     @endif
   </body>

--- a/storage/private_uploads/eula-pdfs/.gitignore
+++ b/storage/private_uploads/eula-pdfs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Posting this here for anyone curious to see how generating PDFs for the EULA acceptance stuff would work. This isn't really done - I added a migration to store the eula and the filename of the PDF as it is as the user is signing it, but it's not being stored anywhere, and we're not actually exposing the PDF anywhere for download, so it's certainly not ready for prime time, but I thought it could be helpful. 

<img width="1035" alt="Screen Shot 2022-03-08 at 10 41 45 AM" src="https://user-images.githubusercontent.com/197404/157304091-dafb36a8-0268-4678-b753-4a6bfefb8220.png">


[accepted-eula-2022-03-08-01-41-26.pdf](https://github.com/snipe/snipe-it/files/8208796/accepted-eula-2022-03-08-01-41-26.pdf)
