### PR TITLE
Don’t use the formatted date for diff days in audit report

### DIFF
--- a/resources/views/notifications/markdown/upcoming-audits.blade.php
+++ b/resources/views/notifications/markdown/upcoming-audits.blade.php
@@ -9,7 +9,7 @@
 @php
 $next_audit_date = Helper::getFormattedDateObject($asset->next_audit_date, 'date', false);
 $last_audit_date = Helper::getFormattedDateObject($asset->last_audit_date, 'date', false);
-$diff = Carbon::parse(Carbon::now())->diffInDays($next_audit_date, false);
+$diff = Carbon::parse(Carbon::now())->diffInDays($asset->next_audit_date, false);
 $icon = ($diff <= 7) ? '🚨' : (($diff <= 14) ? '⚠️' : ' ');
 @endphp
 |{{ $icon }}| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset->id) }}) | {{ $last_audit_date }}| {{ $next_audit_date }} | {{ $diff }}  | {{ ($asset->supplier ? e($asset->supplier->name) : '') }}|{{ ($asset->assignedTo ? $asset->assignedTo->present()->name() : '') }}


### PR DESCRIPTION
This is a tiny change, but we were trying to do diff math and get a numeric result on formatted dates, resulting in an error if there was a `d/m/Y` selected locale:

```
Could not parse '18/08/2022': DateTime::__construct(): Failed to parse time string (18/08/2022) at position 0 (1): Unexpected character (View: /Users/snipe/Sites/snipe-it/snipe-it/resources/views/notifications/markdown/upcoming-audits.blade.php)

  at vendor/nesbot/carbon/src/Carbon/Traits/Creator.php:190
    186▕         } catch (Exception $exception) {
    187▕             $date = @static::now($tz)->change($time);
    188▕
    189▕             if (!$date) {
  ➜ 190▕                 throw new InvalidFormatException("Could not parse '$time': ".$exception->getMessage(), 0, $exception);
    191▕             }
    192▕
    193▕             return $date;
    194▕         }

  1   resources/views/notifications/markdown/upcoming-audits.blade.php:14
      Carbon\Carbon::diffInDays("18/08/2022")

      +8 vendor frames
  10  storage/framework/views/d251964a0aff6f828c489152152b6b523ad716bd.php:14
      Carbon\Carbon::diffInDays("18/08/2022")
```