### PR TITLE
Fixed crashing on date formatting helper when value is not actually a date

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -864,7 +864,7 @@ class Helper
          *
          * While this *shouldn't* typically happen since we validate dates before entering them
          * into the database (and we use date/datetime fields for native fields in the system),
-         * It is a possible scenario that a custom field could be created as an "ANY" field, data gets
+         * it is a possible scenario that a custom field could be created as an "ANY" field, data gets
          * added, and then the custom field format gets edited later. If someone put bad data in the
          * database before then - or if they manually edited the field's value - it will crash.
          *

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -841,6 +841,15 @@ class Helper
         return preg_replace('/\s+/u', '_', trim($string));
     }
 
+    /**
+     * Return an array (or null) of the the raw and formatted date object for easy use in
+     * the API and the bootstrap table listings.
+     *
+     * @param $date
+     * @param $type
+     * @param $array
+     * @return array|string|null
+     */
     public static function getFormattedDateObject($date, $type = 'datetime', $array = true)
     {
         if ($date == '') {
@@ -848,21 +857,42 @@ class Helper
         }
 
         $settings = Setting::getSettings();
-        $tmp_date = new \Carbon($date);
 
-        if ($type == 'datetime') {
-            $dt['datetime'] = $tmp_date->format('Y-m-d H:i:s');
-            $dt['formatted'] = $tmp_date->format($settings->date_display_format.' '.$settings->time_display_format);
-        } else {
-            $dt['date'] = $tmp_date->format('Y-m-d');
-            $dt['formatted'] = $tmp_date->format($settings->date_display_format);
+        /**
+         * Wrap this in a try/catch so that if Carbon crashes, for example if the $date value
+         * isn't actually valid, we don't crash out completely.
+         *
+         * While this *shouldn't* typically happen since we validate dates before entering them
+         * into the database (and we use date/datetime fields for native fields in the system),
+         * It is a possible scenario that a custom field could be created as an "ANY" field, data gets
+         * added, and then the custom field format gets edited later. If someone put bad data in the
+         * database before then - or if they manually edited the field's value - it will crash.
+         *
+         */
+=
+
+        try {
+            $tmp_date = new \Carbon($date);
+
+            if ($type == 'datetime') {
+                $dt['datetime'] = $tmp_date->format('Y-m-d H:i:s');
+                $dt['formatted'] = $tmp_date->format($settings->date_display_format.' '.$settings->time_display_format);
+            } else {
+                $dt['date'] = $tmp_date->format('Y-m-d');
+                $dt['formatted'] = $tmp_date->format($settings->date_display_format);
+            }
+
+            if ($array == 'true') {
+                return $dt;
+            }
+
+            return $dt['formatted'];
+
+        } catch (\Exception $e) {
+            \Log::warning($e);
+            return 'ERROR: Date value is invalid';
         }
 
-        if ($array == 'true') {
-            return $dt;
-        }
-
-        return $dt['formatted'];
     }
 
     // Nicked from Drupal :)

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -891,7 +891,7 @@ class Helper
 
         } catch (\Exception $e) {
             \Log::warning($e);
-            return 'ERROR: Date value is invalid';
+            return $date.' (Invalid '.$type.' value.)';
         }
 
     }

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -850,6 +850,7 @@ class Helper
      * @param $array
      * @return array|string|null
      */
+
     public static function getFormattedDateObject($date, $type = 'datetime', $array = true)
     {
         if ($date == '') {
@@ -869,7 +870,7 @@ class Helper
          * database before then - or if they manually edited the field's value - it will crash.
          *
          */
-=
+
 
         try {
             $tmp_date = new \Carbon($date);


### PR DESCRIPTION
This just wraps the Carbon method in a try/catch to prevent crashing on bad data, so if the $date value isn't actually valid, we don't crash out completely.

While this *shouldn't* typically happen since we validate dates before entering them into the database (and we use date/datetime fields for native fields in the system), it is a possible scenario that a custom field could be created as an "ANY" field, data gets added, and then the custom field format gets edited to DATE or DATETIME later. If someone put bad data in the database before then - or if they manually edited the field's value - it will crash with:

```php
DateTime::__construct(): Failed to parse time string (TBV) at position 0 (T): The timezone could not be found in the database (View: /Users/snipe/Sites/snipe-it/snipe-it/resources/views/hardware/view.blade.php)
```

This will now not crash and will instead return an error that the date is invalid.

<img width="833" alt="Screen Shot 2022-06-03 at 3 37 08 PM" src="https://user-images.githubusercontent.com/197404/171963127-e3bfc06b-3097-4170-9d21-30e1d9dba5b2.png">

While I find it ugly to return a string (instead of false, etc), this method was flat-out crashing as it is now (when there was bad data). A further refractor might be in order down the line, but this at least fixes the immediate problem.