### PR TITLE
Adding audit feature in asset index

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -67,6 +67,11 @@ class AssetsController extends Controller
         $this->authorize('index', Asset::class);
         $company = Company::find($request->input('company_id'));
 
+        $links = session()->has('links') ? session('links') : [];
+        $currentLink = request()->path(); 
+        array_unshift($links, $currentLink); 
+        session(['links' => $links]); 
+
         return view('hardware/index')->with('company', $company);
     }
 
@@ -809,6 +814,7 @@ class AssetsController extends Controller
         $dt = Carbon::now()->addMonths($settings->audit_interval)->toDateString();
         $asset = Asset::findOrFail($id);
 
+
         return view('hardware/audit')->with('asset', $asset)->with('next_audit_date', $dt)->with('locations_list');
     }
 
@@ -816,12 +822,24 @@ class AssetsController extends Controller
     {
         $this->authorize('audit', Asset::class);
 
+        $links = session()->has('links') ? session('links') : [];
+        $currentLink = request()->path(); 
+        array_unshift($links, $currentLink); 
+        session(['links' => $links]); 
+
+
         return view('hardware/audit-due');
     }
 
     public function overdueForAudit()
     {
         $this->authorize('audit', Asset::class);
+
+        $links = session()->has('links') ? session('links') : [];
+        $currentLink = request()->path(); 
+        array_unshift($links, $currentLink); 
+        session(['links' => $links]); 
+
 
         return view('hardware/audit-overdue');
     }
@@ -874,7 +892,7 @@ class AssetsController extends Controller
 
 
             $asset->logAudit($request->input('note'), $request->input('location_id'), $file_name);
-            return redirect()->route('assets.audit.due')->with('success', trans('admin/hardware/message.audit.success'));
+            return redirect(session('links')[0])->with('success', trans('admin/hardware/message.audit.success'));
         }
     }
 

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -909,4 +909,24 @@ class AssetsController extends Controller
 
         return view('hardware/requested', compact('requestedItems'));
     }
+
+    /**
+     * Displaying modal for audit
+     *
+     * @author [A. Rahardianto] [<veenone@gmail.com>]
+     * @param int $id
+     * @since [v6.0.8]
+     * @return View
+     */
+    public function show_modal($id)
+    {
+        $settings = Setting::getSettings();
+        $this->authorize('audit', Asset::class);
+        $dt = Carbon::now()->addMonths($settings->audit_interval)->toDateString();
+        $asset = Asset::findOrFail($id);
+
+
+        return view('modals/quickaudit')->with('asset', $asset)->with('next_audit_date', $dt)->with('locations_list');
+       
+    }
 }

--- a/app/Http/Controllers/ModalController.php
+++ b/app/Http/Controllers/ModalController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Helpers\Helper;
+use App\Models\Setting;
+use Carbon\Carbon;
+use App\Models\Asset;
 
 class ModalController extends Controller
 {
@@ -32,7 +35,9 @@ class ModalController extends Controller
             'statuslabel',
             'supplier',
             'upload-file',
-            'user',         
+            'user',   
+            'id',     
+            'audit', 
         ];
 
 
@@ -44,6 +49,15 @@ class ModalController extends Controller
         }
         if (in_array($type, ['kit-model', 'kit-license', 'kit-consumable', 'kit-accessory'])) {
             $view->with('kitId', $itemId);
+            }
+
+            if ($type == "audit") {
+                $settings = Setting::getSettings();
+                $this->authorize('audit', Asset::class);
+                $dt = Carbon::now()->addMonths($settings->audit_interval)->toDateString();
+                $asset = Asset::findOrFail($itemId);
+                // $view->with('id', $itemId);
+                $view-> with('asset', $asset)->with('next_audit_date', $dt)->with('locations_list');
             }
             return $view;
         }

--- a/app/Http/Controllers/ModalController.php
+++ b/app/Http/Controllers/ModalController.php
@@ -56,7 +56,6 @@ class ModalController extends Controller
                 $this->authorize('audit', Asset::class);
                 $dt = Carbon::now()->addMonths($settings->audit_interval)->toDateString();
                 $asset = Asset::findOrFail($itemId);
