### PR TITLE
Fixed #11521 - Add option to switch to using status meta from status label name 

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -349,6 +349,7 @@ class SettingsController extends Controller
         $setting->privacy_policy_link = $request->input('privacy_policy_link');
 
         $setting->depreciation_method = $request->input('depreciation_method');
+        $setting->dash_chart_type = $request->input('dash_chart_type');
 
         if ($request->input('per_page') != '') {
             $setting->per_page = $request->input('per_page');

--- a/app/Http/Transformers/PieChartTransformer.php
+++ b/app/Http/Transformers/PieChartTransformer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Transformers;
+
+
+use App\Helpers\Helper;/**
+ * Class PieChartTransformer
+ *
+ * This handles the standardized formatting of the API response we need to provide for
+ * the pie charts
+ *
+ * @return \Illuminate\Http\Response
+ *@since [v6.0.11]
+ * @author [A. Gianotto] [<snipe@snipe.net>]
+ */
+class PieChartTransformer
+{
+    public function transformPieChartDate($totals)
+    {
+
+        $labels = [];
+        $counts = [];
+        $default_color_count = 0;
+        $colors_array = [];
+
+        foreach ($totals as $total) {
+
+            if ($total['count'] > 0) {
+
+                $labels[] = $total['label'];
+                $counts[] = $total['count'];
+
+                if (isset($total['color'])) {
+                    $colors_array[] = $total['color'];
+                } else {
+                    $colors_array[] = Helper::defaultChartColors($default_color_count);
+                    $default_color_count++;
+                }
+            }
+        }
+
+        $results = [
+            'labels' => $labels,
+            'datasets' => [[
+                'data' => $counts,
+                'backgroundColor' => $colors_array,
+                'hoverBackgroundColor' =>  $colors_array,
+            ]],
+        ];
+
+
+        return $results;
+    }
+}

--- a/database/migrations/2022_09_29_040231_add_chart_type_to_settings.php
+++ b/database/migrations/2022_09_29_040231_add_chart_type_to_settings.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddChartTypeToSettings extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->string('dash_chart_type')->nullable()->default('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            if (Schema::hasColumn('settings', 'dash_chart_type')) {
+                $table->dropColumn('dash_chart_type');
+            }
+        });
+    }
+}

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -375,6 +375,7 @@ return [
     'na_no_purchase_date'   => 'N/A - No purchase date provided',
     'assets_by_status'      => 'Assets by Status',
     'assets_by_status_type'      => 'Assets by Status Type',
+    'pie_chart_type'        => 'Dashboard Pie Chart Type',
 
 
 ];

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -373,6 +373,8 @@ return [
     'bulk_checkin_success' => 'The items for the selected users have been checked in.',
     'set_to_null' => 'Delete values for this asset|Delete values for all :asset_count assets ',
     'na_no_purchase_date'   => 'N/A - No purchase date provided',
+    'assets_by_status'      => 'Assets by Status',
+    'assets_by_status_type'      => 'Assets by Status Type',
 
 
 ];

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -248,7 +248,7 @@
   <div class="col-md-4">
         <div class="box box-default">
             <div class="box-header with-border">
-                <h2 class="box-title">{{ trans('general.assets') }} {{ trans('general.bystatus') }}</h2>
+                <h2 class="box-title">{{ trans('general.assets_by_status_type') }}</h2>
                 <div class="box-tools pull-right">
                     <button type="button" class="btn btn-box-tool" data-widget="collapse" aria-hidden="true">
                         <i class="fas fa-minus" aria-hidden="true"></i>
@@ -261,7 +261,7 @@
                 <div class="row">
                     <div class="col-md-12">
                         <div class="chart-responsive">
-                            <canvas id="statusPieChart" height="290"></canvas>
+                            <canvas id="statusPieChart" height="260"></canvas>
                         </div> <!-- ./chart-responsive -->
                     </div> <!-- /.col -->
                 </div> <!-- /.row -->
