### PR TITLE
Fixed Double login when switching users

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -473,6 +473,11 @@ class LoginController extends Controller
         }
 
         $request->session()->regenerate(true);
+
+        if ($request->session()->has('password_hash_'.Auth::getDefaultDriver())){
+            $request->session()->remove('password_hash_'.Auth::getDefaultDriver());
+        }
+
         Auth::logout();
 
         if (! empty($sloRedirectUrl)) {


### PR DESCRIPTION
# Description
When changing users (logout with user Foo, then login back with another user Bar), the system appear to not doing anything and re-show the Log In form, no error, no message displayed.

It happens because the previous logged in user's hash is saved in a session value, so when switching users the hash is different as the one trying to log in, so the system logs out us without warning. Second time the session value doesn't exists anymore so it let us log in normally. 

To fix this I remove that value (`password_hash_web`) from the session and now it works as intended. Maybe is worth to think about removing all session values on logout? since I don't think it's necessary to save any session value once we log out?

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 7.4.16
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
