### PR TITLE
Fixed #11679 Importing Licenses - Field Mismatch

### DIFF
--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -56,7 +56,7 @@ abstract class Importer
         'reassignable' => 'reassignable',
         'requestable' => 'requestable',
         'seats' => 'seats',
-        'serial_number' => 'serial number',
+        'serial' => 'serial number',
         'status' => 'status',
         'supplier' => 'supplier',
         'termination_date' => 'termination date',

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -90,7 +90,7 @@ class ItemImporter extends Importer
         $this->item['qty'] = $this->findCsvMatch($row, 'quantity');
         $this->item['requestable'] = $this->findCsvMatch($row, 'requestable');
         $this->item['user_id'] = $this->user_id;
-        $this->item['serial'] = $this->findCsvMatch($row, 'serial');
+        $this->item['serial'] = $this->findCsvMatch($row, 'serial number');
         // NO need to call this method if we're running the user import.
         // TODO: Merge these methods.
         $this->item['checkout_class'] = $this->findCsvMatch($row, 'checkout_class');


### PR DESCRIPTION
# Description
Importing assets using the command line `snipeit:import` command doesn't import the licenses serial number, because the header name of the sample CSV doesn't match the importer column.

Fixes #11679 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
