### PR TITLE
Unify all treatments of assetListingTable in terms of selected columns

### DIFF
--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -74,6 +74,7 @@
                 data-click-to-select="true"
                 data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
                 data-cookie-id-table="assetsListingTable"
+                data-cookie-path="/" {{-- this should make this cookie the same as all other assetsListingTable --}}
                 data-pagination="true"
                 data-id-table="assetsListingTable"
                 data-search="true"

--- a/resources/views/locations/view.blade.php
+++ b/resources/views/locations/view.blade.php
@@ -121,6 +121,7 @@
                           <table
                                   data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
                                   data-cookie-id-table="assetsListingTable"
+                                  data-cookie-path="/" {{-- this should make this cookie the same as all other assetsListingTable --}}
                                   data-pagination="true"
                                   data-id-table="assetsListingTable"
                                   data-search="true"

--- a/resources/views/manufacturers/view.blade.php
+++ b/resources/views/manufacturers/view.blade.php
@@ -50,6 +50,7 @@
           <table
                   data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
                   data-cookie-id-table="assetsListingTable"
+                  data-cookie-path="/" {{-- this should make this cookie the same as all other assetsListingTable --}}
                   data-pagination="true"
                   data-id-table="assetsListingTable"
                   data-toolbar="#assetsBulkEditToolbar"

--- a/resources/views/statuslabels/view.blade.php
+++ b/resources/views/statuslabels/view.blade.php
@@ -17,6 +17,7 @@
                                 <table
                                         data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
                                         data-cookie-id-table="assetsListingTable"
+                                        data-cookie-path="/" {{-- this should make this cookie the same as all other assetsListingTable --}}
                                         data-pagination="true"
                                         data-id-table="assetsListingTable"
                                         data-search="true"


### PR DESCRIPTION
Fixes FD-26323 (or possibly exacerbates it? I guess we'll see).

We have several places throughout our asset views that specifically try to reuse the same column-remembering cookie (`assetsListingTable`) so that whatever columns you select to be visible remain the same all throughout the app. However, Bootstrap Tables will, by default, set a 'URL location' attribute on each cookie that is the same as the path to that page. So the cookie will only be sent on that path or lower (higher? Whatever. You know what I mean).

So it guesses that `/hardware` should be sent with a path of `/`, but `/statuslabels/3` should be sent with a path of `/statuslabels`. This makes setting different visible columns on both pages a little weird. When you're on `/statuslabels/3` you'll get cookies for the `/` path as well as the `/statuslabels` path. This generally just acts pretty weird - sometimes forgetting columns, sometimes remembering them, and generally just acting funky.

This PR unifies all of those column choices. I looked at all of the appropriate screens and they are all very, very similar, and have identical layouts. Generally, if you want to see a certain column on one screen, you're going to want to see it everywhere.