### PR TITLE
Fixes Bulk user edit not updating checked out asset locations

### DIFF
--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -109,12 +109,15 @@ class BulkUsersController extends Controller
         if (!$manager_conflict) {
             $this->conditionallyAddItem('manager_id');
         }
-
-
         // Save the updated info
         User::whereIn('id', $user_raw_array)
             ->where('id', '!=', Auth::id())->update($this->update_array);
 
+        if(array_key_exists('location_id', $this->update_array)){
+            Asset::where('assigned_type', User::class)
+                ->whereIn('assigned_to', $user_raw_array)
+                ->update(['location_id' => $this->update_array['location_id']]);
+        }
         // Only sync groups if groups were selected
         if ($request->filled('groups')) {
             foreach ($users as $user) {


### PR DESCRIPTION
# Description
When we update an user location, the assets that they have checked in also updates the location change to 'follow' the user they are assigned to. 

Bulk-edit doesn't have the query to update the assets' location if we change the user's one, this adds it so it behaves similar to the single user edit.

Fixes internal freshdesk #26942

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
