### PR TITLE
Fixes #10959 - disable view for custom fields in asset index page

### DIFF
--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -271,7 +271,7 @@ class AssetPresenter extends Presenter
                 'formatter'=> 'customFieldsFormatter',
                 'escape' => true,
                 'class' => ($field->field_encrypted == '1') ? 'css-padlock' : '',
-                'visible' => true,
+                'visible' => false,
             ];
         }
 


### PR DESCRIPTION
Disable custom fields display in asset index by default to keep the index page compact and avoids table too wide if custom fields are too many

# Description

Disable custom fields display by default in asset index page to avoid table width too long if the custom field are too many

Fixes #10959

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Test asset index view with update change

**Test Configuration**:
* PHP version: 7.4.27
* MySQL version : 10.4.22
* Webserver version: Apache 2.4.52
* OS version: Windows 10


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Preview
- before
![image](https://user-images.githubusercontent.com/3839381/164888444-20b938b2-d276-4310-9290-051f9a17b3b4.png)

- after
![image](https://user-images.githubusercontent.com/3839381/164888370-328e8c64-553a-4c1d-93d4-10d32abb6488.png)

