### PR TITLE
fixes dropdown column select font color  in bootstrap tables

### DIFF
--- a/resources/assets/less/skins/skin-black-dark.less
+++ b/resources/assets/less/skins/skin-black-dark.less
@@ -137,7 +137,9 @@ a {
 .bootstrap-table .fixed-table-container .table thead th .sortable {
   color: var(--nav-link);
 }
-
+.bootstrap-table .fixed-table-toolbar .columns label {
+  color:#000;
+}
 .thead, .navbar-nav>li>a:link {
   color: var(--nav-link);
 }

--- a/resources/assets/less/skins/skin-blue-dark.less
+++ b/resources/assets/less/skins/skin-blue-dark.less
@@ -132,7 +132,9 @@ a {
 .bootstrap-table .fixed-table-container .table thead th .sortable {
   color: var(--nav-link);
 }
-
+.bootstrap-table .fixed-table-toolbar .columns label {
+  color:#000;
+}
 .thead, .navbar-nav>li>a:link {
   color: var(--nav-link);
 }
@@ -149,7 +151,9 @@ a:link {
 .btn-primary.hover {
   color: var(--nav-link);
 }
-
+.bootstrap-table .fixed-table-toolbar .columns label {
+  color:#000;
+}
 .small-box h3, .small-box p {
   color: var(--nav-link) !important;
   a:hover {

--- a/resources/assets/less/skins/skin-orange-dark.less
+++ b/resources/assets/less/skins/skin-orange-dark.less
@@ -119,6 +119,9 @@
 .bootstrap-table .fixed-table-container .table thead th .sortable {
   color: var(--nav-link);
 }
+.bootstrap-table .fixed-table-toolbar .columns label {
+  color:#000;
+}
 
 .thead, .navbar-nav>li>a:link {
   color: var(--nav-link);

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -132,7 +132,9 @@ a {
 .bootstrap-table .fixed-table-container .table thead th .sortable {
   color: var(--nav-link);
 }
-
+.bootstrap-table .fixed-table-toolbar .columns label {
+  color:#000;
+}
 .thead, .navbar-nav>li>a:link {
   color: var(--nav-link);
 }

--- a/resources/assets/less/skins/skin-red-dark.less
+++ b/resources/assets/less/skins/skin-red-dark.less
@@ -133,6 +133,9 @@ a {
 .bootstrap-table .fixed-table-container .table thead th .sortable {
   color: var(--nav-link);
 }
+.bootstrap-table .fixed-table-toolbar .columns label {
+  color:#000;
+}
 
 .thead, .navbar-nav>li>a:link {
   color: var(--nav-link);

--- a/resources/assets/less/skins/skin-yellow-dark.less
+++ b/resources/assets/less/skins/skin-yellow-dark.less
@@ -103,10 +103,10 @@ a {
   --back-main: #333;
   --back-sub: #3d4144;
   --back-sub-alt: rgba(0, 0, 0, 0.36);
-  --button-default: #FFFF00;
-  --button-primary: darken(#FFFF00, 25%);
-  --button-hover: darken(#FFFF00, 30%);
-  --header: #FFFF00; /* Use same as Header picker */
+  --button-default: #FFCC32;
+  --button-primary: darken(#FFCC32, 25%);
+  --button-hover: darken(#FFCC32, 30%);
+  --header: #FFCC32; /* Use same as Header picker */
   --text-main: #BBB;
   --text-sub: #9b9b9b;
   --link: #F0E68C; /* Use same as Header picker, lighten by 70% */
@@ -131,7 +131,9 @@ a.btn.btn-default{
 .bootstrap-table .fixed-table-container .table thead th .sortable {
   color: var(--nav-link);
 }
-
+.bootstrap-table .fixed-table-toolbar .columns label {
+  color:#000;
+}
 .thead, .navbar-nav>li>a:link {
   color: var(--nav-link);
 }


### PR DESCRIPTION
# Description
The drop down menu in bootstrap tables column selectors was using var(--text-main) which was #FFF. I made a CSS rule for this drop down menu font to be #000 for all dark-mode themes. Also the Yellow dark-mode theme was still highlighter yellow, changed that as well.
![image](https://user-images.githubusercontent.com/47435081/175350748-c11f52ad-6c17-4c73-ad68-de06995fb799.png)


Fixes #  SC-19272

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
