### PR TITLE
Fixed routes for optimize

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -63,7 +63,7 @@ class AccessoryCheckoutController extends Controller
         $this->authorize('checkout', $accessory);
 
         if (! $user = User::find($request->input('assigned_to'))) {
-            return redirect()->route('checkout/accessory', $accessory->id)->with('error', trans('admin/accessories/message.checkout.user_does_not_exist'));
+            return redirect()->route('accessories.checkout.show', $accessory->id)->with('error', trans('admin/accessories/message.checkout.user_does_not_exist'));
         }
 
         // Update the accessory data

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -250,7 +250,7 @@ class BulkAssetsController extends Controller
             $target = $this->determineCheckoutTarget();
 
             if (! is_array($request->get('selected_assets'))) {
-                return redirect()->route('hardware/bulkcheckout')->withInput()->with('error', trans('admin/hardware/message.checkout.no_assets_selected'));
+                return redirect()->route('hardware.bulkcheckout.show')->withInput()->with('error', trans('admin/hardware/message.checkout.no_assets_selected'));
             }
 
             $asset_ids = array_filter($request->get('selected_assets'));
@@ -297,9 +297,9 @@ class BulkAssetsController extends Controller
                 return redirect()->to('hardware')->with('success', trans('admin/hardware/message.checkout.success'));
             }
             // Redirect to the asset management page with error
-            return redirect()->to('hardware/bulk-checkout')->with('error', trans('admin/hardware/message.checkout.error'))->withErrors($errors);
+            return redirect()->route('hardware.bulkcheckout.show')->with('error', trans('admin/hardware/message.checkout.error'))->withErrors($errors);
         } catch (ModelNotFoundException $e) {
-            return redirect()->to('hardware/bulk-checkout')->with('error', $e->getErrors());
+            return redirect()->route('hardware.bulkcheckout.show')->with('error', $e->getErrors());
         }
     }
 }

--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -142,6 +142,6 @@ class SamlController extends Controller
             return view('errors.403');
         }
 
-        return redirect()->route('logout')->with(['saml_logout' => true,'saml_slo_redirect_url' => $sloUrl]);
+        return redirect()->route('logout.get')->with(['saml_logout' => true,'saml_slo_redirect_url' => $sloUrl]);
     }
 }

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -56,7 +56,7 @@ class ConsumableCheckoutController extends Controller
         // Check if the user exists
         if (is_null($user = User::find($assigned_to))) {
             // Redirect to the consumable management page with error
-            return redirect()->route('checkout/consumable', $consumable)->with('error', trans('admin/consumables/message.checkout.user_does_not_exist'));
+            return redirect()->route('consumables.checkout.show', $consumable)->with('error', trans('admin/consumables/message.checkout.user_does_not_exist'));
         }
 
         // Update the consumable data

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -24,13 +24,13 @@
             @if ($accessory->assigned_to != '')
               @can('checkin', \App\Models\Accessory::class)
               <li role="menuitem">
-                <a href="{{ route('checkin/accessory', $accessory->id) }}">{{ trans('admin/accessories/general.checkin') }}</a>
+                <a href="{{ route('accessories.checkin.show', $accessory->id) }}">{{ trans('admin/accessories/general.checkin') }}</a>
               </li>
               @endcan
             @else
               @can('checkout', \App\Models\Accessory::class)
               <li role="menuitem">
-                <a href="{{ route('checkout/accessory', $accessory->id)  }}">{{ trans('admin/accessories/general.checkout') }}</a>
+                <a href="{{ route('accessories.checkout.show', $accessory->id)  }}">{{ trans('admin/accessories/general.checkout') }}</a>
               </li>
               @endcan
             @endif
@@ -171,7 +171,7 @@
           @can('checkout', \App\Models\Accessory::class)
               <div class="row">
                   <div class="col-md-12 text-center">
