### PR TITLE
Fixed Search in activity report for full name in relation

### DIFF
--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Traits;
 
+use DB;
 use App\Models\Asset;
 use App\Models\CustomField;
 use Illuminate\Database\Eloquent\Builder;
@@ -160,6 +161,9 @@ trait Searchable
                         }
 
                         $query->orWhere($table.'.'.$column, 'LIKE', '%'.$term.'%');
+                        if($table == 'users'){
+                            $query->orWhereRaw('CONCAT(users.first_name ," ", users.last_name) LIKE ?', ["%$term%"]);
+                        }
                     }
                 }
             });

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -161,10 +161,11 @@ trait Searchable
                         }
 
                         $query->orWhere($table.'.'.$column, 'LIKE', '%'.$term.'%');
-                        if($table == 'users'){
-                            $query->orWhereRaw('CONCAT(users.first_name ," ", users.last_name) LIKE ?', ["%$term%"]);
-                        }
                     }
+                }
+                // I put this here because I only want to add the concat one time in the end of the user relation search
+                if($relation == 'user') {
+                    $query->orWhereRaw('CONCAT (users.first_name, " ", users.last_name) LIKE ?', ["%$term%"]);
                 }
             });
         }

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -2,7 +2,6 @@
 
 namespace App\Models\Traits;
 
-use DB;
 use App\Models\Asset;
 use App\Models\CustomField;
 use Illuminate\Database\Eloquent\Builder;


### PR DESCRIPTION
# Description
Well this is not a 'cool' or 'good looking', probably not 'the better'. In fact, I'm pretty sure it's not the better. But yeah, it's 'a fix'. When searching trough the Activity Report if you know the complete name of the user, the search doesn't return any result.

I added a condition to do this in the searchable trait when looking inside the relations of the `action_logs table`. I spent more hours than I like to admit looking for a solution and this is the only thing I could think of. Let me know if something is escaping my mind, and if not, well, I think this is working for now.

Fixes internal freshdesk 29988

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
