### PR TITLE
Added notes to audit mail notification

### DIFF
--- a/resources/views/notifications.blade.php
+++ b/resources/views/notifications.blade.php
@@ -50,6 +50,9 @@
                         <li><b>{{ trans('general.asset_name') }} </b> {{ $asset->model->name }}</li>
                     @endisset
                     <li><b>{{ trans('general.asset_tag') }}</b> {{ $asset->asset_tag }}</li>
+		    @isset ($asset->notes)
+		    <li><b>{{ trans('general.notes') }}</b> {{ $asset->notes }}</li>
+		    @endisset
                 </ul>
 
             </div>

--- a/resources/views/notifications/markdown/upcoming-audits.blade.php
+++ b/resources/views/notifications/markdown/upcoming-audits.blade.php
@@ -3,8 +3,8 @@
 ### {{ trans_choice('mail.upcoming-audits', $assets->count(), ['count' => $assets->count(), 'threshold' => $threshold]) }}
 
 @component('mail::table')
-| |{{ trans('mail.name') }}|{{ trans('general.last_audit') }}|{{ trans('general.next_audit_date') }}|{{ trans('mail.Days') }}|{{ trans('mail.supplier') }} | {{ trans('mail.assigned_to') }}
-|-|:------------- |:-------------|:---------|:---------|:---------|:---------|
+| |{{ trans('mail.name') }}|{{ trans('general.last_audit') }}|{{ trans('general.next_audit_date') }}|{{ trans('mail.Days') }}|{{ trans('mail.supplier') }} | {{ trans('mail.assigned_to') }}|{{ trans('general.notes') }}
+|-|:------------- |:-------------|:---------|:---------|:---------|:---------|:---------|
 @foreach ($assets as $asset)
 @php
 $next_audit_date = Helper::getFormattedDateObject($asset->next_audit_date, 'date', false);
@@ -12,7 +12,7 @@ $last_audit_date = Helper::getFormattedDateObject($asset->last_audit_date, 'date
 $diff = Carbon::parse(Carbon::now())->diffInDays($asset->next_audit_date, false);
 $icon = ($diff <= 7) ? '🚨' : (($diff <= 14) ? '⚠️' : ' ');
 @endphp
-|{{ $icon }}| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset->id) }}) | {{ $last_audit_date }}| {{ $next_audit_date }} | {{ $diff }}  | {{ ($asset->supplier ? e($asset->supplier->name) : '') }}|{{ ($asset->assignedTo ? $asset->assignedTo->present()->name() : '') }}
+|{{ $icon }}| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset->id) }}) | {{ $last_audit_date }}| {{ $next_audit_date }} | {{ $diff }}  | {{ ($asset->supplier ? e($asset->supplier->name) : '') }}|{{ ($asset->assignedTo ? $asset->assignedTo->present()->name() : '') }}|{{ $asset->notes }}
 @endforeach
 @endcomponent
 


### PR DESCRIPTION
# Description

As the title says, any notes added to an asset will appear in the next/upcoming audit notification. This is relevant for our company and might be of use to others.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

By adding notes to a test asset, changing the audit date to today and pinging the scheduler to generate a notification (see screenshot attached)

**Test Configuration**:
* PHP version: 7.4.30
* MariaDB version: 10.5.15
* Webserver version: Apache2 2.4.54
* OS version: Debian 10


# Checklist:

- [x ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
![Screenshot 2022-08-31 132220](https://user-images.githubusercontent.com/94169344/187667753-aaffbdec-a268-4719-8bcb-8b6d2d601796.png)
