### PR TITLE
corrects variable to getOriginal(), no longer posts double updates

### DIFF
--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -18,7 +18,7 @@ class AssetObserver
     public function updating(Asset $asset)
     {
         $attributes = $asset->getAttributes();
-        $attributesOriginal = $asset->getAttributes();
+        $attributesOriginal = $asset->getOriginal();
         
         // If the asset isn't being checked out or audited, log the update.
         // (Those other actions already create log entries.)


### PR DESCRIPTION
# Description
No longer posts double updates. 
Changed $attributesOriginal = $asset->getAttributes(); to getOriginal(); as both $attributes and $attributesOriginal were the same data.
<img width="1362" alt="image" src="https://user-images.githubusercontent.com/47435081/162821015-ed9d63c4-c72a-4760-87ec-122a695fe3ab.png">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
