### PR TITLE
Small locations improvements

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -519,10 +519,14 @@ class UsersController extends Controller
     {
         $this->authorize('view', User::class);
         $this->authorize('view', License::class);
-        $user = User::where('id', $id)->withTrashed()->first();
-        $licenses = $user->licenses()->get();
+        
+        if ($user = User::where('id', $id)->withTrashed()->first()) {
+            $licenses = $user->licenses()->get();
+            return (new LicensesTransformer())->transformLicenses($licenses, $licenses->count());
+        }
 
-        return (new LicensesTransformer())->transformLicenses($licenses, $licenses->count());
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/users/message.user_not_found', compact('id'))));
+
     }
 
     /**

--- a/app/Http/Controllers/LocationsController.php
+++ b/app/Http/Controllers/LocationsController.php
@@ -211,23 +211,35 @@ class LocationsController extends Controller
 
     public function print_assigned($id)
     {
-        $location = Location::where('id', $id)->first();
-        $parent = Location::where('id', $location->parent_id)->first();
-        $manager = User::where('id', $location->manager_id)->first();
-        $users = User::where('location_id', $id)->with('company', 'department', 'location')->get();
-        $assets = Asset::where('assigned_to', $id)->where('assigned_type', Location::class)->with('model', 'model.category')->get();
 
-        return view('locations/print')->with('assets', $assets)->with('users', $users)->with('location', $location)->with('parent', $parent)->with('manager', $manager);
+        if ($location = Location::where('id', $id)->first()) {
+            $parent = Location::where('id', $location->parent_id)->first();
+            $manager = User::where('id', $location->manager_id)->first();
+            $users = User::where('location_id', $id)->with('company', 'department', 'location')->get();
+            $assets = Asset::where('assigned_to', $id)->where('assigned_type', Location::class)->with('model', 'model.category')->get();
+            return view('locations/print')->with('assets', $assets)->with('users', $users)->with('location', $location)->with('parent', $parent)->with('manager', $manager);
+
+        }
+
+        return redirect()->route('locations.index')->with('error', trans('admin/locations/message.does_not_exist'));
+
+
+
     }
 
     public function print_all_assigned($id)
     {
-        $location = Location::where('id', $id)->first();
-        $parent = Location::where('id', $location->parent_id)->first();
-        $manager = User::where('id', $location->manager_id)->first();
-        $users = User::where('location_id', $id)->with('company', 'department', 'location')->get();
-        $assets = Asset::where('location_id', $id)->with('model', 'model.category')->get();
+        if ($location = Location::where('id', $id)->first()) {
+            $parent = Location::where('id', $location->parent_id)->first();
+            $manager = User::where('id', $location->manager_id)->first();
+            $users = User::where('location_id', $id)->with('company', 'department', 'location')->get();
+            $assets = Asset::where('location_id', $id)->with('model', 'model.category')->get();
+            return view('locations/print')->with('assets', $assets)->with('users', $users)->with('location', $location)->with('parent', $parent)->with('manager', $manager);
 
-        return view('locations/print')->with('assets', $assets)->with('users', $users)->with('location', $location)->with('parent', $parent)->with('manager', $manager);
+        }
+        return redirect()->route('locations.index')->with('error', trans('admin/locations/message.does_not_exist'));
+
+
+
     }
 }

--- a/resources/lang/en/admin/locations/general.php
+++ b/resources/lang/en/admin/locations/general.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+    'assigned_location' 	                => 'Assigned to :location Location',
+    'asset_management_system' => 'Asset Management System',
+    'assigned_to' => 'Assigned To:',
+    'manager' => 'Manager',
+    'date' => 'Current Date:',
+);

--- a/resources/views/locations/print.blade.php
+++ b/resources/views/locations/print.blade.php
@@ -156,34 +156,23 @@
 <table>
     <tr>
         <td>{{ trans('admin/locations/table.signed_by_asset_auditor') }}</td>
-        <td>___________________________</td>
-        <td></td>
+        <td><br>------------------------------------------------------ &nbsp;&nbsp;&nbsp;<br></td>
         <td>{{ trans('admin/locations/table.date') }}</td>
-        <td>____________________</td>
+        <td><br>------------------------------ &nbsp;&nbsp;&nbsp;<br></td>
     </tr>
-</table>
-<br>
-<br>
-<br>
-<table>
+
     <tr>
         <td>{{ trans('admin/locations/table.signed_by_finance_auditor') }}</td>
-        <td>____________________</td>
-        <td></td>
+        <td><br>------------------------------------------------------ &nbsp;&nbsp;&nbsp;<br></td>
         <td>{{ trans('admin/locations/table.date') }}</td>
-        <td>____________________</td>
+        <td><br>------------------------------ &nbsp;&nbsp;&nbsp;<br></td>
     </tr>
-</table>
-<br>
-<br>
-<br>
-<table>
+
     <tr>
         <td>{{ trans('admin/locations/table.signed_by_location_manager') }}</td>
-        <td>_______________________</td>
-        <td></td>
+        <td><br>------------------------------------------------------ &nbsp;&nbsp;&nbsp;<br></td>
         <td>{{ trans('admin/locations/table.date') }}</td>
-        <td>____________________</td>
+        <td><br>------------------------------ &nbsp;&nbsp;&nbsp;<br></td>
     </tr>
 </table>
 

--- a/resources/views/locations/view.blade.php
+++ b/resources/views/locations/view.blade.php
@@ -191,9 +191,20 @@
 
   <div class="col-md-3">
 
+      <div class="col-md-12">
+          <a href="{{ route('locations.edit', ['location' => $location->id]) }}" style="width: 100%;" class="btn btn-sm btn-primary pull-left">{{ trans('admin/locations/table.update') }} </a>
+      </div>
+      <div class="col-md-12" style="padding-top: 5px;">
+          <a href="{{ route('locations.print_assigned', ['locationId' => $location->id]) }}" style="width: 100%;" class="btn btn-sm btn-default pull-left">{{ trans('admin/locations/table.print_assigned') }} </a>
+      </div>
+      <div class="col-md-12" style="padding-top: 5px; padding-bottom: 20px;">
+          <a href="{{ route('locations.print_all_assigned', ['locationId' => $location->id]) }}" style="width: 100%;" class="btn btn-sm btn-default pull-left">{{ trans('admin/locations/table.print_all_assigned') }} </a>
+      </div>
+
+
     @if ($location->image!='')
       <div class="col-md-12 text-center" style="padding-bottom: 20px;">
-        <img src="{{ Storage::disk('public')->url('locations/'.e($location->image)) }}" class="img-responsive img-thumbnail" alt="{{ $location->name }}">
+        <img src="{{ Storage::disk('public')->url('locations/'.e($location->image)) }}" class="img-responsive img-thumbnail" style="width:100%" alt="{{ $location->name }}">
       </div>
     @endif
       <div class="col-md-12">
@@ -220,21 +231,13 @@
 
         @if (($location->state!='') && ($location->country!='') && (config('services.google.maps_api_key')))
           <div class="col-md-12 text-center">
-            <img src="https://maps.googleapis.com/maps/api/staticmap?markers={{ urlencode($location->address.','.$location->city.' '.$location->state.' '.$location->country.' '.$location->zip) }}&size=500x300&maptype=roadmap&key={{ config('services.google.maps_api_key') }}" class="img-responsive img-thumbnail" alt="Map">
+            <img src="https://maps.googleapis.com/maps/api/staticmap?markers={{ urlencode($location->address.','.$location->city.' '.$location->state.' '.$location->country.' '.$location->zip) }}&size=700x500&maptype=roadmap&key={{ config('services.google.maps_api_key') }}" class="img-thumbnail" style="width:100%" alt="Map">
           </div>
         @endif
 
       </div>
 
-		<div class="col-md-12">
-			<a href="{{ route('locations.edit', ['location' => $location->id]) }}" style="width: 50%;" class="btn btn-sm btn-primary pull-left">{{ trans('admin/locations/table.update') }} </a>
-		</div>
-        <div class="col-md-12" style="padding-top: 5px;">
-			<a href="{{ route('locations.print_assigned', ['locationId' => $location->id]) }}" style="width: 50%;" class="btn btn-sm btn-default pull-left">{{ trans('admin/locations/table.print_assigned') }} </a>
-		</div>
-		<div class="col-md-12" style="padding-top: 5px;">
-			<a href="{{ route('locations.print_all_assigned', ['locationId' => $location->id]) }}" style="width: 50%;" class="btn btn-sm btn-default pull-left">{{ trans('admin/locations/table.print_all_assigned') }} </a>
-		</div>
+
 		
   </div>
 


### PR DESCRIPTION
This PR just fixes a bug where someone goes to the locations print-assigned page on a non-existent license - which generally shouldn't happen, but should in an edge case where a user has the location's screen up and then it gets deleted on another session.

I also took the opportunity to un-jank some of the sidebar elements on locations, from this:

<img width="386" alt="Screen Shot 2022-06-05 at 5 02 15 PM" src="https://user-images.githubusercontent.com/197404/172076073-76dd000a-b540-445a-89b8-34d6d4220372.png">


To this:

<img width="371" alt="Screen Shot 2022-06-05 at 5 03 57 PM" src="https://user-images.githubusercontent.com/197404/172076101-a886604c-2a33-45fe-8988-3393c7a54881.png">

I wonder if listing those tables in tabs (which I think would look better, similar to the user's detail page) might interrupt a workflow I'm not considering. 