### PR TITLE
Accept asset/accessory improvements and fixes 

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -113,11 +113,12 @@ class AcceptanceController extends Controller
             Storage::makeDirectory('private_uploads/eula-pdfs', 775);
         }
 
-        $sig_filename = '';
         $item = $acceptance->checkoutable_type::find($acceptance->checkoutable_id);
         $display_model = '';
         $pdf_view_route = '';
         $pdf_filename = 'accepted-eula-'.date('Y-m-d-h-i-s').'.pdf';
+        $sig_filename='';
+
 
         if ($request->input('asset_acceptance') == 'accepted') {
 
@@ -160,7 +161,7 @@ class AcceptanceController extends Controller
                 'accepted_date' => Carbon::parse($acceptance->accepted_at)->format($branding_settings->date_display_format),
                 'assigned_to' => $assigned_to,
                 'company_name' => $branding_settings->site_name,
-                'signature' => '',
+                'signature' => ($sig_filename) ? storage_path() . '/private_uploads/signatures/' . $sig_filename : null,
                 'logo' => public_path() . '/uploads/' . $branding_settings->logo,
                 'date_settings' => $branding_settings->date_display_format,
             ];

--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -132,27 +132,17 @@ class AcceptanceController extends Controller
 
 
             // this is horrible
-            if ($acceptance->checkoutable_type== 'App\Models\Asset') {
+            if ($acceptance->checkoutable_type == 'App\Models\Asset') {
                 $pdf_view_route ='account.accept.accept-asset-eula';
                 $asset_model = AssetModel::find($item->model_id);
                 $display_model = $asset_model->name;
-
-
-//            } elseif ($acceptance->checkoutable_type== 'App\Models\License') {
-//                $pdf_view_route ='account.accept.accept-license-eula';
-//                $license = License::find($item->id);
-//                $display_model = $license->name;
+                $assigned_to = User::find($item->assigned_to);
 
             } elseif ($acceptance->checkoutable_type== 'App\Models\Accessory') {
                 $pdf_view_route ='account.accept.accept-accessory-eula';
                 $accessory = Accessory::find($item->id);
                 $display_model = $accessory->name;
                 $assigned_to = User::find($item->assigned_to);
-
-//            } elseif ($acceptance->checkoutable_type== 'App\Models\Consumable') {
-//                $pdf_view_route ='account.accept.accept-consumable-eula';
-//                $consumable = Consumable::find($item->id);
-//                $display_model = $consumable->name;
 
             }
 

--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -124,7 +124,7 @@ class AcceptanceController extends Controller
             // The item was accepted, check for a signature
             if ($request->filled('signature_output')) {
                 $sig_filename = 'siglog-'.Str::uuid().'-'.date('Y-m-d-his').'.png';
-                $data_uri = e($request->input('signature_output'));
+                $data_uri = $request->input('signature_output');
                 $encoded_image = explode(',', $data_uri);
                 $decoded_image = base64_decode($encoded_image[1]);
                 Storage::put('private_uploads/signatures/'.$sig_filename, (string) $decoded_image);
@@ -136,18 +136,19 @@ class AcceptanceController extends Controller
                 $pdf_view_route ='account.accept.accept-asset-eula';
                 $asset_model = AssetModel::find($item->model_id);
                 $display_model = $asset_model->name;
-                $assigned_to = User::find($item->assigned_to);
+                $assigned_to = User::find($item->assigned_to)->present()->fullName;
 
             } elseif ($acceptance->checkoutable_type== 'App\Models\Accessory') {
                 $pdf_view_route ='account.accept.accept-accessory-eula';
                 $accessory = Accessory::find($item->id);
                 $display_model = $accessory->name;
-                $assigned_to = User::find($item->assigned_to);
+                $assigned_to = User::find($item->assignedTo);
 
             }
 
             /**
-             * Gather the data for the PDF
+             * Gather the data for the PDF. We fire this whether there is a signature required or not,
+             * since we want the moment-in-time proof of what the EULA was when they accepted it.
              */
             $branding_settings = SettingsController::getPDFBranding();
             $data = [
@@ -159,12 +160,13 @@ class AcceptanceController extends Controller
                 'accepted_date' => Carbon::parse($acceptance->accepted_at)->format($branding_settings->date_display_format),
                 'assigned_to' => $assigned_to,
                 'company_name' => $branding_settings->site_name,
-                'signature' => storage_path() . '/private_uploads/signatures/' . $sig_filename,
+                'signature' => '',
                 'logo' => public_path() . '/uploads/' . $branding_settings->logo,
                 'date_settings' => $branding_settings->date_display_format,
             ];
 
             if ($pdf_view_route!='') {
+                \Log::debug($pdf_filename.' is the filename, and the route was specified.');
                 $pdf = Pdf::loadView($pdf_view_route, $data);
                 Storage::put('private_uploads/eula-pdfs/' .$pdf_filename, $pdf->output());
             }

--- a/app/Http/Controllers/Api/ReportsController.php
+++ b/app/Http/Controllers/Api/ReportsController.php
@@ -52,7 +52,6 @@ class ReportsController extends Controller
             'accept_signature',
             'action_type',
             'note',
-            'stored_eula_file',
         ];
 
         $sort = in_array($request->input('sort'), $allowed_columns) ? e($request->input('sort')) : 'created_at';

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -98,9 +98,6 @@ class AssetCheckinController extends Controller
         }
 
         $asset->location_id = $asset->rtd_location_id;
