### PR TITLE
Fixes #11540 - accessory api routes from get to posts

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -86,7 +86,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
             ]
         )->name('api.accessories.checkedout');
 
-        Route::get('{accessory}/checkout',
+        Route::post('{accessory}/checkout',
             [
                 Api\AccessoriesController::class, 
                 'checkout'
@@ -94,7 +94,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
         )->name('api.accessories.checkout');
 
 
-        Route::get('{accessory}/checkin',
+        Route::post('{accessory}/checkin',
             [
                 Api\AccessoriesController::class, 
                 'checkin'

--- a/routes/api.php
+++ b/routes/api.php
@@ -236,7 +236,20 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
         ]
         )->name('api.components.assets');
 
-      }); 
+      });
+    Route::post('components/{id}/checkin',
+        [
+            Api\ComponentsController::class,
+            'checkin'
+        ]
+    )->name('api.components.checkin');
+
+    Route::post('components/{id}/checkout',
+        [
+            Api\ComponentsController::class,
+            'checkout'
+        ]
+    )->name('api.components.checkout');
 
 
       Route::resource('components', 
@@ -274,7 +287,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
             ]
         )->name('api.consumables.showUsers');
 
-        Route::get('{consumable}/checkout',
+        Route::post('{consumable}/checkout',
             [
                 Api\ConsumablesController::class, 
                 'checkout'


### PR DESCRIPTION
# Description

changes Api routes to POSTs instead of GETs for checkin and checkout .
<img width="613" alt="image" src="https://user-images.githubusercontent.com/47435081/180060657-e011916f-04b1-430d-92a9-5b055d6abb11.png">


Fixes #11540

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
