### PR TITLE
Fixed #11335 Assets transformer date customfields issues

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -100,7 +100,7 @@ class AssetsTransformer
 
                     if ($field->format == 'DATE'){
                         if (Gate::allows('superadmin')){
-                            $value = Helper::getFormattedDateObject($value)['formatted'];
+                            $value = Helper::getFormattedDateObject($value, 'date', false);
                         } else {
                            $value = strtoupper(trans('admin/custom_fields/general.encrypted'));
                         }
@@ -117,7 +117,7 @@ class AssetsTransformer
                     $value = $asset->{$field->convertUnicodeDbSlug()};
 
                     if (($field->format == 'DATE') && (!is_null($value)) && ($value!='')){
-                        $value = Helper::getFormattedDateObject($value)['formatted'];
+                        $value = Helper::getFormattedDateObject($value, 'date', false);
                     }
                     
                     $fields_array[$field->name] = [


### PR DESCRIPTION
# Description
If we create a customfield of type 'text', add data and then we change to type 'date', when we try to look the complete asset list the transformer fails because it tries to access an array element that doesn't exist... 

BUT, the `getFormattedDateObject()` it's so well written that you can ask that it returns a string instead of an array, so I only do that and hope all the observed issues vanishes after this change.

Fixes #11335 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
