### PR TITLE
Add a new `--filter` option to Artisan ldap-sync command

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -17,7 +17,7 @@ class LdapSync extends Command
      *
      * @var string
      */
-    protected $signature = 'snipeit:ldap-sync {--location=} {--location_id=} {--base_dn=} {--summary} {--json_summary}';
+    protected $signature = 'snipeit:ldap-sync {--location=} {--location_id=} {--base_dn=} {--filter=} {--summary} {--json_summary}';
 
     /**
      * The console command description.
@@ -80,7 +80,11 @@ class LdapSync extends Command
             } else {
                 $search_base = null;
             }
-            $results = Ldap::findLdapUsers($search_base);
+            if ($this->option('filter') != '') {
+                $results = Ldap::findLdapUsers($search_base, -1, $this->option('filter'));
+            } else {
+                $results = Ldap::findLdapUsers($search_base);
+            }
         } catch (\Exception $e) {
             if ($this->option('json_summary')) {
                 $json_summary = ['error' => true, 'error_message' => $e->getMessage(), 'summary' => []];
@@ -109,7 +113,7 @@ class LdapSync extends Command
         }
 
         /* Process locations with explicitly defined OUs, if doing a full import. */
-        if ($this->option('base_dn') == '') {
+        if ($this->option('base_dn') == '' && $this->option('filter') == '') {
             // Retrieve locations with a mapped OU, and sort them from the shallowest to deepest OU (see #3993)
             $ldap_ou_locations = Location::where('ldap_ou', '!=', '')->get()->toArray();
             $ldap_ou_lengths = [];

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -275,9 +275,10 @@ class Ldap extends Model
      * @since [v3.0]
      * @param $base_dn
      * @param $count
+     * @param $filter
      * @return array|bool
      */
-    public static function findLdapUsers($base_dn = null, $count = -1)
+    public static function findLdapUsers($base_dn = null, $count = -1, $filter = null)
     {
         $ldapconn = self::connectToLdap();
         self::bindAdminToLdap($ldapconn);
@@ -285,7 +286,9 @@ class Ldap extends Model
         if (is_null($base_dn)) {
             $base_dn = Setting::getSettings()->ldap_basedn;
         }
-        $filter = Setting::getSettings()->ldap_filter;
+        if($filter === null) {
+            $filter = Setting::getSettings()->ldap_filter;
+        }
 
         // Set up LDAP pagination for very large databases
         $page_size = 500;


### PR DESCRIPTION
This follows along with the BaseDN option in our `snipeit:ldap-sync` artisan command to also add a Filter option as well.

Similarl to the BaseDN option, it will skip the per-OU LDAP sync if it is specified. The parameter just becomes an optional argument when the LDAP sync is performed; overriding the default LDAP filter that's used in other LDAP sync commands.

This solves at least one problem that one customer of ours has had recently, and will probably help out a few more. It also doesn't make too many huge changes in our code, so it seems relatively safe?