### PR TITLE
Fixes the calc of months and fixes typo of the word depreciation

### DIFF
--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -76,7 +76,7 @@ class Depreciable extends SnipeModel
 
         if ($months_passed >= $this->get_depreciation()->months){
             //if there is a floor use it
-            if(!$this->get_depreciation()->depreciation_min== null) {
+            if(!$this->get_depreciation()->depreciation_min == null) {
 
                 $current_value = $this->get_depreciation()->depreciation_min;
 

--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -69,14 +69,14 @@ class Depreciable extends SnipeModel
     public function getLinearDepreciatedValue() // TODO - for testing it might be nice to have an optional $relative_to param here, defaulted to 'now'
     {
         if ($this->purchase_date) {
-            $months_passed = $this->purchase_date->diff(now())->m;
+            $months_passed = ($this->purchase_date->diff(now())->m)+($this->purchase_date->diff(now())->y*12);
         } else {
             return null;
         }
 
         if ($months_passed >= $this->get_depreciation()->months){
             //if there is a floor use it
-            if($this->get_depreciation()->deprecation_min->isNotEmpty()) {
+            if(!$this->get_depreciation()->depreciation_min== null) {
 
                 $current_value = $this->get_depreciation()->depreciation_min;
 


### PR DESCRIPTION
# Description

Fixes a typo of the word depreciation and fixes the conversion of years to months for depreciation calculation.

Fixes # FD31357

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
