### PR TITLE
Pass the password along directly instead of retrieving it from the In…

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -185,7 +185,7 @@ class LoginController extends Controller
              Log::debug("Local user ".$request->input('username')." does not exist");
              Log::debug("Creating local user ".$request->input('username'));
 
-             if ($user = Ldap::createUserFromLdap($ldap_user)) { //this handles passwords on its own
+             if ($user = Ldap::createUserFromLdap($ldap_user, $request->input('password'))) {
                  Log::debug("Local user created.");
              } else {
                  Log::debug("Could not create local user.");

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -233,7 +233,7 @@ class Ldap extends Model
      * @param $ldapatttibutes
      * @return array|bool
      */
-    public static function createUserFromLdap($ldapatttibutes)
+    public static function createUserFromLdap($ldapatttibutes, $password)
     {
         $item = self::parseAndMapLdapAttributes($ldapatttibutes);
 
@@ -246,7 +246,8 @@ class Ldap extends Model
             $user->email = $item['email'];
 
             if (Setting::getSettings()->ldap_pw_sync == '1') {
-                $user->password = bcrypt(Input::get('password'));
+
+                $user->password = bcrypt($password);
             } else {
                 $pass = substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, 25);
                 $user->password = bcrypt($pass);


### PR DESCRIPTION
Fixes #11104 - this was affecting 'initial' logins only it seemed - if the user already exists, then it would work.

The solve is that we just pass the password along directly as opposed to trying to extract it from the Request.

I confirmed via Tinker and `Hash::check()` that the password was correctly saved.