### PR TITLE
Fixed #11769: PAT Test hardcoded text

### DIFF
--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -74,7 +74,7 @@ class AssetMaintenance extends Model implements ICompanyableChild
             trans('admin/asset_maintenances/general.maintenance') => trans('admin/asset_maintenances/general.maintenance'),
             trans('admin/asset_maintenances/general.repair')      => trans('admin/asset_maintenances/general.repair'),
             trans('admin/asset_maintenances/general.upgrade')     => trans('admin/asset_maintenances/general.upgrade'),
-            'PAT test'      => 'PAT test',
+            trans('admin/asset_maintenances/general.pat_test')     => trans('admin/asset_maintenances/general.pat_test'),
             trans('admin/asset_maintenances/general.calibration')     => trans('admin/asset_maintenances/general.calibration'),
             trans('admin/asset_maintenances/general.software_support')      => trans('admin/asset_maintenances/general.software_support'),
             trans('admin/asset_maintenances/general.hardware_support')      => trans('admin/asset_maintenances/general.hardware_support'),


### PR DESCRIPTION
# Description

Changed a hard-coded text to use a translation, just like all other items in the list. This is to allow proper translation and localization of this item ("PAT Test")


Fixes #11769

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested by changing the translations is the following files:
resources/lang/en/admin/asset_maintenances/general.php
resources/lang/es-MX/admin/asset_maintenances/general.php

and changing the 'pat_test' => 'PAT Test' to 'Other test' for en (English) and 'PAT prueba' for es-MX (Spanish, Mexico)

And then you can go to the Maintenance tab on an asset, in English or in Spanish, and Create New and see the new translation as an option ("Other test" or "PAT prueba" vs "PAT Test")


**Test Configuration**:
* PHP version: 8.1.9
Apache
* OS version Ubuntu


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
