### PR TITLE
Fixes the margin top adjustment for desktop

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -685,6 +685,3 @@ th.css-accessory > .th-inner::before
     margin-top:51px
   }
 }
-.main-sidebar{
-  margin-top:50px;
-}


### PR DESCRIPTION
# Description

Removes the margin-top added for desktop.
<img width="1323" alt="image" src="https://user-images.githubusercontent.com/47435081/194381627-d4bc94c7-5b66-47fe-af7f-e1b677a65fbb.png">


Fixes #11929 
## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
