### PR TITLE
Added custom field option to view assets

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -86,15 +86,24 @@ class CustomFieldsController extends Controller
     {
         $this->authorize('create', CustomField::class);
 
+        $show_in_email = $request->get("show_in_email", 0);
+        $display_in_user_view = $request->get("display_in_user_view", 0);
+
+        // Override the display settings if the field is encrypted
+        if ($request->get("field_encrypted") == '1') {
+            $show_in_email = '0';
+            $display_in_user_view = '0';
+        }
+
         $field = new CustomField([
             "name" => trim($request->get("name")),
             "element" => $request->get("element"),
             "help_text" => $request->get("help_text"),
             "field_values" => $request->get("field_values"),
             "field_encrypted" => $request->get("field_encrypted", 0),
-            "show_in_email" => $request->get("show_in_email", 0),
+            "show_in_email" => $show_in_email,
             "is_unique" => $request->get("is_unique", 0),
-            "display_in_user_view" => $request->get("display_in_user_view", 0),
+            "display_in_user_view" => $display_in_user_view,
             "user_id" => Auth::id()
         ]);
 
@@ -222,14 +231,24 @@ class CustomFieldsController extends Controller
 
         $this->authorize('update', $field);
 
+
+        $show_in_email = $request->get("show_in_email", 0);
+        $display_in_user_view = $request->get("display_in_user_view", 0);
+
+        // Override the display settings if the field is encrypted
+        if ($request->get("field_encrypted") == '1') {
+            $show_in_email = '0';
+            $display_in_user_view = '0';
+        }
+        
         $field->name          = trim(e($request->get("name")));
         $field->element       = e($request->get("element"));
         $field->field_values  = e($request->get("field_values"));
         $field->user_id       = Auth::id();
         $field->help_text     = $request->get("help_text");
-        $field->show_in_email = $request->get("show_in_email", 0);
+        $field->show_in_email = $show_in_email;
         $field->is_unique     = $request->get("is_unique", 0);
-        $field->display_in_user_view = $request->get("display_in_user_view", 0);
+        $field->display_in_user_view = $display_in_user_view;
 
         if ($request->get('format') == 'CUSTOM REGEX') {
             $field->format = e($request->get('custom_format'));

--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -94,6 +94,7 @@ class CustomFieldsController extends Controller
             "field_encrypted" => $request->get("field_encrypted", 0),
             "show_in_email" => $request->get("show_in_email", 0),
             "is_unique" => $request->get("is_unique", 0),
+            "display_in_user_view" => $request->get("display_in_user_view", 0),
             "user_id" => Auth::id()
         ]);
 
@@ -228,6 +229,7 @@ class CustomFieldsController extends Controller
         $field->help_text     = $request->get("help_text");
         $field->show_in_email = $request->get("show_in_email", 0);
         $field->is_unique     = $request->get("is_unique", 0);
+        $field->display_in_user_view = $request->get("display_in_user_view", 0);
 
         if ($request->get('format') == 'CUSTOM REGEX') {
             $field->format = e($request->get('custom_format'));

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -38,13 +38,17 @@ class ViewAssetsController extends Controller
             'licenses',
         )->find(Auth::user()->id);
 
-
+        // Loop through all the custom fields that are applied to any model the user has assigned
         foreach ($user->assets as $asset) {
             foreach ($asset->model->fieldset->fields as $field) {
-                $field_array[$field->db_column] = $field->name;
+                // check and make sure they're allowed to see the value of the custom field
+                if ($field->display_in_user_view == '1') {
+                    $field_array[$field->db_column] = $field->name;
+                }
             }
         }
 
