### PR TITLE
Fixes - migrations on restore

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1278,6 +1278,12 @@ class SettingsController extends Controller
                 // If it's greater than 300, it probably worked
                 $output = Artisan::output();
 
+                /* Run migrations */
+                \Log::debug('Migrating database...');
+                Artisan::call('migrate', ['--force' => true]);
+                $migrate_output = Artisan::output();
+                \Log::debug($migrate_output);
+
                 if (strlen($output) > 300) {
                     $find_user = DB::table('users')->where('first_name', $user->first_name)->where('last_name', $user->last_name)->exists();
 
@@ -1287,15 +1293,8 @@ class SettingsController extends Controller
                         $new_user->push();
                     }
 
-
                     \Log::debug('Logging all users out..');
                     Artisan::call('snipeit:global-logout', ['--force' => true]);
-                    
-                    /* run migrations */
-                    \Log::debug('Migrating database...');
-                    Artisan::call('migrate', ['--force' => true]);
-                    $migrate_output = Artisan::output();
-                    \Log::debug($migrate_output);
 
                     DB::table('users')->update(['remember_token' => null]);
                     \Auth::logout();
@@ -1303,7 +1302,6 @@ class SettingsController extends Controller
                     return redirect()->route('login')->with('success', 'Your system has been restored. Please login again.');
                 } else {
                     return redirect()->route('settings.backups.index')->with('error', $output);
-
                 }
 
             } else {

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1284,24 +1284,22 @@ class SettingsController extends Controller
                 $migrate_output = Artisan::output();
                 \Log::debug($migrate_output);
 
-                if (strlen($output) > 300) {
-                    $find_user = DB::table('users')->where('first_name', $user->first_name)->where('last_name', $user->last_name)->exists();
-
-                    if (!$find_user){
-                        \Log::warning('Attempting to restore user: ' . $user->first_name . ' ' . $user->last_name);
-                        $new_user = $user->replicate();
-                        $new_user->push();
-                    }
-
-                    \Log::debug('Logging all users out..');
-                    Artisan::call('snipeit:global-logout', ['--force' => true]);
-
-                    DB::table('users')->update(['remember_token' => null]);
-                    \Auth::logout();
-
-                    return redirect()->route('login')->with('success', 'Your system has been restored. Please login again.');
+                $find_user = DB::table('users')->where('username', $user->username)->exists();
+                if (!$find_user){
+                    \Log::warning('Attempting to restore user: ' . $user->username);
+                    $new_user = $user->replicate();
+                    $new_user->push();
                 } else {
-                    return redirect()->route('settings.backups.index')->with('error', $output);
+                    \Log::debug('User: ' . $user->username .' already exists.');
+                }
+
+                \Log::debug('Logging all users out..');
+                Artisan::call('snipeit:global-logout', ['--force' => true]);
+
+                DB::table('users')->update(['remember_token' => null]);
+                \Auth::logout();
+
+                return redirect()->route('login')->with('success', 'Your system has been restored. Please login again.');
                 }
 
             } else {

--- a/database/migrations/2022_03_09_001334_add_eula_to_checkout_acceptance.php
+++ b/database/migrations/2022_03_09_001334_add_eula_to_checkout_acceptance.php
@@ -13,10 +13,12 @@ class AddEulaToCheckoutAcceptance extends Migration
      */
     public function up()
     {
-        Schema::table('checkout_acceptances', function (Blueprint $table) {
-            $table->text('stored_eula')->nullable()->default(null);
-            $table->string('stored_eula_file')->nullable()->default(null);
-        });
+        if (!Schema::hasColumn('checkout_acceptances', 'stored_eula')) {
+            Schema::table('checkout_acceptances', function (Blueprint $table) {
+                $table->text('stored_eula')->nullable()->default(null);
+                $table->string('stored_eula_file')->nullable()->default(null);
+            });
+        }
     }
 
     /**
@@ -26,13 +28,15 @@ class AddEulaToCheckoutAcceptance extends Migration
      */
     public function down()
     {
-        Schema::table('checkout_acceptances', function (Blueprint $table) {
-            if (Schema::hasColumn('checkout_acceptances', 'stored_eula')) {
-                $table->dropColumn('stored_eula');
-            }
-            if (Schema::hasColumn('checkout_acceptances', 'stored_eula_file')) {
-                $table->dropColumn('stored_eula_file');
-            }
-        });
+        if (Schema::hasColumn('checkout_acceptances', 'stored_eula')) {
+            Schema::table('checkout_acceptances', function (Blueprint $table) {
+                if (Schema::hasColumn('checkout_acceptances', 'stored_eula')) {
+                    $table->dropColumn('stored_eula');
+                }
+                if (Schema::hasColumn('checkout_acceptances', 'stored_eula_file')) {
+                    $table->dropColumn('stored_eula_file');
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
This is taking a stab at fixing the fact that migrations don't always run (at least on the hosted platform) after a restore. Output in the logs is:

```
[2022-07-08 16:45:28] local.DEBUG: Found a sql file!
[2022-07-08 16:45:39] local.DEBUG: Migrating database...
[2022-07-08 16:45:39] local.DEBUG: Migrating: 2022_03_09_001334_add_eula_to_checkout_acceptance
Migrated:  2022_03_09_001334_add_eula_to_checkout_acceptance (1.92ms)
Migrating: 2022_03_10_175740_add_eula_to_action_logs
Migrated:  2022_03_10_175740_add_eula_to_action_logs (93.76ms)
Migrating: 2022_03_21_162724_adds_ldap_manager
Migrated:  2022_03_21_162724_adds_ldap_manager (81.05ms)
Migrating: 2022_05_16_235350_remove_stored_eula_field
Migrated:  2022_05_16_235350_remove_stored_eula_field (103.86ms)
Migrating: 2022_06_23_164407_add_user_id_to_users
Migrated:  2022_06_23_164407_add_user_id_to_users (80.72ms)
Migrating: 2022_06_28_234539_add_username_index_to_users
Migrated:  2022_06_28_234539_add_username_index_to_users (33.37ms)
Migrating: 2022_07_07_010406_add_indexes_to_license_seats
Migrated:  2022_07_07_010406_add_indexes_to_license_seats (122.37ms)

[2022-07-08 16:45:39] local.DEBUG: Logging all users out..
```

I'd love some testing against this, especially with older backups where the schema is not the same. 