### PR TITLE
Fixed wrong calculation of assigned components

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -623,7 +623,7 @@ class Helper
     {
         $consumables = Consumable::withCount('consumableAssignments as consumable_assignments_count')->whereNotNull('min_amt')->get();
         $accessories = Accessory::withCount('users as users_count')->whereNotNull('min_amt')->get();
-        $components = Component::withCount('assets as assets_count')->whereNotNull('min_amt')->get();
+        $components = Component::whereNotNull('min_amt')->get();
 
         $avail_consumables = 0;
         $items_array = [];
@@ -668,7 +668,9 @@ class Helper
         }
 
         foreach ($components as $component) {
-            $avail = $component->qty - $component->assets_count;
+            $assets_count = \DB::table('components_assets')->where('component_id', $component->id)->sum('assigned_qty');
+
+            $avail = $component->qty - $assets_count;
             if ($avail < ($component->min_amt) + \App\Models\Setting::getSettings()->alert_threshold) {
                 if ($component->qty > 0) {
                     $percent = number_format((($avail / $component->qty) * 100), 0);

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -668,9 +668,7 @@ class Helper
         }
 
         foreach ($components as $component) {
-            $assets_count = \DB::table('components_assets')->where('component_id', $component->id)->sum('assigned_qty');
-
-            $avail = $component->qty - $assets_count;
+            $avail = $component->numRemaining();
             if ($avail < ($component->min_amt) + \App\Models\Setting::getSettings()->alert_threshold) {
                 if ($component->qty > 0) {
                     $percent = number_format((($avail / $component->qty) * 100), 0);


### PR DESCRIPTION
# Description
Components remaining are calculating just the rows of relation (table) `components_assets`, but every record on that table have a field called `assigned_qty` that needs to be added so the calculation of remaining components is correct.

Fixes freshdesk 29961

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
