### PR TITLE
Fixed bulk-user reset-password links returning 500

### DIFF
--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -46,9 +46,9 @@ class BulkUsersController extends Controller
                 foreach ($users as $user) {
                     if (($user->activated == '1') && ($user->email != '')) {
                         $credentials = ['email' => $user->email];
-                        Password::sendResetLink($credentials, function (Message $message) {
-                            $message->subject($this->getEmailSubject());
-                        });
+                        Password::sendResetLink($credentials/* , function (Message $message) {
+                        $message->subject($this->getEmailSubject()); // TODO - I'm not sure if we still need this, but this second parameter is no longer accepted in later Laravel versions.
+                        } */ );                                      // TODO - so hopefully this doesn't give us generic password reset messages? But it at least _works_
                     }
                 }
                 return redirect()->back()->with('success', trans('admin/users/message.password_resets_sent'));


### PR DESCRIPTION
Fixes #11100 [sc-19078] - Bulk user password reset causes 500.

It seems that the signature for `Password::sendResetLink()` has changed its signature, and no longer accepts a closure as the second parameter - it just wants the first parameter, which is the `$credentials`.

This removes that second parameter with some notes for us to look back on later in case this fix removes any custom message subject we might have wanted to use for the password reset emails.