### PR TITLE
Added time diff to EOL in asset view

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -789,7 +789,7 @@ class ReportsController extends Controller
 
                     if ($request->filled('warranty')) {
                         $row[] = ($asset->warranty_months) ? $asset->warranty_months : '';
-                        $row[] = $asset->present()->warrantee_expires();
+                        $row[] = $asset->present()->warranty_expires();
                     }
 
                     if ($request->filled('depreciation')) {

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -498,7 +498,7 @@ class AssetPresenter extends Presenter
     }
 
     /**
-     * Date the warantee expires.
+     * Date the warranty expires.
      * @return false|string
      */
     public function warranty_expires()

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -501,7 +501,7 @@ class AssetPresenter extends Presenter
      * Date the warantee expires.
      * @return false|string
      */
-    public function warrantee_expires()
+    public function warranty_expires()
     {
         if (($this->purchase_date) && ($this->warranty_months)) {
             $date = date_create($this->purchase_date);

--- a/app/Presenters/DepreciationReportPresenter.php
+++ b/app/Presenters/DepreciationReportPresenter.php
@@ -371,7 +371,7 @@ class DepreciationReportPresenter extends Presenter
      * Date the warantee expires.
      * @return false|string
      */
-    public function warrantee_expires()
+    public function warranty_expires()
     {
         if (($this->purchase_date) && ($this->warranty_months)) {
             $date = date_create($this->purchase_date);

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -574,7 +574,7 @@
 
 
                                     @if ($asset->warranty_months)
-                                        <div class="row{!! $asset->present()->warrantee_expires() < date("Y-m-d") ? ' warning' : '' !!}">
+                                        <div class="row{!! $asset->present()->warranty_expires() < date("Y-m-d") ? ' warning' : '' !!}">
                                             <div class="col-md-2">
                                                 <strong>
                                                     {{ trans('admin/hardware/form.warranty') }}
@@ -584,10 +584,24 @@
                                                 {{ $asset->warranty_months }}
                                                 {{ trans('admin/hardware/form.months') }}
 
-                                                ({{ trans('admin/hardware/form.expires') }}
-                                                {{ $asset->present()->warrantee_expires() }})
+
                                             </div>
                                         </div>
+
+                                            <div class="row{!! $asset->present()->warranty_expires() < date("Y-m-d") ? ' warning' : '' !!}">
+                                                <div class="col-md-2">
+                                                    <strong>
+                                                        {{ trans('admin/hardware/form.warranty_expires') }}
+                                                    </strong>
+                                                </div>
+                                                <div class="col-md-6">
+                                                    {{ Helper::getFormattedDateObject($asset->present()->warranty_expires(), 'date', false) }}
+                                                    -
+                                                    {{ Carbon::parse($asset->present()->warranty_expires())->diffForHumans() }}
+
+                                                </div>
+                                            </div>
+
                                     @endif
 
                                     @if (($asset->model) && ($asset->depreciation))
@@ -600,8 +614,7 @@
                                             <div class="col-md-6">
                                                 {{ $asset->depreciation->name }}
                                                 ({{ $asset->depreciation->months }}
-                                                {{ trans('admin/hardware/form.months') }}
-                                                )
+                                                {{ trans('admin/hardware/form.months') }})
                                             </div>
                                         </div>
                                         <div class="row">
@@ -611,13 +624,10 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-6">
-                                                @if ($asset->time_until_depreciated()->y > 0)
-                                                    {{ $asset->time_until_depreciated()->y }}
-                                                    {{ trans('admin/hardware/form.years') }},
-                                                @endif
-                                                {{ $asset->time_until_depreciated()->m }}
-                                                {{ trans('admin/hardware/form.months') }}
-                                                ({{ $asset->depreciated_date()->format('Y-m-d') }})
+                                                {{ Helper::getFormattedDateObject($asset->depreciated_date()->format('Y-m-d'), 'date', false) }}
+                                                -
+                                                {{ Carbon::parse($asset->depreciated_date())->diffForHumans() }}
+
                                             </div>
                                         </div>
                                     @endif
@@ -644,20 +654,9 @@
                                             </div>
                                             <div class="col-md-6">
                                                 {{ Helper::getFormattedDateObject($asset->present()->eol_date(), 'date', false) }}
-
-
-                                                @if ($asset->present()->months_until_eol())
-                                                    -
-                                                    @if ($asset->present()->months_until_eol()->y > 0)
-                                                        {{ $asset->present()->months_until_eol()->y }}
-                                                        {{ trans('general.years') }},
-                                                    @endif
-
-                                                    {{ $asset->present()->months_until_eol()->m }}
-                                                    {{ trans('general.months') }}
-
-                                                @endif
-
+                                                -
+                                                {{ Carbon::parse($asset->present()->eol_date())->diffForHumans() }}
+                                                
                                             </div>
                                         </div>
                                     @endif

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -574,7 +574,7 @@
 
 
                                     @if ($asset->warranty_months)
-                                        <div class="row{!! $asset->present()->warranty_expires() < date("Y-m-d") ? ' warning' : '' !!}">
+                                        <div class="row">
                                             <div class="col-md-2">
                                                 <strong>
                                                     {{ trans('admin/hardware/form.warranty') }}
@@ -588,13 +588,15 @@
                                             </div>
                                         </div>
 
-                                            <div class="row{!! $asset->present()->warranty_expires() < date("Y-m-d") ? ' warning' : '' !!}">
+                                            <div class="row">
                                                 <div class="col-md-2">
                                                     <strong>
                                                         {{ trans('admin/hardware/form.warranty_expires') }}
+                                                        {!! $asset->present()->warranty_expires() < date("Y-m-d") ? '<i class="fas fa-exclamation-triangle text-orange" aria-hidden="true"></i>' : '' !!}
                                                     </strong>
                                                 </div>
                                                 <div class="col-md-6">
+
                                                     {{ Helper::getFormattedDateObject($asset->present()->warranty_expires(), 'date', false) }}
                                                     -
                                                     {{ Carbon::parse($asset->present()->warranty_expires())->diffForHumans() }}

--- a/resources/views/notifications/markdown/report-expiring-assets.blade.php
+++ b/resources/views/notifications/markdown/report-expiring-assets.blade.php
@@ -6,8 +6,8 @@
 <tr><td>&nbsp;</td><td>{{ trans('mail.name') }}</td><td>{{ trans('mail.Days') }}</td><td>{{ trans('mail.expires') }}</td><td>{{ trans('mail.supplier') }}</td><td>{{ trans('mail.assigned_to') }}</td></tr>
 @foreach ($assets as $asset)
 @php
-$expires = Helper::getFormattedDateObject($asset->present()->warrantee_expires, 'date');
-$diff = round(abs(strtotime($asset->present()->warrantee_expires) - strtotime(date('Y-m-d')))/86400);
+$expires = Helper::getFormattedDateObject($asset->present()->warranty_expires, 'date');
+$diff = round(abs(strtotime($asset->present()->warranty_expires) - strtotime(date('Y-m-d')))/86400);
 $icon = ($diff <= ($threshold / 2)) ? '🚨' : (($diff <= $threshold) ? '⚠️' : ' ');
 @endphp
 <tr><td>{{ $icon }} </td><td> <a href="{{ route('hardware.show', $asset->id) }}">{{ $asset->present()->name }}</a> </td><td> {{ $diff }} {{ trans('mail.Days') }} </td><td> {{ $expires['formatted'] }} </td><td> {{ ($asset->supplier ? e($asset->supplier->name) : '') }} </td><td> {{ ($asset->assignedTo ? e($asset->assignedTo->present()->name()) : '') }} </td></tr>


### PR DESCRIPTION
This adds relative time to more of the fields in the asset view, and also uses the correct date/time formatter in a few more spots. I've also removed some extraneous warning formatting (that apparently never worked) and also renamed a very old function from `warrantee_expires()` to `warranty_expires()`.

Before:

<img width="593" alt="Screen Shot 2022-08-02 at 7 10 12 PM" src="https://user-images.githubusercontent.com/197404/182510299-d9563418-b554-4166-87cc-b8ed94689654.png">

After:

<img width="579" alt="Screen Shot 2022-08-02 at 7 19 01 PM" src="https://user-images.githubusercontent.com/197404/182510340-0b5fbd04-9e36-40a7-afb0-c3f5200f4136.png">
