### PR TITLE
Fixes Carbon\Exceptions\InvalidFormatException: DateTime::__construct(): Failed to parse time string develop

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -97,10 +97,12 @@ class AssetImporter extends ItemImporter
             $item['rtd_location_id'] = $this->item['location_id'];
         }
 
+        $item['last_audit_date'] = null;
         if (isset($this->item['last_audit_date'])) {
             $item['last_audit_date'] = $this->item['last_audit_date'];
         }
 
+        $item['next_audit_date'] = null;
         if (isset($this->item['next_audit_date'])) {
             $item['next_audit_date'] = $this->item['next_audit_date'];
         }

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -47,14 +47,22 @@ class LicenseImporter extends ItemImporter
             $license = new License;
         }
         $asset_tag = $this->item['asset_tag'] = $this->findCsvMatch($row, 'asset_tag'); // used for checkout out to an asset.
-        $this->item['expiration_date'] = $this->findCsvMatch($row, 'expiration_date');
+
+        $this->item['expiration_date'] = null;
+        if ($this->findCsvMatch($row, 'expiration_date') != '') {
+            $this->item['expiration_date'] = date('Y-m-d 00:00:01', strtotime($this->findCsvMatch($row, 'expiration_date')));
+        }
         $this->item['license_email'] = $this->findCsvMatch($row, 'license_email');
         $this->item['license_name'] = $this->findCsvMatch($row, 'license_name');
         $this->item['maintained'] = $this->findCsvMatch($row, 'maintained');
         $this->item['purchase_order'] = $this->findCsvMatch($row, 'purchase_order');
         $this->item['reassignable'] = $this->findCsvMatch($row, 'reassignable');
         $this->item['seats'] = $this->findCsvMatch($row, 'seats');
-        $this->item['termination_date'] = $this->findCsvMatch($row, 'termination_date');
+        
+        $this->item['termination_date'] = null;
+        if ($this->findCsvMatch($row, 'termination_date') != '') {
+            $this->item['termination_date'] = date('Y-m-d 00:00:01', strtotime($this->findCsvMatch($row, 'termination_date')));
+        }
 
         if ($editingLicense) {
             $license->update($this->sanitizeItemForUpdating($license));


### PR DESCRIPTION
# Description
Same as #10811 but for develop branch.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
