### PR TITLE
Added `null` option for `purchase_date` and `expected_checkin` dates

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -103,6 +103,8 @@ class BulkAssetsController extends Controller
             || ($request->filled('company_id'))
             || ($request->filled('status_id'))
             || ($request->filled('model_id'))
+            || ($request->filled('null_purchase_date'))
+            || ($request->filled('null_expected_checkin_date'))
         ) {
             foreach ($assets as $assetId) {
 
@@ -116,6 +118,14 @@ class BulkAssetsController extends Controller
                     ->conditionallyAddItem('status_id')
                     ->conditionallyAddItem('supplier_id')
                     ->conditionallyAddItem('warranty_months');
+
+                if ($request->input('null_purchase_date')=='1') {
+                    $this->update_array['purchase_date'] = null;
+                }
+
+                if ($request->input('null_expected_checkin_date')=='1') {
+                    $this->update_array['expected_checkin'] = null;
+                }
 
                 if ($request->filled('purchase_cost')) {
                     $this->update_array['purchase_cost'] =  Helper::ParseCurrency($request->input('purchase_cost'));

--- a/resources/lang/en/admin/hardware/form.php
+++ b/resources/lang/en/admin/hardware/form.php
@@ -6,7 +6,7 @@ return [
   'bulk_delete_warn'	=> 'You are about to delete :asset_count assets.',
     'bulk_update'		=> 'Bulk Update Assets',
     'bulk_update_help'	=> 'This form allows you to update multiple assets at once. Only fill in the fields you need to change. Any fields left blank will remain unchanged. ',
-    'bulk_update_warn'	=> 'You are about to edit the properties of :asset_count assets.',
+    'bulk_update_warn'	=> 'You are about to edit the properties of a single asset.|You are about to edit the properties of :asset_count assets.',
     'checkedout_to'		=> 'Checked Out To',
     'checkout_date'		=> 'Checkout Date',
     'checkin_date'		=> 'Checkin Date',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -371,6 +371,7 @@ return [
     'bulk_soft_delete'      =>'Also soft-delete these users. Their asset history will remain intact unless/until you purge deleted records in the Admin Settings.',
     'bulk_checkin_delete_success' => 'Your selected users have been deleted and their items have been checked in.',
     'bulk_checkin_success' => 'The items for the selected users have been checked in.',
+    'set_to_null' => 'Delete values for this asset|Delete values for all :asset_count assets ',
 
 
 ];

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -31,24 +31,38 @@
           <!-- Purchase Date -->
           <div class="form-group {{ $errors->has('purchase_date') ? ' has-error' : '' }}">
             <label for="purchase_date" class="col-md-3 control-label">{{ trans('admin/hardware/form.date') }}</label>
-            <div class="input-group col-md-3">
+            <div class="col-md-3">
               <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
                 <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="purchase_date" id="purchase_date" value="{{ old('purchase_date') }}">
                 <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
               </div>
               {!! $errors->first('purchase_date', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
             </div>
+            <div class="col-md-3">
+              <label>
+                {{ Form::checkbox('null_purchase_date', '1', false, ['class' => 'minimal']) }}
+                {{ trans_choice('general.set_to_null', count($assets),['asset_count' => count($assets)]) }}
+              </label>
+            </div>
+
           </div>
           <!-- Expected Checkin Date -->
           <div class="form-group {{ $errors->has('expected_checkin') ? ' has-error' : '' }}">
              <label for="expected_checkin" class="col-md-3 control-label">{{ trans('admin/hardware/form.expected_checkin') }}</label>
-             <div class="input-group col-md-3">
+             <div class="col-md-3">
                   <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
                       <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ old('expected_checkin') }}">
                       <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
                  </div>
+
                  {!! $errors->first('expected_checkin', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
              </div>
+              <div class="col-md-3">
+                <label>
+                  {{ Form::checkbox('null_expected_checkin_date', '1', false, ['class' => 'minimal']) }}
+                  {{ trans_choice('general.set_to_null', count($assets), ['asset_count' => count($assets)]) }}
+                </label>
+              </div>
           </div>
 
 

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -20,7 +20,7 @@
     <p>{{ trans('admin/hardware/form.bulk_update_help') }}</p>
 
     <div class="callout callout-warning">
-      <i class="fas fa-exclamation-triangle"></i> {{ trans('admin/hardware/form.bulk_update_warn', ['asset_count' => count($assets)]) }}
+      <i class="fas fa-exclamation-triangle"></i> {{ trans_choice('admin/hardware/form.bulk_update_warn', count($assets), ['asset_count' => count($assets)]) }}
     </div>
 
     <form class="form-horizontal" method="post" action="{{ route('hardware/bulksave') }}" autocomplete="off" role="form">

--- a/resources/views/partials/forms/edit/location-select.blade.php
+++ b/resources/views/partials/forms/edit/location-select.blade.php
@@ -2,7 +2,7 @@
 <div id="{{ $fieldname }}" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
 
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
-    <div class="col-md-6{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
+    <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
         <select class="js-data-ajax" data-endpoint="locations" data-placeholder="{{ trans('general.select_location') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ $fieldname }}_location_select" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' data-validation="required" required' : '' !!}>
             @if ($location_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $location_id }}" selected="selected" role="option" aria-selected="true"  role="option">


### PR DESCRIPTION
This adds a new checkbox to the bulk edit screen that will allow you to set `purchase_date` and `expected_checkin` to null, for example in the case of data entry error. 

### One asset selected

<img width="1110" alt="Screen Shot 2022-08-11 at 6 26 54 PM" src="https://user-images.githubusercontent.com/197404/184268461-0a98efab-1efb-43fb-ae79-ad42528ddd0b.png">

### Multiple assets selected
<img width="1106" alt="Screen Shot 2022-08-11 at 6 27 07 PM" src="https://user-images.githubusercontent.com/197404/184268471-f24a4217-6b04-4dc4-8c4b-81278e9750ff.png">
