### PR TITLE
Fixed #11378 - Added better excel export

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -92,7 +92,7 @@
             },
                 exportOptions: export_options,
 
-            exportTypes: ['csv', 'excel', 'doc', 'txt','json', 'xml', 'pdf'],
+            exportTypes: ['xlsx', 'excel', 'csv', 'pdf','json', 'xml', 'txt', 'sql', 'doc' ],
             onLoadSuccess: function () {
                 $('[data-toggle="tooltip"]').tooltip(); // Needed to attach tooltips after ajax call
             }


### PR DESCRIPTION
This adds a few more export options to the table export, including more modern support for MS Excel. I also re-ordered the export options so that the most common options are first.

Note: Png export is an option in BS tables, however I left it out of this PR because I'm getting an html2canvas error when I try to export as png. Which is dumb because html2canvas exists, but that's a fight for another day. 

Fixes #11378