### PR TITLE
Added style to readonly date fields

### DIFF
--- a/resources/views/partials/forms/edit/purchase_date.blade.php
+++ b/resources/views/partials/forms/edit/purchase_date.blade.php
@@ -3,7 +3,7 @@
    <label for="purchase_date" class="col-md-3 control-label">{{ trans('general.purchase_date') }}</label>
    <div class="input-group col-md-4">
         <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="purchase_date" id="purchase_date" readonly value="{{ old('purchase_date', ($item->purchase_date) ? $item->purchase_date->format('Y-m-d') : '') }}">
+            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="purchase_date" id="purchase_date" readonly value="{{ old('purchase_date', ($item->purchase_date) ? $item->purchase_date->format('Y-m-d') : '') }}" style="background-color:inherit">
             <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
        </div>
        {!! $errors->first('purchase_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}


### PR DESCRIPTION
This just applies a style to the recent PR (#11726) that makes the date picker "readonly" to disallow freeform text. While the date picker worked as expected, the readonly attribute was rending (as you would expect) to *appear* as though it's not editable, even though it *is* via the date picker.

### Before
<img width="849" alt="Screen Shot 2022-08-24 at 5 09 29 PM" src="https://user-images.githubusercontent.com/197404/186545751-b992759d-405b-4b62-95cc-967e2da850e2.png">

### After 
<img width="834" alt="Screen Shot 2022-08-24 at 5 10 01 PM" src="https://user-images.githubusercontent.com/197404/186545753-d8f6a0d2-b5a1-4923-a9e9-541c0bc768aa.png">

I test this with alternate skins as well, and it seems to be behaving as expected. 