### PR TITLE
Reduce saml debugging

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -104,15 +104,12 @@ class LoginController extends Controller
      */
     private function loginViaSaml(Request $request)
     {
-        \Log::debug('Attempting to login via SAML');
         $saml = $this->saml;
         $samlData = $request->session()->get('saml_login');
 
         if ($saml->isEnabled() && ! empty($samlData)) {
-            \Log::debug('SAML is enabled, and the samleData is not empty');
 
             try {
-                Log::debug('Attempting to log user in by SAML authentication.');
                 $user = $saml->samlLogin($samlData);
 
                 if (!is_null($user)) {

--- a/app/Services/Saml.php
+++ b/app/Services/Saml.php
@@ -130,11 +130,12 @@ class Saml
             $this->clearData();
         }
 
-        \Log::debug('Trying to create a new OneLogin_Saml2_Auth object ');
         try {
             $this->_auth = new OneLogin_Saml2_Auth($this->_settings);
         } catch (Exception $e) {
-            \Log::error('Trying OneLogin_Saml2_Auth failed. Setting SAML enabled to false. OneLogin_Saml2_Auth error message is: '.  $e->getMessage());
+            if ( $this->isEnabled() ) { // $this->loadSettings() initializes this to true if SAML is enabled by settings.
+                \Log::error('Trying OneLogin_Saml2_Auth failed. Setting SAML enabled to false. OneLogin_Saml2_Auth error message is: '.  $e->getMessage());
+            }
             $this->_enabled = false;
         }
     }
@@ -157,7 +158,6 @@ class Saml
         $this->_enabled = $setting->saml_enabled == '1';
 
         if ($this->isEnabled()) {
-            \Log::debug('SAML is enabled according to loadSettings()');
             //Let onelogin/php-saml know to use 'X-Forwarded-*' headers if it is from a trusted proxy
             OneLogin_Saml2_Utils::setProxyVars(request()->isFromTrustedProxy());
 


### PR DESCRIPTION
I yanked some - but not all - of the SAML debugging lines from the logs system. They really only ought to fire if some kind of weird error condition is present - like SAML being enabled, but the settings not being valid for whatever reason. This hopefully strikes more of a balance between verbosity, but still being able to detect errors and report them back, at least via logs, to the administrator.

Fixed #11117