### PR TITLE
Fixed #7704 Unable to see asset history

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -126,7 +126,7 @@ class AuthServiceProvider extends ServiceProvider
         // Reports
         // -----------------------------------------
         Gate::define('reports.view', function ($user) {
-            if ($user->hasAccess('reports.view')) {
+            if ($user->hasAccess('reports.view') || $user->hasAccess('admin') ) {
                 return true;
             }
         });


### PR DESCRIPTION
# Description
If a user with Admin permissions wanted to see some reports, for example the history of an asset, the system doesn't let them.

This PR adds permission to see asset history reports and a few more guarded by the Gate `reports.view`.

Fixes #7704 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
