### PR TITLE
Fixed #11708 - pre-create private_storage directories for Docker restores

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -19,6 +19,13 @@ fi
 # create data directories
 for dir in \
   'data/private_uploads' \
+  'data/private_uploads/assets' \
+  'data/private_uploads/audits' \
+  'data/private_uploads/imports' \
+  'data/private_uploads/assetmodels' \
+  'data/private_uploads/users' \
+  'data/private_uploads/licenses' \
+  'data/private_uploads/signatures' \
   'data/uploads/accessories' \
   'data/uploads/avatars' \
   'data/uploads/barcodes' \


### PR DESCRIPTION
# Description

A user reports that Docker restores did not work for them because the assetmodels subdirectory did not already exist. I took the liberty of pre-creating *all* of the directories that the Restore tool wants to have in-place.

Fixes # 11708

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I did a local `docker build .` and the image successfully built.