### PR TITLE
Fixes #9019 Import page returns error 500

### DIFF
--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -218,6 +218,7 @@ class Setting extends Model
      */
     public static function fileSizeConvert($bytes): string
     {
+        $result = 0;
         $bytes = floatval($bytes);
         $arBytes = [
                 0 => [


### PR DESCRIPTION
# Description
If an import file have filesize of 0, the Import page fails. This small change prevent that to happen.

Fixes #9019 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version:7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
