### PR TITLE
Fixed missing backups help string

### DIFF
--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -28,6 +28,7 @@ return [
     'auto_increment_prefix'		=> 'Prefix (optional)',
     'auto_incrementing_help'    => 'Enable auto-incrementing asset tags first to set this',
     'backups'					=> 'Backups',
+    'backups_help'              => 'Create, download, and restore backups ',
     'backups_restoring'         => 'Restoring from Backup',
     'backups_upload'            => 'Upload Backup',
     'backups_path'              => 'Backups on the server are stored in <code>:path</code>',


### PR DESCRIPTION
Adds the missing string for the settings overview page