### PR TITLE
[Security] Upgrade bootstrap-table from 1.20.0 to 1.20.2 🍵 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2938,9 +2938,9 @@
             "integrity": "sha1-EQPWvADPv6jPyaJZmrUYxVZD2j8="
         },
         "bootstrap-table": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.20.0.tgz",
-            "integrity": "sha512-e6lOTG44aAeSFuOqFSjuMakXUlVF2jSkgtlDqa2lXbwq/Hn3Sn4TMSSJgSKdMnwX8WOpdlF3DIGUKQLiQ9vlXA=="
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/bootstrap-table/-/bootstrap-table-1.20.2.tgz",
+            "integrity": "sha512-6j9zfjjK6VZyJj8KsH+LnGczqglmMvMctGAoEAKDvrQ92ExQbA3mHGYPQr9iPrzoyeGL8+6Dyx6LqJbWmWmBoA=="
         },
         "brace-expansion": {
             "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "bootstrap-colorpicker": "^2.5.3",
         "bootstrap-datepicker": "^1.9.0",
         "bootstrap-less": "^3.3.8",
-        "bootstrap-table": "1.20.0",
+        "bootstrap-table": "1.20.2",
         "chart.js": "^2.9.4",
         "css-loader": "^3.6.0",
         "ekko-lightbox": "^5.1.1",


### PR DESCRIPTION
# Security Fix

Due to Cross-site Scripting (XSS) of bootstrap-table we need to patch the security bug issue.

1. https://security.snyk.io/vuln/SNYK-JS-BOOTSTRAPTABLE-2812823
2. https://security.snyk.io/vuln/SNYK-JS-BOOTSTRAPTABLE-2825191