### PR TITLE
Fixes license file(s) delete modal showing entire model data instead of just the name

### DIFF
--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -503,7 +503,7 @@
                 </td>
                 <td>{{ $file->created_at }}</td>
                 <td>
-                  <a class="btn delete-asset btn-danger btn-sm" href="{{ route('delete/licensefile', [$license->id, $file->id]) }}" data-content="{{ trans('general.delete_confirm', array('item' => $file)) }}" data-title="{{ trans('general.delete') }} {{ $file->filename }}?">
+                  <a class="btn delete-asset btn-danger btn-sm" href="{{ route('delete/licensefile', [$license->id, $file->id]) }}" data-content="{{ trans('general.delete_confirm', ['item' => $file->filename]) }}" data-title="{{ trans('general.delete') }}">
                     <i class="fas fa-trash icon-white" aria-hidden="true"></i>
                     <span class="sr-only">{{ trans('general.delete') }}</span>
                   </a>
@@ -576,4 +576,3 @@
 @section('moar_scripts')
   @include ('partials.bootstrap-table')
 @stop
-


### PR DESCRIPTION
# Description
Before:
![image](https://user-images.githubusercontent.com/55674383/178120614-7b6562a4-64c3-486e-b2d6-4857e7c53268.png)

After:
![image](https://user-images.githubusercontent.com/55674383/178120615-f2c1b1d2-7b74-4ed7-ba48-834a4af9e264.png)


Matched this to the asset file delete modal.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Just a change to the displayed data. Still fully functional. 


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
