### PR TITLE
Fixed 500 error if uploaded file is missing from asset view

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1198,10 +1198,14 @@
                                                     @endif
                                                 </td>
                                                 <td>
+                                                    @if (Storage::exists('private_uploads/assets/'.$file->filename))
                                                     {{ $file->filename }}
+                                                    @else
+                                                    <del>{{ $file->filename }}</del>
+                                                    @endif
                                                 </td>
-                                                <td data-value="{{ @Storage::size('private_uploads/assets/'.$file->filename) }}">
-                                                    {{ @Helper::formatFilesizeUnits(Storage::size('private_uploads/assets/'.$file->filename)) }}
+                                                <td data-value="{{ (Storage::exists('private_uploads/assets/'.$file->filename) ? Storage::size('private_uploads/assets/'.$file->filename) : '') }}">
+                                                    {{ @Helper::formatFilesizeUnits(Storage::exists('private_uploads/assets/'.$file->filename) ? Storage::size('private_uploads/assets/'.$file->filename) : '') }}
                                                 </td>
                                                 <td>
                                                     @if ($file->note)
@@ -1291,10 +1295,14 @@
                                                     @endif
                                                 </td>
                                                 <td>
-                                                    {{ $file->filename }}
+                                                    @if (Storage::exists('private_uploads/assetmodels/'.$file->filename))
+                                                        {{ $file->filename }}
+                                                    @else
+                                                        <del>{{ $file->filename }}</del>
+                                                    @endif
                                                 </td>
-                                                <td data-value="{{ Storage::size('private_uploads/assetmodels/'.$file->filename) }}">
-                                                    {{ Helper::formatFilesizeUnits(Storage::size('private_uploads/assetmodels/'.$file->filename)) }}
+                                                <td data-value="{{ (Storage::exists('private_uploads/assetmodels/'.$file->filename) ? Storage::size('private_uploads/assetmodels/'.$file->filename) : '') }}">
+                                                    {{ Helper::formatFilesizeUnits(@Storage::size('private_uploads/assetmodels/'.$file->filename)) }}
                                                 </td>
                                                 <td>
                                                     @if ($file->note)

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1213,7 +1213,7 @@
                                                     @endif
                                                 </td>
                                                 <td>
-                                                    @if ($file->filename)
+                                                    @if (($file->filename) && (Storage::exists('private_uploads/assets/'.$file->filename)))
                                                         <a href="{{ route('show/assetfile', [$asset->id, $file->id]) }}" class="btn btn-default">
                                                             <i class="fas fa-download" aria-hidden="true"></i>
                                                         </a>
@@ -1310,7 +1310,7 @@
                                                     @endif
                                                 </td>
                                                 <td>
-                                                    @if ($file->filename)
+                                                    @if (($file->filename) && (Storage::exists('private_uploads/assetmodels/'.$file->filename)))
                                                         <a href="{{ route('show/modelfile', [$asset->model->id, $file->id]) }}" class="btn btn-default">
                                                             <i class="fas fa-download" aria-hidden="true"></i>
                                                         </a>


### PR DESCRIPTION
Turns out, using an `@` doesn't suppress `Storage::` exceptions, so I've updated this to check if the file exists, versus throwing a 500.

<img width="1577" alt="Screen Shot 2022-09-15 at 4 14 15 PM" src="https://user-images.githubusercontent.com/197404/190524550-f58f64a8-ee9b-4063-83f1-e13ed549eb2b.png">
