### PR TITLE
Fixes Accessories total quantity shows a negative number

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -128,7 +128,7 @@ class AccessoriesController extends Controller
             return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.does_not_exist'));
         }
 
-        $min = $accessory->numCHeckedOut();
+        $min = $accessory->numCheckedOut;
         $validator = Validator::make($request->all(), [
             "qty" => "required|numeric|min:$min"
         ]);

--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -8,6 +8,7 @@ use App\Models\Accessory;
 use App\Models\Company;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
 use Redirect;
 
 /** This controller handles all actions related to Accessories for
@@ -125,6 +126,17 @@ class AccessoriesController extends Controller
     {
         if (is_null($accessory = Accessory::find($accessoryId))) {
             return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.does_not_exist'));
+        }
+
+        $min = $accessory->numCHeckedOut();
+        $validator = Validator::make($request->all(), [
+            "qty" => "required|numeric|min:$min"
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()
+                ->withErrors($validator)
+                ->withInput();
         }
 
         $this->authorize($accessory);

--- a/app/Http/Controllers/Components/ComponentsController.php
+++ b/app/Http/Controllers/Components/ComponentsController.php
@@ -124,7 +124,7 @@ class ComponentsController extends Controller
         if (is_null($component = Component::find($componentId))) {
             return redirect()->route('components.index')->with('error', trans('admin/components/message.does_not_exist'));
         }
-        $min = $component->numCHeckedOut();
+        $min = $component->numCheckedOut();
         $validator = Validator::make($request->all(), [
             "qty" => "required|numeric|min:$min"
         ]);

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -9,6 +9,7 @@ use App\Models\Company;
 use App\Models\Consumable;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Input;
+use Illuminate\Support\Facades\Validator;
 
 /**
  * This controller handles all actions related to Consumables for
@@ -129,6 +130,17 @@ class ConsumablesController extends Controller
     {
         if (is_null($consumable = Consumable::find($consumableId))) {
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.does_not_exist'));
+        }
+
+        $min = $consumable->numCHeckedOut();
+        $validator = Validator::make($request->all(), [
+            "qty" => "required|numeric|min:$min"
+        ]);
+
+        if ($validator->fails()) {
+            return redirect()->back()
+                ->withErrors($validator)
+                ->withInput();
         }
 
         $this->authorize($consumable);

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -132,7 +132,7 @@ class ConsumablesController extends Controller
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.does_not_exist'));
         }
 
-        $min = $consumable->numCHeckedOut();
+        $min = $consumable->numCheckedOut();
         $validator = Validator::make($request->all(), [
             "qty" => "required|numeric|min:$min"
         ]);

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -310,6 +310,21 @@ class Accessory extends SnipeModel
             return null;
     }
 
+     /**
+     * Check how many items within an accessory are checked out
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v5.0]
+     * @return int
+     */
+    public function numCheckedOut()
+    {
+        $checkedout = 0;
+        $checkedout = $this->users->count();
+
+        return $checkedout;
+    }
+
     /**
      * Check how many items of an accessory remain
      *

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -277,6 +277,21 @@ class Consumable extends SnipeModel
 
     }
 
+     /**
+     * Check how many items within a consumable are checked out
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v5.0]
+     * @return int
+     */
+    public function numCheckedOut()
+    {
+        $checkedout = 0;
+        $checkedout = $this->users->count();
+
+        return $checkedout;
+    }
+
     /**
      * Checks the number of available consumables
      *


### PR DESCRIPTION
# Description
The ticket that this PR attempt to fix reads like this: "Accessories are able to be updated to have a lower quantity than what is currently checked out. This results in a negative number for the accessory. I would expect to have the same error as a component when trying to do this."

So a validation was added to not let the user have a number minor to the quantity of already checked out Accessories or Consumables based on the one that Components implements.

Fixes freshdesk ticket #26709

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
