### PR TITLE
Fixed #11052 - add file sizes to upload displays

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1059,4 +1059,34 @@ class Helper
 
         return $file_name;
     }
+
+    public static function formatFilesizeUnits($bytes)
+    {
+        if ($bytes >= 1073741824)
+        {
+            $bytes = number_format($bytes / 1073741824, 2) . ' GB';
+        }
+        elseif ($bytes >= 1048576)
+        {
+            $bytes = number_format($bytes / 1048576, 2) . ' MB';
+        }
+        elseif ($bytes >= 1024)
+        {
+            $bytes = number_format($bytes / 1024, 2) . ' KB';
+        }
+        elseif ($bytes > 1)
+        {
+            $bytes = $bytes . ' bytes';
+        }
+        elseif ($bytes == 1)
+        {
+            $bytes = $bytes . ' byte';
+        }
+        else
+        {
+            $bytes = '0 bytes';
+        }
+
+        return $bytes;
+    }
 }

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -115,6 +115,7 @@ return [
     'files'                 => 'Files',
     'file_name'				=> 'File',
     'file_type'             => 'File Type',
+    'filesize'              => 'File Size',
     'file_uploads'			=> 'File Uploads',
     'file_upload'           => 'File Upload',
     'generate'				=> 'Generate',

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1122,6 +1122,7 @@
                       data-id-table="assetFileHistory"
                       data-search="true"
                       data-side-pagination="client"
+                      data-sortable="true"
                       data-show-columns="true"
                       data-show-refresh="true"
                       data-sort-order="desc"
@@ -1134,12 +1135,13 @@
                                             data-cookie-id-table="assetFileHistory">
                                         <thead>
                                         <tr>
-                                            <th data-visible="true" data-field="icon">{{trans('general.file_type')}}</th>
-                                            <th class="col-md-2" data-searchable="true" data-visible="true" data-field="notes">{{ trans('general.notes') }}</th>
+                                            <th data-visible="true" data-field="icon" data-sortable="true">{{trans('general.file_type')}}</th>
                                             <th class="col-md-2" data-searchable="true" data-visible="true" data-field="image">{{ trans('general.image') }}</th>
-                                            <th class="col-md-2" data-searchable="true" data-visible="true" data-field="filename">{{ trans('general.file_name') }}</th>
-                                            <th class="col-md-2" data-searchable="true" data-visible="true" data-field="download">{{ trans('general.download') }}</th>
-                                            <th class="col-md-2" data-searchable="true" data-visible="true" data-field="created_at">{{ trans('general.created_at') }}</th>
+                                            <th class="col-md-2" data-searchable="true" data-visible="true" data-field="filename" data-sortable="true">{{ trans('general.file_name') }}</th>
+                                            <th class="col-md-1" data-searchable="true" data-visible="true" data-field="filesize">{{ trans('general.filesize') }}</th>
+                                            <th class="col-md-2" data-searchable="true" data-visible="true" data-field="notes" data-sortable="true">{{ trans('general.notes') }}</th>
+                                            <th class="col-md-1" data-searchable="true" data-visible="true" data-field="download">{{ trans('general.download') }}</th>
+                                            <th class="col-md-2" data-searchable="true" data-visible="true" data-field="created_at" data-sortable="true">{{ trans('general.created_at') }}</th>
                                             <th class="col-md-1" data-searchable="true" data-visible="true" data-field="actions">{{ trans('table.actions') }}</th>
                                         </tr>
                                         </thead>
@@ -1148,11 +1150,6 @@
                                         @foreach ($asset->uploads as $file)
                                             <tr>
                                                 <td><i class="{{ Helper::filetype_icon($file->filename) }} icon-med" aria-hidden="true"></i></td>
-                                                <td>
-                                                    @if ($file->note)
-                                                        {{ $file->note }}
-                                                    @endif
-                                                </td>
                                                 <td>
                                                     @if ( Helper::checkUploadIsImage($file->get_src('assets')))
                                                         <a href="{{ route('show/assetfile', ['assetId' => $asset->id, 'fileId' =>$file->id]) }}" data-toggle="lightbox" data-type="image" data-title="{{ $file->filename }}" data-footer="{{ Helper::getFormattedDateObject($asset->last_checkout, 'datetime', false) }}">
@@ -1163,6 +1160,14 @@
                                                 <td>
                                                     {{ $file->filename }}
                                                 </td>
+                                                <td data-value="{{ filesize(storage_path('private_uploads/assets/').$file->filename) }}">
+                                                    {{ Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/assets/').$file->filename)) }}
+                                                </td>
+                                                <td>
+                                                    @if ($file->note)
+                                                        {{ $file->note }}
+                                                    @endif
+                                                </td>
                                                 <td>
                                                     @if ($file->filename)
                                                         <a href="{{ route('show/assetfile', [$asset->id, $file->id]) }}" class="btn btn-default">
@@ -1170,14 +1175,11 @@
                                                         </a>
                                                     @endif
                                                 </td>
-
                                                 <td>
                                                     @if ($file->created_at)
                                                         {{ Helper::getFormattedDateObject($file->created_at, 'datetime', false) }}
                                                     @endif
                                                 </td>
-
-
                                                 <td>
                                                     @can('update', \App\Models\Asset::class)
                                                         <a class="btn delete-asset btn-sm btn-danger btn-sm" href="{{ route('delete/assetfile', [$asset->id, $file->id]) }}" data-tooltip="true" data-title="Delete" data-content="{{ trans('general.delete_confirm', ['item' => $file->filename]) }}"><i class="fas fa-trash icon-white" aria-hidden="true"></i></a>

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -454,13 +454,14 @@
                     }'>
             <thead>
               <tr>
-                <th data-visible="true" aria-hidden="true">{{ trans('admin/hardware/table.icon') }}</th>
-                <th class="col-md-3" data-field="file_name" data-visible="true" data-sortable="true" data-switchable="true">{{ trans('general.file_name') }}</th>
-                <th class="col-md-3" data-field="notes" data-visible="true" data-sortable="true" data-switchable="true">{{ trans('general.notes') }}</th>
-                <th class="col-md-2" data-field="created_at" data-visible="true"  data-sortable="true" data-switchable="true">{{ trans('general.created_at') }}</th>
-                <th class="col-md-2" data-searchable="true" data-visible="true">{{ trans('general.image') }}</th>
-                <th class="col-md-2" data-field="download" data-visible="true"  data-sortable="false" data-switchable="true">{{ trans('general.download') }}</th>
-                <th class="col-md-2" data-field="delete" data-visible="true"  data-sortable="false" data-switchable="true">{{ trans('general.delete') }}</th>
+                <th data-visible="true" data-field="icon" data-sortable="true">{{trans('general.file_type')}}</th>
+                <th class="col-md-2" data-searchable="true" data-visible="true" data-field="image">{{ trans('general.image') }}</th>
+                <th class="col-md-2" data-searchable="true" data-visible="true" data-field="filename" data-sortable="true">{{ trans('general.file_name') }}</th>
+                <th class="col-md-1" data-searchable="true" data-visible="true" data-field="filesize">{{ trans('general.filesize') }}</th>
+                <th class="col-md-2" data-searchable="true" data-visible="true" data-field="notes" data-sortable="true">{{ trans('general.notes') }}</th>
+                <th class="col-md-1" data-searchable="true" data-visible="true" data-field="download">{{ trans('general.download') }}</th>
+                <th class="col-md-2" data-searchable="true" data-visible="true" data-field="created_at" data-sortable="true">{{ trans('general.created_at') }}</th>
+                <th class="col-md-1" data-searchable="true" data-visible="true" data-field="actions">{{ trans('table.actions') }}</th>
               </tr>
             </thead>
             <tbody>
@@ -473,21 +474,23 @@
 
                 </td>
                 <td>
-                  {{ $file->filename }}
-
+                  @if ($file->filename)
+                    @if ( Helper::checkUploadIsImage($file->get_src('licenses')))
+                      <a href="{{ route('show.licensefile', ['licenseId' => $license->id, 'fileId' => $file->id, 'download' => 'false']) }}" data-toggle="lightbox" data-type="image"><img src="{{ route('show.licensefile', ['licenseId' => $license->id, 'fileId' => $file->id]) }}" class="img-thumbnail" style="max-width: 50px;"></a>
+                    @endif
+                  @endif
                 </td>
+                <td>
+                  {{ $file->filename }}
+                </td>
+                <td data-value="{{ filesize(storage_path('private_uploads/licenses/').$file->filename) }}">
+                  {{ Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/licenses/').$file->filename)) }}
+                </td>
+
                 <td>
                   @if ($file->note)
                     {{ $file->note }}
                   @endif
-                </td>
-                <td>{{ $file->created_at }}</td>
-                <td>
-                @if ($file->filename)
-                    @if ( Helper::checkUploadIsImage($file->get_src('licenses')))
-                      <a href="{{ route('show.licensefile', ['licenseId' => $license->id, 'fileId' => $file->id, 'download' => 'false']) }}" data-toggle="lightbox" data-type="image"><img src="{{ route('show.licensefile', ['licenseId' => $license->id, 'fileId' => $file->id]) }}" class="img-thumbnail" style="max-width: 50px;"></a>
-                    @endif
-                @endif
                 </td>
                 <td>
                   @if ($file->filename)
@@ -497,6 +500,7 @@
                     </a>
                   @endif
                 </td>
+                <td>{{ $file->created_at }}</td>
                 <td>
                   <a class="btn delete-asset btn-danger btn-sm" href="{{ route('delete/licensefile', [$license->id, $file->id]) }}" data-content="{{ trans('general.delete_confirm', array('item' => $file)) }}" data-title="{{ trans('general.delete') }} {{ $file->filename }}?">
                     <i class="fas fa-trash icon-white" aria-hidden="true"></i>
@@ -507,7 +511,7 @@
               @endforeach
             @else
               <tr>
-              <td colspan="6">{{ trans('general.no_results') }}</td>
+              <td colspan="8">{{ trans('general.no_results') }}</td>
               </tr>
             @endif
             </tbody>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -757,38 +757,83 @@
 
             <div class="col-md-12 col-sm-12">
               <div class="table-responsive">
-                <table id="files-table" class="table display table-striped">
+                  <table
+                          data-cookie-id-table="userUploadsTable"
+                          data-id-table="userUploadsTable"
+                          id="userUploadsTable"
+                          data-search="true"
+                          data-pagination="true"
+                          data-side-pagination="client"
+                          data-show-columns="true"
+                          data-show-export="true"
+                          data-show-footer="true"
+                          data-toolbar="#upload-toolbar"
+                          data-show-refresh="true"
+                          data-sort-order="asc"
+                          data-sort-name="name"
+                          class="table table-striped snipe-table"
+                          data-export-options='{
+                    "fileName": "export-license-uploads-{{ str_slug($license->name) }}-{{ date('Y-m-d') }}",
+                    "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","delete","download","icon"]
+                    }'>
+
                   <thead>
                     <tr>
-                      <th class="col-md-5">{{ trans('general.notes') }}</th>
-                      <th class="col-md-5"><span class="line"></span>{{ trans('general.file_name') }}</th>
-                      <th class="col-md-2">{{ trans('general.download') }}</th>
-                      <th class="col-md-2">{{ trans('general.delete') }}</th>
+                        <th data-visible="true" data-field="icon" data-sortable="true">{{trans('general.file_type')}}</th>
+                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="image">{{ trans('general.image') }}</th>
+                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="filename" data-sortable="true">{{ trans('general.file_name') }}</th>
+                        <th class="col-md-1" data-searchable="true" data-visible="true" data-field="filesize">{{ trans('general.filesize') }}</th>
+                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="notes" data-sortable="true">{{ trans('general.notes') }}</th>
+                        <th class="col-md-1" data-searchable="true" data-visible="true" data-field="download">{{ trans('general.download') }}</th>
+                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="created_at" data-sortable="true">{{ trans('general.created_at') }}</th>
+                        <th class="col-md-1" data-searchable="true" data-visible="true" data-field="actions">{{ trans('table.actions') }}</th>
                     </tr>
                   </thead>
                   <tbody>
                     @foreach ($user->uploads as $file)
-                    <tr>
-                      <td>
-                        @if ($file->note)
-                        {{ $file->note }}
-                        @endif
-                      </td>
-                      <td>
-                      {{ $file->filename }}
-                      </td>
-                      <td>
-                        @if ($file->filename)
-                        <a href="{{ route('show/userfile', [$user->id, $file->id]) }}" class="btn btn-default">{{ trans('general.download') }}</a>
-                        @endif
-                      </td>
-                      <td>
-                        @can('update', $user)
-                        <a class="btn delete-asset btn-danger btn-sm hidden-print" href="{{ route('userfile.destroy', [$user->id, $file->id]) }}" data-content="Are you sure you wish to delete this file?" data-title="Delete {{ $file->filename }}?"><i class="fas fa-trash icon-white" aria-hidden="true"></i><span class="sr-only">Delete</span></a>
-                        @endcan
-                      </td>
-                    </tr>
+                        <tr>
+                            <td>
+                                <i class="{{ Helper::filetype_icon($file->filename) }} icon-med" aria-hidden="true"></i>
+                                <span class="sr-only">{{ Helper::filetype_icon($file->filename) }}</span>
+
+                            </td>
+                            <td>
+                                @if ($file->filename)
+                                    @if ( Helper::checkUploadIsImage($file->get_src('users')))
+                                        <a href="{{ route('show/userfile', ['userId' => $user->id, 'fileId' => $file->id, 'download' => 'false']) }}" data-toggle="lightbox" data-type="image"><img src="{{ route('show/userfile', ['userId' => $user->id, 'fileId' => $file->id]) }}" class="img-thumbnail" style="max-width: 50px;"></a>
+                                    @endif
+                                @endif
+                            </td>
+                            <td>
+                                {{ $file->filename }}
+                            </td>
+                            <td>
+                                {{ Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/users/').$file->filename)) }}
+                            </td>
+
+                            <td>
+                                @if ($file->note)
+                                    {{ $file->note }}
+                                @endif
+                            </td>
+                            <td>
+                                @if ($file->filename)
+                                    <a href="{{ route('show/userfile', [$user->id, $file->id]) }}" class="btn btn-default">
+                                        <i class="fas fa-download" aria-hidden="true"></i>
+                                        <span class="sr-only">{{ trans('general.download') }}</span>
+                                    </a>
+                                @endif
+                            </td>
+                            <td>{{ $file->created_at }}</td>
+                            <td>
+                                <a class="btn delete-asset btn-danger btn-sm" href="{{ route('delete/licensefile', [$license->id, $file->id]) }}" data-content="{{ trans('general.delete_confirm', array('item' => $file)) }}" data-title="{{ trans('general.delete') }} {{ $file->filename }}?">
+                                    <i class="fas fa-trash icon-white" aria-hidden="true"></i>
+                                    <span class="sr-only">{{ trans('general.delete') }}</span>
+                                </a>
+                            </td>
+                        </tr>
                     @endforeach
+
                   </tbody>
                 </table>
               </div>


### PR DESCRIPTION
This adds file sizes to the uploads display.

This is ready for review and merge, but we do need to add in the storage facades so we can handle this properly for S3.

Also todo: figure out the correct data value for the td to assign the numeric value as the sort value while still displaying the formatting value (dates, file sizes, etc) in the column.

Fixes #11052