### PR TITLE
Fixed #11827 Throw exception when there are no available seats for checkout.

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckoutController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckoutController.php
@@ -60,7 +60,9 @@ class LicenseCheckoutController extends Controller
         $this->authorize('checkout', $license);
 
         $licenseSeat = $this->findLicenseSeatToCheckout($license, $seatId);
+        dd($licenseSeat);
         $licenseSeat->user_id = Auth::id();
+        
 
         $checkoutMethod = 'checkoutTo'.ucwords(request('checkout_to_type'));
         if ($this->$checkoutMethod($licenseSeat)) {
@@ -74,16 +76,21 @@ class LicenseCheckoutController extends Controller
     {
         $licenseSeat = LicenseSeat::find($seatId) ?? $license->freeSeat();
 
+        if(is_null($licenseSeat)){
+            throw new \Illuminate\Http\Exceptions\HttpResponseException(redirect()->route('licenses.index')->with('error', 'This Seat is not available for checkout.'));
+
+        }
+
         if (! $licenseSeat) {
             if ($seatId) {
-                return redirect()->route('licenses.index')->with('error', 'This Seat is not available for checkout.');
+                throw new \Illuminate\Http\Exceptions\HttpResponseException(redirect()->route('licenses.index')->with('error', 'This Seat is not available for checkout.'));
             }
-
-            return redirect()->route('licenses.index')->with('error', 'There are no available seats for this license');
+            
+            throw new \Illuminate\Http\Exceptions\HttpResponseException(redirect()->route('licenses.index')->with('error', 'There are no available seats for this license.'));
         }
 
         if (! $licenseSeat->license->is($license)) {
-            return redirect()->route('licenses.index')->with('error', 'The license seat provided does not match the license.');
+            throw new \Illuminate\Http\Exceptions\HttpResponseException(redirect()->route('licenses.index')->with('error', 'The license seat provided does not match the license.'));
         }
 
         return $licenseSeat;

--- a/app/Http/Controllers/Licenses/LicenseCheckoutController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckoutController.php
@@ -75,11 +75,6 @@ class LicenseCheckoutController extends Controller
     {
         $licenseSeat = LicenseSeat::find($seatId) ?? $license->freeSeat();
 
-        if(is_null($licenseSeat)){
-            throw new \Illuminate\Http\Exceptions\HttpResponseException(redirect()->route('licenses.index')->with('error', 'This Seat is not available for checkout.'));
-
-        }
-
         if (! $licenseSeat) {
             if ($seatId) {
                 throw new \Illuminate\Http\Exceptions\HttpResponseException(redirect()->route('licenses.index')->with('error', 'This Seat is not available for checkout.'));

--- a/app/Http/Controllers/Licenses/LicenseCheckoutController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckoutController.php
@@ -60,7 +60,6 @@ class LicenseCheckoutController extends Controller
         $this->authorize('checkout', $license);
 
         $licenseSeat = $this->findLicenseSeatToCheckout($license, $seatId);
-        dd($licenseSeat);
         $licenseSeat->user_id = Auth::id();
         
 


### PR DESCRIPTION
# Description
If no available License Seats are found in `LicenseCheckoutController::findLicenseSeatToCheckout()` function, for some reason the `return redirect()` statements aren't redirecting but returning an object of type `HttpResponse`. So I found another way to make the redirect.

Looks kind of gross... but it works now. Let me know if you think it can be done better.

Fixes #11827 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1.10
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
