### PR TITLE
Fixed route names (partially)

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -63,7 +63,7 @@ class AccessoryCheckoutController extends Controller
         $this->authorize('checkout', $accessory);
 
         if (! $user = User::find($request->input('assigned_to'))) {
-            return redirect()->route('checkout/accessory', $accessory->id)->with('error', trans('admin/accessories/message.checkout.user_does_not_exist'));
+            return redirect()->route('accessories.checkout.show', $accessory->id)->with('error', trans('admin/accessories/message.checkout.user_does_not_exist'));
         }
 
         // Update the accessory data

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -247,14 +247,14 @@ class BulkAssetsController extends Controller
     {
 
         $this->authorize('checkout', Asset::class);
-
+        $admin = Auth::user();
         try {
-            $admin = Auth::user();
+
 
             $target = $this->determineCheckoutTarget();
 
             if (! is_array($request->get('selected_assets'))) {
-                return redirect()->route('hardware/bulkcheckout')->withInput()->with('error', trans('admin/hardware/message.checkout.no_assets_selected'));
+                return redirect()->route('hardware.bulkcheckout.show')->withInput()->with('error', trans('admin/hardware/message.checkout.no_assets_selected'));
             }
 
             $asset_ids = array_filter($request->get('selected_assets'));
@@ -298,12 +298,12 @@ class BulkAssetsController extends Controller
 
             if (! $errors) {
                 // Redirect to the new asset page
-                return redirect()->to('hardware')->with('success', trans('admin/hardware/message.checkout.success'));
+                return redirect()->route('hardware.index')->with('success', trans('admin/hardware/message.checkout.success'));
             }
             // Redirect to the asset management page with error
-            return redirect()->to('hardware/bulk-checkout')->with('error', trans('admin/hardware/message.checkout.error'))->withErrors($errors);
+            return redirect()->route('hardware.bulkcheckout.show')->with('error', trans('admin/hardware/message.checkout.error'))->withErrors($errors);
         } catch (ModelNotFoundException $e) {
-            return redirect()->to('hardware/bulk-checkout')->with('error', $e->getErrors());
+            return redirect()->route('hardware.bulkcheckout.show')->with('error', $e->getErrors());
         }
     }
 }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -54,7 +54,7 @@ class LoginController extends Controller
     public function __construct(Saml $saml)
     {
         parent::__construct();
-        $this->middleware('guest', ['except' => ['logout', 'postTwoFactorAuth', 'getTwoFactorAuth', 'getTwoFactorEnroll']]);
+        $this->middleware('guest', ['except' => ['logout.store', 'logout.show','postTwoFactorAuth', 'getTwoFactorAuth', 'getTwoFactorEnroll']]);
         Session::put('backUrl', \URL::previous());
         // $this->ldap = $ldap;
         $this->saml = $saml;
@@ -484,7 +484,7 @@ class LoginController extends Controller
             return redirect()->away($customLogoutUrl);
         }
 
-        return redirect()->route('login')->with(['success' => trans('auth/message.logout.success'), 'loggedout' => true]);
+        return redirect()->route('login.show')->with(['success' => trans('auth/message.logout.success'), 'loggedout' => true]);
     }
 
 

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -142,6 +142,6 @@ class SamlController extends Controller
             return view('errors.403');
         }
 
-        return redirect()->route('logout')->with(['saml_logout' => true,'saml_slo_redirect_url' => $sloUrl]);
+        return redirect()->route('logout.show')->with(['saml_logout' => true,'saml_slo_redirect_url' => $sloUrl]);
     }
 }

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -56,7 +56,7 @@ class ConsumableCheckoutController extends Controller
         // Check if the user exists
         if (is_null($user = User::find($assigned_to))) {
             // Redirect to the consumable management page with error
-            return redirect()->route('checkout/consumable', $consumable)->with('error', trans('admin/consumables/message.checkout.user_does_not_exist'));
+            return redirect()->route('consumables.checkout.show', $consumable)->with('error', trans('admin/consumables/message.checkout.user_does_not_exist'));
         }
 
         // Update the consumable data

--- a/app/Http/Middleware/CheckForTwoFactor.php
+++ b/app/Http/Middleware/CheckForTwoFactor.php
@@ -11,7 +11,7 @@ class CheckForTwoFactor
     /**
      * Routes to ignore for Two Factor Auth
      */
