### PR TITLE
Added personal access endpoint to API

### DIFF
--- a/app/Console/Commands/GeneratePersonalAccessToken.php
+++ b/app/Console/Commands/GeneratePersonalAccessToken.php
@@ -69,16 +69,22 @@ class GeneratePersonalAccessToken extends Command
 
         if ($user = User::find($this->option('user_id'))) {
 
+            $createAccessToken = $user->createToken($accessTokenName)->accessToken;
+
             if ($this->option('key-only')) {
-                $this->info($user->createToken($accessTokenName)->accessToken);
+                $this->info($createAccessToken);
+
             } else {
-                $token = DB::table('oauth_access_tokens')->where('user_id', '=', $user->id)->where('name','=',$accessTokenName)->orderBy('created_at', 'desc')->first();
 
                 $this->warn('Your API Token has been created. Be sure to copy this token now, as it will not be accessible again.');
-                $this->info('API Token ID: '.$token->id);
+
+                if ($token = DB::table('oauth_access_tokens')->where('user_id', '=', $user->id)->where('name','=',$accessTokenName)->orderBy('created_at', 'desc')->first()) {
+                    $this->info('API Token ID: '.$token->id);
+                }
+
                 $this->info('API Token User: '.$user->present()->fullName.' ('.$user->username.')');
                 $this->info('API Token Name: '.$accessTokenName);
-                $this->info('API Token: '.$user->createToken($accessTokenName)->accessToken);
+                $this->info('API Token: '.$createAccessToken);
             }
         } else {
            return $this->error('ERROR: Invalid user. API key was not created.');

--- a/app/Console/Commands/GeneratePersonalAccessToken.php
+++ b/app/Console/Commands/GeneratePersonalAccessToken.php
@@ -71,6 +71,7 @@ class GeneratePersonalAccessToken extends Command
                 $this->info($user->createToken($accessTokenName)->accessToken);
             } else {
                 $this->warn('Your API Token has been created. Be sure to copy this token now, as it will not be accessible again.');
+                $this->info('API Token User: '.$user->present()->fullName.' ('.$user->username.')');
                 $this->info('API Token Name: '.$accessTokenName);
                 $this->info('API Token: '.$user->createToken($accessTokenName)->accessToken);
             }

--- a/app/Console/Commands/GeneratePersonalAccessToken.php
+++ b/app/Console/Commands/GeneratePersonalAccessToken.php
@@ -19,14 +19,14 @@ class GeneratePersonalAccessToken extends Command
     protected $signature = 'snipeit:make-api-key 
                         {user : The ID of the user to create the token for}
                         {--name= : The name of the new API token}
-                        {--key-only= : Only return the value of the API key}';
+                        {--key-only : Only return the value of the API key}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'This console command allows you to generate Personal API tokens to be used with the Snipe-IT JSON REST API on behalf of a user.';
 
 
     /**
@@ -68,7 +68,7 @@ class GeneratePersonalAccessToken extends Command
 
         if ($user = User::find($this->argument('user'))) {
 
-            if ($this->option('key-only')=='true') {
+            if ($this->option('key-only')) {
                 $this->info($user->createToken($accessTokenName)->accessToken);
             } else {
                 $this->warn('Your API Token has been created. Be sure to copy this token now, as it will not be accessible again.');

--- a/app/Console/Commands/GeneratePersonalAccessToken.php
+++ b/app/Console/Commands/GeneratePersonalAccessToken.php
@@ -17,7 +17,7 @@ class GeneratePersonalAccessToken extends Command
      * @var string
      */
     protected $signature = 'snipeit:make-api-key 
-                        {user : The ID of the user to create the token for}
+                        {--user_id= : The ID of the user to create the token for.}
                         {--name= : The name of the new API token}
                         {--key-only : Only return the value of the API key}';
 
@@ -62,11 +62,11 @@ class GeneratePersonalAccessToken extends Command
             $accessTokenName = 'CLI Auth Token';
         }
 
