### PR TITLE
Renamed column back to assets_count for legacy

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -27,7 +27,7 @@ class LocationsController extends Controller
         $allowed_columns = [
             'id', 'name', 'address', 'address2', 'city', 'state', 'country', 'zip', 'created_at',
             'updated_at', 'manager_id', 'image',
-            'assigned_assets_count', 'users_count', 'assets_count','assigned_assets_count', 'assets_location_count', 'rtd_assets_count', 'currency', 'ldap_ou', ];
+            'assigned_assets_count', 'users_count', 'assets_count','assigned_assets_count', 'assets_count', 'rtd_assets_count', 'currency', 'ldap_ou', ];
 
         $locations = Location::with('parent', 'manager', 'children')->select([
             'locations.id',
@@ -46,7 +46,7 @@ class LocationsController extends Controller
             'locations.ldap_ou',
             'locations.currency',
         ])->withCount('assignedAssets as assigned_assets_count')
-            ->withCount('assets as assets_location_count')
+            ->withCount('assets as assets_count')
             ->withCount('rtd_assets as rtd_assets_count')
             ->withCount('users as users_count');
 
@@ -157,7 +157,7 @@ class LocationsController extends Controller
                 'locations.currency',
             ])
             ->withCount('assignedAssets as assigned_assets_count')
-            ->withCount('assets as assets_location_count')
+            ->withCount('assets as assets_count')
             ->withCount('rtd_assets as rtd_assets_count')
             ->withCount('users as users_count')
             ->findOrFail($id);

--- a/app/Http/Transformers/LocationsTransformer.php
+++ b/app/Http/Transformers/LocationsTransformer.php
@@ -44,7 +44,7 @@ class LocationsTransformer
                 'country' => ($location->country) ? e($location->country) : null,
                 'zip' => ($location->zip) ? e($location->zip) : null,
                 'assigned_assets_count' => (int) $location->assigned_assets_count,
-                'assets_location_count'    => (int) $location->assets_location_count,
+                'assets_count'    => (int) $location->assets_count,
                 'rtd_assets_count'    => (int) $location->rtd_assets_count,
                 'users_count'    => (int) $location->users_count,
                 'currency' =>  ($location->currency) ? e($location->currency) : null,

--- a/app/Presenters/LocationPresenter.php
+++ b/app/Presenters/LocationPresenter.php
@@ -51,7 +51,7 @@ class LocationPresenter extends Presenter
             ],
 
             [
-                'field' => 'assets_location_count',
+                'field' => 'assets_count',
                 'searchable' => false,
                 'sortable' => true,
                 'switchable' => true,


### PR DESCRIPTION
In #12035, I had renamed the `count as` statement from `assets_count` to `assets_location_count` for clarity, since we're now returning many more "counts" in those queries, but that broke things for folks using the API directly. (I hadn't thought that many people were using the location API endpoints, but seeing as how quickly someone opened an issue about it - 7 hours later, it seems I was wrong!)

This PR just reverts it back to the older, albeit slightly more confusing name. 

Fixes #12039