### PR TITLE
Fixed wrong icons for mobile view for locations listing

### DIFF
--- a/resources/views/locations/view.blade.php
+++ b/resources/views/locations/view.blade.php
@@ -21,7 +21,7 @@
               <li class="active">
                   <a href="#users" data-toggle="tab">
                         <span class="hidden-lg hidden-md">
-                            <i class="fas fa-info-circle fa-2x"></i>
+                            <i class="fas fa-users fa-2x"></i>
                         </span>
                       <span class="hidden-xs hidden-sm">
                           {{ trans('general.users') }}

--- a/resources/views/locations/view.blade.php
+++ b/resources/views/locations/view.blade.php
@@ -46,7 +46,7 @@
               <li>
                   <a href="#accessories" data-toggle="tab">
                     <span class="hidden-lg hidden-md">
-                        <i class="fas fa-barcode fa-2x" aria-hidden="true"></i>
+                        <i class="fas fa-keyboard fa-2x" aria-hidden="true"></i>
                     </span>
                       <span class="hidden-xs hidden-sm">
                           {{ trans('general.accessories') }}
@@ -58,7 +58,7 @@
               <li>
                   <a href="#consumables" data-toggle="tab">
                     <span class="hidden-lg hidden-md">
-                        <i class="fas fa-barcode fa-2x" aria-hidden="true"></i>
+                        <i class="fas fa-tint fa-2x" aria-hidden="true"></i>
                     </span>
                       <span class="hidden-xs hidden-sm">
                           {{ trans('general.consumables') }}
@@ -70,7 +70,7 @@
               <li>
                   <a href="#components" data-toggle="tab">
                     <span class="hidden-lg hidden-md">
-                        <i class="fas fa-barcode fa-2x" aria-hidden="true"></i>
+                        <i class="fas fa-hdd fa-2x" aria-hidden="true"></i>
                     </span>
                       <span class="hidden-xs hidden-sm">
                           {{ trans('general.components') }}
@@ -144,7 +144,7 @@
 
                       </div><!-- /.table-responsive -->
               </div><!-- /.tab-pane -->
-
+              
 
 
               <div class="tab-pane" id="accessories">


### PR DESCRIPTION
This corrects the locations icons visible only on the mobile view. Small detail, but it was bugging me :)

<img width="576" alt="Screen Shot 2022-10-17 at 8 03 09 PM" src="https://user-images.githubusercontent.com/197404/196326685-94ffb792-3bf8-44ef-a107-531a601d05b0.png">

<img width="571" alt="Screen Shot 2022-10-17 at 8 08 30 PM" src="https://user-images.githubusercontent.com/197404/196326687-3e4f786a-9cb3-44b6-8734-857d54ec3dd3.png">