-        \Log::debug('After Location ID: '.$asset->location_id);
-        \Log::debug('After RTD Location ID: '.$asset->rtd_location_id);
-
 
         if ($request->filled('location_id')) {
             \Log::debug('NEW Location ID: '.$request->get('location_id'));

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -59,9 +59,14 @@ class ActionlogsTransformer
             $array = [
             'id'          => (int) $actionlog->id,
             'icon'          => $icon,
-            'file' => ($actionlog->filename!='') ?
+            'file' => ($actionlog->filename!='')
+                ?
                 [
-                    'url' => route('show/assetfile', ['assetId' => $actionlog->item->id, 'fileId' => $actionlog->id]),
+                    'url' => ($actionlog->present()->actionType()=='accepted')
+                            ?
+                            route('log.storedeula.download', ['filename' => $actionlog->filename])
+                            :
+                            route('show/assetfile', ['assetId' => $actionlog->id, 'fileId' => $actionlog->id]),
                     'filename' => $actionlog->filename,
                     'inlineable' => (bool) Helper::show_file_inline($actionlog->filename),
                 ] : null,
@@ -96,7 +101,6 @@ class ActionlogsTransformer
             'signature_file'   => ($actionlog->accept_signature) ? route('log.signature.view', ['filename' => $actionlog->accept_signature ]) : null,
             'log_meta'          => ((isset($clean_meta)) && (is_array($clean_meta))) ? $clean_meta: null,
             'action_date'   => ($actionlog->action_date) ? Helper::getFormattedDateObject($actionlog->action_date, 'datetime'): Helper::getFormattedDateObject($actionlog->created_at, 'datetime'),
-            'stored_eula_file' => ($actionlog->stored_eula_file) ? route('log.storedeula.download', ['filename' => $actionlog->stored_eula_file]) : null,
         ];
         //\Log::info("Clean Meta is: ".print_r($clean_meta,true));
 

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -24,10 +24,14 @@ use Illuminate\Support\Facades\Notification;
 class CheckoutableListener
 {
     /**
-     * Notify the user about the checked out checkoutable
+     * Notify the user about the checked out checkoutable and add a record to the
+     * checkout_requests table.
      */
     public function onCheckedOut($event)
     {
+
+        \Log::debug('onCheckedOut in the Checkoutable listener fired');
+
         /**
          * When the item wasn't checked out to a user, we can't send notifications
          */
@@ -58,14 +62,12 @@ class CheckoutableListener
      */    
     public function onCheckedIn($event)
     {
-        \Log::debug('checkin fired');
+        \Log::debug('onCheckedIn in the Checkoutable listener fired');
 
         /**
          * When the item wasn't checked out to a user, we can't send notifications
          */
         if (! $event->checkedOutTo instanceof User) {
-            \Log::debug('checked out to not a user');
-
             return;
         }
 
@@ -81,16 +83,14 @@ class CheckoutableListener
                 $acceptance->delete();
             }
         }
-        \Log::debug('checked out to a user');
+
+        // Use default locale
         if (! $event->checkedOutTo->locale) {
-            \Log::debug('Use default settings locale');
             Notification::locale(Setting::getSettings()->locale)->send(
                 $this->getNotifiables($event),
                 $this->getCheckinNotification($event)
             );
         } else {
-            \Log::debug('Use user locale? I do not think this works as expected yet');
-            // \Log::debug(print_r($this->getNotifiables($event), true));
             Notification::send(
                 $this->getNotifiables($event),
                 $this->getCheckinNotification($event)
@@ -150,10 +150,6 @@ class CheckoutableListener
      */
     private function getCheckinNotification($event)
     {
-
-        // $model = get_class($event->checkoutable);
-
-
 
         $notificationClass = null;
 

--- a/app/Listeners/LogListener.php
+++ b/app/Listeners/LogListener.php
@@ -22,24 +22,44 @@ use App\Models\LicenseSeat;
 
 class LogListener
 {
+    /**
+     * These onBlah methods are used by the subscribe() method further down in this file.
+     * This one creates an action_logs entry for the checkin
+     * @param CheckoutableCheckedIn $event
+     * @return void
+     *
+     */
     public function onCheckoutableCheckedIn(CheckoutableCheckedIn $event)
     {
         $event->checkoutable->logCheckin($event->checkedOutTo, $event->note, $event->action_date);
     }
 
+    /**
+     * These onBlah methods are used by the subscribe() method further down in this file.
+     * This one creates an action_logs entry for the checkout
+     *
+     * @param CheckoutableCheckedOut $event
+     * @return void
+     *
+     */
     public function onCheckoutableCheckedOut(CheckoutableCheckedOut $event)
     {
         $event->checkoutable->logCheckout($event->note, $event->checkedOutTo, $event->checkoutable->last_checkout);
     }
 
+    /**
+     * These onBlah methods are used by the subscribe() method further down in this file.
+     * This creates the entry in the action_logs table for the accept/decline action
+     */
     public function onCheckoutAccepted(CheckoutAccepted $event)
     {
 
+        \Log::error('event passed to the onCheckoutAccepted listener:');
         $logaction = new Actionlog();
         $logaction->item()->associate($event->acceptance->checkoutable);
         $logaction->target()->associate($event->acceptance->assignedTo);
         $logaction->accept_signature = $event->acceptance->signature_filename;
-        $logaction->stored_eula_file = $event->acceptance->stored_eula_file;
+        $logaction->filename = $event->acceptance->stored_eula_file;
         $logaction->action_type = 'accepted';
 
         // TODO: log the actual license seat that was checked out
@@ -47,6 +67,7 @@ class LogListener
             $logaction->item()->associate($event->acceptance->checkoutable->license);
         }
 
+        \Log::debug('New onCheckoutAccepted Listener fired. logaction: '.print_r($logaction, true));
         $logaction->save();
     }
 

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -25,7 +25,7 @@ class Actionlog extends SnipeModel
 
     protected $table = 'action_logs';
     public $timestamps = true;
-    protected $fillable = ['created_at', 'item_type', 'user_id', 'item_id', 'action_type', 'note', 'target_id', 'target_type', 'stored_eula', 'stored_eula_file'];
+    protected $fillable = ['created_at', 'item_type', 'user_id', 'item_id', 'action_type', 'note', 'target_id', 'target_type', 'stored_eula'];
 
     use Searchable;
 

--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -57,20 +57,24 @@ class CheckoutAcceptance extends Model
     }
 
     /**
-     * Accept the checkout acceptance
+     * Add a record to the checkout_acceptance table ONLY.
+     * Do not add stuff here that doesn't have a corresponding column in the
+     * checkout_acceptances table or you'll get an error.
      *
      * @param  string $signature_filename
      */
-    public function accept($signature_filename)
+    public function accept($signature_filename, $eula = null, $filename = null)
     {
         $this->accepted_at = now();
         $this->signature_filename = $signature_filename;
+        $this->stored_eula = $eula;
+        $this->stored_eula_file = $filename;
         $this->save();
 
         /**
          * Update state for the checked out item
          */
-        $this->checkoutable->acceptedCheckout($this->assignedTo, $signature_filename);
+        $this->checkoutable->acceptedCheckout($this->assignedTo, $signature_filename, $filename);
     }
 
     /**

--- a/app/Models/Traits/Acceptable.php
+++ b/app/Models/Traits/Acceptable.php
@@ -17,8 +17,9 @@ trait Acceptable
      * @param  User   $acceptedBy
      * @param  string $signature
      */
-    public function acceptedCheckout(User $acceptedBy, $signature)
+    public function acceptedCheckout(User $acceptedBy, $signature, $filename = null)
     {
+        \Log::debug('acceptedCheckout in Acceptable trait fired, tho it doesn\'t do anything?');
     }
 
     /**

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -54,7 +54,6 @@ class CheckinAssetNotification extends Notification
          * has the corresponding checkbox checked.
          */
         if ($this->item->checkin_email() && $this->target instanceof User && $this->target->email != '') {
-            \Log::debug('use email');
             $notifyBy[] = 'mail';
         }
 

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -36,6 +36,11 @@ class SettingsServiceProvider extends ServiceProvider
 
         // Model paths and URLs
 
+
+        \App::singleton('eula_pdf_path', function () {
+            return 'eula_pdf_path/';
+        });
+
         \App::singleton('assets_upload_path', function () {
             return 'assets/';
         });

--- a/database/migrations/2022_05_16_235350_remove_stored_eula_field.php
+++ b/database/migrations/2022_05_16_235350_remove_stored_eula_field.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Actionlog;
+
+class RemoveStoredEulaField extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+        $actionlog_eulas = Actionlog::whereNotNull('stored_eula_file')->get();
+
+        foreach ($actionlog_eulas as $eula_file) {
+            $eula_file->filename = $eula_file->stored_eula_file;
+            $eula_file->save();
+        }
+
+        $actionlog_bad_action_type = Actionlog::where('item_id', '=', 0)->whereNull('target_type')->whereNull('action_type')->whereNull('target_type')->get();
+
+        foreach ($actionlog_bad_action_type as $bad_action_type) {
+            $bad_action_type->delete();
+        }
+
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->dropColumn('stored_eula_file');
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->string('stored_eula_file')->nullable()->default(null);
+        });
+    }
+}

