### PR TITLE
Revert a change in our Linear Depreciation math

### DIFF
--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -66,16 +66,11 @@ class Depreciable extends SnipeModel
     /**
      * @return float|int
      */
-    public function getLinearDepreciatedValue()
+    public function getLinearDepreciatedValue() // TODO - for testing it might be nice to have an optional $relative_to param here, defaulted to 'now'
     {
-        $numerator= (($this->purchase_cost-($this->purchase_cost*12/($this->get_depreciation()->months))));
-        $denominator=$this->get_depreciation()->months/12;
-        $deprecation_per_year= $numerator/$denominator;
-        $deprecation_per_month= $deprecation_per_year/12;
-
         $months_remaining = $this->time_until_depreciated()->m + 12 * $this->time_until_depreciated()->y; //UGlY
-        $months_depreciated=$this->get_depreciation()->months-$months_remaining;
-        $current_value = $this->purchase_cost-($deprecation_per_month*$months_depreciated);
+
+        $current_value = round(($months_remaining / $this->get_depreciation()->months) * $this->purchase_cost, 2);
 
         if($this->get_depreciation()->depreciation_min > $current_value) {
 


### PR DESCRIPTION
I think the old algorithm was correct.

This relates to GitHub issue #10639 and PR #10607, as well as a customer report regarding the accuracy of depreciation reports: [fd-28620]

First off, the PR's implementation exactly matches the math on the GH issue - which is good!

However, I believe the original GH issue had an error in its math, and incorrectly values an asset that is beyond its depreciation date.

This restores the old functionality. I've done a bit of back-of-the-envelope testing with it and it seems right. But we could stand to have some actual automated tests here. I've thrown in a TODO so that we can at least keep track of this.