### PR TITLE
Fixed #11509 allow-ldap-anonymous-bind

### DIFF
--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -176,16 +176,22 @@ class Ldap extends Model
             throw new Exception('Your app key has changed! Could not decrypt LDAP password using your current app key, so LDAP authentication has been disabled. Login with a local account, update the LDAP password and re-enable it in Admin > Settings.');
         }
 
-        if (! $ldapbind = @ldap_bind($connection, $ldap_username, $ldap_pass)) {
-            throw new Exception('Could not bind to LDAP: '.ldap_error($connection));
-        }
-        // TODO - this just "falls off the end" but the function states that it should return true or false
-        // unfortunately, one of the use cases for this function is wrong and *needs* for that failure mode to fire
-        // so I don't want to fix this right now.
-        // this method MODIFIES STATE on the passed-in $connection and just returns true or false (or, in this case, undefined)
-        // at the next refactor, this should be appropriately modified to be more consistent.
-    }
-
+		if ( $ldap_username ) {
+			if (! $ldapbind = @ldap_bind($connection, $ldap_username, $ldap_pass)) {
+				throw new Exception('Could not bind to LDAP: '.ldap_error($connection));
+			}
+			// TODO - this just "falls off the end" but the function states that it should return true or false
+			// unfortunately, one of the use cases for this function is wrong and *needs* for that failure mode to fire
+			// so I don't want to fix this right now.
+			// this method MODIFIES STATE on the passed-in $connection and just returns true or false (or, in this case, undefined)
+			// at the next refactor, this should be appropriately modified to be more consistent.
+		} else {
+			// LDAP should also work with anonymous bind (no dn, no password available)
+			if (! $ldapbind = @ldap_bind($connection )) {
+				throw new Exception('Could not bind to LDAP: '.ldap_error($connection));
+			}
+		}
+	}
 
     /**
      * Parse and map LDAP attributes based on settings

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -169,14 +169,14 @@ class Ldap extends Model
     {
         $ldap_username = Setting::getSettings()->ldap_uname;
 
-        // Lets return some nicer messages for users who donked their app key, and disable LDAP
-        try {
-            $ldap_pass = \Crypt::decrypt(Setting::getSettings()->ldap_pword);
-        } catch (Exception $e) {
-            throw new Exception('Your app key has changed! Could not decrypt LDAP password using your current app key, so LDAP authentication has been disabled. Login with a local account, update the LDAP password and re-enable it in Admin > Settings.');
-        }
-
 		if ( $ldap_username ) {
+			// Lets return some nicer messages for users who donked their app key, and disable LDAP
+			try {
+				$ldap_pass = \Crypt::decrypt(Setting::getSettings()->ldap_pword);
+			} catch (Exception $e) {
+				throw new Exception('Your app key has changed! Could not decrypt LDAP password using your current app key, so LDAP authentication has been disabled. Login with a local account, update the LDAP password and re-enable it in Admin > Settings.');
+			}
+
 			if (! $ldapbind = @ldap_bind($connection, $ldap_username, $ldap_pass)) {
 				throw new Exception('Could not bind to LDAP: '.ldap_error($connection));
 			}


### PR DESCRIPTION
# Description

Our ldap server can only be queried with anonymous bind. Therefore we need that feature. After merging you needn't fill the LDAP Bind Username + LDAP Bind Password field if not wanted.

## Type of change

Please delete options that are not relevant.

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Replaced app/Modles/Ldap.php. Tried with anonymous and password-based bind. Did ldap test sync and user test login. Read log files and debugging output.

**Test Configuration**:
* PHP version: php8.1
* MySQL version: mariadb-server   1:10.6.8-1
* Webserver version: apache2 2.4.54-2
* OS version: Debian bullseye


# Checklist:

- [ x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [.] New and existing unit tests pass locally with my changes
      (unit tests errors refer to missing database.sqlite and have nothing to do with the change)
