### PR TITLE
Fixes #11193 File Uploads don't show target in Activity report

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -55,25 +55,35 @@ class ActionlogsTransformer
             }
         }
 
+        $url = '';
+        if($actionlog->filename!='') {
+            if ($actionlog->present()->actionType() == 'accepted') {
+                $url = route('log.storedeula.download', ['filename' => $actionlog->filename]);
+            } else {
+                if ($actionlog->itemType() == 'asset') {
+                    $url = route('show/assetfile', ['assetId' => $actionlog->id, 'fileId' => $actionlog->id]);
+                } elseif ($actionlog->itemType() == 'license') {
+                    $url = route('show.licensefile', ['licenseId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
+                } elseif ($actionlog->itemType() == 'user') {
+                    $url = route('show/userfile', ['userId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
+                }
+            }
+        }
 
-            $array = [
+        $array = [
             'id'          => (int) $actionlog->id,
             'icon'          => $icon,
             'file' => ($actionlog->filename!='')
                 ?
                 [
-                    'url' => ($actionlog->present()->actionType()=='accepted')
-                            ?
-                            route('log.storedeula.download', ['filename' => $actionlog->filename])
-                            :
-                            route('show/assetfile', ['assetId' => $actionlog->id, 'fileId' => $actionlog->id]),
+                    'url' => $url,
                     'filename' => $actionlog->filename,
                     'inlineable' => (bool) Helper::show_file_inline($actionlog->filename),
                 ] : null,
 
             'item' => ($actionlog->item) ? [
                 'id' => (int) $actionlog->item->id,
-                'name' => ($actionlog->itemType()=='user') ? $actionlog->filename : e($actionlog->item->getDisplayNameAttribute()),
+                'name' => ($actionlog->itemType()=='user') ? e($actionlog->item->getFullNameAttribute()) : e($actionlog->item->getDisplayNameAttribute()),
                 'type' => e($actionlog->itemType()),
             ] : null,
             'location' => ($actionlog->location) ? [
@@ -104,6 +114,7 @@ class ActionlogsTransformer
         ];
         //\Log::info("Clean Meta is: ".print_r($clean_meta,true));
 
+        //dd($array);
         return $array;
     }
 

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -55,17 +55,17 @@ class ActionlogsTransformer
             }
         }
 
-        $url = '';
+        $file_url = '';
         if($actionlog->filename!='') {
             if ($actionlog->present()->actionType() == 'accepted') {
-                $url = route('log.storedeula.download', ['filename' => $actionlog->filename]);
+                $file_url = route('log.storedeula.download', ['filename' => $actionlog->filename]);
             } else {
                 if ($actionlog->itemType() == 'asset') {
-                    $url = route('show/assetfile', ['assetId' => $actionlog->id, 'fileId' => $actionlog->id]);
+                    $file_url = route('show/assetfile', ['assetId' => $actionlog->id, 'fileId' => $actionlog->id]);
                 } elseif ($actionlog->itemType() == 'license') {
-                    $url = route('show.licensefile', ['licenseId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
+                    $file_url = route('show.licensefile', ['licenseId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
                 } elseif ($actionlog->itemType() == 'user') {
-                    $url = route('show/userfile', ['userId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
+                    $file_url = route('show/userfile', ['userId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
                 }
             }
         }
@@ -76,7 +76,7 @@ class ActionlogsTransformer
             'file' => ($actionlog->filename!='')
                 ?
                 [
-                    'url' => $url,
+                    'url' => $file_url,
                     'filename' => $actionlog->filename,
                     'inlineable' => (bool) Helper::show_file_inline($actionlog->filename),
                 ] : null,

--- a/resources/views/reports/activity.blade.php
+++ b/resources/views/reports/activity.blade.php
@@ -47,6 +47,7 @@
                             <th class="col-sm-3" data-searchable="false" data-sortable="true" data-field="action_date" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
                             <th class="col-sm-2" data-searchable="true" data-sortable="true" data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
                             <th class="col-sm-2" data-field="action_type">{{ trans('general.action') }}</th>
+                            <th class="col-sm-2" data-field="file" data-formatter="fileUploadNameFormatter">{{ trans('general.file_name') }}</th>
                             <th class="col-sm-1" data-field="type" data-formatter="itemTypeFormatter">{{ trans('general.type') }}</th>
                             <th class="col-sm-3" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>
                             <th class="col-sm-2" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.to') }}</th>

--- a/resources/views/reports/activity.blade.php
+++ b/resources/views/reports/activity.blade.php
@@ -47,7 +47,7 @@
                             <th class="col-sm-3" data-searchable="false" data-sortable="true" data-field="action_date" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
                             <th class="col-sm-2" data-searchable="true" data-sortable="true" data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
                             <th class="col-sm-2" data-field="action_type">{{ trans('general.action') }}</th>
-                            <th class="col-sm-2" data-field="file" data-formatter="fileUploadNameFormatter">{{ trans('general.file_name') }}</th>
+                            <th class="col-sm-2" data-field="file" data-visible="false" data-formatter="fileUploadNameFormatter">{{ trans('general.file_name') }}</th>
                             <th class="col-sm-1" data-field="type" data-formatter="itemTypeFormatter">{{ trans('general.type') }}</th>
                             <th class="col-sm-3" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>
                             <th class="col-sm-2" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.to') }}</th>


### PR DESCRIPTION
# Description
I think the linked issue is not exactly how this needs to works, but let me know what you think:

When uploading a file to an asset, license or user the target is already the entity that 'receives' the file... so if the report says that an `Action->upload` is happening over an `Item->Heidi Emerich` of `Type->user`, that's the target, like this. 

![image](https://user-images.githubusercontent.com/653557/170389481-39eb9de0-d7e7-46a8-ba02-4422fe99137b.png)

Of course that I can repeat the target with this data... but I opted for add a column called `File` that contains the file that was uploaded, Since the file is already stored in the ActionLog, I just change a little bit the actionlog transformer and the view of the Activity Report. So the column is hidden by default, and can be activated as preferred. Looking now like this:

![image](https://user-images.githubusercontent.com/653557/170389920-3497c937-56c7-49eb-aa8d-ea2b0815d61a.png)
 
Fixes #11193 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
