### PR TITLE
Fixed missing archived tooltip

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -188,6 +188,7 @@
                 var status_meta = {
                   'deployed': '{{ strtolower(trans('general.deployed')) }}',
                   'deployable': '{{ strtolower(trans('admin/hardware/general.deployable')) }}',
+                  'archived': '{{ strtolower(trans('general.archived')) }}',
                   'pending': '{{ strtolower(trans('general.pending')) }}'
                 }
 


### PR DESCRIPTION
This fixed a small UI bug where we weren't defining `archived` as a status label meta option, so it would show "undefined" when you moused over the status label.

<img width="982" alt="Screen Shot 2022-06-23 at 5 31 27 PM" src="https://user-images.githubusercontent.com/197404/175437130-927a0f5e-0d34-4376-8be1-a09ba827adc6.png">

It now properly displays the (translated) word for "archived").

<img width="1104" alt="Screen Shot 2022-06-23 at 5 34 05 PM" src="https://user-images.githubusercontent.com/197404/175437182-b60fab03-57e8-4479-92a6-a56c07d217fe.png">


Signed-off-by: snipe <snipe@snipe.net>
