### PR TITLE
Fixes issue where asset images were showing up in checkin emails

### DIFF
--- a/resources/views/notifications/markdown/checkin-asset.blade.php
+++ b/resources/views/notifications/markdown/checkin-asset.blade.php
@@ -4,7 +4,7 @@
 {{ trans('mail.the_following_item') }}
 
 @if ($item->getImageUrl())
-<center><img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;"></center>
+<center><img src="{{ app\Models\Setting::getSettings()->show_images_in_email =='1' && $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;"></center>
 @endif
 
 @component('mail::table')


### PR DESCRIPTION
[fd-28487] - We generally respect the 'show images in email' setting but apparently not in Checkin emails.

This fixes that (allegedly?).