-                // $view->with('id', $itemId);
                 $view-> with('asset', $asset)->with('next_audit_date', $dt)->with('locations_list');
             }
             return $view;

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -141,6 +141,7 @@ class AssetsTransformer
             'restore'       => ($asset->deleted_at!='' && Gate::allows('create', Asset::class)) ? true : false,
             'update'        => ($asset->deleted_at=='' && Gate::allows('update', Asset::class)) ? true : false,
             'delete'        => ($asset->deleted_at=='' && $asset->assigned_to =='' && Gate::allows('delete', Asset::class)) ? true : false,
+            'audit'         => Gate::allows('audit', Asset::class) ? true : false,
         ];      
 
 

--- a/resources/views/modals/audit.blade.php
+++ b/resources/views/modals/audit.blade.php
@@ -1,0 +1,99 @@
+
+    <div class="modal-dialog modal-dialog-centered modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title">
+                {{ trans('admin/hardware/form.tag') }} {{ $asset->asset_tag }}
+                </h2>
+                
+            </div>
+            <div class="modal-body">
+
+                {{ Form::open([
+                  'method' => 'POST',
+                  'route' => ['asset.audit.store', $asset->id],
+                  'files' => true,
+                  'class' => 'form-horizontal' ]) }}
+                    
+                    {{csrf_field()}}
+                    @if ($asset->model->name)
+                        <!-- Asset name -->
+                            <div class="form-group {{ $errors->has('name') ? 'error' : '' }}">
+                                {{ Form::label('name', trans('admin/hardware/form.model'), array('class' => 'col-md-3 control-label')) }}
+                                <div class="col-md-8">
+                                    <p class="form-control-static">{{ $asset->model->name }}</p>
+                                </div>
+                            </div>
+                    @endif
+
+                    <!-- Asset Name -->
+                        <div class="form-group {{ $errors->has('name') ? 'error' : '' }}">
+                            {{ Form::label('name', trans('admin/hardware/form.name'), array('class' => 'col-md-3 control-label')) }}
+                            <div class="col-md-8">
+                                <p class="form-control-static">{{ $asset->name }}</p>
+                            </div>
+                        </div>
+
+                        <!-- Locations -->
+                    @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'location_id'])
+
+                    <!-- Update location -->
+                        <div class="form-group">
+                            <div class="col-sm-offset-3 col-md-9">
+                                <label>
+                                    <input type="checkbox" value="1" name="update_location" class="minimal" {{ Request::old('update_location') == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/hardware/form.asset_location') }}
+                                </label>
+
+                                @include ('partials.more-info', ['helpText' => trans('help.audit_help'), 'helpPosition' => 'right'])
+
+
+
+                            </div>
+                        </div>
+
+
+                        <!-- Next Audit -->
+                        <div class="form-group {{ $errors->has('next_audit_date') ? 'error' : '' }}">
+                            {{ Form::label('name', trans('general.next_audit_date'), array('class' => 'col-md-3 control-label')) }}
+                            <div class="col-mb-0">
+                                <div class="input-group date m align-self-start col-sm-3" data-provide="datepicker" data-date-format="yyyy-mm-dd">
+                                    <input type="text" class="form-control" placeholder="{{ trans('general.next_audit_date') }}" name="next_audit_date" id="next_audit_date" value="{{ old('next_audit_date', $next_audit_date) }}">
+                                    <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
+                                </div>
+                                {!! $errors->first('next_audit_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                            </div>
+                        </div>
+
+
+                        <!-- Note -->
+                        <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
+                            {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
+                            <div class="col-md-8">
+                                <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note', $asset->note) }}</textarea>
+                                {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                            </div>
+                        </div>
+
+
+                        <!-- Images -->
+                        @include ('partials.forms.edit.image-upload')
+                    
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ trans('button.cancel') }}</button>                        
+                        <button type="submit" class="btn btn-primary btn-success pull-right"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('general.audit') }}</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+
+
+
+<script nonce="{{ csrf_token() }}">
+$(function() {
+    $('#auditmodal').modal('show');
+});
+
+</script>
+

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -287,8 +287,12 @@
 
             if ((row.available_actions.audit == true) && (dest == 'hardware'))
             {
-                actions += '&nbsp;&nbsp;<a href="{{ url('/') }}/' + dest + '/audit/' + row.id + '" class="btn btn-sm bg-blue" data-tooltip="true" title="{{ trans('general.audit') }}"><i class="fas fa-check-circle" aria-hidden="true"></i><span class="sr-only">{{ trans('general.audit') }}</span></a>&nbsp;';      
+                // current approach with individual audit buttons
+                // actions += '&nbsp;&nbsp;<a href="{{ url('/') }}/' + dest + '/audit/' + row.id + '" class="btn btn-sm bg-blue" data-tooltip="true" title="{{ trans('general.audit') }}"><i class="fas fa-check-circle" aria-hidden="true"></i><span class="sr-only">{{ trans('general.audit') }}</span></a>&nbsp;';   
                 
+                var url = '{{ route("auditmodal.show", ":id") }}';
+                url = url.replace(':id', row.id);
+                actions += '&nbsp;&nbsp;&nbsp;<a href="' +url+'" data-toggle="modal" data-target="#createModal"  data-select="category_select_id"  class="btn btn-sm bg-navy"><i class="fas fa-check-circle" aria-hidden="true"  data-tooltip="true" title="{{ trans('general.audit') }}"></i><span class="sr-only">{{ trans('general.audit') }}</span></a>';
             }
             actions +='</nobr>';
             return actions;

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -287,9 +287,6 @@
 
             if ((row.available_actions.audit == true) && (dest == 'hardware'))
             {
-                // current approach with individual audit buttons
-                // actions += '&nbsp;&nbsp;<a href="{{ url('/') }}/' + dest + '/audit/' + row.id + '" class="btn btn-sm bg-blue" data-tooltip="true" title="{{ trans('general.audit') }}"><i class="fas fa-check-circle" aria-hidden="true"></i><span class="sr-only">{{ trans('general.audit') }}</span></a>&nbsp;';   
-                
                 var url = '{{ route("auditmodal.show", ":id") }}';
                 url = url.replace(':id', row.id);
                 actions += '&nbsp;&nbsp;&nbsp;<a href="' +url+'" data-toggle="modal" data-target="#createModal"  data-select="category_select_id"  class="btn btn-sm bg-navy"><i class="fas fa-check-circle" aria-hidden="true"  data-tooltip="true" title="{{ trans('general.audit') }}"></i><span class="sr-only">{{ trans('general.audit') }}</span></a>';

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -285,6 +285,11 @@
                 actions += '<button class="btn btn-sm btn-warning" data-toggle="tooltip" title="{{ trans('general.restore') }}"><i class="far fa-retweet"></i></button>&nbsp;';
             }
 
+            if ((row.available_actions.audit == true) && (dest == 'hardware'))
+            {
+                actions += '&nbsp;&nbsp;<a href="{{ url('/') }}/' + dest + '/audit/' + row.id + '" class="btn btn-sm bg-blue" data-tooltip="true" title="{{ trans('general.audit') }}"><i class="fas fa-check-circle" aria-hidden="true"></i><span class="sr-only">{{ trans('general.audit') }}</span></a>&nbsp;';      
+                
+            }
             actions +='</nobr>';
             return actions;
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -112,6 +112,11 @@ Route::group(['middleware' => 'auth', 'prefix' => 'modals'], function () {
     Route::get('{type}/{itemId?}', [ModalController::class, 'show'] )->name('modal.show');
 });
 
+
+Route::group(['middleware' => 'auth', 'prefix' => 'modals'], function () {
+    Route::get('audit/{id}', [ModalController::class, 'show'] )->name('auditmodal.show');
+});
+
 /*
 |--------------------------------------------------------------------------
 | Log Routes


### PR DESCRIPTION
# Description

This PR implements new function to enable quick audit from asset index page.
A new button has been added to enable auditing assets while browsing the asset list.
A modal is used to make the audit process stays in the same view

Fixes #11322 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version: 7.4.27
* MySQL version
* Webserver version: 
* OS version


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

# Screenshots:
## New quick audit button in asset index
![image](https://user-images.githubusercontent.com/3839381/181139691-3bb01288-1311-462e-9cd9-2f1d1c8a6d85.png)

## Modal implementation 
![image](https://user-images.githubusercontent.com/3839381/181139724-5241bf86-16e1-46a0-8686-62c27943fe0e.png)

