### PR TITLE
Fixed #11742: display correct file sizes when using S3(-like) storage

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1184,8 +1184,8 @@
                                                 <td>
                                                     {{ $file->filename }}
                                                 </td>
-                                                <td data-value="{{ @filesize(storage_path('private_uploads/assets/').$file->filename) }}">
-                                                    {{ @Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/assets/').$file->filename)) }}
+                                                <td data-value="{{ @Storage::size('private_uploads/assets/'.$file->filename) }}">
+                                                    {{ @Helper::formatFilesizeUnits(Storage::size('private_uploads/assets/'.$file->filename)) }}
                                                 </td>
                                                 <td>
                                                     @if ($file->note)
@@ -1277,8 +1277,8 @@
                                                 <td>
                                                     {{ $file->filename }}
                                                 </td>
-                                                <td data-value="{{ filesize(storage_path('private_uploads/assetmodels/').$file->filename) }}">
-                                                    {{ Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/assetmodels/').$file->filename)) }}
+                                                <td data-value="{{ Storage::size('private_uploads/assetmodels/'.$file->filename) }}">
+                                                    {{ Helper::formatFilesizeUnits(Storage::size('private_uploads/assetmodels/'.$file->filename)) }}
                                                 </td>
                                                 <td>
                                                     @if ($file->note)

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -469,8 +469,8 @@
                 <td>
                   {{ $file->filename }}
                 </td>
-                <td data-value="{{ filesize(storage_path('private_uploads/licenses/').$file->filename) }}">
-                  {{ Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/licenses/').$file->filename)) }}
+                <td data-value="{{ Storage::size('private_uploads/licenses/'.$file->filename) }}">
+                  {{ Helper::formatFilesizeUnits(Storage::size('private_uploads/licenses/'.$file->filename)) }}
                 </td>
 
                 <td>

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -154,8 +154,8 @@
                                             <td>
                                                 {{ $file->filename }}
                                             </td>
-                                            <td data-value="{{ filesize(storage_path('private_uploads/assetmodels/').$file->filename) }}">
-                                                {{ Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/assetmodels/').$file->filename)) }}
+                                            <td data-value="{{ Storage::size('private_uploads/assetmodels/'.$file->filename) }}">
+                                                {{ Helper::formatFilesizeUnits(Storage::size('private_uploads/assetmodels/'.$file->filename)) }}
                                             </td>
                                             <td>
                                                 @if ($file->note)

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -842,7 +842,7 @@
                                 {{ $file->filename }}
                             </td>
                             <td>
-                                {{ Helper::formatFilesizeUnits(filesize(storage_path('private_uploads/users/').$file->filename)) }}
+                                {{ Helper::formatFilesizeUnits(Storage::size('private_uploads/users/'.$file->filename)) }}
                             </td>
 
                             <td>


### PR DESCRIPTION
# Description

Use `Storage::size()` instead of `filesize()` in order to follow Laravel's FS configuration instead of just trying to read a path on the local FS, which prevents crashes or file size = 0 when using a S3-like storage.

Fixes #11742

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I only tested changes on `resources/views/hardware/view.blade.php`: I am patching my own instance with this fix for multiple months.

Other changes are just the exact same bug pattern I fixed the exact same way.

**Test Configuration**:
* PHP version: 8.0.21
* MySQL version: 8.0.22
* Webserver version: whatever Apache server Clever Cloud is using
* OS version: Linux (whatever Clever Cloud is using, I think it is Exherbo)


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
