### PR TITLE
Fixed default ldap version if not specified

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -942,7 +942,7 @@ class SettingsController extends Controller
             $setting->ldap_lname_field = $request->input('ldap_lname_field');
             $setting->ldap_fname_field = $request->input('ldap_fname_field');
             $setting->ldap_auth_filter_query = $request->input('ldap_auth_filter_query');
-            $setting->ldap_version = $request->input('ldap_version');
+            $setting->ldap_version = $request->input('ldap_version', 3);
             $setting->ldap_active_flag = $request->input('ldap_active_flag');
             $setting->ldap_emp_num = $request->input('ldap_emp_num');
             $setting->ldap_email = $request->input('ldap_email');

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -37,7 +37,7 @@ class Ldap extends Model
     public static function connectToLdap()
     {
         $ldap_host = Setting::getSettings()->ldap_server;
-        $ldap_version = Setting::getSettings()->ldap_version;
+        $ldap_version = Setting::getSettings()->ldap_version ?: 3;
         $ldap_server_cert_ignore = Setting::getSettings()->ldap_server_cert_ignore;
         $ldap_use_tls = Setting::getSettings()->ldap_tls;
 


### PR DESCRIPTION
This PR should hopefully solve some of the LDAP configs that some users have been having issues with. This should prevent the `ldap_search(): Search: Partial results and referral received` error that could occur if the LDAP version field was left blank in the LDAP settings.

Previous versions of Snipe-IT automatically *assumed* v3 of LDAP (because in 9 years of running this project I have never seen any other version used), but somehow when we had to forklift the old LDAP functionality from v4 to un-do the AdLdap package stuff, that default got dropped in the shuffle. 

 Next iteration we will likely remove that field in the LDAP settings screen altogether, since LDAP v2 has been EOL forever and LDAP v4 is unlikely. It's pretty much always going to be v3. 