### PR TITLE
Fixed regression: missing restore option for assets via API

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -483,7 +483,18 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:'.config('app.
             'checkout'
         ]
         )->name('api.asset.checkout');
-      }); 
+
+      Route::post('{asset_id}/restore',
+          [
+              Api\AssetsController::class,
+              'restore'
+          ]
+      )->name('api.assets.restore');
+
+      });
+
+
+
 
 
         Route::resource('hardware', 


### PR DESCRIPTION
Not sure how this got dropped, but this should restore the restore asset functionality to the API.