+        // Since some models may re-use the same fieldsets/fields, let's make the array unique so we don't repeat columns
         array_unique($field_array);
 
         if (isset($user->id)) {

--- a/app/Http/Transformers/CustomFieldsTransformer.php
+++ b/app/Http/Transformers/CustomFieldsTransformer.php
@@ -47,6 +47,7 @@ class CustomFieldsTransformer
             'field_values_array'   => ($field->field_values) ? explode("\r\n", e($field->field_values)) : null,
             'type'   =>  e($field->element),
             'required'   =>  (($field->pivot) && ($field->pivot->required=='1')) ? true : false,
+            'display_in_user_view' =>  ($field->display_in_user_view =='1') ? true : false,
             'created_at' => Helper::getFormattedDateObject($field->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($field->updated_at, 'datetime'),
         ];

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -64,6 +64,7 @@ class CustomField extends Model
         'help_text',
         'show_in_email',
         'is_unique',
+        'display_in_user_view',
     ];
 
     /**

--- a/database/migrations/2022_11_07_134348_add_display_to_user_in_custom_fields.php
+++ b/database/migrations/2022_11_07_134348_add_display_to_user_in_custom_fields.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDisplayToUserInCustomFields extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('custom_fields', function (Blueprint $table) {
+            $table->boolean('display_in_user_view')->nullable()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('custom_fields', function (Blueprint $table) {
+            $table->dropColumn('display_in_user_view');
+        });
+    }
+}

--- a/resources/lang/en/admin/custom_fields/general.php
+++ b/resources/lang/en/admin/custom_fields/general.php
@@ -44,4 +44,6 @@ return [
     'db_convert_warning' => 'WARNING. This field is in the custom fields table as <code>:db_column</code> but should be <code>:expected</code>.',
     'is_unique' => 'This value must be unique across all assets',
     'unique' => 'Unique',
+    'display_in_user_view' => 'Allow the checked out user to view these values in their View Assigned Assets page',
+    'display_in_user_view_table' => 'Visible to User',
 ];

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -397,7 +397,7 @@
                   }'>
                     <thead>
                     <tr>
-                      <th class="col-md-1">#</t>
+                      <th class="col-md-1">#</th>
                       <th class="col-md-1">{{ trans('general.image') }}</th>
                       <th class="col-md-2" data-switchable="true" data-visible="true">{{ trans('general.category') }}</th>
                       <th class="col-md-2" data-switchable="true" data-visible="true">{{ trans('admin/hardware/table.asset_tag') }}</th>

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -397,7 +397,7 @@
                   }'>
                     <thead>
                     <tr>
-                      <th>#</th>
+                      <th class="col-md-1">#</t>
                       <th class="col-md-1">{{ trans('general.image') }}</th>
                       <th class="col-md-2" data-switchable="true" data-visible="true">{{ trans('general.category') }}</th>
                       <th class="col-md-2" data-switchable="true" data-visible="true">{{ trans('admin/hardware/table.asset_tag') }}</th>

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -129,7 +129,7 @@
 
 
                   <div class="col-md-12" style="padding-top: 5px;">
-                    @if(!empty($user->email))
+                    @if (!empty($user->email))
                       <form action="{{ route('profile.email_assets') }}" method="POST">
                         {{ csrf_field() }}
                         <button style="width: 100%;" class="btn btn-sm btn-primary hidden-print" rel="noopener">{{ trans('admin/users/general.email_assigned') }}</button>
@@ -404,6 +404,11 @@
                       <th class="col-md-2" data-switchable="true" data-visible="true">{{ trans('general.name') }}</th>
                       <th class="col-md-2" data-switchable="true" data-visible="true">{{ trans('admin/hardware/table.asset_model') }}</th>
                       <th class="col-md-3" data-switchable="true" data-visible="true">{{ trans('admin/hardware/table.serial') }}</th>
+
+                      @foreach ($field_array as $db_column => $field_name)
+                        <th class="col-md-1" data-switchable="true" data-visible="true">{{ $field_name }}</th>
+                      @endforeach
+
                     </tr>
 
                     </thead>
@@ -459,6 +464,11 @@
                                 <img src="{{ Storage::disk('public')->url(app('models_upload_path').e($asset->model->image)) }}" height="50" width="50">
                               @endif
                             </td>
+
+                            @foreach ($field_array as $db_column => $field_value)
+                              <td>{{ $asset->{$db_column} }} skjgh</td>
+                            @endforeach
+                            
                           </tr>
                           @php
                             $assignedCounter++
@@ -551,7 +561,7 @@
                 <tbody>
                 @foreach ($user->accessories as $accessory)
                   <tr>
-                    <td>{!! $accessory->name !!}</td>
+                    <td>{{ $accessory->name }}</td>
                     <td>
                       {!! Helper::formatCurrencyOutput($accessory->purchase_cost) !!}
                     </td>
@@ -599,7 +609,7 @@
                 <tbody>
                 @foreach ($user->consumables as $consumable)
                   <tr>
-                    <td>{!! $consumable->name !!}</td>
+                    <td>{{ $consumable->name }}</td>
                     <td>
                       {!! Helper::formatCurrencyOutput($consumable->purchase_cost) !!}
                     </td>

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -439,42 +439,15 @@
                           @endif
                         </td>
                         <td>{{ $asset->serial }}</td>
-                      </tr>
-                      @if($settings->show_assigned_assets)
-                        @php
-                          $assignedCounter = 1
-                        @endphp
-                        @foreach ($asset->assignedAssets as $asset)
-                          <tr>
-                            <td>{{ $counter }}.{{ $assignedCounter }}</td>
-                            <td>{{ $asset->model->category->name }}</td>
-                            <td>{{ $asset->asset_tag }}</td>
-                            <td>{{ $asset->name }}</td>
-                            <td>
-                              @if ($asset->physical=='1')
-                                {{ $asset->model->name }}
-                              @endif
-                            </td>
-                            <td>{{ $asset->serial }}</td>
-                            <td>
-                              @if (($asset->image) && ($asset->image!=''))
-                                <img src="{{ Storage::disk('public')->url(app('assets_upload_path').e($asset->image)) }}" height="50" width="50">
 
-                              @elseif (($asset->model) && ($asset->model->image!=''))
-                                <img src="{{ Storage::disk('public')->url(app('models_upload_path').e($asset->model->image)) }}" height="50" width="50">
-                              @endif
-                            </td>
-
-                            @foreach ($field_array as $db_column => $field_value)
-                              <td>{{ $asset->{$db_column} }} skjgh</td>
-                            @endforeach
-                            
-                          </tr>
-                          @php
-                            $assignedCounter++
-                          @endphp
+                        @foreach ($field_array as $db_column => $field_value)
+                          <td>
+                            {{ $asset->{$db_column} }}
+                          </td>
                         @endforeach
-                      @endif
+
+                      </tr>
+
                       @php
                         $counter++
                       @endphp

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -217,11 +217,13 @@
     $('#field_encrypted').on('ifChecked', function(event){
         $("#encrypt_warning").show();
         $("#show_in_email").hide();
+        $("#display_in_user_view").hide();
     });
 
     $('#field_encrypted').on('ifUnchecked', function(event){
         $("#encrypt_warning").hide();
         $("#show_in_email").show();
+        $("#display_in_user_view").show();
     });
 
 </script>

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -116,6 +116,17 @@
 
           </div>
 
+          <!-- Show in View All Assets profile view  -->
+          <div class="form-group {{ $errors->has('display_in_user_view') ? ' has-error' : '' }}"  id="display_in_user_view">
+              <div class="col-md-8 col-md-offset-4">
+                  <label for="display_in_user_view">
+                      <input type="checkbox" name="display_in_user_view" aria-label="display_in_user_view" value="1" class="minimal"{{ (old('display_in_user_view') || $field->display_in_user_view) ? ' checked="checked"' : '' }}>
+                      {{ trans('admin/custom_fields/general.display_in_user_view') }}
+                  </label>
+              </div>
+
+          </div>
+
           <!-- Value Must be Unique -->
           <div class="form-group {{ $errors->has('is_unique') ? ' has-error' : '' }}"  id="is_unique">
             <div class="col-md-8 col-md-offset-4">

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -126,16 +126,17 @@
                 }'>
           <thead>
             <tr>
-              <th data-searchable="true">{{ trans('general.name') }}</th>
-              <th data-searchable="true">{{ trans('admin/custom_fields/general.help_text')}}</th>
-              <th data-searchable="true">{{ trans('general.email') }}</th>
-              <th data-searchable="true">{{ trans('admin/custom_fields/general.unique') }}</th>
-              <th data-visible="false">{{ trans('admin/custom_fields/general.db_field') }}</th>
-              <th data-searchable="true">{{ trans('admin/custom_fields/general.field_format') }}</th>
-              <th><i class="fa fa-lock" aria-hidden="true"></i>
+              <th data-sortable="true" data-searchable="true">{{ trans('general.name') }}</th>
+              <th data-sortable="true" data-searchable="true">{{ trans('admin/custom_fields/general.help_text')}}</th>
+              <th data-sortable="true" data-searchable="true">{{ trans('admin/custom_fields/general.unique') }}</th>
+              <th data-sortable="true" data-visible="false">{{ trans('admin/custom_fields/general.db_field') }}</th>
+              <th data-sortable="true" data-searchable="true">{{ trans('admin/custom_fields/general.field_format') }}</th>
+              <th data-sortable="true"><i class="fa fa-lock" aria-hidden="true"></i>
                 <span class="hidden-xs hidden-sm hidden-md hidden-lg">{{ trans('admin/custom_fields/general.encrypted') }}</span>
               </th>
-              <th data-searchable="true">{{ trans('admin/custom_fields/general.field_element_short') }}</th>
+              <th data-visible="false" data-sortable="true"><i class="fa fa-eye" aria-hidden="true"><span class="sr-only">Visible to User</span></i></th>
+              <th data-sortable="true" data-searchable="true"><i class="fa fa-envelope" aria-hidden="true"><span class="sr-only">Show in Email</span></i></th>
+              <th data-sortable="true" data-searchable="true">{{ trans('admin/custom_fields/general.field_element_short') }}</th>
               <th data-searchable="true">{{ trans('admin/custom_fields/general.fieldsets') }}</th>
               <th>{{ trans('button.actions') }}</th>
             </tr>
@@ -145,7 +146,7 @@
             <tr>
               <td>{{ $field->name }}</td>
               <td>{{ $field->help_text }}</td>
-              <td class='text-center'>{!! ($field->show_in_email=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"><span class="sr-only">'.trans('general.yes').'</span></i>' : '<i class="fas fa-times text-danger" aria-hidden="true"><span class="sr-only">'.trans('general.no').'</span></i>'  !!}</td>
+
               <td class='text-center'>{!! ($field->is_unique=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"><span class="sr-only">'.trans('general.yes').'</span></i>' : '<i class="fas fa-times text-danger" aria-hidden="true"><span class="sr-only">'.trans('general.no').'</span></i>'  !!}</td>
               <td>
                  <code>{{ $field->convertUnicodeDbSlug() }}</code>
@@ -156,6 +157,8 @@
               </td>
               <td>{{ $field->format }}</td>
               <td>{!!  ($field->field_encrypted=='1' ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times text-danger"></i>') !!}</td>
+              <td>{!!  ($field->display_in_user_view=='1' ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times text-danger"></i>') !!}</td>
+              <td class='text-center'>{!! ($field->show_in_email=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"><span class="sr-only">'.trans('general.yes').'</span></i>' : '<i class="fas fa-times text-danger" aria-hidden="true"><span class="sr-only">'.trans('general.no').'</span></i>'  !!}</td>
               <td>{{ $field->element }}</td>
               <td>
                 @foreach($field->fieldset as $fieldset)


### PR DESCRIPTION
This PR allows you to set the visibility on a custom field for the user with that asset checked out to them when they go to `View Assigned Assets` in their profile section. 

<img width="1305" alt="Screen Shot 2022-11-10 at 5 45 41 PM" src="https://user-images.githubusercontent.com/197404/201169036-c4bd231b-0dcd-4897-a697-45ba825aa65f.png">

<img width="1248" alt="Screen Shot 2022-11-10 at 5 45 59 PM" src="https://user-images.githubusercontent.com/197404/201169121-236e280d-29be-4076-8370-5d94faa80e79.png">

This also adds a new column to the custom fields interface to show whether the field is displayed to the user or not. 

Note: This does NOT currently display fields that are encrypted and doesn't currently handle any fancy formatting like dates, etc. 