### PR TITLE
Improved Asset Search: use zerofill for searchbar

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -445,7 +445,17 @@ class AssetsController extends Controller
     {
         $topsearch = ($request->get('topsearch') == 'true');
 
-        if (! $asset = Asset::where('asset_tag', '=', $request->get('assetTag'))->first()) {
+		$settings = Setting::getSettings();
+		$assetTag = $request->get('assetTag');
+		if(str_starts_with($assetTag, $settings->auto_increment_prefix)) {
+			$assetTag = substr($assetTag, strlen($settings->auto_increment_prefix));
+			$assetTag = Asset::zerofill($assetTag, $settings->zerofill_count);
+			$assetTag = $settings->auto_increment_prefix . $assetTag;
+		} else {
+			$assetTag = Asset::zerofill($assetTag, $settings->zerofill_count);
+		}
+
+        if (! $asset = Asset::where('asset_tag', '=', $assetTag)->first()) {
             return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.does_not_exist'));
         }
         $this->authorize('view', $asset);


### PR DESCRIPTION
I updated the Asset:getAssetByTag Method to use zerofill.
Now you don't have to write the whole AssetTag, only the short version.

**Example**
Before: 000000001
Now: 1