-                      <a href="{{ route('checkout/accessory', $accessory->id) }}" style="margin-right:5px;" class="btn btn-primary btn-sm" {{ (($accessory->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
+                      <a href="{{ route('accessories.checkout.show', $accessory->id) }}" style="margin-right:5px;" class="btn btn-primary btn-sm" {{ (($accessory->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
                   </div>
               </div>
           @endcan

--- a/resources/views/auth/two_factor.blade.php
+++ b/resources/views/auth/two_factor.blade.php
@@ -42,13 +42,13 @@
                             <button class="btn btn-lg btn-primary btn-block">{{ trans('general.submit')  }}</button>
                         </div>
                         <div class="col-md-12 col-sm-12 col-xs-12 text-right" style="padding-top: 10px;">
-                            <a href="{{ route('logout') }}" onclick="document.getElementById('logout-form').submit(); return false;">
+                            <a href="{{ route('logout.get') }}" onclick="document.getElementById('logout-form').submit(); return false;">
                                 {{ trans('general.cancel')  }}
                             </a>
                         </div>
             </div>
             </form>
-            <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+            <form id="logout-form" action="{{ route('logout.post') }}" method="POST" style="display: none;">
             {{ csrf_field() }}
             </form>
 

--- a/resources/views/components/checkin.blade.php
+++ b/resources/views/components/checkin.blade.php
@@ -17,7 +17,7 @@
     <div class="row">
         <!-- left column -->
         <div class="col-md-7">
-            <form class="form-horizontal" method="post" action="{{ route('component.checkin.save', $component_assets->id) }}" autocomplete="off">
+            <form class="form-horizontal" method="post" action="{{ route('components.checkin.store', $component_assets->id) }}" autocomplete="off">
                 {{csrf_field()}}
 
                 <div class="box box-default">

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -21,7 +21,7 @@
         @if ($component->assigned_to != '')
           @can('checkin', $component)
           <li role="menuitem">
-            <a href="{{ route('checkin/component', $component->id) }}">
+            <a href="{{ route('components.checkin.show', $component->id) }}">
               {{ trans('admin/components/general.checkin') }}
             </a>
           </li>
@@ -29,7 +29,7 @@
         @else
           @can('checkout', $component)
           <li role="menuitem">
-            <a href="{{ route('component.checkout.show', $component->id)  }}">
+            <a href="{{ route('components.checkout.show', $component->id)  }}">
               {{ trans('admin/components/general.checkout') }}
             </a>
           </li>

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -29,7 +29,7 @@
         @else
           @can('checkout', $component)
           <li role="menuitem">
-            <a href="{{ route('checkout/component', $component->id)  }}">
+            <a href="{{ route('component.checkout.show', $component->id)  }}">
               {{ trans('admin/components/general.checkout') }}
             </a>
           </li>

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -127,7 +127,7 @@
 
     @can('checkout', \App\Models\Consumable::class)
     <div class="col-md-12">
-                    <a href="{{ route('checkout/consumable', $consumable->id) }}" style="padding-bottom:5px;" class="btn btn-primary btn-sm" {{ (($consumable->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
+                    <a href="{{ route('consumables.checkout.show', $consumable->id) }}" style="padding-bottom:5px;" class="btn btn-primary btn-sm" {{ (($consumable->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
                 </div>
                 @endcan
 

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -28,11 +28,11 @@
           <div class="col-md-12">
             @if ($backto=='user')
               <form class="form-horizontal" method="post"
-                    action="{{ route('checkin/hardware', array('assetId'=> $asset->id, 'backto'=>'user')) }}"
+                    action="{{ route('hardware.checkin.store', array('assetId'=> $asset->id, 'backto'=>'user')) }}"
                     autocomplete="off">
                 @else
                   <form class="form-horizontal" method="post"
-                        action="{{ route('checkin/hardware', $asset->id) }}" autocomplete="off">
+                        action="{{ route('hardware.checkin.store', array('assetId'=> $asset->id)) }}" autocomplete="off">
                   @endif
                   {{csrf_field()}}
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -22,7 +22,7 @@
                     @if (($asset->assigned_to != '') && ($asset->deleted_at==''))
                         @can('checkin', \App\Models\Asset::class)
                             <li role="menuitem">
-                                <a href="{{ route('checkin/hardware', $asset->id) }}">
+                                <a href="{{ route('hardware.checkin.create', $asset->id) }}">
                                     {{ trans('admin/hardware/general.checkin') }}
                                 </a>
                             </li>
@@ -30,7 +30,7 @@
                     @elseif (($asset->assigned_to == '') && ($asset->deleted_at==''))
                         @can('checkout', \App\Models\Asset::class)
                             <li role="menuitem">
-                                <a href="{{ route('checkout/hardware', $asset->id)  }}">
+                                <a href="{{ route('hardware.checkout.create', $asset->id)  }}">
                                     {{ trans('admin/hardware/general.checkout') }}
                                 </a>
                             </li>

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -354,11 +354,11 @@
                      <li class="divider"></li>
                      <li>
 
-                        <a href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                        <a href="{{ route('logout.get') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
                             <i class="fa fa-sign-out fa-fw"></i> {{ trans('general.logout') }}
                         </a>
                         
-                        <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                        <form id="logout-form" action="{{ route('logout.post') }}" method="POST" style="display: none;">
                             {{ csrf_field() }}
                         </form>
 

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -486,7 +486,7 @@
 
                     @can('checkout', \App\Models\Asset::class)
                     <li{!! (Request::is('hardware/bulkcheckout') ? ' class="active"' : '') !!}>
-                        <a href="{{ route('hardware/bulkcheckout') }}">
+                        <a href="{{ route('hardware.bulkcheckout.show') }}">
                             {{ trans('general.bulk_checkout') }}
                         </a>
                     </li>

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -16,10 +16,10 @@
             <ul class="dropdown-menu">
                 @if ($model->deleted_at=='')
                     <li><a href="{{ route('models.edit', $model->id) }}">{{ trans('admin/models/table.edit') }}</a></li>
-                    <li><a href="{{ route('clone/model', $model->id) }}">{{ trans('admin/models/table.clone') }}</a></li>
+                    <li><a href="{{ route('models.clone.create', $model->id) }}">{{ trans('admin/models/table.clone') }}</a></li>
                     <li><a href="{{ route('hardware.create', ['model_id' => $model->id]) }}">{{ trans('admin/hardware/form.create') }}</a></li>
                 @else
-                    <li><a href="{{ route('restore/model', $model->id) }}">{{ trans('admin/models/general.restore') }}</a></li>
+                    <li><a href="{{ route('models.restore.store', $model->id) }}">{{ trans('admin/models/general.restore') }}</a></li>
                 @endif
             </ul>
         </div>
@@ -316,7 +316,7 @@
 
             @can('create', \App\Models\AssetModel::class)
             <div class="col-md-12" style="padding-bottom: 5px;">
-                <a href="{{ route('clone/model', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('admin/models/table.clone') }}</a>
+                <a href="{{ route('models.clone.create', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('admin/models/table.clone') }}</a>
             </div>
             @endcan
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -113,7 +113,7 @@
             </a>
             <ul class="dropdown-menu">
               <li><a href="{{ route('users.edit', $user->id) }}">{{ trans('admin/users/general.edit') }}</a></li>
-              <li><a href="{{ route('clone/user', $user->id) }}">{{ trans('admin/users/general.clone') }}</a></li>
+              <li><a href="{{ route('users.clone.show', $user->id) }}">{{ trans('admin/users/general.clone') }}</a></li>
               @if ((Auth::user()->id !== $user->id) && (!config('app.lock_passwords')) && ($user->deleted_at==''))
                 <li><a href="{{ route('users.destroy', $user->id) }}">{{ trans('button.delete') }}</a></li>
               @endif
@@ -173,7 +173,7 @@
 
               @can('create', $user)
                 <div class="col-md-12" style="padding-top: 5px;">
-                  <a href="{{ route('clone/user', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('admin/users/general.clone') }}</a>
+                  <a href="{{ route('users.clone.show', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('admin/users/general.clone') }}</a>
                 </div>
                @endcan
 
@@ -228,7 +228,7 @@
                     </div>
                   @else
                     <div class="col-md-12" style="padding-top: 5px;">
-                        <form method="POST" action="{{ route('restore/user', $user->id) }}">
+                        <form method="POST" action="{{ route('users.restore.store', $user->id) }}">
                             @csrf
                             <button style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('button.restore') }}</button>
                         </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -467,12 +467,12 @@ Route::group(['middleware' => 'web'], function () {
     Route::get(
         'logout',
         [LoginController::class, 'logout']
-    )->name('logout');
+    )->name('logout.get');
 
     Route::post(
         'logout',
         [LoginController::class, 'logout']
-    )->name('logout');
+    )->name('logout.post');
 });
 
 //Auth::routes();

--- a/routes/web/accessories.php
+++ b/routes/web/accessories.php
@@ -10,22 +10,22 @@ Route::group(['prefix' => 'accessories', 'middleware' => ['auth']], function () 
     Route::get(
         '{accessoryID}/checkout',
         [Accessories\AccessoryCheckoutController::class, 'create']
-    )->name('checkout/accessory');
+    )->name('accessories.checkout.show');
 
     Route::post(
         '{accessoryID}/checkout',
         [Accessories\AccessoryCheckoutController::class, 'store']
-    )->name('checkout/accessory');
+    )->name('accessories.checkout.store');
 
     Route::get(
         '{accessoryID}/checkin/{backto?}',
         [Accessories\AccessoryCheckinController::class, 'create']
-    )->name('checkin/accessory');
+    )->name('accessories.checkin.show');
 
     Route::post(
         '{accessoryID}/checkin/{backto?}',
         [Accessories\AccessoryCheckinController::class, 'store']
-    )->name('checkin/accessory');
+    )->name('accessories.checkin.store');
 
 });
 

--- a/routes/web/components.php
+++ b/routes/web/components.php
@@ -8,17 +8,17 @@ Route::group(['prefix' => 'components', 'middleware' => ['auth']], function () {
     Route::get(
         '{componentID}/checkout',
         [Components\ComponentCheckoutController::class, 'create']
-    )->name('component.checkout.show');
+    )->name('components.checkout.show');
 
     Route::post(
         '{componentID}/checkout',
         [Components\ComponentCheckoutController::class, 'store']
-    )->name('component.checkout.store');
+    )->name('components.checkout.store');
 
     Route::get(
         '{componentID}/checkin/{backto?}',
         [Components\ComponentCheckinController::class, 'create']
-    )->name('component.checkin.show');
+    )->name('components.checkin.show');
 
     Route::post(
         '{componentID}/checkin/{backto?}',

--- a/routes/web/components.php
+++ b/routes/web/components.php
@@ -8,22 +8,22 @@ Route::group(['prefix' => 'components', 'middleware' => ['auth']], function () {
     Route::get(
         '{componentID}/checkout',
         [Components\ComponentCheckoutController::class, 'create']
-    )->name('checkout/component');
+    )->name('component.checkout.show');
 
     Route::post(
         '{componentID}/checkout',
         [Components\ComponentCheckoutController::class, 'store']
-    )->name('checkout/component');
+    )->name('component.checkout.store');
 
     Route::get(
         '{componentID}/checkin/{backto?}',
         [Components\ComponentCheckinController::class, 'create']
-    )->name('checkin/component');
+    )->name('component.checkin.show');
 
     Route::post(
         '{componentID}/checkin/{backto?}',
         [Components\ComponentCheckinController::class, 'store']
-    )->name('component.checkin.save');
+    )->name('components.checkin.store');
 
 });
 

--- a/routes/web/consumables.php
+++ b/routes/web/consumables.php
@@ -9,12 +9,12 @@ Route::group(['prefix' => 'consumables', 'middleware' => ['auth']], function () 
     Route::get(
         '{consumablesID}/checkout',
         [Consumables\ConsumableCheckoutController::class, 'create']
-    )->name('checkout/consumable');
+    )->name('consumables.checkout.show');
 
     Route::post(
         '{consumablesID}/checkout',
         [Consumables\ConsumableCheckoutController::class, 'store']
-    )->name('checkout/consumable');
+    )->name('consumables.checkout.store');
 
 
 });

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -108,19 +108,19 @@ Route::group(
 
         Route::get('{assetId}/checkout',
             [AssetCheckoutController::class, 'create']
-        )->name('checkout/hardware');
+        )->name('hardware.checkout.create');
 
         Route::post('{assetId}/checkout',
             [AssetCheckoutController::class, 'store']
-        )->name('checkout/hardware');
+        )->name('hardware.checkout.store');
 
         Route::get('{assetId}/checkin/{backto?}',
             [AssetCheckinController::class, 'create']
-        )->name('checkin/hardware');
+        )->name('hardware.checkin.create');
 
         Route::post('{assetId}/checkin/{backto?}',
             [AssetCheckinController::class, 'store']
-        )->name('checkin/hardware');
+        )->name('hardware.checkin.store');
 
         Route::get('{assetId}/view',
             [AssetsController::class, 'show']
@@ -168,11 +168,11 @@ Route::group(
         // Bulk checkout / checkin
         Route::get('bulkcheckout',
             [BulkAssetsController::class, 'showCheckout']
-        )->name('hardware/bulkcheckout');
+        )->name('hardware.bulkcheckout.show');
 
         Route::post('bulkcheckout',
             [BulkAssetsController::class, 'storeCheckout']
-        )->name('hardware/bulkcheckout');
+        )->name('hardware.bulkcheckout.store');
     });
 
 Route::resource('hardware', 

--- a/routes/web/models.php
+++ b/routes/web/models.php
@@ -28,7 +28,7 @@ Route::group(['prefix' => 'models', 'middleware' => ['auth']], function () {
             AssetModelsController::class, 
             'getClone'
         ]
-    )->name('clone/model');
+    )->name('models.clone.create');
 
     Route::post(
         '{modelId}/clone',
@@ -36,7 +36,7 @@ Route::group(['prefix' => 'models', 'middleware' => ['auth']], function () {
             AssetModelsController::class, 
             'postCreate'
         ]
-    )->name('clone/model');
+    )->name('models.clone.store');
 
     Route::get(
         '{modelId}/view',
@@ -52,7 +52,7 @@ Route::group(['prefix' => 'models', 'middleware' => ['auth']], function () {
             AssetModelsController::class, 
             'getRestore'
         ]
-    )->name('restore/model');
+    )->name('models.restore.store');
 
     Route::get(
         '{modelId}/custom_fields',

--- a/routes/web/users.php
+++ b/routes/web/users.php
@@ -38,7 +38,7 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
             Users\UsersController::class, 
             'getClone'
         ]
