### PR TITLE
Fixed #11711 clearfix missing on admin settings page  to prevent blanking divs

### DIFF
--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -56,7 +56,7 @@
 
 
     <!-- search filter list -->
-    <div class="list">
+    <div class="list clearfix">
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
           <div class="box box-default">


### PR DESCRIPTION
# Description

The admin settings page was disappearing when resized between a width of 768 and 991. This just adds a clearfix to prevent that.

Fixes #11711 

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
