### PR TITLE
Fixes observer fails when creating and assigning a new asset

### DIFF
--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -19,12 +19,21 @@ class AssetObserver
     {
         $attributes = $asset->getAttributes();
         $attributesOriginal = $asset->getRawOriginal();
+        $same_checkout_counter = false;
+        $same_checkin_counter = false;
+
+        if (array_key_exists('checkout_counter', $attributes) && array_key_exists('checkout_counter', $attributesOriginal)){
+            $same_checkout_counter = (($attributes['checkout_counter'] == $attributesOriginal['checkout_counter']));
+        }
+
+        if (array_key_exists('checkin_counter', $attributes)  && array_key_exists('checkin_counter', $attributesOriginal)){
+            $same_checkin_counter = (($attributes['checkin_counter'] == $attributesOriginal['checkin_counter']));
+        }
 
         // If the asset isn't being checked out or audited, log the update.
         // (Those other actions already create log entries.)
 	if (($attributes['assigned_to'] == $attributesOriginal['assigned_to']) 
-	    && ($attributes['checkout_counter'] == $attributesOriginal['checkout_counter'])
-	    && ($attributes['checkin_counter'] == $attributesOriginal['checkin_counter'])
+	    && ($same_checkout_counter) && ($same_checkin_counter)
             && ((isset( $attributes['next_audit_date']) ? $attributes['next_audit_date'] : null) == (isset($attributesOriginal['next_audit_date']) ? $attributesOriginal['next_audit_date']: null))
             && ($attributes['last_checkout'] == $attributesOriginal['last_checkout']))
         {


### PR DESCRIPTION
# Description
If user wants to checkout an asset at the moment of creation, the Asset Observer fails because a couple fields that it checks to decide if log or not the changes doesn't exist yet.

This changes check that those fields already exist to try and log changes over the assets.

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
