### PR TITLE
Fixed writes to the `externalId` from SCIM

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -41,8 +41,10 @@ class SnipeSCIMConfig extends \ArieTimmerman\Laravel\SCIMServer\SCIMConfig
             } 
         );
 
-        $config['validations'][$core.'externalId'] = 'string'; // not required, but supported mostly just for Okta
-        $mappings['externalId'] = AttributeMapping::eloquent('scim_externalid');
+        // externalId support
+        $config['validations'][$core.'externalId'] = 'string|nullable'; // not required, but supported mostly just for Okta
+        // note that the mapping is *not* namespaced like the other $mappings
+        $config['mapping']['externalId'] = AttributeMapping::eloquent('scim_externalid');
 
         $config['validations'][$core.'emails'] = 'nullable|array';         // emails are not required in Snipe-IT...
         $config['validations'][$core.'emails.*.value'] = 'email'; // ...(had to remove the recommended 'required' here)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -61,6 +61,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         'remote',
         'start_date',
         'end_date',
+        'scim_externalid'
     ];
 
     protected $casts = [


### PR DESCRIPTION
Mostly needed just for Okta. We were correctly returning the values that were put in the database, but we weren't correctly updating the database with the values being passed-in via SCIM.

This has been tested by trying to use SCIM to create users both with and without the `externalId` attribute, and it seems to work either way.