### PR TITLE
Sets nullable attribute on validation

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -923,8 +923,8 @@ class SettingsController extends Controller
 
         $validator = Validator::make($setting->toArray(), [
             'ldap_username_field' => 'not_in:sAMAccountName',
-            'ldap_auth_filter_query' => 'not_in:uid=samaccountname',
-            'ldap_filter' => 'regex:"^[^(]"',
+            'ldap_auth_filter_query' => 'not_in:uid=samaccountname|required_if:ldap_enabled,1',
+            'ldap_filter' => 'nullable|regex:"^[^(]"|required_if:ldap_enabled,1',
         ],  $messages);
 
 


### PR DESCRIPTION
This just makes the `ldap_filter` field optional on the LDAP settings *view* page. If you recall, this validation on the view page is only to help legacy bad LDAP settings to surface a little easier. The real validation happens on save, and this does not affect those. 