### PR TITLE
Added filter by status_type in StatusLabels API index endpoint

### DIFF
--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -42,7 +42,6 @@ class StatuslabelsController extends Controller
             } elseif (strtolower($request->input('status_type'))== 'undeployable') {
                 $statuslabels = $statuslabels->Undeployable();
             }
-
         }
 
         // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which

--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -30,6 +30,21 @@ class StatuslabelsController extends Controller
             $statuslabels = $statuslabels->TextSearch($request->input('search'));
         }
 
+
+        // if a status_type is passed, filter by that
+        if ($request->filled('status_type')) {
+            if (strtolower($request->input('status_type'))== 'pending') {
+                $statuslabels = $statuslabels->Pending();
+            } elseif (strtolower($request->input('status_type'))== 'archived') {
+                $statuslabels = $statuslabels->Archived();
+            } elseif (strtolower($request->input('status_type'))== 'deployable') {
+                $statuslabels = $statuslabels->Deployable();
+            } elseif (strtolower($request->input('status_type'))== 'undeployable') {
+                $statuslabels = $statuslabels->Undeployable();
+            }
+
+        }
+
         // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
         // case we override with the actual count, so we should return 0 items.
         $offset = (($statuslabels) && ($request->get('offset') > $statuslabels->count())) ? $statuslabels->count() : $request->get('offset', 0);

--- a/app/Models/Statuslabel.php
+++ b/app/Models/Statuslabel.php
@@ -121,6 +121,18 @@ class Statuslabel extends SnipeModel
     }
 
     /**
+     * Query builder scope for deployable status types
+     *
+     * @return \Illuminate\Database\Query\Builder Modified query builder
+     */
+    public function scopeUndeployable()
+    {
+        return $this->where('pending', '=', 0)
+            ->where('archived', '=', 0)
+            ->where('deployable', '=', 0);
+    }
+
+    /**
      * Helper function to determine type attributes
      *
      * @author A. Gianotto <snipe@snipe.net>

--- a/app/Models/Statuslabel.php
+++ b/app/Models/Statuslabel.php
@@ -121,7 +121,7 @@ class Statuslabel extends SnipeModel
     }
 
     /**
-     * Query builder scope for deployable status types
+     * Query builder scope for undeployable status types
      *
      * @return \Illuminate\Database\Query\Builder Modified query builder
      */


### PR DESCRIPTION
This allows the API to filter by `status_type` in the status labels API endpoint. For example, `/api/v1/statuslabels?status_type=Undeployable`

The status types are:

- deployable
- undeployable
- archived
- pending

These can be entered in any case (Pending vs pending)