### PR TITLE
Fixed #11026 - add bulk edit to other asset views

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -224,6 +224,9 @@ class BulkAssetsController extends Controller
      */
     public function storeCheckout(Request $request)
     {
+
+        $this->authorize('checkout', Asset::class);
+
         try {
             $admin = Auth::user();
 

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -31,7 +31,8 @@ class BulkAssetsController extends Controller
         $this->authorize('update', Asset::class);
 
         if (! $request->filled('ids')) {
-            return redirect()->back()->with('error', 'No assets selected');
+            return redirect()->back()->with('error', trans('admin/hardware/message.update.no_assets_selected'));
+
         }
 
         // Figure out where we need to send the user after the update is complete, and store that in the session
@@ -217,7 +218,7 @@ class BulkAssetsController extends Controller
             // no values given, nothing to update
         }
 
-        return redirect($bulk_back_url)->with('info', trans('admin/hardware/message.delete.nothing_updated'));
+        return redirect($bulk_back_url)->with('error', trans('admin/hardware/message.delete.nothing_updated'));
     }
 
     /**

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -83,7 +83,11 @@ class BulkAssetsController extends Controller
         $this->authorize('update', Asset::class);
 
         // Get the back url from the session and then destroy the session
-        $bulk_back_url = $request->session()->pull('bulk_back_url');
+        $bulk_back_url = route('hardware');
+        if ($request->session()->has('bulk_back_url')) {
+            $bulk_back_url = $request->session()->pull('bulk_back_url');
+        }
+
 
         if (! $request->filled('ids') || count($request->input('ids')) <= 0) {
             return redirect($bulk_back_url)->with('error', trans('admin/hardware/message.update.no_assets_selected'));
@@ -200,8 +204,10 @@ class BulkAssetsController extends Controller
     {
         $this->authorize('delete', Asset::class);
 
-        // Get the back url from the session and then destroy the session
-        $bulk_back_url = $request->session()->pull('bulk_back_url');
+        $bulk_back_url = route('hardware');
+        if ($request->session()->has('bulk_back_url')) {
+            $bulk_back_url = $request->session()->pull('bulk_back_url');
+        }
 
         if ($request->filled('ids')) {
             $assets = Asset::find($request->get('ids'));

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -85,7 +85,7 @@ class BulkAssetsController extends Controller
         $bulk_back_url = $request->session()->pull('bulk_back_url');
 
         if (! $request->filled('ids') || count($request->input('ids')) <= 0) {
-            return redirect($back_to_url)->with('warning', trans('No assets selected, so nothing was updated.'));
+            return redirect($bulk_back_url)->with('error', trans('admin/hardware/message.update.no_assets_selected'));
         }
 
         $assets = array_keys($request->input('ids'));

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -11,6 +11,7 @@ use App\Models\Setting;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Session;
 
 class BulkAssetsController extends Controller
 {
@@ -32,6 +33,12 @@ class BulkAssetsController extends Controller
         if (! $request->filled('ids')) {
             return redirect()->back()->with('error', 'No assets selected');
         }
+        
+        $bulk_back_url = request()->headers->get('referer');
+        session(['bulk_back_url' => $bulk_back_url]);
+
+        \Log::debug('Back to url: '.$bulk_back_url);
+
 
 
         $asset_ids = array_values(array_unique($request->input('ids')));
@@ -73,10 +80,11 @@ class BulkAssetsController extends Controller
     {
         $this->authorize('update', Asset::class);
 
-        \Log::debug($request->input('ids'));
+        // Get the back url from the session and then destroy the session
+        $bulk_back_url = $request->session()->pull('bulk_back_url');
 
         if (! $request->filled('ids') || count($request->input('ids')) <= 0) {
-            return redirect()->route('hardware.index')->with('warning', trans('No assets selected, so nothing was updated.'));
+            return redirect($back_to_url)->with('warning', trans('No assets selected, so nothing was updated.'));
         }
 
         $assets = array_keys($request->input('ids'));
@@ -147,11 +155,13 @@ class BulkAssetsController extends Controller
                     ->update($this->update_array);
             } // endforeach
 
-            return redirect()->route('hardware.index')->with('success', trans('admin/hardware/message.update.success'));
-            // no values given, nothing to update
+            return redirect($bulk_back_url)->with('success', trans('admin/hardware/message.update.success'));
+
+
         }
 
-        return redirect()->route('hardware.index')->with('warning', trans('admin/hardware/message.update.nothing_updated'));
+        // no values given, nothing to update
+        return redirect($bulk_back_url)->with('warning', trans('admin/hardware/message.update.nothing_updated'));
     }
 
     /**
@@ -188,6 +198,9 @@ class BulkAssetsController extends Controller
     {
         $this->authorize('delete', Asset::class);
 
+        // Get the back url from the session and then destroy the session
+        $bulk_back_url = $request->session()->pull('bulk_back_url');
+
         if ($request->filled('ids')) {
             $assets = Asset::find($request->get('ids'));
             foreach ($assets as $asset) {
@@ -199,11 +212,11 @@ class BulkAssetsController extends Controller
                     ->update($update_array);
             } // endforeach
 
-            return redirect()->to('hardware')->with('success', trans('admin/hardware/message.delete.success'));
+            return redirect($bulk_back_url)->with('success', trans('admin/hardware/message.delete.success'));
             // no values given, nothing to update
         }
 
-        return redirect()->to('hardware')->with('info', trans('admin/hardware/message.delete.nothing_updated'));
+        return redirect($bulk_back_url)->with('info', trans('admin/hardware/message.delete.nothing_updated'));
     }
 
     /**

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -33,7 +33,8 @@ class BulkAssetsController extends Controller
         if (! $request->filled('ids')) {
             return redirect()->back()->with('error', 'No assets selected');
         }
-        
+
+        // Figure out where we need to send the user after the update is complete, and store that in the session
         $bulk_back_url = request()->headers->get('referer');
         session(['bulk_back_url' => $bulk_back_url]);
 

--- a/app/Presenters/AssetAuditPresenter.php
+++ b/app/Presenters/AssetAuditPresenter.php
@@ -18,6 +18,10 @@ class AssetAuditPresenter extends Presenter
     {
         $layout = [
              [
+                'field' => 'checkbox',
+                'checkbox' => true,
+             ],
+             [
                 'field' => 'id',
                 'searchable' => false,
                 'sortable' => true,

--- a/resources/lang/am/admin/hardware/message.php
+++ b/resources/lang/am/admin/hardware/message.php
@@ -14,9 +14,10 @@ return [
     ],
 
     'update' => [
-        'error'   			=> 'Asset was not updated, please try again',
-        'success' 			=> 'Asset updated successfully.',
-        'nothing_updated'	=>  'No fields were selected, so nothing was updated.',
+        'error'   			  => 'Asset was not updated, please try again',
+        'success' 			  => 'Asset updated successfully.',
+        'nothing_updated'	  =>  'No fields were selected, so nothing was updated.',
+        'no_assets_selected'  =>  'No assets were selected, so nothing was updated.',
     ],
 
     'restore' => [

--- a/resources/lang/en/admin/hardware/message.php
+++ b/resources/lang/en/admin/hardware/message.php
@@ -17,6 +17,7 @@ return [
         'error'   			=> 'Asset was not updated, please try again',
         'success' 			=> 'Asset updated successfully.',
         'nothing_updated'	=>  'No fields were selected, so nothing was updated.',
+        'no_assets_selected'  =>  'No assets were selected, so nothing was updated.',
     ],
 
     'restore' => [

--- a/resources/views/categories/view.blade.php
+++ b/resources/views/categories/view.blade.php
@@ -28,6 +28,9 @@
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-body">
+          @if ($category->category_type=='asset')
+            @include('partials.asset-bulk-actions')
+          @endif
 
         <table
 

--- a/resources/views/hardware/audit-due.blade.php
+++ b/resources/views/hardware/audit-due.blade.php
@@ -23,11 +23,9 @@
         <div class="col-md-12">
             <div class="box">
                 <div class="box-body">
-                    {{ Form::open([
-                      'method' => 'POST',
-                      'route' => ['hardware/bulkedit'],
-                      'class' => 'form-inline',
-                       'id' => 'bulkForm']) }}
+
+                    @include('partials.asset-bulk-actions')
+
                     <div class="row">
                         <div class="col-md-12">
 

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -143,7 +143,7 @@
                 <input type="radio" class="minimal" name="requestable" value="0"> {{ trans('general.no')}}
               </label>
               <label class="radio">
-                <input type="radio" class="minimal" name="requestable" value=""> {{ trans('general.do_not_change')}}
+                <input type="radio" class="minimal" name="requestable" value="" checked> {{ trans('general.do_not_change')}}
               </label>
             </div>
           </div>

--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -62,27 +62,10 @@
             <div class="col-md-12">
               
               @if (Request::get('status')!='Deleted')
-              
-                 
-                    
-                    <div id="toolbar">
-                      {{ Form::open([
-                        'method' => 'POST',
-                        'route' => ['hardware/bulkedit'],
-                        'class' => 'form-inline',
-                        'id' => 'bulkForm']) }}
-                        
-                     
-                      <label for="bulk_actions"><span class="sr-only">{{ trans('button.bulk_actions') }}</span></label>
-                      <select name="bulk_actions" class="form-control select2" aria-label="bulk_actions">
-                        <option value="edit">{{ trans('button.edit') }}</option>
-                        <option value="delete">{{ trans('button.delete') }}</option>
-                        <option value="labels">{{ trans_choice('button.generate_labels', 2) }}</option>
-                      </select>
-                      
-                      <button class="btn btn-primary" id="bulkEdit" disabled>{{ trans('button.go') }}</button>
-                      {{ Form::close() }}   
-                    </div>
+
+
+
+                @include('partials.asset-bulk-actions')
                    
               @endif
 

--- a/resources/views/locations/view.blade.php
+++ b/resources/views/locations/view.blade.php
@@ -23,6 +23,7 @@
         </div>
     </div>
       <div class="box-body">
+
             <div class="table table-responsive">
 
                 <table
@@ -56,6 +57,10 @@
           </div>
         </div>
         <div class="box-body">
+
+
+            @include('partials.asset-bulk-actions')
+
               <div class="table table-responsive">
 
                   <table

--- a/resources/views/manufacturers/view.blade.php
+++ b/resources/views/manufacturers/view.blade.php
@@ -45,6 +45,8 @@
       <div class="tab-content">
         <div class="tab-pane fade in active" id="assets">
 
+          @include('partials.asset-bulk-actions')
+          <div class="table table-responsive">
           <table
                   data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
                   data-cookie-id-table="assetsListingTable"
@@ -65,6 +67,7 @@
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
               }'>
           </table>
+          </div>
 
         </div> <!-- /.tab-pane assets -->
 

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -42,21 +42,11 @@
         </div><!-- /.box-header -->
       @endif
       <div class="box-body">
-          <div class="row">
-              <div class="col-md-12">
-                  {{ Form::open([
-                     'method' => 'POST',
-                     'route' => ['hardware/bulkedit'],
-                     'class' => 'form-inline',
-                      'id' => 'bulkForm']) }}
-                  <div id="toolbar">
-                      <select name="bulk_actions" class="form-control select2">
-                          <option value="edit">{{ trans('button.edit') }}</option>
-                          <option value="delete">{{ trans('button.delete') }}</option>
-                          <option value="labels">{{ trans_choice('button.generate_labels', 2) }}</option>
-                      </select>
-                      <button class="btn btn-primary" id="bulkEdit" disabled>{{ trans('button.go') }}</button>
-                  </div>
+
+          @include('partials.asset-bulk-actions')
+
+
+
 
                   <table
                   data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -69,8 +69,7 @@
                 }'>
                 </table>
                   {{ Form::close() }}
-              </div>
-          </div>
+
       </div> <!-- /.box-body-->
     </div> <!-- /.box-default-->
   </div> <!-- /.col-md-9-->

--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -1,0 +1,22 @@
+<div id="toolbar">
+    {{ Form::open([
+      'method' => 'POST',
+      'route' => ['hardware/bulkedit'],
+      'class' => 'form-inline',
+      'id' => 'bulkForm']) }}
+
+
+    <label for="bulk_actions">
+        <span class="sr-only">
+            {{ trans('button.bulk_actions') }}
+        </span>
+    </label>
+    <select name="bulk_actions" class="form-control select2" aria-label="bulk_actions">
+        <option value="edit">{{ trans('button.edit') }}</option>
+        <option value="delete">{{ trans('button.delete') }}</option>
+        <option value="labels">{{ trans_choice('button.generate_labels', 2) }}</option>
+    </select>
+
+    <button class="btn btn-primary" id="bulkEdit" disabled>{{ trans('button.go') }}</button>
+    {{ Form::close() }}
+</div>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -566,10 +566,13 @@
           </div> <!--/.row-->
         </div><!-- /.tab-pane -->
 
-
         <div class="tab-pane" id="asset">
           <!-- checked out assets table -->
-          <div class="table-responsive table-striped">
+
+            @include('partials.asset-bulk-actions')
+
+            <div class="table table-responsive">
+
             <table
                     data-click-to-select="true"
                     data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -61,7 +61,8 @@
         <li>
           <a href="#consumables" data-toggle="tab">
             <span class="hidden-lg hidden-md">
-            <i class="fas fa-tint fa-2x"></i></span>
+                <i class="fas fa-tint fa-2x"></i>
+            </span>
             <span class="hidden-xs hidden-sm">{{ trans('general.consumables') }}
               {!! ($user->consumables->count() > 0 ) ? '<badge class="badge badge-secondary">'.$user->consumables->count().'</badge>' : '' !!}
             </span>
@@ -71,7 +72,8 @@
         <li>
           <a href="#files" data-toggle="tab">
             <span class="hidden-lg hidden-md">
-            <i class="far fa-file fa-2x"></i></span>
+                <i class="far fa-file fa-2x"></i>
+            </span>
             <span class="hidden-xs hidden-sm">{{ trans('general.file_uploads') }}
               {!! ($user->uploads->count() > 0 ) ? '<badge class="badge badge-secondary">'.$user->uploads->count().'</badge>' : '' !!}
             </span>
@@ -81,7 +83,8 @@
         <li>
           <a href="#history" data-toggle="tab">
             <span class="hidden-lg hidden-md">
-            <i class="fas fa-history fa-2x"></i></span>
+                <i class="fas fa-history fa-2x"></i>
+            </span>
             <span class="hidden-xs hidden-sm">{{ trans('general.history') }}</span>
           </a>
         </li>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -345,7 +345,7 @@
                       <div class="row">
 
                         <div class="col-md-3">
-                          {{ trans('admin/users/table.employee_num') }}<
+                          {{ trans('admin/users/table.employee_num') }}
                         </div>
                         <div class="col-md-9">
                           {{ $user->employee_num }}

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -799,6 +799,7 @@
         <div class="tab-pane" id="history">
           <div class="table-responsive">
 
+
             <table
                     data-click-to-select="true"
                     data-cookie-id-table="usersHistoryTable"
@@ -810,7 +811,6 @@
                     data-show-export="true"
                     data-show-refresh="true"
                     data-sort-order="desc"
-                    data-toolbar="#toolbar"
                     id="usersHistoryTable"
                     class="table table-striped snipe-table"
                     data-url="{{ route('api.activity.index', ['target_id' => $user->id, 'target_type' => 'user']) }}"


### PR DESCRIPTION
This PR extends the bulk asset edit functionality to more screens where listings of assets appear. I broke the bulk asset edit toolbar into a partial, and then included it where it made sense. 

In order to handle the usability mess of always redirecting back to the /hardware page, I determine the referer in the router that handles bulk asset tasks (`app/Http/Controllers/Assets/BulkAssetController@edit`) and then stash that in the session. Once the bulk action has been completed, we drop that value from the session so it doesn't get confused if you bulk edit from a few different places. (I'm pretty pleased with that solution tbh.)

This is not yet 100% across the boards, as there is some wonkiness I still need to look into, such as:

- Inconsistent display width of the bulk edit box (sometimes normal, sometimes not wide enough). I'm sure there some dumb HTML nonsense I'm overlooking, but I can tweak that later on. 
- Need to tweak the JS in bootstrap tables to handle the toolbars - specifically the functionality where the "go" button only gets clickable if you've selected at least one checkbox. We end up with two CSS IDs that are the same for asset bulk edit and models bulk edit. This only happens on pages where both models and assets can be bulk edited. 

<img width="404" alt="Screen Shot 2022-05-06 at 5 25 28 AM" src="https://user-images.githubusercontent.com/197404/167131343-cbb71c7b-1f83-410c-9b41-6b1953bfcc0b.png">
<img width="297" alt="Screen Shot 2022-05-06 at 5 26 06 AM" src="https://user-images.githubusercontent.com/197404/167131346-53e46cbd-bf5e-4c57-b4d6-b2df07782e82.png">

Both of these things will be addressed in future PRs, but this seems like it's better than what we had for now. This fixes #11026.
