### PR TITLE
Only care about the custom field's converted name when updating the custom field itself

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -544,11 +544,11 @@ class AssetsController extends Controller
             foreach ($model->fieldset->fields as $field) {
 
                 // Set the field value based on what was sent in the request
-                $field_val = $request->input($field->convertUnicodeDbSlug(), null);
+                $field_val = $request->input($field->db_column, null);
 
                 // If input value is null, use custom field's default value
                 if ($field_val == null) {
-                    \Log::debug('Field value for '.$field->convertUnicodeDbSlug().' is null');
+                    \Log::debug('Field value for '.$field->db_column.' is null');
                     $field_val = $field->defaultValue($request->get('model_id'));
                     \Log::debug('Use the default fieldset value of '.$field->defaultValue($request->get('model_id')));
                 }
@@ -563,13 +563,13 @@ class AssetsController extends Controller
                         if (($field_val == null) && ($request->has('model_id') != '')) {
                             $field_val = \Crypt::encrypt($field->defaultValue($request->get('model_id')));
                         } else {
-                            $field_val = \Crypt::encrypt($request->input($field->convertUnicodeDbSlug()));
+                            $field_val = \Crypt::encrypt($request->input($field->db_column));
                         }
                     }
                 }
 
 
-                $asset->{$field->convertUnicodeDbSlug()} = $field_val;
+                $asset->{$field->db_column} = $field_val;
             }
         }
 
