### PR TITLE
Fixes log update action even if no changes are made to assets [sc-19131]

### DIFF
--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -26,7 +26,7 @@ class AssetObserver
 	    && ($attributes['checkout_counter'] == $attributesOriginal['checkout_counter'])
 	    && ($attributes['checkin_counter'] == $attributesOriginal['checkin_counter'])
             && ((isset( $attributes['next_audit_date']) ? $attributes['next_audit_date'] : null) == (isset($attributesOriginal['next_audit_date']) ? $attributesOriginal['next_audit_date']: null))
-            && ($attributes['last_checkout']   == $attributesOriginal['last_checkout']))
+            && ($attributes['last_checkout'] == $attributesOriginal['last_checkout']))
         {
             $changed = [];
 
@@ -35,7 +35,11 @@ class AssetObserver
                     $changed[$key]['old'] = $asset->getRawOriginal()[$key];
                     $changed[$key]['new'] = $asset->getAttributes()[$key];
                 }
-            }
+	    }
+
+	    if (empty($changed)){
+	        return;
+	    }
 
             $logAction = new Actionlog();
             $logAction->item_type = Asset::class;


### PR DESCRIPTION
# Description
If we open the edit form of assets and just click 'save' without change anything, the observer still logs an update action with blank data.

We want that if nothing is changed in the asset, no history of that change is saved, so I added an early return before the observer saves the action if the changed array is empty.

Fixes [sc-19131]

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
