### PR TITLE
Downgrade jQuery to 3.5.1 from 3.6.0 to re-enable select2 autofocus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4224,7 +4224,7 @@
         "deep-equal": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-            "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+            "integrity": "sha1-tcmMlCzv+vfLBR4k4UNKJaLmB2o=",
             "requires": {
                 "is-arguments": "^1.0.4",
                 "is-date-object": "^1.0.1",
@@ -15624,9 +15624,9 @@
             }
         },
         "jquery": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-            "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+            "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
         },
         "jquery-form-validator": {
             "version": "2.3.79",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@fortawesome/fontawesome-free": "^5.15.4",
         "axios": "^0.20.0",
         "babel-preset-latest": "^6.24.1",
-        "jquery": "^3.6.0",
+        "jquery": "<3.6.0",
         "laravel-mix": "^6.0.39",
         "lodash": "^4.17.20",
         "postcss": "^8.4.5",


### PR DESCRIPTION
**NOTE: requires npm install/asset rebuild**

Fixes [sc-19093]. This is actually a select2+jQuery 3.6.0 bug, as documented here: https://github.com/select2/select2/issues/5993

There are several different workarounds, some that are different in a Bootstrap Modal context, and some elsewhere (we need both) - but they junk up the code and they didn't work very consistently for me - and I tried many, if not all, of them.

Instead what I went with was downgrading jQuery to 3.5.1. I was concerned that the previous version of jQuery might have some security vulnerabilities, but I didn't see anything here: https://snyk.io/vuln/npm:jquery@3.5.1 nor elsewhere, so I *think* we may be okay?

Once a newer version of Select2 is released (there is a v4.1 that is in beta), we may be able to upgrade both packages and have the autofocus still work - but it doesn't necessarily seem like that based on what I'm seeing in the Select2 repository right now.