### PR TITLE
Fixed string for invalid current password

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -164,7 +164,7 @@ class ProfileController extends Controller
         $validator = \Validator::make($request->all(), $rules);
         $validator->after(function ($validator) use ($request, $user) {
             if (! Hash::check($request->input('current_password'), $user->password)) {
-                $validator->errors()->add('current_password', trans('validation.hashed_pass'));
+                $validator->errors()->add('current_password', trans('validation.custom.hashed_pass'));
             }
 
             // This checks to make sure that the user's password isn't the same as their username,


### PR DESCRIPTION
We were using the wrong custom validation error for users trying to reset their password. This PR fixes that.

### Before
<img width="650" alt="Screen Shot 2022-10-26 at 12 20 03 PM" src="https://user-images.githubusercontent.com/197404/198117262-a4e24bd5-4111-4215-b195-1d67c93fc3b7.png">


### After
<img width="733" alt="Screen Shot 2022-10-26 at 12 18 58 PM" src="https://user-images.githubusercontent.com/197404/198117157-66fe4b38-7138-4aa8-b2aa-eddc12c574c0.png">
