### PR TITLE
Dropped log level to warn on SAML error

### DIFF
--- a/app/Services/Saml.php
+++ b/app/Services/Saml.php
@@ -134,7 +134,7 @@ class Saml
             $this->_auth = new OneLogin_Saml2_Auth($this->_settings);
         } catch (Exception $e) {
             if ( $this->isEnabled() ) { // $this->loadSettings() initializes this to true if SAML is enabled by settings.
-                \Log::error('Trying OneLogin_Saml2_Auth failed. Setting SAML enabled to false. OneLogin_Saml2_Auth error message is: '.  $e->getMessage());
+                \Log::warning('Trying OneLogin_Saml2_Auth failed. Setting SAML enabled to false. OneLogin_Saml2_Auth error message is: '.  $e->getMessage());
             }
             $this->_enabled = false;
         }


### PR DESCRIPTION
Switching to a warning level error message, since it was junking up our rollbar alerts.

Fixes Rollbar #16584