### PR TITLE
Fixed  #11224 - only show menu options if the user is allowed

### DIFF
--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -12,8 +12,12 @@
         </span>
     </label>
     <select name="bulk_actions" class="form-control select2" aria-label="bulk_actions">
-        <option value="edit">{{ trans('button.edit') }}</option>
-        <option value="delete">{{ trans('button.delete') }}</option>
+        @can('update', \App\Models\Asset::class)
+            <option value="edit">{{ trans('button.edit') }}</option>
+        @endcan
+        @can('delete', \App\Models\Asset::class)
+            <option value="delete">{{ trans('button.delete') }}</option>
+        @endcan
         <option value="labels">{{ trans_choice('button.generate_labels', 2) }}</option>
     </select>
 


### PR DESCRIPTION
Fixes  #11224 by adding a `@can()` gate around the individual options in bulk edit.

<img width="534" alt="Screen Shot 2022-06-05 at 10 42 48 PM" src="https://user-images.githubusercontent.com/197404/172102094-942983ae-d69a-4d41-a192-a8f5f99451df.png">
<img width="725" alt="Screen Shot 2022-06-05 at 10 43 33 PM" src="https://user-images.githubusercontent.com/197404/172102097-f7207d6f-b958-4e18-b7d5-50a82475738d.png">
