### PR TITLE
Fixes #10898 (invalid consumable date time info in user view)

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -308,7 +308,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function consumables()
     {
-        return $this->belongsToMany(\App\Models\Consumable::class, 'consumables_users', 'assigned_to', 'consumable_id')->withPivot('id')->withTrashed();
+        return $this->belongsToMany(\App\Models\Consumable::class, 'consumables_users', 'assigned_to', 'consumable_id')->withPivot('id','created_at')->withTrashed();
     }
 
     /**

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -738,7 +738,7 @@
                   <td>
                     {!! Helper::formatCurrencyOutput($consumable->purchase_cost) !!}
                   </td>
-                  <td>{{ $consumable->created_at }}</td>
+                  <td>{{ $consumable->pivot->created_at }}</td>                      
                 </tr>
                 @endforeach
               </tbody>


### PR DESCRIPTION
# Description

Small fix on the date timestamp data for consumables in users view

Fixes #10898 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Comparing timestamp in user view with the one in consumable view

**Test Configuration**:
* PHP version: 7.4.27
* MySQL version : 10.4.22
* Webserver version: Apache 2.4.52
* OS version: Windows 10


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
