### PR TITLE
Added models view (and bulk edit) in category detail view

### DIFF
--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -70,6 +70,10 @@ class AssetModelsController extends Controller
             $assetmodels->onlyTrashed();
         }
 
+        if ($request->filled('category_id')) {
+            $assetmodels = $assetmodels->where('models.category_id', '=', $request->input('category_id'));
+        }
+
         if ($request->filled('search')) {
             $assetmodels->TextSearch($request->input('search'));
         }

--- a/resources/views/categories/view.blade.php
+++ b/resources/views/categories/view.blade.php
@@ -129,11 +129,13 @@
                         <div class="row">
                             <div class="col-md-12">
 
+                                @can('update', \App\Models\AssetModel::class)
                                 @if ($category->models->count() > 0)
                                     @if ($category->category_type=='asset')
                                         @include('partials.models-bulk-actions')
                                     @endif
                                 @endif
+                                @endcan
 
                                     <table
                                             data-columns="{{ \App\Presenters\AssetModelPresenter::dataTableLayout() }}"
@@ -152,7 +154,7 @@
                                             data-sort-order="asc"
                                             id="asssetModelsTable"
                                             class="table table-striped snipe-table"
-                                            data-url="{{ route('api.models.index', ['status' => request('status')]) }}"
+                                            data-url="{{ route('api.models.index', ['status' => request('status'), 'category_id' => $category->id]) }}"
                                             data-export-options='{
               "fileName": "export-models-{{ date('Y-m-d') }}",
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]

--- a/resources/views/categories/view.blade.php
+++ b/resources/views/categories/view.blade.php
@@ -32,7 +32,7 @@
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs">
                     <li class="active">
-                        <a href="#items" data-toggle="tab" title="{{ trans('general.items') }}">{{ trans('general.'.$category->category_type) }}
+                        <a href="#items" data-toggle="tab" title="{{ trans('general.items') }}"> {{ ucwords($category_type_route) }}
                             @if ($category->category_type=='asset')
                             <badge class="badge badge-secondary"> {{ $category->assets->count() }}</badge>
                             @endif

--- a/resources/views/categories/view.blade.php
+++ b/resources/views/categories/view.blade.php
@@ -24,82 +24,154 @@
 {{-- Page content --}}
 @section('content')
 
-<div class="row">
-  <div class="col-md-12">
-    <div class="box box-default">
-      <div class="box-body">
-          @if ($category->category_type=='asset')
-            @include('partials.asset-bulk-actions')
-          @endif
 
-        <table
 
-                @if ($category->category_type=='asset')
+    <div class="row">
+        <div class="col-md-12">
 
-                  data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
-                  data-cookie-id-table="categoryAssetsTable"
-                  id="categoryAssetsTable"
-                  data-id-table="categoryAssetsTable"
-                  data-export-options='{
+            <div class="nav-tabs-custom">
+                <ul class="nav nav-tabs">
+                    <li class="active">
+                        <a href="#items" data-toggle="tab" title="{{ trans('general.items') }}">{{ trans('general.'.$category->category_type) }}
+                            @if ($category->category_type=='asset')
+                            <badge class="badge badge-secondary"> {{ $category->assets->count() }}</badge>
+                            @endif
+                        </a>
+                    </li>
+                    @if ($category->category_type=='asset')
+                    <li>
+                        <a href="#models" data-toggle="tab" title="{{ trans('general.asset_models') }}">{{ trans('general.asset_models') }}
+                            <badge class="badge badge-secondary"> {{ $category->models->count()}}</badge>
+                        </a>
+                    </li>
+                   @endif
+                </ul>
+                <div class="tab-content">
+                    <div class="tab-pane fade in active" id="items">
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="table-responsive">
+                                    @if ($category->category_type=='asset')
+                                        @include('partials.asset-bulk-actions')
+                                    @endif
+
+                                    <table
+
+                                            @if ($category->category_type=='asset')
+
+                                            data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
+                                            data-cookie-id-table="categoryAssetsTable"
+                                            id="categoryAssetsTable"
+                                            data-id-table="categoryAssetsTable"
+                                            data-toolbar="#assetsBulkEditToolbar"
+                                            data-bulk-button-id="#bulkAssetEditButton"
+                                            data-bulk-form-id="#assetsBulkForm"
+                                            data-export-options='{
                     "fileName": "export-{{ str_slug($category->name) }}-assets-{{ date('Y-m-d') }}",
                     "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                     }'
-                @elseif ($category->category_type=='accessory')
-                  data-columns="{{ \App\Presenters\AccessoryPresenter::dataTableLayout() }}"
-                  data-cookie-id-table="categoryAccessoryTable"
-                  id="categoryAccessoryTable"
-                  data-id-table="categoryAccessoryTable"
-                  data-export-options='{
+                                            @elseif ($category->category_type=='accessory')
+                                                data-columns="{{ \App\Presenters\AccessoryPresenter::dataTableLayout() }}"
+                                            data-cookie-id-table="categoryAccessoryTable"
+                                            id="categoryAccessoryTable"
+                                            data-id-table="categoryAccessoryTable"
+                                            data-export-options='{
                       "fileName": "export-{{ str_slug($category->name) }}-accessories-{{ date('Y-m-d') }}",
                       "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                       }'
