### PR TITLE
Backport the license index fix from Develop onto the v5 branch

### DIFF
--- a/database/migrations/2022_01_10_182548_add_license_id_index_to_license_seats.php
+++ b/database/migrations/2022_01_10_182548_add_license_id_index_to_license_seats.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddLicenseIdIndexToLicenseSeats extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('license_seats', function (Blueprint $table) {
+            $table->index(['license_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('license_seats', function (Blueprint $table) {
+            $table->dropIndex(['license_id']);
+        });
+    }
+}


### PR DESCRIPTION
This is the exact file that we're already using in `develop` for v6 - a simple migration that adds an index to the `license_id` table for `license_seats`. The filename is exactly the same, so the migration should only run once. My quick testing on a live instance showed that with this index the license page did not get horribly bogged down when there were a lot of licenses.