### PR TITLE
Fixed custom asset report timeout - removed assetlog

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -589,7 +589,7 @@ class ReportsController extends Controller
             \Log::debug('Added headers: '.$executionTime);
 
             $assets = \App\Models\Company::scopeCompanyables(Asset::select('assets.*'))->with(
-                'location', 'assetstatus', 'assetlog', 'company', 'defaultLoc', 'assignedTo',
+                'location', 'assetstatus', 'company', 'defaultLoc', 'assignedTo',
                 'model.category', 'model.manufacturer', 'supplier');
             
             if ($request->filled('by_location_id')) {


### PR DESCRIPTION
This fix would only apply for situations where the `action_logs` table is very bloated (have a million records or more). Since I don't think we actually use that table in this query anymore (we de-normed a lot over the years), this should just speed up that report quite a lot.