### PR TITLE
Send notifications when Acceptance Assets actions occur [sc-9917]

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -19,6 +19,7 @@ use App\Models\Accessory;
 use App\Models\License;
 use App\Models\Component;
 use App\Models\Consumable;
+use App\Notifications\AcceptanceAssetAcceptedNotification;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -236,6 +237,7 @@ class AcceptanceController extends Controller
             }
 
             $acceptance->accept($sig_filename, $item->getEula(), $pdf_filename);
+            $acceptance->notify(new AcceptanceAssetAcceptedNotification($data));
             event(new CheckoutAccepted($acceptance));
 
             $return_msg = trans('admin/users/message.accepted');

--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -5,10 +5,11 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Notifications\Notifiable;
 
 class CheckoutAcceptance extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes, Notifiable;
 
     protected $casts = [
         'accepted_at' => 'datetime',

--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -16,6 +16,14 @@ class CheckoutAcceptance extends Model
         'declined_at' => 'datetime',
     ];
 
+    // Get the mail recipient from the config
+    public function routeNotificationForMail(): string
+    {
+        // At this point the endpoint is the same for everything.
+        //  In the future this may want to be adapted for individual notifications.
+        return config('mail.reply_to.address');
+    }
+
     /**
      * The resource that was is out
      *

--- a/app/Notifications/AcceptanceAssetAcceptedNotification.php
+++ b/app/Notifications/AcceptanceAssetAcceptedNotification.php
@@ -54,7 +54,7 @@ class AcceptanceAssetAcceptedNotification extends Notification
      */
     public function toMail()
     {
-        $message = (new MailMessage)->markdown('notifications.markdown.asset-requested',
+        $message = (new MailMessage)->markdown('notifications.markdown.asset-acceptance',
             [
                 'item_tag'      => $this->item_tag,
                 'item_model'    => $this->item_model,

--- a/app/Notifications/AcceptanceAssetAcceptedNotification.php
+++ b/app/Notifications/AcceptanceAssetAcceptedNotification.php
@@ -24,7 +24,7 @@ class AcceptanceAssetAcceptedNotification extends Notification
         $this->item_tag = $params['item_tag'];
         $this->item_model = $params['item_model'];
         $this->item_serial = $params['item_serial'];
-        $this->accepted_date = Helper::getFormattedDateObject($params['accepted_date'], 'datetime', false);
+        $this->accepted_date = Helper::getFormattedDateObject($params['accepted_date'], 'date', false);
         $this->assigned_to = $params['assigned_to'];
         $this->company_name = $params['company_name'];
         $this->settings = Setting::getSettings();

--- a/app/Notifications/AcceptanceAssetAcceptedNotification.php
+++ b/app/Notifications/AcceptanceAssetAcceptedNotification.php
@@ -21,30 +21,14 @@ class AcceptanceAssetAcceptedNotification extends Notification
      */
     public function __construct($params)
     {
-        $this->target = $params['target'];
-        $this->item = $params['item'];
-        $this->item_type = $params['item_type'];
-        $this->item_quantity = $params['item_quantity'];
-        $this->note = '';
-        $this->last_checkout = '';
-        $this->expected_checkin = '';
-        $this->requested_date = Helper::getFormattedDateObject($params['requested_date'], 'datetime',
-            false);
+        $this->item_tag = $params['item_tag'];
+        $this->item_model = $params['item_model'];
+        $this->item_serial = $params['item_serial'];
+        $this->accepted_date = Helper::getFormattedDateObject($params['accepted_date'], 'datetime', false);
+        $this->assigned_to = $params['assigned_to'];
+        $this->company_name = $params['company_name'];
         $this->settings = Setting::getSettings();
 
-        if (array_key_exists('note', $params)) {
-            $this->note = $params['note'];
-        }
-
-        if ($this->item->last_checkout) {
-            $this->last_checkout = Helper::getFormattedDateObject($this->item->last_checkout, 'date',
-                false);
-        }
-
-        if ($this->item->expected_checkin) {
-            $this->expected_checkin = Helper::getFormattedDateObject($this->item->expected_checkin, 'date',
-                false);
-        }
     }
 
     /**
@@ -55,11 +39,6 @@ class AcceptanceAssetAcceptedNotification extends Notification
      */
     public function via()
     {
-        $notifyBy = [];
-
-        if (Setting::getSettings()->slack_endpoint != '') {
-            $notifyBy[] = 'slack';
-        }
 
         $notifyBy[] = 'mail';
 
@@ -75,24 +54,15 @@ class AcceptanceAssetAcceptedNotification extends Notification
      */
     public function toMail()
     {
-        $fields = [];
-
-        // Check if the item has custom fields associated with it
-        if (($this->item->model) && ($this->item->model->fieldset)) {
-            $fields = $this->item->model->fieldset->fields;
-        }
-
         $message = (new MailMessage)->markdown('notifications.markdown.asset-requested',
             [
-                'item'          => $this->item,
-                'note'          => $this->note,
-                'requested_by'  => $this->target,
-                'requested_date' => $this->requested_date,
-                'fields'        => $fields,
-                'last_checkout' => $this->last_checkout,
-                'expected_checkin'  => $this->expected_checkin,
-                'intro_text'        => trans('mail.acceptance_asset_accepted'),
-                'qty'           => $this->item_quantity,
+                'item_tag'      => $this->item_tag,
+                'item_model'    => $this->item_model,
+                'item_serial'   => $this->item_serial,
+                'accepted_date' => $this->accepted_date,
+                'assigned_to'   => $this->assigned_to,
+                'company_name'  => $this->company_name,
+                'intro_text'    => trans('mail.acceptance_asset_accepted'),
             ])
             ->subject(trans('mail.acceptance_asset_accepted'));
 

--- a/app/Notifications/AcceptanceAssetAcceptedNotification.php
+++ b/app/Notifications/AcceptanceAssetAcceptedNotification.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Helpers\Helper;
+use App\Models\Setting;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+
+class AcceptanceAssetAcceptedNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($params)
+    {
+        $this->target = $params['target'];
+        $this->item = $params['item'];
+        $this->item_type = $params['item_type'];
+        $this->item_quantity = $params['item_quantity'];
+        $this->note = '';
+        $this->last_checkout = '';
+        $this->expected_checkin = '';
+        $this->requested_date = Helper::getFormattedDateObject($params['requested_date'], 'datetime',
+            false);
+        $this->settings = Setting::getSettings();
+
+        if (array_key_exists('note', $params)) {
+            $this->note = $params['note'];
+        }
+
+        if ($this->item->last_checkout) {
+            $this->last_checkout = Helper::getFormattedDateObject($this->item->last_checkout, 'date',
+                false);
+        }
+
+        if ($this->item->expected_checkin) {
+            $this->expected_checkin = Helper::getFormattedDateObject($this->item->expected_checkin, 'date',
+                false);
+        }
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via()
+    {
+        $notifyBy = [];
+
+        if (Setting::getSettings()->slack_endpoint != '') {
+            $notifyBy[] = 'slack';
+        }
+
+        $notifyBy[] = 'mail';
+
+        return $notifyBy;
+
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail()
+    {
+        $fields = [];
+
+        // Check if the item has custom fields associated with it
+        if (($this->item->model) && ($this->item->model->fieldset)) {
+            $fields = $this->item->model->fieldset->fields;
+        }
+
+        $message = (new MailMessage)->markdown('notifications.markdown.asset-requested',
+            [
+                'item'          => $this->item,
+                'note'          => $this->note,
+                'requested_by'  => $this->target,
+                'requested_date' => $this->requested_date,
+                'fields'        => $fields,
+                'last_checkout' => $this->last_checkout,
+                'expected_checkin'  => $this->expected_checkin,
+                'intro_text'        => trans('mail.acceptance_asset_accepted'),
+                'qty'           => $this->item_quantity,
+            ])
+            ->subject(trans('mail.acceptance_asset_accepted'));
+
+        return $message;
+    }
+
+}

--- a/app/Notifications/AcceptanceAssetDeclinedNotification.php
+++ b/app/Notifications/AcceptanceAssetDeclinedNotification.php
@@ -24,7 +24,7 @@ class AcceptanceAssetDeclinedNotification extends Notification
         $this->item_tag = $params['item_tag'];
         $this->item_model = $params['item_model'];
         $this->item_serial = $params['item_serial'];
-        $this->accepted_date = Helper::getFormattedDateObject($params['accepted_date'], 'datetime', false);
+        $this->declined_date = Helper::getFormattedDateObject($params['declined_date'], 'date', false);
         $this->assigned_to = $params['assigned_to'];
         $this->company_name = $params['company_name'];
         $this->settings = Setting::getSettings();
@@ -52,19 +52,12 @@ class AcceptanceAssetDeclinedNotification extends Notification
      */
     public function toMail($notifiable)
     {
-        $fields = [];
-
-        // Check if the item has custom fields associated with it
-        if (($this->item->model) && ($this->item->model->fieldset)) {
-            $fields = $this->item->model->fieldset->fields;
-        }
-
-        $message = (new MailMessage)->markdown('notifications.markdown.asset-requested',
+        $message = (new MailMessage)->markdown('notifications.markdown.asset-acceptance',
             [
                 'item_tag'      => $this->item_tag,
                 'item_model'    => $this->item_model,
                 'item_serial'   => $this->item_serial,
-                'accepted_date' => $this->accepted_date,
+                'declined_date' => $this->declined_date,
                 'assigned_to'   => $this->assigned_to,
                 'company_name'  => $this->company_name,
                 'intro_text'    => trans('mail.acceptance_asset_declined'),

--- a/app/Notifications/AcceptanceAssetDeclinedNotification.php
+++ b/app/Notifications/AcceptanceAssetDeclinedNotification.php
@@ -21,30 +21,13 @@ class AcceptanceAssetDeclinedNotification extends Notification
      */
     public function __construct($params)
     {
-        $this->target = $params['target'];
-        $this->item = $params['item'];
-        $this->item_type = $params['item_type'];
-        $this->item_quantity = $params['item_quantity'];
-        $this->note = '';
-        $this->last_checkout = '';
-        $this->expected_checkin = '';
-        $this->requested_date = Helper::getFormattedDateObject($params['requested_date'], 'datetime',
-            false);
+        $this->item_tag = $params['item_tag'];
+        $this->item_model = $params['item_model'];
+        $this->item_serial = $params['item_serial'];
+        $this->accepted_date = Helper::getFormattedDateObject($params['accepted_date'], 'datetime', false);
+        $this->assigned_to = $params['assigned_to'];
+        $this->company_name = $params['company_name'];
         $this->settings = Setting::getSettings();
-
-        if (array_key_exists('note', $params)) {
-            $this->note = $params['note'];
-        }
-
-        if ($this->item->last_checkout) {
-            $this->last_checkout = Helper::getFormattedDateObject($this->item->last_checkout, 'date',
-                false);
-        }
-
-        if ($this->item->expected_checkin) {
-            $this->expected_checkin = Helper::getFormattedDateObject($this->item->expected_checkin, 'date',
-                false);
-        }
     }
 
     /**
@@ -55,12 +38,6 @@ class AcceptanceAssetDeclinedNotification extends Notification
      */
     public function via($notifiable)
     {
-        $notifyBy = [];
-
-        if (Setting::getSettings()->slack_endpoint != '') {
-            $notifyBy[] = 'slack';
-        }
-
         $notifyBy[] = 'mail';
 
         return $notifyBy;
@@ -84,15 +61,13 @@ class AcceptanceAssetDeclinedNotification extends Notification
 
         $message = (new MailMessage)->markdown('notifications.markdown.asset-requested',
             [
-                'item'          => $this->item,
-                'note'          => $this->note,
-                'requested_by'  => $this->target,
-                'requested_date' => $this->requested_date,
-                'fields'        => $fields,
-                'last_checkout' => $this->last_checkout,
-                'expected_checkin'  => $this->expected_checkin,
-                'intro_text'        => trans('mail.acceptance_asset_declined'),
-                'qty'           => $this->item_quantity,
+                'item_tag'      => $this->item_tag,
+                'item_model'    => $this->item_model,
+                'item_serial'   => $this->item_serial,
+                'accepted_date' => $this->accepted_date,
+                'assigned_to'   => $this->assigned_to,
+                'company_name'  => $this->company_name,
+                'intro_text'    => trans('mail.acceptance_asset_declined'),
             ])
             ->subject(trans('mail.acceptance_asset_declined'));
 

--- a/app/Notifications/AcceptanceAssetDeclinedNotification.php
+++ b/app/Notifications/AcceptanceAssetDeclinedNotification.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Helpers\Helper;
+use App\Models\Setting;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+
+class AcceptanceAssetDeclinedNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($params)
+    {
+        $this->target = $params['target'];
+        $this->item = $params['item'];
+        $this->item_type = $params['item_type'];
+        $this->item_quantity = $params['item_quantity'];
+        $this->note = '';
+        $this->last_checkout = '';
+        $this->expected_checkin = '';
+        $this->requested_date = Helper::getFormattedDateObject($params['requested_date'], 'datetime',
+            false);
+        $this->settings = Setting::getSettings();
+
+        if (array_key_exists('note', $params)) {
+            $this->note = $params['note'];
+        }
+
+        if ($this->item->last_checkout) {
+            $this->last_checkout = Helper::getFormattedDateObject($this->item->last_checkout, 'date',
+                false);
+        }
+
+        if ($this->item->expected_checkin) {
+            $this->expected_checkin = Helper::getFormattedDateObject($this->item->expected_checkin, 'date',
+                false);
+        }
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        $notifyBy = [];
+
+        if (Setting::getSettings()->slack_endpoint != '') {
+            $notifyBy[] = 'slack';
+        }
+
+        $notifyBy[] = 'mail';
+
+        return $notifyBy;
+
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $fields = [];
+
+        // Check if the item has custom fields associated with it
+        if (($this->item->model) && ($this->item->model->fieldset)) {
+            $fields = $this->item->model->fieldset->fields;
+        }
+
+        $message = (new MailMessage)->markdown('notifications.markdown.asset-requested',
+            [
+                'item'          => $this->item,
+                'note'          => $this->note,
+                'requested_by'  => $this->target,
+                'requested_date' => $this->requested_date,
+                'fields'        => $fields,
+                'last_checkout' => $this->last_checkout,
+                'expected_checkin'  => $this->expected_checkin,
+                'intro_text'        => trans('mail.acceptance_asset_declined'),
+                'qty'           => $this->item_quantity,
+            ])
+            ->subject(trans('mail.acceptance_asset_declined'));
+
+        return $message;
+    }
+
+}

--- a/resources/lang/en/mail.php
+++ b/resources/lang/en/mail.php
@@ -1,6 +1,8 @@
 <?php
 
 return [
+    'acceptance_asset_accepted' => 'A user has accepted an item',
+    'acceptance_asset_declined' => 'A user has declined an item',
     'a_user_canceled' => 'A user has canceled an item request on the website',
     'a_user_requested' => 'A user has requested an item on the website',
     'accessory_name' => 'Accessory Name:',

--- a/resources/views/notifications/markdown/asset-acceptance.blade.php
+++ b/resources/views/notifications/markdown/asset-acceptance.blade.php
@@ -3,15 +3,16 @@
 
 {{ $intro_text }}.
 
-@if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
-<center><img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;"></center>
-@endif
-
 @component('mail::table')
 |        |          |
 | ------------- | ------------- |
-| **{{ trans('mail.user') }}** | [{{ $assigned_to->present()->fullName() }}]({{ route('users.show', $assigned_to->id) }}) |
-| **{{ trans('general.requested') }}** | {{ $accepted_date }} |
+| **{{ trans('mail.user') }}** | {{ $assigned_to }} |
+@if (isset($accepted_date))
+| **{{ ucfirst(trans('general.accepted')) }}** | {{ $accepted_date }} |
+@endif
+@if (isset($declined_date))
+| **{{ trans('general.declined') }}** | {{ $declined_date }} |
+@endif
 @if ((isset($item_tag)) && ($item_tag!=''))
 | **{{ trans('mail.asset_tag') }}** | {{ $item_tag }} |
 @endif

--- a/resources/views/notifications/markdown/asset-acceptance.blade.php
+++ b/resources/views/notifications/markdown/asset-acceptance.blade.php
@@ -1,0 +1,33 @@
+@component('mail::message')
+# {{ trans('mail.hello') }},
+
+{{ $intro_text }}.
+
+@if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
+<center><img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;"></center>
+@endif
+
+@component('mail::table')
+|        |          |
+| ------------- | ------------- |
+| **{{ trans('mail.user') }}** | [{{ $assigned_to->present()->fullName() }}]({{ route('users.show', $assigned_to->id) }}) |
+| **{{ trans('general.requested') }}** | {{ $accepted_date }} |
+@if ((isset($item_tag)) && ($item_tag!=''))
+| **{{ trans('mail.asset_tag') }}** | {{ $item_tag }} |
+@endif
+@if ((isset($item_model)) && ($item_model!=''))
+| **{{ trans('mail.asset_name') }}** | {{ $item_model }} |
+@endif
+@if (isset($item->model))
+| **{{ trans('general.asset_model') }}** | {{ $item->model->name }} |
+@endif
+@if (isset($item_serial))
+| **{{ trans('mail.serial') }}** | {{ $item_serial }} |
+@endif
+@endcomponent
+
+{{ trans('mail.best_regards') }}
+
+{{ $snipeSettings->site_name }}
+
+@endcomponent


### PR DESCRIPTION
# Description
When users got checked out assets to them, if the asset got the Accept/Decline functionality we don't send notifications. Some customers want to know if the asset was declined, but I figure out that maybe if the asset is accepted we also want to send a notification. I only add notifications via mail this time... 

As always, let me know if something looks funky or a better solution is available request the changes :D 

Fixes shortcut 9917

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
