### PR TITLE
Fixed #11822 - depreciation calculations off

### DIFF
--- a/app/Http/Transformers/DepreciationsTransformer.php
+++ b/app/Http/Transformers/DepreciationsTransformer.php
@@ -3,6 +3,7 @@
 namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
+use App\Models\Depreciable;
 use App\Models\Depreciation;
 use Gate;
 use Illuminate\Database\Eloquent\Collection;
@@ -19,13 +20,14 @@ class DepreciationsTransformer
         return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
-    public function transformDepreciation(Depreciation $depreciation)
+    public function transformDepreciation(Depreciation $depreciation, Depreciable $monthly_depreciation)
     {
         $array = [
             'id' => (int) $depreciation->id,
             'name' => e($depreciation->name),
             'months' => $depreciation->months.' '.trans('general.months'),
             'depreciation_min' => $depreciation->depreciation_min,
+            'monthly_depreciation' => $monthly_depreciation->getMonthlyDepreciation(),
             'created_at' => Helper::getFormattedDateObject($depreciation->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($depreciation->updated_at, 'datetime')
         ];

--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -68,9 +68,10 @@ class Depreciable extends SnipeModel
      */
     public function getLinearDepreciatedValue() // TODO - for testing it might be nice to have an optional $relative_to param here, defaulted to 'now'
     {
-        $months_remaining = $this->time_until_depreciated()->m + 12 * $this->time_until_depreciated()->y; //UGlY
+        $months_passed = $this->purchase_date->diff(now())->m;
 
-        $current_value = round(($months_remaining / $this->get_depreciation()->months) * $this->purchase_cost, 2);
+        // The equation here is (Purchase_Cost-Floor_min)*(Months_passed/Months_til_depreciated)
+        $current_value= round((($this->purchase_cost-$this->get_depreciation()->depreciation_min)*($months_passed/$this->get_depreciation()->months)),2);
 
         if($this->get_depreciation()->depreciation_min > $current_value) {
 

--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -70,18 +70,29 @@ class Depreciable extends SnipeModel
     {
         $months_passed = $this->purchase_date->diff(now())->m;
 
-        // The equation here is (Purchase_Cost-Floor_min)*(Months_passed/Months_til_depreciated)
-        $current_value= round((($this->purchase_cost-$this->get_depreciation()->depreciation_min)*($months_passed/$this->get_depreciation()->months)),2);
+        if($months_passed >= $this->get_depreciation()->months){
+            //if there is a floor use it
+            if($this->get_depreciation()->deprecation_min->isNotEmpty()) {
 
-        if($this->get_depreciation()->depreciation_min > $current_value) {
+                $current_value = $this->get_depreciation()->depreciation_min;
 
-            $current_value=round($this->get_depreciation()->depreciation_min,2);
+            }else{
+                $current_value = 0;
+            }
         }
-        if ($current_value < 0) {
-            $current_value = 0;
+        else {
+            // The equation here is (Purchase_Cost-Floor_min)*(Months_passed/Months_til_depreciated)
+            $current_value = round(($this->purchase_cost-($this->purchase_cost - ($this->get_depreciation()->depreciation_min)) * ($months_passed / $this->get_depreciation()->months)), 2);
+
         }
 
         return $current_value;
+    }
+
+    public function getMonthlyDepreciation(){
+
+        return ($this->purchase_cost-$this->get_depreciation()->depreciation_min)/$this->get_depreciation()->months;
+
     }
 
     /**


### PR DESCRIPTION
# Description

Fixes the Depreciation calculations of current value and monthly depreciation.



Fixes #11822 

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