@@ -438,7 +438,7 @@
           dataType: 'json',
           success: function (data) {
               var myPieChart = new Chart(ctx,{
-                  type   : 'doughnut',
+                  type   : 'pie',
                   data   : data,
                   options: pieOptions
               });

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -248,7 +248,9 @@
   <div class="col-md-4">
         <div class="box box-default">
             <div class="box-header with-border">
-                <h2 class="box-title">{{ trans('general.assets_by_status_type') }}</h2>
+                <h2 class="box-title">
+                    {{ (\App\Models\Setting::getSettings()->dash_chart_type == 'name') ? trans('general.assets_by_status') : trans('general.assets_by_status_type') }}
+                </h2>
                 <div class="box-tools pull-right">
                     <button type="button" class="btn btn-box-tool" data-widget="collapse" aria-hidden="true">
                         <i class="fas fa-minus" aria-hidden="true"></i>
@@ -430,7 +432,7 @@
 
       $.ajax({
           type: 'GET',
-          url: '{{  route('api.statuslabels.assets.bytype') }}',
+          url: '{{ (\App\Models\Setting::getSettings()->dash_chart_type == 'name') ? route('api.statuslabels.assets.byname') : route('api.statuslabels.assets.bytype') }}',
           headers: {
               "X-Requested-With": 'XMLHttpRequest',
               "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr('content')

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -287,6 +287,21 @@
                                {{ Form::checkbox('show_in_model_list[]', 'model_number', old('show_in_model_list', $snipeSettings->modellistCheckedValue('model_number')),array('class' => 'minimal', 'aria-label'=>'show_in_model_list' )) }} {{ trans('general.model_no') }}<br>
                            </div>
                        </div>
+
+
+                       <!-- dash chart -->
+                       <div class="form-group {{ $errors->has('dash_chart_type') ? 'error' : '' }}">
+                           <div class="col-md-3">
+                               {{ Form::label('show_in_model_list',
+                                              trans('general.pie_chart_type')) }}
+                           </div>
+                           <div class="col-md-9">
+                               {{ Form::select('dash_chart_type', array(
+                                   'name' => 'Status Label Name',
+                                   'type' => 'Status Label Type'), Request::old('dash_chart_type', $setting->dash_chart_type), ['class' =>'select2', 'style' => 'width: 80%']) }}
+                           </div>
+                       </div>
+
                        
                        <!-- Depreciation method -->
                        <div class="form-group {{ $errors->has('depreciation_method') ? 'error' : '' }}">

--- a/routes/api.php
+++ b/routes/api.php
@@ -859,10 +859,17 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
                 ]
             )->name('api.statuslabels.selectlist');
 
-            Route::get('assets',
+            Route::get('assets/name',
                 [
                     Api\StatuslabelsController::class, 
                     'getAssetCountByStatuslabel'
+                ]
+            )->name('api.statuslabels.assets.byname');
+
+            Route::get('assets/type',
+                [
+                    Api\StatuslabelsController::class,
+                    'getAssetCountByMetaStatus'
                 ]
             )->name('api.statuslabels.assets.bytype');
 


### PR DESCRIPTION
This adds the option to pick whether you want the pie chart on the dashboard to reflect the status label *name* or the status label type, and adds a database field to remember your choice (found in Admin > General).

<img width="515" alt="Screen Shot 2022-09-29 at 4 18 27 AM" src="https://user-images.githubusercontent.com/197404/193018162-97b9bd93-33f5-45b8-967d-f0834807ab14.png">

<img width="865" alt="Screen Shot 2022-09-29 at 4 18 40 AM" src="https://user-images.githubusercontent.com/197404/193018180-6af623c2-b17f-4704-8d16-4e0c7d02aea1.png">

<img width="518" alt="Screen Shot 2022-09-29 at 4 18 52 AM" src="https://user-images.githubusercontent.com/197404/193018189-1020fc14-5fc1-4413-8256-af58f352868c.png">

The "Assets by Status" option includes and respects the colors selected in the status labels section, while they wouldn't make sense in the "Assets by Status Type", since we don't use colors anywhere else there.

<img width="1127" alt="Screen Shot 2022-09-29 at 4 28 44 AM" src="https://user-images.githubusercontent.com/197404/193020011-e69f059d-903a-42b2-96b8-c85451e56aee.png">

Eventually I'd like to make this a switchable tabbed option on the dashboard and deprecate the select box, since I hate adding extraneous database fields and UI choices like this, but I also know that if I change this out from under existing users, we'll get hate mail for it. 

I had wanted to save this feature for the dashboard revamp, but this is a first stab at this issue, I guess.

This also adds a transformer for the pie charts so we have potential flexibility with other options moving forward and simplifies some of that controller code.