### PR TITLE
Fix auto incrementing in CSV importer [sc-19366]

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -55,6 +55,11 @@ class AssetImporter extends ItemImporter
     {
         $editingAsset = false;
         $asset_tag = $this->findCsvMatch($row, 'asset_tag');
+
+        if(empty($asset_tag)){
+            $asset_tag = Asset::autoincrement_asset();
+        }
+
         $asset = Asset::where(['asset_tag'=> $asset_tag])->first();
         if ($asset) {
             if (! $this->updating) {


### PR DESCRIPTION
# Description
The asset importer takes the asset tag as a required field so  if the CSV have the column empty the import fails. But it doesn't consider if the user have the asset tags set to autoincrement, which let them to import assets without asset tags and let the system handle that for them.

Fixes shortcut 19366

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
