### PR TITLE
Use unique_undeleted instead of unique for custom fields

### DIFF
--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -87,7 +87,7 @@ class CustomFieldset extends Model
             }
 
             if ($field->is_unique == '1') {
-                    $rule[] = 'unique';
+                    $rule[] = 'unique_undeleted';
             }
 
             array_push($rule, $field->attributes['format']);


### PR DESCRIPTION
This replaces the `unique` validator for custom fields (when they have been selected to be unique) to exclude deleted items. 