### PR TITLE
Fixed bug where username wasn’t showing for regular users

### DIFF
--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -271,12 +271,16 @@
                       <div class="col-md-9">
 
                         @if ($user->isSuperUser())
-                          <label class="label label-danger"><i class="fas fa-crown" title="superuser"></i></label> {{ $user->username }}
+                          <label class="label label-danger">
+                              <i class="fas fa-crown" title="superuser"></i>
+                          </label>
                         @elseif ($user->hasAccess('admin'))
-                          <label class="label label-warning"><i class="fas fa-crown" title="superuser"></i></label> {{ $user->username }}
+                          <label class="label label-warning">
+                              <i class="fas fa-crown" title="admin"></i>
+                          </label>
                         @endif
+                         {{ $user->username }}
 
-                      
                       </div>
 
                     </div>


### PR DESCRIPTION
This fixes a small bug where the person's username would not be present if they were a "regular" user. 