### PR TITLE
Check for `licenses.files` permissions

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseFilesController.php
+++ b/app/Http/Controllers/Licenses/LicenseFilesController.php
@@ -135,6 +135,7 @@ class LicenseFilesController extends Controller
         // the license is valid
         if (isset($license->id)) {
             $this->authorize('view', $license);
+            $this->authorize('licenses.files', $license);
 
             if (! $log = Actionlog::find($fileId)) {
                 return response('No matching record for that asset/file', 500)
@@ -171,6 +172,6 @@ class LicenseFilesController extends Controller
             }
         }
 
-        return redirect()->route('license.index')->with('error', trans('admin/licenses/message.does_not_exist', ['id' => $fileId]));
+        return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.does_not_exist', ['id' => $fileId]));
     }
 }

--- a/app/Policies/LicensePolicy.php
+++ b/app/Policies/LicensePolicy.php
@@ -42,8 +42,12 @@ class LicensePolicy extends CheckoutablePermissionsPolicy
      * @param  \App\Models\User  $user
      * @return mixed
      */
-    public function files(User $user)
+    public function viewFiles(User $user)
     {
-        return $user->hasAccess($this->columnName().'.files');
+        if ($user->hasAccess('licenses.files'))  {
+            return true;
+        }
+        return false;
+
     }
 }

--- a/app/Policies/LicensePolicy.php
+++ b/app/Policies/LicensePolicy.php
@@ -42,7 +42,7 @@ class LicensePolicy extends CheckoutablePermissionsPolicy
      * @param  \App\Models\User  $user
      * @return mixed
      */
-    public function viewFiles(User $user)
+    public function files(User $user, $license = null)
     {
         if ($user->hasAccess('licenses.files'))  {
             return true;

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -61,6 +61,11 @@ abstract class SnipePermissionsPolicy
         return $user->hasAccess($this->columnName().'.view');
     }
 
+    public function files(User $user, $item = null)
+    {
+        return $user->hasAccess($this->columnName().'.files');
+    }
+
     /**
      * Determine whether the user can create accessories.
      *

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -122,6 +122,13 @@ class AuthServiceProvider extends ServiceProvider
         });
 
 
+        Gate::define('licenses.files', function ($user) {
+            if ($user->hasAccess('licenses.files')) {
+                return true;
+            }
+        });
+
+
         // -----------------------------------------
         // Reports
         // -----------------------------------------

--- a/resources/lang/en/admin/licenses/message.php
+++ b/resources/lang/en/admin/licenses/message.php
@@ -2,7 +2,7 @@
 
 return array(
 
-    'does_not_exist' => 'License does not exist.',
+    'does_not_exist' => 'License does not exist or you do not have permission to view it.',
     'user_does_not_exist' => 'User does not exist.',
     'asset_does_not_exist' 	=> 'The asset you are trying to associate with this license does not exist.',
     'owner_doesnt_match_asset' => 'The asset you are trying to associate with this license is owned by somene other than the person selected in the assigned to dropdown.',

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -36,7 +36,8 @@
 
             </a>
         </li>
-        
+
+        @can('licenses.files', $license)
         <li>
           <a href="#files" data-toggle="tab">
             <span class="hidden-lg hidden-md">
@@ -46,6 +47,7 @@
             </span>
           </a>
         </li>
+        @endcan
 
         <li>
           <a href="#history" data-toggle="tab">
@@ -416,7 +418,7 @@
           </div> <!--/.row-->
         </div> <!-- /.tab-pane -->
 
-        @can('files', $license)
+        @can('licenses.files', $license)
         <div class="tab-pane" id="files">
           <div class="table-responsive">
             <table


### PR DESCRIPTION
This is a security fix to actually check that the user has permission to view files (not just licenses themselves.)

### Without permissions

<img width="728" alt="Screen Shot 2022-09-16 at 2 07 00 PM" src="https://user-images.githubusercontent.com/197404/190746829-8df66621-148b-4466-9fcc-8482bae1ddab.png">


### With permissions

<img width="821" alt="Screen Shot 2022-09-16 at 2 01 51 PM" src="https://user-images.githubusercontent.com/197404/190747057-2833f421-26bf-4580-8466-eabe6558e49a.png">

The user will get a sad panda if they try to access files they do not have access to.