### PR TITLE
Fixed #12009 - Added ability to reflect color in sidenav if one is given

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -420,7 +420,9 @@
                     @if (count($status_navs) > 0)
                         @foreach ($status_navs as $status_nav)
                             <li><a href="{{ route('statuslabels.show', ['statuslabel' => $status_nav->id]) }}">
-                                <i class="fas fa-circle text-grey fa-fw" aria-hidden="true"></i>
+                                <i class="fas fa-circle text-grey fa-fw" aria-hidden="true"{!!  ($status_nav->color!='' ? ' style="color: '.e($status_nav->color).'"' : '') !!}>
+
+                                </i>
                                  {{ $status_nav->name }} ({{ $status_nav->asset_count }})</a></li>
                         @endforeach
                     @endif

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -420,9 +420,7 @@
                     @if (count($status_navs) > 0)
                         @foreach ($status_navs as $status_nav)
                             <li><a href="{{ route('statuslabels.show', ['statuslabel' => $status_nav->id]) }}">
-                                <i class="fas fa-circle text-grey fa-fw" aria-hidden="true"{!!  ($status_nav->color!='' ? ' style="color: '.e($status_nav->color).'"' : '') !!}>
-
-                                </i>
+                                <i class="fas fa-circle text-grey fa-fw" aria-hidden="true"{!!  ($status_nav->color!='' ? ' style="color: '.e($status_nav->color).'"' : '') !!}></i>
                                  {{ $status_nav->name }} ({{ $status_nav->asset_count }})</a></li>
                         @endforeach
                     @endif


### PR DESCRIPTION
This uses the color specified in the Status Labels `color` field in the sidebar as well. If no color is specified, the default grey will be used. 

### Before 
<img width="838" alt="Screen Shot 2022-10-26 at 10 47 37 AM" src="https://user-images.githubusercontent.com/197404/198099518-2122e947-7404-47dd-ada9-ba664a7be4c1.png">

### After
<img width="1060" alt="Screen Shot 2022-10-26 at 10 47 57 AM" src="https://user-images.githubusercontent.com/197404/198099522-ef175d7d-210f-4180-baf2-bba3d4b30b02.png">

This fixes #12009
