### PR TITLE
Added: API endpoint to trigger a user email notification with their assigned assets

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -976,6 +976,13 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
             ]
             )->name('api.users.assetlist');
 
+            Route::post('{user}/email',
+                [
+                    Api\UsersController::class,
+                    'emailAssetList'
+                ]
+            )->name('api.users.email_assets');
+
             Route::get('{user}/accessories',
             [
                 Api\UsersController::class, 


### PR DESCRIPTION
# Description

To automatically notify our active users we need to trigger the notification email with all their assigned assets via a api request. I just added the same functionality that is already existing in the GUI to the api functionality.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested the endpoint locally with different user ids

**Test Configuration**:
* PHP version: 8.1.11
* MySQL version: 8.0.27
* Webserver version: Laravel Valet 3.1.9


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
