### PR TITLE
[Fix] changes the query for the accept signature on print blade

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -67,7 +67,7 @@
                 <th style="width: 20%;">{{ trans('general.name') }}</th>
                 <th style="width: 10%;">{{ trans('general.category') }}</th>
                 <th style="width: 20%;">{{ trans('general.asset_model') }}</th>
-                <th style="width: 20%;">{{ trans('general.asset_serial') }}</th>
+                <th style="width: 20%;">{{ trans('admin/hardware/form.serial') }}</th>
                 <th style="width: 10%;">{{ trans('general.checked_out') }}</th>
                 <th data-formatter="imageFormatter" style="width: 20%;">{{ trans('general.signature') }}</th>
             </tr>
@@ -86,7 +86,7 @@
                 {{ $asset->last_checkout }}</td>
             <td>
                 @if ($asset->assetlog->first())
-                <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->first()->accept_signature }}">
+                    <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->firstWhere('action_type', 'accepted')->accept_signature}}">
                 @endif
            </td>
         </tr>


### PR DESCRIPTION
# Description
fixes an issue with the signatures not displaying in the print blade for user's asset list solution by @[Alberto-Colab](https://github.com/Alberto-Colab)

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Fixes #8856

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
