### PR TITLE
Fixes some issues in the asset observer

### DIFF
--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -18,19 +18,21 @@ class AssetObserver
     public function updating(Asset $asset)
     {
         $attributes = $asset->getAttributes();
-        $attributesOriginal = $asset->getOriginal();
-        
+        $attributesOriginal = $asset->getRawOriginal();
+
         // If the asset isn't being checked out or audited, log the update.
         // (Those other actions already create log entries.)
-          if (($attributes['assigned_to'] == $attributesOriginal['assigned_to'])
+	if (($attributes['assigned_to'] == $attributesOriginal['assigned_to']) 
+	    && ($attributes['checkout_counter'] == $attributesOriginal['checkout_counter'])
+	    && ($attributes['checkin_counter'] == $attributesOriginal['checkin_counter'])
             && ((isset( $attributes['next_audit_date']) ? $attributes['next_audit_date'] : null) == (isset($attributesOriginal['next_audit_date']) ? $attributesOriginal['next_audit_date']: null))
             && ($attributes['last_checkout']   == $attributesOriginal['last_checkout']))
         {
             $changed = [];
 
-            foreach ($asset->getOriginal() as $key => $value) {
-                if ($asset->getOriginal()[$key] != $asset->getAttributes()[$key]) {
-                    $changed[$key]['old'] = $asset->getOriginal()[$key];
+            foreach ($asset->getRawOriginal() as $key => $value) {
+                if ($asset->getRawOriginal()[$key] != $asset->getAttributes()[$key]) {
+                    $changed[$key]['old'] = $asset->getRawOriginal()[$key];
                     $changed[$key]['new'] = $asset->getAttributes()[$key];
                 }
             }


### PR DESCRIPTION
# Description
When the observer compares original versus changed attributes of the asset, if the changed field is a date field the original is read as a Carbon object and the changed one is read as a text string, which makes those fields always logged in the 'changed' column even if it's the same date. I used the `getRawOriginal()` method, so it compares both values only.

Also, when doing a Checkin or Checkout of the asset, changes where logged as duplicates: one for the checkout/checkin and another as an update, which is not desired. I write logic to only log updates if the `checkin_counter` and `checkout_counter` are the same in addition to the other conditions that already exists, that appears to do the trick.

One remaining issue that I'm open to discuss is, if the user click the `edit` button, doesn't change anything and then click `save` the Observer logs an entry with the 'changed' column blank. I left this because I think it's technically correct that the user does 'update' the asset and no change was actually done. But maybe not log this activity also makes sense, to not fill the history data with blank 'changes'.

Fixes #11174 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
