### PR TITLE
Fixed - No action logs registered during check in or check out for editable attribute fields

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -6,14 +6,13 @@ use App\Events\CheckoutableCheckedIn;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetCheckinRequest;
-use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\CheckoutAcceptance;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\View;
-use App\Observers\AssetObserver;
+
 
 class AssetCheckinController extends Controller
 {
@@ -133,7 +132,6 @@ class AssetCheckinController extends Controller
 
         // Was the asset updated?
         if ($asset->save()) {
-
             event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $checkin_at));
 
             if ((isset($user)) && ($backto == 'user')) {
@@ -145,5 +143,4 @@ class AssetCheckinController extends Controller
         // Redirect to the asset management page with error
         return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.checkin.error').$asset->getErrors());
     }
-
 }

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -6,12 +6,14 @@ use App\Events\CheckoutableCheckedIn;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetCheckinRequest;
+use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\CheckoutAcceptance;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\View;
+use App\Observers\AssetObserver;
 
 class AssetCheckinController extends Controller
 {
@@ -131,6 +133,7 @@ class AssetCheckinController extends Controller
 
         // Was the asset updated?
         if ($asset->save()) {
+
             event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $checkin_at));
 
             if ((isset($user)) && ($backto == 'user')) {
@@ -142,4 +145,5 @@ class AssetCheckinController extends Controller
         // Redirect to the asset management page with error
         return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.checkin.error').$asset->getErrors());
     }
+
 }

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -13,7 +13,6 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\View;
 
-
 class AssetCheckinController extends Controller
 {
     /**

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -17,14 +17,8 @@ class AssetObserver
      */
     public function updating(Asset $asset)
     {
-        $attributes = $asset->getAttributes();
-        $attributesOriginal = $asset->getOriginal();
-        
-        // If the asset isn't being checked out or audited, log the update.
-        // (Those other actions already create log entries.)
-          if (($attributes['assigned_to'] == $attributesOriginal['assigned_to'])
-            && ((isset( $attributes['next_audit_date']) ? $attributes['next_audit_date'] : null) == (isset($attributesOriginal['next_audit_date']) ? $attributesOriginal['next_audit_date']: null))
-            && ($attributes['last_checkout']   == $attributesOriginal['last_checkout']))
+        // if anything changes on the model level of the asset an action log will be registered.
+        if($asset->isDirty())
         {
             $changed = [];
 


### PR DESCRIPTION
# Description

Edits you would make during the check in or check out process (e.g name change) would not register with the Asset observer as a change due to the fact it was still with the same user.

This does remove `if (($attributes['assigned_to'] == $attributesOriginal['assigned_to'])
            && ((isset( $attributes['next_audit_date']) ? $attributes['next_audit_date'] : null) == (isset($attributesOriginal['next_audit_date']) ? $attributesOriginal['next_audit_date']: null))
            && ($attributes['last_checkout']   == $attributesOriginal['last_checkout']))` because it was conflicting.

Fixes # FD27546

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
