### PR TITLE
Fixed: #11098 - Smartly overwrite fields with default values for custom fields

### DIFF
--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -151,9 +151,9 @@
                     //now re-populate the custom fields based on the previously saved values
                     $('#custom_fields_content').find('input,select').each(function (index,elem) {
                         if(transformed_oldvals[elem.name]) {
-                             {{-- If there already *is* is a previously input 'transformed_oldvals' handy, 
-                                  only overwrite with previously that value *IF* this is an edit of an existing item *OR* 
-                                  there is no new default custom field value coming from the model --}}
+                             {{-- If there already *is* is a previously-input 'transformed_oldvals' handy,
+                                  overwrite with that previously-input value *IF* this is an edit of an existing item *OR*
+                                  if there is no new default custom field value coming from the model --}}
                             if({{ $item->id ? 'true' : 'false' }} || $(elem).val() == '') {
                                 $(elem).val(transformed_oldvals[elem.name]).trigger('change'); //the trigger is for select2-based objects, if we have any
                             }

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -151,7 +151,12 @@
                     //now re-populate the custom fields based on the previously saved values
                     $('#custom_fields_content').find('input,select').each(function (index,elem) {
                         if(transformed_oldvals[elem.name]) {
-                            $(elem).val(transformed_oldvals[elem.name]).trigger('change'); //the trigger is for select2-based objects, if we have any
+                             {{-- If there already *is* is a previously input 'transformed_oldvals' handy, 
+                                  only overwrite with previously that value *IF* this is an edit of an existing item *OR* 
+                                  there is no new default custom field value coming from the model --}}
+                            if({{ $item->id ? 'true' : 'false' }} || $(elem).val() == '') {
+                                $(elem).val(transformed_oldvals[elem.name]).trigger('change'); //the trigger is for select2-based objects, if we have any
+                            }
                         }
 
                     });


### PR DESCRIPTION
When you're creating *or* editing a new asset, we try and be 'smart' and copy custom field values that you've already input into the new custom fields whenever you switch models.

This gets a little tricker when we are dealing with custom fields with per-model default values.

The logic I went with is: if you are editing an _existing_ asset, always try to do those same intelligent overwrites (if there was a value there already).

However, if you're creating a _new_ asset, only do that same intelligent overwrites if there _isn't_ a default value.

So let me give an example - I created a new custom field with default values for "rack units" - and created two models, one with a default value of 1 RU, and one with 3 RU.

1. When you're trying to create a new asset -
 - When you flip back and forth between the two models, the 'Rack Units' value flips back and forth between the two values. Even if you try and edit it in right before you change the model, it will still flip to the new default value.
 - Custom Fields _without_ default values will persist when you flip between models (if both models support the field).
2. When you're trying to edit an existing asset -
 - When you flip back and forth between two models, the 'Rack Units' value **DOES NOT CHANGE** - if it already had a value! This makes sense to me. This is an existing asset. You're trying to edit it. What's in the database takes precedence, or you wouldn't have saved it.
 - But **if** you _blank the value_, **then** flip models, the new default value will populate the field.
 - Other custom fields (without default values) continue to retain their values when you flip models (if both models support the same custom field in each)