-    const IGNORE_ROUTES = ['two-factor', 'two-factor-enroll', 'setup', 'logout'];
+    const IGNORE_ROUTES = ['two-factor', 'two-factor-enroll', 'setup', 'logout.store', 'logout.show'];
 
     /**
      * Handle an incoming request.

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -24,13 +24,13 @@
             @if ($accessory->assigned_to != '')
               @can('checkin', \App\Models\Accessory::class)
               <li role="menuitem">
-                <a href="{{ route('checkin/accessory', $accessory->id) }}">{{ trans('admin/accessories/general.checkin') }}</a>
+                <a href="{{ route('accessories.checkin.store', $accessory->id) }}">{{ trans('admin/accessories/general.checkin') }}</a>
               </li>
               @endcan
             @else
               @can('checkout', \App\Models\Accessory::class)
               <li role="menuitem">
-                <a href="{{ route('checkout/accessory', $accessory->id)  }}">{{ trans('admin/accessories/general.checkout') }}</a>
+                <a href="{{ route('accessories.checkout.show', $accessory->id)  }}">{{ trans('admin/accessories/general.checkout') }}</a>
               </li>
               @endcan
             @endif
@@ -171,7 +171,7 @@
           @can('checkout', \App\Models\Accessory::class)
               <div class="row">
                   <div class="col-md-12 text-center">
-                      <a href="{{ route('checkout/accessory', $accessory->id) }}" style="margin-right:5px;" class="btn btn-primary btn-sm" {{ (($accessory->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
+                      <a href="{{ route('accessories.checkout.show', $accessory->id) }}" style="margin-right:5px;" class="btn btn-primary btn-sm" {{ (($accessory->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
                   </div>
               </div>
           @endcan

--- a/resources/views/auth/two_factor.blade.php
+++ b/resources/views/auth/two_factor.blade.php
@@ -42,13 +42,13 @@
                             <button class="btn btn-lg btn-primary btn-block">{{ trans('general.submit')  }}</button>
                         </div>
                         <div class="col-md-12 col-sm-12 col-xs-12 text-right" style="padding-top: 10px;">
-                            <a href="{{ route('logout') }}" onclick="document.getElementById('logout-form').submit(); return false;">
+                            <a href="{{ route('logout.store') }}" onclick="document.getElementById('logout-form').submit(); return false;">
                                 {{ trans('general.cancel')  }}
                             </a>
                         </div>
             </div>
             </form>
-            <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+            <form id="logout-form" action="{{ route('logout.store') }}" method="POST" style="display: none;">
             {{ csrf_field() }}
             </form>
 

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -29,7 +29,7 @@
         @else
           @can('checkout', $component)
           <li role="menuitem">
-            <a href="{{ route('checkout/component', $component->id)  }}">
+            <a href="{{ route('components.checkout.show', $component->id)  }}">
               {{ trans('admin/components/general.checkout') }}
             </a>
           </li>

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -127,7 +127,7 @@
 
     @can('checkout', \App\Models\Consumable::class)
     <div class="col-md-12">
-                    <a href="{{ route('checkout/consumable', $consumable->id) }}" style="padding-bottom:5px;" class="btn btn-primary btn-sm" {{ (($consumable->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
+                    <a href="{{ route('consumables.checkout.show', $consumable->id) }}" style="padding-bottom:5px;" class="btn btn-primary btn-sm" {{ (($consumable->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
                 </div>
                 @endcan
 

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -23,7 +23,7 @@
       <i class="fas fa-exclamation-triangle"></i> {{ trans('admin/hardware/form.bulk_update_warn', ['asset_count' => count($assets)]) }}
     </div>
 
-    <form class="form-horizontal" method="post" action="{{ route('hardware/bulksave') }}" autocomplete="off" role="form">
+    <form class="form-horizontal" method="post" action="{{ route('hardware.bulkedit.store') }}" autocomplete="off" role="form">
       {{ csrf_field() }}
 
       <div class="box box-default">

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -28,11 +28,11 @@
           <div class="col-md-12">
             @if ($backto=='user')
               <form class="form-horizontal" method="post"
-                    action="{{ route('checkin/hardware', array('assetId'=> $asset->id, 'backto'=>'user')) }}"
+                    action="{{ route('hardware.checkin.store', array('assetId'=> $asset->id, 'backto'=>'user')) }}"
                     autocomplete="off">
                 @else
                   <form class="form-horizontal" method="post"
-                        action="{{ route('checkin/hardware', $asset->id) }}" autocomplete="off">
+                        action="{{ route('hardware.checkin.store', $asset->id) }}" autocomplete="off">
                   @endif
                   {{csrf_field()}}
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Page title --}}
 @section('title')
-    {{ trans('admin/hardware/general.view') }} {{ $asset->asset_tag }}
+    {{ trans('admin/hardware/general.show') }} {{ $asset->asset_tag }}
     @parent
 @stop
 
@@ -22,7 +22,7 @@
                     @if (($asset->assigned_to != '') && ($asset->deleted_at==''))
                         @can('checkin', \App\Models\Asset::class)
                             <li role="menuitem">
-                                <a href="{{ route('checkin/hardware', $asset->id) }}">
+                                <a href="{{ route('hardware.checkin.show', $asset->id) }}">
                                     {{ trans('admin/hardware/general.checkin') }}
                                 </a>
                             </li>
@@ -30,7 +30,7 @@
                     @elseif (($asset->assigned_to == '') && ($asset->deleted_at==''))
                         @can('checkout', \App\Models\Asset::class)
                             <li role="menuitem">
-                                <a href="{{ route('checkout/hardware', $asset->id)  }}">
+                                <a href="{{ route('hardware.checkout.show', $asset->id)  }}">
                                     {{ trans('admin/hardware/general.checkout') }}
                                 </a>
                             </li>

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -354,11 +354,11 @@
                      <li class="divider"></li>
                      <li>
 
-                        <a href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                        <a href="{{ route('logout.store') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
                             <i class="fa fa-sign-out fa-fw"></i> {{ trans('general.logout') }}
                         </a>
                         
-                        <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                        <form id="logout-form" action="{{ route('logout.store') }}" method="POST" style="display: none;">
                             {{ csrf_field() }}
                         </form>
 
@@ -486,7 +486,7 @@
 
                     @can('checkout', \App\Models\Asset::class)
                     <li{!! (Request::is('hardware/bulkcheckout') ? ' class="active"' : '') !!}>
-                        <a href="{{ route('hardware/bulkcheckout') }}">
+                        <a href="{{ route('hardware.bulkcheckout.show') }}">
                             {{ trans('general.bulk_checkout') }}
                         </a>
                     </li>

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -16,10 +16,10 @@
             <ul class="dropdown-menu">
                 @if ($model->deleted_at=='')
                     <li><a href="{{ route('models.edit', $model->id) }}">{{ trans('admin/models/table.edit') }}</a></li>
-                    <li><a href="{{ route('clone/model', $model->id) }}">{{ trans('admin/models/table.clone') }}</a></li>
+                    <li><a href="{{ route('models.clone.show', $model->id) }}">{{ trans('admin/models/table.clone') }}</a></li>
                     <li><a href="{{ route('hardware.create', ['model_id' => $model->id]) }}">{{ trans('admin/hardware/form.create') }}</a></li>
                 @else
-                    <li><a href="{{ route('restore/model', $model->id) }}">{{ trans('admin/models/general.restore') }}</a></li>
+                    <li><a href="{{ route('models.restore', $model->id) }}">{{ trans('admin/models/general.restore') }}</a></li>
                 @endif
             </ul>
         </div>
@@ -316,7 +316,7 @@
 
             @can('create', \App\Models\AssetModel::class)
             <div class="col-md-12" style="padding-bottom: 5px;">
-                <a href="{{ route('clone/model', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('admin/models/table.clone') }}</a>
+                <a href="{{ route('models.clone.show', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('admin/models/table.clone') }}</a>
             </div>
             @endcan
 

--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -1,7 +1,7 @@
 <div id="assetsBulkEditToolbar" style="min-width:400px">
     {{ Form::open([
       'method' => 'POST',
-      'route' => ['hardware/bulkedit'],
+      'route' => ['hardware.bulksave.update'],
       'class' => 'form-inline',
       'id' => 'assetsBulkForm']) }}
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -113,7 +113,7 @@
             </a>
             <ul class="dropdown-menu">
               <li><a href="{{ route('users.edit', $user->id) }}">{{ trans('admin/users/general.edit') }}</a></li>
-              <li><a href="{{ route('clone/user', $user->id) }}">{{ trans('admin/users/general.clone') }}</a></li>
+              <li><a href="{{ route('users.clone.show', $user->id) }}">{{ trans('admin/users/general.clone') }}</a></li>
               @if ((Auth::user()->id !== $user->id) && (!config('app.lock_passwords')) && ($user->deleted_at==''))
                 <li><a href="{{ route('users.destroy', $user->id) }}">{{ trans('button.delete') }}</a></li>
               @endif
@@ -142,7 +142,7 @@
                   <i class="icon fas fa-exclamation-triangle"></i>
                   {{ trans('admin/users/message.user_deleted_warning') }}
                   @can('update', $user)
-                      <a href="{{ route('restore/user', $user->id) }}">
+                      <a href="{{ route('users.restore.show', $user->id) }}">
                         {{ trans('admin/users/general.restore_user') }}
                       </a>
                   @endcan
@@ -178,7 +178,7 @@
 
               @can('create', $user)
                 <div class="col-md-12" style="padding-top: 5px;">
-                  <a href="{{ route('clone/user', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('admin/users/general.clone') }}</a>
+                  <a href="{{ route('users.clone.show', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('admin/users/general.clone') }}</a>
                 </div>
                @endcan
 
@@ -220,7 +220,7 @@
                     </div>
                   @else
                     <div class="col-md-12" style="padding-top: 5px;">
-                      <a href="{{ route('restore/user', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('button.restore') }}</a>
+                      <a href="{{ route('users.restore.show', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('button.restore') }}</a>
                     </div>
                   @endif
                 @endcan
@@ -723,7 +723,7 @@
                     </td>
                     <td class="hidden-print">
                       @can('checkin', $accessory)
-                        <a href="{{ route('checkin/accessory', array('accessoryID'=> $accessory->pivot->id, 'backto'=>'user')) }}" class="btn btn-primary btn-sm hidden-print">{{ trans('general.checkin') }}</a>
+                        <a href="{{ route('accessories.checkout.store', array('accessoryID'=> $accessory->pivot->id, 'backto'=>'user')) }}" class="btn btn-primary btn-sm hidden-print">{{ trans('general.checkin') }}</a>
                       @endcan
                     </td>
                   </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -473,12 +473,12 @@ Route::group(['middleware' => 'web'], function () {
     Route::get(
         'logout',
         [LoginController::class, 'logout']
-    )->name('logout');
+    )->name('logout.show');
 
     Route::post(
         'logout',
         [LoginController::class, 'logout']
-    )->name('logout');
+    )->name('logout.store');
 });
 
 //Auth::routes();

--- a/routes/web/accessories.php
+++ b/routes/web/accessories.php
@@ -10,22 +10,22 @@ Route::group(['prefix' => 'accessories', 'middleware' => ['auth']], function () 
     Route::get(
         '{accessoryID}/checkout',
         [Accessories\AccessoryCheckoutController::class, 'create']
-    )->name('checkout/accessory');
+    )->name('accessories.checkout.show');
 
     Route::post(
         '{accessoryID}/checkout',
         [Accessories\AccessoryCheckoutController::class, 'store']
-    )->name('checkout/accessory');
+    )->name('accessories.checkout.store');
 
     Route::get(
         '{accessoryID}/checkin/{backto?}',
         [Accessories\AccessoryCheckinController::class, 'create']
-    )->name('checkin/accessory');
+    )->name('accessories.checkin.show');
 
     Route::post(
         '{accessoryID}/checkin/{backto?}',
         [Accessories\AccessoryCheckinController::class, 'store']
-    )->name('checkin/accessory');
+    )->name('accessories.checkin.store');
 
 });
 

--- a/routes/web/components.php
+++ b/routes/web/components.php
@@ -8,12 +8,12 @@ Route::group(['prefix' => 'components', 'middleware' => ['auth']], function () {
     Route::get(
         '{componentID}/checkout',
         [Components\ComponentCheckoutController::class, 'create']
-    )->name('checkout/component');
+    )->name('components.checkout.show');
 
     Route::post(
         '{componentID}/checkout',
         [Components\ComponentCheckoutController::class, 'store']
-    )->name('checkout/component');
+    )->name('components.checkout.store');
 
     Route::get(
         '{componentID}/checkin/{backto?}',

--- a/routes/web/consumables.php
+++ b/routes/web/consumables.php
@@ -9,12 +9,12 @@ Route::group(['prefix' => 'consumables', 'middleware' => ['auth']], function () 
     Route::get(
         '{consumablesID}/checkout',
         [Consumables\ConsumableCheckoutController::class, 'create']
-    )->name('checkout/consumable');
+    )->name('consumables.checkout.show');
 
     Route::post(
         '{consumablesID}/checkout',
         [Consumables\ConsumableCheckoutController::class, 'store']
-    )->name('checkout/consumable');
+    )->name('consumables.checkout.store');
 
 
 });

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -108,23 +108,19 @@ Route::group(
 
         Route::get('{assetId}/checkout',
             [AssetCheckoutController::class, 'create']
-        )->name('checkout/hardware');
+        )->name('hardware.checkout.show');
 
         Route::post('{assetId}/checkout',
             [AssetCheckoutController::class, 'store']
-        )->name('checkout/hardware');
+        )->name('hardware.checkout.store');
 
         Route::get('{assetId}/checkin/{backto?}',
             [AssetCheckinController::class, 'create']
-        )->name('checkin/hardware');
+        )->name('hardware.checkin.show');
 
         Route::post('{assetId}/checkin/{backto?}',
             [AssetCheckinController::class, 'store']
-        )->name('checkin/hardware');
-
-        Route::get('{assetId}/view',
-            [AssetsController::class, 'show']
-        )->name('hardware.view');
+        )->name('hardware.checkin.store');
 
         Route::get('{assetId}/qr_code', 
             [AssetsController::class, 'getQrCode']
@@ -153,26 +149,26 @@ Route::group(
         Route::post(
             'bulkedit',
             [BulkAssetsController::class, 'edit']
-        )->name('hardware/bulkedit');
+        )->name('hardware.bulksave.update');
 
         Route::post(
             'bulkdelete',
             [BulkAssetsController::class, 'destroy']
-        )->name('hardware/bulkdelete');
+        )->name('hardware.bulkdelete.store');
 
         Route::post(
             'bulksave',
             [BulkAssetsController::class, 'update']
-        )->name('hardware/bulksave');
+        )->name('hardware.bulkedit.store');
 
         // Bulk checkout / checkin
         Route::get('bulkcheckout',
             [BulkAssetsController::class, 'showCheckout']
-        )->name('hardware/bulkcheckout');
+        )->name('hardware.bulkcheckout.show');
 
         Route::post('bulkcheckout',
             [BulkAssetsController::class, 'storeCheckout']
-        )->name('hardware/bulkcheckout');
+        )->name('hardware.bulkcheckout.store');
     });
 
 Route::resource('hardware', 

--- a/routes/web/models.php
+++ b/routes/web/models.php
@@ -28,7 +28,7 @@ Route::group(['prefix' => 'models', 'middleware' => ['auth']], function () {
             AssetModelsController::class, 
             'getClone'
         ]
-    )->name('clone/model');
+    )->name('models.clone.show');
 
     Route::post(
         '{modelId}/clone',
@@ -36,7 +36,7 @@ Route::group(['prefix' => 'models', 'middleware' => ['auth']], function () {
             AssetModelsController::class, 
             'postCreate'
         ]
-    )->name('clone/model');
+    )->name('models.clone.store');
 
     Route::get(
         '{modelId}/view',
@@ -52,7 +52,7 @@ Route::group(['prefix' => 'models', 'middleware' => ['auth']], function () {
             AssetModelsController::class, 
             'getRestore'
         ]
-    )->name('restore/model');
+    )->name('models.restore.store');
 
     Route::get(
         '{modelId}/custom_fields',

--- a/routes/web/users.php
+++ b/routes/web/users.php
@@ -19,15 +19,7 @@ use Illuminate\Support\Facades\Route;
             Users\UsersController::class, 
             'getRestore'
         ]
-    )->name('restore/user');
-
-    Route::get(
-        '{userId}/unsuspend',
-        [
-            Users\UsersController::class, 
-            'getUnsuspend'
-        ]
-    )->name('unsuspend/user');
+    )->name('users.restore.store');
 
     Route::post(
         '{userId}/upload',
@@ -78,15 +70,15 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
             Users\UsersController::class, 
             'getClone'
         ]
-    )->name('clone/user');
+    )->name('users.clone.show');
 
     Route::post(
         '{userId}/clone',
         [
-            Users\UsersController::class, 
+            Users\UsersController::class,
             'postCreate'
         ]
-    )->name('clone/user');
+    )->name('users.clone.store');
 
     Route::get(
         '{userId}/restore',
@@ -94,7 +86,7 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
             Users\UsersController::class, 
             'getRestore'
         ]
-    )->name('restore/user');
+    )->name('users.restore.show');
 
     Route::get(
         '{userId}/unsuspend',
@@ -104,21 +96,6 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
         ]
     )->name('unsuspend/user');
 
-    Route::post(
-        '{userId}/upload',
-        [
-            Users\UserFilesController::class, 
-            'store'
-        ]
-    )->name('upload/user');
-
-    Route::delete(
-        '{userId}/deletefile/{fileId}',
-        [
-            Users\UserFilesController::class, 
-            'destroy'
-        ]
-    )->name('userfile.destroy');
 
     Route::get(
         '{userId}/showfile/{fileId}',


### PR DESCRIPTION
These fixes are the beginning of renaming all of our routes to use the `item.action.method` convention that we use for the API. This also fixes the duplicately named routes, which used to be allowed in earlier Laravel, but would cause `php artisan optimize` to fail.

I know it's a lot, so we'll need to spend quite some time testing this. 

Signed-off-by: snipe <snipe@snipe.net>
