### PR TITLE
Fixes Carbon\Exceptions\InvalidFormatException: DateTime::__construct(): Failed to parse time string

### DIFF
--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -46,14 +46,22 @@ class LicenseImporter extends ItemImporter
             $license = new License;
         }
         $asset_tag = $this->item['asset_tag'] = $this->findCsvMatch($row, 'asset_tag'); // used for checkout out to an asset.
-        $this->item['expiration_date'] = $this->findCsvMatch($row, 'expiration_date');
+        
+        $this->item["expiration_date"] = null;
+        if ($this->findCsvMatch($row, "expiration_date")!='') {
+            $this->item["expiration_date"] = date("Y-m-d 00:00:01", strtotime($this->findCsvMatch($row, "expiration_date")));
+        }
         $this->item['license_email'] = $this->findCsvMatch($row, "license_email");
         $this->item['license_name'] = $this->findCsvMatch($row, "license_name");
         $this->item['maintained'] = $this->findCsvMatch($row, 'maintained');
         $this->item['purchase_order'] = $this->findCsvMatch($row, 'purchase_order');
         $this->item['reassignable'] = $this->findCsvMatch($row, 'reassignable');
         $this->item['seats'] = $this->findCsvMatch($row, 'seats');
-        $this->item['termination_date'] = $this->findCsvMatch($row, 'termination_date');
+        
+        $this->item["termination_date"] = null;
+        if ($this->findCsvMatch($row, "termination_date")!='') {
+            $this->item["termination_date"] = date("Y-m-d 00:00:01", strtotime($this->findCsvMatch($row, "termination_date")));
+        }
 
         if ($editingLicense) {
             $license->update($this->sanitizeItemForUpdating($license));


### PR DESCRIPTION
# Description
The importer takes a couple of dates as the user put exactly in the CSV file trying to import, which sometimes leads to errors. I sanitize the input values as it's already done with `purchase_date`.

Fixes internal rollbar #16165

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
