### PR TITLE
Fixed 500 error when sending unaccepted assets reminder

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1006,7 +1006,11 @@ class ReportsController extends Controller
         }
         $assetItem = $acceptance->checkoutable;
 
-        $logItem = $assetItem->checkouts()->where('created_at', '=', $acceptance->created_at)->get()[0];
+        if (is_null($acceptance->created_at)){
+            return redirect()->route('reports/unaccepted_assets')->with('error', trans('general.bad_data'));
+        } else {
+            $logItem = $assetItem->checkouts()->where('created_at', '=', $acceptance->created_at)->get()[0];
+        }
 
         if(!$assetItem->assignedTo->locale){
             Notification::locale(Setting::getSettings()->locale)->send(


### PR DESCRIPTION
# Description
In the Unaccepted Assets report, users can resend reminders to users that haven't accepted or declined assets that require acceptance. 

But to get some of the data needed in the notification, we associate the `action_logs` table with the `checkout_acceptances` using the column `created_at` in both tables. This is because an asset can have "n" registers in the `action_logs` and we want to only link the one that's created when the asset got checked out. The problem is that I found data on the `checkout_acceptances` table with a null value in the `created_at` column, so it can't get associate with the correspondent action log, and when the system needs that data to create the notifications it fails with an error 500.

This PR return with an error if that column have a null value instead of fail, but maybe there' s a better way to handle this, since the data that it needs doesn´t look that important, let me know what you think.

Fixes freshdesk 30231

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
