### PR TITLE
[Feature] - Regrouping Hardware requested menu & requestable menu

### DIFF
--- a/resources/lang/en/admin/hardware/general.php
+++ b/resources/lang/en/admin/hardware/general.php
@@ -40,5 +40,6 @@ return [
     'error_messages' => 'Error messages:',
     'success_messages' => 'Success messages:',
     'alert_details' => 'Please see below for details.',
-    'custom_export' => 'Custom Export'
+    'custom_export' => 'Custom Export',
+    'requestable_list' => 'Requestable Assets'
 ];

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -358,4 +358,6 @@ return [
     'maintenance_mode'      => 'The service is temporarily unavailable for system updates. Please check back later.',
     'maintenance_mode_title' => 'System Temporarily Unavailable',
     'ldap_import'           => 'User password should not be managed by LDAP. (This allows you to send forgotten password requests.)',
+    'request_manager'       => 'Request Manager',
+    'requested_list'        => 'Incoming Requests',    
 ];

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -490,10 +490,6 @@
                             {{ trans('general.bulk_checkout') }}
                         </a>
                     </li>
-                    <li{!! (Request::is('hardware/requested') ? ' class="active"' : '') !!}>
-                        <a href="{{ route('assets.requested') }}">
-                            {{ trans('general.requested') }}</a>
-                    </li>
                     @endcan
 
                     @can('create', \App\Models\Asset::class)
@@ -719,6 +715,11 @@
                         </a>
                     </li>
                     <li>
+                        <a href="{{ url('reports/eol_assets') }}" {{ (Request::is('reports/eol_assets') ? ' class="active"' : '') }}>
+                            {{ trans('general.eol_assets_report') }}
+                        </a>
+                    </li>
+                    <li>
                         <a href="{{ url('reports/custom') }}" {{ (Request::is('reports/custom') ? ' class="active"' : '') }}>
                             {{ trans('general.custom_report') }}
                         </a>
@@ -728,11 +729,29 @@
             @endcan
 
             @can('viewRequestable', \App\Models\Asset::class)
-            <li{!! (Request::is('account/requestable-assets') ? ' class="active"' : '') !!}>
-            <a href="{{ route('requestable-assets') }}">
-            <i class="fa fa-laptop"></i>
-            <span>{{ trans('admin/hardware/general.requestable') }}</span>
-            </a>
+            <li class="treeview{{ (Request::is('account/requestable-assets') ? ' active' : '') }}">
+                <a href="#"  class="dropdown-toggle">
+                    <i class="fas fa-clipboard-list"></i>
+                    <span>{{ trans('general.request_manager') }}</span>
+                    <i class="fa fa-angle-left pull-right"></i>
+                </a>
+
+                <ul class="treeview-menu">
+                    <li{!! (Request::is('account/requestable-assets') ? ' class="active"' : '') !!}>
+                        <a href="{{ route('requestable-assets') }}">
+                            <i class="fas fa-laptop"></i>
+                            <span>{{ trans('admin/hardware/general.requestable_list') }}</span>
+                        </a>
+                    </li>
+                    @can('checkout', \App\Models\Asset::class)
+                    <li{!! (Request::is('hardware/requested') ? ' class="active"' : '') !!}>
+                        <a href="{{ route('assets.requested') }}">
+                        <i class="fas fa-check"></i>
+                            <span>{{ trans('general.requested_list') }}</span>
+                        </a>
+                    </li>
+                    @endcan
+                </ul>
             </li>
             @endcan
 


### PR DESCRIPTION
# Description

To improve the correlation on request management perspective, the  requestable & asset requested menu is grouped together pertaining the original access condition for both.

By grouping them in a group called Request Manager, the activity of requesting & handling request will be in the same place and IMO will be less confusing

Fixes #11334 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Test A : test the new layout & the functionalities
- [X] Test B : test the layout with different user role

**Test Configuration**:
* PHP version: 7.4.27
* MySQL version
* Webserver version
* OS version: Windows 10


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


# Screenshots
## Before
![image](https://user-images.githubusercontent.com/3839381/174342917-90c2e913-e997-4de0-b14d-edf5b98ceac1.png)
![image](https://user-images.githubusercontent.com/3839381/174343015-b100f28a-ae5d-48ab-9c15-e9a630ad8e62.png)

## After
![image](https://user-images.githubusercontent.com/3839381/174343301-9609e7a7-68d8-482c-9a29-a1d059a91fb1.png)
![image](https://user-images.githubusercontent.com/3839381/174342560-b68aaa8e-770b-4da3-9ac8-fe3ce2ae67f9.png)
