### PR TITLE
Fixes the color choice for the ldap_test_results

### DIFF
--- a/resources/assets/less/skins/skin-black-dark.less
+++ b/resources/assets/less/skins/skin-black-dark.less
@@ -132,6 +132,9 @@ a {
   --nav-link: #FFF; /* Use same as Header picker */
   --light-link: #fff; /* Use same as Header picker */
 }
+#ldapad_test_results {
+  color: var(--back-main);
+}
 
 .main-header .navbar, .main-header .logo {
   background-color: var(--header);

--- a/resources/assets/less/skins/skin-black-dark.less
+++ b/resources/assets/less/skins/skin-black-dark.less
@@ -132,7 +132,7 @@ a {
   --nav-link: #FFF; /* Use same as Header picker */
   --light-link: #fff; /* Use same as Header picker */
 }
-#ldapad_test_results {
+#ldapad_test_results.well.well-sm{
   color: var(--back-main);
 }
 

--- a/resources/assets/less/skins/skin-blue-dark.less
+++ b/resources/assets/less/skins/skin-blue-dark.less
@@ -129,7 +129,7 @@ a {
   --light-link: #fff; /* Use same as Header picker */
 }
 
-#ldapad_test_results {
+#ldapad_test_results.well.well-sm{
   color: var(--back-main);
 }
 

--- a/resources/assets/less/skins/skin-blue-dark.less
+++ b/resources/assets/less/skins/skin-blue-dark.less
@@ -129,6 +129,10 @@ a {
   --light-link: #fff; /* Use same as Header picker */
 }
 
+#ldapad_test_results {
+  color: var(--back-main);
+}
+
 .main-header .navbar, .main-header .logo {
   background-color: var(--header);
   background: -webkit-linear-gradient(top,  var(--header) 0%,var(--header) 100%);

--- a/resources/assets/less/skins/skin-green-dark.less
+++ b/resources/assets/less/skins/skin-green-dark.less
@@ -128,7 +128,7 @@ a {
   --light-link: #fff; /* Use same as Header picker */
 }
 
-#ldapad_test_results {
+#ldapad_test_results.well.well-sm{
   color: var(--back-main);
 }
 

--- a/resources/assets/less/skins/skin-green-dark.less
+++ b/resources/assets/less/skins/skin-green-dark.less
@@ -128,6 +128,10 @@ a {
   --light-link: #fff; /* Use same as Header picker */
 }
 
+#ldapad_test_results {
+  color: var(--back-main);
+}
+
 .main-header .navbar, .main-header .logo {
   background-color: var(--header);
   background: -webkit-linear-gradient(top,  var(--header) 0%,var(--header) 100%);

--- a/resources/assets/less/skins/skin-orange-dark.less
+++ b/resources/assets/less/skins/skin-orange-dark.less
@@ -116,6 +116,10 @@ li.dropdown-item-marker {
   --light-link: #fff; /* Use same as Header picker */
 }
 
+#ldapad_test_results {
+  color: var(--back-main);
+}
+
 .main-header .navbar, .main-header .logo {
   background-color: var(--header);
   background: -webkit-linear-gradient(top,  var(--header) 0%,var(--header) 100%);

--- a/resources/assets/less/skins/skin-orange-dark.less
+++ b/resources/assets/less/skins/skin-orange-dark.less
@@ -116,7 +116,7 @@ li.dropdown-item-marker {
   --light-link: #fff; /* Use same as Header picker */
 }
 
-#ldapad_test_results {
+#ldapad_test_results.well.well-sm{
   color: var(--back-main);
 }
 

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -129,7 +129,7 @@ a {
   --light-link: #fff; /* Use same as Header picker */
 }
 
-#ldapad_test_results {
+#ldapad_test_results.well.well-sm{
   color: var(--back-main);
 }
 

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -129,6 +129,10 @@ a {
   --light-link: #fff; /* Use same as Header picker */
 }
 
+#ldapad_test_results {
+  color: var(--back-main);
+}
+
 .main-header .navbar, .main-header .logo {
   background-color: var(--header);
   background: -webkit-linear-gradient(top,  var(--header) 0%,var(--header) 100%);

--- a/resources/assets/less/skins/skin-red-dark.less
+++ b/resources/assets/less/skins/skin-red-dark.less
@@ -131,6 +131,10 @@ a {
   --light-link: #fff; /* Use same as Header picker */
 }
 
+#ldapad_test_results {
+  color: var(--back-main);
+}
+
 .main-header .navbar, .main-header .logo {
   background-color: var(--header);
   background: -webkit-linear-gradient(top,  var(--header) 0%,var(--header) 100%);

--- a/resources/assets/less/skins/skin-red-dark.less
+++ b/resources/assets/less/skins/skin-red-dark.less
@@ -131,7 +131,7 @@ a {
   --light-link: #fff; /* Use same as Header picker */
 }
 
-#ldapad_test_results {
+#ldapad_test_results.well.well-sm{
   color: var(--back-main);
 }
 

--- a/resources/assets/less/skins/skin-yellow-dark.less
+++ b/resources/assets/less/skins/skin-yellow-dark.less
@@ -122,6 +122,10 @@ a {
   --light-link: #545454; /* Use same as Header picker */
 }
 
+#ldapad_test_results {
+  color: var(--back-main);
+}
+
 .main-header .navbar, .main-header .logo {
   background-color: var(--header);
   background: -webkit-linear-gradient(top,  var(--header) 0%,var(--header) 100%);

--- a/resources/assets/less/skins/skin-yellow-dark.less
+++ b/resources/assets/less/skins/skin-yellow-dark.less
@@ -122,7 +122,7 @@ a {
   --light-link: #545454; /* Use same as Header picker */
 }
 
-#ldapad_test_results {
+#ldapad_test_results.well.well-sm{
   color: var(--back-main);
 }
 


### PR DESCRIPTION
# Description

Fixes the color choice on `ldap_test_results` as well as the query text in between in dark mode skins to a more viewable color:
<img width="491" alt="image" src="https://user-images.githubusercontent.com/47435081/191094858-15b6f441-72af-4779-88cd-01f3e24d37c3.png">


Fixes # SC-19527

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
