### PR TITLE
Fixes #11116 Error exception in getimagesize

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -152,6 +152,13 @@ class AcceptanceController extends Controller
              * since we want the moment-in-time proof of what the EULA was when they accepted it.
              */
             $branding_settings = SettingsController::getPDFBranding();
+
+            if (is_null($branding_settings->logo)){
+                $path_logo = "";
+            } else {
+                $path_logo = public_path() . '/uploads/' . $branding_settings->logo;
+            }
+            
             $data = [
                 'item_tag' => $item->asset_tag,
                 'item_model' => $display_model,
@@ -162,7 +169,7 @@ class AcceptanceController extends Controller
                 'assigned_to' => $assigned_to,
                 'company_name' => $branding_settings->site_name,
                 'signature' => ($sig_filename) ? storage_path() . '/private_uploads/signatures/' . $sig_filename : null,
-                'logo' => public_path() . '/uploads/' . $branding_settings->logo,
+                'logo' => $path_logo,
                 'date_settings' => $branding_settings->date_display_format,
             ];
 


### PR DESCRIPTION
# Description
If no logo is uploaded in Settings > Branding, when the system tries to create the Acceptance PDF the getimagesize function fails.


Fixes #11116 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
