### PR TITLE
updated less files for license details to adhere to dark skin themes

### DIFF
--- a/resources/assets/less/skins/skin-black-dark.less
+++ b/resources/assets/less/skins/skin-black-dark.less
@@ -355,6 +355,14 @@ input[type=text], input[type=search] {
   background-color: var(--back-sub-alt);
   color: var(--text-main);
 }
+.row-new-striped > .row:nth-of-type(odd){
+  background-color: var(--back-sub);
+  color: var(--text-main);
+}
+.row-new-striped > .row:nth-of-type(even){
+  background-color: var(--back-sub-alt);
+  color: var(--text-main);
+}
 #webui>div>div>div>div>div>table>tbody>tr>td>a>i.fa, .box-body, .box-footer, .box-header {
   color: var(--text-main);
 }
@@ -406,4 +414,7 @@ a {
 
 .search-highlight, .search-highlight:hover {
   background-color: #e9d15b;
+}
+div.container.row-new-striped{
+  background-color:  var(--back-sub);
 }

--- a/resources/assets/less/skins/skin-blue-dark.less
+++ b/resources/assets/less/skins/skin-blue-dark.less
@@ -386,6 +386,14 @@ a {
   border-top: 1px solid #dddddd;
   display: table-cell;
 }
+.row-new-striped > .row:nth-of-type(odd){
+  background-color: var(--back-sub);
+  color: var(--text-main);
+}
+.row-new-striped > .row:nth-of-type(even){
+  background-color: var(--back-sub-alt);
+  color: var(--text-main);
+}
 
 .search-highlight, .search-highlight:hover {
   background-color: #e9d15b;

--- a/resources/assets/less/skins/skin-green-dark.less
+++ b/resources/assets/less/skins/skin-green-dark.less
@@ -386,6 +386,14 @@ a {
   border-top: 1px solid #dddddd;
   display: table-cell;
 }
+.row-new-striped > .row:nth-of-type(odd){
+  background-color: var(--back-sub);
+  color: var(--text-main);
+}
+.row-new-striped > .row:nth-of-type(even){
+  background-color: var(--back-sub-alt);
+  color: var(--text-main);
+}
 
 
 .search-highlight, .search-highlight:hover {

--- a/resources/assets/less/skins/skin-orange-dark.less
+++ b/resources/assets/less/skins/skin-orange-dark.less
@@ -388,7 +388,14 @@ a {
   border-top: 1px solid #dddddd;
   display: table-cell;
 }
-
+.row-new-striped > .row:nth-of-type(odd){
+  background-color: var(--back-sub);
+  color: var(--text-main);
+}
+.row-new-striped > .row:nth-of-type(even){
+  background-color: var(--back-sub-alt);
+  color: var(--text-main);
+}
 .search-highlight, .search-highlight:hover {
   background-color: #e9d15b;
 }

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -388,6 +388,14 @@ a {
   border-top: 1px solid #dddddd;
   display: table-cell;
 }
+.row-new-striped > .row:nth-of-type(odd){
+  background-color: var(--back-sub);
+  color: var(--text-main);
+}
+.row-new-striped > .row:nth-of-type(even){
+  background-color: var(--back-sub-alt);
+  color: var(--text-main);
+}
 
 .search-highlight, .search-highlight:hover {
   background-color: #e9d15b;

--- a/resources/assets/less/skins/skin-red-dark.less
+++ b/resources/assets/less/skins/skin-red-dark.less
@@ -389,6 +389,15 @@ a {
   display: table-cell;
 }
 
+.row-new-striped > .row:nth-of-type(odd){
+  background-color: var(--back-sub);
+  color: var(--text-main);
+}
+.row-new-striped > .row:nth-of-type(even){
+  background-color: var(--back-sub-alt);
+  color: var(--text-main);
+}
+
 .search-highlight, .search-highlight:hover {
   background-color: #e9d15b;
 }

--- a/resources/assets/less/skins/skin-yellow-dark.less
+++ b/resources/assets/less/skins/skin-yellow-dark.less
@@ -387,6 +387,15 @@ a {
   display: table-cell;
 }
 
+.row-new-striped > .row:nth-of-type(odd){
+  background-color: var(--back-sub);
+  color: var(--text-main);
+}
+.row-new-striped > .row:nth-of-type(even){
+  background-color: var(--back-sub-alt);
+  color: var(--text-main);
+}
+
 .search-highlight, .search-highlight:hover {
   background-color: #e9d15b;
 }


### PR DESCRIPTION
# Description
Fixes the License detail tab from not respecting the dark skin themes.

Details now look like this:
![image](https://user-images.githubusercontent.com/47435081/169110882-cc1b9e60-de78-43ec-a912-523a54b8f391.png)


Fixes #11146 

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
