### PR TITLE
[rollbar] fix broken rollbar setup

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -37,7 +37,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => ['single', 'rollbar'],
             'ignore_exceptions' => false,
         ],
 
@@ -70,6 +70,12 @@ return [
                 'host' => env('PAPERTRAIL_URL'),
                 'port' => env('PAPERTRAIL_PORT'),
             ],
+        ],
+        'rollbar' => [
+            'driver' => 'monolog',
+            'handler' => \Rollbar\Laravel\MonologHandler::class,
+            'access_token' => env('ROLLBAR_TOKEN'),
+            'level' => 'error',
         ],
 
         'stderr' => [


### PR DESCRIPTION
# Description
We noticed that we haven't been getting rollbars for a while. While we'd
like to think that's because we fixed every last bug, we know ourselves
better than that

After some investigation, it seems we’re configuring rollbar an OLD way, via this:

https://docs.rollbar.com/docs/laravel#:~:text=%24this%2D%3Eapp%2D%3Eregister(%5CRollbar%5CLaravel%5CRollbarServiceProvider%3A%3Aclass)%3B

which is indicated for “laravel 5.5 and lower”

Adding it as a logger (top of that page) works swimmingly.

I think this is from the rollbar/rollbar v2.0.0 -> v2.1.0 upgrade we did back in june: https://github.com/snipe/snipe-it/blame/aa3f94973f5efe595bdc2adb411666dcdf3b427f/composer.lock#L7894-L7895

THAT BEING SAID… there’s nothing about it in the changelog… https://github.com/rollbar/rollbar-php/releases/tag/v2.1.0.   but then there’s ~nothing in the changelog for 2.1.0 even though there are 230+ commits :eyeroll:

INTERESTINGLY, removing The Old Way also made it not work, so I'm
leaving both in for this PR


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] created exception... got rollbar with the fix. didn't without