### PR TITLE
Use the new scim-trace feature from our fork of laravel-scim-server lib

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -78,19 +78,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/grokability/laravel-scim-server.git",
-                "reference": "d0e3d7c0b5da2ec76283b8a2fa2e672a91596509"
+                "reference": "9e7a8fd51a7380bc18ca1f01256574d75a2c6b49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/d0e3d7c0b5da2ec76283b8a2fa2e672a91596509",
-                "reference": "d0e3d7c0b5da2ec76283b8a2fa2e672a91596509",
+                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/9e7a8fd51a7380bc18ca1f01256574d75a2c6b49",
+                "reference": "9e7a8fd51a7380bc18ca1f01256574d75a2c6b49",
                 "shasum": ""
             },
             "require": {
                 "illuminate/console": "^6.0|^7.0|^8.0",
                 "illuminate/database": "^6.0|^7.0|^8.0",
                 "illuminate/support": "^6.0|^7.0|^8.0",
-                "php": "^7.0|^8.0",
+                "php": "^7.4|^8.0",
                 "tmilos/scim-filter-parser": "^1.3",
                 "tmilos/scim-schema": "^0.1.0"
             },
@@ -133,7 +133,7 @@
             "support": {
                 "source": "https://github.com/grokability/laravel-scim-server/tree/master"
             },
-            "time": "2022-07-18T22:15:42+00:00"
+            "time": "2022-10-06T00:42:37+00:00"
         },
         {
             "name": "asm89/stack-cors",
@@ -13530,5 +13530,5 @@
         "ext-pdo": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/config/logging.php
+++ b/config/logging.php
@@ -100,6 +100,11 @@ return [
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
         ],
+
+        'scimtrace' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/scim.log')
+        ]
     ],
 
 ];

--- a/config/scim.php
+++ b/config/scim.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
-    "publish_routes" => false
+    "publish_routes" => false,
+    "trace" => env("SCIM_TRACE",false)
 ];


### PR DESCRIPTION
We have had a lot of SCIM issues of late, which have been hard to track down. This change enables us to use the newest version of our own fork of the laravel-scim-server library, which now has a scim-tracing feature which will write (almost) every single request and response that comes from SCIM into its own log file. (Requests against non-existent resources still will get caught at the routing layer, due to route-model binding, so we can't `catch` those just yet. But they will show up in `laravel.log` and will be pretty apparent).

@snipe had expressed some concerns about whether or not we would have to add the new `scim.log` file to the `.gitignore` - but it's not showing up as changed on my local so that seems fine already. She also talked about the idea of adding an empty `scim.log` file to the `./storage/logs` directory - but I fear this is going to make the file be 'tracked by git' so I'm going to not add that just yet. But if you have the Linux chops to be able to twiddle the `.env` to add your `SCIM_TRACE` variable to it, then you can just as easily do a `touch` on that file, I figure.

If it turns out that this latest change to the `composer.lock` file actually blows things up, we can just do a simple revert and it should pull us back to the prior release, so that should keep us relatively safe.