### PR TITLE
Added Applecare lookup link if manufacturer is apple

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -584,7 +584,11 @@
                                                 {{ $asset->warranty_months }}
                                                 {{ trans('admin/hardware/form.months') }}
 
-
+                                                @if (($asset->serial && $asset->model->manufacturer) && $asset->model->manufacturer->name == 'Apple')
+                                                    <a href="https://checkcoverage.apple.com/us/{{ \App\Models\Setting::getSettings()->locale  }}/?sn={{ $asset->serial }}" target="_blank">
+                                                        <i class="fa-brands fa-apple" aria-hidden="true"><span class="sr-only">Applecare Statys Lookup</span></i>
+                                                    </a>
+                                                @endif
                                             </div>
                                         </div>
 


### PR DESCRIPTION
This is a really small, trivial changes, but it adds a linked AppleCare icon to the warranty info if the manufacturer name is Apple. This is obviously not going to work for everyone - if you're a windows shop, or if you (for example) entered Apple as "Apple, Inc", it won't show -- and Apple uses a captcha which actually prevents us from linking directly at least if you're not logged in - but it's an easy win that could potentiaily make *some* people's lives a little easier. 

<img width="386" alt="Screen Shot 2022-09-14 at 7 43 58 PM" src="https://user-images.githubusercontent.com/197404/190301771-78f131ca-1bfb-4234-a758-40f0b8e19519.png">
