### PR TITLE
Disallow checkout if qty = 0

### DIFF
--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -126,10 +126,21 @@
                 @endif
 
     @can('checkout', \App\Models\Consumable::class)
-    <div class="col-md-12">
-                    <a href="{{ route('consumables.checkout.show', $consumable->id) }}" style="padding-bottom:5px;" class="btn btn-primary btn-sm" {{ (($consumable->numRemaining() > 0 ) ? '' : ' disabled') }}>{{ trans('general.checkout') }}</a>
-                </div>
-                @endcan
+
+      <div class="col-md-12">
+        
+        @if ($consumable->numRemaining() > 0)
+          <a href="{{ route('consumables.checkout.show', $consumable->id) }}" style="padding-bottom:5px;" class="btn btn-primary btn-sm">
+            {{ trans('general.checkout') }}
+          </a>
+        @else
+          <button style="padding-bottom:5px;" class="btn btn-primary btn-sm disabled">
+            {{ trans('general.checkout') }}
+          </button>
+        @endif
+      </div>
+
+    @endcan
 
     @if ($consumable->notes)
        


### PR DESCRIPTION
This is kind of a janky fix, but since we use a link (not a button) for checkout, even though it's "disabled" in CSS, it's still clickable. While the visual cue should be enough to make folks not click on it, it currently does let you click on it. This changes it to a disabled button with no destination, so it's truly disabled. 

Consumables is going through a bit of rework right now so I don't want to mess with it too much, but eventually will need some good UI love. 