### PR TITLE
Switched to conditionally adding the nbsp; that the table needs for proper layout if cell is empty

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -472,9 +472,13 @@
                                                         @elseif (($field->format=='DATE') && ($asset->{$field->db_column_name()}!=''))
                                                             {{ \App\Helpers\Helper::getFormattedDateObject($asset->{$field->db_column_name()}, 'date', false) }}
                                                         @else
-                                                            {!! nl2br(e($asset->{$field->db_column_name()})) !!} &nbsp;
+                                                            {!! nl2br(e($asset->{$field->db_column_name()})) !!}
                                                         @endif
 
+                                                    @endif
+
+                                                    @if ($asset->{$field->db_column_name()}=='')
+                                                        &nbsp;
                                                     @endif
                                                 </div>
                                             </div>


### PR DESCRIPTION
This is really kind of a shim IMHO as the problem should really be fixed at the CSS level, but this removes the extra space in the custom fields if there is an existing value on the view page, and only inserts it if the cell is empty and would result in a weird layout for the table striping. 