### PR TITLE
Fix #10810 unaccepted assets

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -933,12 +933,17 @@ class ReportsController extends Controller
         /**
          * Get all assets with pending checkout acceptances
          */
-
-        $acceptances = CheckoutAcceptance::pending()->with('assignedTo')->get();
+        if($showDeleted) {
+            $acceptances = CheckoutAcceptance::pending()->withTrashed()->with(['assignedTo' , 'checkoutable.assignedTo', 'checkoutable.model'])->get();
+        } else {
+            $acceptances = CheckoutAcceptance::pending()->with(['assignedTo' => function ($query) {
+                $query->withTrashed();
+            }, 'checkoutable.assignedTo', 'checkoutable.model'])->get();
+        }
 
         $assetsForReport = $acceptances
-            ->filter(function($acceptance) {
-                return $acceptance->checkoutable_type == 'App\Models\Asset' && !is_null($acceptance->assignedTo);
+            ->filter(function ($acceptance) {
+                return $acceptance->checkoutable_type == 'App\Models\Asset';
             })
             ->map(function($acceptance) {
                 return ['assetItem' => $acceptance->checkoutable, 'acceptance' => $acceptance];

--- a/resources/views/reports/unaccepted_assets.blade.php
+++ b/resources/views/reports/unaccepted_assets.blade.php
@@ -71,7 +71,7 @@
                   @if ($item['assetItem'])
                   <tr @if($item['acceptance']->trashed()) style="text-decoration: line-through" @endif>
                     <td>{{ $item['acceptance']->created_at }}</td>
-                    <td>{{ ($item['assetItem']->company) ? $assetItem->company->name : '' }}</td>
+                    <td>{{ ($item['assetItem']->company) ? $item['assetItem']->company->name : '' }}</td>
                     <td>{!! $item['assetItem']->model->category->present()->nameUrl() !!}</td>
                     <td>{!! $item['assetItem']->present()->modelUrl() !!}</td>
                     <td>{!! $item['assetItem']->present()->nameUrl() !!}</td>


### PR DESCRIPTION
# Description

I refactored the unaccepted assets report and missed one variable rename

Fixes #10810 

Also reverts #9508 as it broke the show/hide deleted entries functionality
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I reproduced the error, applied the fix and the error no longer occurs

- Check out asset with acceptance which is assigned to a company
