### PR TITLE
Only set manager ID when the lookup succeeds.

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -213,12 +213,14 @@ class LdapSync extends Command
                 $user->country = $item['country'];
                 $user->department_id = $department->id;
 
-                if($item['manager']!= null) {
+                if($item['manager'] != null) {
                     //Captures only the Canonical Name
                     $item['manager'] = ltrim($item['manager'], "CN=");
                     $item['manager'] = substr($item['manager'],0, strpos($item['manager'], ','));
                     $ldap_manager = User::where('username', $item['manager'])->first();
-                    $user->manager_id = $ldap_manager->id;
+                    if ( $ldap_manager && isset($ldap_manager->id) ) {
+                        $user->manager_id = $ldap_manager->id;
+                    }
                 }
 
 


### PR DESCRIPTION
Fixes #11086 - problem with Manager sync in LDAP.

If you have a manager configured but that manager doesn't exist on Snipe-IT, the LDAP sync will error out. One way to do this is create a user in your directory without a First Name, and assign that user as a manager of somebody. Snipe-IT will not allow a user without a first name to be created, so the LDAP sync errors out.

This just adds a simple guard condition to keep the sync running. This does mean if you set someone's manager to be a real user, then sync, then set their user to be someone who will not sync into Snipe-IT correctly, the old manager attribute will remain. I guess this is ok? I could see some logic in unsetting the manager attribute at that point, but let's see how often this comes up. I wwouldn't want for someone to change the manager attribute on a user and then have n LDAP sync fire and blow the data out. So that's why I decided not to unset the manager if we can't find them in Snipe-IT.