### PR TITLE
Fixes #11096 Backup created_at time is incorrect

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1061,7 +1061,7 @@ class SettingsController extends Controller
                         'filename' => basename($backup_files[$f]),
                         'filesize' => Setting::fileSizeConvert(Storage::size($backup_files[$f])),
                         'modified_value' => $file_timestamp,
-                        'modified_display' => Helper::getFormattedDateObject($file_timestamp, $type = 'datetime', false),
+                        'modified_display' => date("M d, Y g:i A", $file_timestamp),
                         
                     ];
                 }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1044,7 +1044,7 @@ class SettingsController extends Controller
      */
     public function getBackups()
     {
-
+        $settings = Setting::getSettings();
         $path = 'app/backups';
         $backup_files = Storage::files($path);
         $files_raw = [];
@@ -1061,7 +1061,7 @@ class SettingsController extends Controller
                         'filename' => basename($backup_files[$f]),
                         'filesize' => Setting::fileSizeConvert(Storage::size($backup_files[$f])),
                         'modified_value' => $file_timestamp,
-                        'modified_display' => date("M d, Y g:i A", $file_timestamp),
+                        'modified_display' => date($settings->date_display_format.' '.$settings->time_display_format, $file_timestamp),
                         
                     ];
                 }


### PR DESCRIPTION
# Description
We used to display the backups dates using the `date()` function, but for v6 we changed to `Helper::getFormattedDateObject()` that uses Carbon to format the date. Where we shouldn't have any problem because we use UNIX timestamps to show the date, but I believe that in Carbon the timezone is defaulting to UTC, and don't care of the timezone that we have in the env file.

So, as I didn't want to affect the Helper function that we use in other places, I just formatted the timestamp as we used to make it before.

Fixes #11096 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
