### PR TITLE
Fixed #11695 Problem with checkin all and delete user.

### DIFF
--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -231,8 +231,14 @@ class BulkUsersController extends Controller
     protected function logItemCheckinAndDelete($items, $itemType)
     {
         foreach ($items as $item) {
+            $item_id = $item->id;
             $logAction = new Actionlog();
-            $logAction->item_id = $item->id;
+
+            if($itemType == License::class){
+                $item_id = $item->license_id;
+            }
+
+            $logAction->item_id = $item_id;
             // We can't rely on get_class here because the licenses/accessories fetched above are not eloquent models, but simply arrays.
             $logAction->item_type = $itemType;
             $logAction->target_id = $item->assigned_to;


### PR DESCRIPTION
# Description
When a user have licenses checked in to them and an admin tries to 'Checkin-all & Delete' the user. The action log saves the `id` of the item, which is really a LicenseSeat, so when we search the action in the Recent Activity report, the transformer doesn't find a license with that id.

This changes look if the logged item is a License and if it is, saves the correct License id that LicenseSeat belongs to. 

Fixes #11695 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
