### PR TITLE
Fixes Dates in Print All Assigned report doesn't match to history

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -305,7 +305,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function consumables()
     {
-        return $this->belongsToMany('\App\Models\Consumable', 'consumables_users', 'assigned_to', 'consumable_id')->withPivot('id')->withTrashed();
+        return $this->belongsToMany('\App\Models\Consumable', 'consumables_users', 'assigned_to', 'consumable_id')->withPivot('id', 'created_at')->withTrashed();
     }
 
     /**
@@ -317,7 +317,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function licenses()
     {
-        return $this->belongsToMany('\App\Models\License', 'license_seats', 'assigned_to', 'license_id')->withPivot('id');
+        return $this->belongsToMany('\App\Models\License', 'license_seats', 'assigned_to', 'license_id')->withPivot('id', 'created_at');
     }
 
     /**

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -152,7 +152,7 @@
                        <i class="fa-lock" aria-hidden="true"></i> {{ str_repeat('x', 15) }}
                     @endcan
                 </td>
-                <td>{{  $license->assetlog->first()->created_at }}</td>
+                <td>{{  $license->pivot->created_at }}</td>
             </tr>
             @php
                 $lcounter++
@@ -188,7 +188,7 @@
                     <td>{{ $acounter }}</td>
                     <td>{{ ($accessory->manufacturer) ? $accessory->manufacturer->name : '' }} {{ $accessory->name }} {{ $accessory->model_number }}</td>
                     <td>{{ $accessory->category->name }}</td>
-                    <td>{{  $accessory->assetlog->first()->created_at }}</td>
+                    <td>{{ $accessory->pivot->created_at }}</td>
                 </tr>
                 @php
                     $acounter++
@@ -232,7 +232,7 @@
                     @endif
                 </td>
                     <td>{{ ($consumable->category) ? $consumable->category->name : ' invalid/deleted category' }} </td>
-                    <td>{{  $consumable->assetlog->first()->created_at }}</td>
+                    <td>{{  $consumable->pivot->created_at }}</td>
                 </tr>
                 @php
                     $ccounter++


### PR DESCRIPTION
# Description
The Print All Assigned report inside the user's view takes the checkout dates from the asset log table, but if another action is made to that consumable/license/accessory the report updates the date, which is erroneous. Instead I take the dates now of the pivot tables that made the relationship between users->the types in the system we had that we can assign.

Fixes internal short cut #27041

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
