### PR TITLE
Fixes Checkout date missing in asset delivery mail

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -130,7 +130,7 @@ class AssetImporter extends ItemImporter
             //-- user_id is a property of the abstract class Importer, which this class inherits from and it's setted by
             //-- the class that needs to use it (command importer or GUI importer inside the project).
             if (isset($target)) {
-                $asset->fresh()->checkOut($target, $this->user_id);
+                $asset->fresh()->checkOut($target, $this->user_id, date('Y-m-d H:i:s'));
             }
 
             return;


### PR DESCRIPTION
# Description
Another one for the importer... When an asset is checked out via Importer, the notification mail lacked the date of the checkout. This only add it to the checkout call.

Fixes freshdesk 25321

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
