### PR TITLE
Fixed Purchase date "readonly" value makes purchase date unable to be nulled in update form [sc-19540]

### DIFF
--- a/resources/views/partials/forms/edit/purchase_date.blade.php
+++ b/resources/views/partials/forms/edit/purchase_date.blade.php
@@ -6,7 +6,7 @@
             <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="purchase_date" id="purchase_date" readonly value="{{ old('purchase_date', ($item->purchase_date) ? $item->purchase_date->format('Y-m-d') : '') }}" style="background-color:inherit">
             <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
        </div>
-       <a onclick="document.getElementById('purchase_date').value = ''"> Clear </a>
+       <a style="cursor:pointer" onclick="document.getElementById('purchase_date').value = ''"> Clear </a>
        {!! $errors->first('purchase_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
    </div>
 </div>

--- a/resources/views/partials/forms/edit/purchase_date.blade.php
+++ b/resources/views/partials/forms/edit/purchase_date.blade.php
@@ -6,6 +6,7 @@
             <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="purchase_date" id="purchase_date" readonly value="{{ old('purchase_date', ($item->purchase_date) ? $item->purchase_date->format('Y-m-d') : '') }}" style="background-color:inherit">
             <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
        </div>
+       <a onclick="document.getElementById('purchase_date').value = ''"> Clear </a>
        {!! $errors->first('purchase_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
    </div>
 </div>


### PR DESCRIPTION
# Description
When I make the Purchase Date input as read only, the capacity to delete the content of that input was lost. As the Purchase Date is an optional field, this was effectively an introduced bug.

This PR takes care of that error adding a link that allows to delete the date in the input and save the asset if for some reason we need to delete that value. For some reason my cursor stays as an i-beam instead of changing to a hand (link), but I don't think that was an issue.

Fixes shortcut 19540  [sc-19540]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1.10
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
