### PR TITLE
fixes translation references in the users ldap blade

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -257,6 +257,7 @@ return [
     'undeployable'			=> 'Un-deployable',
     'unknown_admin'			=> 'Unknown Admin',
     'username_format'		=> 'Username Format',
+    'username'              => 'Username',
     'update'                => 'Update',
     'upload_filetypes_help'      => 'Allowed filetypes are png, gif, jpg, jpeg, doc, docx, pdf, xls, xlsx, txt, lic, xml, zip, rtf and rar. Max upload size allowed is :size.',
     'uploaded'              => 'Uploaded',

--- a/resources/views/users/ldap.blade.php
+++ b/resources/views/users/ldap.blade.php
@@ -69,7 +69,7 @@
         <table class="table table-bordered">
           <tr>
               <th>{{ trans('general.username') }}</th><th>{{ trans('general.employee_number') }}</th>
-              <th>{{ trans('general.firstname') }}</th><th>{{ trans('general.lastname') }}</th>
+              <th>{{ trans('general.first_name') }}</th><th>{{ trans('general.last_name') }}</th>
               <th>{{ trans('general.email') }}</th><th>{{ trans('general.notes') }}</th>
           </tr>
 


### PR DESCRIPTION
# Description
references the correct translation strings now in the users ldap sync screen
<img width="994" alt="image" src="https://user-images.githubusercontent.com/47435081/172673294-eb736927-b87c-47a2-bd9a-f666806f8a22.png">

Fixes # SC-19134

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
