### PR TITLE
Fixed #11285 - Depreciation index table missing pagination

### DIFF
--- a/app/Http/Transformers/DepreciationsTransformer.php
+++ b/app/Http/Transformers/DepreciationsTransformer.php
@@ -9,14 +9,14 @@ use Illuminate\Database\Eloquent\Collection;
 
 class DepreciationsTransformer
 {
-    public function transformDepreciations(Collection $depreciations)
+    public function transformDepreciations(Collection $depreciations, $total)
     {
         $array = [];
         foreach ($depreciations as $depreciation) {
             $array[] = self::transformDepreciation($depreciation);
         }
 
-        return (new DatatablesTransformer)->transformDatatables($array);
+        return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
     public function transformDepreciation(Depreciation $depreciation)
@@ -27,8 +27,7 @@ class DepreciationsTransformer
             'months' => $depreciation->months.' '.trans('general.months'),
             'depreciation_min' => $depreciation->depreciation_min,
             'created_at' => Helper::getFormattedDateObject($depreciation->created_at, 'datetime'),
-            'updated_at' => Helper::getFormattedDateObject($depreciation->updated_at, 'datetime'),
-            'depreciation_min' =>($depreciation->depreciation_min),
+            'updated_at' => Helper::getFormattedDateObject($depreciation->updated_at, 'datetime')
         ];
 
         $permissions_array['available_actions'] = [


### PR DESCRIPTION
# Description

Fixes #11285. 

Total argument was missing from transformDepreciations and subsequently was not passed to the DatatablesTransformer. Modified to add the total arguments to match all the other transformers.  This seemed to be the only one missing it.

Also while there removed a duplicate array key in transformDeprecation function.

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 8.0.20
* MySQL version: MySQL 8.0.29-0ubuntu0.20.04.3
* Webserver version: Apache 2.4.41
* OS version: Ubuntu 20.04.4 LTS


# Checklist:

- [x ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