@@ -634,13 +634,13 @@ class AssetsController extends Controller
             // Update custom fields
             if (($model = AssetModel::find($asset->model_id)) && (isset($model->fieldset))) {
                 foreach ($model->fieldset->fields as $field) {
-                    if ($request->has($field->convertUnicodeDbSlug())) {
+                    if ($request->has($field->db_column)) {
                         if ($field->field_encrypted == '1') {
                             if (Gate::allows('admin')) {
-                                $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt($request->input($field->convertUnicodeDbSlug()));
+                                $asset->{$field->db_column} = \Crypt::encrypt($request->input($field->db_column));
                             }
                         } else {
-                            $asset->{$field->convertUnicodeDbSlug()} = $request->input($field->convertUnicodeDbSlug());
+                            $asset->{$field->db_column} = $request->input($field->db_column);
                         }
                     }
                 }

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -168,17 +168,17 @@ class AssetsController extends Controller
                 foreach ($model->fieldset->fields as $field) {
                     if ($field->field_encrypted == '1') {
                         if (Gate::allows('admin')) {
-                            if (is_array($request->input($field->convertUnicodeDbSlug()))) {
-                                $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt(implode(', ', $request->input($field->convertUnicodeDbSlug())));
+                            if (is_array($request->input($field->db_column))) {
+                                $asset->{$field->db_column} = \Crypt::encrypt(implode(', ', $request->input($field->db_column)));
                             } else {
-                                $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt($request->input($field->convertUnicodeDbSlug()));
+                                $asset->{$field->db_column} = \Crypt::encrypt($request->input($field->db_column));
                             }
                         }
                     } else {
-                        if (is_array($request->input($field->convertUnicodeDbSlug()))) {
-                            $asset->{$field->convertUnicodeDbSlug()} = implode(', ', $request->input($field->convertUnicodeDbSlug()));
+                        if (is_array($request->input($field->db_column))) {
+                            $asset->{$field->db_column} = implode(', ', $request->input($field->db_column));
                         } else {
-                            $asset->{$field->convertUnicodeDbSlug()} = $request->input($field->convertUnicodeDbSlug());
+                            $asset->{$field->db_column} = $request->input($field->db_column);
                         }
                     }
                 }
@@ -362,17 +362,17 @@ class AssetsController extends Controller
             foreach ($model->fieldset->fields as $field) {
                 if ($field->field_encrypted == '1') {
                     if (Gate::allows('admin')) {
-                        if (is_array($request->input($field->convertUnicodeDbSlug()))) {
-                            $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt(implode(', ', $request->input($field->convertUnicodeDbSlug())));
+                        if (is_array($request->input($field->db_column))) {
+                            $asset->{$field->db_column} = \Crypt::encrypt(implode(', ', $request->input($field->db_column)));
                         } else {
-                            $asset->{$field->convertUnicodeDbSlug()} = \Crypt::encrypt($request->input($field->convertUnicodeDbSlug()));
+                            $asset->{$field->db_column} = \Crypt::encrypt($request->input($field->db_column));
                         }
                     }
                 } else {
-                    if (is_array($request->input($field->convertUnicodeDbSlug()))) {
-                        $asset->{$field->convertUnicodeDbSlug()} = implode(', ', $request->input($field->convertUnicodeDbSlug()));
+                    if (is_array($request->input($field->db_column))) {
+                        $asset->{$field->db_column} = implode(', ', $request->input($field->db_column));
                     } else {
-                        $asset->{$field->convertUnicodeDbSlug()} = $request->input($field->convertUnicodeDbSlug());
+                        $asset->{$field->db_column} = $request->input($field->db_column);
                     }
                 }
             }

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -94,8 +94,8 @@ class AssetsTransformer
             $fields_array = [];
 
             foreach ($asset->model->fieldset->fields as $field) {
-                if ($field->isFieldDecryptable($asset->{$field->convertUnicodeDbSlug()})) {
-                    $decrypted = Helper::gracefulDecrypt($field, $asset->{$field->convertUnicodeDbSlug()});
+                if ($field->isFieldDecryptable($asset->{$field->db_column})) {
+                    $decrypted = Helper::gracefulDecrypt($field, $asset->{$field->db_column});
                     $value = (Gate::allows('superadmin')) ? $decrypted : strtoupper(trans('admin/custom_fields/general.encrypted'));
 
                     if ($field->format == 'DATE'){
@@ -107,21 +107,21 @@ class AssetsTransformer
                     }
 
                     $fields_array[$field->name] = [
-                            'field' => e($field->convertUnicodeDbSlug()),
+                            'field' => e($field->db_column),
                             'value' => e($value),
                             'field_format' => $field->format,
                             'element' => $field->element,
                         ];
 
                 } else {
-                    $value = $asset->{$field->convertUnicodeDbSlug()};
+                    $value = $asset->{$field->db_column};
 
                     if (($field->format == 'DATE') && (!is_null($value)) && ($value!='')){
                         $value = Helper::getFormattedDateObject($value, 'date', false);
                     }
                     
                     $fields_array[$field->name] = [
-                        'field' => e($field->convertUnicodeDbSlug()),
+                        'field' => e($field->db_column),
                         'value' => e($value),
                         'field_format' => $field->format,
                         'element' => $field->element,

--- a/app/Http/Transformers/ComponentsAssetsTransformer.php
+++ b/app/Http/Transformers/ComponentsAssetsTransformer.php
@@ -39,7 +39,7 @@ class ComponentsAssetsTransformer
 
         if ($asset->model->fieldset) {
             foreach ($asset->model->fieldset->fields as $field) {
-                $fields_array = [$field->name => $asset->{$field->convertUnicodeDbSlug()}];
+                $fields_array = [$field->name => $asset->{$field->db_column}];
                 $array += $fields_array;
             }
         }

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -111,7 +111,7 @@ class CustomField extends Model
 
             // Column already exists on the assets table - nothing to do here.
             // This *shouldn't* happen in the wild.
-            if (Schema::hasColumn(self::$table_name, $custom_field->convertUnicodeDbSlug())) {
+            if (Schema::hasColumn(self::$table_name, $custom_field->db_column)) {
                 return false;
             }
 
@@ -156,7 +156,7 @@ class CustomField extends Model
         // Drop the assets column if we've deleted it from custom fields
         self::deleting(function ($custom_field) {
             return Schema::table(self::$table_name, function ($table) use ($custom_field) {
-                $table->dropColumn($custom_field->convertUnicodeDbSlug());
+                $table->dropColumn($custom_field->db_column);
             });
         });
     }

--- a/app/Presenters/AssetAuditPresenter.php
+++ b/app/Presenters/AssetAuditPresenter.php
@@ -248,7 +248,7 @@ class AssetAuditPresenter extends Presenter
 
         foreach ($fields as $field) {
             $layout[] = [
-                'field' => 'custom_fields.'.$field->convertUnicodeDbSlug(),
+                'field' => 'custom_fields.'.$field->db_column,
                 'searchable' => true,
                 'sortable' => true,
                 'visible' => false,

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -263,7 +263,7 @@ class AssetPresenter extends Presenter
         // name can break the listings page. - snipe
         foreach ($fields as $field) {
             $layout[] = [
-                'field' => 'custom_fields.'.$field->convertUnicodeDbSlug(),
+                'field' => 'custom_fields.'.$field->db_column,
                 'searchable' => true,
                 'sortable' => true,
                 'switchable' => true,


### PR DESCRIPTION
Related to https://github.com/snipe/snipe-it/pull/11404, this PR switches from us using the `->convertUnicodeDbSlug()` modifier in most places (except when saving the custom field). The recent transliteration issues are a real pain in the bunghole, and at the end of the day, we shouldn't care if the custom field `db_column` is "correct", just that it agrees with whatever is in on the assets table. When a custom field is updated, update that `db_column` value in the `custom_fields` table, and then just use the field's `db_column` value for things moving forward for displaying/editing assets, etc. 