### PR TITLE
[feature] adds button to email user list of assets from profile

### DIFF
--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -23,6 +23,7 @@ use Redirect;
 use Str;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use View;
+use App\Notifications\CurrentInventory;
 
 /**
  * This controller handles all actions related to Users for
@@ -613,6 +614,19 @@ class UsersController extends Controller
             ->with('consumables', $consumables)
             ->with('show_user', $show_user)
             ->with('settings', Setting::getSettings());
+    }
+    public function emailAssetList($id)
+    {
+        $this->authorize('view', User::class);
+
+        if( User::where('id', $id)->first()->exists())
+            {
+                $user= User::where('id', $id)->first();
+                $user->notify((new CurrentInventory($user)));
+                return redirect()->back()->with('success', 'admin/users/general.user_notified');
+            }
+
+        return redirect()->back()->with('error', 'admin/accessories/message.user_does_not_exist');
     }
 
     /**

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -615,6 +615,15 @@ class UsersController extends Controller
             ->with('show_user', $show_user)
             ->with('settings', Setting::getSettings());
     }
+
+    /**
+     * Emails user a list of assigned assets
+     *
+     * @author [G. Martinez] [<godmartinz@gmail.com>]
+     * @since [v6.0.5]
+     * @param  \App\Http\Controllers\Users\UsersController  $id
+     * @return \Illuminate\Http\RedirectResponse
+     */
     public function emailAssetList($id)
     {
         $this->authorize('view', User::class);

--- a/resources/lang/en/admin/users/general.php
+++ b/resources/lang/en/admin/users/general.php
@@ -17,6 +17,8 @@ return [
     'last_login'        => 'Last Login',
     'ldap_config_text'  => 'LDAP configuration settings can be found Admin > Settings. The (optional) selected location will be set for all imported users.',
     'print_assigned'    => 'Print All Assigned',
+    'email_assigned'    => 'Email List of All Assigned',
+    'user_notified'     => 'User has been emailed a list of their currently assigned items.',
     'software_user'     => 'Software Checked out to :name',
     'send_email_help'   => 'You must provide an email address for this user to send them credentials. Emailing credentials can only be done on user creation. Passwords are stored in a one-way hash and cannot be retrieved once saved.',
     'view_user'         => 'View User :name',

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -67,7 +67,6 @@
                 <th style="width: 20%;">{{ trans('admin/hardware/table.asset_tag') }}</th>
                 <th style="width: 20%;">{{ trans('general.name') }}</th>
                 <th style="width: 10%;">{{ trans('general.category') }}</th>
-                <th style="width: 20%;">{{ trans('admin/hardware/form.serial') }}</th>
                 <th style="width: 20%;">{{ trans('admin/hardware/form.model') }}</th>
                 <th style="width: 20%;">{{ trans('admin/hardware/form.serial') }}</th>
                 <th style="width: 10%;">{{ trans('admin/hardware/table.checkout_date') }}</th>

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -67,6 +67,7 @@
                 <th style="width: 20%;">{{ trans('admin/hardware/table.asset_tag') }}</th>
                 <th style="width: 20%;">{{ trans('general.name') }}</th>
                 <th style="width: 10%;">{{ trans('general.category') }}</th>
+                <th style="width: 20%;">{{ trans('admin/hardware/form.serial') }}</th>
                 <th style="width: 20%;">{{ trans('admin/hardware/form.model') }}</th>
                 <th style="width: 20%;">{{ trans('admin/hardware/form.serial') }}</th>
                 <th style="width: 10%;">{{ trans('admin/hardware/table.checkout_date') }}</th>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -188,6 +188,15 @@
                 </div>
                 @endcan
 
+                @can('view', $user)
+                    <div class="col-md-12" style="padding-top: 5px;">
+                        <form action="{{ route('users.email',['userId'=> $user->id]) }}" method="POST">
+                            {{ csrf_field() }}
+                            <button style="width: 100%;" class="btn btn-sm btn-primary hidden-print" rel="noopener">{{ trans('admin/users/general.email_assigned') }}</button>
+                        </form>
+                    </div>
+                @endcan
+
                 @can('update', $user)
                   @if (($user->activated == '1') && ($user->email != '') && ($user->ldap_import == '0'))
                       <div class="col-md-12" style="padding-top: 5px;">

--- a/routes/web/users.php
+++ b/routes/web/users.php
@@ -145,6 +145,14 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
     )->name('users.print');
 
     Route::post(
+        '{userId}/email',
+        [
+            Users\UsersController::class,
+            'emailAssetList'
+        ]
+    )->name('users.email');
+
+    Route::post(
         'bulkedit',
         [
             Users\BulkUsersController::class, 


### PR DESCRIPTION
# Description
adds a button to email a user a list of their assets from their profile page.

<img width="298" alt="image" src="https://user-images.githubusercontent.com/47435081/176507408-1ceb2f5d-82e8-4ded-b3c5-59f138d8714e.png">


Fixes # SC-18949

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
