### PR TITLE
Fixes check for archived setting on counts

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1148,7 +1148,11 @@ class Asset extends Depreciable
 
 
     /**
-     * Query builder scope for Archived assets
+     * Query builder scope for Archived assets counting
+     *
+     * This is primarily used for the tab counters so that IF the admin
+     * has chosen to not display archived assets in their regular lists
+     * and views, it will return the correct number.
      *
      * @param  \Illuminate\Database\Query\Builder $query Query builder instance
      *

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1147,6 +1147,27 @@ class Asset extends Depreciable
     }
 
 
+    /**
+     * Query builder scope for Archived assets
+     *
+     * @param  \Illuminate\Database\Query\Builder $query Query builder instance
+     *
+     * @return \Illuminate\Database\Query\Builder          Modified query builder
+     */
+
+    public function scopeAssetsForShow($query)
+    {
+
+        if (Setting::getSettings()->show_archived_in_list!=1) {
+            return $query->whereHas('assetstatus', function ($query) {
+                $query->where('archived', '=', 0);
+            });
+        } else {
+            return $query;
+        }
+
+    }
+
   /**
    * Query builder scope for Archived assets
    *

--- a/resources/views/categories/view.blade.php
+++ b/resources/views/categories/view.blade.php
@@ -39,7 +39,7 @@
                     <li class="active">
                         <a href="#items" data-toggle="tab" title="{{ trans('general.items') }}"> {{ ucwords($category_type_route) }}
                             @if ($category->category_type=='asset')
-                            <badge class="badge badge-secondary"> {{ $category->assets->count() }}</badge>
+                            <badge class="badge badge-secondary"> {{ $category->assets()->AssetsForShow()->count() }}</badge>
                             @endif
                         </a>
                     </li>

--- a/resources/views/companies/view.blade.php
+++ b/resources/views/companies/view.blade.php
@@ -21,7 +21,7 @@
                             <i class="fas fa-barcode" aria-hidden="true"></i>
                             </span>
                             <span class="hidden-xs hidden-sm">{{ trans('general.assets') }}
-                                {!! (($company->assets) && ($company->assets->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($company->assets->count()).'</badge>' : '' !!}
+                                {!! (($company->assets) && ($company->assets()->AssetsForShow()->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($company->assets()->AssetsForShow()->count()).'</badge>' : '' !!}
 
                             </span>
                         </a>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -33,7 +33,7 @@
     <!-- small box -->
     <div class="small-box bg-teal">
       <div class="inner">
-        <h3>{{ number_format($counts['asset']) }}</h3>
+        <h3>{{ number_format(\App\Models\Asset::AssetsForShow()->count()) }}</h3>
         <p>{{ strtolower(trans('general.assets')) }}</p>
       </div>
       <div class="icon" aria-hidden="true">

--- a/resources/views/locations/view.blade.php
+++ b/resources/views/locations/view.blade.php
@@ -38,7 +38,7 @@
                     </span>
                     <span class="hidden-xs hidden-sm">
                           {{ trans('general.assets') }}
-                          {!! (($location->assets) && ($location->assets->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($location->assets->count()).'</badge>' : '' !!}
+                          {!! (($location->assets) && ($location->assets()->AssetsForShow()->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($location->assets()->AssetsForShow()->count()).'</badge>' : '' !!}
                     </span>
                   </a>
               </li>

--- a/resources/views/manufacturers/view.blade.php
+++ b/resources/views/manufacturers/view.blade.php
@@ -41,7 +41,7 @@
             </span>
             <span class="hidden-xs hidden-sm">
                 {{ trans('general.assets') }}
-                {!! (($manufacturer->assets) && ($manufacturer->assets->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($manufacturer->assets->count()).'</badge>' : '' !!}
+                {!! (($manufacturer->assets) && ($manufacturer->assets()->AssetsForShow()->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($manufacturer->assets()->AssetsForShow()->count()).'</badge>' : '' !!}
             </span>
 
           </a>

--- a/resources/views/suppliers/view.blade.php
+++ b/resources/views/suppliers/view.blade.php
@@ -35,7 +35,7 @@
                 </span>
                 <span class="hidden-xs hidden-sm">
                     {{ trans('general.assets') }}
-                    {!! (($supplier->assets) && ($supplier->assets->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($supplier->assets->count()).'</badge>' : '' !!}
+                    {!! (($supplier->assets) && ($supplier->assets()->AssetsForShow()->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($supplier->assets()->AssetsForShow()->count()).'</badge>' : '' !!}
                </span>
 
             </a>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -31,7 +31,7 @@
             <i class="fas fa-barcode fa-2x" aria-hidden="true"></i>
             </span>
             <span class="hidden-xs hidden-sm">{{ trans('general.assets') }}
-              {!! ($user->assets->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($user->assets->count()).'</badge>' : '' !!}
+              {!! ($user->assets()->AssetsForShow()->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($user->assets()->AssetsForShow()->count()).'</badge>' : '' !!}
             </span>
           </a>
         </li>


### PR DESCRIPTION
In [a previous PR](https://github.com/snipe/snipe-it/pull/11324), I had mentioned that we'd need to scope the counts on the tabs to consider if archived assets should be shown in the list, because there is a perceptual confusion, since the number on the tab and the number displayed in the list might not be the same if the admin has elected to hide archived assets from lists. This should handle that problem. 

There is still the existential confusion of people not knowing (or remembering) that that option was checked and seeing fewer assets than they expect, but I'm not sure there's a way around that, since people want that option.