### PR TITLE
[Feature] adds the ability to email a user a list of all assets currently using from profile

### DIFF
--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -611,6 +611,17 @@ class UsersController extends Controller
             ->with('show_user', $show_user)
             ->with('settings', Setting::getSettings());
     }
+    public function emailAssetList($id)
+    {
+        $this->authorize('view', User::class);
+        $show_user = User::where('id', $id)->withTrashed()->first();
+        $assets = Asset::where('assigned_to', $id)->where('assigned_type', User::class)->with('model', 'model.category')->get();
+        $accessories = $show_user->accessories()->get();
+        $consumables = $show_user->consumables()->get();
+
+    //Should we go with a PDF, was there a command already set up for this somewhere. Ponder on this I must.
+
+    }
 
     /**
      * Send individual password reset email

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -23,6 +23,7 @@ use Redirect;
 use Str;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use View;
+use App\Notifications\CurrentInventory;
 
 /**
  * This controller handles all actions related to Users for
@@ -614,10 +615,11 @@ class UsersController extends Controller
     public function emailAssetList($id)
     {
         $this->authorize('view', User::class);
-        $show_user = User::where('id', $id)->withTrashed()->first();
-        $assets = Asset::where('assigned_to', $id)->where('assigned_type', User::class)->with('model', 'model.category')->get();
-        $accessories = $show_user->accessories()->get();
-        $consumables = $show_user->consumables()->get();
+        $user = User::where('id', $id)->withTrashed()->first();
+        $user->notify((new CurrentInventory($user)));
+
+        return redirect()->back()->with('success', 'admin/users/general.user_notified');
+
 
     //Should we go with a PDF, was there a command already set up for this somewhere. Ponder on this I must.
 

--- a/resources/lang/en/admin/users/general.php
+++ b/resources/lang/en/admin/users/general.php
@@ -18,6 +18,7 @@ return [
     'ldap_config_text'  => 'LDAP configuration settings can be found Admin > Settings. The (optional) selected location will be set for all imported users.',
     'print_assigned'    => 'Print All Assigned',
     'email_assigned'    => 'Email List of All Assigned',
+    'user_notified'     => 'User has been notified.',
     'software_user'     => 'Software Checked out to :name',
     'send_email_help'   => 'You must provide an email address for this user to send them credentials. Emailing credentials can only be done on user creation. Passwords are stored in a one-way hash and cannot be retrieved once saved.',
     'view_user'         => 'View User :name',

--- a/resources/lang/en/admin/users/general.php
+++ b/resources/lang/en/admin/users/general.php
@@ -18,7 +18,7 @@ return [
     'ldap_config_text'  => 'LDAP configuration settings can be found Admin > Settings. The (optional) selected location will be set for all imported users.',
     'print_assigned'    => 'Print All Assigned',
     'email_assigned'    => 'Email List of All Assigned',
-    'user_notified'     => 'User has been notified.',
+    'user_notified'     => 'User has been emailed a list of their currently assigned items.',
     'software_user'     => 'Software Checked out to :name',
     'send_email_help'   => 'You must provide an email address for this user to send them credentials. Emailing credentials can only be done on user creation. Passwords are stored in a one-way hash and cannot be retrieved once saved.',
     'view_user'         => 'View User :name',

--- a/resources/lang/en/admin/users/general.php
+++ b/resources/lang/en/admin/users/general.php
@@ -17,6 +17,7 @@ return [
     'last_login'        => 'Last Login',
     'ldap_config_text'  => 'LDAP configuration settings can be found Admin > Settings. The (optional) selected location will be set for all imported users.',
     'print_assigned'    => 'Print All Assigned',
+    'email_assigned'    => 'Email List of All Assigned',
     'software_user'     => 'Software Checked out to :name',
     'send_email_help'   => 'You must provide an email address for this user to send them credentials. Emailing credentials can only be done on user creation. Passwords are stored in a one-way hash and cannot be retrieved once saved.',
     'view_user'         => 'View User :name',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -341,7 +341,6 @@
     'notification_warning'   => 'Warning:',
     'notification_info'      => 'Info:',
     'asset_information'     => 'Asset Information',
-    'asset_serial'          => 'Serial',
     'model_name'            => 'Model Name:',
     'asset_name'            => 'Asset Name:',
     'consumable_information' => 'Consumable Information:',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -341,6 +341,7 @@
     'notification_warning'   => 'Warning:',
     'notification_info'      => 'Info:',
     'asset_information'     => 'Asset Information',
+    'asset_serial'          => 'Serial',
     'model_name'            => 'Model Name:',
     'asset_name'            => 'Asset Name:',
     'consumable_information' => 'Consumable Information:',

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -67,7 +67,7 @@
                 <th style="width: 20%;">{{ trans('general.name') }}</th>
                 <th style="width: 10%;">{{ trans('general.category') }}</th>
                 <th style="width: 20%;">{{ trans('general.asset_model') }}</th>
-                <th style="width: 20%;">{{ trans('general.asset_serial') }}</th>
+                <th style="width: 20%;">{{ trans('admin/hardware/form.serial') }}</th>
                 <th style="width: 10%;">{{ trans('general.checked_out') }}</th>
                 <th data-formatter="imageFormatter" style="width: 20%;">{{ trans('general.signature') }}</th>
             </tr>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -186,7 +186,10 @@
                 @endcan
                 @can('view', $user)
                     <div class="col-md-12" style="padding-top: 5px;">
-                        <a href="{{ route('users.print', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print" target="_blank" rel="noopener">{{ trans('admin/users/general.email_assigned') }}</a>
+                        <form action="{{ route('users.email',['userId'=> $user->id]) }}" method="POST">
+                            {{ csrf_field() }}
+                            <button style="width: 100%;" class="btn btn-sm btn-primary hidden-print" rel="noopener">{{ trans('admin/users/general.email_assigned') }}</button>
+                        </form>
                     </div>
                 @endcan
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -184,6 +184,11 @@
                   <a href="{{ route('users.print', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print" target="_blank" rel="noopener">{{ trans('admin/users/general.print_assigned') }}</a>
                 </div>
                 @endcan
+                @can('view', $user)
+                    <div class="col-md-12" style="padding-top: 5px;">
+                        <a href="{{ route('users.print', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print" target="_blank" rel="noopener">{{ trans('admin/users/general.email_assigned') }}</a>
+                    </div>
+                @endcan
 
                 @can('update', $user)
                   @if (($user->activated == '1') && ($user->email != '') && ($user->ldap_import == '0'))

--- a/routes/web/users.php
+++ b/routes/web/users.php
@@ -144,6 +144,14 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
         ]
     )->name('users.print');
 
+    Route::get(
+        '{userId}/email',
+        [
+            Users\UsersController::class,
+            'emailAssetList'
+        ]
+    )->name('users.print');
+
     Route::post(
         'bulkedit',
         [

--- a/routes/web/users.php
+++ b/routes/web/users.php
@@ -144,13 +144,13 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
         ]
     )->name('users.print');
 
-    Route::get(
+    Route::post(
         '{userId}/email',
         [
             Users\UsersController::class,
             'emailAssetList'
         ]
-    )->name('users.print');
+    )->name('users.email');
 
     Route::post(
         'bulkedit',


### PR DESCRIPTION
# Description
adds a button on User Profiles that allows you to email a list of assets, accessories and licenses they currently are in possession of.

<img width="1368" alt="image" src="https://user-images.githubusercontent.com/47435081/163451243-e2651285-c6cc-411c-b6b8-1da1cbebcca3.png">

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Fixes #10667 

## Type of change
Adding the ability to email a user a list of all assets, licenses etc. from the user profile screen.


- [ x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
