### PR TITLE
Fixed Validation error when empty default customfield values 

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -471,7 +471,7 @@ class AssetModelsController extends Controller
             // (we are at model level, the rule still applies when creating a new asset using this model)
             $index = array_search('required', $validation);
             if ($index !== false){
-                unset($validation[$index]);
+                $validation[$index] = 'nullable';
             }
             $rules[$fieldset] = $validation;
         }


### PR DESCRIPTION
# Description
This builds over #11724, in that PR I eliminate the `required` rule if it exists, but then if an input is set as an empty string and another rule on the custom field look for a date or a custom regex or something like that, the validator still fails.

So in this one instead of remove the `required` rule I replace it with a  `nullable` rule, to let pass the validator in such cases.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
