### PR TITLE
Fixed #10840 - defaulting to 0 on supplier ID if no value provided

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -521,7 +521,7 @@ class AssetsController extends Controller
         $asset->purchase_cost           = Helper::ParseCurrency($request->get('purchase_cost')); // this is the API's store method, so I don't know that I want to do this? Confusing. FIXME (or not?!)
         $asset->purchase_date           = $request->get('purchase_date', null);
         $asset->assigned_to             = $request->get('assigned_to', null);
-        $asset->supplier_id             = $request->get('supplier_id', 0);
+        $asset->supplier_id             = $request->get('supplier_id');
         $asset->requestable             = $request->get('requestable', 0);
         $asset->rtd_location_id         = $request->get('rtd_location_id', null);
         $asset->location_id             = $request->get('rtd_location_id', null);

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -137,12 +137,12 @@ class AssetsController extends Controller
             $asset->archived                = '0';
             $asset->physical                = '1';
             $asset->depreciate              = '0';
-            $asset->status_id               = request('status_id', 0);
+            $asset->status_id               = request('status_id');
             $asset->warranty_months         = request('warranty_months', null);
             $asset->purchase_cost           = Helper::ParseCurrency($request->get('purchase_cost'));
             $asset->purchase_date           = request('purchase_date', null);
             $asset->assigned_to             = request('assigned_to', null);
-            $asset->supplier_id             = request('supplier_id', 0);
+            $asset->supplier_id             = request('supplier_id', null);
             $asset->requestable             = request('requestable', 0);
             $asset->rtd_location_id         = request('rtd_location_id', null);
 


### PR DESCRIPTION
Ugh, this bug is very old :( For some reason I cannot explain, we were defaulting to `0` instead of `null` if no supplier was selected on asset creation. What's more curious here is that on `master`, the bug also exists, and we *are* checking for the validity of the supplier ID, so I don't really understand why this problem is new, or why it's only showing up on PHP8. But this should resolve the issue. I should probably write a migration that updates all suppliers to `null` if the ID is `0` in the database just to clean up some of that older data. 

Don't bother to `git blame` - I'm certain it was me. 

![da25D](https://user-images.githubusercontent.com/197404/159141655-030b8953-87f4-408d-beb7-d305d56dc443.gif)

