### PR TITLE
Fixed #11393 - reject acceptance if no file is present

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -133,6 +133,12 @@ class AcceptanceController extends Controller
                 $encoded_image = explode(',', $data_uri);
                 $decoded_image = base64_decode($encoded_image[1]);
                 Storage::put('private_uploads/signatures/'.$sig_filename, (string) $decoded_image);
+
+            // No image data is present, kick them back.
+            // This mostly only applies to users on supoer-deuper crapola browsers *cough* IE *cough*
+            } else {
+                return redirect()->back()->with('error', trans('general.shitty_browser'));
+
             }
 
 

--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -135,7 +135,7 @@ class AcceptanceController extends Controller
                 Storage::put('private_uploads/signatures/'.$sig_filename, (string) $decoded_image);
 
             // No image data is present, kick them back.
-            // This mostly only applies to users on supoer-deuper crapola browsers *cough* IE *cough*
+            // This mostly only applies to users on super-duper crapola browsers *cough* IE *cough*
             } else {
                 return redirect()->back()->with('error', trans('general.shitty_browser'));
 

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -363,5 +363,6 @@ return [
     'purge_not_allowed'     => 'Purging deleted data has been disabled in the .env file. Contact support or your systems administrator.',
     'backup_delete_not_allowed'     => 'Deleting backups has been disabled in the .env file. Contact support or your systems administrator.',
     'additional_files'           => 'Additional Files',
+    'shitty_browser'        => 'No signature detected. If you are using an older browser, please use a more modern browser to complete your asset acceptance.',
 
 ];

--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -40,7 +40,7 @@
 
 
         <div class="row">
-            <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
+            <div class="col-sm-12 col-sm-offset-1 col-md-10 col-md-offset-1">
                 <div class="panel box box-default">
                     <div class="box-body">
                         @if ($acceptance->checkoutable->getEula())


### PR DESCRIPTION
This is an edge case, but for certain companies where asset acceptance is part of a legal process, the signature validation system (checking to see if the user actually signed it) could be bypassed by turning off javascript, or by using a really old browser like IE.

<img width="1595" alt="Screen Shot 2022-06-30 at 9 00 19 PM" src="https://user-images.githubusercontent.com/197404/176821180-674335ba-7156-4538-bb3a-41cda1f6adae.png">

Fixes #11393
