### PR TITLE
Added status_id to asset checkout API

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -788,6 +788,9 @@ class AssetsController extends Controller
             $error_payload['target_type'] = 'user';
         }
 
+        if ($request->filled('status_id')) {
+            $asset->status_id = $request->get('status_id');
+        }
 
 
         if (!isset($target)) {

--- a/app/Http/Requests/AssetCheckoutRequest.php
+++ b/app/Http/Requests/AssetCheckoutRequest.php
@@ -25,6 +25,7 @@ class AssetCheckoutRequest extends Request
             "assigned_user"         => 'required_without_all:assigned_asset,assigned_location',
             "assigned_asset"        => 'required_without_all:assigned_user,assigned_location',
             "assigned_location"     => 'required_without_all:assigned_user,assigned_asset',
+            'status_id'             => 'exists:status_labels,id,deployable,1',
             "checkout_to_type"      => 'required|in:asset,location,user'
         ];
 


### PR DESCRIPTION
This allows you to pass a `status_id` via the asset checkout API, and also adds validation to the `AssetCheckoutRequest` and also makes sure that the `status_id` that gets passed is one that is a deployable status.

```json
{
    "status": "error",
    "messages": {
        "status_id": [
            "The selected status id is invalid."
        ],
        "checkout_to_type": [
            "The checkout to type field is required."
        ]
    },
    "payload": null
}
```

Fixes FD-27240