### PR TITLE
Fixed #9949 Unable to update field values for custom field without changing the name

### DIFF
--- a/app/Http/Controllers/Api/CustomFieldsController.php
+++ b/app/Http/Controllers/Api/CustomFieldsController.php
@@ -65,8 +65,7 @@ class CustomFieldsController extends Controller
          * @var array
          */
         $data = $request->except(['field_encrypted']);
-
-        $validator = Validator::make($data, $field->validationRules());
+        $validator = Validator::make($data, ['name' => 'required', 'element' => 'required']);
         if ($validator->fails()) {
             return response()->json(Helper::formatStandardApiResponse('error', null, $validator->errors()));
         }


### PR DESCRIPTION
# Description
When updating Custom Fields via the API the Validator was using the rules from the CustomField model. Which works well when creating a new CustomField ie: Name is required because we cannot create a CustomField without one, and cannot already be taken on another CustomField. But when we are updating one this rule is causing that we need to pass the name field to the PUT method and if passed we cannot pass the same name that field already has.

I'm creating a custom validator, because the PUT method has the `name` and `element` fields as required, but we can pass the same existent values if we don't want to change the name, for example. My problem is the PATCH method, because that can change whatever it passes. So I don't know how to 'detect' when it's a PATCH so I can remove those validation rules...

Fixes #9949

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
