### PR TITLE
This disables the display of HTML content during exports

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -32,9 +32,16 @@
 
         $('.snipe-table').bootstrapTable('destroy').each(function () {
             data_export_options = $(this).attr('data-export-options');
-            export_options = data_export_options? JSON.parse(data_export_options): {};
-            export_options['htmlContent'] = true; //always enforce this on the given data-export-options (to prevent XSS)
-
+            export_options = data_export_options ? JSON.parse(data_export_options) : {};
+            export_options['htmlContent'] = false; // this is already the default; but let's be explicit about it
+            // the following callback method is necessary to prevent XSS vulnerabilities
+            // (this is taken from Bootstrap Tables's default wrapper around jQuery Table Export)
+            export_options['onCellHtmlData'] = function (cell, rowIndex, colIndex, htmlData) {
+                if (cell.is('th')) {
+                    return cell.find('.th-inner').text()
+                }
+                return htmlData
+            }
             $(this).bootstrapTable({
             classes: 'table table-responsive table-no-bordered',
             ajaxOptions: {


### PR DESCRIPTION
But without enabling XSS attacks.

This requires extensive testing to ensure that it really does not enable attacks, but it really does seem like it does not at this point.

Before this, CSV exports had HTML garbage markup in them. If I toggle `htmlContent` back to `false`, but I do not put in the `onCellHtmlData` callback, then I'm able to execute XSS attacks. But with the enclosed callback parameter, it seems like I cannot execute the attack any more, but the ugly HTML no longer shows up in my CSV's (I made sure to open them up in a text editor to be extra-super-sure).

I'll cherry-pick this over to `master` as well so we can have this on both.