### PR TITLE
Fixes PR #12106 missing slash for std class

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -131,7 +131,7 @@ class AssetsTransformer
                 $array['custom_fields'] = $fields_array;
             }
         } else {
-            $array['custom_fields'] = new stdClass; // HACK to force generation of empty object instead of empty list
+            $array['custom_fields'] = new \stdClass; // HACK to force generation of empty object instead of empty list
         }
 
         $permissions_array['available_actions'] = [


### PR DESCRIPTION
Was missing a slash, which causing an error.