--- a/resources/views/account/accept/accept-accessory-eula.blade.php
+++ b/resources/views/account/accept/accept-accessory-eula.blade.php
@@ -7,12 +7,13 @@
     <style>
         body {
             font-family: Arial, Helvetica, sans-serif;
+            font-size: 11px;
         }
     </style>
 </head>
 <body>
 
-@if ($signature)
+@if ($logo)
     <center>
         <img src="{{ $logo }}">
         <p>{{$company_name}}</p>
@@ -22,10 +23,8 @@
 
 <p>
     {{ trans('general.date') }}: {{ date($date_settings) }} <br>
-    {{ trans('general.asset_tag') }}: {{ $item_tag }}<br>
     {{ trans('general.asset_model') }}: {{ $item_model }}<br>
-    {{ trans('general.serial') }}: {{ $item_serial }}</p>
-
+</p>
 
 @if ($eula)
     <hr>
@@ -36,15 +35,13 @@
 
 <p>
     Assigned on: {{$check_out_date}}<br>
-    Assigned to: {{$assigned_to}}
+    Assigned to: {{$assigned_to}}<br>
+    Accepted on: {{$accepted_date}}
 </p>
 
 
-@if ($signature)
-    <div style="width: 60%; float:left">
-        <img src="{{ $signature }}" style="max-width: 100%; border-bottom: black solid 1px;"><br>
-        {{ trans('general.signature') }}: {{$accepted_date}}
-    </div>
+@if ($signature!='')
+    <img src="{{ $signature }}" style="max-width: 600px; border-bottom: black solid 1px;">
 @endif
 </body>
 </html>

