### PR TITLE
We inadvertently used the wrong label for one of the headers

### DIFF
--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -48,7 +48,7 @@
               <th data-sortable="true">{{ trans('general.file_name') }}</th>
               <th data-sortable="true" data-field="modified_display" data-sort-name="modified_value">{{ trans('admin/settings/table.created') }}</th>
               <th data-field="modified_value" data-visible="false"></th>
-              <th data-sortable="true">{{ trans('admin/settings/table.created') }}</th>
+              <th data-sortable="true">{{ trans('admin/settings/table.size') }}</th>
               <th><span class="sr-only">{{ trans('general.delete') }}</span></th>
               </tr>
             </thead>


### PR DESCRIPTION
 on the backups page

Found this while I was trying to track down something else - we seem to repeat the same column header in the table twice; and I think we meant this second thing, instead.