### PR TITLE
FixesArgument 1 passed to App\Http\Requests\ItemImportRequest::import() must be an instance of App\Models\Import, null given

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -134,7 +134,14 @@ class ImportController extends Controller
             \Log::debug('NO BACKUP requested via importer');
         }
 
-        $errors = $request->import(Import::find($import_id));
+        $import = Import::find($import_id);
+
+        if(is_null($import)){
+            $error[0][0] = trans("validation.exists", ["attribute" => "file"]);
+            return response()->json(Helper::formatStandardApiResponse('import-errors', null, $error), 500);
+        }
+
+        $errors = $request->import($import);
         $redirectTo = 'hardware.index';
         switch ($request->get('import-type')) {
             case 'asset':


### PR DESCRIPTION
# Description
When processin an Import,  we make a search for a record in the DB of an Import entity. If, for some reason that record isn't found the system crashes. I put an early return if the entity is not found, so it returns an error instead of just crash without give useful feedback to the user.

Fixes rollbar 16130

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
