### PR TITLE
Fixed #11304 Trying to access array offset on value of type null at .../Transformers/AssetsTransformer.php

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -117,9 +117,10 @@ class AssetsTransformer
                 } else {
                     $value = $asset->{$field->convertUnicodeDbSlug()};
 
-                    if ($field->format == 'DATE'){
+                    if ($field->format == 'DATE' && !is_null($value)){
                         $value = Helper::getFormattedDateObject($value)['formatted'];
                     }
+                    
                     $fields_array[$field->name] = [
                         'field' => e($field->convertUnicodeDbSlug()),
                         'value' => e($value),


### PR DESCRIPTION
# Description
I introduced a bug in the AssetTransformer. I try to format the date in a customfield of the type 'DATE' as the user has decided in their settings, but if the value of that field is empty on some Asset, the whole list doesn't charge :(.

In this changes I check if the value of the field is not empty, then I try to format it. If not it's simply ignored. Sorry folks :(. On the other hand... first bug fix of 6.0.3!! Yay (?)

So very sorry.

Fixes #11304 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
