### PR TITLE
Remove extraneous `{` in migration

### DIFF
--- a/database/migrations/2015_09_21_235926_create_custom_field_custom_fieldset.php
+++ b/database/migrations/2015_09_21_235926_create_custom_field_custom_fieldset.php
@@ -13,7 +13,6 @@ class CreateCustomFieldCustomFieldset extends Migration
     public function up()
     {
         Schema::create('custom_field_custom_fieldset', function (Blueprint $table) {
-		{
             $table->bigIncrements('id');
             $table->integer('custom_field_id');
             $table->integer('custom_fieldset_id');


### PR DESCRIPTION
It looks like we inadvertently got an extra `{` in here - I noticed it because my IDE threw a big red dot on this migration. We must've accidentally put that in when we were adding the 'id' column.

I feel a little weirded-out that nobody's reported it though. I would've figured _someone_ would've run into this before now?