### PR TITLE
Fixes #10769 - return to Due for Audit screen after auditing

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -861,7 +861,7 @@ class AssetsController extends Controller
 
 
             $asset->logAudit($request->input('note'), $request->input('location_id'), $file_name);
-            return redirect()->to('hardware')->with('success', trans('admin/hardware/message.audit.success'));
+            return redirect()->route('assets.audit.due')->with('success', trans('admin/hardware/message.audit.success'));
         }
     }
 


### PR DESCRIPTION
This could probably take a little reworking, since if you are auditing from the Overdue for Audit page, we’d want to take you back *there* instead of the Due for Audit page.