### PR TITLE
Removed experimental feature policies

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -42,7 +42,6 @@ class SecurityHeaders
         //           - https://github.com/w3c/webappsec-feature-policy/issues/189
 
         $feature_policy[] = "accelerometer 'none'";
-        $feature_policy[] = "animations 'none'";
         $feature_policy[] = "autoplay 'none'";
         $feature_policy[] = "camera 'none'";
         $feature_policy[] = "display-capture 'none'";
@@ -51,7 +50,6 @@ class SecurityHeaders
         $feature_policy[] = "fullscreen 'none'";
         $feature_policy[] = "geolocation 'none'";
         $feature_policy[] = "sync-xhr 'none'";
-        $feature_policy[] = "unsized-media 'none'";
         $feature_policy[] = "usb 'none'";
         $feature_policy[] = "xr-spatial-tracking 'none'";
 

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -42,30 +42,17 @@ class SecurityHeaders
         //           - https://github.com/w3c/webappsec-feature-policy/issues/189
 
         $feature_policy[] = "accelerometer 'none'";
-        $feature_policy[] = "ambient-light-sensor 'none'";
         $feature_policy[] = "animations 'none'";
         $feature_policy[] = "autoplay 'none'";
-        $feature_policy[] = "battery 'none'";
         $feature_policy[] = "camera 'none'";
         $feature_policy[] = "display-capture 'none'";
         $feature_policy[] = "document-domain 'none'";
         $feature_policy[] = "encrypted-media 'none'";
         $feature_policy[] = "fullscreen 'none'";
         $feature_policy[] = "geolocation 'none'";
-        $feature_policy[] = "gyroscope 'none'";
-        $feature_policy[] = "legacy-image-formats 'none'";
-        $feature_policy[] = "magnetometer 'none'";
-        $feature_policy[] = "microphone 'none'";
-        $feature_policy[] = "midi 'none'";
-        $feature_policy[] = "oversized-images 'none'";
-        $feature_policy[] = "payment 'none'";
-        $feature_policy[] = "picture-in-picture 'none'";
-        $feature_policy[] = "publickey-credentials 'none'";
         $feature_policy[] = "sync-xhr 'none'";
         $feature_policy[] = "unsized-media 'none'";
         $feature_policy[] = "usb 'none'";
-        $feature_policy[] = "vibrate 'none'";
-        $feature_policy[] = "wake-lock 'none'";
         $feature_policy[] = "xr-spatial-tracking 'none'";
 
         $feature_policy = implode(';', $feature_policy);


### PR DESCRIPTION
This just removed some feature headers that are [considered experimental](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental) and are largely unsupported (which causes them to barf all over Chrome's console with warnings.)

<img width="575" alt="Screen Shot 2022-03-08 at 8 06 49 PM" src="https://user-images.githubusercontent.com/197404/157370897-d068b85e-0354-44d5-8725-0072e89bdd69.png">

They don't really cause any harm, but they're not doing any good either, so no sense in keeping them.