### PR TITLE
Fixed date format for Current Date output on location print assigned

### DIFF
--- a/resources/views/locations/print.blade.php
+++ b/resources/views/locations/print.blade.php
@@ -58,7 +58,7 @@
 @if ($manager)
     <b>{{ trans('admin/locations/general.manager') }}</b> {{ $manager->present()->fullName() }}<br>
 @endif
-<b>{{ trans('admin/locations/general.date') }}</b> {{ date("d/m/Y h:i:s A") }}<br><br>
+<b>{{ trans('admin/locations/general.date') }}</b>  {{ \App\Helpers\Helper::getFormattedDateObject(now(), 'datetime', false) }}<br><br>
 
 @if ($users->count() > 0)
     @php


### PR DESCRIPTION
We missed a date formatter in the print assigned screen for location. 