### PR TITLE
Fixed #11092 - Add element type of customfield to API response

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -102,6 +102,8 @@ class AssetsTransformer
                             'field' => e($field->convertUnicodeDbSlug()),
                             'value' => e($value),
                             'field_format' => $field->format,
+                            'element' =>$field->element,
+
                         ];
 
                 } else {
@@ -109,6 +111,7 @@ class AssetsTransformer
                         'field' => e($field->convertUnicodeDbSlug()),
                         'value' => e($asset->{$field->convertUnicodeDbSlug()}),
                         'field_format' => $field->format,
+                        'element' =>$field->element,
                     ];
 
 

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -102,7 +102,7 @@ class AssetsTransformer
                             'field' => e($field->convertUnicodeDbSlug()),
                             'value' => e($value),
                             'field_format' => $field->format,
-                            'element' =>$field->element,
+                            'element' => $field->element,
 
                         ];
 
@@ -111,7 +111,7 @@ class AssetsTransformer
                         'field' => e($field->convertUnicodeDbSlug()),
                         'value' => e($asset->{$field->convertUnicodeDbSlug()}),
                         'field_format' => $field->format,
-                        'element' =>$field->element,
+                        'element' => $field->element,
                     ];
 
 


### PR DESCRIPTION
# Description
When requesting an asset with customfields via the API, the type of element it have is not returned in the response, making uncomfortable to guess which is what. This changes adds the type to the API response.

Fixes #11092
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
