### PR TITLE
Fixes asset model restore not working (similar to issue #11452) 

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -282,7 +282,7 @@
             if ((row.available_actions) && (row.available_actions.restore === true)) {
                 actions += '<form style="display: inline;" method="POST" action="{{ url('/') }}/' + dest + '/' + row.id + '/restore"> ';
                 actions += '@csrf';
-                actions += '<a href="{{ url('/') }}/' + dest + '/' + row.id + '/restore" class="btn btn-sm btn-warning" data-toggle="tooltip" title="{{ trans('general.restore') }}"><i class="far fa-clone"></i></a>&nbsp;';
+                actions += '<button class="btn btn-sm btn-warning" data-toggle="tooltip" title="{{ trans('general.restore') }}"><i class="far fa-clone"></i></button>&nbsp;';
                 actions += '<i class="fa fa-retweet" aria-hidden="true"></i><span class="sr-only">{{ trans('general.restore') }}</span></button></form>&nbsp;';
             }
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -141,11 +141,6 @@
                 <div class="callout callout-warning">
                   <i class="icon fas fa-exclamation-triangle"></i>
                   {{ trans('admin/users/message.user_deleted_warning') }}
-                  @can('update', $user)
-                      <a href="{{ route('restore/user', $user->id) }}">
-                        {{ trans('admin/users/general.restore_user') }}
-                      </a>
-                  @endcan
                 </div>
               </div>
             @endif
@@ -229,7 +224,10 @@
                     </div>
                   @else
                     <div class="col-md-12" style="padding-top: 5px;">
-                      <a href="{{ route('restore/user', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('button.restore') }}</a>
+                        <form method="POST" action="{{ route('restore/user', $user->id) }}">
+                            @csrf
+                            <button style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('button.restore') }}</button>
+                        </form>
                     </div>
                   @endif
                 @endcan

--- a/routes/web/users.php
+++ b/routes/web/users.php
@@ -4,47 +4,7 @@ use App\Http\Controllers\Users;
 use App\Http\Controllers\Users\UserFilesController;
 use Illuminate\Support\Facades\Route;
 
-    // User Management
-    Route::post(
-        '{userId}/clone',
-        [
-            Users\UsersController::class, 
-            'postCreate'
-        ]
-    );
-
-    Route::post(
-        '{userId}/restore',
-        [
-            Users\UsersController::class, 
-            'getRestore'
-        ]
-    )->name('restore/user');
-
-    Route::get(
-        '{userId}/unsuspend',
-        [
-            Users\UsersController::class, 
-            'getUnsuspend'
-        ]
-    )->name('unsuspend/user');
-
-    Route::post(
-        '{userId}/upload',
-        [
-            Users\UserFilesController::class, 
-            'store'
-        ]
-    )->name('upload/user');
-
-    Route::delete(
-        '{userId}/deletefile/{fileId}',
-        [
-            Users\UserFilesController::class, 
-            'destroy'
-        ]
-    )->name('userfile.destroy');
-
+// User Management
 
 Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
 

--- a/routes/web/users.php
+++ b/routes/web/users.php
@@ -88,7 +88,7 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
         ]
     )->name('clone/user');
 
-    Route::get(
+    Route::post(
         '{userId}/restore',
         [
             Users\UsersController::class, 


### PR DESCRIPTION
# Description

While checking out issue #14452, I found that asset models also have the same issue. This time the route was POST and the button was a link (GET). Modifying the genericActionsFormatter also effected the users restore from the deleted users table. 

Bootstrap tables partial view:
Change genericActionsFormatter to have a POST form instead of link for restore.

User Routes:
Changed restore route to POST.
Removed duplicate routes.

Users view:
Updated the user view to use a POST form a well.
Removed the link in the alert since it just duplicated the action button on the ride side. If you want I can add that back as a form. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Asset models now restore properly.
User restore functioning from both deleted user list and user view.

**Test Configuration**:
* PHP version: 8.0.20
* MySQL version 8.0.29
* Webserver version Apache 2.4.41
* OS version Ubuntu 20.4.04


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
