### PR TITLE
Fixed validation for purchase cost allowed to be negative

### DIFF
--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -61,7 +61,7 @@ class Accessory extends SnipeModel
         'category_id'       => 'required|integer|exists:categories,id',
         'company_id'        => 'integer|nullable',
         'min_amt'           => 'integer|min:0|nullable',
-        'purchase_cost'     => 'numeric|nullable',
+        'purchase_cost'     => 'numeric|nullable|gte:0',
     ];
 
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -111,7 +111,7 @@ class Asset extends Depreciable
         'asset_tag'       => 'required|min:1|max:255|unique_undeleted',
         'status'          => 'integer',
         'serial'          => 'unique_serial|nullable',
-        'purchase_cost'   => 'numeric|nullable',
+        'purchase_cost'   => 'numeric|nullable|gte:0',
         'next_audit_date' => 'date|nullable',
         'last_audit_date' => 'date|nullable',
         'supplier_id'     => 'exists:suppliers,id|nullable',

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -36,7 +36,7 @@ class Component extends SnipeModel
         'company_id'     => 'integer|nullable',
         'min_amt'        => 'integer|min:0|nullable',
         'purchase_date'  => 'date|nullable',
-        'purchase_cost'  => 'numeric|nullable',
+        'purchase_cost'  => 'numeric|nullable|gte:0',
     ];
 
     /**

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -39,7 +39,7 @@ class Consumable extends SnipeModel
         'category_id' => 'required|integer',
         'company_id'  => 'integer|nullable',
         'min_amt'     => 'integer|min:0|nullable',
-        'purchase_cost'   => 'numeric|nullable',
+        'purchase_cost'   => 'numeric|nullable|gte:0',
     ];
 
     /**

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -48,6 +48,7 @@ class License extends Depreciable
         'notes'   => 'string|nullable',
         'category_id' => 'required|exists:categories,id',
         'company_id' => 'integer|nullable',
+        'purchase_cost'=> 'numeric|nullable|gte:0',
     ];
 
     /**

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -91,6 +91,10 @@ return [
     'url'                  => 'The :attribute format is invalid.',
     'unique_undeleted'     => 'The :attribute must be unique.',
     'non_circular'         => 'The :attribute must not create a circular reference.',
+    'gte'                  => [
+        'numeric'          => 'Value cannot be negative'
+    ],
+
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
# Description
Prevents users from entering negative values for purchase cost. Zero is the minimum cost allowed.

<img width="420" alt="image" src="https://user-images.githubusercontent.com/47435081/167740152-67c84fbb-5790-4c2d-8293-29546551c643.png">



Fixes # SC18989

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
