### PR TITLE
Delete vendor/symfony/translation/TranslatorInterface.php in upgrader

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -181,6 +181,7 @@ $unused_files = [
     "bootstrap/cache/compiled.php",
     "bootstrap/cache/services.php",
     "bootstrap/cache/config.php",
+    "vendor/symfony/translation/TranslatorInterface.php"
 ];
 
 foreach ($unused_files as $unused_file) {

--- a/upgrade.php
+++ b/upgrade.php
@@ -181,7 +181,7 @@ $unused_files = [
     "bootstrap/cache/compiled.php",
     "bootstrap/cache/services.php",
     "bootstrap/cache/config.php",
-    "vendor/symfony/translation/TranslatorInterface.php"
+    "vendor/symfony/translation/TranslatorInterface.php",
 ];
 
 foreach ($unused_files as $unused_file) {


### PR DESCRIPTION
This file isn't used anymore, and while it *shouldn't* cause problems, I have seen it happen that the importer screen 500s if this file is still there. This simply removes it to avoid having to do it manually.

Signed-off-by: snipe <snipe@snipe.net>

