### PR TITLE
Delete duplicate fields from the importer dropdown menu [sc-19547]

### DIFF
--- a/resources/assets/js/components/importer/importer-file.vue
+++ b/resources/assets/js/components/importer/importer-file.vue
@@ -150,8 +150,6 @@
                     assets: [
                         {id: 'asset_tag', text: 'Asset Tag' },
                         {id: 'asset_model', text: 'Model Name' },
-                        {id: 'asset_notes', text: 'Asset Notes' },
-                        {id: 'model_notes', text: 'Model Notes' },
                         {id: 'checkout_class', text: 'Checkout Type' },
                         {id: 'checkout_location', text: 'Checkout Location' },
                         {id: 'image', text: 'Image Filename' },
@@ -196,7 +194,6 @@
                         {id: 'address', text: 'Address' },
                         {id: 'city', text: 'City' },
                         {id: 'state', text: 'State' },
-                        {id: 'zip', text: 'ZIP' },
                         {id: 'country', text: 'Country' },
                         {id: 'zip', text: 'ZIP' },
 

--- a/resources/assets/js/components/importer/importer-file.vue
+++ b/resources/assets/js/components/importer/importer-file.vue
@@ -189,7 +189,6 @@
                         {id: 'manager_first_name', text: 'Manager First Name' },
                         {id: 'notes', text: 'Notes' },
                         {id: 'manager_last_name', text: 'Manager Last Name' },
-                        {id: 'notes', text: 'Notes' },
                         {id: 'activated', text: 'Activated' },
                         {id: 'address', text: 'Address' },
                         {id: 'city', text: 'City' },

--- a/resources/assets/js/components/importer/importer-file.vue
+++ b/resources/assets/js/components/importer/importer-file.vue
@@ -172,7 +172,6 @@
                         {id: 'asset_tag', text: 'Assigned To Asset'},
                         {id: 'expiration_date', text: 'Expiration Date' },
                         {id: 'full_name', text: 'Full Name' },
-                        {id: 'notes', text: 'Notes' },
                         {id: 'license_email', text: 'Licensed To Email' },
                         {id: 'license_name', text: 'Licensed To Name' },
                         {id: 'notes', text: 'Notes' },


### PR DESCRIPTION
# Description
Some fields in the importer were duplicated, this PR just got rid off them.

Fixes freshdesk issue #30895 [sc-19547]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