--- a/resources/views/account/accept/accept-accessory-eula.blade.php
+++ b/resources/views/account/accept/accept-accessory-eula.blade.php
@@ -4,6 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <style>
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+        }
+    </style>
 </head>
 <body>
 
@@ -15,22 +20,31 @@
 @endif
 <br>
 
-<p>Date: {{ date($date_settings) }} </p><br>
-<p>Asset Tag: {{ $item_tag }}</p>
-<p>Asset Model: {{ $item_model }}</p>
+<p>
+    {{ trans('general.date') }}: {{ date($date_settings) }} <br>
+    {{ trans('general.asset_tag') }}: {{ $item_tag }}<br>
+    {{ trans('general.asset_model') }}: {{ $item_model }}<br>
+    {{ trans('general.serial') }}: {{ $item_serial }}</p>
+
+
 @if ($eula)
+    <hr>
     {!!  $eula !!}
+    <hr>
 @endif
 
-<br>
 
-<p>Assigned on: {{$check_out_date}}</p>
-<p>Accepted on: {{$accepted_date}}</p>
-<p>Assigned to: {{$assigned_to}}</p>
+<p>
+    Assigned on: {{$check_out_date}}<br>
+    Assigned to: {{$assigned_to}}
+</p>
+
+
 @if ($signature)
