### PR TITLE
Upgraded our fork of laravel-scim-server to better support scim creates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -78,12 +78,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/grokability/laravel-scim-server.git",
-                "reference": "10be959682d47bb8c78255168262a7cbb7586146"
+                "reference": "630c5373e03c796c62cbc4f3fe9fff5379c27236"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/10be959682d47bb8c78255168262a7cbb7586146",
-                "reference": "10be959682d47bb8c78255168262a7cbb7586146",
+                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/630c5373e03c796c62cbc4f3fe9fff5379c27236",
+                "reference": "630c5373e03c796c62cbc4f3fe9fff5379c27236",
                 "shasum": ""
             },
             "require": {
@@ -133,7 +133,7 @@
             "support": {
                 "source": "https://github.com/grokability/laravel-scim-server/tree/master"
             },
-            "time": "2022-03-31T19:29:59+00:00"
+            "time": "2022-07-18T19:38:39+00:00"
         },
         {
             "name": "asm89/stack-cors",
@@ -13845,5 +13845,5 @@
         "ext-pdo": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -78,12 +78,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/grokability/laravel-scim-server.git",
-                "reference": "630c5373e03c796c62cbc4f3fe9fff5379c27236"
+                "reference": "d0e3d7c0b5da2ec76283b8a2fa2e672a91596509"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/630c5373e03c796c62cbc4f3fe9fff5379c27236",
-                "reference": "630c5373e03c796c62cbc4f3fe9fff5379c27236",
+                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/d0e3d7c0b5da2ec76283b8a2fa2e672a91596509",
+                "reference": "d0e3d7c0b5da2ec76283b8a2fa2e672a91596509",
                 "shasum": ""
             },
             "require": {
@@ -133,7 +133,7 @@
             "support": {
                 "source": "https://github.com/grokability/laravel-scim-server/tree/master"
             },
-            "time": "2022-07-18T19:38:39+00:00"
+            "time": "2022-07-18T22:15:42+00:00"
         },
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Our SCIM support was breaking in Azure when a pre-existing user existed in Snipe-IT, and Azure's SCIM service also tried to simultaneously create one. The error shows up weird, as a strange redirect to the login page, because a weird exception was thrown and Laravel didn't quite know how to handle it, so it assumed it was an authentication problem - it wasn't, it was actually a model-level validation problem.

I've upgraded our fork of laravel-scim-server, and this change to the `composer.lock` makes sure we pull the correct version down when people do composer installs. I'll need to do some testing to make 100% sure that the new changes *will* get pulled down when the `composer.lock` file gets changed. If not, I'll have to go another way to make sure that we're always pulling the latest.

Once I've finished the testing, I'll switch this PR out of WIP status.