### PR TITLE
Fixed #9801 #11199 Default Values for Checkbox Field Types Unaccessible

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -235,6 +235,10 @@ class CustomFieldsController extends Controller
             $field->format = e($request->get('format'));
         }
 
+        if($field->element == 'checkbox' || $field->element == 'radio'){
+            $field->format = 'ANY';
+        }
+
         if ($field->save()) {
             return redirect()->route('fields.index')->with('success', trans('admin/custom_fields/message.field.update.success'));
         }

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -46,7 +46,9 @@
                                         <input type='radio' name="default_values[{{ $field->id }}]" value="{{$field_value}}" {{ $field->defaultValue($model_id) == $field_value ? 'checked="checked"': '' }} />{{ $field_value }}<br />
                                     @endforeach
                                 @elseif($field->element == "checkbox")
-                                    <input type='checkbox' name="default_values[{{ $field->id }}]" {{ $field->defaultValue($model_id) ? 'checked="checked"': '' }}/>
+                                    @foreach(explode("\r\n", $field->field_values) as $field_value)
+                                        <input type='checkbox' name="default_values[{{ $field->id }}]" value="{{$field_value}}" {{ $field->defaultValue($model_id) == $field_value ? 'checked="checked"': '' }} /> {{ $field_value }}<br />
+                                    @endforeach
                                 @else
                                     <span class="help-block form-error">
                                         Unknown field element: {{ $field->element }}

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -47,7 +47,7 @@
                                     @endforeach
                                 @elseif($field->element == "checkbox")
                                     @foreach(explode("\r\n", $field->field_values) as $field_value)
-                                        <input type='checkbox' name="default_values[{{ $field->id }}]" value="{{$field_value}}" {{ $field->defaultValue($model_id) == $field_value ? 'checked="checked"': '' }} /> {{ $field_value }}<br />
+                                        <input type='checkbox' name="default_values[{{ $field->id }}][]" value="{{$field_value}}" {{ in_array($field_value, explode(', ',$field->defaultValue($model_id))) ? 'checked="checked"': '' }} /> {{ $field_value }}<br />
                                     @endforeach
                                 @else
                                     <span class="help-block form-error">


### PR DESCRIPTION
# Description
I love when a proper PR fixes a couple or more of issues. When we had an element type of checkbox in a custom field, and we tried to assign default values to that element, the controls doesn't show up properly, so now they are showing and functioning nicely. Also, while fixing this I ended up addressing an issue where when changing an element, textbox for example, with a format of type numeric, if we change it to a radiobutton or a checkbox, they conserve the numeric format and we can't set values alphanumeric to those checkboxes, making 'em not usable.

Fixes #9801 #11199

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
