### PR TITLE
Fixes Asset location doesn't change when assigned user's location change via importer

### DIFF
--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -2,6 +2,7 @@
 
 namespace App\Importer;
 
+use App\Models\Asset;
 use App\Models\Department;
 use App\Models\Setting;
 use App\Models\User;
@@ -79,6 +80,12 @@ class UserImporter extends ItemImporter
             $this->log('Updating User');
             $user->update($this->sanitizeItemForUpdating($user));
             $user->save();
+
+            // Update the location of any assets checked out to this user
+            Asset::where('assigned_type', User::class)
+                ->where('assigned_to', $user->id)
+                ->update(['location_id' => $user->location_id]);
+            
             // \Log::debug('UserImporter.php Updated User ' . print_r($user, true));
             return;
         }


### PR DESCRIPTION
# Description
If an Asset is checkedout to an user, the location of the asset changes to the same location as the user have assigned. If we manually change the user location via GUI, all the assets checked out to them 'follows' the location change.

If we update user's location via Importer, the system behaves different, and the location change on the user doesn't reflect on the assets assigned to them. This change emulates the GUI behavior.

Fixes freshdesk 18777

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
