### PR TITLE
Allow to specify redis database

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -111,6 +111,7 @@ CACHE_PREFIX=snipeit
 REDIS_HOST=redis
 REDIS_PASSWORD=null
 REDIS_PORT=6379
+REDIS_DATABASE=0
 
 # --------------------------------------------
 # OPTIONAL: MEMCACHED SETTINGS

--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,7 @@ CACHE_PREFIX=snipeit
 REDIS_HOST=null
 REDIS_PASSWORD=null
 REDIS_PORT=null
+REDIS_DATABASE=null
 
 # --------------------------------------------
 # OPTIONAL: MEMCACHED SETTINGS

--- a/config/database.php
+++ b/config/database.php
@@ -154,7 +154,7 @@ return [
             'host'     => env('REDIS_HOST', 'localhost'),
             'password' => env('REDIS_PASSWORD', null),
             'port'     => env('REDIS_PORT', 6379),
-            'database' => 0,
+            'database' => env('REDIS_DATABASE', 0),
         ],
 
     ],


### PR DESCRIPTION
# Description

As you know one redis instance can hold several databases (0-16 by default). Different application can use the same redis instance when using different databases.

In my homelab I have active-active keydb (redis fork) cluster with HA and monitoring, the load is minimal so it is convenient to me to setup just one cluster.

Right now redis database is hardcoded to `0`. This change should allow to specify redis database.

I'm not sure how to update [heroku](https://github.com/snipe/snipe-it/blob/master/heroku/startup.php#L29) script.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

In process
- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
