### PR TITLE
Moved the settings search box higher

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -744,7 +744,7 @@
 
       <!-- Content Wrapper. Contains page content -->
 
-      <div class="content-wrapper" role="main">
+      <div class="content-wrapper" role="main" id="setting-list">
 
           @if ($debug_in_production)
               <div class="row" style="margin-bottom: 0px; background-color: red; color: white; font-size: 15px;">

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -8,17 +8,25 @@
 
 @section('header_right')
 
-  <a href="{{ route('settings.index') }}" class="btn btn-primary text-right" style="margin-right: 10px;">{{ trans('general.back') }}</a>
+
 
   <!-- search filter box -->
   <div class="pull-right">
+
+
     <form onsubmit="return false;">
       <div class="btn-group">
         <input id="searchinput" name="search" type="search" class="search form-control" placeholder="{{ trans('admin/settings/general.filter_by_keyword') }}">
         <span id="searchclear" class="fas fa-times" aria-hidden="true"></span>
         <button type="submit" disabled style="display: none" aria-hidden="true"></button>
       </div>
+      <a href="{{ route('settings.index') }}" class="btn btn-primary pull-right" style="margin-left: 10px;">{{ trans('general.back') }}</a>
+
     </form>
+
+
+
+
   </div>
   <!--/ search filter box -->
 @stop

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -6,6 +6,24 @@
 @parent
 @stop
 
+@section('header_right')
+
+  <a href="{{ route('settings.index') }}" class="btn btn-primary text-right" style="margin-right: 10px;">{{ trans('general.back') }}</a>
+
+  <!-- search filter box -->
+  <div class="pull-right">
+    <form onsubmit="return false;">
+      <div class="btn-group">
+        <input id="searchinput" name="search" type="search" class="search form-control" placeholder="{{ trans('admin/settings/general.filter_by_keyword') }}">
+        <span id="searchclear" class="fas fa-times" aria-hidden="true"></span>
+        <button type="submit" disabled style="display: none" aria-hidden="true"></button>
+      </div>
+    </form>
+  </div>
+  <!--/ search filter box -->
+@stop
+
+
 {{-- Page content --}}
 @section('content')
 
@@ -27,20 +45,6 @@
       color: #ccc;
     }
   </style>
-
-  <div class="row" id="setting-list">
-
-    <!-- search filter box -->
-    <div class="col-md-3 col-md-offset-9 form-group">
-      <form onsubmit="return false;">
-        <div class="btn-group">
-          <input id="searchinput" name="search" type="search" class="search form-control" placeholder="{{ trans('admin/settings/general.filter_by_keyword') }}">
-          <span id="searchclear" class="fas fa-times" aria-hidden="true"></span>
-          <button type="submit" disabled style="display: none" aria-hidden="true"></button>
-        </div>
-      </form>
-    </div>
-    <!--/ search filter box -->
 
 
     <!-- search filter list -->
@@ -386,11 +390,11 @@
     valueNames: [ 'name', 'keywords', 'summary', 'help-block']
   };
 
-  var userList = new List('setting-list', options);
+  var settingList = new List('setting-list', options);
 
   $("#searchclear").click(function(){
     $("#searchinput").val('');
-    userList.search();
+    settingList.search();
   });
 
 


### PR DESCRIPTION
This PR moves the settings filter search higher on the page and adds a back button.

Old:

<img width="1236" alt="Screen Shot 2022-06-23 at 7 24 20 PM" src="https://user-images.githubusercontent.com/197404/175449920-433c7cbc-864d-4b80-9303-7829f4387315.png">

New:

<img width="1237" alt="Screen Shot 2022-06-23 at 7 30 16 PM" src="https://user-images.githubusercontent.com/197404/175450392-74492c1a-7cff-4f54-ae40-d0e60e01ce27.png">



Signed-off-by: snipe <snipe@snipe.net>