### PR TITLE
Fixed crash on Asset View if file doesn’t exist on server

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1184,8 +1184,8 @@
                                                 <td>
                                                     {{ $file->filename }}
                                                 </td>
-                                                <td data-value="{{ filesize(storage_path('private_uploads/assets/').$file->filename) }}">
-                                                    {{ Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/assets/').$file->filename)) }}
+                                                <td data-value="{{ @filesize(storage_path('private_uploads/assets/').$file->filename) }}">
+                                                    {{ @Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/assets/').$file->filename)) }}
                                                 </td>
                                                 <td>
                                                     @if ($file->note)


### PR DESCRIPTION
This is kind of a gross way to handle this, but it should generally be kind of an edge case. Basically, if the database thinks there is a file attached, but the file can't be found on the server, it would crash on the `filesize()` method. Probably better to handle this a little better at the controller method down the line, but this at least prevents the crash.