### PR TITLE
Validate custom fieldset only if the asset have one

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -196,12 +196,12 @@ class Asset extends Depreciable
 
             if (($model) && ($model->fieldset)) {
                 $this->rules += $model->fieldset->validation_rules();
-            }
-        }
 
-        foreach ($this->model->fieldset->fields as $field){
-            if($field->format == 'BOOLEAN'){
-                $this->{$field->db_column} = filter_var($this->{$field->db_column}, FILTER_VALIDATE_BOOLEAN);
+                foreach ($this->model->fieldset->fields as $field){
+                    if($field->format == 'BOOLEAN'){
+                        $this->{$field->db_column} = filter_var($this->{$field->db_column}, FILTER_VALIDATE_BOOLEAN);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
# Description
This issue was introduced in https://github.com/snipe/snipe-it/commit/42220cc566043d7f2e31e391d5e3d385f5d2341a where if the asset edit/checkedout doesn't have a customfield assigned the system crash :(

I put the code that converts the strings 'true'/'false' to boolean inside the validation for assets with customfields which is the way @snipe fixed it in master. Thanks and sorry!!


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
