### PR TITLE
Added a simple .env checker into the upgrader

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -26,6 +26,7 @@ echo "--------------------------------------------------------\n\n";
 echo "This script will attempt to: \n\n";
 echo "- validate some very basic .env file settings \n";
 echo "- check your PHP version and extension requirements \n";
+echo "- check directory permissions \n";
 echo "- do a git pull to bring you to the latest version \n";
 echo "- run composer install to get your vendors up to date \n";
 echo "- run migrations to get your schema up to date \n";
@@ -199,21 +200,72 @@ if ($ext_missing!='') {
 }
 
 
+
 echo "--------------------------------------------------------\n";
-echo "STEP 3: Backing up database: \n";
+echo "STEP 3: Checking directory permissions: \n";
+echo "--------------------------------------------------------\n\n";
+
+
+$writable_dirs_array =
+    [
+        'bootstrap/cache',
+        'storage',
+        'storage/logs',
+        'storage/logs/laravel.log',
+        'storage/framework',
+        'storage/framework/cache',
+        'storage/framework/sessions',
+        'storage/framework/views',
+        'storage/app',
+        'storage/app/backups',
+        'storage/app/backups-temp',
+        'storage/private_uploads',
+        'public/uploads',
+    ];
+
+$dirs_writable = '';
+$dirs_not_writable = '';
+
+// Loop through the directories that need to be writable
+foreach ($writable_dirs_array as $writable_dir) {
+    if (is_writable($writable_dir)) {
+        $dirs_writable .= '√ '.getcwd().'/'.$writable_dir." is writable \n";
+    } else {
+        $dirs_not_writable .= '✘ PERMISSIONS ERROR: '.getcwd().'/'.$writable_dir." is NOT writable\n";
+    }
+}
+
+echo $dirs_writable."\n";
+
+// Print out a useful error message
+if ($dirs_not_writable!='') {
+    echo "--------------------------------------------------------\n";
+    echo "The following directories/files do not seem writable: \n";
+    echo "--------------------------------------------------------\n";
+
+    echo $dirs_not_writable;
+
+    echo "--------------------- !! ERROR !! ----------------------\n";
+    echo "Please check the permissions on the directories above and re-run this script.\n";
+    echo "------------------------- :( ---------------------------\n";
+}
+
+
+echo "--------------------------------------------------------\n";
+echo "STEP 4: Backing up database: \n";
 echo "--------------------------------------------------------\n\n";
 $backup = shell_exec('php artisan snipeit:backup');
 echo '-- '.$backup."\n\n";
 
 echo "--------------------------------------------------------\n";
-echo "STEP 4: Putting application into maintenance mode: \n";
+echo "STEP 5: Putting application into maintenance mode: \n";
 echo "--------------------------------------------------------\n\n";
 $down = shell_exec('php artisan down');
 echo '-- '.$down."\n";
 
 
 echo "--------------------------------------------------------\n";
-echo "STEP 5: Pulling latest from Git (".$branch." branch): \n";
+echo "STEP 6: Pulling latest from Git (".$branch." branch): \n";
 echo "--------------------------------------------------------\n\n";
 $git_version = shell_exec('git --version');
 
