### PR TITLE
Fixes Activity Report Download all action fails creating the CSV report.

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -272,13 +272,18 @@ class ReportsController extends Controller
                         }
                     }
 
+                    if($actionlog->item){
+                        $item_name = e($actionlog->item->getDisplayNameAttribute());
+                    } else {
+                        $item_name ='';
+                    }
 
                     $row = [
                         $actionlog->created_at,
                         ($actionlog->user) ? e($actionlog->user->getFullNameAttribute()) : '',
                         $actionlog->present()->actionType(),
                         e($actionlog->itemType()),
-                        ($actionlog->itemType()=='user') ? $actionlog->filename : e($actionlog->item->getDisplayNameAttribute()),
+                        ($actionlog->itemType()=='user') ? $actionlog->filename : $item_name,
                         $target_name,
                         ($actionlog->note) ? e($actionlog->note): '',
                         $actionlog->log_meta,


### PR DESCRIPTION
# Description
When downloading the Activity Report in CSV format ('Download all' button) if the item (accessory, license, asset, etc) doesn't exist anymore, the system fails trying to get the item name (method called on null exception).

This PR cheks if the item still exists in the database, and if not it puts a blank string in the report. 

Fixes intern freshdesk #27514

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
