### PR TITLE
Fixed #11706 Manager name

### DIFF
--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -33,7 +33,7 @@ class UsersTransformer
                 'employee_num' => e($user->employee_num),
                 'manager' => ($user->manager) ? [
                     'id' => (int) $user->manager->id,
-                    'name'=> e($user->manager->username),
+                    'name'=> e($user->manager->first_name).' '.e($user->manager->last_name),
                 ] : null,
                 'jobtitle' => ($user->jobtitle) ? e($user->jobtitle) : null,
                 'phone' => ($user->phone) ? e($user->phone) : null,


### PR DESCRIPTION
Fixed #11706
# Description

Minor visual change. Changing the display of People Current Users, Manager column to show Managers First Last Name, instead of Managers username.

Previous code shows Managers username:
`'name'=> e($user->manager->username),`

New updated code shows Managers First Last Name:

`'name'=> e($user->manager->first_name).' '.e($user->manager->last_name),`

## Type of change

- [ x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Visually.
