### PR TITLE
Fixed Mini quantity field values are not importing into Snipe-IT

### DIFF
--- a/app/Importer/AccessoryImporter.php
+++ b/app/Importer/AccessoryImporter.php
@@ -43,6 +43,7 @@ class AccessoryImporter extends ItemImporter
         $this->log('No Matching Accessory, Creating a new one');
         $accessory = new Accessory();
         $this->item['model_number'] = $this->findCsvMatch($row, "model_number");
+        $this->item['min_amt'] = $this->findCsvMatch($row, "min_amt");
         $accessory->fill($this->sanitizeItemForStoring($accessory));
 
         //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.

--- a/app/Importer/ConsumableImporter.php
+++ b/app/Importer/ConsumableImporter.php
@@ -43,6 +43,7 @@ class ConsumableImporter extends ItemImporter
         $consumable = new Consumable();
         $this->item['model_number'] = $this->findCsvMatch($row, 'model_number');
         $this->item['item_no'] = $this->findCsvMatch($row, 'item_number');
+        $this->item['min_amt'] = $this->findCsvMatch($row, "min_amt");
         $consumable->fill($this->sanitizeItemForStoring($consumable));
         //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.
         $consumable->unsetEventDispatcher();


### PR DESCRIPTION
# Description
The CSV importer for Consumables and Accessories doesn't include the `min_amt` field, so this PR adds it.

Fixes  freshdesk #30628 and shortcut [sc-19520]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
