### PR TITLE
Fixes custom fields not populating when creating asset from asset model page

### DIFF
--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -158,6 +158,12 @@
 
 <script nonce="{{ csrf_token() }}">
 
+    @if(Request::has('model_id'))
+    $(document).ready(function() {
+        fetchCustomFields()
+    });
+    @endif
+
     var transformed_oldvals={};
 
     function fetchCustomFields() {

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -159,6 +159,7 @@
 <script nonce="{{ csrf_token() }}">
 
     @if(Request::has('model_id'))
+        //TODO: Refactor custom fields to use Livewire, populate from server on page load when requested with model_id
     $(document).ready(function() {
         fetchCustomFields()
     });


### PR DESCRIPTION
# Description

When creating an asset from the model page, the expected behavior would be that the custom fields would populate.

This is maybe "hacky" way to to make the fields populate on page load if model_id is present in the request.

I feel like livewire would be a better solution but this should get it working for now. 


## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


**Test Configuration**:
* PHP version: 8.0.20
* MySQL version 8.0.29
* Webserver version Apache 2.4.41
* OS version Ubuntu 20.04.4


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
