### PR TITLE
Fixed: Okta LDAP Manager Attribute - Better handle LDAP Manager settings

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -218,10 +218,24 @@ class LdapSync extends Command
 
                 if($item['manager'] != null) {
                     // Get the LDAP Manager
-                    $ldap_manager = Ldap::findLdapUsers($item['manager'], -1, $this->option('filter'));
+                    try {
+                        $ldap_manager = Ldap::findLdapUsers($item['manager'], -1, $this->option('filter')); // *THIS* call might be messing us up, somehow? Like, maybe breaking pagination or something?
+                    } catch (\Exception $e) {
+                        \Log::warn("Manager lookup caused an exception: ".$e->getMessage().". Falling back to direct username lookup");
+                        // Hail-mary for Okta manager 'shortnames' - will only work if
+                        // Okta configuration is using full email-address-style usernames
+                        $ldap_manager = [
+                            "count" => 1,
+                            0 => [
+                                $ldap_result_username => [$item['manager']]
+                            ]
+                        ];
+                    }
 
-                    if($ldap_manager["count"] > 0) { 
-                        // Get the Managers username
+                    if ($ldap_manager["count"] > 0) {
+
+                        // Get the Manager's username
+                        // PHP LDAP returns every LDAP attribute as an array, and 90% of the time it's an array of just one item. But, hey, it's an array.
                         $ldapManagerUsername = $ldap_manager[0][$ldap_result_username][0];
 
                         // Get User from Manager username.
@@ -233,7 +247,6 @@ class LdapSync extends Command
                         }
                     }
                 }
-
                 // Sync activated state for Active Directory.
                 if ( !empty($ldap_result_active_flag)) { // IF we have an 'active' flag set....
                     // ....then *most* things that are truthy will activate the user. Anything falsey will deactivate them.

--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -247,6 +247,7 @@ class LdapSync extends Command
                         }
                     }
                 }
+
                 // Sync activated state for Active Directory.
                 if ( !empty($ldap_result_active_flag)) { // IF we have an 'active' flag set....
                     // ....then *most* things that are truthy will activate the user. Anything falsey will deactivate them.

--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -219,7 +219,7 @@ class LdapSync extends Command
                 if($item['manager'] != null) {
                     // Get the LDAP Manager
                     try {
-                        $ldap_manager = Ldap::findLdapUsers($item['manager'], -1, $this->option('filter')); // *THIS* call might be messing us up, somehow? Like, maybe breaking pagination or something?
+                        $ldap_manager = Ldap::findLdapUsers($item['manager'], -1, $this->option('filter'));
                     } catch (\Exception $e) {
                         \Log::warn("Manager lookup caused an exception: ".$e->getMessage().". Falling back to direct username lookup");
                         // Hail-mary for Okta manager 'shortnames' - will only work if


### PR DESCRIPTION
A customer had a problem where their Okta configuration was failing to synchronize. It turns out they had an "LDAP Manager" attribute set to `managerid`. It turns out that Okta doesn't return a fully-qualified DN for their Managers - just an 'email-address-looking-like' username.

Instead of janking up our Manager lookup code, I've just thrown a `try/catch` around it, and set it to 'fall-back' to do a straight lookup on whatever that Manager was against our `username` field. I think this will work when people have their Okta configured to use 'email-address-esque' usernames, but it will probably fail with 'short usernames'.

But, all that being said, this is at least slightly better than what we were doing before. And if the LDAP lookup causes an exception, it won't abort the entire synchronization process. That's at least something.