-    <center>
-        <img src="{{ $signature }}" style="max-width: 50%">
-    </center>
+    <div style="width: 60%; float:left">
+        <img src="{{ $signature }}" style="max-width: 100%; border-bottom: black solid 1px;"><br>
+        {{ trans('general.signature') }}: {{$accepted_date}}
+    </div>
 @endif
 </body>
 </html>

--- a/resources/views/account/accept/accept-asset-eula.blade.php
+++ b/resources/views/account/accept/accept-asset-eula.blade.php
@@ -25,7 +25,8 @@
 {{ trans('general.date') }}: {{ date($date_settings) }} <br>
 {{ trans('general.asset_tag') }}: {{ $item_tag }}<br>
 {{ trans('general.asset_model') }}: {{ $item_model }}<br>
-{{ trans('admin/hardware/form.serial') }}: {{ $item_serial }}</p>
+{{ trans('admin/hardware/form.serial') }}: {{ $item_serial }}
+</p>
 
 
 @if ($eula)
@@ -37,15 +38,13 @@
 
 <p>
 Assigned on: {{$check_out_date}}<br>
-Assigned to: {{$assigned_to}}
+Assigned to: {{$assigned_to}}<br>
+Accepted on: {{$accepted_date}}
 </p>
 
 
-@if ($signature)
-    <div style="width: 60%; float:left">
-        <img src="{{ $signature }}" style="max-width: 100%; border-bottom: black solid 1px;"><br>
-        {{ trans('general.signature') }}: {{$accepted_date}}
-    </div>
+@if ($signature!='')
+<img src="{{ $signature }}" style="max-width: 600px; border-bottom: black solid 1px;">
 @endif
 </body>
 </html>

--- a/resources/views/account/accept/accept-asset-eula.blade.php
+++ b/resources/views/account/accept/accept-asset-eula.blade.php
@@ -36,7 +36,6 @@
 
 <p>
 Assigned on: {{$check_out_date}}<br>
-Accepted on: {{$accepted_date}}<br>
 Assigned to: {{$assigned_to}}
 </p>
 
@@ -44,11 +43,7 @@ Assigned to: {{$assigned_to}}
 @if ($signature)
     <div style="width: 60%; float:left">
         <img src="{{ $signature }}" style="max-width: 100%; border-bottom: black solid 1px;"><br>
-        {{ trans('general.signature') }}
-    </div>
-    <div style="width: 40%; float:left">
-
-        {{$accepted_date}}
+        {{ trans('general.signature') }}: {{$accepted_date}}
     </div>
 @endif
 </body>

--- a/resources/views/account/accept/accept-asset-eula.blade.php
+++ b/resources/views/account/accept/accept-asset-eula.blade.php
@@ -13,7 +13,7 @@
 </head>
 <body>
 
