### PR TITLE
Fixed #10826 - parse error on translation string for print all assets

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -230,7 +230,7 @@
                         {{ ($consumable->manufacturer) ? $consumable->manufacturer->name : '' }}  {{ $consumable->name }} {{ $consumable->model_number }}
                     @endif
                 </td>
-                    <td>{{ ($consumable->category) ? $consumable->category->name : '{{ trans('general.invalid_category') }}' }} </td>
+                    <td>{{ ($consumable->category) ? $consumable->category->name :  trans('general.invalid_category') }} </td>
                     <td>{{  $consumable->assetlog->first()->created_at }}</td>
                 </tr>
                 @php


### PR DESCRIPTION
Fixed incorrect handling of transaction string in operator

Signed-off-by: snipe <snipe@snipe.net>