### PR TITLE
Fixed: Log user out of other devices when they change their password

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\ImageUploadRequest;
 use App\Models\Setting;
-use Auth;
+use Illuminate\Support\Facades\Auth;
 use Gate;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
@@ -133,7 +133,7 @@ class ProfileController extends Controller
     public function password()
     {
         $user = Auth::user();
-
+        
         return view('account/change-password', compact('user'));
     }
 
@@ -186,6 +186,9 @@ class ProfileController extends Controller
         if (! $validator->fails()) {
             $user->password = Hash::make($request->input('password'));
             $user->save();
+
+            // Log the user out of other devices
+            Auth::logoutOtherDevices($request->input('password'));
             return redirect()->route('account.password.index')->with('success', 'Password updated!');
 
         }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -43,6 +43,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\CheckForTwoFactor::class,
             \Laravel\Passport\Http\Middleware\CreateFreshApiToken::class,
             \App\Http\Middleware\AssetCountForSidebar::class,
+            \Illuminate\Session\Middleware\AuthenticateSession::class,
         ],
 
         'api' => [


### PR DESCRIPTION
This PR forces a user's other sessions to be logged out when they change their password to prevent session fixation attacks.  Fixes [this Huntr.Dev report](https://huntr.dev/bounties/c09bf21b-50d2-49f0-8c92-49f6b3c358d8/).