### PR TITLE
Made asset checkinbytag consistent with existingAPI

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -907,18 +907,21 @@ class AssetsController extends Controller
      * @since [v6.0]
      * @return JsonResponse
      */
-    public function checkinByTag(Request $request)
+    public function checkinByTag(Request $request, $tag = null)
     {
         $this->authorize('checkin', Asset::class);
-        $asset = Asset::where('asset_tag', $request->input('asset_tag'))->first();
+        if(null == $tag && null !== ($request->input('asset_tag'))) {
+            $tag = $request->input('asset_tag');
+        }
+        $asset = Asset::where('asset_tag', $tag)->first();
 
         if($asset) {
             return $this->checkin($request, $asset->id);
         }
 
         return response()->json(Helper::formatStandardApiResponse('error', [
-            'asset'=> e($request->input('asset_tag'))
-        ], 'Asset with tag '.e($request->input('asset_tag')).' not found'));
+            'asset'=> e($tag)
+        ], 'Asset with tag '.e($tag).' not found'));
     }
 
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -469,6 +469,20 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
             ]
         )->name('api.assets.checkout.bytag');
 
+        Route::post('bytag/{any}/checkin',
+            [
+                Api\AssetsController::class,
+                'checkinbytag'
+            ]
+        )->name('api.asset.checkinbytagPath');
+
+        Route::post('checkinbytag',
+            [
+                Api\AssetsController::class,
+                'checkinbytag'
+            ]
+        )->name('api.asset.checkinbytag');
+
         Route::get('byserial/{any}',
             [
                 Api\AssetsController::class, 
@@ -497,13 +511,6 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
             'checkin'
         ]
         )->name('api.asset.checkin');
-
-        Route::post('checkinbytag',
-            [
-                Api\AssetsController::class,
-                'checkinbytag'
-            ]
-        )->name('api.asset.checkinbytag');
 
         Route::post('{id}/checkout',
         [


### PR DESCRIPTION
# Description

This is a non-breaking change to the newish Asset "checkinbytag" endpoint, to bring it inline with the usage/formatting of the other bytag endpoints that currently exist - using the URL path to define the asset_tag instead of passing it through as a url query.
E.g. instead of:
 /hardware/checkinbytag?asset_tag=000242
The endpoint will now accept:
 /hardware/bytag/000242/checkin

Both methods will work, but the URL Path method will take precedence if it is used (and the asset_tag query will be ignored if included at the same time)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Test /hardware/bytag/xxxxxxxx/checkin endpoint with valid asset tag - asset checked in as expected
- [x] Test /hardware/bytag/xxxxxxxx/checkin endpoint with invalid asset tag - asset not found as expected
- [x] Test /hardware/bytag/xxxxxxxx/checkin endpoint with valid asset tag in both the request URL path AND as a query parameter to match the old method - asset checked in as expected
- [x] Test /hardware/checkinbytag endpoint with valid asset tag passed as a query parameter - asset checked in as expected
- [x] Test /hardware/checkinbytag endpoint with invalid asset tag passed as a query parameter - asset not found as expected

**Test Configuration**:
* PHP version: 8.0.20
* MySQL version 8.0
* Webserver version 6.0.2
* OS version Windows Server 2019


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
