### PR TITLE
Features/users checkin without delete

### DIFF
--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -5,10 +5,13 @@ namespace App\Http\Controllers\Users;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Models\Accessory;
+use App\Models\License;
 use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\Group;
 use App\Models\LicenseSeat;
+use App\Models\ConsumableAssignment;
+use App\Models\Consumable;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -162,13 +165,11 @@ class BulkUsersController extends Controller
         if ((! $request->filled('ids')) || (count($request->input('ids')) == 0)) {
             return redirect()->back()->with('error', 'No users selected');
         }
-        if ((! $request->filled('status_id')) || ($request->input('status_id') == '')) {
-            return redirect()->route('users.index')->with('error', 'No status selected');
-        }
 
         if (config('app.lock_passwords')) {
             return redirect()->route('users.index')->with('error', 'Bulk delete is not enabled in this installation');
         }
+
         $user_raw_array = request('ids');
 
         if (($key = array_search(Auth::id(), $user_raw_array)) !== false) {
@@ -179,11 +180,18 @@ class BulkUsersController extends Controller
         $assets = Asset::whereIn('assigned_to', $user_raw_array)->where('assigned_type', \App\Models\User::class)->get();
         $accessories = DB::table('accessories_users')->whereIn('assigned_to', $user_raw_array)->get();
         $licenses = DB::table('license_seats')->whereIn('assigned_to', $user_raw_array)->get();
+        $consumables = DB::table('consumables_users')->whereIn('assigned_to', $user_raw_array)->get();
+
+        if ((($assets->count() > 0) && ((!$request->filled('status_id')) || ($request->input('status_id') == '')))) {
+            return redirect()->route('users.index')->with('error', 'No status selected');
+        }
 
 
         $this->logItemCheckinAndDelete($assets, Asset::class);
         $this->logItemCheckinAndDelete($accessories, Accessory::class);
-        $this->logItemCheckinAndDelete($licenses, LicenseSeat::class);
+        $this->logItemCheckinAndDelete($licenses, License::class);
+        $this->logItemCheckinAndDelete($consumables, Consumable::class);
+
 
         Asset::whereIn('id', $assets->pluck('id'))->update([
             'status_id'     => e(request('status_id')),
@@ -193,13 +201,26 @@ class BulkUsersController extends Controller
 
 
         LicenseSeat::whereIn('id', $licenses->pluck('id'))->update(['assigned_to' => null]);
+        ConsumableAssignment::whereIn('id', $consumables->pluck('id'))->delete();
+
 
         foreach ($users as $user) {
+
+            $user->consumables()->sync([]);
             $user->accessories()->sync([]);
-            $user->delete();
+            if ($request->input('delete_user')=='1') {
+                $user->delete();
+            }
+
         }
 
-        return redirect()->route('users.index')->with('success', 'Your selected users have been deleted and their assets have been updated.');
+        $msg = trans('general.bulk_checkin_success');
+        if ($request->input('delete_user')=='1') {
+            $msg = trans('general.bulk_checkin_delete_success');
+        }
+
+
+        return redirect()->route('users.index')->with('success', $msg);
     }
 
     /**
@@ -217,7 +238,7 @@ class BulkUsersController extends Controller
             $logAction->target_id = $item->assigned_to;
             $logAction->target_type = User::class;
             $logAction->user_id = Auth::id();
-            $logAction->note = 'Bulk checkin items and delete user';
+            $logAction->note = 'Bulk checkin items';
             $logAction->logaction('checkin from');
         }
     }

--- a/resources/lang/en/admin/users/general.php
+++ b/resources/lang/en/admin/users/general.php
@@ -34,7 +34,7 @@ return [
     'admin_permission_warning' => 'Only users with admins rights or greater may grant a user admin access.',
     'remove_group_memberships' => 'Remove Group Memberships',
     'warning_deletion' => 'WARNING:',
-    'warning_deletion_information' => 'You are about to delete the :count user(s) listed below. Super admin names are highlighted in red.',
+    'warning_deletion_information' => 'You are about to checkin ALL items from the :count user(s) listed below. Super admin names are highlighted in red.',
     'update_user_assets_status' => 'Update all assets for these users to this status',
     'checkin_user_properties' => 'Check in all properties associated with these users',
     'remote_label'   => 'This is a remote user',

--- a/resources/lang/en/button.php
+++ b/resources/lang/en/button.php
@@ -4,7 +4,7 @@ return [
     'actions' 	                => 'Actions',
     'add'    	                => 'Add New',
     'cancel'                    => 'Cancel',
-    'checkin_and_delete'  	    => 'Checkin & Delete User',
+    'checkin_and_delete'  	    => 'Checkin All / Delete User',
     'delete'  	                => 'Delete',
     'edit'    	                => 'Edit',
     'restore' 	                => 'Restore',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -37,7 +37,7 @@ return [
     'bulk_edit'             => 'Bulk Edit',
     'bulk_delete'           => 'Bulk Delete',
     'bulk_actions'          => 'Bulk Actions',
-    'bulk_checkin_delete'   => 'Bulk Checkin &amp; Delete',
+    'bulk_checkin_delete'   => 'Bulk Checkin Items from Users',
     'bystatus'              => 'by Status',
     'cancel'  				=> 'Cancel',
     'categories'			=> 'Categories',
@@ -365,5 +365,9 @@ return [
     'backup_delete_not_allowed'     => 'Deleting backups has been disabled in the .env file. Contact support or your systems administrator.',
     'additional_files'           => 'Additional Files',
     'shitty_browser'        => 'No signature detected. If you are using an older browser, please use a more modern browser to complete your asset acceptance.',
+    'bulk_soft_delete'      =>'Also soft-delete these users. Their asset history will remain intact unless/until you purge deleted records in the Admin Settings.',
+    'bulk_checkin_delete_success' => 'Your selected users have been deleted and their items have been checked in.',
+    'bulk_checkin_success' => 'The items for the selected users have been checked in.',
+
 
 ];

--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -42,6 +42,7 @@
                     <th class="col-md-5">{{ trans('general.assets') }}</th>
                     <th class="col-md-5">{{ trans('general.accessories') }}</th>
                     <th class="col-md-5">{{ trans('general.licenses') }}</th>
+                    <th class="col-md-5">{{ trans('general.consumables') }}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -49,14 +50,14 @@
                   <tr {!! ($user->isSuperUser() ? ' class="danger"':'') !!}>
                     <td>
                       @if (Auth::id()!=$user->id)
-                      <input type="checkbox" name="ids[]" value="{{ $user->id }}" checked="checked">
+                      <input type="checkbox" name="ids[]" value="{{ $user->id }}" class="minimal" checked="checked">
                       @else
-                      <input type="checkbox" name="ids[]" value="{{ $user->id }}" disabled>
+                      <input type="checkbox" name="ids[]" value="{{ $user->id }}" class="minimal" disabled>
                       @endif
                     </td>
 
                     <td>
-                      <span {{ (Auth::user()->id==$user->id ? ' style="text-decoration: line-through"' : '') }}>
+                      <span {!! (Auth::user()->id==$user->id ? ' style="text-decoration: line-through"' : '') !!}>
                         {{ $user->present()->fullName() }} ({{ $user->username }})
                       </span>
                       {{ (Auth::id()==$user->id ? ' (cannot delete yourself)' : '') }}
@@ -77,19 +78,26 @@
                     <td>
                       {{ number_format($user->licenses()->count())  }}
                     </td>
+                    <td>
+                      {{ number_format($user->consumables()->count())  }}
+                    </td>
                   </tr>
                   @endforeach
                 </tbody>
                 <tfoot>
+
                   <tr>
-                    <td colspan="6" class="warning">
+                    <td colspan="7">
                       {{ Form::select('status_id', $statuslabel_list , Request::old('status_id'), array('class'=>'select2', 'style'=>'width:250px')) }}
-                      <label>{{ trans('admin/users/general.update_user_assets_status') }}</label></label>
+                      <label>{{ trans('admin/users/general.update_user_assets_status') }}</label>
                     </td>
                   </tr>
                   <tr>
-                    <td colspan="6" class="warning">
-                      <label><input type="checkbox" name="ids['.e($user->id).']" checked>{{ trans('admin/users/general.checkin_user_properties') }}</label>
+                    <td colspan="7" class="text-danger">
+                      <label>
+                        <input type="checkbox" name="delete_user" value="1" class="minimal">
+                        <i class="fa fa-warning text-danger"></i> {{ trans('general.bulk_soft_delete') }}
+                      </label>
                     </td>
                   </tr>
                 </tfoot>

--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -26,7 +26,7 @@
           @if (config('app.lock_passwords'))
             <div class="col-md-12">
               <div class="callout callout-warning">
-                <p>{{ trans('feature_disabled') }}</p>
+                <p>{{ trans('general.feature_disabled') }}</p>
               </div>
             </div>
           @endif


### PR DESCRIPTION
This expands the current functionality of "checkin and delete" by allowing you to checkin from all users WITHOUT deleting them. In general, we recommend deleting users if they are no longer in circulation, but this at least gives you a choice.

Before:

<img width="1267" alt="Screen Shot 2022-07-20 at 6 01 22 PM" src="https://user-images.githubusercontent.com/197404/180107709-10667d64-29fe-4c98-8845-a9ba86c03389.png">

After:

<img width="1134" alt="Screen Shot 2022-07-20 at 6 00 12 PM" src="https://user-images.githubusercontent.com/197404/180107733-e24dede1-19ff-4a24-9848-53bc243bbb6f.png">
