### PR TITLE
Fixes Importer always update existing values

### DIFF
--- a/app/Http/Requests/ItemImportRequest.php
+++ b/app/Http/Requests/ItemImportRequest.php
@@ -61,8 +61,8 @@ class ItemImportRequest extends FormRequest
         }
         $importer->setCallbacks([$this, 'log'], [$this, 'progress'], [$this, 'errorCallback'])
                  ->setUserId(Auth::id())
-                 ->setUpdating($this->has('import-update'))
-                 ->setShouldNotify($this->has('send-welcome'))
+                 ->setUpdating($this->get('import-update'))
+                 ->setShouldNotify($this->get('send-welcome'))
                  ->setUsernameFormat('firstname.lastname')
                  ->setFieldMappings($fieldMappings);
         // $logFile = storage_path('logs/importer.log');

--- a/resources/assets/js/components/importer/importer-file.vue
+++ b/resources/assets/js/components/importer/importer-file.vue
@@ -21,7 +21,7 @@
                         <label for="import-update">Update Existing Values?:</label>
                     </div>
                     <div class="col-md-7 col-xs-12">
-                        <input type="checkbox" class="iCheck minimal" name="import-update" v-model="options.update">
+                        <input type="checkbox" class="icheckbox_minimal" name="import-update" v-model="options.update">
                     </div>
                 </div><!-- /dynamic-form-row -->
 
@@ -30,7 +30,7 @@
                         <label for="send-welcome">Send Welcome Email for new Users?</label>
                     </div>
                     <div class="col-md-7 col-xs-12">
-                        <input type="checkbox" class="minimal" name="send-welcome" v-model="options.send_welcome">
+                        <input type="checkbox" class="icheckbox_minimal" name="send-welcome" v-model="options.send_welcome">
                     </div>
                 </div><!-- /dynamic-form-row -->
 
@@ -39,7 +39,7 @@
                         <label for="run-backup">Backup before importing?</label>
                     </div>
                     <div class="col-md-7 col-xs-12">
-                        <input type="checkbox" class="minimal" name="run-backup" v-model="options.run_backup">
+                        <input type="checkbox" class="icheckbox_minimal" name="run-backup" v-model="options.run_backup">
                     </div>
                 </div><!-- /dynamic-form-row -->
 
@@ -111,6 +111,8 @@
                 options: {
                     importType: this.file.import_type,
                     update: false,
+                    send_welcome: false,
+                    run_backup: false,
                     importTypes: [
                         { id: 'asset', text: 'Assets' },
                         { id: 'accessory', text: 'Accessories' },


### PR DESCRIPTION
# Description
When using the importer we ask the user if the item imported should be updated in case it already exists in the system. But the value of the checkbox is not get, instead it only check if the field `import-update` exists. I believe it's like that because for a normal checkbox if it's not checked, the form doesn't send the field, but when VueJS was added that behaviour change and now it has to evaluate what is the actual value that field contents.

Also, a weird issue arose... if the checkbox use the class `minimal` it doesn't work with the laravel binding, so the component doesn't actually change its value. So... I change the checkbox class to `icheckbox_minimal` that doesn't looks as good, but at least doesn't break the functionality. I find this very strange, but I couldn't found the answer to maintain the same class and look. :/

Fixes internal freshdesk 26952

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
