### PR TITLE
Logout user when their activated status is switched to off

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -39,6 +39,7 @@ class Kernel extends HttpKernel
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \App\Http\Middleware\CheckLocale::class,
+            \App\Http\Middleware\CheckUserIsActivated::class,
             \App\Http\Middleware\CheckForTwoFactor::class,
             \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
             \App\Http\Middleware\AssetCountForSidebar::class,

--- a/app/Http/Middleware/CheckUserIsActivated.php
+++ b/app/Http/Middleware/CheckUserIsActivated.php
@@ -4,8 +4,9 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
+use Auth;
 
-class Authenticate
+class CheckUserIsActivated
 {
     /**
      * The Guard implementation.
@@ -34,14 +35,16 @@ class Authenticate
      */
     public function handle($request, Closure $next)
     {
-        if ($this->auth->guest()) {
-            if ($request->ajax()) {
-                return response('Unauthorized.', 401);
-            } else {
-                return redirect()->guest('login');
-            }
+
+        // If there is a user AND the user is NOT activated, send them to the login page
+        // This prevents people who still have active sessions logged in and their status gets toggled
+        // to inactive (aka unable to login)
+        if (($request->user()) && (!$request->user()->isActivated())) {
+            Auth::logout();
+            return redirect()->guest('login');
         }
 
         return $next($request);
+
     }
 }

--- a/resources/lang/en/auth/message.php
+++ b/resources/lang/en/auth/message.php
@@ -3,7 +3,7 @@
 return array(
 
     'account_already_exists' => 'An account with the this email already exists.',
-    'account_not_found'      => 'The username or password is incorrect.',
+    'account_not_found'      => 'The username or password is incorrect or this user is not approved to login.',
     'account_not_activated'  => 'This user account is not activated.',
     'account_suspended'      => 'This user account is suspended.',
     'account_banned'         => 'This user account is banned.',


### PR DESCRIPTION
Hey nerds,

This PR fixes a potential issue in business logic where when a user's status is toggled from activated to deactivated (and therefore should not be able to be logged in anymore). While we would disallow the user from ever logging in *again* if that flag is toggled, we weren't checking on their activated status on page load (via middleware for example), so a user who had an *existing* active session could still potentially see things that should be gated behind an activated user account. 

This could normally be mitigated by using the `KillAllSessions` console command, clearing the contents of the `storage/framework/sessions` directory, or changing the cookie name, but all of those options logout ALL users, which could be kind of annoying. 

This fixes https://huntr.dev/bounties/ebc26354-2414-4f72-88aa-f044aec2b2e1/ (which may not be visible until the CVE is publicly issued.)

We've tested this locally and I think it should be good to go,  but always appreciate extra eyeballs. TY!