### PR TITLE
Fix cancel button in two-factor sign-in screen

### DIFF
--- a/resources/views/auth/two_factor.blade.php
+++ b/resources/views/auth/two_factor.blade.php
@@ -42,15 +42,16 @@
                             <button class="btn btn-lg btn-primary btn-block">{{ trans('general.submit')  }}</button>
                         </div>
                         <div class="col-md-12 col-sm-12 col-xs-12 text-right" style="padding-top: 10px;">
-                            <a href="{{ route('logout') }}" onclick="function (event) { event.preventDefault(); document.getElementById('logout-form').submit();}">
+                            <a href="{{ route('logout') }}" onclick="document.getElementById('logout-form').submit(); return false;">
                                 {{ trans('general.cancel')  }}
                             </a>
-                            <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
-                            {{ csrf_field() }}
-                            </form>
                         </div>
             </div>
             </form>
+            <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+            {{ csrf_field() }}
+            </form>
+
         </div>
     </div>
 


### PR DESCRIPTION
The 'cancel' button was broken because we try to POST to /logout rather than just GET.

This throws in a little bit of JS to instead submit an invisible logout form.