### PR TITLE
Added warnings for common LDAP misconfigs

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -917,11 +917,13 @@ class SettingsController extends Controller
         $messages = [
             'ldap_username_field.not_in' => '<code>sAMAccountName</code> (mixed case) will likely not work. You should use <code>samaccountName</code> (lowercase) instead. ',
             'ldap_auth_filter_query.not_in' => '<code>uid=samaccountname</code> is probably not a valud auth filter. You probably want <code>uid=</code> ',
+            'ldap_filter.regex' => 'This value should probably not be wrapped in parentheses.',
         ];
 
         $validator = Validator::make($setting->toArray(), [
             'ldap_username_field' => 'not_in:sAMAccountName',
             'ldap_auth_filter_query' => 'not_in:uid=samaccountname',
+            'ldap_filter' => 'regex:"^[^(]"',
         ],  $messages);
 
 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -915,7 +915,7 @@ class SettingsController extends Controller
          * This validator is only temporary (famous last words.) - @snipe
          */
         $messages = [
-            'ldap_username_field.not_in' => '<code>sAMAccountName</code> (mixed case) will likely not work. You should use <code>samaccountName</code> (lowercase) instead. ',
+            'ldap_username_field.not_in' => '<code>sAMAccountName</code> (mixed case) will likely not work. You should use <code>samaccountname</code> (lowercase) instead. ',
             'ldap_auth_filter_query.not_in' => '<code>uid=samaccountname</code> is probably not a valud auth filter. You probably want <code>uid=</code> ',
             'ldap_filter.regex' => 'This value should probably not be wrapped in parentheses.',
         ];

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -25,6 +25,7 @@ use Response;
 use App\Http\Requests\SlackSettingsRequest;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Artisan;
+use Validator;
 
 /**
  * This controller handles all actions related to Settings for
@@ -910,7 +911,22 @@ class SettingsController extends Controller
     {
         $setting = Setting::getSettings();
 
-        return view('settings.ldap', compact('setting'));
+        /**
+         * This validator is only temporary (famous last words.) - @snipe
+         */
+        $messages = [
+            'ldap_username_field.not_in' => '<code>sAMAccountName</code> (mixed case) will likely not work. You should use <code>samaccountName</code> (lowercase) instead. ',
+            'ldap_auth_filter_query.not_in' => '<code>uid=samaccountname</code> is probably not a valud auth filter. You probably want <code>uid=</code> ',
+        ];
+
+        $validator = Validator::make($setting->toArray(), [
+            'ldap_username_field' => 'not_in:sAMAccountName',
+            'ldap_auth_filter_query' => 'not_in:uid=samaccountname',
+        ],  $messages);
+
+
+
+        return view('settings.ldap', compact('setting'))->withErrors($validator);
     }
 
     /**


### PR DESCRIPTION
Since LDAP configuration is clunky and difficult and is a common source of frustration for our users, this PR throws errors on the LDAP settings page if we detect any of the most common wrong settings. While this is not a panacea, it will at least hopefully provide some more useful feedback to the user so they can see what might be wrong.

Note: this happens on the LDAP settings page LOAD, not SAVE. We're not actually interfering with the user's data submission, but we're making it clear that it's unlikely to work. This does not modify the behavior of LDAP or the saved settings in any way.

<img width="945" alt="Screen Shot 2022-06-30 at 3 15 30 PM" src="https://user-images.githubusercontent.com/197404/176788020-67a6279a-2fe1-422f-a0d3-97a44f3a08fd.png">
