### PR TITLE
Fixed #11093 - Return true/false for custom fields/fieldsets required value in API

### DIFF
--- a/app/Http/Transformers/CustomFieldsTransformer.php
+++ b/app/Http/Transformers/CustomFieldsTransformer.php
@@ -46,7 +46,7 @@ class CustomFieldsTransformer
             'field_values'   => ($field->field_values) ? e($field->field_values) : null,
             'field_values_array'   => ($field->field_values) ? explode("\r\n", e($field->field_values)) : null,
             'type'   =>  e($field->element),
-            'required'   =>  $field->pivot ? $field->pivot->required : false,
+            'required'   =>  (($field->pivot) && ($field->pivot->required=='1')) ? true : false,
             'created_at' => Helper::getFormattedDateObject($field->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($field->updated_at, 'datetime'),
         ];


### PR DESCRIPTION
This change just males the `required` field return true/false. There was a bug in the transformer that would return `1` if required, `false` if not. 