-        if ($this->argument('user')=='') {
-            return false;
+        if ($this->option('user_id')=='') {
+            return $this->error('ERROR: user_id cannot be blank.');
         }
 
-        if ($user = User::find($this->argument('user'))) {
+        if ($user = User::find($this->option('user_id'))) {
 
             if ($this->option('key-only')) {
                 $this->info($user->createToken($accessTokenName)->accessToken);

--- a/app/Console/Commands/GeneratePersonalAccessToken.php
+++ b/app/Console/Commands/GeneratePersonalAccessToken.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Helpers\Helper;
+use Illuminate\Console\Command;
+use App\Models\User;
+use Laravel\Passport\TokenRepository;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+
+class GeneratePersonalAccessToken extends Command
+{
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:make-api-key 
+                        {user : The ID of the user to create the token for}
+                        {--name= : The name of the new API token}
+                        {--key-only= : Only return the value of the API key}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+
+    /**
+     * The token repository implementation.
+     *
+     * @var \Laravel\Passport\TokenRepository
+     */
+    protected $tokenRepository;
+
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(TokenRepository $tokenRepository, ValidationFactory $validation)
+    {
+        $this->validation = $validation;
+        $this->tokenRepository = $tokenRepository;
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+
+        if ($this->option('name')=='') {
+            $accessTokenName = 'CLI Auth Token';
+        }
+
+        if ($this->argument('user')=='') {
+            return false;
+        }
+
+        if ($user = User::find($this->argument('user'))) {
+
+            if ($this->option('key-only')=='true') {
+                $this->info($user->createToken($accessTokenName)->accessToken);
+            } else {
+                $this->warn('Your API Token has been created. Be sure to copy this token now, as it will not be accessible again.');
+                $this->info('API Token Name: '.$accessTokenName);
+                $this->info('API Token: '.$user->createToken($accessTokenName)->accessToken);
+            }
+        } else {
+           return $this->error('ERROR: Invalid user. API key was not created.');
+        }
+
+
+
+
+    }
+}

--- a/app/Console/Commands/GeneratePersonalAccessToken.php
+++ b/app/Console/Commands/GeneratePersonalAccessToken.php
@@ -57,7 +57,8 @@ class GeneratePersonalAccessToken extends Command
     public function handle()
     {
 
-        if ($this->option('name')=='') {
+        $accessTokenName = $this->option('name');
+        if ($accessTokenName=='') {
             $accessTokenName = 'CLI Auth Token';
         }
 

--- a/app/Console/Commands/GeneratePersonalAccessToken.php
+++ b/app/Console/Commands/GeneratePersonalAccessToken.php
@@ -7,6 +7,7 @@ use Illuminate\Console\Command;
 use App\Models\User;
 use Laravel\Passport\TokenRepository;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+use DB;
 
 class GeneratePersonalAccessToken extends Command
 {
@@ -71,7 +72,10 @@ class GeneratePersonalAccessToken extends Command
             if ($this->option('key-only')) {
                 $this->info($user->createToken($accessTokenName)->accessToken);
             } else {
+                $token = DB::table('oauth_access_tokens')->where('user_id', '=', $user->id)->where('name','=',$accessTokenName)->orderBy('created_at', 'desc')->first();
+
                 $this->warn('Your API Token has been created. Be sure to copy this token now, as it will not be accessible again.');
+                $this->info('API Token ID: '.$token->id);
                 $this->info('API Token User: '.$user->present()->fullName.' ('.$user->username.')');
                 $this->info('API Token Name: '.$accessTokenName);
                 $this->info('API Token: '.$user->createToken($accessTokenName)->accessToken);

--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -145,10 +145,11 @@ class ProfileController extends Controller
         }
         
         $tokens = $this->tokenRepository->forUser(Auth::user()->getAuthIdentifier());
-
-        return $tokens->load('client')->filter(function ($token) {
+        $token_values = $tokens->load('client')->filter(function ($token) {
             return $token->client->personal_access_client && ! $token->revoked;
         })->values();
+
+        return response()->json(Helper::formatStandardApiResponse('success', $token_values, null));
 
     }
 

--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Request;
 use Laravel\Passport\TokenRepository;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Gate;
+use DB;
 
 class ProfileController extends Controller
 {
@@ -87,9 +88,14 @@ class ProfileController extends Controller
         $accessTokenName = $request->input('name', 'Auth Token');
 
         if ($accessToken = Auth::user()->createToken($accessTokenName)->accessToken) {
-            return response()->json(Helper::formatStandardApiResponse('success', $accessToken, 'Personal access token '.$accessTokenName.' created successfully'));
-        }
 
+            // Get the ID so we can return that with the payload
+            $token = DB::table('oauth_access_tokens')->where('user_id', '=', Auth::user()->id)->where('name','=',$accessTokenName)->orderBy('created_at', 'desc')->first();
+            $accessTokenData['id'] = $token->id;
+            $accessTokenData['token'] = $accessToken;
+            $accessTokenData['name'] = $accessTokenName;
+            return response()->json(Helper::formatStandardApiResponse('success', $accessTokenData, 'Personal access token '.$accessTokenName.' created successfully'));
+        }
         return response()->json(Helper::formatStandardApiResponse('error', null, 'Token could not be created.'));
 
     }

--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use Laravel\Passport\TokenRepository;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+use Gate;
 
 class ProfileController extends Controller
 {
@@ -79,6 +80,10 @@ class ProfileController extends Controller
      */
     public function createApiToken(Request $request) {
 
+        if (!Gate::allows('self.api')) {
+            abort(403);
+        }
+
         $accessTokenName = $request->input('name', 'Auth Token');
 
         if ($accessToken = Auth::user()->createToken($accessTokenName)->accessToken) {
@@ -99,6 +104,10 @@ class ProfileController extends Controller
      * @return \Illuminate\Http\Response
      */
     public function deleteApiToken($tokenId) {
+
+        if (!Gate::allows('self.api')) {
+            abort(403);
+        }
 
         $token = $this->tokenRepository->findForUser(
             $tokenId, Auth::user()->getAuthIdentifier()
@@ -125,6 +134,10 @@ class ProfileController extends Controller
      */
     public function showApiTokens(Request $request) {
 
+        if (!Gate::allows('self.api')) {
+            abort(403);
+        }
+        
         $tokens = $this->tokenRepository->forUser(Auth::user()->getAuthIdentifier());
 
         return $tokens->load('client')->filter(function ($token) {

--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -5,10 +5,35 @@ namespace App\Http\Controllers\Api;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Models\CheckoutRequest;
-use Auth;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
+use Laravel\Passport\TokenRepository;
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 
 class ProfileController extends Controller
 {
+
+    /**
+     * The token repository implementation.
+     *
+     * @var \Laravel\Passport\TokenRepository
+     */
+    protected $tokenRepository;
+
+    /**
+     * Create a controller instance.
+     *
+     * @param  \Laravel\Passport\TokenRepository  $tokenRepository
+     * @param  \Illuminate\Contracts\Validation\Factory  $validation
+     * @return void
+     */
+    public function __construct(TokenRepository $tokenRepository, ValidationFactory $validation)
+    {
+        $this->validation = $validation;
+        $this->tokenRepository = $tokenRepository;
+    }
+
     /**
      * Display a listing of requested assets.
      *
@@ -42,4 +67,72 @@ class ProfileController extends Controller
 
         return $results;
     }
+
+
+    /**
+     * Delete an API token
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v6.0.5]
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function createApiToken(Request $request) {
+
+        $accessTokenName = $request->input('name', 'Auth Token');
+
+        if ($accessToken = Auth::user()->createToken($accessTokenName)->accessToken) {
+            return response()->json(Helper::formatStandardApiResponse('success', $accessToken, 'Personal access token '.$accessTokenName.' created successfully'));
+        }
+
+        return response()->json(Helper::formatStandardApiResponse('error', null, 'Token could not be created.'));
+
+    }
+
+
+    /**
+     * Delete an API token
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v6.0.5]
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function deleteApiToken($tokenId) {
+
+        $token = $this->tokenRepository->findForUser(
+            $tokenId, Auth::user()->getAuthIdentifier()
+        );
+
+        if (is_null($token)) {
+            return new Response('', 404);
+        }
+
+        $token->revoke();
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+
+    }
+
+
+    /**
+     * Show user's API tokens
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v6.0.5]
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function showTokens(Request $request) {
+
+        $tokens = $this->tokenRepository->forUser(Auth::user()->getAuthIdentifier());
+
+        return $tokens->load('client')->filter(function ($token) {
+            return $token->client->personal_access_client && ! $token->revoked;
+        })->values();
+
+    }
+
+
+
 }

--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -123,7 +123,7 @@ class ProfileController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function showTokens(Request $request) {
+    public function showApiTokens(Request $request) {
 
         $tokens = $this->tokenRepository->forUser(Auth::user()->getAuthIdentifier());
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -48,7 +48,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
             ]
         )->name('api.assets.requestable');
 
-        Route::post('personal-access-token',
+        Route::post('personal-access-tokens',
             [
                 Api\ProfileController::class,
                 'createApiToken'
@@ -62,7 +62,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
             ]
         )->name('api.personal-access-token.index');
 
-        Route::delete('personal-access-token/{tokenId}',
+        Route::delete('personal-access-tokens/{tokenId}',
             [
                 Api\ProfileController::class,
                 'deleteApiToken'

--- a/routes/api.php
+++ b/routes/api.php
@@ -58,7 +58,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
         Route::get('personal-access-tokens',
             [
                 Api\ProfileController::class,
-                'showTokens'
+                'showApiTokens'
             ]
         )->name('api.personal-access-token.index');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -48,6 +48,27 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
             ]
         )->name('api.assets.requestable');
 
+        Route::post('personal-access-token',
+            [
+                Api\ProfileController::class,
+                'createApiToken'
+            ]
+        )->name('api.personal-access-token.create');
+
+        Route::get('personal-access-tokens',
+            [
+                Api\ProfileController::class,
+                'showTokens'
+            ]
+        )->name('api.personal-access-token.index');
+
+        Route::delete('personal-access-token/{tokenId}',
+            [
+                Api\ProfileController::class,
+                'deleteApiToken'
+            ]
+        )->name('api.personal-access-token.delete');
+
 
 
      }); // end account group


### PR DESCRIPTION
This needs testing! Go to `/api/v1/account/personal-access-token` via cURL or postman. This also includes a console script that allows you to create API tokens on behalf of users.

```
php artisan snipeit:make-api-key --help
php artisan snipeit:make-api-key --user_id=1 --key-only
php artisan snipeit:make-api-key --user_id=1
php artisan snipeit:make-api-key --user_id=1 > api.txt
```

<img width="1242" alt="Screen Shot 2022-06-28 at 10 27 26 PM" src="https://user-images.githubusercontent.com/197404/176358463-4aafe5b7-32a3-4a25-a1ea-f86b16b7a5a6.png">

