### PR TITLE
Added try/catch wrap notifications to catch notification failures on checkin/checkout

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -20,6 +20,8 @@ use App\Notifications\CheckoutConsumableNotification;
 use App\Notifications\CheckoutLicenseNotification;
 use App\Notifications\CheckoutLicenseSeatNotification;
 use Illuminate\Support\Facades\Notification;
+use Exception;
+use Log;
 
 class CheckoutableListener
 {
@@ -43,16 +45,20 @@ class CheckoutableListener
          */
         $acceptance = $this->getCheckoutAcceptance($event);       
 
-        if (! $event->checkedOutTo->locale) {
-            Notification::locale(Setting::getSettings()->locale)->send(
-                $this->getNotifiables($event), 
-                $this->getCheckoutNotification($event, $acceptance)
-            );
-        } else {
-            Notification::send(
-                $this->getNotifiables($event), 
-                $this->getCheckoutNotification($event, $acceptance)
-            );
+        try {
+            if (! $event->checkedOutTo->locale) {
+                Notification::locale(Setting::getSettings()->locale)->send(
+                    $this->getNotifiables($event),
+                    $this->getCheckoutNotification($event, $acceptance)
+                );
+            } else {
+                Notification::send(
+                    $this->getNotifiables($event),
+                    $this->getCheckoutNotification($event, $acceptance)
+                );
+            }
+        } catch (Exception $e) {
+            Log::error("Exception caught during checkout notification: ".$e->getMessage());
         }
     }
 
@@ -83,17 +89,21 @@ class CheckoutableListener
             }
         }
 
-        // Use default locale
-        if (! $event->checkedOutTo->locale) {
-            Notification::locale(Setting::getSettings()->locale)->send(
-                $this->getNotifiables($event),
-                $this->getCheckinNotification($event)
-            );
-        } else {
-            Notification::send(
-                $this->getNotifiables($event),
-                $this->getCheckinNotification($event)
-            );
+        try {
+            // Use default locale
+            if (! $event->checkedOutTo->locale) {
+                Notification::locale(Setting::getSettings()->locale)->send(
+                    $this->getNotifiables($event),
+                    $this->getCheckinNotification($event)
+                );
+            } else {
+                Notification::send(
+                    $this->getNotifiables($event),
+                    $this->getCheckinNotification($event)
+                );
+            }
+        } catch (Exception $e) {
+            Log::error("Exception caught during checkin notification: ".$e->getMessage());
         }
     }      
 


### PR DESCRIPTION
This is an attempt to better-handle problematic notifications - incorrect Slack webhooks, invalid email addresses, and the like. A try/catch block now wraps the notifications that fire on both checkin and checkout.

I *was* able to see the Log entry when the checkout fired to a user with an invalid email address, but I haven't yet been able to see the log entries fire on checkin - which makes me wonder if those are somehow firing in a different way.

I also *wasn't* able to replicate the Slack issues we had been having - where incorrect slack webhooks cause server-level 5xx errors.

I'll definitely be happy to take any advice on how to better trigger some of these error conditions so we can see if my try/catch stuff is actually working correctly.

One other thing I'm curious about is if there's a way to capture the results of the event-dispatch (which fires the notifications), so we can warn users "The asset was checked out, but notifications were unable to be sent" (and something similar for checkin?) But I'm not sure exactly how that we can return values from event handles and have them bubble up to our controllers. There is documented some stuff about doing a 'return false' within an event handler, which should halt event propagation, I just don't know if the `event()` facade is going to propagate that `false` back to us from when we invoked it.