### PR TITLE
Fixed model export filename to use str_slug for filename for JS export (like we do elsewhere)

### DIFF
--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -74,7 +74,7 @@
                   data-url="{{ route('api.assets.index',['model_id'=> $model->id]) }}"
                   class="table table-striped snipe-table"
                   data-export-options='{
-                "fileName": "export-models-{{ $model->name }}-assets-{{ date('Y-m-d') }}",
+                "fileName": "export-models-{{ str_slug($model->name) }}-assets-{{ date('Y-m-d') }}",
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                 }'>
                 </table>


### PR DESCRIPTION
This fixes a bug in the models view where the filename directive wasn't being escaped, so if you had quotes in the model name, it would monkey up the JSON that gets sent to the javaScript for the FileExport stuff. 