### PR TITLE
Use apropiate string for license actions

### DIFF
--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -78,8 +78,8 @@
               <span class="caret"></span>
             </a>
             <ul class="dropdown-menu">
-              <li><a href="{{ route('licenses.edit', $user->id) }}">{{ trans('admin/users/general.edit') }}</a></li>
-              <li><a href="{{ route('clone/license', $user->id) }}">{{ trans('admin/users/general.clone') }}</a></li>
+              <li><a href="{{ route('licenses.edit', $user->id) }}">{{ trans('admin/licenses/general.edit') }}</a></li>
+              <li><a href="{{ route('clone/license', $user->id) }}">{{ trans('admin/licenses/general.clone') }}</a></li>
             </ul>
           </li>
         @endcan

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -7,21 +7,6 @@
 @parent
 @stop
 
-{{-- Right header --}}
-@section('header_right')
-<div class="btn-group pull-right">
-  @can('update', $license)
-    <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">{{ trans('button.actions') }}
-        <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu" role="menu">
-        <li role="menuitem"><a href="{{ route('licenses.edit', ['license' => $license->id]) }}">{{ trans('admin/licenses/general.edit') }}</a></li>
-        <li role="menuitem"><a href="{{ route('clone/license', $license->id) }}">{{ trans('admin/licenses/general.clone') }}</a></li>
-    </ul>
-   @endcan
-</div>
-@stop
-
 {{-- Page content --}}
 @section('content')
 <div class="row">
@@ -78,8 +63,8 @@
               <span class="caret"></span>
             </a>
             <ul class="dropdown-menu">
-              <li><a href="{{ route('licenses.edit', $user->id) }}">{{ trans('admin/licenses/general.edit') }}</a></li>
-              <li><a href="{{ route('clone/license', $user->id) }}">{{ trans('admin/licenses/general.clone') }}</a></li>
+              <li><a href="{{ route('licenses.edit', $license->id) }}">{{ trans('admin/licenses/general.edit') }}</a></li>
+              <li><a href="{{ route('clone/license', $license->id) }}">{{ trans('admin/licenses/general.clone') }}</a></li>
             </ul>
           </li>
         @endcan


### PR DESCRIPTION
# Description
In the licenses view, when clicking the gear menu, the string to actions 'clone' and 'edit' were wrongly putting users.



Fixes freshdesk 29913

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
