### PR TITLE
Prevent to delete a user if still has consumables associated to them

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -441,6 +441,10 @@ class UsersController extends Controller
             return response()->json(Helper::formatStandardApiResponse('error', null, 'This user still has '.$user->accessories->count().' accessories associated with them.'));
         }
 
+        if (($user->consumables) && ($user->consumables->count() > 0)) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, 'This user still has '.$user->consumables->count().' consumables associated with them.'));
+        }
+
         if (($user->managedLocations()) && ($user->managedLocations()->count() > 0)) {
             return response()->json(Helper::formatStandardApiResponse('error', null, 'This user still has '.$user->managedLocations()->count().' locations that they manage.'));
         }

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -348,6 +348,12 @@ class UsersController extends Controller
                     ->with('error', 'This user still has '.$accessoriesCount.' accessories associated with them.');
             }
 
+            if (($user->consumables()) && (($consumablesCount = $user->consumables()->count())) > 0) {
+                // Redirect to the user management page
+                return redirect()->route('users.index')
+                    ->with('error', 'This user still has '.$consumablesCount.' consumables associated with them.');
+            }
+
             if (($user->managedLocations()) && (($managedLocationsCount = $user->managedLocations()->count())) > 0) {
                 // Redirect to the user management page
                 return redirect()->route('users.index')


### PR DESCRIPTION
# Description
If users have consumables assigned to them the system still let 'em to get deleted, which with other type of items is not permitted. This PR adds that functionality to the API and the 'normal' controller.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
