### PR TITLE
Fixes monthly_depreciation and diff values for reports

### DIFF
--- a/app/Http/Transformers/DepreciationReportTransformer.php
+++ b/app/Http/Transformers/DepreciationReportTransformer.php
@@ -56,21 +56,22 @@ class DepreciationReportTransformer
         if ($asset->purchase_cost!='') {
             $purchase_cost = $asset->purchase_cost;
         }
-       
-
         /**
          * Override the previously set null values if there is a valid model and associated depreciation
          */
+        if($asset->get_depreciation() != null){
+            $monthly_depreciation = Helper::formatCurrencyOutput(($asset->purchase_cost - $asset->get_depreciation()->depreciation_min)/$asset->get_depreciation()->months);
+
+        }
+        else {
+            $monthly_depreciation = Helper::formatCurrencyOutput(($asset->model->eol > 0 ? ($asset->purchase_cost / $asset->model->eol) : 0));
+        }
         if (($asset->model) && ($asset->model->depreciation)) {
             $depreciated_value = Helper::formatCurrencyOutput($asset->getDepreciatedValue());
-            if($asset->model->eol==0 || $asset->model->eol==null ){
-                $monthly_depreciation = Helper::formatCurrencyOutput($asset->purchase_cost / $asset->model->depreciation->months);
-            }
-            else {
-                $monthly_depreciation = Helper::formatCurrencyOutput(($asset->model->eol > 0 ? ($asset->purchase_cost / $asset->model->eol) : 0));
-            }
-            $diff = Helper::formatCurrencyOutput(($asset->purchase_cost - $asset->getDepreciatedValue()));
         }
+
+        $diff = Helper::formatCurrencyOutput(($asset->purchase_cost - $asset->getDepreciatedValue()));
+
 
 
         if ($asset->assigned) {

--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -68,25 +68,15 @@ class Depreciable extends SnipeModel
      */
     public function getLinearDepreciatedValue() // TODO - for testing it might be nice to have an optional $relative_to param here, defaulted to 'now'
     {
-        if ($this->purchase_date) {
-            $months_passed = $this->purchase_date->diff(now())->m;
-        } else {
-            return null;
-        }
+        $months_passed = ($this->purchase_date->diff(now())->y*12) +($this->purchase_date->diff(now())->m);
 
         if ($months_passed >= $this->get_depreciation()->months){
             //if there is a floor use it
-            if($this->get_depreciation()->deprecation_min->isNotEmpty()) {
-
-                $current_value = $this->get_depreciation()->depreciation_min;
-
-            }else{
-                $current_value = 0;
-            }
+          $current_value = $this->get_depreciation()->depreciation_min;
         }
         else {
             // The equation here is (Purchase_Cost-Floor_min)*(Months_passed/Months_til_depreciated)
-            $current_value = round(($this->purchase_cost-($this->purchase_cost - ($this->get_depreciation()->depreciation_min)) * ($months_passed / $this->get_depreciation()->months)), 2);
+          $current_value = round(($this->purchase_cost-($this->purchase_cost - ($this->get_depreciation()->depreciation_min)) * ($months_passed / $this->get_depreciation()->months)), 2);
 
         }
 


### PR DESCRIPTION

# Description
Fixes the way `monthly_depreciations` value was being calculated in the transformer. Also the `diff` was acting weird when the `months_passed` was greater than 12 months. I didnt realize I had to add the years manually.

![image](https://user-images.githubusercontent.com/47435081/192349768-d079b1c9-a7d3-440a-9fde-242e5a98d0f0.png)
Fixes #11822 

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
