### PR TITLE
fixed issue with misplaced div

### DIFF
--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -54,9 +54,9 @@
 
             <li class="active">
                 <a href="#details" data-toggle="tab">
-                          <span class="hidden-lg hidden-md">
-                          <i class="fas fa-info-circle fa-2x"x></i>
-                          </span>
+                  <span class="hidden-lg hidden-md">
+                  <i class="fas fa-info-circle fa-2x"x></i>
+                  </span>
                     <span class="hidden-xs hidden-sm">{{ trans('admin/users/general.info') }}</span>
                 </a>
             </li>
@@ -106,7 +106,7 @@
 
 
 
-          <!-- side address column -->
+<!-- side address column -->
 
 <div class="col-md-3">
 
@@ -153,7 +153,7 @@
               {!! nl2br(e($accessory->notes)) !!}
           </div>
 
-  @endif
+     @endif
 
 
       <div class="row">
@@ -218,8 +218,8 @@
             </div> <!-- /.row-->
         </div><!--tab history-->
     </div><!--tab-content-->
-        @stop
 </div><!--/.nav-tabs-custom-->
+        git
 
 
 

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -219,7 +219,7 @@
         </div><!--tab history-->
     </div><!--tab-content-->
 </div><!--/.nav-tabs-custom-->
-        git
+@stop
 
 
 


### PR DESCRIPTION
# Description
There was a `@stop` tag in the wrong place that was causing issues with the css rules.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
