### PR TITLE
Changed model file icon

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -180,7 +180,7 @@
                     <li>
                     <a href="#modelfiles" data-toggle="tab">
                           <span class="hidden-lg hidden-md">
-                            <i class="far fa-file fa-2x" aria-hidden="true"></i>
+                              <i class="fa-solid fa-laptop-file fa-2x" aria-hidden="true"></i>
                           </span>
                         <span class="hidden-xs hidden-sm">
                             {{ trans('general.additional_files') }}


### PR DESCRIPTION
For the new model files icon for the assets view, the icon is now as seen below:

<img width="62" alt="Screen Shot 2022-07-07 at 4 18 41 PM" src="https://user-images.githubusercontent.com/197404/177887039-d52942b2-7cad-4a5d-abae-39a6384117a0.png">
