### PR TITLE
Fixes 500 in depreciation on asset view when no purchase date

### DIFF
--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -68,9 +68,13 @@ class Depreciable extends SnipeModel
      */
     public function getLinearDepreciatedValue() // TODO - for testing it might be nice to have an optional $relative_to param here, defaulted to 'now'
     {
-        $months_passed = $this->purchase_date->diff(now())->m;
+        if ($this->purchase_date) {
+            $months_passed = $this->purchase_date->diff(now())->m;
+        } else {
+            return null;
+        }
 
-        if($months_passed >= $this->get_depreciation()->months){
+        if ($months_passed >= $this->get_depreciation()->months){
             //if there is a floor use it
             if($this->get_depreciation()->deprecation_min->isNotEmpty()) {
 

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -372,6 +372,7 @@ return [
     'bulk_checkin_delete_success' => 'Your selected users have been deleted and their items have been checked in.',
     'bulk_checkin_success' => 'The items for the selected users have been checked in.',
     'set_to_null' => 'Delete values for this asset|Delete values for all :asset_count assets ',
+    'na_no_purchase_date'   => 'N/A - No purchase date provided',
 
 
 ];

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -519,7 +519,7 @@
                                             </div>
                                         </div>
                                     @endif
-                                    @if (($asset->model) && ($asset->depreciation))
+                                    @if (($asset->model) && ($asset->depreciation) && ($asset->purchase_date))
                                         <div class="row">
                                             <div class="col-md-2">
                                                 <strong>
@@ -597,14 +597,17 @@
                                                     <strong>
                                                         {{ trans('admin/hardware/form.warranty_expires') }}
                                                         {!! $asset->present()->warranty_expires() < date("Y-m-d") ? '<i class="fas fa-exclamation-triangle text-orange" aria-hidden="true"></i>' : '' !!}
+
                                                     </strong>
                                                 </div>
                                                 <div class="col-md-6">
-
+                                                    @if ($asset->purchase_date)
                                                     {{ Helper::getFormattedDateObject($asset->present()->warranty_expires(), 'date', false) }}
                                                     -
                                                     {{ Carbon::parse($asset->present()->warranty_expires())->diffForHumans() }}
-
+                                                    @else
+                                                        {{ trans('general.na_no_purchase_date') }}
+                                                    @endif
                                                 </div>
                                             </div>
 
@@ -630,9 +633,13 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-6">
+                                                @if ($asset->purchase_date)
                                                 {{ Helper::getFormattedDateObject($asset->depreciated_date()->format('Y-m-d'), 'date', false) }}
                                                 -
                                                 {{ Carbon::parse($asset->depreciated_date())->diffForHumans() }}
+                                                @else
+                                                    {{ trans('general.na_no_purchase_date') }}
+                                                @endif
 
                                             </div>
                                         </div>
@@ -659,10 +666,13 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-6">
+                                                @if ($asset->purchase_date)
                                                 {{ Helper::getFormattedDateObject($asset->present()->eol_date(), 'date', false) }}
                                                 -
                                                 {{ Carbon::parse($asset->present()->eol_date())->diffForHumans() }}
-                                                
+                                                @else
+                                                    {{ trans('general.na_no_purchase_date') }}
+                                                @endif
                                             </div>
                                         </div>
                                     @endif

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -596,7 +596,9 @@
                                                 <div class="col-md-2">
                                                     <strong>
                                                         {{ trans('admin/hardware/form.warranty_expires') }}
+                                                        @if ($asset->purchase_date)
                                                         {!! $asset->present()->warranty_expires() < date("Y-m-d") ? '<i class="fas fa-exclamation-triangle text-orange" aria-hidden="true"></i>' : '' !!}
+                                                        @endif
 
                                                     </strong>
                                                 </div>


### PR DESCRIPTION
This was (I think) created by a PR from a week or so ago, and would only show up if you had a category with a depreciation set but no purchase cost. The change in the other PR set up a `->diff()` method, but that will crash if `$this->purchase_date` is null.

```php
[2022-09-15 15:32:16] local.ERROR: Error: Call to a member function diff() on null in /Users/snipe/Sites/snipe-it/snipe-it/app/Models/Depreciable.php:71
Stack trace:
#0 /Users/snipe/Sites/snipe-it/snipe-it/app/Models/Depreciable.php(60): App\Models\Depreciable->getLinearDepreciatedValue()
```

This is what that output looks like now (versus a 500):

<img width="455" alt="Screen Shot 2022-09-15 at 3 42 28 PM" src="https://user-images.githubusercontent.com/197404/190521370-5de6ba87-cbc7-455b-8c53-13afab09e6f5.png">