-@if ($signature)
+@if ($logo)
     <center>
         <img src="{{ $logo }}">
         <p>{{$company_name}}</p>
@@ -25,7 +25,7 @@
 {{ trans('general.date') }}: {{ date($date_settings) }} <br>
 {{ trans('general.asset_tag') }}: {{ $item_tag }}<br>
 {{ trans('general.asset_model') }}: {{ $item_model }}<br>
-{{ trans('admin/hardward/form.serial') }}: {{ $item_serial }}</p>
+{{ trans('admin/hardware/form.serial') }}: {{ $item_serial }}</p>
 
 
 @if ($eula)

--- a/resources/views/account/accept/accept-asset-eula.blade.php
+++ b/resources/views/account/accept/accept-asset-eula.blade.php
@@ -7,6 +7,7 @@
     <style>
         body {
             font-family: Arial, Helvetica, sans-serif;
+            font-size: 11px;
         }
     </style>
 </head>
@@ -24,7 +25,7 @@
 {{ trans('general.date') }}: {{ date($date_settings) }} <br>
 {{ trans('general.asset_tag') }}: {{ $item_tag }}<br>
 {{ trans('general.asset_model') }}: {{ $item_model }}<br>
-{{ trans('general.serial') }}: {{ $item_serial }}</p>
+{{ trans('admin/hardward/form.serial') }}: {{ $item_serial }}</p>
 
 
 @if ($eula)

--- a/resources/views/account/accept/accept-asset-eula.blade.php
+++ b/resources/views/account/accept/accept-asset-eula.blade.php
@@ -4,6 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <style>
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+        }
+    </style>
 </head>
 <body>
 
@@ -15,23 +20,36 @@
 @endif
 <br>
 
-<p>Date: {{ date($date_settings) }} </p><br>
-<p>Asset Tag: {{ $item_tag }}</p>
-<p>Asset Model: {{ $item_model }}</p>
-<p>Asset Serial: {{ $item_serial }}</p><br>
+<p>
+{{ trans('general.date') }}: {{ date($date_settings) }} <br>
+{{ trans('general.asset_tag') }}: {{ $item_tag }}<br>
+{{ trans('general.asset_model') }}: {{ $item_model }}<br>
+{{ trans('general.serial') }}: {{ $item_serial }}</p>
+
+
 @if ($eula)
+    <hr>
     {!!  $eula !!}
+    <hr>
 @endif
 
-<br>
 
-<p>Assigned on: {{$check_out_date}}</p>
-<p>Accepted on: {{$accepted_date}}</p>
-<p>Assigned to: {{$assigned_to}}</p>
+<p>
+Assigned on: {{$check_out_date}}<br>
+Accepted on: {{$accepted_date}}<br>
+Assigned to: {{$assigned_to}}
+</p>
+
+
 @if ($signature)
-    <center>
-        <img src="{{ $signature }}" style="max-width: 50%">
-    </center>
+    <div style="width: 60%; float:left">
+        <img src="{{ $signature }}" style="max-width: 100%; border-bottom: black solid 1px;"><br>
+        {{ trans('general.signature') }}
+    </div>
+    <div style="width: 40%; float:left">
+
+        {{$accepted_date}}
+    </div>
 @endif
 </body>
 </html>

--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -46,14 +46,14 @@
           <div class="col-md-12">
             <div class="radio">
               <label>
-                <input type="radio" name="asset_acceptance" id="accepted" value="accepted">
+                <input type="radio" name="asset_acceptance" id="accepted" value="accepted" class="minimal">
                 {{ trans('general.i_accept') }}
               </label>
             </div>
 
             <div class="radio">
               <label>
-                <input type="radio" name="asset_acceptance" id="declined" value="declined">
+                <input type="radio" name="asset_acceptance" id="declined" value="declined" class="minimal">
                 {{ trans('general.i_decline') }}
               </label>
             </div>
@@ -77,7 +77,7 @@
                     <input type="hidden" name="signature_output" id="signature_output">
                 </div>
                <div class="col-md-12 col-sm-12 col-lg-12 col-xs-12 text-center">
