### PR TITLE
Fixed #11847 404 error during Import if a checkout type of location is specified and no checkout location is passed

### DIFF
--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -112,7 +112,7 @@ class ItemImporter extends Importer
             return $this->createOrFetchUser($row);
         }
 
-        if (strtolower($this->item['checkout_class']) === 'location') {
+        if (strtolower($this->item['checkout_class']) === 'location' && $this->findCsvMatch($row, 'checkout_location') != null ) {
             return Location::findOrFail($this->createOrFetchLocation($this->findCsvMatch($row, 'checkout_location')));
         }
 


### PR DESCRIPTION
# Description
Adds a condition to see if a checkout location is passed from the CSV to the importer. I just ignored the field if the CSV have the field empty, because looking at the code, `rtd_location` is used as base checked-out to location, and then overwriten for the one passed in `checkout_location`, so I thought the best approach was to not look for a location if no location is specified.

Fixes #11847 

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1.10
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
