### PR TITLE
Fix HTTP AssetTransformer to generate an empty object for missing custom fields

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -131,7 +131,7 @@ class AssetsTransformer
                 $array['custom_fields'] = $fields_array;
             }
         } else {
-            $array['custom_fields'] = [];
+            $array['custom_fields'] = new stdClass; // HACK to force generation of empty object instead of empty list
         }
 
         $permissions_array['available_actions'] = [


### PR DESCRIPTION
# Description

If an asset does not have any associated custom fields the application is returning an empty array instead of an empty object defrauding output type expectation for the property.

Fixes # (issue)

https://github.com/snipe/snipe-it/issues/9700

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
