### PR TITLE
Fixed #10892 - MySQL 8 compatibilty requires primary key

### DIFF
--- a/database/migrations/2015_09_21_235926_create_custom_field_custom_fieldset.php
+++ b/database/migrations/2015_09_21_235926_create_custom_field_custom_fieldset.php
@@ -14,13 +14,14 @@ class CreateCustomFieldCustomFieldset extends Migration {
 	{
 		Schema::create('custom_field_custom_fieldset', function(Blueprint $table)
 		{
+            $table->bigIncrements('id')->first();
 			$table->integer('custom_field_id');
 			$table->integer('custom_fieldset_id');
-
 			$table->integer('order');
 			$table->boolean('required');
-      $table->engine = 'InnoDB';
+            $table->engine = 'InnoDB';
 		});
+
 	}
 
 	/**

--- a/database/migrations/2022_04_05_135340_add_primary_key_to_custom_fields_pivot.php
+++ b/database/migrations/2022_04_05_135340_add_primary_key_to_custom_fields_pivot.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPrimaryKeyToCustomFieldsPivot extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('custom_field_custom_fieldset', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('custom_field_custom_fieldset', function (Blueprint $table) {
+            if (Schema::hasColumn('custom_field_custom_fieldset', 'id')) {
+                $table->dropColumn('id');
+            }
+        });
+    }
+}

--- a/database/migrations/2022_04_05_135340_add_primary_key_to_custom_fields_pivot.php
+++ b/database/migrations/2022_04_05_135340_add_primary_key_to_custom_fields_pivot.php
@@ -13,9 +13,14 @@ class AddPrimaryKeyToCustomFieldsPivot extends Migration
      */
     public function up()
     {
+
+        // Check if the ID primary key already exists, if not, add it
         Schema::table('custom_field_custom_fieldset', function (Blueprint $table) {
-            $table->bigIncrements('id')->first();
+            if (!Schema::hasColumn('custom_field_custom_fieldset', 'id')) {
+                $table->bigIncrements('id')->first();
+            }
         });
+
     }
 
     /**


### PR DESCRIPTION
What it says on the tin. Adds a primary key to the `custom_field_custom_fieldset` pivot table. 