### PR TITLE
Fixed #10953: show site name if show images in emails is not enabled

### DIFF
--- a/app/Http/Controllers/Components/ComponentsController.php
+++ b/app/Http/Controllers/Components/ComponentsController.php
@@ -129,7 +129,7 @@ class ComponentsController extends Controller
         if (is_null($component = Component::find($componentId))) {
             return redirect()->route('components.index')->with('error', trans('admin/components/message.does_not_exist'));
         }
-        $min = $component->numCHeckedOut();
+        $min = $component->numCheckedOut();
         $validator = Validator::make($request->all(), [
             'qty' => "required|numeric|min:$min",
         ]);

--- a/app/Http/Controllers/Components/ComponentsController.php
+++ b/app/Http/Controllers/Components/ComponentsController.php
@@ -129,7 +129,7 @@ class ComponentsController extends Controller
         if (is_null($component = Component::find($componentId))) {
             return redirect()->route('components.index')->with('error', trans('admin/components/message.does_not_exist'));
         }
-        $min = $component->numCheckedOut();
+        $min = $component->numCHeckedOut();
         $validator = Validator::make($request->all(), [
             'qty' => "required|numeric|min:$min",
         ]);

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -34,7 +34,12 @@
 @elseif (($snipeSettings->brand == '2') && ($snipeSettings->show_images_in_email=='1' ))
 @if ($snipeSettings->logo!='')
     <img class="navbar-brand-img logo" src="{{ url('/') }}/uploads/{{ $snipeSettings->logo }}">
+<<<<<<< HEAD
 >>>>>>> 0a7c57e51 (show site name if show images in emails is not enabled)
+=======
+@else
+    {{ $snipeSettings->site_name }}
+>>>>>>> 9a9192148 (fallback if show images is selected but no logo exists)
 @endif
 
 @else

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -2,6 +2,7 @@
 {{-- Header --}}
 @slot('header')
 @component('mail::header', ['url' => config('app.url')])
+<<<<<<< HEAD
 @if (isset($snipeSettings) && ($snipeSettings->show_images_in_email=='1' ) && ($snipeSettings::setupCompleted()))
 
 @if ($snipeSettings->brand == '3')
@@ -10,17 +11,30 @@
 <img style="max-height: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->email_logo)) }}">
 @elseif ($snipeSettings->logo!='')
 <img style="max-height: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->logo)) }}">
+=======
+@if ($snipeSettings::setupCompleted())
+
+@if (($snipeSettings->brand == '3') && ($snipeSettings->show_images_in_email=='1' ))
+@if ($snipeSettings->logo!='')
+    <img class="navbar-brand-img logo" src="{{ url('/') }}/uploads/{{ $snipeSettings->logo }}">
+>>>>>>> 0a7c57e51 (show site name if show images in emails is not enabled)
 @endif
 <br><br>
 {{ $snipeSettings->site_name }}
 <br><br>
 
+<<<<<<< HEAD
 @elseif ($snipeSettings->brand == '2')
 @if ($snipeSettings->email_logo!='')
 
 <img style="max-width: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->email_logo)) }}">
 @elseif ($snipeSettings->logo!='')
 <img style="max-width: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->logo)) }}">
+=======
+@elseif (($snipeSettings->brand == '2') && ($snipeSettings->show_images_in_email=='1' ))
+@if ($snipeSettings->logo!='')
+    <img class="navbar-brand-img logo" src="{{ url('/') }}/uploads/{{ $snipeSettings->logo }}">
+>>>>>>> 0a7c57e51 (show site name if show images in emails is not enabled)
 @endif
 
 @else

--- a/resources/views/vendor/mail/markdown/message.blade.php
+++ b/resources/views/vendor/mail/markdown/message.blade.php
@@ -38,6 +38,8 @@ Snipe-IT
                 @elseif (($snipeSettings->brand == '2') && ($snipeSettings->show_images_in_email=='1' ))
                     @if ($snipeSettings->logo!='')
                         <img class="navbar-brand-img logo" src="{{ url('/') }}/uploads/{{ $snipeSettings->logo }}">
+                    @else
+                        {{ $snipeSettings->site_name }}
                     @endif
                 @else
                     {{ $snipeSettings->site_name }}

--- a/resources/views/vendor/mail/markdown/message.blade.php
+++ b/resources/views/vendor/mail/markdown/message.blade.php
@@ -1,4 +1,5 @@
 @component('mail::layout')
+<<<<<<< HEAD
 {{-- Header --}}
 @slot('header')
 @component('mail::header', ['url' => config('app.url')])
@@ -22,6 +23,31 @@ Snipe-IT
 @endif
 @endcomponent
 @endslot
+=======
+    {{-- Header --}}
+    @slot('header')
+        @component('mail::header', ['url' => config('app.url')])
+            @if ($snipeSettings::setupCompleted())
+
+                @if (($snipeSettings->brand == '3') && ($snipeSettings->show_images_in_email=='1' ))
+                    @if ($snipeSettings->logo!='')
+                        <img class="navbar-brand-img logo" src="{{ url('/') }}/uploads/{{ $snipeSettings->logo }}">
+                    @endif
+                    {{ $snipeSettings->site_name }}
+
+                @elseif (($snipeSettings->brand == '2') && ($snipeSettings->show_images_in_email=='1' ))
+                    @if ($snipeSettings->logo!='')
+                        <img class="navbar-brand-img logo" src="{{ url('/') }}/uploads/{{ $snipeSettings->logo }}">
+                    @endif
+                @else
+                    {{ $snipeSettings->site_name }}
+                @endif
+            @else
+                Snipe-IT
+            @endif
+        @endcomponent
+    @endslot
+>>>>>>> 0a7c57e51 (show site name if show images in emails is not enabled)
 
 {{-- Body --}}
 {{ $slot }}


### PR DESCRIPTION
# Description

Fixes the email heading where "Snipe-IT" is shown instead of the site name when the "show images in emails" is not checked.

Fixes # (#10953)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested HTML email with the setting disabled/enabled - I believe that the markdown should function similarly.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
#10953