### PR TITLE
Adds validation to custom fields' default values

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -92,7 +92,7 @@ class AssetModelsController extends Controller
         if ($model->save()) {
             if ($this->shouldAddDefaultValues($request->input())) {
                 if (!$this->assignCustomFieldsDefaultValues($model, $request->input('default_values'))){
-                    return redirect()->back()->withInput()->withErrors($model->getErrors());
+                    return redirect()->back()->withInput()->with('error', trans('admin/custom_fields/message.fieldset_default_value.error'));
                 }
             }
 
@@ -167,7 +167,7 @@ class AssetModelsController extends Controller
 
             if ($this->shouldAddDefaultValues($request->input())) {
                 if (!$this->assignCustomFieldsDefaultValues($model, $request->input('default_values'))){
-                    return redirect()->back()->withInput()->withErrors("Error");
+                    return redirect()->back()->withInput()->with('error', trans('admin/custom_fields/message.fieldset_default_value.error'));
                 }
             }
         }

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -8,6 +8,7 @@ use App\Models\AssetModel;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\Facades\Validator;
 use Redirect;
 use Request;
 use Storage;
@@ -90,7 +91,9 @@ class AssetModelsController extends Controller
         // Was it created?
         if ($model->save()) {
             if ($this->shouldAddDefaultValues($request->input())) {
-                $this->assignCustomFieldsDefaultValues($model, $request->input('default_values'));
+                if (!$this->assignCustomFieldsDefaultValues($model, $request->input('default_values'))){
+                    return redirect()->back()->withInput()->withErrors($model->getErrors());
+                }
             }
 
             // Redirect to the new model  page
@@ -163,7 +166,9 @@ class AssetModelsController extends Controller
             $model->fieldset_id = $request->input('custom_fieldset');
 
             if ($this->shouldAddDefaultValues($request->input())) {
-                $this->assignCustomFieldsDefaultValues($model, $request->input('default_values'));
+                if (!$this->assignCustomFieldsDefaultValues($model, $request->input('default_values'))){
+                    return redirect()->back()->withInput()->withErrors("Error");
+                }
             }
         }
 
@@ -451,6 +456,21 @@ class AssetModelsController extends Controller
      */
     private function assignCustomFieldsDefaultValues(AssetModel $model, array $defaultValues)
     {
+        $data = array();
+        foreach ($defaultValues as $customFieldId => $defaultValue) {
+            $customField = \App\Models\CustomField::find($customFieldId);
+
+            $data[$customField->db_column] = $defaultValue;
+        }
+
+        $rules = $model->fieldset->validation_rules();
+
+        $validator = Validator::make($data, $rules);
+
+        if($validator->fails()){
+            return false;
+        }
+
         foreach ($defaultValues as $customFieldId => $defaultValue) {
             if(is_array($defaultValue)){
                 $model->defaultValues()->attach($customFieldId, ['default_value' => implode(', ', $defaultValue)]);
@@ -458,6 +478,7 @@ class AssetModelsController extends Controller
                 $model->defaultValues()->attach($customFieldId, ['default_value' => $defaultValue]);
             }
         }
+        return true;
     }
 
     /**

--- a/resources/lang/en/admin/custom_fields/message.php
+++ b/resources/lang/en/admin/custom_fields/message.php
@@ -49,6 +49,12 @@ return array(
 
     ),
 
+    'fieldset_default_value' => array(
+
+        'error' => 'Error validating default fieldset values.',
+
+    ),
+
 
 
 

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -22,8 +22,14 @@
                             <label class="col-md-3 control-label{{ $errors->has($field->name) ? ' has-error' : '' }}" for="default-value{{ $field->id }}">{{ $field->name }}</label>
 
                             <div class="col-md-7">
-
-                                @if ($field->element == "text")
+                                @if ($field->format == "DATE")
+                                    <div class="input-group col-md-4" style="padding-left: 0px;">
+                                        <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
+                                            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="{{ $field->db_column_name() }}" id="{{ $field->db_column_name() }}" value="{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}">
+                                            <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
+                                        </div>
+                                    </div>
+                                @elseif ($field->element == "text")
                                     <input class="form-control m-b-xs" type="text" value="{{ $field->defaultValue($model_id) }}" id="default-value{{ $field->id }}" name="default_values[{{ $field->id }}]">
                                 @elseif($field->element == "textarea")
                                     <textarea class="form-control" id="default-value{{ $field->id }}" name="default_values[{{ $field->id }}]">{{ $field->defaultValue($model_id) }}</textarea><br>

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -25,7 +25,7 @@
                                 @if ($field->format == "DATE")
                                     <div class="input-group col-md-4" style="padding-left: 0px;">
                                         <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-                                            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="{{ $field->db_column_name() }}" id="{{ $field->db_column_name() }}" value="{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}">
+                                            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="default_values[{{ $field->id }}]" id="default-value{{ $field->id }}" value="{{ $field->defaultValue($model_id) }}">
                                             <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
                                         </div>
                                     </div>


### PR DESCRIPTION
# Description
When creating/editing models, if we want to add default values to the fieldsets the form doesn't check the validation rules of them. So we can save whatever value we want as default value even when we set the format to the custom field.

This changes tries to fix that and also adds some control dates so it's less probable the user sets the date format incorrectly.

Fixes #11230 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
