### PR TITLE
Fixed #10890 - Use translation strings in assigned printout instead of hardcoded English

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -229,6 +229,7 @@
     'show_current'  		=> 'Show Current',
     'sign_in'				=> 'Sign in',
     'signature'             => 'Signature',
+    'signed_off_by'         => 'Signed Off By',
     'skin'       			=> 'Skin',
     'slack_msg_note'        => 'A slack message will be sent',
     'slack_test_msg'        => 'Oh hai! Looks like your Slack integration with Snipe-IT is working!',

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -64,11 +64,11 @@
         <thead>
             <tr>
                 <th style="width: 20px;"></th>
-                <th style="width: 20%;">Asset Tag</th>
-                <th style="width: 20%;">Name</th>
-                <th style="width: 10%;">Category</th>
-                <th style="width: 20%;">Model</th>
-                <th style="width: 20%;">Serial</th>
+                <th style="width: 20%;">{{ trans('admin/hardware/table.asset_tag') }}</th>
+                <th style="width: 20%;">{{ trans('general.name') }}</th>
+                <th style="width: 10%;">{{ trans('general.category') }}</th>
+                <th style="width: 20%;">{{ trans('admin/hardware/form.model') }}</th>
+                <th style="width: 20%;">{{ trans('admin/hardware/form.serial') }}</th>
                 <th style="width: 10%;">Checked Out</th>
                 <th data-formatter="imageFormatter" style="width: 20%;">{{ trans('general.signature') }}</th>
             </tr>
@@ -131,9 +131,9 @@
         <thead>
             <tr>
                 <th style="width: 20px;"></th>
-                <th style="width: 40%;">Name</th>
-                <th style="width: 50%;">Serial/Product Key</th>
-                <th style="width: 10%;">Checked Out</th>
+                <th style="width: 40%;">{{ trans('general.name') }}</th>
+                <th style="width: 50%;">{{ trans('admin/licenses/form.license_key') }}</th>
+                <th style="width: 10%;">{{ trans('admin/hardware/table.checkout_date') }}</th>
             </tr>
         </thead>
         @php
@@ -173,9 +173,9 @@
         <thead>
             <tr>
                 <th style="width: 20px;"></th>
-                <th style="width: 40%;">Name</th>
-                <th style="width: 50%;">Category</th>
-                <th style="width: 10%;">Checked Out</th>
+                <th style="width: 40%;">{{ trans('general.name') }}</th>
+                <th style="width: 50%;">{{ trans('general.category') }}</th>
+                <th style="width: 10%;">{{ trans('admin/hardware/table.checkout_date') }}</th>
             </tr>
         </thead>
         @php
@@ -209,9 +209,9 @@
         <thead>
         <tr>
             <th style="width: 20px;"></th>
-            <th style="width: 40%;">Name</th>
-            <th style="width: 50%;">Category</th>
-            <th style="width: 10%;">Checked Out</th>
+            <th style="width: 40%;">{{ trans('general.name') }}</th>
+            <th style="width: 50%;">{{ trans('general.category') }}</th>
+            <th style="width: 10%;">{{ trans('admin/hardware/table.checkout_date') }}</th>
         </tr>
         </thead>
         @php
@@ -247,10 +247,10 @@
 <br>
 <table>
     <tr>
-        <td>Signed Off By:</td>
+        <td>{{ trans('general.signed_off_by') }}:</td>
         <td>________________________________________________________</td>
         <td></td>
-        <td>Date:</td>
+        <td>{{ trans('general.date') }}:</td>
         <td>________________________________________________________</td>
     </tr>
 </table>

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title>Assigned to {{ $show_user->present()->fullName() }}</title>


### PR DESCRIPTION
This fixes #10890 on master (which will then be merged into develop before final v6 release).