-                  <button type="button" class="btn btn-sm btn-default clear" data-action="clear" id="clear_button">{{ trans('general.clear_signature') }}</button>
+                  <button type="button" class="btn btn-sm btn-primary clear" data-action="clear" id="clear_button">{{ trans('general.clear_signature') }}</button>
                 </div>
               </div>
             </div> <!-- .col-md-12.text-center-->

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1100,8 +1100,10 @@
                   <th class="col-sm-2" data-visible="true" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>
                   <th class="col-sm-2" data-visible="true" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.target') }}</th>
                   <th class="col-sm-2" data-field="note">{{ trans('general.notes') }}</th>
-                  <th class="col-sm-1" data-field="stored_eula_file" data-visible="true" data-formatter="downloadFormatter">{{ trans('general.accept_eula') }}</th>
-                  <th class="col-md-3" data-visible="false" data-field="file" data-visible="false"  data-formatter="fileUploadFormatter">{{ trans('general.download') }}</th>
+                    @if  ($snipeSettings->require_accept_signature=='1')
+                        <th class="col-md-3" data-field="signature_file" data-visible="false"  data-formatter="imageFormatter">{{ trans('general.signature') }}</th>
+                    @endif
+                    <th class="col-md-3" data-visible="false" data-field="file" data-visible="false"  data-formatter="fileUploadFormatter">{{ trans('general.download') }}</th>
                   <th class="col-sm-2" data-field="log_meta" data-visible="true" data-formatter="changeLogFormatter">{{ trans('admin/hardware/table.changed')}}</th>
                 </tr>
                 </thead>

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,7 +125,7 @@ Route::group(['middleware' => 'auth'], function () {
         [ActionlogController::class, 'displaySig']
     )->name('log.signature.view');
     Route::get(
-        'stored-eula-file/{filename}/',
+        'stored-eula-file/{filename}',
         [ActionlogController::class, 'getStoredEula']
     )->name('log.storedeula.download');
 });


### PR DESCRIPTION
We're seeing a handful of problems and inconsistencies with asset acceptance, so this is a whack at refactoring some of that. 

### Problem 1:

The `storage/eula-pdfs` directory did not have a `.gitignore` in it, which means it wasn't checked into the repo, so users trying to store the PDF would end up with errors, since the file couldn't be written to a non-existent directory. (We were also not checking to see the directory actually exists before trying to write to it.)

### Problem 2:

We had added an extra column to the `action_logs` table called `stored_eula_file`, but that ended up being difficult to normalize in the API and the UI - and we already have a `filename` column on that table, so it makes more sense to just use that. (I'm still not entirely sure why we're duplicating the all of the data in the `action_logs` table in the `checkout_acceptances` table, but that's for another time.)

Normalizing this format means we go from something like this:

<img width="1570" alt="Screen Shot 2022-05-16 at 11 10 55 PM" src="https://user-images.githubusercontent.com/197404/168832384-46f5dbe3-e709-4cf9-9fe0-fc8f137cbadd.png">

to something like this:

<img width="1542" alt="Screen Shot 2022-05-17 at 7 17 03 AM" src="https://user-images.githubusercontent.com/197404/168832964-7bb73096-6595-44f7-bd55-e65aa6076e34.png">

where the "uploads" and "acceptance pdfs" both show up in a unified way in the history tab.

### Problem 3:

The `stored_eula`, the actual EULA text at the time of the acceptance, is being stored but not displayed anywhere. It will likely be long, and with the PDF support, I don't see any reason to try to cram it into the UI un the history tab. 

I still need to do a little refactoring in the acceptance controller and clean that up a bit, but I think this isn't a bad start.

I also cleaned up the PDF layout a bit, so it looks like this now:

<img width="1054" alt="Screen Shot 2022-05-17 at 7 23 39 AM" src="https://user-images.githubusercontent.com/197404/168834553-26a951aa-d234-41e8-a8dd-365efb20f32a.png">

Still a few more tweaks to go, but I think it looks a little cleaner.

This will eventually hopefully fix #11116.
