### PR TITLE
Added covering indexes for performance on `license_seats`

### DIFF
--- a/database/migrations/2022_07_07_010406_add_indexes_to_license_seats.php
+++ b/database/migrations/2022_07_07_010406_add_indexes_to_license_seats.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndexesToLicenseSeats extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('license_seats', function (Blueprint $table) {
+            $table->index(['assigned_to','license_id']);
+            $table->index(['asset_id','license_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('license_seats', function (Blueprint $table) {
+            $table->dropIndex(['assigned_to','license_id']);
+            $table->dropIndex(['asset_id','license_id']);
+        });
+    }
+}


### PR DESCRIPTION
We saw some performance issues in-the-wild regarding the`license_seats` table when there were widely differing numbers of checkouts to different users - a few thousand to one or so, and 10 or so to just about everyone else. The query optimizer couldn't quite figure out the best query to make. And the choice it ended up with was very bad.

This creates two indexes for when licenses are assigned to either users **or** to assets. I went with a multicolumn index in both cases because the extraneous second-column information isn't going to hurt anyone if it's not needed, but very often, you're going to want to join back to the Licenses table so the second column will help, and keep most queries from touching the source table at all - grabbing everything directly from the index.