### PR TITLE
Fixed depreciation API call

### DIFF
--- a/app/Http/Transformers/DepreciationsTransformer.php
+++ b/app/Http/Transformers/DepreciationsTransformer.php
@@ -20,14 +20,13 @@ class DepreciationsTransformer
         return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
-    public function transformDepreciation(Depreciation $depreciation, Depreciable $monthly_depreciation)
+    public function transformDepreciation(Depreciation $depreciation)
     {
         $array = [
             'id' => (int) $depreciation->id,
             'name' => e($depreciation->name),
             'months' => $depreciation->months.' '.trans('general.months'),
             'depreciation_min' => $depreciation->depreciation_min,
-            'monthly_depreciation' => $monthly_depreciation->getMonthlyDepreciation(),
             'created_at' => Helper::getFormattedDateObject($depreciation->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($depreciation->updated_at, 'datetime')
         ];


### PR DESCRIPTION
This should fix a regression created by #11822 which was causing the depreciations API response (and therefore the depreciations listing page) to not load properly.