### PR TITLE
Removed the long-lived JWT token in favor of new middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -41,12 +41,14 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\CheckLocale::class,
             \App\Http\Middleware\CheckUserIsActivated::class,
             \App\Http\Middleware\CheckForTwoFactor::class,
-            \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
+            // \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class, //these tokens are too long-lived
             \App\Http\Middleware\AssetCountForSidebar::class,
         ],
 
         'api' => [
-            'auth:api',
+            //'auth:api', // the old way
+            //'any:auth,auth:api' //any of 'auth' or 'auth:api' needs to pass for this middleware to call $next() (doesn't work :/)
+            'anyauth'
         ],
     ];
 
@@ -64,5 +66,6 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'anyauth' => \App\Http\Middleware\AnyAuthMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/AnyAuthMiddleware.php
+++ b/app/Http/Middleware/AnyAuthMiddleware.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+//use Illuminate\Routing\MiddlewareNameResolver;
+use \Illuminate\Auth\Middleware\Authenticate;
+use \Illuminate\Auth\AuthenticationException;
+
+class AnyAuthMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next) {
+        $auth = resolve(Authenticate::class);
+        $middleware_results = null;
+        $last_exception = null;
+
+        foreach( [ 'empty', 'api' ] as $middleware_parameter ) { // first try 'auth', then 'auth:api'
+
+            $auth_worked = false;
+
+            // We have to assemble together an array of parameters, then use the splat
+            // operator (...) to call the function with the right number of parameters
+            $midparms = [$request, function ($subrequest) use (&$auth_worked) {
+                $auth_worked = true;
+                $last_exception = null;
+            }];
+
+            if ($middleware_parameter != 'empty') {
+                $midparms[] = $middleware_parameter;
+            }
+
+            try {
+                $middleware_results = $auth->handle(...$midparms); //I hate that this is so awkward :(
+            } catch (AuthenticationException $e) {
+                $auth_worked = false;
+                $last_exception = $e;
+            }
+
+            if ( $auth_worked ) {
+                return $next($request);
+            }
+        }
+
+        // If there was an exception thrown during the final failure, re-throw that. Otherwise return the final failed result
+        if ($last_exception) {
+            throw $last_exception;
+        } else {
+            return $middleware_results;
+        }
+    }
+
+    // This below method is cooler and could help if there were other times we wanted 'any' middleware to work, but it doesn't work
+    // I had too much trouble with the MiddlewareNameResolver :/
+    /* public function handle($request, Closure $next, $middleware_string)
+    {
+        \Log::info("Middleware string: $middleware_string");
+        $middlewares = explode(",",$middleware_string);
+
+        foreach($middlewares as $middleware) {
+            $middleware_bits = explode(':', $middleware);
+            $this_thing = MiddlewareNameResolver::resolve($middleware_bits[0]);
+
+            $called_next = false;
+            $results = $this_thing->handle( $request, function () use ($called_next) {
+                $called_next = true;
+            }, $middleware_bits[1] );
+
+            if( $called_next == true ) { //short-circuit any further middleware checks; we're good!
+                return $next($request);
+            }
+        }
+        return $results; //nothing ever got properly short-circuited, so return the error from the *LAST* middleware
+    } */
+
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -78,7 +78,9 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapApiRoutes()
     {
         Route::group([
-            'middleware' => 'auth:api',
+            // this seems scary to comment-out, but the 'anyauth' middleware is explicitly
+            // mentioned in the api middleware route-group, so I think it's ok.
+            //'middleware' => 'auth:api',
             'namespace' => $this->namespace,
             'prefix' => 'api',
         ], function ($router) {


### PR DESCRIPTION
This resolves a potential security issue with overly-long-lived temporary cookie-based API tokens.

Since this messes around with auth, we should test it much more thoroughly than I have. We should test that API routes still work with API keys, and that API routes also work with regular Laravel session tokens. We will need to be extra careful to blow out any cookies we might have, as those _are_ still valid tokens.

The approach originally was that I wanted to make a generic 'any' Middleware which could take a comma-separated list of other middleware names, and if any of them pass, then the middleware continues. That didn't work because I couldn't get the middleware resolver to work quite right.

So I backed off and instead hardcoded the two middlewares that we wanted 'any' of - 'auth' and 'auth:api'. It seems to work fine like that.

As a couple of fun side effects - we will end up sending fewer cookies with much less bytes this way. Helps to save the environment! :) And it's much easier to open up an API endpoint in your browser - so long as you're logged in, you see the JSON output right there and most browsers will 'pretty-print' it for you.