### PR TITLE
Fixed Translation String: wrong key at request canceled message

### DIFF
--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -165,7 +165,7 @@ class ViewAssetsController extends Controller
             $settings->notify(new RequestAssetCancelation($data));
 
             return redirect()->route('requestable-assets')
-                ->with('success')->with('success', trans('admin/hardware/message.requests.cancel'));
+                ->with('success')->with('success', trans('admin/hardware/message.requests.canceled'));
         }
 
         $logaction->logaction('requested');


### PR DESCRIPTION
# Description

The translation key misses an "ed" at the end.