### PR TITLE
Add index across username and deleted_at to improve performance

### DIFF
--- a/database/migrations/2022_06_28_234539_add_username_index_to_users.php
+++ b/database/migrations/2022_06_28_234539_add_username_index_to_users.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUsernameIndexToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->index(['username', 'deleted_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['username','deleted_at']);
+        });
+    }
+}


### PR DESCRIPTION
Specifically, large directory sync performance.

I tested by running the migration, and rolling it back. Also tested against a database, and it definitely helped.