### PR TITLE
Fixes #8155 -  improve the workflow during asset creation

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -20,6 +20,7 @@ use Gate;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Cookie;
 use Input;
 use Intervention\Image\Facades\Image;
 use League\Csv\Reader;
@@ -201,17 +202,35 @@ class AssetsController extends Controller
                 }
 
                 $success = true;
+                
+                // $cookie = Cookie::queue(Cookie::make('optional_info', $_POST['options'],$minutes));
+                // $data = $request->session()->all();
+                
+                // dd($_POST['options']);
+                
             }
         }
 
         if ($success) {
             // Redirect to the asset listing page
+            $minutes = 518400;
+            // dd( $_POST['options']);
+            // Cookie::queue(Cookie::make('optional_info', json_decode($_POST['options']), $minutes));
             return redirect()->route('hardware.index')
-                ->with('success', trans('admin/hardware/message.create.success'));
+                ->with('success', trans('admin/hardware/message.create.success'))
+                ->withCookie(cookie('optional_info',json_encode($_POST['options']),$minutes,null,null,null,false));
+               
+      
         }
 
         return redirect()->back()->withInput()->withErrors($asset->getErrors());
     }
+
+    public function getOptionCookie(Request $request){
+        $value = $request->cookie('optional_info');
+        echo $value;
+        return $value;
+     }
 
     /**
      * Returns a view that presents a form to edit an existing asset.

--- a/resources/lang/en/admin/hardware/form.php
+++ b/resources/lang/en/admin/hardware/form.php
@@ -46,4 +46,6 @@ return [
     'asset_not_deployable' => 'That asset status is not deployable. This asset cannot be checked out.',
     'asset_deployable' => 'That status is deployable. This asset can be checked out.',
     'processing_spinner' => 'Processing...',
+    'optional_infos'  => 'Optional Information',
+    'order_details'   => 'Order Related Information'
 ];

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -15,7 +15,6 @@
 
     @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
 
-
   <!-- Asset Tag -->
   <div class="form-group {{ $errors->has('asset_tag') ? ' has-error' : '' }}">
     <label for="asset_tag" class="col-md-3 control-label">{{ trans('admin/hardware/form.tag') }}</label>
@@ -41,77 +40,103 @@
           </div>
       @endif
   </div>
-    @include ('partials.forms.edit.serial', ['fieldname'=> 'serials[1]', 'translated_serial' => trans('admin/hardware/form.serial')])
+    
 
     <div class="input_fields_wrap">
     </div>
 
 
     @include ('partials.forms.edit.model-select', ['translated_name' => trans('admin/hardware/form.model'), 'fieldname' => 'model_id', 'field_req' => true])
+    @include ('partials.forms.edit.serial', ['fieldname'=> 'serials[1]', 'translated_serial' => trans('admin/hardware/form.serial')])
 
 
-  <div id='custom_fields_content'>
-      <!-- Custom Fields -->
-      @if ($item->model && $item->model->fieldset)
-      <?php $model=$item->model; ?>
-      @endif
-      @if (Request::old('model_id'))
-        <?php $model=\App\Models\AssetModel::find(Request::old('model_id')); ?>
-      @elseif (isset($selected_model))
-        <?php $model=$selected_model; ?>
-      @endif
-      @if (isset($model) && $model)
-      @include("models/custom_fields_form",["model" => $model])
-      @endif
-  </div>
+    @include ('partials.forms.edit.status', [ 'required' => 'true'])
+    @if (!$item->id)
+        @include ('partials.forms.checkout-selector', ['user_select' => 'true','asset_select' => 'true', 'location_select' => 'true', 'style' => 'display:none;'])
+        @include ('partials.forms.edit.user-select', ['translated_name' => trans('admin/hardware/form.checkout_to'), 'fieldname' => 'assigned_user', 'style' => 'display:none;', 'required' => 'false'])
+        @include ('partials.forms.edit.asset-select', ['translated_name' => trans('admin/hardware/form.checkout_to'), 'fieldname' => 'assigned_asset', 'style' => 'display:none;', 'required' => 'false'])
+        @include ('partials.forms.edit.location-select', ['translated_name' => trans('admin/hardware/form.checkout_to'), 'fieldname' => 'assigned_location', 'style' => 'display:none;', 'required' => 'false'])
+    @elseif (($item->assignedTo) && ($item->deleted_at==''))
+        <!-- This is an asset and it's currently deployed, so let them edit the expected checkin date -->
+        @include ('partials.forms.edit.datepicker', ['translated_name' => trans('admin/hardware/form.expected_checkin'),'fieldname' => 'expected_checkin'])
+    @endif
 
-  @include ('partials.forms.edit.status', [ 'required' => 'true'])
-  @if (!$item->id)
-      @include ('partials.forms.checkout-selector', ['user_select' => 'true','asset_select' => 'true', 'location_select' => 'true', 'style' => 'display:none;'])
-      @include ('partials.forms.edit.user-select', ['translated_name' => trans('admin/hardware/form.checkout_to'), 'fieldname' => 'assigned_user', 'style' => 'display:none;', 'required' => 'false'])
-      @include ('partials.forms.edit.asset-select', ['translated_name' => trans('admin/hardware/form.checkout_to'), 'fieldname' => 'assigned_asset', 'style' => 'display:none;', 'required' => 'false'])
-      @include ('partials.forms.edit.location-select', ['translated_name' => trans('admin/hardware/form.checkout_to'), 'fieldname' => 'assigned_location', 'style' => 'display:none;', 'required' => 'false'])
-  @elseif (($item->assignedTo) && ($item->deleted_at==''))
-      <!-- This is an asset and it's currently deployed, so let them edit the expected checkin date -->
-      @include ('partials.forms.edit.datepicker', ['translated_name' => trans('admin/hardware/form.expected_checkin'),'fieldname' => 'expected_checkin'])
-  @endif
+    @include ('partials.forms.edit.notes')
+    @include ('partials.forms.edit.location-select', ['translated_name' => trans('admin/hardware/form.default_location'), 'fieldname' => 'rtd_location_id'])
+    @include ('partials.forms.edit.requestable', ['requestable_text' => trans('admin/hardware/general.requestable')])
 
-  @include ('partials.forms.edit.name', ['translated_name' => trans('admin/hardware/form.name')])
-  @include ('partials.forms.edit.purchase_date')
-  @include ('partials.forms.edit.supplier-select', ['translated_name' => trans('general.supplier'), 'fieldname' => 'supplier_id'])
-  @include ('partials.forms.edit.order_number')
-    <?php
-    $currency_type=null;
-    if ($item->id && $item->location) {
-        $currency_type = $item->location->currency;
-    }
-    ?>
-  @include ('partials.forms.edit.purchase_cost', ['currency_type' => $currency_type])
-  @include ('partials.forms.edit.warranty')
-  @include ('partials.forms.edit.notes')
+    <!-- Image -->
+    @if ($item->image)
+    <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
+        <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
+        <div class="col-md-5">
+            <label class="control-label" for="image_delete">
+            <input type="checkbox" value="1" name="image_delete" id="image_delete" class="minimal" {{ Request::old('image_delete') == '1' ? ' checked="checked"' : '' }}>
+            {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+            </label>
+            <div style="margin-top: 0.5em">
+                <img src="{{ Storage::disk('public')->url(app('assets_upload_path').e($item->image)) }}" class="img-responsive" />
+            </div>
+        </div>
+    </div>
+    @endif
 
-  @include ('partials.forms.edit.location-select', ['translated_name' => trans('admin/hardware/form.default_location'), 'fieldname' => 'rtd_location_id'])
+    @include ('partials.forms.edit.image-upload')
 
+    <div id='custom_fields_content'>
+        <!-- Custom Fields -->
+        @if ($item->model && $item->model->fieldset)
+        <?php $model=$item->model; ?>
+        @endif
+        @if (Request::old('model_id'))
+            <?php $model=\App\Models\AssetModel::find(Request::old('model_id')); ?>
+        @elseif (isset($selected_model))
+            <?php $model=$selected_model; ?>
+        @endif
+        @if (isset($model) && $model)
+        @include("models/custom_fields_form",["model" => $model])
+        @endif
+    </div>
 
-  @include ('partials.forms.edit.requestable', ['requestable_text' => trans('admin/hardware/general.requestable')])
+    <div class="form-group" >
+    <label class="col-md-3 control-label"></label> 
+        <div class="col-md-2 col-sm-2 text-left form-check" style="z-index:1;">   
+        <input class="form-check-input" type="checkbox" id="optional_info" >
+        <label class="form-check-label" for="flexCheckDefault">
+        {{ trans('admin/hardware/form.optional_infos') }}
+        </label>
+        </div>
+        
+        <div id="optional_details" class="col-md-12">
+        @include ('partials.forms.edit.name', ['translated_name' => trans('admin/hardware/form.name')])
+        @include ('partials.forms.edit.warranty')
+        </div>
+    </div>
 
-  <!-- Image -->
-  @if ($item->image)
-  <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-      <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-      <div class="col-md-5">
-          <label class="control-label" for="image_delete">
-          <input type="checkbox" value="1" name="image_delete" id="image_delete" class="minimal" {{ Request::old('image_delete') == '1' ? ' checked="checked"' : '' }}>
-          {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
-          </label>
-          <div style="margin-top: 0.5em">
-              <img src="{{ Storage::disk('public')->url(app('assets_upload_path').e($item->image)) }}" class="img-responsive" />
-          </div>
-      </div>
-  </div>
-  @endif
+    <div class="form-group">
+    <label class="col-md-3 control-label"></label> 
+        <div class="col-md-2 col-sm-2 text-left form-check" style="z-index:2;">   
+        <input class="form-check-input" type="checkbox" id="order_info" >
+        <label class="form-check-label" for="flexCheckDefault">
+        {{ trans('admin/hardware/form.order_details') }}
+    </label>
+        </div>
 
-@include ('partials.forms.edit.image-upload')
+        <div id='order_details' class="col-md-12" style="z-index:1;">
+            @include ('partials.forms.edit.order_number')
+            @include ('partials.forms.edit.purchase_date')
+            @include ('partials.forms.edit.supplier-select', ['translated_name' => trans('general.supplier'), 'fieldname' => 'supplier_id'])
+
+                <?php
+                $currency_type=null;
+                if ($item->id && $item->location) {
+                    $currency_type = $item->location->currency;
+                }
+                ?>
+            @include ('partials.forms.edit.purchase_cost', ['currency_type' => $currency_type])
+
+        </div>
+    </div>
 
 @stop
 
@@ -278,6 +303,32 @@
         })
     });
 
+    $( document ).ready(function() {
+    checkOrderDetailOption();
+    checkOptionalOption();
+    });
 
+    $('#order_info').change(function(){
+        checkOrderDetailOption();
+    });
+
+    $('#optional_info').change(function(){
+        checkOptionalOption();
+    });
+
+    function checkOptionalOption(){
+    if ($("#optional_info").prop('checked')==true) {
+        $('#optional_details').fadeIn('slow');
+    } else {
+        $('#optional_details').fadeOut('slow');
+    }                   
+    }
+    function checkOrderDetailOption(){
+    if ($("#order_info").prop('checked')==true) {
+        $('#order_details').fadeIn('slow');
+    } else {
+        $('#order_details').fadeOut('slow');
+    }                   
+    }
 </script>
 @stop

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -10,15 +10,16 @@
 
 
 {{-- Page content --}}
-
 @section('inputFields')
 
     @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
 
+
+<!-- {{Request::cookie('optional_info');}} -->
   <!-- Asset Tag -->
   <div class="form-group {{ $errors->has('asset_tag') ? ' has-error' : '' }}">
     <label for="asset_tag" class="col-md-3 control-label">{{ trans('admin/hardware/form.tag') }}</label>
-
+    
       <!-- we are editing an existing asset -->
       @if  ($item->id)
           <div class="col-md-7 col-sm-12{{  (Helper::checkIfRequired($item, 'asset_tag')) ? ' required' : '' }}">
@@ -101,13 +102,14 @@
     <div class="form-group" >
     <label class="col-md-3 control-label"></label> 
         <div class="col-md-2 col-sm-2 text-left form-check" style="z-index:1;">   
-        <input class="form-check-input" type="checkbox" id="optional_info" >
+
+        <input class="form-check-input" type="checkbox" id="optional_info" name="options[]" value="optional" <?php if (!empty (json_decode(Cookie::get('optional_info')))) {if(in_array('optional',json_decode(Cookie::get('optional_info')))) {echo 'checked';} else {echo 'unchecked';}} else {echo 'unchecked';} ?>>
         <label class="form-check-label" for="flexCheckDefault">
         {{ trans('admin/hardware/form.optional_infos') }}
         </label>
         </div>
         
-        <div id="optional_details" class="col-md-12">
+        <div id="optional_details" class="col-md-12" style="display:none">
         @include ('partials.forms.edit.name', ['translated_name' => trans('admin/hardware/form.name')])
         @include ('partials.forms.edit.warranty')
         </div>
@@ -116,13 +118,13 @@
     <div class="form-group">
     <label class="col-md-3 control-label"></label> 
         <div class="col-md-2 col-sm-2 text-left form-check" style="z-index:2;">   
-        <input class="form-check-input" type="checkbox" id="order_info" >
+        <input class="form-check-input" type="checkbox" id="order_info" name="options[]" value="order" <?php if (!empty (json_decode(Cookie::get('optional_info')))) {if(in_array('order',json_decode(Cookie::get('optional_info')))) {echo 'checked';} else {echo 'unchecked';}} else {echo 'unchecked';} ?>>
         <label class="form-check-label" for="flexCheckDefault">
         {{ trans('admin/hardware/form.order_details') }}
     </label>
         </div>
 
-        <div id='order_details' class="col-md-12" style="z-index:1;">
+        <div id='order_details' class="col-md-12" style="z-index:1;"  style="display:none">
             @include ('partials.forms.edit.order_number')
             @include ('partials.forms.edit.purchase_date')
             @include ('partials.forms.edit.supplier-select', ['translated_name' => trans('general.supplier'), 'fieldname' => 'supplier_id'])
@@ -137,7 +139,7 @@
 
         </div>
     </div>
-
+   
 @stop
 
 @section('moar_scripts')
@@ -145,7 +147,6 @@
 
 
 <script nonce="{{ csrf_token() }}">
-
 
     var transformed_oldvals={};
 
@@ -303,32 +304,42 @@
         })
     });
 
-    $( document ).ready(function() {
-    checkOrderDetailOption();
-    checkOptionalOption();
+    $(document).ready(function() {
+        checkOrderDetailOption();
+        checkOptionalOption();
     });
 
+    if ($('#order_info').is(":checked")){
+        checkOrderDetailOption();
+    }
+    
     $('#order_info').change(function(){
         checkOrderDetailOption();
     });
+
+    if ($('#optional_info').is(":checked")){
+        checkOptionalOption();
+    }
 
     $('#optional_info').change(function(){
         checkOptionalOption();
     });
 
     function checkOptionalOption(){
-    if ($("#optional_info").prop('checked')==true) {
-        $('#optional_details').fadeIn('slow');
-    } else {
-        $('#optional_details').fadeOut('slow');
-    }                   
+        if ($("#optional_info").prop('checked')==true) {
+            $('#optional_details').show();
+        } else {
+            $('#optional_details').hide();
+        }             
     }
+
     function checkOrderDetailOption(){
-    if ($("#order_info").prop('checked')==true) {
-        $('#order_details').fadeIn('slow');
-    } else {
-        $('#order_details').fadeOut('slow');
-    }                   
+        if ($("#order_info").prop('checked')==true) {
+            $('#order_details').show();
+        } else {
+            $('#order_details').hide();
+        }                   
     }
+
 </script>
 @stop


### PR DESCRIPTION
- Fixes #8155 
- Adding 2 checkboxes to hide optional information
- Relocate custom fields location

# Description

I'm trying to help improving the workflow during asset creation by adjusting the layout ordering as mentioned in the original issue. I hope this implementation meets the needs of the request

Fixes #8155 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

the new layout has been tested by doing the following:

- [X] Test creating assets without optional fields filled
- [X] Test creating assets with optional fields filled

**Test Configuration**:
- PHP version: 7.4.27
- MySQL version : 10.4.22
- Webserver version: Apache 2.4.52
- OS version: Windows 10

# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Preview
some fields are moved and add 2 checkboxes which disabled by default
![image](https://user-images.githubusercontent.com/3839381/164886693-0af61dae-4f1b-4b8c-89cd-8037c1cec569.png)

the content of each checkboxes group
![image](https://user-images.githubusercontent.com/3839381/164886741-a645af19-1964-40d0-b279-d496118a4778.png)

custom fields location from model is now placed before the checkboxes also to give positional consistency during asset creation
![image](https://user-images.githubusercontent.com/3839381/164886972-8a6b4e03-b06c-4ea9-838a-bb7a5a97a638.png)


Please inform me if this PR acceptable or not