### PR TITLE
Added relations to report search

### DIFF
--- a/app/Http/Controllers/Api/ReportsController.php
+++ b/app/Http/Controllers/Api/ReportsController.php
@@ -20,7 +20,7 @@ class ReportsController extends Controller
     {
         $this->authorize('reports.view');
 
-        $actionlogs = Actionlog::with('item', 'user', 'target', 'location');
+        $actionlogs = Actionlog::with('item', 'user', 'admin', 'target', 'location');
 
         if ($request->filled('search')) {
             $actionlogs = $actionlogs->TextSearch(e($request->input('search')));

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -95,11 +95,11 @@ class ActionlogsTransformer
             'next_audit_date' => ($actionlog->itemType()=='asset') ? Helper::getFormattedDateObject($actionlog->calcNextAuditDate(null, $actionlog->item), 'date'): null,
             'days_to_next_audit' => $actionlog->daysUntilNextAudit($settings->audit_interval, $actionlog->item),
             'action_type'   => $actionlog->present()->actionType(),
-            'admin' => ($actionlog->user) ? [
-                'id' => (int) $actionlog->user->id,
-                'name' => e($actionlog->user->getFullNameAttribute()),
-                'first_name'=> e($actionlog->user->first_name),
-                'last_name'=> e($actionlog->user->last_name)
+            'admin' => ($actionlog->admin) ? [
+                'id' => (int) $actionlog->admin->id,
+                'name' => e($actionlog->admin->getFullNameAttribute()),
+                'first_name'=> e($actionlog->admin->first_name),
+                'last_name'=> e($actionlog->admin->last_name)
             ] : null,
             'target' => ($actionlog->target) ? [
                 'id' => (int) $actionlog->target->id,

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -43,7 +43,9 @@ class Actionlog extends SnipeModel
      */
     protected $searchableRelations = [
         'company' => ['name'],
-        'user' => ['first_name','last_name','username'],
+        'admin' => ['first_name','last_name','username', 'email'],
+        'user'  => ['first_name','last_name','username', 'email'],
+        'assets'  => ['asset_tag','name'],
     ];
 
     /**
@@ -93,6 +95,19 @@ class Actionlog extends SnipeModel
     public function company()
     {
         return $this->hasMany(\App\Models\Company::class, 'id', 'company_id');
+    }
+
+
+    /**
+     * Establishes the actionlog -> asset relationship
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v3.0]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function assets()
+    {
+        return $this->hasMany(\App\Models\Asset::class, 'id', 'item_id');
     }
 
     /**
@@ -155,6 +170,19 @@ class Actionlog extends SnipeModel
     }
 
     /**
+     * Establishes the actionlog -> admin user relationship
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v3.0]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function admin()
+    {
+        return $this->belongsTo(User::class, 'user_id')
+                    ->withTrashed();
+    }
+
+    /**
      * Establishes the actionlog -> user relationship
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
@@ -163,8 +191,8 @@ class Actionlog extends SnipeModel
      */
     public function user()
     {
-        return $this->belongsTo(User::class, 'user_id')
-                    ->withTrashed();
+        return $this->belongsTo(User::class, 'target_id')
+            ->withTrashed();
     }
 
     /**


### PR DESCRIPTION
This is an attempt to add a few more fields to the reports API search. This gets a little tricky because of the weird morphing stuff we do. We cannot add `target` as a relation here, since that will result in `Column not found: 1054 Unknown column 'laravel_reserved_-1.name' in 'where clause'`, which I've seen before but I forgot what it means (temp columns I think.)

This does make querying that table pretty gnarly, since the query gets very big very fast, and the `action_logs` table can get very big, but it's the best way I can come up with other than rewriting the Searchable stuff for the action logs. 

(The original issue I'm trying to fix here is that you cannot search for a target's name in the activity report. 

@uberbrady @inietov - I'd love it if you could really kick the tires on this one and make sure I didn't miss anything. Thanks! ❤️‍🩹

(Hopefully) fixes FD-27919