### PR TITLE
Incorrect logging for Manager lookup fallback

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -221,7 +221,7 @@ class LdapSync extends Command
                     try {
                         $ldap_manager = Ldap::findLdapUsers($item['manager'], -1, $this->option('filter'));
                     } catch (\Exception $e) {
-                        \Log::warn("Manager lookup caused an exception: ".$e->getMessage().". Falling back to direct username lookup");
+                        \Log::warning("Manager lookup caused an exception: ".$e->getMessage().". Falling back to direct username lookup");
                         // Hail-mary for Okta manager 'shortnames' - will only work if
                         // Okta configuration is using full email-address-style usernames
                         $ldap_manager = [


### PR DESCRIPTION
Ugh, so depressing - I used the wrong `Log` statement :(

This fixes it.