### PR TITLE
Fixed #11126: don't entitise custom CSS on the labels view

### DIFF
--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -103,7 +103,7 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='')
         }
     }
     @if ($snipeSettings->custom_css)
-        {{ $snipeSettings->show_custom_css() }}
+        {!! $snipeSettings->show_custom_css() !!}
     @endif
 </style>
 


### PR DESCRIPTION
# Description

Update labels view to not entitise custom CSS as is already the case in all other views

Fixes #11126

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Generated HTML source  review
Added CSS containing double quotes and greater than signs and manually inspected the resulting (generate) HTML source code on the labels page to verify the custom CSS is not encoded
- [X] Generated labels font
Added custom CSS to use the slashed-zero variant of the "Inter" font for labels which requires the use of double quotes and verified that the CSS is correctly interpreted / rendered the browser

**Test Configuration**:
* PHP version: 8.1.6
* MySQL version: 5.6.51 (Percona Server)
* Webserver version:  httpd-2.4.6-97.el7.centos.5.x86_64
* OS version: CentOS v7


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
