### PR TITLE
Declare DB_PORT in all .env files

### DIFF
--- a/.env.dusk.local
+++ b/.env.dusk.local
@@ -21,6 +21,7 @@ PUBLIC_FILESYSTEM_DISK=local_public
 # --------------------------------------------
 DB_CONNECTION=mysql
 DB_HOST=localhost
+DB_PORT=3309
 DB_DATABASE=snipeit-local
 DB_USERNAME=snipeit-local
 DB_PASSWORD=snipeit-local

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ PUBLIC_FILESYSTEM_DISK=local_public
 # --------------------------------------------
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
+DB_PORT=3309
 DB_DATABASE=null
 DB_USERNAME=null
 DB_PASSWORD=null

--- a/.env.testing
+++ b/.env.testing
@@ -14,6 +14,7 @@ FILESYSTEM_DISK=local
 # --------------------------------------------
 DB_CONNECTION=sqlite_testing
 DB_HOST=localhost
+DB_PORT=3309
 DB_DATABASE=testing.sqlite
 DB_USERNAME=null
 DB_PASSWORD=null

--- a/.env.testing-ci
+++ b/.env.testing-ci
@@ -14,6 +14,7 @@ FILESYSTEM_DISK=local
 # --------------------------------------------
 DB_CONNECTION=sqlite
 DB_HOST=localhost
+DB_PORT=3309
 DB_DATABASE='sqlite_testing'
 DB_USERNAME=root
 DB_PASSWORD=null

--- a/.env.tests
+++ b/.env.tests
@@ -4,6 +4,7 @@ APP_URL=http://snipe-it.localapp
 DB_CONNECTION=mysql
 DB_DEFAULT=mysql
 DB_HOST=localhost
+DB_PORT=3309
 DB_DATABASE=snipeittests
 DB_USERNAME=snipeit
 DB_PASSWORD=snipe

--- a/.env.unit-tests
+++ b/.env.unit-tests
@@ -4,6 +4,7 @@ APP_URL=http://snipe-it.localapp
 DB_CONNECTION=sqlite_testing
 DB_DEFAULT=sqlite_testing
 DB_HOST=localhost
+DB_PORT=3309
 APP_KEY=base64:tu9NRh/a6+dCXBDGvg0Gv/0TcABnFsbT4AKxrr8mwQo=
 
 


### PR DESCRIPTION
# Description

Simple declaration of DB_PORT in all .env files. This resolves the 500 error that is generated when attempting to use both the web GUI backup and PHP artisan snipeit:backup

The error was generating the following

```
[2022-08-12 14:53:07] production.ERROR: Argument 1 passed to Spatie\DbDumper\DbDumper::setPort() must be of the type int, string given, called in /var/www/html/vendor/spatie/laravel-backup/src/Tasks/Backup/DbDumperFactory.php on line 51 {"userId":331,"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Argument 1 passed to Spatie\\DbDumper\\DbDumper::setPort() must be of the type int, string given, called in /var/www/html/vendor/spatie/laravel-backup/src/Tasks/Backup/DbDumperFactory.php on line 51 at /var/www/html/vendor/spatie/db-dumper/src/DbDumper.php:120)
[stacktrace]
```

Fixes #7353

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested and confirmed in my own Docker instance of snipeit:latest (v5.4.4 build 6829 (gfd71b4848))

- [x] Test before change
- [x] Test after provision of DB_PORT=3306

**Test Configuration**:
* PHP version:7.4.3
* MySQL version: mariadb:10.8.2
* OS version: dockerised, in Debian 10


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
