### PR TITLE
Added externalId support to SCIM integration

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -41,6 +41,9 @@ class SnipeSCIMConfig extends \ArieTimmerman\Laravel\SCIMServer\SCIMConfig
             } 
         );
 
+        $config['validations'][$core.'externalId'] = 'string'; // not required, but supported mostly just for Okta
+        $mappings['externalId'] = AttributeMapping::eloquent('scim_externalid');
+
         $config['validations'][$core.'emails'] = 'nullable|array';         // emails are not required in Snipe-IT...
         $config['validations'][$core.'emails.*.value'] = 'email'; // ...(had to remove the recommended 'required' here)
 

--- a/database/migrations/2022_10_25_193823_add_externalid_to_users.php
+++ b/database/migrations/2022_10_25_193823_add_externalid_to_users.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddExternalidToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('scim_externalid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('scim_externalid');
+        });
+    }
+}

--- a/database/migrations/2022_10_25_193823_add_externalid_to_users.php
+++ b/database/migrations/2022_10_25_193823_add_externalid_to_users.php
@@ -14,7 +14,7 @@ class AddExternalidToUsers extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('scim_externalid');
+            $table->string('scim_externalid')->nullable()->default(null);
         });
     }
 


### PR DESCRIPTION
It turns out that Okta requires that you support the `externalId` attribute, which is a value that is generated by the SCIM client, and transparently stored (and queried) on the SCIM server (which is Snipe-IT).

This adds this new field to the Users table, and maps it back out in SCIM so if it's used, it will be correctly set and returned.

I've tested that if I change the database to set an externalId, then it is returned.