### PR TITLE
Fixed #6899 Docker container's php configuration isn't congruent with snipe-it uploads setting size. 

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -47,6 +47,7 @@ if [ -v "PHP_UPLOAD_LIMIT" ]
 then
     echo "Changing upload limit to ${PHP_UPLOAD_LIMIT}"
     sed -i "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_LIMIT}M/" /etc/php/*/apache2/php.ini
+    sed -i "s/^post_max_size.*/post_max_size = ${PHP_UPLOAD_LIMIT}M/" /etc/php/*/apache2/php.ini
 fi
 
 # If the Oauth DB files are not present copy the vendor files over to the db migrations


### PR DESCRIPTION
# Description

For docker deployments.

The PHP_UPLOAD_LIMIT environmental variable only adjusts upload_max_size in php.ini.

Since the post_max_size is still left at 8MB, file uploads will remain capped at 8MB even if the user sets the PHP_UPLOAD_LIMIT to something greater. 

This adds an additional line to set the post_max_size to as well, enabling the upload maximum to be set to greater than 8MB. 

Fixed #6899: Docker container's php configuration isn't congruent with snipe-it uploads setting size. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Added to startup.sh in personal deployment. Verified changes in help text and uploading large PDFs (manuals) to assets.

**Test Configuration**:
* Docker (Swarm Mode): 20.10.12
* MariaDB (Galera) version: 10.4.25
* Docker Image: 6.0.8
  * PHP version: 7.4
  * Webserver version: Apache 2.4.41
  * OS version: Ubuntu 20.04