### PR TITLE
Fixes Departments update/store  to allow company and/or location ids to be null

### DIFF
--- a/app/Http/Controllers/DepartmentsController.php
+++ b/app/Http/Controllers/DepartmentsController.php
@@ -54,7 +54,8 @@ class DepartmentsController extends Controller
         $department->fill($request->all());
         $department->user_id = Auth::user()->id;
         $department->manager_id = ($request->filled('manager_id') ? $request->input('manager_id') : null);
-
+        $department->location_id = ($request->filled('location_id') ? $request->input('location_id') : null);
+        $department->company_id = ($request->filled('company_id') ? $request->input('company_id') : null);
         $department = $request->handleImages($department);
 
         if ($department->save()) {
@@ -167,6 +168,8 @@ class DepartmentsController extends Controller
 
         $department->fill($request->all());
         $department->manager_id = ($request->filled('manager_id') ? $request->input('manager_id') : null);
+        $department->location_id = ($request->filled('location_id') ? $request->input('location_id') : null);
+        $department->company_id = ($request->filled('company_id') ? $request->input('company_id') : null);
 
         $department = $request->handleImages($department);
 


### PR DESCRIPTION
# Description

when updating a Department by removing a location or company the value of null was not saved. It would only update if the field was filled with another location or company.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
