### PR TITLE
Ensure LDAP filters are always parentheses-wrapped and run with `&`

### DIFF
--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -114,8 +114,16 @@ class Ldap extends Model
         }
 
         $filterQuery = $settings->ldap_auth_filter_query.$username;
-        $filter = Setting::getSettings()->ldap_filter; //FIXME - this *does* respect the ldap filter, but I believe that AdLdap2 did *not*.
-        $filterQuery = "({$filter}({$filterQuery}))";
+        $filter = Setting::getSettings()->ldap_filter;
+
+        // TODO - this is copypasta from findLdapUsers() - we should abstract this out and put it somewhere (static method?)
+        if ($filter != '' && substr($filter, 0, 1) != '(') { // wrap parens around NON-EMPTY filters that DON'T have them, for back-compatibility with AdLdap2-based filters
+            $filter = "($filter)";
+        } elseif ($filter == '') {
+            $filter = '(cn=*)';
+        }
+
+        $filterQuery = "(&{$filter}({$filterQuery}))"; // ensuring that the $filter is wrapped with parentheses (above) ensures that this is always interpreted as an 'AND' query.
 
         \Log::debug('Filter query: '.$filterQuery);
 


### PR DESCRIPTION
We've gotten a few weird problems with LDAP filters under v6, and it mostly looks due to configuration quirks in how v5 handled filters versus how we do it in v6.

The way we used to assemble the filters before was:
- start with an opening `(`
- add the contents of the LDAP filter query, which we assumed started with `&`
- add a second-level `(`
- put in the auth query
- close the second-level with a `)`
- add the final close paren `)`

But under v5, we started to allow Filters that were wrapped with parentheses.

So we need to support filters that look like:
- `&(cn=*)`
- or `(cn=*)`

So what this does is assemble the query like this:
- `(&`, then the ensure-parentheses-wrapped-version of the filter, then the parentheses-wrapped auth query

So for the first example, a sample LDAP auth query might look like:

```
(&(&(cn=*))(uid=testuser))
```

I've tested that, and that is a valid lookup, and gets you the results you'd expect.

For the second example, what you'd end up with is:

```
(&(cn=*)(uid=testuser))
```

# Caveats

1. This messes with LDAP which is scary. I've tested it but my brain is fried right now and I want to try again.
2. I don't like that if you use the 'correct' format that we have documented, you get 'punished' with a jankier-looking LDAP filter for lookup. I'm hoping the LDAP servers don't care and will optimize the jank out?
3. I still can't explain the `uid=samaccountname` auth query, at all. I can't figure out where this got introduced, and I can't figure out how it ever worked, and I can't replicate anything with it at all. It seems to be a filter that will always return zero results, at least, on AD. Very weird.