-                @elseif ($category->category_type=='consumable')
-                  data-columns="{{ \App\Presenters\ConsumablePresenter::dataTableLayout() }}"
-                  data-cookie-id-table="categoryConsumableTable"
-                  id="categoryConsumableTable"
-                  data-id-table="categoryConsumableTable"
-                  data-export-options='{
+                                            @elseif ($category->category_type=='consumable')
+                                                data-columns="{{ \App\Presenters\ConsumablePresenter::dataTableLayout() }}"
+                                            data-cookie-id-table="categoryConsumableTable"
+                                            id="categoryConsumableTable"
+                                            data-id-table="categoryConsumableTable"
+                                            data-export-options='{
                       "fileName": "export-{{ str_slug($category->name) }}-consumables-{{ date('Y-m-d') }}",
                       "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                       }'
-                @elseif ($category->category_type=='component')
-                  data-columns="{{ \App\Presenters\ComponentPresenter::dataTableLayout() }}"
-                  data-cookie-id-table="categoryCompomnentTable"
-                  id="categoryCompomnentTable"
-                  data-id-table="categoryCompomnentTable"
-                  data-export-options='{
+                                            @elseif ($category->category_type=='component')
+                                                data-columns="{{ \App\Presenters\ComponentPresenter::dataTableLayout() }}"
+                                            data-cookie-id-table="categoryCompomnentTable"
+                                            id="categoryCompomnentTable"
+                                            data-id-table="categoryCompomnentTable"
+                                            data-export-options='{
                       "fileName": "export-{{ str_slug($category->name) }}-components-{{ date('Y-m-d') }}",
                       "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                       }'
-                @elseif ($category->category_type=='license')
-                data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayout() }}"
-                data-cookie-id-table="categoryLicenseTable"
-                id="categoryLicenseTable"
-                data-id-table="categoryLicenseTable"
-                data-export-options='{
+                                            @elseif ($category->category_type=='license')
+                                                data-columns="{{ \App\Presenters\LicensePresenter::dataTableLayout() }}"
+                                            data-cookie-id-table="categoryLicenseTable"
+                                            id="categoryLicenseTable"
+                                            data-id-table="categoryLicenseTable"
+                                            data-export-options='{
                       "fileName": "export-{{ str_slug($category->name) }}-licenses-{{ date('Y-m-d') }}",
                       "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                       }'
-                @endif
+                                            @endif
 
-                data-pagination="true"
-                data-search="true"
-                data-show-footer="true"
-                data-side-pagination="server"
-                data-show-columns="true"
-                data-show-export="true"
-                data-show-refresh="true"
-                data-sort-order="asc"
-                class="table table-striped snipe-table"
-                data-url="{{ route('api.'.$category_type_route.'.index',['category_id'=> $category->id]) }}">
-            
-      </table>
+                                            data-pagination="true"
+                                            data-search="true"
+                                            data-show-footer="true"
+                                            data-side-pagination="server"
+                                            data-show-columns="true"
+                                            data-show-export="true"
+                                            data-show-refresh="true"
+                                            data-sort-order="asc"
+                                            class="table table-striped snipe-table"
+                                            data-url="{{ route('api.'.$category_type_route.'.index',['category_id'=> $category->id]) }}">
 
-      </div>
-    </div>
-  </div>
-</div>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="tab-pane fade" id="models">
+                        <div class="row">
+                            <div class="col-md-12">
+
+                                @if ($category->models->count() > 0)
+                                    @if ($category->category_type=='asset')
+                                        @include('partials.models-bulk-actions')
+                                    @endif
+                                @endif
+
+                                    <table
+                                            data-columns="{{ \App\Presenters\AssetModelPresenter::dataTableLayout() }}"
+                                            data-cookie-id-table="asssetModelsTable"
+                                            data-pagination="true"
+                                            data-id-table="asssetModelsTable"
+                                            data-search="true"
+                                            data-show-footer="true"
+                                            data-side-pagination="server"
+                                            data-show-columns="true"
+                                            data-toolbar="#modelsBulkEditToolbar"
+                                            data-bulk-button-id="#bulkModelsEditButton"
+                                            data-bulk-form-id="#modelsBulkForm"
+                                            data-show-export="true"
+                                            data-show-refresh="true"
+                                            data-sort-order="asc"
+                                            id="asssetModelsTable"
+                                            class="table table-striped snipe-table"
+                                            data-url="{{ route('api.models.index', ['status' => request('status')]) }}"
+                                            data-export-options='{
+              "fileName": "export-models-{{ date('Y-m-d') }}",
+              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+              }'>
+                                    </table>
+
+                            </div>
+                        </div>
+                    </div>
+
+                </div> <!-- .tab-content-->
+            </div> <!-- .nav-tabs-custom -->
+        </div> <!-- .col-md-12> -->
+    </div> <!-- .row -->
 @stop
