### PR TITLE
Added session killer artisan command

### DIFF
--- a/app/Console/Commands/KillAllSessions.php
+++ b/app/Console/Commands/KillAllSessions.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class KillAllSessions extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:global-logout';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command will destroy all web sessions on disk and will force a re-login for all users.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if ($this->confirm("\n****************************************************\nTHIS WILL FORCE A LOGIN FOR ALL LOGGED IN USERS.\n\nAre you SURE you wish to continue? "))  {
+
+            $session_files = glob(storage_path("framework/sessions/*"));
+
+            $count = 0;
+            foreach ($session_files as $file) {
+
+                if (is_file($file))
+                    unlink($file);
+                    $count++;
+            }
+            \DB::table('users')->update(['remember_token' => null]);
+
+            $this->info($count. ' sessions cleared!');
+        }
+//
+    }
+}

--- a/app/Console/Commands/KillAllSessions.php
+++ b/app/Console/Commands/KillAllSessions.php
@@ -11,7 +11,7 @@ class KillAllSessions extends Command
      *
      * @var string
      */
-    protected $signature = 'snipeit:global-logout';
+    protected $signature = 'snipeit:global-logout  {--force : Skip the danger prompt; assuming you enter "y"} ';
 
     /**
      * The console command description.
@@ -37,21 +37,23 @@ class KillAllSessions extends Command
      */
     public function handle()
     {
-        if ($this->confirm("\n****************************************************\nTHIS WILL FORCE A LOGIN FOR ALL LOGGED IN USERS.\n\nAre you SURE you wish to continue? "))  {
 
-            $session_files = glob(storage_path("framework/sessions/*"));
-
-            $count = 0;
-            foreach ($session_files as $file) {
-
-                if (is_file($file))
-                    unlink($file);
-                    $count++;
-            }
-            \DB::table('users')->update(['remember_token' => null]);
-
-            $this->info($count. ' sessions cleared!');
+        if (!$this->option('force') && !$this->confirm("****************************************************\nTHIS WILL FORCE A LOGIN FOR ALL LOGGED IN USERS.\n\nAre you SURE you wish to continue? ")) {
+            return $this->error("Session loss not confirmed");
         }
-//
+
+        $session_files = glob(storage_path("framework/sessions/*"));
+
+        $count = 0;
+        foreach ($session_files as $file) {
+
+            if (is_file($file))
+                unlink($file);
+                $count++;
+        }
+        \DB::table('users')->update(['remember_token' => null]);
+
+        $this->info($count. ' sessions cleared!');
+
     }
 }

--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -14,7 +14,7 @@ class RestoreFromBackup extends Command
      * @var string
      */
     protected $signature = 'snipeit:restore 
-                                            {--force : Skip the danger prompt; assuming you hit "y"} 
+                                            {--force : Skip the danger prompt; assuming you enter "y"} 
                                             {filename : The zip file to be migrated}
                                             {--no-progress : Don\'t show a progress bar}';
 


### PR DESCRIPTION
Simple artisan command to logout all users - especially useful when using the restore command. If you restore without killing all sessions, and your user ID isn't the same, your session will persist, and you could be logged in as someone else. (This is why we destroy sessions in v6 on the GUI restore.)

Using the `--force` flag will override confirmation prompts, in the event we want to use this non-interactively. 

Signed-off-by: snipe <snipe@snipe.net>