### PR TITLE
Fixed #11889 - API route for status labels asset listing

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -866,7 +866,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
                 ]
             )->name('api.statuslabels.assets.bytype');
 
-            Route::get('assetlist',
+            Route::get('{id}/assetlist',
                 [
                     Api\StatuslabelsController::class, 
                     'assets'


### PR DESCRIPTION
This should fix #11889 - the `{id}` parameter was missing from the route. IIRC, this route isn't used anywhere within the GUI, so this should not break anything. 