+
+
+
+
 
 @section('moar_scripts')
 @include ('partials.bootstrap-table')

--- a/resources/views/categories/view.blade.php
+++ b/resources/views/categories/view.blade.php
@@ -10,6 +10,10 @@
 @stop
 
 @section('header_right')
+
+    <a href="{{ URL::previous() }}" class="btn btn-primary" style="margin-right: 10px;">
+        {{ trans('general.back') }}</a>
+
 <div class="btn-group pull-right">
   <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">{{ trans('button.actions') }}
     <span class="caret"></span>
@@ -18,6 +22,7 @@
     <li><a href="{{ route('categories.edit', ['category' => $category->id]) }}">{{ trans('admin/categories/general.edit') }}</a></li>
     <li><a href="{{ route('categories.create') }}">{{ trans('general.create') }}</a></li>
   </ul>
+
 </div>
 @stop
 

--- a/resources/views/models/index.blade.php
+++ b/resources/views/models/index.blade.php
@@ -36,24 +36,7 @@
     <div class="box box-default">
       <div class="box-body">
 
-        {{ Form::open([
-          'method' => 'POST',
-          'route' => ['models.bulkedit.index'],
-          'class' => 'form-inline',
-           'id' => 'modelsBulkForm']) }}
-        <div class="row">
-          <div class="col-md-12">
-
-            @if (Request::get('status')!='deleted')
-              <div id="modelBulkEditToolbar">
-                <label for="bulk_actions" class="sr-only">{{ trans('general.bulk_actions') }}</label>
-                <select id="bulk_actions" name="bulk_actions" class="form-control select2" aria-label="bulk_actions" style="width: 300px;">
-                  <option value="edit">{{ trans('general.bulk_edit') }}</option>
-                  <option value="delete">{{ trans('general.bulk_delete') }}</option>
-                </select>
-                <button class="btn btn-primary" id="bulkModelsEditButton" disabled>{{ trans('button.go') }}</button>
-              </div>
-            @endif
+        @include('partials.models-bulk-actions')
               <div class="table-responsive">
                 <table
                         data-columns="{{ \App\Presenters\AssetModelPresenter::dataTableLayout() }}"

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -123,7 +123,9 @@
     });
 
     $('.snipe-table').on('uncheck.bs.table .btSelectItem', function (row, $element) {
-        $( "#checkbox_" + $element.id).remove();
+        var tableId =  $(this).data('id-table');
+        $( "#" + tableId + "checkbox_" + $element.id).remove();
+        console.log("#" + tableId + "checkbox_" + $element.id);
     });
 
 
@@ -157,7 +159,7 @@
         var tableId =  $(this).data('id-table');
 
         for (var i in rowsBefore) {
-            $( tableId + "_checkbox_" + rowsBefore[i].id).remove();
+            $('#' + tableId + "_checkbox_" + rowsBefore[i].id).remove();
         }
 
     });

--- a/resources/views/partials/models-bulk-actions.blade.php
+++ b/resources/views/partials/models-bulk-actions.blade.php
@@ -1,0 +1,23 @@
+<div id="modelsBulkEditToolbar">
+    {{ Form::open([
+              'method' => 'POST',
+              'route' => ['models.bulkedit.index'],
+              'class' => 'form-inline',
+              'id' => 'modelsBulkForm']) }}
+
+    @if (request('status')!='deleted')
+        @can('delete', \App\Models\User::class)
+            <div id="models-toolbar">
+                <label for="bulk_actions" class="sr-only">{{ trans('general.bulk_actions') }}</label>
+                <select name="bulk_actions" class="form-control select2" style="width: 200px;" aria-label="bulk_actions">
+                    <option value="edit">{{ trans('general.bulk_edit') }}</option>
+                    <option value="delete">{{ trans('general.bulk_delete') }}</option>
+                </select>
+                <button class="btn btn-primary" id="bulkModelsEditButton" disabled>{{ trans('button.go') }}</button>
+            </div>
+        @endcan
+    @endif
+    {{ Form::close() }}
+</div>
+
+


### PR DESCRIPTION
Previously when you drilled down into a category, you could only see the assets associated through that category. This PR allows you to see (and therefore bulk edit) the models that belong to that category if they are asset models. 


https://user-images.githubusercontent.com/197404/173489591-7f595687-f8d3-42d0-8ada-f41691288e54.mov


There is a small UX oddity that I need to fix, adding the same cookie flow to return people back from whence they came after a bulk edit that we do on bulk people and assets, but that's for another PR.

As an added bonus, this also adds the filter onto the models API endpoint to be able to filter by category ID.