### PR TITLE
Fixed kit checkout permissions if admin is not superadmin

### DIFF
--- a/app/Http/Controllers/Kits/CheckoutKitController.php
+++ b/app/Http/Controllers/Kits/CheckoutKitController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Kits;
 use App\Http\Controllers\CheckInOutRequest;
 use App\Http\Controllers\Controller;
 use App\Models\PredefinedKit;
+use App\Models\Asset;
 use App\Models\PredefinedLicence;
 use App\Models\PredefinedModel;
 use App\Models\User;

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -83,6 +83,18 @@ abstract class SnipePermissionsPolicy
         return $user->hasAccess($this->columnName().'.edit');
     }
 
+
+    /**
+     * Determine whether the user can update the accessory.
+     *
+     * @param  \App\Models\User  $user
+     * @return mixed
+     */
+    public function checkout(User $user, $item = null)
+    {
+        return $user->hasAccess($this->columnName().'.checkout');
+    }
+
     /**
      * Determine whether the user can delete the accessory.
      *

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -292,13 +292,6 @@ return array(
             'note'       => '',
             'display'    => true,
         ),
-
-        array(
-            'permission' => 'kits.checkout',
-            'label'      => 'Checkout ',
-            'note'       => '',
-            'display'    => true,
-        ),
     ),
 
 


### PR DESCRIPTION
This is kind of a shit solution to a bigger problem. Kits have always had a problem since it was first introduced, and this does NOT solve that problem - it just puts it back to the back the way it was before (which was kinda broken.)

The real issue is that there should never have been a Kits:checkout permission. Kits are just a collection of things, so if you don't have permission to check out assets, you shouldn't be able to check out assets via kit. 

Kits will be completely revamped after v6 launches on Friday, but this at least restores the previous functionality. A change we made recently removed the checkout button from kits if you were not a superadmin - which kinda makes sense, since a superadmin would have the ability to check out all of the things within a kit (assets, licenses, etc). You may still hit forbidden errors if you don't have asset checkout permission as a non-super admin, but that part was always true anyway. I suspect the majority of use cases here use assets as the primary thing that's being checked out. 