### PR TITLE
Fixes EOL field doesn't have date formatter applied

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -626,7 +626,7 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-6">
-                                                {{ $asset->present()->eol_date() }}
+                                                {{ Helper::getFormattedDateObject($asset->present()->eol_date(), 'date', false) }}
 
 
                                                 @if ($asset->present()->months_until_eol())


### PR DESCRIPTION
# Description
Before:
![image](https://user-images.githubusercontent.com/653557/172499820-52b8157b-fc30-4354-8daa-cd81239e0ede.png)

After:
![image](https://user-images.githubusercontent.com/653557/172499911-dba11c11-af3e-44f4-b97c-90f9e04b2612.png)


Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.23
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
