### PR TITLE
Added counts to Dashboard Pie Chart legends and tooltips

### DIFF
--- a/app/Http/Transformers/PieChartTransformer.php
+++ b/app/Http/Transformers/PieChartTransformer.php
@@ -3,14 +3,15 @@
 namespace App\Http\Transformers;
 
 
-use App\Helpers\Helper;/**
+use App\Helpers\Helper;
+/**
  * Class PieChartTransformer
  *
  * This handles the standardized formatting of the API response we need to provide for
  * the pie charts
  *
  * @return \Illuminate\Http\Response
- *@since [v6.0.11]
+ * @since [v6.0.11]
  * @author [A. Gianotto] [<snipe@snipe.net>]
  */
 class PieChartTransformer
@@ -27,7 +28,7 @@ class PieChartTransformer
 
             if ($total['count'] > 0) {
 
-                $labels[] = $total['label'];
+                $labels[] = $total['label']." (".$total['count'].")";
                 $counts[] = $total['count'];
 
                 if (isset($total['color'])) {

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -427,6 +427,13 @@
                   position: 'top',
                   responsive: true,
                   maintainAspectRatio: true,
+              },
+              tooltips: {
+                callbacks: {
+                    label: function(tooltipItem, data) {
+                        return data.labels[tooltipItem.datasetIndex] || '';
+                    }
+                }
               }
           };
 


### PR DESCRIPTION
Please pardon the small formatting changes I also threw in - they were just bugging me.

This makes it so that the Dashboard Pie Chart legends now have counts in them - as do the tooltip labels - but without duplications. We could probably iterate on this pretty easily and leave the counts in the legends, but throw percentages in the tooltips - but that's for some later PR :)

<img width="450" alt="Screen Shot 2022-09-29 at 1 26 01 PM" src="https://user-images.githubusercontent.com/36335/193134846-421e9948-021b-4053-b7e0-327024e59d61.png">
