### PR TITLE
WIP experimenting with repopulating asset form fields

### DIFF
--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -30,7 +30,12 @@
       @else
           <!-- we are creating a new asset - let people use more than one asset tag -->
           <div class="col-md-7 col-sm-12{{  (Helper::checkIfRequired($item, 'asset_tag')) ? ' required' : '' }}">
-              <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ Request::old('asset_tag', \App\Models\Asset::autoincrement_asset()) }}" data-validation="required">
+              <input class="form-control" type="text" name="asset_tags[1]" id="asset_tags[1]" value="{{ old('asset_tag', \App\Models\Asset::autoincrement_asset()) }}" data-validation="required">
+              @if(old('asset_tag'))
+                  @for( $i=1; $i < count(old('asset_tags')); $i++)
+              <input class="form-control" type="text" name="asset_tags[{{$i}}]" id="asset_tags[{{$i}}]" value="{{ old('asset_tag.'.$i, \App\Models\Asset::autoincrement_asset()) }}" data-validation="required">
+                  @endfor
+              @endif
               {!! $errors->first('asset_tags', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
               {!! $errors->first('asset_tag', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
           </div>

--- a/resources/views/partials/forms/edit/serial.blade.php
+++ b/resources/views/partials/forms/edit/serial.blade.php
@@ -3,6 +3,11 @@
     <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ trans('admin/hardware/form.serial') }} </label>
     <div class="col-md-7 col-sm-12{{  (Helper::checkIfRequired($item, 'serial')) ? ' required' : '' }}">
         <input class="form-control" type="text" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old('serial', $item->serial) }}" />
+        @if(old('serial'))
+            @for( $i=1; $i < count(old('serials')); $i++)
+        <input class="form-control" type="text" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old('serial.'.$i, $item->serial) }}" />
+            @endfor
+        @endif
         {!! $errors->first('serial', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>


### PR DESCRIPTION
# Description
 Experimenting with ways to get Asset tag and Serial to repopulate on validation failure. They are unique fields in that there can be multiples of each that would need to be repopulated.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
