### PR TITLE
Fix bs tables export options

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -30,62 +30,69 @@
             return false;
         }
 
-        $('.snipe-table').bootstrapTable('destroy').bootstrapTable({
-            classes: 'table table-responsive table-no-bordered',
-            ajaxOptions: {
-                headers: {
-                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
-                }
-            },
-            stickyHeader: true,
-            stickyHeaderOffsetY: stickyHeaderOffsetY + 'px',
-            undefinedText: '',
-            iconsPrefix: 'fa',
-            cookie: true,
-            cookieExpire: '2y',
-            mobileResponsive: true,
-            maintainSelected: true,
-            trimOnSearch: false,
-            showSearchClearButton: true,
-            paginationFirstText: "{{ trans('general.first') }}",
-            paginationLastText: "{{ trans('general.last') }}",
-            paginationPreText: "{{ trans('general.previous') }}",
-            paginationNextText: "{{ trans('general.next') }}",
-            pageList: ['10','20', '30','50','100','150','200'{!! ((config('app.max_results') > 200) ? ",'500'" : '') !!}{!! ((config('app.max_results') > 500) ? ",'".config('app.max_results')."'" : '') !!}],
-            pageSize: {{  (($snipeSettings->per_page!='') && ($snipeSettings->per_page > 0)) ? $snipeSettings->per_page : 20 }},
-            paginationVAlign: 'both',
-            queryParams: function (params) {
-                var newParams = {};
-                for(var i in params) {
-                    if(!keyBlocked(i)) { // only send the field if it's not in blockedFields
-                        newParams[i] = params[i];
+        $('.snipe-table').bootstrapTable('destroy').each(function () {
+            {{-- console.warn("Okay, what's 'this'?");
+            console.dir(this); --}}
+            export_options = JSON.parse($(this).attr('data-export-options'));
+            export_options['htmlContent'] = true //always append this to the given data-export-options
+            
+            console.log("Export options on the table are:");
+            console.dir(export_options)
+
+            $(this).bootstrapTable({
+                classes: 'table table-responsive table-no-bordered',
+                ajaxOptions: {
+                    headers: {
+                        'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
                     }
+                },
+                stickyHeader: true,
+                stickyHeaderOffsetY: stickyHeaderOffsetY + 'px',
+                undefinedText: '',
+                iconsPrefix: 'fa',
+                cookie: true,
+                cookieExpire: '2y',
+                mobileResponsive: true,
+                maintainSelected: true,
+                trimOnSearch: false,
+                showSearchClearButton: true,
+                paginationFirstText: "{{ trans('general.first') }}",
+                paginationLastText: "{{ trans('general.last') }}",
+                paginationPreText: "{{ trans('general.previous') }}",
+                paginationNextText: "{{ trans('general.next') }}",
+                pageList: ['10','20', '30','50','100','150','200'{!! ((config('app.max_results') > 200) ? ",'500'" : '') !!}{!! ((config('app.max_results') > 500) ? ",'".config('app.max_results')."'" : '') !!}],
+                pageSize: {{  (($snipeSettings->per_page!='') && ($snipeSettings->per_page > 0)) ? $snipeSettings->per_page : 20 }},
+                paginationVAlign: 'both',
+                queryParams: function (params) {
+                    var newParams = {};
+                    for(var i in params) {
+                        if(!keyBlocked(i)) { // only send the field if it's not in blockedFields
+                            newParams[i] = params[i];
+                        }
+                    }
+                    return newParams;
+                },
+                formatLoadingMessage: function () {
+                    return '<h2><i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Loading... please wait.... </h4>';
+                },
+                icons: {
+                    advancedSearchIcon: 'fa fa-search-plus',
+                    paginationSwitchDown: 'fa-caret-square-o-down',
+                    paginationSwitchUp: 'fa-caret-square-o-up',
+                    columns: 'fa-columns',
+                    refresh: 'fa-refresh',
+                    export: 'fa-download',
+                    clearSearch: 'fa-times'
+                },
+                exportOptions: export_options,
+
+                exportTypes: ['csv', 'excel', 'doc', 'txt','json', 'xml', 'pdf'],
+                onLoadSuccess: function () {
+                    $('[data-toggle="tooltip"]').tooltip(); // Needed to attach tooltips after ajax call
                 }
-                return newParams;
-            },
-            formatLoadingMessage: function () {
-                return '<h2><i class="fa fa-spinner fa-spin" aria-hidden="true"></i> Loading... please wait.... </h4>';
-            },
-            icons: {
-                advancedSearchIcon: 'fa fa-search-plus',
-                paginationSwitchDown: 'fa-caret-square-o-down',
-                paginationSwitchUp: 'fa-caret-square-o-up',
-                columns: 'fa-columns',
-                refresh: 'fa-refresh',
-                export: 'fa-download',
-                clearSearch: 'fa-times'
-            },
-            exportOptions: {
-                htmlContent: true,
-            },
 
-            exportTypes: ['csv', 'excel', 'doc', 'txt','json', 'xml', 'pdf'],
-            onLoadSuccess: function () {
-                $('[data-toggle="tooltip"]').tooltip(); // Needed to attach tooltips after ajax call
-            }
-
-        });   
-
+            });
+        });
     });
 
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -31,14 +31,9 @@
         }
 
         $('.snipe-table').bootstrapTable('destroy').each(function () {
-            {{-- console.warn("Okay, what's 'this'?");
-            console.dir(this); --}}
             export_options = JSON.parse($(this).attr('data-export-options'));
-            export_options['htmlContent'] = true //always append this to the given data-export-options
+            export_options['htmlContent'] = true; //always enforce this on the given data-export-options (to prevent XSS)
             
-            console.log("Export options on the table are:");
-            console.dir(export_options)
-
             $(this).bootstrapTable({
                 classes: 'table table-responsive table-no-bordered',
                 ajaxOptions: {


### PR DESCRIPTION
This grabs the attribute-based export options that we set on each table and ensures those export options are properly respected.

Because I had to change the nesting-level of the indented JS object, the change shows up bigger than it really is. Probably best to try and 'ignore whitespace' when looking at this.

The htmlContent bit that we do makes the CSV exports super-duper gross, and I hate that. I don't know a good way to work around that though; I'm pretty sure we put that in to avoid XSS attacks, and I would like to continue to do that. There *are* some kinda-interesting table-export options we might be able to use in order to screen out potential XSS though? We'll have to talk it over.

But, with this change, the appropriate columns are correctly ignored, and the downloaded export file is appropriately named. Yay.