### PR TITLE
[Feature] - Add checkoutByTag API endpoint for assets

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -756,7 +756,7 @@ class AssetsController extends Controller
      */
     public function checkoutByTag(AssetCheckoutRequest $request, $tag)
     {
-        if ($asset = Asset::with('assetstatus')->with('assignedTo')->where('asset_tag', $tag)->first()) {
+        if ($asset = Asset::where('asset_tag', $tag)->first()) {
             return $this->checkout($request, $asset->id);
         }
         return response()->json(Helper::formatStandardApiResponse('error', null, 'Asset not found'), 200);

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -746,7 +746,21 @@ class AssetsController extends Controller
         return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/hardware/message.does_not_exist')), 200);
     }
 
-
+    /**
+     * Checkout an asset by its tag.
+     *
+     * @author [N. Butler]
+     * @param string $tag
+     * @since [v6.0.5]
+     * @return JsonResponse
+     */
+    public function checkoutByTag(AssetCheckoutRequest $request, $tag)
+    {
+        if ($asset = Asset::with('assetstatus')->with('assignedTo')->where('asset_tag', $tag)->first()) {
+            return $this->checkout($request, $asset->id);
+        }
+        return response()->json(Helper::formatStandardApiResponse('error', null, 'Asset not found'), 200);
+    }
 
     /**
      * Checkout an asset

--- a/config/version.php
+++ b/config/version.php
@@ -1,10 +1,10 @@
 <?php
 return array (
   'app_version' => 'v6.0.5',
-  'full_app_version' => 'v6.0.5 - build 8230-g393c32558',
-  'build_version' => '8230',
+  'full_app_version' => 'v6.0.5 - build 8229-g94e723a88',
+  'build_version' => '8229',
   'prerelease_version' => '',
-  'hash_version' => 'g393c32558',
-  'full_hash' => 'v6.0.5-102-g393c32558',
-  'branch' => 'master',
+  'hash_version' => 'g94e723a88',
+  'full_hash' => 'v6.0.5-101-g94e723a88',
+  'branch' => 'develop',
 );

--- a/config/version.php
+++ b/config/version.php
@@ -1,10 +1,10 @@
 <?php
 return array (
   'app_version' => 'v6.0.5',
-  'full_app_version' => 'v6.0.5 - build 8229-g94e723a88',
-  'build_version' => '8229',
+  'full_app_version' => 'v6.0.5 - build 8230-g393c32558',
+  'build_version' => '8230',
   'prerelease_version' => '',
-  'hash_version' => 'g94e723a88',
-  'full_hash' => 'v6.0.5-101-g94e723a88',
-  'branch' => 'develop',
+  'hash_version' => 'g393c32558',
+  'full_hash' => 'v6.0.5-102-g393c32558',
+  'branch' => 'master',
 );

--- a/routes/api.php
+++ b/routes/api.php
@@ -441,6 +441,13 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
         )->name('api.assets.show.bytag')
         ->where('any', '.*');
 
+        Route::post('bytag/{any}/checkout',
+            [
+                Api\AssetsController::class, 
+                'checkoutByTag'
+            ]
+        )->name('api.assets.checkout.bytag');
+
         Route::get('byserial/{any}',
             [
                 Api\AssetsController::class, 


### PR DESCRIPTION
# Description

Seeing as asset tags are unique, it should be safe to, and would be useful to be able to call the API and check out an asset using it's asset tag. We have each asset tagged with a barcode, and have an internally developed mobile app to quickly scan user ID cards, then the asset tag. 

This extra endpoint means we no longer need to run a separate API call to look up the asset to get it's internal snipe ID first.

This uses essentially the same code from the GET /hardware/bytag/:asset_tag endpoint, and if the asset is found, calls the existing checkout function.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
**NOTE** - there seems to be an undocumented new API endpoint for checkinByTag, which should be updated too. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test API call with existing deployable check-in asset - asset checked out as expected
- [x] Test API call with existing deployable check-out asset - asset not available to be checked out as expected
- [x] Test API call with non-existing asset tag - asset not found as expected

**Test Configuration**:
* PHP version: 8.0.20
* MySQL version: 8.0
* Webserver version: 6.0.2
* OS version: Windows Server 2019


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
