### PR TITLE
Fixed #11255 - add address 2 field to locations listing

### DIFF
--- a/app/Presenters/LocationPresenter.php
+++ b/app/Presenters/LocationPresenter.php
@@ -91,6 +91,14 @@ class LocationPresenter extends Presenter
                 'visible' => true,
             ],
             [
+                'field' => 'address2',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' =>  trans('admin/locations/table.address'),
+                'visible' => false,
+            ],
+            [
                 'field' => 'city',
                 'searchable' => true,
                 'sortable' => true,


### PR DESCRIPTION
Added the address2 field to the presenter to expose it in the locations listing. 

The column name here might be a little confusing, since we don't actually have a corresponding field for "Address 2" in the location create/edit forms. They will sort correctly, but may be visually a little confusing. This new column is hidden by default, since most people don't care about address 2, but if they choose to expose it in that view, the cookie will remember their choice. 

<img width="1561" alt="Screen Shot 2022-06-06 at 7 32 49 PM" src="https://user-images.githubusercontent.com/197404/172283445-eecc59f7-1c7d-4bf0-9632-415ecc22de71.png">


Fixes #11255.

