### PR TITLE
Small fixes for asset tag regeneration script

### DIFF
--- a/app/Console/Commands/RegenerateAssetTags.php
+++ b/app/Console/Commands/RegenerateAssetTags.php
@@ -60,7 +60,7 @@ class RegenerateAssetTags extends Command
             }
 
             foreach ($total_assets as $asset) {
-                $start_tag++;
+
                 $output['info'][] = 'Asset tag:'.$asset->asset_tag;
                 $asset->asset_tag = $settings->auto_increment_prefix.$settings->auto_increment_prefix.$start_tag;
 
@@ -72,7 +72,14 @@ class RegenerateAssetTags extends Command
 
                 // Use forceSave here to override model level validation
                 $asset->forceSave();
+                $start_tag++;
+                if ($bar) {
+                    $bar->advance();
+                }
             }
+
+            $settings->next_auto_tag_base = Asset::zerofill($start_tag, $settings->zerofill_count);
+            $settings->save();
 
             $bar->finish();
             $this->info("\n");


### PR DESCRIPTION
This just fixes a few small oversights on the `snipeit:regenerate-tags` script which:

1) Starts the counter at 0, instead of 1
2) Updates the next_auto_tag value in the settings table.
3) Correctly displays the progress bar now

Signed-off-by: snipe <snipe@snipe.net>

