### PR TITLE
Fixed #10819 - use full url for label barcodes

### DIFF
--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -113,7 +113,7 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='')
 
         @if ($settings->qr_code=='1')
             <div class="qr_img">
-                <img src="./{{ $asset->id }}/qr_code" class="qr_img">
+                <img src="{{ config('app.url') }}/hardware/{{ $asset->id }}/qr_code" class="qr_img">
             </div>
         @endif
 
@@ -159,7 +159,7 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='')
 
         @if ((($settings->alt_barcode_enabled=='1') && $settings->alt_barcode!=''))
             <div class="barcode_container">
-                <img src="./{{ $asset->id }}/barcode" class="barcode">
+                <img src="{{ config('app.url') }}/hardware/{{ $asset->id }}/barcode" class="barcode">
             </div>
         @endif
 


### PR DESCRIPTION
This fixes #10819. While I don't know why you'd call the labels page that way in real life (especially since it will give you weird results, as it's not expecting an asset ID in that URL), this uses the full URL to the QR/barcodes. The image was breaking since it was referring to `./` as the path, since the URL itself isn't expected to be one more directory down. 