### PR TITLE
Added created_by to users

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -36,6 +36,7 @@ class UsersController extends Controller
 
         $users = User::select([
             'users.activated',
+            'users.created_by',
             'users.address',
             'users.avatar',
             'users.city',
@@ -66,7 +67,7 @@ class UsersController extends Controller
             'users.remote',
             'users.ldap_import',
 
-        ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables')
+        ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables', 'adminuser',)
             ->withCount('assets as assets_count', 'licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count');
         $users = Company::scopeCompanyables($users);
 
@@ -87,6 +88,10 @@ class UsersController extends Controller
 
         if ($request->filled('location_id')) {
             $users = $users->where('users.location_id', '=', $request->input('location_id'));
+        }
+
+        if ($request->filled('created_by')) {
+            $users = $users->where('users.created_by', '=', $request->input('created_by'));
         }
 
         if ($request->filled('email')) {
@@ -181,6 +186,9 @@ class UsersController extends Controller
                 break;
             case 'department':
                 $users = $users->OrderDepartment($order);
+                break;
+            case 'created_by':
+                $users = $users->OrderAdmin($order);
                 break;
             case 'company':
                 $users = $users->OrderCompany($order);

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -67,7 +67,7 @@ class UsersController extends Controller
             'users.remote',
             'users.ldap_import',
 
-        ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables', 'adminuser',)
+        ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables', 'createdBy',)
             ->withCount('assets as assets_count', 'licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count');
         $users = Company::scopeCompanyables($users);
 

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -188,7 +188,7 @@ class UsersController extends Controller
                 $users = $users->OrderDepartment($order);
                 break;
             case 'created_by':
-                $users = $users->OrderAdmin($order);
+                $users = $users->CreatedBy($order);
                 break;
             case 'company':
                 $users = $users->OrderCompany($order);

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -117,6 +117,7 @@ class UsersController extends Controller
         $user->zip = $request->input('zip', null);
         $user->remote = $request->input('remote', 0);
         $user->website = $request->input('website', null);
+        $user->created_by = Auth::user()->id;
 
         // Strip out the superuser permission if the user isn't a superadmin
         $permissions_array = $request->input('permission');

--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -63,9 +63,9 @@ class UsersTransformer
                 'accessories_count' => (int) $user->accessories_count,
                 'consumables_count' => (int) $user->consumables_count,
                 'company' => ($user->company) ? ['id' => (int) $user->company->id, 'name'=> e($user->company->name)] : null,
-                'created_by' => ($user->adminuser) ? [
-                    'id' => (int) $user->adminuser->id,
-                    'name'=> e($user->adminuser->present()->fullName),
+                'created_by' => ($user->createdBy) ? [
+                    'id' => (int) $user->createdBy->id,
+                    'name'=> e($user->createdBy->present()->fullName),
                 ] : null,
                 'created_at' => Helper::getFormattedDateObject($user->created_at, 'datetime'),
                 'updated_at' => Helper::getFormattedDateObject($user->updated_at, 'datetime'),

--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -63,6 +63,10 @@ class UsersTransformer
                 'accessories_count' => (int) $user->accessories_count,
                 'consumables_count' => (int) $user->consumables_count,
                 'company' => ($user->company) ? ['id' => (int) $user->company->id, 'name'=> e($user->company->name)] : null,
+                'created_by' => ($user->adminuser) ? [
+                    'id' => (int) $user->adminuser->id,
+                    'name'=> e($user->adminuser->present()->fullName),
+                ] : null,
                 'created_at' => Helper::getFormattedDateObject($user->created_at, 'datetime'),
                 'updated_at' => Helper::getFormattedDateObject($user->updated_at, 'datetime'),
                 'last_login' => Helper::getFormattedDateObject($user->last_login, 'datetime'),

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -568,7 +568,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      * @since [v1.0]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function adminuser()
+    public function createdBy()
     {
         return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
     }
@@ -705,7 +705,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      *
      * @return \Illuminate\Database\Query\Builder          Modified query builder
      */
-    public function scopeOrderAdmin($query, $order)
+    public function scopeCreatedBy($query, $order)
     {
         // Left join here, or it will only return results with parents
         return $query->leftJoin('users as admin_user', 'users.created_by', '=', 'admin_user.id')

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -562,10 +562,10 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     }
 
     /**
-     * Get action logs history for this asset
+     * Get the admin user who created this user
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v1.0]
+     * @since [v6.0.5]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
     public function createdBy()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -562,6 +562,18 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     }
 
     /**
+     * Get action logs history for this asset
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v1.0]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function adminuser()
+    {
+        return $this->belongsTo(\App\Models\User::class, 'created_by')->withTrashed();
+    }
+
+    /**
      * Check whether two-factor authorization is required and the user has activated it
      * and enrolled a device
      *
@@ -684,6 +696,23 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     {
         return $query->leftJoin('departments as departments_users', 'users.department_id', '=', 'departments_users.id')->orderBy('departments_users.name', $order);
     }
+
+    /**
+     * Query builder scope to order on admin user
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query  Query builder instance
+     * @param string                              $order         Order
+     *
+     * @return \Illuminate\Database\Query\Builder          Modified query builder
+     */
+    public function scopeOrderAdmin($query, $order)
+    {
+        // Left join here, or it will only return results with parents
+        return $query->leftJoin('users as admin_user', 'users.created_by', '=', 'admin_user.id')
+            ->orderBy('admin_user.first_name', $order)
+            ->orderBy('admin_user.last_name', $order);
+    }
+
 
     /**
      * Query builder scope to order on company

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -290,7 +290,7 @@ class UserPresenter extends Presenter
                 'searchable' => false,
                 'sortable' => true,
                 'title' => trans('general.admin'),
-                'visible' => true,
+                'visible' => false,
                 'formatter' => 'usersLinkObjFormatter',
             ],
             [

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -286,6 +286,14 @@ class UserPresenter extends Presenter
                 'formatter' => 'trueFalseFormatter',
             ],
             [
+                'field' => 'created_by',
+                'searchable' => false,
+                'sortable' => true,
+                'title' => trans('general.admin'),
+                'visible' => true,
+                'formatter' => 'usersLinkObjFormatter',
+            ],
+            [
                 'field' => 'created_at',
                 'searchable' => true,
                 'sortable' => true,

--- a/database/migrations/2022_06_23_164407_add_user_id_to_users.php
+++ b/database/migrations/2022_06_23_164407_add_user_id_to_users.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUserIdToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->integer('created_by')->after('activated')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'created_by')) {
+                $table->dropColumn('created_by');
+            }
+        });
+    }
+}

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -467,7 +467,7 @@
                           @if ($user->createdBy)
                               by
                               @if ($user->createdBy->deleted_at=='')
-                                  <a href="{{ route('users.show', ['user' => $user->user_id]) }}">{{ $user->createdBy->present()->fullName }}</a>
+                                  <a href="{{ route('users.show', ['user' => $user->created_by]) }}">{{ $user->createdBy->present()->fullName }}</a>
                               @else
                                   <del>{{ $user->createdBy->present()->fullName }}</del>
                               @endif

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -464,12 +464,12 @@
                       <div class="col-md-9">
                         {{ \App\Helpers\Helper::getFormattedDateObject($user->created_at, 'datetime')['formatted']}}
 
-                          @if ($user->adminuser)
+                          @if ($user->createdBy)
                               by
-                              @if ($user->adminuser->deleted_at=='')
-                                  <a href="{{ route('users.show', ['user' => $user->user_id]) }}">{{ $user->adminuser->present()->fullName }}</a>
+                              @if ($user->createdBy->deleted_at=='')
+                                  <a href="{{ route('users.show', ['user' => $user->user_id]) }}">{{ $user->createdBy->present()->fullName }}</a>
                               @else
-                                  <del>{{ $user->adminuser->present()->fullName }}</del>
+                                  <del>{{ $user->createdBy->present()->fullName }}</del>
                               @endif
 
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -463,6 +463,17 @@
                       </div>
                       <div class="col-md-9">
                         {{ \App\Helpers\Helper::getFormattedDateObject($user->created_at, 'datetime')['formatted']}}
+
+                          @if ($user->adminuser)
+                              by
+                              @if ($user->adminuser->deleted_at=='')
+                                  <a href="{{ route('users.show', ['user' => $user->user_id]) }}">{{ $user->adminuser->present()->fullName }}</a>
+                              @else
+                                  <del>{{ $user->adminuser->present()->fullName }}</del>
+                              @endif
+
+
+                          @endif
                       </div>
                     </div>
                     @endif


### PR DESCRIPTION
I am frankly shocked that I didn't have this on the user's table before - seems like a real boner move TBH - everything else in the system records who created the thing, but we somehow missed it 9 years ago and never noticed. (To be fair, nobody asked for it, but still... weird that I'd have missed something so obvious.)

Anyway... this adds a DB column called `created_by` to the users table. **It is important to note that this is a divergence from our standard convention.** We typically use the (very confusing) field name `user_id` to denote the Snipe-IT user id of the person who created the thing - but since it's confusing, I will be changing that over time to use a more common `created_by`, so it's clearer what that field means. I didn't want to include that in this PR though, since it's a breaking change to the API.

In the user view blade, we check to see if that admin has been (soft) deleted, and if it has, we strike it through. If not, we link to the person who created the user. 

<img width="587" alt="Screen Shot 2022-06-23 at 5 04 50 PM" src="https://user-images.githubusercontent.com/197404/175436307-800c00f1-0a3d-4882-9ef5-a5ac4e9b382f.png">

The API payload is standard for what we return for users, managers, etc.

<img width="252" alt="Screen Shot 2022-06-23 at 5 05 15 PM" src="https://user-images.githubusercontent.com/197404/175436309-f846e8b9-0adf-4fdb-a10b-e11494b63767.png">
