### PR TITLE
WIP: Trying to make LDAP login search subtrees for accounts to log into

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -959,6 +959,7 @@ class SettingsController extends Controller
             $setting->ldap_dept = $request->input('ldap_dept');
             $setting->ldap_client_tls_cert   = $request->input('ldap_client_tls_cert');
             $setting->ldap_client_tls_key    = $request->input('ldap_client_tls_key');
+            $setting->ldap_append_basedn_to_username = $request->input('ldap_append_basedn_to_username','0');
 
 
         }

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -132,7 +132,10 @@ class Ldap extends Model
         \Log::debug("The calculated LDAP username IS: ".print_r(array_change_key_case($user)[$ldap_username_field],true));
 
         $username = array_change_key_case($user)[$ldap_username_field][0]; // TODO - is this right?
-        $userDn = $ldap_username_field.'='.$username.','.$settings->ldap_basedn; // FIXME (do we still append basedn?) <- this was the 'classic' way of assembling a userDn - simple string appends
+        $userDn = $ldap_username_field.'='.$username;
+        if ( $settings->ldap_append_basedn_to_username ) { // TODO - we *could* actually disable/enable this field based on whether AD is on or not? (it will be ignored if AD is on, right?)
+            $userDn .= ','.$settings->ldap_basedn;
+        }
         \Log::debug("initial username we think is: $userDn");
         // *Now* we should try to bind as that found user
         // first, AD has its own username-assembly system

--- a/database/migrations/2022_05_10_032248_add_append_base_d_n_checkbox_to_ldap_settings.php
+++ b/database/migrations/2022_05_10_032248_add_append_base_d_n_checkbox_to_ldap_settings.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAppendBaseDNCheckboxToLdapSettings extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->boolean('ldap_append_basedn_to_username')->default(1)->after('ldap_basedn');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('ldap_append_basedn_to_username');
+        });
+    }
+}

--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -99,6 +99,7 @@ return [
     'ldap_country'              => 'LDAP Country',
     'ldap_pword'                => 'LDAP Bind Password',
     'ldap_basedn'               => 'Base Bind DN',
+    'ldap_append_basedn_to_username' => 'Append "," and Base DN to username',
     'ldap_filter'               => 'LDAP Filter',
     'ldap_pw_sync'              => 'LDAP Password Sync',
     'ldap_pw_sync_help'         => 'Uncheck this box if you do not wish to keep LDAP passwords synced with local passwords. Disabling this means that your users may not be able to login if your LDAP server is unreachable for some reason.',

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -256,6 +256,20 @@
                             </div>
                         </div>
 
+                        <!-- LDAP append basedn to username -->
+                        <div class="form-group {{ $errors->has('ldap_basedn') ? 'error' : '' }}">
+                            <div class="col-md-3">
+                                {{ Form::label('ldap_append_basedn_to_username', trans('admin/settings/general.ldap_append_basedn_to_username')) }}
+                            </div>
+                            <div class="col-md-9">
+                                {{ Form::checkbox('ldap_append_basedn_to_username', '1', Request::old('ldap_append_basedn_to_username', $setting->ldap_append_basedn_to_username), [((config('app.lock_passwords')===true)) ? 'disabled ': '', 'class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                {!! $errors->first('ldap_append_basedn_to_username', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                @if (config('app.lock_passwords')===true)
+                                    <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
+                                @endif
+                            </div>
+                        </div>
+
                         <!-- LDAP filter -->
                         <div class="form-group {{ $errors->has('ldap_filter') ? 'error' : '' }}">
                             <div class="col-md-3">


### PR DESCRIPTION
Possible fix for #9903 - allowing logins to access the entire subtree.

Since we *already* do a query to grab the attributes for the user in question, but we do so *after* we have bound as that user, we can flip that around, and do a search first, and *then* do the 'bind', as that found user, and that should work.

As I was thinking about it, I figured that I might be able to do this as just one change that modifies how the current system works. But I think it's going to break too many people - way too many - and is going to set our helpdesk (and GitHub) on fire. So I'm probably going to have to add that "Classic-vs-Subtree" mode-switch in there somewhere, anyways. I hate that, because I hate to hold on to that bit of complexity - but I also don't want to break existing, working configs.

But, regardless, if you want to see what the subtree logic might look like, this would be it.

Lots of `TODO` and `FIXME` and tons of debugging that I should rip out, and definitely a few unanswered questions that I should probably handle, too. But, this is what I got so far. Just would love some eyes on this to see if it possibly handles some use cases that are out there.