### PR TITLE
Fixes Monthly depreciation calculation if EOL is blank

### DIFF
--- a/app/Http/Transformers/DepreciationReportTransformer.php
+++ b/app/Http/Transformers/DepreciationReportTransformer.php
@@ -63,9 +63,15 @@ class DepreciationReportTransformer
          */
         if (($asset->model) && ($asset->model->depreciation)) {
             $depreciated_value = Helper::formatCurrencyOutput($asset->getDepreciatedValue());
-            $monthly_depreciation = Helper::formatCurrencyOutput(($asset->model->eol > 0 ? ($asset->purchase_cost / $asset->model->eol) : 0));
+            if($asset->model->eol==0 || $asset->model->eol==null ){
+                $monthly_depreciation = Helper::formatCurrencyOutput($asset->purchase_cost / $asset->model->depreciation->months);
+            }
+            else {
+                $monthly_depreciation = Helper::formatCurrencyOutput(($asset->model->eol > 0 ? ($asset->purchase_cost / $asset->model->eol) : 0));
+            }
             $diff = Helper::formatCurrencyOutput(($asset->purchase_cost - $asset->getDepreciatedValue()));
         }
+
 
         if ($asset->assigned) {
             $checkout_target = $asset->assigned->name;


### PR DESCRIPTION
# Description

If an EOL (end of life) date is missing from Asset models the monthly depreciation will now still be calculated with the months stated in the depreciation model attached to said Asset model for depreciation reports.

Without EOLs:
![image](https://user-images.githubusercontent.com/47435081/183770439-2c241e58-eed9-4dbf-82e2-7c1c3c3ffb9b.png)

With EOLs:
![image](https://user-images.githubusercontent.com/47435081/183770480-d7b0537f-c810-468b-a942-abd206f5e05d.png)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
