### PR TITLE
Fixes Username required on import process

### DIFF
--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -3,6 +3,7 @@
 namespace App\Importer;
 
 use App\Models\Department;
+use App\Models\Setting;
 use App\Models\User;
 use App\Notifications\WelcomeNotification;
 
@@ -60,6 +61,13 @@ class UserImporter extends ItemImporter
         if ($this->shouldUpdateField($user_department)) {
             $this->item['department_id'] = $this->createOrFetchDepartment($user_department);
         }
+
+        if (is_null($this->item['username']) || $this->item['username'] == "") {
+            $user_full_name = $this->item['first_name'] . ' ' . $this->item['last_name'];
+            $user_formatted_array = User::generateFormattedNameFromFullName($user_full_name, Setting::getSettings()->username_format);
+            $this->item['username'] = $user_formatted_array['username'];
+        }
+        
         $user = User::where('username', $this->item['username'])->first();
         if ($user) {
             if (! $this->updating) {


### PR DESCRIPTION
# Description
We can import User from two types of imports: in the Asset import and in the User import. The Asset importer allows that the username is not passed in the CSV and it takes care of creating one using the Full name column. But in the User Importer we don't allow that, making the system inconsistent and our documentation wrong.

This changes calls the `User::generateFormattedNameFromFullName()` method if the user doesn't provides a username in the CSV when importing Users.

Fixes freshdesk 27955

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
