### PR TITLE
Don't crash JS when there are no data-export-options (as is true in Dashboard) Fixes #10872

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -31,7 +31,8 @@
         }
 
         $('.snipe-table').bootstrapTable('destroy').each(function () {
-            export_options = JSON.parse($(this).attr('data-export-options'));
+            data_export_options = $(this).attr('data-export-options');
+            export_options = data_export_options? JSON.parse(data_export_options): {};
             export_options['htmlContent'] = true; //always enforce this on the given data-export-options (to prevent XSS)
             
             $(this).bootstrapTable({


### PR DESCRIPTION
The dashboard was broken by my fix that tries to parse the `data-export-options` attribute. We don't have that attribute set at all in the Dashboard. This just changes the logic to be more tolerant of when that attribute is not set on a bootstrap-table.