### PR TITLE
Modified dashboard tooltips to add percentage as well as count

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -431,7 +431,13 @@
               tooltips: {
                 callbacks: {
                     label: function(tooltipItem, data) {
-                        return data.labels[tooltipItem.datasetIndex] || '';
+                        counts = data.datasets[0].data;
+                        total = 0;
+                        for(var i in counts) {
+                            total += counts[i];
+                        }
+                        prefix = data.labels[tooltipItem.index] || '';
+                        return prefix+" "+Math.round(counts[tooltipItem.index]/total*100)+"%";
                     }
                 }
               }


### PR DESCRIPTION
Tweaked some of the tooltips to also add a percentage. I would love to further alter the formatting, but that wouldn't be possible without even more callbacks which I'd like to avoid for now.

I also might have been calculating the labels not quite right before, so this fixes that.