-    )->name('clone/user');
+    )->name('users.clone.show');
 
     Route::post(
         '{userId}/clone',
@@ -46,7 +46,7 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
             Users\UsersController::class, 
             'postCreate'
         ]
-    )->name('clone/user');
+    )->name('users.clone.store');
 
     Route::post(
         '{userId}/restore',
@@ -54,7 +54,7 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
             Users\UsersController::class, 
             'getRestore'
         ]
-    )->name('restore/user');
+    )->name('users.restore.store');
 
     Route::get(
         '{userId}/unsuspend',


### PR DESCRIPTION
This is a pared down version of https://github.com/snipe/snipe-it/pull/11422, that ONLY handles the routes that conflict with `php artisan optimize` (basically, those with conflicting route names).

In newer versions of Laravel, since they reworked all of how routes worked,  they also started disallowing duplicate route names, even if they were GET vs POST. Our convention had been to keep the route names the same for consistency, but that stopped working when we upgraded Laravel. That is to say, they still *worked* in the app, but it would return an error if you tried to run `php artisan optimize` - which hey, not everyone does, but it's been impossible to do so since Snipe-IT v6 was released. 

I closed PR  https://github.com/snipe/snipe-it/pull/11422 simply because it was biting off a little more than it could chew. The route names are all over the place, for sure, and we *should* go back and refactor them for consistency, but that PR will be bigger and messier. 

Note: This PR **ONLY** touches web routes, not API routes, which in general are named less stupidly anyway.