### PR TITLE
Fixes - set crons as app user in installer

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -237,7 +237,7 @@ install_snipeit () {
   log "php $APP_PATH/artisan migrate --force"
 
   echo "* Creating scheduler cron."
-  (run_as_app_user crontab -l ; echo "* * * * * /usr/bin/php $APP_PATH/artisan schedule:run >> /dev/null 2>&1") | crontab -
+  (run_as_app_user crontab -l ; echo "* * * * * /usr/bin/php $APP_PATH/artisan schedule:run >> /dev/null 2>&1") | run_as_app_user crontab -
 }
 
 set_firewall () {

--- a/snipeit.sh
+++ b/snipeit.sh
@@ -237,7 +237,7 @@ install_snipeit () {
   log "php $APP_PATH/artisan migrate --force"
 
   echo "* Creating scheduler cron."
-  (crontab -l ; echo "* * * * * /usr/bin/php $APP_PATH/artisan schedule:run >> /dev/null 2>&1") | crontab -
+  (run_as_app_user crontab -l ; echo "* * * * * /usr/bin/php $APP_PATH/artisan schedule:run >> /dev/null 2>&1") | crontab -
 }
 
 set_firewall () {


### PR DESCRIPTION
This should create the cronjobs (or corncobs, as autocorrect would have it) as the snipeitapp user instead of as root. 

