### PR TITLE
Try conditional formatting to support apache 2.2 and 2.4

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -37,6 +37,22 @@
 </IfModule>
 Options -Indexes
 
-<Files "web.config">
-    Deny from all
-</Files>
+# DENY ACCESS TO IIS CONFIG FILE
+
+# Apache 2.2+
+<IfModule !authz_core_module>
+	<Files "web.config">
+	    Order allow,deny
+    	Deny from all
+    </Files>
+</IfModule>
+
+# Apache 2.4+
+<IfModule authz_core_module>
+	<Files "web.config">
+      Require all denied
+    </Files>
+</IfModule>
+
+
+


### PR DESCRIPTION
This was broken for 2.4 when we denied access to the web.config file. I haven't tested this since we don't run apache anywhere.