### PR TITLE
Fixed #9757 - Added model uploads

### DIFF
--- a/app/Http/Controllers/AssetModelsFilesController.php
+++ b/app/Http/Controllers/AssetModelsFilesController.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Helpers\StorageHelper;
+use App\Http\Requests\AssetFileRequest;
+use App\Models\Actionlog;
+use App\Models\AssetModel;
+use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\Storage;
+use enshrined\svgSanitize\Sanitizer;
+
+class AssetModelsFilesController extends Controller
+{
+    /**
+     * Upload a file to the server.
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @param AssetFileRequest $request
+     * @param int $modelId
+     * @return Redirect
+     * @since [v1.0]
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function store(AssetFileRequest $request, $modelId = null)
+    {
+        if (! $model = AssetModel::find($modelId)) {
+            return redirect()->route('models.index')->with('error', trans('admin/hardware/message.does_not_exist'));
+        }
+
+        $this->authorize('update', $model);
+
+        if ($request->hasFile('file')) {
+            if (! Storage::exists('private_uploads/assetmodels')) {
+                Storage::makeDirectory('private_uploads/assetmodels', 775);
+            }
+
+            foreach ($request->file('file') as $file) {
+
+                $extension = $file->getClientOriginalExtension();
+                $file_name = 'model-'.$model->id.'-'.str_random(8).'-'.str_slug(basename($file->getClientOriginalName(), '.'.$extension)).'.'.$extension;
+
+                // Check for SVG and sanitize it
+                if ($extension=='svg') {
+                    \Log::debug('This is an SVG');
+
+                    $sanitizer = new Sanitizer();
+                    $dirtySVG = file_get_contents($file->getRealPath());
+                    $cleanSVG = $sanitizer->sanitize($dirtySVG);
+
+                    try {
+                        Storage::put('private_uploads/assetmodels/'.$file_name, $cleanSVG);
+                    } catch (\Exception $e) {
+                        \Log::debug('Upload no workie :( ');
+                        \Log::debug($e);
+                    }
+                } else {
+                    Storage::put('private_uploads/assetmodels/'.$file_name, file_get_contents($file));
+                }
+
+
+                $model->logUpload($file_name, e($request->get('notes')));
+            }
+
+            return redirect()->back()->with('success', trans('admin/hardware/message.upload.success'));
+        }
+
+        return redirect()->back()->with('error', trans('admin/hardware/message.upload.nofiles'));
+    }
+
+    /**
+     * Check for permissions and display the file.
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @param  int $modelId
+     * @param  int $fileId
+     * @since [v1.0]
+     * @return View
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function show($modelId = null, $fileId = null, $download = true)
+    {
+        $model = AssetModel::find($modelId);
+        // the asset is valid
+        if (isset($model->id)) {
+            $this->authorize('view', $model);
+
+            if (! $log = Actionlog::find($fileId)) {
+                return response('No matching record for that model/file', 500)
+                    ->header('Content-Type', 'text/plain');
+            }
+
+            $file = 'private_uploads/assetmodels/'.$log->filename;
+            \Log::debug('Checking for '.$file);
+
+
+            if (! Storage::exists($file)) {
+                return response('File '.$file.' not found on server', 404)
+                    ->header('Content-Type', 'text/plain');
+            }
+
+            if ($download != 'true') {
+                if ($contents = file_get_contents(Storage::url($file))) {
+                    return Response::make(Storage::url($file)->header('Content-Type', mime_content_type($file)));
+                }
+
+                return JsonResponse::create(['error' => 'Failed validation: '], 500);
+            }
+
+            return StorageHelper::downloader($file);
+        }
+        // Prepare the error message
+        $error = trans('admin/hardware/message.does_not_exist', ['id' => $fileId]);
+
+        // Redirect to the hardware management page
+        return redirect()->route('hardware.index')->with('error', $error);
+    }
+
+    /**
+     * Delete the associated file
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @param  int $modelId
+     * @param  int $fileId
+     * @since [v1.0]
+     * @return View
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function destroy($modelId = null, $fileId = null)
+    {
+        $model = AssetModel::find($modelId);
+        $this->authorize('update', $model);
+        $rel_path = 'private_uploads/assetmodels';
+
+        // the asset is valid
+        if (isset($model->id)) {
+            $this->authorize('update', $model);
+            $log = Actionlog::find($fileId);
+            if ($log) {
+                if (Storage::exists($rel_path.'/'.$log->filename)) {
+                    Storage::delete($rel_path.'/'.$log->filename);
+                }
+                $log->delete();
+
+                return redirect()->back()->with('success', trans('admin/hardware/message.deletefile.success'));
+            }
+
+            return redirect()->back()
+                ->with('success', trans('admin/hardware/message.deletefile.success'));
+        }
+
+        // Redirect to the hardware management page
+        return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.does_not_exist'));
+    }
+}

--- a/app/Models/AssetModel.php
+++ b/app/Models/AssetModel.php
@@ -20,7 +20,7 @@ class AssetModel extends SnipeModel
     use HasFactory;
     use SoftDeletes;
     protected $presenter = \App\Presenters\AssetModelPresenter::class;
-    use Requestable, Presentable;
+    use Loggable, Requestable, Presentable;
 
     protected $table = 'models';
     protected $hidden = ['user_id', 'deleted_at'];
@@ -180,6 +180,23 @@ class AssetModel extends SnipeModel
 
         return false;
     }
+
+    /**
+     * Get uploads for this model
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v4.0]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function uploads()
+    {
+        return $this->hasMany('\App\Models\Actionlog', 'item_id')
+            ->where('item_type', '=', AssetModel::class)
+            ->where('action_type', '=', 'uploaded')
+            ->whereNotNull('filename')
+            ->orderBy('created_at', 'desc');
+    }
+
 
     /**
      * -----------------------------------------------

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -362,5 +362,6 @@ return [
     'ldap_import'           => 'User password should not be managed by LDAP. (This allows you to send forgotten password requests.)',
     'purge_not_allowed'     => 'Purging deleted data has been disabled in the .env file. Contact support or your systems administrator.',
     'backup_delete_not_allowed'     => 'Deleting backups has been disabled in the .env file. Contact support or your systems administrator.',
+    'additional_files'           => 'Additional Files',
 
 ];

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -177,6 +177,18 @@
                         </a>
                     </li>
 
+                    <li>
+                    <a href="#modelfiles" data-toggle="tab">
+                          <span class="hidden-lg hidden-md">
+                            <i class="far fa-file fa-2x" aria-hidden="true"></i>
+                          </span>
+                        <span class="hidden-xs hidden-sm">
+                            {{ trans('general.additional_files') }}
+                            {!! ($asset->model->uploads->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($asset->model->uploads->count()).'</badge>' : '' !!}
+                          </span>
+                    </a>
+                    </li>
+
                    
                     @can('update', \App\Models\Asset::class)
                         <li class="pull-right">
@@ -186,6 +198,7 @@
                             </a>
                         </li>
                     @endcan
+
 
                 </ul>
                 
@@ -1189,6 +1202,99 @@
                                                 <td>
                                                     @can('update', \App\Models\Asset::class)
                                                         <a class="btn delete-asset btn-sm btn-danger btn-sm" href="{{ route('delete/assetfile', [$asset->id, $file->id]) }}" data-tooltip="true" data-title="Delete" data-content="{{ trans('general.delete_confirm', ['item' => $file->filename]) }}"><i class="fas fa-trash icon-white" aria-hidden="true"></i></a>
+                                                    @endcan
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                        </tbody>
+                                    </table>
+
+                                @else
+
+                                    <div class="alert alert-info alert-block">
+                                        <i class="fas fa-info-circle"></i>
+                                        {{ trans('general.no_results') }}
+                                    </div>
+                                @endif
+
+                            </div> <!-- /.col-md-12 -->
+                        </div> <!-- /.row -->
+                    </div> <!-- /.tab-pane files -->
+
+                    <div class="tab-pane fade" id="modelfiles">
+                        <div class="row">
+                            <div class="col-md-12">
+
+                                @if ($asset->model->uploads->count() > 0)
+                                    <table
+                                            class="table table-striped snipe-table"
+                                            id="assetModelFileHistory"
+                                            data-pagination="true"
+                                            data-id-table="assetModelFileHistory"
+                                            data-search="true"
+                                            data-side-pagination="client"
+                                            data-sortable="true"
+                                            data-show-columns="true"
+                                            data-show-fullscreen="true"
+                                            data-show-refresh="true"
+                                            data-sort-order="desc"
+                                            data-sort-name="created_at"
+                                            data-show-export="true"
+                                            data-export-options='{
+                         "fileName": "export-assetmodel-{{ $asset->model->id }}-files",
+                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                       }'
+                                            data-cookie-id-table="assetFileHistory">
+                                        <thead>
+                                        <tr>
+                                            <th data-visible="true" data-field="icon" data-sortable="true">{{trans('general.file_type')}}</th>
+                                            <th class="col-md-2" data-searchable="true" data-visible="true" data-field="image">{{ trans('general.image') }}</th>
+                                            <th class="col-md-2" data-searchable="true" data-visible="true" data-field="filename" data-sortable="true">{{ trans('general.file_name') }}</th>
+                                            <th class="col-md-1" data-searchable="true" data-visible="true" data-field="filesize">{{ trans('general.filesize') }}</th>
+                                            <th class="col-md-2" data-searchable="true" data-visible="true" data-field="notes" data-sortable="true">{{ trans('general.notes') }}</th>
+                                            <th class="col-md-1" data-searchable="true" data-visible="true" data-field="download">{{ trans('general.download') }}</th>
+                                            <th class="col-md-2" data-searchable="true" data-visible="true" data-field="created_at" data-sortable="true">{{ trans('general.created_at') }}</th>
+                                            <th class="col-md-1" data-searchable="true" data-visible="true" data-field="actions">{{ trans('table.actions') }}</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
+
+                                        @foreach ($asset->model->uploads as $file)
+                                            <tr>
+                                                <td><i class="{{ Helper::filetype_icon($file->filename) }} icon-med" aria-hidden="true"></i></td>
+                                                <td>
+                                                    @if ( Helper::checkUploadIsImage($file->get_src('assets')))
+                                                        <a href="{{ route('show/modelfile', ['assetId' => $asset->model->id, 'fileId' =>$file->id]) }}" data-toggle="lightbox" data-type="image" data-title="{{ $file->filename }}" data-footer="{{ Helper::getFormattedDateObject($asset->last_checkout, 'datetime', false) }}">
+                                                            <img src="{{ route('show/modelfile', ['assetId' => $asset->model->id, 'fileId' =>$file->id]) }}" style="max-width: 50px;">
+                                                        </a>
+                                                    @endif
+                                                </td>
+                                                <td>
+                                                    {{ $file->filename }}
+                                                </td>
+                                                <td data-value="{{ filesize(storage_path('private_uploads/assetmodels/').$file->filename) }}">
+                                                    {{ Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/assetmodels/').$file->filename)) }}
+                                                </td>
+                                                <td>
+                                                    @if ($file->note)
+                                                        {{ $file->note }}
+                                                    @endif
+                                                </td>
+                                                <td>
+                                                    @if ($file->filename)
+                                                        <a href="{{ route('show/modelfile', [$asset->model->id, $file->id]) }}" class="btn btn-default">
+                                                            <i class="fas fa-download" aria-hidden="true"></i>
+                                                        </a>
+                                                    @endif
+                                                </td>
+                                                <td>
+                                                    @if ($file->created_at)
+                                                        {{ Helper::getFormattedDateObject($file->created_at, 'datetime', false) }}
+                                                    @endif
+                                                </td>
+                                                <td>
+                                                    @can('update', \App\Models\AssetModel::class)
+                                                        <a class="btn delete-asset btn-sm btn-danger btn-sm" href="{{ route('delete/modelfile', [$asset->model->id, $file->id]) }}" data-tooltip="true" data-title="Delete" data-content="{{ trans('general.delete_confirm', ['item' => $file->filename]) }}"><i class="fas fa-trash icon-white" aria-hidden="true"></i></a>
                                                     @endcan
                                                 </td>
                                             </tr>

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -204,13 +204,6 @@
 
     <div class="col-md-3">
         <div class="row">
-        <div class="col-md-12" style="padding-bottom: 5px;">
-            <a href="{{ route('models.edit', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('admin/models/table.edit') }}</a>
-        </div>
-        <div class="col-md-12" style="padding-bottom: 10px;">
-            <a href="{{ route('clone/model', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('admin/models/table.clone') }}</a>
-        </div>
-
             <div class="col-md-12">
                 <div class="box box-default">
                     <div class="box-header with-border">
@@ -315,6 +308,31 @@
             </div>
         </div>
         </div>
+            @can('update', \App\Models\AssetModel::class)
+            <div class="col-md-12" style="padding-bottom: 5px;">
+                <a href="{{ route('models.edit', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('admin/models/table.edit') }}</a>
+            </div>
+            @endcan
+
+            @can('create', \App\Models\AssetModel::class)
+            <div class="col-md-12" style="padding-bottom: 5px;">
+                <a href="{{ route('clone/model', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('admin/models/table.clone') }}</a>
+            </div>
+            @endcan
+
+            @can('delete', \App\Models\AssetModel::class)
+                @if ($model->assets->count() > 0)
+
+                    <div class="col-md-12" style="padding-bottom: 5px;">
+                        <a href="{{ route('models.destroy', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-danger hidden-print disabled">{{ trans('general.delete') }}</a>
+                    </div>
+                @else
+
+                    <div class="col-md-12" style="padding-bottom: 10px;">
+                        <a href="{{ route('models.destroy', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-danger hidden-print">{{ trans('general.delete') }}</a>
+                    </div>
+                @endif
+           @endcan
         </div>
 </div> <!-- /.row -->
 

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -56,7 +56,14 @@
                         </span>
                         <span class="hidden-xs hidden-sm">
                             {{ trans('general.files') }}
-                        </span>
+                            {!! ($model->uploads->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($model->uploads->count()).'</badge>' : '' !!}
+                          </span>
+                    </a>
+                </li>
+                <li class="pull-right">
+                    <a href="#" data-toggle="modal" data-target="#uploadFileModal">
+                        <i class="fas fa-paperclip" aria-hidden="true"></i>
+                        {{ trans('button.upload') }}
                     </a>
                 </li>
 
@@ -92,13 +99,101 @@
                 }'>
                     </table>
                     {{ Form::close() }}
-                    </div>
-
                 </div> <!-- /.tab-pane assets -->
+
 
                 <div class="tab-pane fade" id="uploads">
 
-                   kljhglfh
+                    <div class="row">
+                        <div class="col-md-12">
+
+                            @if ($model->uploads->count() > 0)
+                                <table
+                                        class="table table-striped snipe-table"
+                                        id="modelFileHistory"
+                                        data-pagination="true"
+                                        data-id-table="modelFileHistory"
+                                        data-search="true"
+                                        data-side-pagination="client"
+                                        data-sortable="true"
+                                        data-show-columns="true"
+                                        data-show-fullscreen="true"
+                                        data-show-refresh="true"
+                                        data-sort-order="desc"
+                                        data-sort-name="created_at"
+                                        data-show-export="true"
+                                        data-export-options='{
+                         "fileName": "export-asset-{{ $model->id }}-files",
+                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                       }'
+                                        data-cookie-id-table="assetFileHistory">
+                                    <thead>
+                                    <tr>
+                                        <th data-visible="true" data-field="icon" data-sortable="true">{{trans('general.file_type')}}</th>
+                                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="image">{{ trans('general.image') }}</th>
+                                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="filename" data-sortable="true">{{ trans('general.file_name') }}</th>
+                                        <th class="col-md-1" data-searchable="true" data-visible="true" data-field="filesize">{{ trans('general.filesize') }}</th>
+                                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="notes" data-sortable="true">{{ trans('general.notes') }}</th>
+                                        <th class="col-md-1" data-searchable="true" data-visible="true" data-field="download">{{ trans('general.download') }}</th>
+                                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="created_at" data-sortable="true">{{ trans('general.created_at') }}</th>
+                                        <th class="col-md-1" data-searchable="true" data-visible="true" data-field="actions">{{ trans('table.actions') }}</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+
+                                    @foreach ($model->uploads as $file)
+                                        <tr>
+                                            <td><i class="{{ Helper::filetype_icon($file->filename) }} icon-med" aria-hidden="true"></i></td>
+                                            <td>
+                                                @if ( Helper::checkUploadIsImage($file->get_src('assets')))
+                                                    <a href="{{ route('show/modelFile', ['modelId' => $model->id, 'fileId' =>$file->id]) }}" data-toggle="lightbox" data-type="image" data-title="{{ $file->filename }}" data-footer="{{ Helper::getFormattedDateObject($asset->last_checkout, 'datetime', false) }}">
+                                                        <img src="{{ route('show/modelfile', ['assetId' => $model->id, 'fileId' =>$file->id]) }}" style="max-width: 50px;">
+                                                    </a>
+                                                @endif
+                                            </td>
+                                            <td>
+                                                {{ $file->filename }}
+                                            </td>
+                                            <td data-value="{{ filesize(storage_path('private_uploads/assetmodels/').$file->filename) }}">
+                                                {{ Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/assetmodels/').$file->filename)) }}
+                                            </td>
+                                            <td>
+                                                @if ($file->note)
+                                                    {{ $file->note }}
+                                                @endif
+                                            </td>
+                                            <td>
+                                                @if ($file->filename)
+                                                    <a href="{{ route('show/modelfile', [$model->id, $file->id]) }}" class="btn btn-default">
+                                                        <i class="fas fa-download" aria-hidden="true"></i>
+                                                    </a>
+                                                @endif
+                                            </td>
+                                            <td>
+                                                @if ($file->created_at)
+                                                    {{ Helper::getFormattedDateObject($file->created_at, 'datetime', false) }}
+                                                @endif
+                                            </td>
+                                            <td>
+                                                @can('update', \App\Models\AssetModel::class)
+                                                    <a class="btn delete-asset btn-sm btn-danger btn-sm" href="{{ route('delete/assetfile', [$model->id, $file->id]) }}" data-tooltip="true" data-title="Delete" data-content="{{ trans('general.delete_confirm', ['item' => $file->filename]) }}"><i class="fas fa-trash icon-white" aria-hidden="true"></i></a>
+                                                @endcan
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                    </tbody>
+                                </table>
+
+                            @else
+
+                                <div class="alert alert-info alert-block">
+                                    <i class="fas fa-info-circle"></i>
+                                    {{ trans('general.no_results') }}
+                                </div>
+                            @endif
+
+                        </div> <!-- /.col-md-12 -->
+                    </div> <!-- /.row -->
 
                 </div>
 
@@ -106,14 +201,26 @@
             </div> <!-- /.tab-content -->
         </div>  <!-- /.nav-tabs-custom -->
     </div><!-- /. col-md-12 -->
+
     <div class="col-md-3">
-        <div class="box box-default">
-            <div class="box-header with-border">
-                <div class="box-heading">
-                    <h2 class="box-title"> {{ trans('general.moreinfo') }}:</h2>
-                </div>
-            </div><!-- /.box-header -->
-            <div class="box-body">
+        <div class="row">
+        <div class="col-md-12" style="padding-bottom: 5px;">
+            <a href="{{ route('models.edit', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('admin/models/table.edit') }}</a>
+        </div>
+        <div class="col-md-12" style="padding-bottom: 10px;">
+            <a href="{{ route('clone/model', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('admin/models/table.clone') }}</a>
+        </div>
+
+            <div class="col-md-12">
+                <div class="box box-default">
+                    <div class="box-header with-border">
+                        <div class="box-heading">
+                            <h2 class="box-title"> {{ trans('general.moreinfo') }}:</h2>
+                        </div>
+                    </div><!-- /.box-header -->
+                    <div class="box-body">
+
+
 
                 @if ($model->image)
                     <img src="{{ Storage::disk('public')->url(app('models_upload_path').e($model->image)) }}" class="img-responsive"></li>
@@ -207,7 +314,13 @@
                 @endif
             </div>
         </div>
+        </div>
+        </div>
 </div> <!-- /.row -->
+
+@can('update', \App\Models\AssetModel::class)
+    @include ('modals.upload-file', ['item_type' => 'models', 'item_id' => $model->id])
+@endcan
 @stop
 
 @section('moar_scripts')

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -2,189 +2,215 @@
 
 {{-- Page title --}}
 @section('title')
-{{ trans('admin/models/table.view') }}
-{{ $model->model_tag }}
+    {{ $model->name }}
+    {{ ($model->model_number) ? '(#'.$model->model_number.')' : '' }}
 @parent
 @stop
 
 @section('header_right')
-  @can('update', \App\Models\AssetModel::class)
-  <div class="btn-group pull-right">
-     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">{{ trans('button.actions') }}
-          <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu">
-          @if ($model->deleted_at=='')
-            <li><a href="{{ route('models.edit', $model->id) }}">{{ trans('admin/models/table.edit') }}</a></li>
-            <li><a href="{{ route('clone/model', $model->id) }}">{{ trans('admin/models/table.clone') }}</a></li>
-            <li><a href="{{ route('hardware.create', ['model_id' => $model->id]) }}">{{ trans('admin/hardware/form.create') }}</a></li>
-          @else
-            <li><a href="{{ route('restore/model', $model->id) }}">{{ trans('admin/models/general.restore') }}</a></li>
-          @endif
-      </ul>
-  </div>
-  @endcan
+    @can('update', \App\Models\AssetModel::class)
+        <div class="btn-group pull-right">
+            <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">{{ trans('button.actions') }}
+                <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+                @if ($model->deleted_at=='')
+                    <li><a href="{{ route('models.edit', $model->id) }}">{{ trans('admin/models/table.edit') }}</a></li>
+                    <li><a href="{{ route('clone/model', $model->id) }}">{{ trans('admin/models/table.clone') }}</a></li>
+                    <li><a href="{{ route('hardware.create', ['model_id' => $model->id]) }}">{{ trans('admin/hardware/form.create') }}</a></li>
+                @else
+                    <li><a href="{{ route('restore/model', $model->id) }}">{{ trans('admin/models/general.restore') }}</a></li>
+                @endif
+            </ul>
+        </div>
+    @endcan
 @stop
 
 {{-- Page content --}}
 @section('content')
 
+
 <div class="row">
-  <div class="col-md-9">
-    <div class="box box-default">
-      @if ($model->id)
-        <div class="box-header with-border">
-          <div class="box-heading">
-            <h2 class="box-title"> {{ $model->name }}
-                {{ ($model->model_number) ? '(#'.$model->model_number.')' : '' }}
-            </h2>
-          </div>
-        </div><!-- /.box-header -->
-      @endif
-      <div class="box-body">
+    <div class="col-md-9">
+        <div class="nav-tabs-custom">
 
-          @include('partials.asset-bulk-actions')
+            <ul class="nav nav-tabs">
+                <li class="active">
+                    <a href="#assets" data-toggle="tab">
 
+                        <span class="hidden-lg hidden-md">
+                          <i class="fas fa-barcode fa-2x"></i>
+                        </span>
+                                    <span class="hidden-xs hidden-sm">
+                            {{ trans('general.assets') }}
+                                        {!! (($model->assets) && ($model->assets->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($model->assets->count()).'</badge>' : '' !!}
+                        </span>
+                    </a>
+                </li>
 
+                <li>
+                    <a href="#uploads" data-toggle="tab">
 
+                        <span class="hidden-lg hidden-md">
+                          <i class="fas fa-barcode fa-2x"></i>
+                        </span>
+                        <span class="hidden-xs hidden-sm">
+                            {{ trans('general.files') }}
+                        </span>
+                    </a>
+                </li>
 
-                  <table
-                  data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
-                  data-cookie-id-table="assetListingTable"
-                  data-pagination="true"
-                  data-id-table="assetListingTable"
-                  data-search="true"
-                  data-side-pagination="server"
-                  data-show-columns="true"
-                  data-show-fullscreen="true"
-                  data-toolbar="#assetsBulkEditToolbar"
-                  data-bulk-button-id="#bulkAssetEditButton"
-                  data-bulk-form-id="#assetsBulkForm"
-                  data-click-to-select="true"
-                  data-show-export="true"
-                  data-show-refresh="true"
-                  data-sort-order="asc"
-                  id="assetListingTable"
-                  data-url="{{ route('api.assets.index',['model_id'=> $model->id]) }}"
-                  class="table table-striped snipe-table"
-                  data-export-options='{
+            </ul>
+
+            <div class="tab-content">
+                <div class="tab-pane fade in active" id="assets">
+
+                    @include('partials.asset-bulk-actions')
+
+                    <table
+                            data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
+                            data-cookie-id-table="assetListingTable"
+                            data-pagination="true"
+                            data-id-table="assetListingTable"
+                            data-search="true"
+                            data-side-pagination="server"
+                            data-show-columns="true"
+                            data-show-fullscreen="true"
+                            data-toolbar="#assetsBulkEditToolbar"
+                            data-bulk-button-id="#bulkAssetEditButton"
+                            data-bulk-form-id="#assetsBulkForm"
+                            data-click-to-select="true"
+                            data-show-export="true"
+                            data-show-refresh="true"
+                            data-sort-order="asc"
+                            id="assetListingTable"
+                            data-url="{{ route('api.assets.index',['model_id'=> $model->id]) }}"
+                            class="table table-striped snipe-table"
+                            data-export-options='{
                 "fileName": "export-models-{{ str_slug($model->name) }}-assets-{{ date('Y-m-d') }}",
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                 }'>
-                </table>
-                  {{ Form::close() }}
+                    </table>
+                    {{ Form::close() }}
+                    </div>
 
-      </div> <!-- /.box-body-->
-    </div> <!-- /.box-default-->
-  </div> <!-- /.col-md-9-->
+                </div> <!-- /.tab-pane assets -->
 
-  <!-- side address column -->
-  <div class="col-md-3">
-      <div class="box box-default">
-              <div class="box-header with-border">
-                  <div class="box-heading">
-                      <h2 class="box-title"> {{ trans('general.moreinfo') }}:</h2>
-                  </div>
-              </div><!-- /.box-header -->
-          <div class="box-body">
+                <div class="tab-pane fade" id="uploads">
 
-              @if ($model->image)
-                  <img src="{{ Storage::disk('public')->url(app('models_upload_path').e($model->image)) }}" class="img-responsive"></li>
-              @endif
+                   kljhglfh
+
+                </div>
 
 
-            <ul class="list-unstyled" style="line-height: 25px;">
-              @if ($model->manufacturer)
-              <li>
-                {{ trans('general.manufacturer') }}:
-              @can('view', \App\Models\Manufacturer::class)
-                  <a href="{{ route('manufacturers.show', $model->manufacturer->id) }}">
-                      {{ $model->manufacturer->name }}
-                  </a>
-              @else
-                  {{ $model->manufacturer->name }}
-              @endcan
-              </li>
+            </div> <!-- /.tab-content -->
+        </div>  <!-- /.nav-tabs-custom -->
+    </div><!-- /. col-md-12 -->
+    <div class="col-md-3">
+        <div class="box box-default">
+            <div class="box-header with-border">
+                <div class="box-heading">
+                    <h2 class="box-title"> {{ trans('general.moreinfo') }}:</h2>
+                </div>
+            </div><!-- /.box-header -->
+            <div class="box-body">
 
-                  @if ($model->manufacturer->url)
-                      <li>
-                          <i class="fas fa-globe-americas"></i> <a href="{{ $model->manufacturer->url }}">{{ $model->manufacturer->url }}</a>
-                      </li>
-                  @endif
-
-                  @if ($model->manufacturer->support_url)
-                      <li>
-                          <i class="far fa-life-ring"></i> <a href="{{ $model->manufacturer->support_url }}">{{ $model->manufacturer->support_url }}</a>
-                      </li>
-                  @endif
-
-                  @if ($model->manufacturer->support_phone)
-                      <li>
-                          <i class="fas fa-phone"></i>
-                          <a href="tel:{{ $model->manufacturer->support_phone }}">{{ $model->manufacturer->support_phone }}</a>
-
-                      </li>
-                  @endif
-
-                  @if ($model->manufacturer->support_email)
-                      <li>
-                          <i class="far fa-envelope"></i> <a href="mailto:{{ $model->manufacturer->support_email }}">{{ $model->manufacturer->support_email }}</a>
-                      </li>
-                  @endif
+                @if ($model->image)
+                    <img src="{{ Storage::disk('public')->url(app('models_upload_path').e($model->image)) }}" class="img-responsive"></li>
                 @endif
-              @if ($model->model_number)
-              <li>
-                {{ trans('general.model_no') }}:
-                {{ $model->model_number }}
-              </li>
-              @endif
-
-              @if ($model->depreciation)
-              <li>
-                {{ trans('general.depreciation') }}:
-                {{ $model->depreciation->name }} ({{ $model->depreciation->months.' '.trans('general.months')}})
-              </li>
-              @endif
-
-              @if ($model->eol)
-              <li>{{ trans('general.eol') }}:
-                {{ $model->eol .' '. trans('general.months') }}
-              </li>
-              @endif
-
-              @if ($model->fieldset)
-              <li>{{ trans('admin/models/general.fieldset') }}:
-                <a href="{{ route('fieldsets.show', $model->fieldset->id) }}">{{ $model->fieldset->name }}</a>
-              </li>
-              @endif
-
-              @if ($model->notes)
-                  <li>
-                      {{ trans('general.notes') }}:
-                      {{ $model->notes }}
-                  </li>
-              @endif
 
 
+                <ul class="list-unstyled" style="line-height: 25px;">
+                    @if ($model->manufacturer)
+                        <li>
+                            {{ trans('general.manufacturer') }}:
+                            @can('view', \App\Models\Manufacturer::class)
+                                <a href="{{ route('manufacturers.show', $model->manufacturer->id) }}">
+                                    {{ $model->manufacturer->name }}
+                                </a>
+                            @else
+                                {{ $model->manufacturer->name }}
+                            @endcan
+                        </li>
 
-              @if  ($model->deleted_at!='')
-               <li><br /><a href="{{ route('restore/model', $model->id) }}" class="btn-flat large info ">{{ trans('admin/models/general.restore') }}</a></li>
-              @endif
-            </ul>
+                        @if ($model->manufacturer->url)
+                            <li>
+                                <i class="fas fa-globe-americas"></i> <a href="{{ $model->manufacturer->url }}">{{ $model->manufacturer->url }}</a>
+                            </li>
+                        @endif
 
-            @if ($model->note)
-            Notes:
-            <p>
-              {!! $model->present()->note() !!}
-            </p>
-            @endif
-          </div>
-      </div>
-  </div>
-  </div>
-</div>
+                        @if ($model->manufacturer->support_url)
+                            <li>
+                                <i class="far fa-life-ring"></i> <a href="{{ $model->manufacturer->support_url }}">{{ $model->manufacturer->support_url }}</a>
+                            </li>
+                        @endif
+
+                        @if ($model->manufacturer->support_phone)
+                            <li>
+                                <i class="fas fa-phone"></i>
+                                <a href="tel:{{ $model->manufacturer->support_phone }}">{{ $model->manufacturer->support_phone }}</a>
+
+                            </li>
+                        @endif
+
+                        @if ($model->manufacturer->support_email)
+                            <li>
+                                <i class="far fa-envelope"></i> <a href="mailto:{{ $model->manufacturer->support_email }}">{{ $model->manufacturer->support_email }}</a>
+                            </li>
+                        @endif
+                    @endif
+                    @if ($model->model_number)
+                        <li>
+                            {{ trans('general.model_no') }}:
+                            {{ $model->model_number }}
+                        </li>
+                    @endif
+
+                    @if ($model->depreciation)
+                        <li>
+                            {{ trans('general.depreciation') }}:
+                            {{ $model->depreciation->name }} ({{ $model->depreciation->months.' '.trans('general.months')}})
+                        </li>
+                    @endif
+
+                    @if ($model->eol)
+                        <li>{{ trans('general.eol') }}:
+                            {{ $model->eol .' '. trans('general.months') }}
+                        </li>
+                    @endif
+
+                    @if ($model->fieldset)
+                        <li>{{ trans('admin/models/general.fieldset') }}:
+                            <a href="{{ route('fieldsets.show', $model->fieldset->id) }}">{{ $model->fieldset->name }}</a>
+                        </li>
+                    @endif
+
+                    @if ($model->notes)
+                        <li>
+                            {{ trans('general.notes') }}:
+                            {{ $model->notes }}
+                        </li>
+                    @endif
+
+
+
+                    @if  ($model->deleted_at!='')
+                        <li><br /><a href="{{ route('restore/model', $model->id) }}" class="btn-flat large info ">{{ trans('admin/models/general.restore') }}</a></li>
+                    @endif
+                </ul>
+
+                @if ($model->note)
+                    Notes:
+                    <p>
+                        {!! $model->present()->note() !!}
+                    </p>
+                @endif
+            </div>
+        </div>
+</div> <!-- /.row -->
 @stop
 
 @section('moar_scripts')
-@include ('partials.bootstrap-table')
+    @include ('partials.bootstrap-table', ['exportFile' => 'manufacturer' . $model->name . '-export', 'search' => false])
+
 @stop

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -322,6 +322,9 @@
             } else if (value.type == 'location') {
                 item_destination = 'locations'
                 item_icon = 'fas fa-map-marker-alt';
+            } else if (value.type == 'model') {
+                item_destination = 'models'
+                item_icon = '';
             }
 
             return '<nobr><a href="{{ url('/') }}/' + item_destination +'/' + value.id + '" data-tooltip="true" title="' + value.type + '"><i class="' + item_icon + ' text-{{ $snipeSettings->skin!='' ? $snipeSettings->skin : 'blue' }} "></i> ' + value.name + '</a></nobr>';

--- a/routes/web/models.php
+++ b/routes/web/models.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AssetModelsController;
+use App\Http\Controllers\AssetModelsFilesController;
 use App\Http\Controllers\BulkAssetModelsController;
 use Illuminate\Support\Facades\Route;
 
@@ -8,6 +9,18 @@ use Illuminate\Support\Facades\Route;
 
 
 Route::group(['prefix' => 'models', 'middleware' => ['auth']], function () {
+
+    Route::post('{modelID}/upload',
+        [AssetModelsFilesController::class, 'store']
+    )->name('upload/models');
+
+    Route::get('{modelID}/showfile/{fileId}/{download?}',
+        [AssetModelsFilesController::class, 'show']
+    )->name('show/modelfile');
+
+    Route::delete('{modelID}/showfile/{fileId}/delete',
+        [AssetModelsFilesController::class, 'destroy']
+    )->name('delete/modelfile');
 
     Route::get(
         '{modelId}/clone',
@@ -72,6 +85,7 @@ Route::group(['prefix' => 'models', 'middleware' => ['auth']], function () {
             'destroy'
         ]
     )->name('models.bulkdelete.store');
+
 
 
 });


### PR DESCRIPTION
This adds a file upload option to asset models. 

<img width="1630" alt="Screen Shot 2022-06-28 at 4 18 32 PM" src="https://user-images.githubusercontent.com/197404/176320523-a27abe00-6813-468f-8cf6-14171dffa5aa.png">
<img width="1630" alt="Screen Shot 2022-06-28 at 4 19 42 PM" src="https://user-images.githubusercontent.com/197404/176320528-5ab7907d-b983-4e47-8ffa-63170af707b9.png">


### Next Steps:

- Rename the `AssetFileRequest` to be more generic
- Possibly Traitify files so that there's less repetition
- Add files endpoint to API so we can BS tables those mofos

Fixes #9757 and FD-28554