@@ -239,7 +291,7 @@ if ((strpos('git version', $git_version)) === false) {
 
 
 echo "--------------------------------------------------------\n";
-echo "STEP 6: Cleaning up old cached files:\n";
+echo "STEP 7: Cleaning up old cached files:\n";
 echo "--------------------------------------------------------\n\n";
 
 // Build an array of the files we generally want to delete because they
@@ -272,7 +324,7 @@ echo '-- '.$view_clear;
 echo "\n";
 
 echo "--------------------------------------------------------\n";
-echo "STEP 7: Updating composer dependencies:\n";
+echo "STEP 8: Updating composer dependencies:\n";
 echo "(This may take a moment.)\n";
 echo "--------------------------------------------------------\n\n";
 
@@ -298,7 +350,7 @@ echo $composer;
 
 
 echo "--------------------------------------------------------\n";
-echo "STEP 8: Migrating database:\n";
+echo "STEP 9: Migrating database:\n";
 echo "--------------------------------------------------------\n\n";
 
 $migrations = shell_exec('php artisan migrate --force');
@@ -306,7 +358,7 @@ echo $migrations."\n";
 
 
 echo "--------------------------------------------------------\n";
-echo "STEP 9: Checking for OAuth keys:\n";
+echo "STEP 10: Checking for OAuth keys:\n";
 echo "--------------------------------------------------------\n\n";
 
 
@@ -320,7 +372,7 @@ if ((!file_exists('storage/oauth-public.key')) || (!file_exists('storage/oauth-p
 
 
 echo "--------------------------------------------------------\n";
-echo "STEP 10: Taking application out of maintenance mode:\n";
+echo "STEP 11: Taking application out of maintenance mode:\n";
 echo "--------------------------------------------------------\n\n";
 
 $up = shell_exec('php artisan up');

--- a/upgrade.php
+++ b/upgrade.php
@@ -218,7 +218,7 @@ $writable_dirs_array =
         'storage/framework/views',
         'storage/app',
         'storage/app/backups',
-        'storage/app/backups-temp',
+        'storage/app/backup-temp',
         'storage/private_uploads',
         'public/uploads',
     ];
@@ -247,8 +247,9 @@ if ($dirs_not_writable!='') {
 
     echo "--------------------- !! ERROR !! ----------------------\n";
     echo "Please check the permissions on the directories above and re-run this script.\n";
-    echo "------------------------- :( ---------------------------\n";
+    echo "------------------------- :( ---------------------------\n\n";
 }
+
 
 
 echo "--------------------------------------------------------\n";

--- a/upgrade.php
+++ b/upgrade.php
@@ -53,6 +53,15 @@ foreach ($env as $line_num => $line) {
 
         $env_value = trim($env_value);
 
+        if ($env_key == 'APP_KEY') {
+            if (($env_value=='')  || (strlen($env_value) < 20)) {
+                echo "✘ APP_KEY ERROR in your .env: Your APP_KEY should not be blank. Run php artisan key:generate to generate one.";
+                $env_error_count++;
+            } else {
+                echo "√ Your APP_KEY is not blank. \n";
+            }
+        }
+
         if ($env_key == 'APP_URL') {
 
             $app_url_length = strlen($env_value);

--- a/upgrade.php
+++ b/upgrade.php
@@ -43,6 +43,8 @@ echo "--------------------------------------------------------\n\n";
 // Check the .env looks ok
 $env = file('.env');
 $env_error_count = 0;
+$env_good = '';
+$env_bad = '';
 
 // Loop through each line of the .env
 foreach ($env as $line_num => $line) {
@@ -51,14 +53,16 @@ foreach ($env as $line_num => $line) {
 
         list ($env_key, $env_value) = $env_line = explode('=', $line);
 
+        // The array starts at 0
+        $show_line_num = $line_num+1;
+
         $env_value = trim($env_value);
 
         if ($env_key == 'APP_KEY') {
             if (($env_value=='')  || (strlen($env_value) < 20)) {
-                echo "✘ APP_KEY ERROR in your .env: Your APP_KEY should not be blank. Run php artisan key:generate to generate one.";
-                $env_error_count++;
+                $env_bad .= "✘ APP_KEY ERROR in your .env on line #'.$show_line_num.': Your APP_KEY should not be blank. Run `php artisan key:generate` to generate one.\n";
             } else {
-                echo "√ Your APP_KEY is not blank. \n";
+                $env_good .= "√ Your APP_KEY is not blank. \n";
             }
         }
 
@@ -67,26 +71,23 @@ foreach ($env as $line_num => $line) {
             $app_url_length = strlen($env_value);
 
             if (($env_value!="null") && ($env_value!="")) {
-                echo '√ Your APP_URL is not null or blank. It is set to '.$env_value."\n";
+                $env_good .= '√ Your APP_URL is not null or blank. It is set to '.$env_value."\n";
 
                 if (!str_begins(trim($env_value), 'http://') && (!str_begins($env_value, 'https://'))) {
-                    echo '✘ APP_URL ERROR in your .env on line #'.$line_num.' of your .env: Your APP_URL should start with https:// or http://!! It is currently set to: '.$env_value;
-                    $env_error_count++;
+                    $env_bad .= '✘ APP_URL ERROR in your .env on line #'.$show_line_num.': Your APP_URL should start with https:// or http://!! It is currently set to: '.$env_value;
                 } else {
-                    echo '√ Your APP_URL is set to '.$env_value.' and starts with the protocol (https:// or http://)'."\n";
+                    $env_good .= '√ Your APP_URL is set to '.$env_value.' and starts with the protocol (https:// or http://)'."\n";
                 }
 
                 if (str_ends(trim($env_value), "/")) {
-                    echo '✘ APP_URL ERROR in your .env on line #'.$line_num.' of your .env: Your APP_URL should NOT end with a trailing slash. It is currently set to: '.$env_value;
-                    $env_error_count++;
+                    $env_bad .= '✘ APP_URL ERROR in your .env on line #'.$show_line_num.': Your APP_URL should NOT end with a trailing slash. It is currently set to: '.$env_value;
                 } else {
-                    echo '√ Your APP_URL ('.$env_value.') does not have a trailing slash.'."\n";
+                    $env_good .= '√ Your APP_URL ('.$env_value.') does not have a trailing slash.'."\n";
                 }
 
 
             } else {
-                echo "✘ APP_URL ERROR in your .env on line #".$line_num.": Your APP_URL CANNOT be set to null or left blank.\n";
-                $env_error_count++;
+                $env_bad .= "✘ APP_URL ERROR in your .env on line #".$show_line_num.": Your APP_URL CANNOT be set to null or left blank.\n";
             }
 
         }
@@ -96,15 +97,21 @@ foreach ($env as $line_num => $line) {
 
 }
 
-if ($env_error_count > 0) {
-    echo "\n\n--------------------- !! ERROR !! ----------------------\n";
+echo $env_good;
+
+if ($env_bad !='') {
+
+    echo "\n--------------------- !! ERROR !! ----------------------\n";
     echo "Your .env file is misconfigured. Upgrade cannot continue.\n";
-    echo "------------------------- :( ---------------------------\n";
+    echo "--------------------------------------------------------\n\n";
+    echo $env_bad;
+    echo "\n\n--------------------------------------------------------\n";
     echo "ABORTING THE INSTALLER  \n";
     echo "Please correct the issues above in ".getcwd()."/.env and try again.\n";
-    echo "------------------------- :( ---------------------------\n";
+    echo "--------------------------------------------------------\n";
     exit;
 }
+
 
 echo "--------------------------------------------------------\n";
 echo "STEP 2: Checking PHP requirements: \n";
@@ -198,10 +205,10 @@ if ($ext_missing!='') {
 
     echo "--------------------- !! ERROR !! ----------------------\n";
     echo $ext_missing;
-    echo "------------------------- :( ---------------------------\n";
+    echo "--------------------------------------------------------\n";
     echo "ABORTING THE INSTALLER  \n";
     echo "Please install the extensions above and re-run this script.\n";
-    echo "------------------------- :( ---------------------------\n";
+    echo "--------------------------------------------------------\n";
     exit;
 } else {
     echo $ext_installed."\n";

--- a/upgrade.php
+++ b/upgrade.php
@@ -60,14 +60,14 @@ foreach ($env as $line_num => $line) {
                 echo '√ Your APP_URL is not null or blank. It is set to '.$env_value."\n";
 
                 if (!str_begins(trim($env_value), 'http://') && (!str_begins($env_value, 'https://'))) {
-                    echo '✘ APP_URL ERROR in Line #'.$line_num.' of your .env: Your APP_URL should start with https:// or http://!! It is currently set to: '.$env_value;
+                    echo '✘ APP_URL ERROR in your .env on line #'.$line_num.' of your .env: Your APP_URL should start with https:// or http://!! It is currently set to: '.$env_value;
                     $env_error_count++;
                 } else {
                     echo '√ Your APP_URL is set to '.$env_value.' and starts with the protocol (https:// or http://)'."\n";
                 }
 
                 if (str_ends(trim($env_value), "/")) {
-                    echo '✘ APP_URL ERROR in Line #'.$line_num.' of your .env: Your APP_URL should NOT end with a trailing slash. It is currently set to: '.$env_value;
+                    echo '✘ APP_URL ERROR in your .env on line #'.$line_num.' of your .env: Your APP_URL should NOT end with a trailing slash. It is currently set to: '.$env_value;
                     $env_error_count++;
                 } else {
                     echo '√ Your APP_URL ('.$env_value.') does not have a trailing slash.'."\n";
@@ -75,7 +75,7 @@ foreach ($env as $line_num => $line) {
 
 
             } else {
-                echo "✘ APP_URL ERROR in Line #".$line_num.": Your APP_URL CANNOT be set to null or left blank.\n";
+                echo "✘ APP_URL ERROR in your .env on line #".$line_num.": Your APP_URL CANNOT be set to null or left blank.\n";
                 $env_error_count++;
             }
 


### PR DESCRIPTION
This adds a very simple `APP_URL` checker to the upgrader. Since anecdotally, the vast majority of the issues I'm seeing on Github for the v6 upgrade are related to folks not having their `.env` configured correctly, this would prevent them from continuing with the upgrade if the URL is: `null`, blank, doesn't start with `http://` or `https://` or ends in `/`. (The framework itself spits out very confusing errors related to `Request::create()` being null, etc, when the `APP_URL` is donked.)

<img width="787" alt="Screen Shot 2022-05-24 at 5 45 51 PM" src="https://user-images.githubusercontent.com/197404/170154821-01ab2375-0227-407d-8eed-e2957f9d4378.png">

<img width="787" alt="Screen Shot 2022-05-24 at 5 46 51 PM" src="https://user-images.githubusercontent.com/197404/170154964-51e3e2b4-8eb2-4c98-9dd6-c2c94c64e337.png">

<img width="787" alt="Screen Shot 2022-05-24 at 5 47 24 PM" src="https://user-images.githubusercontent.com/197404/170154981-9f84da96-579a-49c6-8e7a-4c6abc908031.png">

It's kinda ugly, but we write this in pure PHP specifically so that if the framework is having problems, this script operates outside of it.

