### PR TITLE
Use admin ID for audit log notification

### DIFF
--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -189,7 +189,7 @@ trait Loggable
         $params = [
             'item' => $log->item,
             'filename' => $log->filename,
-            'admin' => $log->user,
+            'admin' => $log->admin,
             'location' => ($location) ? $location->name : '',
             'note' => $note,
         ];


### PR DESCRIPTION
Looks like we were sending an empty admin parameter on auditing, so if someone had slack integration turned on, an audit would 500. 