### PR TITLE
Updated Asset Model gate to correctly display the button on view

### DIFF
--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -8,7 +8,7 @@
 @stop
 
 @section('header_right')
-  @can('superuser')
+  @can('update', \App\Models\AssetModel::class)
   <div class="btn-group pull-right">
      <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">{{ trans('button.actions') }}
           <span class="caret"></span>


### PR DESCRIPTION
Looks like we were requiring superuser access to display the button menu on the asset models view page. This should correct that issue.