### PR TITLE
Fixed #9063: Ask LDAP for user DN, don't concatenate username+baseDN.

### DIFF
--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -95,6 +95,7 @@ class Ldap extends Model
         $connection = self::connectToLdap();
         $ldap_username_field = $settings->ldap_username_field;
         $baseDn = $settings->ldap_basedn;
+	// userDn should *not* depend on baseDN if LDAP auth -> redeclared further down
         $userDn = $ldap_username_field.'='.$username.','.$settings->ldap_basedn;
 
         if ($settings->is_ad == '1') {
@@ -118,6 +119,25 @@ class Ldap extends Model
         $filterQuery = "({$filter}({$filterQuery}))";
 
         \Log::debug('Filter query: '.$filterQuery);
+
+	// userDn should be independent from baseDn (maybe you want to search in >=2 subtrees)
+	// -> better ask LDAP for user dn, that's why it is for
+	if ($settings->is_ad != '1') {
+		$userresults = ldap_search($connection, $baseDn, $filterQuery);
+		$userentries = ldap_get_entries($connection, $userresults);
+		// Can be empty if user does not exist
+		if ( $userentries["count"] > 0 ) {
+			$dn = $userentries[0]['dn'];
+			if ( $dn ) {
+				\Log::debug('User dn is: ' .$dn);
+				$userDn = $dn;
+			} else {
+				\Log::debug('User dn is empty.');
+			}
+		} else {
+			\Log::debug('Status of LDAP entries for user ' .$username. ': no result.');
+		}
+	}
 
         if (! $ldapbind = @ldap_bind($connection, $userDn, $password)) {
             \Log::debug("Status of binding user: $userDn to directory: (directly!) ".($ldapbind ? "success" : "FAILURE"));


### PR DESCRIPTION
# Description

Until now in the LDAP authentication the bind dn was concatenated with username and basedn. There might be cases where you want users from different subtrees (can be solved by using a corresponding filter), or maybe stay open if there will be some LDAP group mapping feature added later on.
Therefore when the user enters his/her name in the login form the backend should find out the corresponding dn and use that one for LDAP binding.
If no dn is found the previous mechanism (concatenation username+basedn) will go on.
The statements above are only valid for LDAP (not AD related).

Fixes #9063

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Used the LDAP Synchronisation and Test LDAP Login function and the login page in debugging mode with correct user, correct and wrong password, wrong user.

- [x] Check with correct username and wrong password and base dn for the whole domain (dc=example,dc=com) -> no login
- [x] Check with correct username snd correct password -> login
- [x] Check with wrong username and some password -> no login

**Test Configuration**:
* PHP version:  php8.1
* MySQL version: mariadb-server 1:10.6.8-1
* Webserver version: apache2 2.4.54-2
* OS version: Debian bullseye


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [.] New and existing unit tests pass locally with my changes
       (unit tests errors refer to missing database.sqlite and have nothing to do with the change)
