### PR TITLE
Fixed #11124 - updated maintenance page

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -354,4 +354,6 @@ return [
     'checkout_tooltip' => 'Check this item out',
     'checkin_tooltip' => 'Check this item in',
     'checkout_user_tooltip' => 'Check this item out to a user',
+    'maintenance_mode'      => 'The service is temporarily unavailable for system updates. Please check back later.',
+    'maintenance_mode_title' => 'System Temporarily Unavilable',
 ];

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Page title --}}
 @section('title')
-System Unavailable
+  {{ trans('general.maintenance_mode_title') }}
 @parent
 @stop
 
@@ -11,35 +11,34 @@ System Unavailable
 @section('content')
 
 
-<style>
-  p {
-    font-size: 16px;
-  }
 
-  h3 {
-    padding-bottom: 10px;
-  }
-</style>
+<div class="container">
 <div class="row">
   <div class="col-md-9 col-md-offset-1">
-    <div class="col-md-2">
-      <img src="{{ url('/') }}/img/sad-panda.png" class="pull-right" style="width: 140px; height: 140px;">
+
+    <div class="box box-warning">
+
+      <div class="box-header with-border">
+        <h1 class="box-title">
+          <i class="fas fa-exclamation-triangle text-orange" aria-hidden="true"></i>
+          {{ trans('general.maintenance_mode_title') }}
+        </h1>
+      </div><!-- /.box-header -->
+
+      <div class="box-body">
+        <div class="col-md-12">
+
+          <div class="col-md-2">
+            <img src="{{ url('/') }}/img/sad-panda.png" class="pull-right" style="width: 140px; height: 140px;">
+          </div>
+          <div class="alert alert-warning fade in">
+            <h2> {{ trans('general.maintenance_mode') }}</h2>
+          </div>
+
+        </div> <!-- /.div -->
+      </div><!-- /.box-body -->
+
     </div>
-    <div class="col-md-10">
-      <div class="callout callout-danger">
-        <h2><i class="icon fas fa-exclamation-triangle"></i> System Unavailable</h2>
-      <p>{!! json_decode(file_get_contents(storage_path('framework/down')), true)['message'] !!}</p>
-      </div>
-    </div>
 
-
-
-
-
-
-
-
-
-    </div>
 </div>
 @stop


### PR DESCRIPTION
Fixed #11124. Laravel removed the `--message` option in v8. https://github.com/laravel/framework/issues/34211 

<img width="1310" alt="Screen Shot 2022-05-17 at 7 04 44 PM" src="https://user-images.githubusercontent.com/197404/168942214-8119f15f-31e4-4b7f-a403-194edd666787.png">

This moved the maintenance language into the language files - which is less ideal, but should work for most use cases.
