### PR TITLE
Fixes #10753 Licenses assigned to assets don't follow users

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -111,6 +111,13 @@ class AssetCheckinController extends Controller
             $checkin_at = $request->input('checkin_at');
         }
 
+        if(!empty($asset->licenseseats->all())){
+            foreach ($asset->licenseseats as $seat){
+                $seat->assigned_to = null;
+                $seat->save();
+            }
+        }
+
         // Get all pending Acceptances for this asset and delete them
         $acceptances = CheckoutAcceptance::pending()->whereHasMorph('checkoutable',
             [Asset::class],

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -80,6 +80,15 @@ class AssetCheckoutController extends Controller
                 $asset->status_id = $request->get('status_id');
             }
 
+            if(!empty($asset->licenseseats->all())){
+                if(request('checkout_to_type') == 'user') {
+                    foreach ($asset->licenseseats as $seat){
+                        $seat->assigned_to = $target->id;
+                        $seat->save();
+                    }
+                }
+            }
+
             if ($asset->checkOut($target, $admin, $checkout_at, $expected_checkin, e($request->get('note')), $request->get('name'))) {
                 return redirect()->route('hardware.index')->with('success', trans('admin/hardware/message.checkout.success'));
             }


### PR DESCRIPTION
# Description
Use case:
An asset have a license assigned. If that asset is checked out to a user, the license seat doesn't show the user that have the asset (and for extension the license seat) assigned.

I check if the asset have license seats assigned and if the checkout is going to be to an user, if both conditions are met I update the license seat `assigned_to` field to the user that will have the asset checked out to.

In the checkin if the asset have license seats it puts the seat as `null` before checking in.

Fixes #10753 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
