### PR TITLE
Make sure to decrypt Textareas as well as input type=text

### DIFF
--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -12,8 +12,7 @@
                   Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, htmlspecialchars($item->{$field->db_column_name()}, ENT_QUOTES)) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
 
               @elseif ($field->element=='textarea')
-                      <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ Request::old($field->db_column_name(),(isset($item) ? $item->{$field->db_column_name()} : $field->defaultValue($model->id))) }}</textarea>
-
+                      <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ Request::old($field->db_column_name(), Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}), (isset($item) ? $item->{$field->db_column_name()} : $field->defaultValue($model->id))) }}</textarea>
 
               @elseif ($field->element=='checkbox')
                     <!-- Checkboxes -->


### PR DESCRIPTION
Fixes #6180 . We correct decrypt fields that display as: `<input type='text'>` but we don't do the same for `<textarea>`. This fixes that oversight.

This isn't super-urgent in that it's been a problem for some time, and we haven't heard a lot about it. But I think we can do this soon after v6 launches.