### PR TITLE
Fixes #11496 - Wrong URL generated for download of asset acceptance PDF if locale was not en

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -57,7 +57,7 @@ class ActionlogsTransformer
 
         $file_url = '';
         if($actionlog->filename!='') {
-            if ($actionlog->present()->actionType() == 'accepted') {
+            if ($actionlog->action_type == 'accepted') {
                 $file_url = route('log.storedeula.download', ['filename' => $actionlog->filename]);
             } else {
                 if ($actionlog->itemType() == 'asset') {


### PR DESCRIPTION
# Description
Fixes #11496 

The ActionLogs transformer was pulling the action type from the presenter which translates the action type. Changed it to using the actual value in the model. It seemed like this was only translated once I changed my APP_LOCALE but it shouldn't be compared to the translated string anyways. Since it was comparing the english `accepted` to the translation it would pass to the else and match based on model type. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Correct download URL is now generated. 

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
