### PR TITLE
Fixes #10482 - Downgrade bootstrap-table so columns stay remembered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2693,9 +2693,9 @@
       "integrity": "sha1-EQPWvADPv6jPyaJZmrUYxVZD2j8="
     },
     "bootstrap-table": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.19.1.tgz",
-      "integrity": "sha512-WvV+l1AI/C+zThaKmfHmi/IuayVNB0qdFyEhFx1jyZhO0oLtNJNANkCR3rvJf6Dkh72dsLElxpE/bzK9seEQLA=="
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.18.3.tgz",
+      "integrity": "sha512-/eFLkldDlNFi37qC/d9THfRVxMUGD34E8fQBFtXJLDHLBOVKWDTq7BV+udoP7k3FfCEyhM1jWQnQ0rMQdBv//w=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4233,7 +4233,7 @@
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "integrity": "sha1-tcmMlCzv+vfLBR4k4UNKJaLmB2o=",
       "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bootstrap-colorpicker": "^2.5.3",
     "bootstrap-datepicker": "^1.9.0",
     "bootstrap-less": "^3.3.8",
-    "bootstrap-table": "^1.19.1",
+    "bootstrap-table": "1.18.x",
     "chart.js": "^2.9.4",
     "css-loader": "^3.6.0",
     "ekko-lightbox": "^5.1.1",


### PR DESCRIPTION
We have a really annoying bug where the user's selected columns keep getting 'forgotten' - if you add any non-default fields to your bootstrap-table display list (such as 'id' on the Assets list), when you browse away, then browse back - your added columns aren't selected, as they should be.

This fixes that by backing off the version of Bootstrap tables to 1.18.3 from 1.19.1. Unfortunately, we took that upgrade because of a known vulnerability in Bootstrap tables v1.18.3. See: https://github.com/snipe/snipe-it/pull/10313 for details. Specifically, here is the actual vulnerability: https://security.snyk.io/vuln/SNYK-JS-BOOTSTRAPTABLE-1657597

I *believe* that we are not vulnerable to this. This requires a 'type confusion' where the server needs to send back array data instead of string data. The one place where we *used* to do this was with the `log_meta` parsing and response, but that was fixed by a previous PR (I think).

We'll need to test the heck out of this and be really sure. Note that this PR requires that assets be rebuilt, but as per @snipe 's request I do not include those rebuilt assets here.