### PR TITLE
WIP adds media queries for the sidebar menu to display on all screen sizes

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -656,3 +656,38 @@ th.css-accessory > .th-inner::before
 .select2-container--default .select2-selection--multiple {
   border-radius: 0px;
 }
+@media screen and (max-width: 280px){
+  .sidebar-menu {
+    margin-top: 153px;
+  }
+}
+@media screen and (max-width: 300px){
+  .sidebar-menu {
+    margin-top: 85px;
+  }
+}
+@media screen and (max-width: 480px){
+  .sidebar-menu {
+    margin-top: 85px;
+  }
+}
+@media screen and (max-width: 375px){
+  .sidebar-menu {
+    margin-top:25px;
+  }
+}
+@media screen and (max-width: 400px){
+  .sidebar-menu {
+    margin-top:25px;
+  }
+}
+@media screen and (max-width: 420px){
+  .sidebar-menu {
+    margin-top:217px;
+  }
+}
+@media screen and (max-width: 768px){
+  .sidebar-menu {
+    margin-top:105px;
+  }
+}


### PR DESCRIPTION
# Description

Adds  `@media` queries for all screen sizes so that the sidebar-menu lines up well.

Currently having a default-to @768px rules problem with seemingly random widths. could be ghosts, could be something.
<img width="412" alt="image" src="https://user-images.githubusercontent.com/47435081/176530331-23e361db-f90b-47f3-bbdd-1b9c82ae490c.png">


Fixes # SC-16128

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
