### PR TITLE
Adds Boolean to Users Table for Auto Assigning Licenses

### DIFF
--- a/app/Console/Commands/CheckoutLicenseToAllUsers.php
+++ b/app/Console/Commands/CheckoutLicenseToAllUsers.php
@@ -56,7 +56,7 @@ class CheckoutLicenseToAllUsers extends Command
             return false;
         }
 
-        $users = User::whereNull('deleted_at')->where('should_autoassign', '==', 0)->with('licenses')->get();
+        $users = User::whereNull('deleted_at')->where('autoassign_licenses', '==', 1)->with('licenses')->get();
 
         if ($users->count() > $license->getAvailSeatsCountAttribute()) {
             $this->info('You do not have enough free seats to complete this task, so we will check out as many as we can. ');

--- a/app/Console/Commands/CheckoutLicenseToAllUsers.php
+++ b/app/Console/Commands/CheckoutLicenseToAllUsers.php
@@ -56,7 +56,7 @@ class CheckoutLicenseToAllUsers extends Command
             return false;
         }
 
-        $users = User::whereNull('deleted_at')->with('licenses')->get();
+        $users = User::whereNull('deleted_at')->where('should_autoassign', '==', 1)->with('licenses')->get();
 
         if ($users->count() > $license->getAvailSeatsCountAttribute()) {
             $this->info('You do not have enough free seats to complete this task, so we will check out as many as we can. ');

--- a/app/Console/Commands/CheckoutLicenseToAllUsers.php
+++ b/app/Console/Commands/CheckoutLicenseToAllUsers.php
@@ -57,7 +57,7 @@ class CheckoutLicenseToAllUsers extends Command
         }
 
         $users = User::whereNull('deleted_at')->where('should_autoassign', '==', 0)->with('licenses')->get();
-        dd($users);
+
         if ($users->count() > $license->getAvailSeatsCountAttribute()) {
             $this->info('You do not have enough free seats to complete this task, so we will check out as many as we can. ');
         }

--- a/app/Console/Commands/CheckoutLicenseToAllUsers.php
+++ b/app/Console/Commands/CheckoutLicenseToAllUsers.php
@@ -56,8 +56,8 @@ class CheckoutLicenseToAllUsers extends Command
             return false;
         }
 
-        $users = User::whereNull('deleted_at')->where('should_autoassign', '==', 1)->with('licenses')->get();
-
+        $users = User::whereNull('deleted_at')->where('should_autoassign', '==', 0)->with('licenses')->get();
+        dd($users);
         if ($users->count() > $license->getAvailSeatsCountAttribute()) {
             $this->info('You do not have enough free seats to complete this task, so we will check out as many as we can. ');
         }

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -121,6 +121,7 @@ class UsersController extends Controller
         $user->created_by = Auth::user()->id;
         $user->start_date = $request->input('start_date', null);
         $user->end_date = $request->input('end_date', null);
+        $user->should_autoassign= $request->input('should_autoassign', 0);
 
         // Strip out the superuser permission if the user isn't a superadmin
         $permissions_array = $request->input('permission');
@@ -274,6 +275,7 @@ class UsersController extends Controller
         $user->website = $request->input('website', null);
         $user->start_date = $request->input('start_date', null);
         $user->end_date = $request->input('end_date', null);
+        $user->should_autoassign = $request->input('should_autoassign', 0);
 
         // Update the location of any assets checked out to this user
         Asset::where('assigned_type', User::class)

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -121,7 +121,7 @@ class UsersController extends Controller
         $user->created_by = Auth::user()->id;
         $user->start_date = $request->input('start_date', null);
         $user->end_date = $request->input('end_date', null);
-        $user->should_autoassign= $request->input('should_autoassign', 0);
+        $user->autoassign_licenses= $request->input('autoassign_licenses', 1);
 
         // Strip out the superuser permission if the user isn't a superadmin
         $permissions_array = $request->input('permission');
@@ -275,7 +275,7 @@ class UsersController extends Controller
         $user->website = $request->input('website', null);
         $user->start_date = $request->input('start_date', null);
         $user->end_date = $request->input('end_date', null);
-        $user->should_autoassign = $request->input('should_autoassign', 0);
+        $user->autoassign_licenses = $request->input('autoassign_licenses', 1);
 
         // Update the location of any assets checked out to this user
         Asset::where('assigned_type', User::class)

--- a/database/migrations/2022_11_15_232525_adds_should_autoassign_bool_to_users_table.php
+++ b/database/migrations/2022_11_15_232525_adds_should_autoassign_bool_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddsShouldAutoassignBoolToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('should_autoassign')->nullable(false)->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('should_autoassign');
+        });
+    }
+}

--- a/database/migrations/2022_11_15_232525_adds_should_autoassign_bool_to_users_table.php
+++ b/database/migrations/2022_11_15_232525_adds_should_autoassign_bool_to_users_table.php
@@ -14,7 +14,7 @@ class AddsShouldAutoassignBoolToUsersTable extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->boolean('should_autoassign')->nullable(false)->default(0);
+            $table->boolean('autoassign_licenses')->nullable(false)->default(1);
         });
     }
 

--- a/database/migrations/2022_11_15_232525_adds_should_autoassign_bool_to_users_table.php
+++ b/database/migrations/2022_11_15_232525_adds_should_autoassign_bool_to_users_table.php
@@ -26,7 +26,7 @@ class AddsShouldAutoassignBoolToUsersTable extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropColumn('should_autoassign');
+            $table->dropColumn('autoassign_licenses');
         });
     }
 }

--- a/resources/lang/en/admin/users/general.php
+++ b/resources/lang/en/admin/users/general.php
@@ -19,7 +19,7 @@ return [
     'print_assigned'    => 'Print All Assigned',
     'email_assigned'    => 'Email List of All Assigned',
     'user_notified'     => 'User has been emailed a list of their currently assigned items.',
-    'auto_assign_label' => 'User should be skipped during auto assignment commands',
+    'auto_assign_label' => 'Include this user when auto-assigning eligible licenses',
     'auto_assign_help'  => 'Skip this user in auto assignment of licenses',
     'software_user'     => 'Software Checked out to :name',
     'send_email_help'   => 'You must provide an email address for this user to send them credentials. Emailing credentials can only be done on user creation. Passwords are stored in a one-way hash and cannot be retrieved once saved.',

--- a/resources/lang/en/admin/users/general.php
+++ b/resources/lang/en/admin/users/general.php
@@ -19,7 +19,7 @@ return [
     'print_assigned'    => 'Print All Assigned',
     'email_assigned'    => 'Email List of All Assigned',
     'user_notified'     => 'User has been emailed a list of their currently assigned items.',
-    'auto_assign_label' => 'User should skipped during auto assignment commands',
+    'auto_assign_label' => 'User should be skipped during auto assignment commands',
     'auto_assign_help'  => 'Skip this user in auto assignment of licenses',
     'software_user'     => 'Software Checked out to :name',
     'send_email_help'   => 'You must provide an email address for this user to send them credentials. Emailing credentials can only be done on user creation. Passwords are stored in a one-way hash and cannot be retrieved once saved.',

--- a/resources/lang/en/admin/users/general.php
+++ b/resources/lang/en/admin/users/general.php
@@ -19,6 +19,8 @@ return [
     'print_assigned'    => 'Print All Assigned',
     'email_assigned'    => 'Email List of All Assigned',
     'user_notified'     => 'User has been emailed a list of their currently assigned items.',
+    'auto_assign_label' => 'User should skipped during auto assignment commands',
+    'auto_assign_help'  => 'Skip this user in auto assignment of licenses',
     'software_user'     => 'Software Checked out to :name',
     'send_email_help'   => 'You must provide an email address for this user to send them credentials. Emailing credentials can only be done on user creation. Passwords are stored in a one-way hash and cannot be retrieved once saved.',
     'view_user'         => 'View User :name',

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -379,8 +379,8 @@
                           <!-- Auto Assign checkbox -->
                           <div class="form-group">
                               <div class="col-md-7 col-md-offset-3">
-                                  <label for="should_autoassign">
-                                      <input type="checkbox" value="1" name="should_autoassign" class="minimal" {{ (old('should_autoassign', $user->should_autoassign)) == '1' ? ' checked="checked"' : '' }} aria-label="should_autoassign">
+                                  <label for="autoassign_licenses">
+                                      <input type="checkbox" value="1" name="autoassign_licenses" class="minimal" {{ (old('autoassign_licenses', $user->autoassign_licenses)) == '1' ? ' checked="checked"' : '' }} aria-label="autoassign_licenses">
                                       {{ trans('admin/users/general.auto_assign_label') }}
 
                                   </label>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -376,6 +376,19 @@
                               </div>
                           </div>
 
+                          <!-- Auto Assign checkbox -->
+                          <div class="form-group">
+                              <div class="col-md-7 col-md-offset-3">
+                                  <label for="should_autoassign">
+                                      <input type="checkbox" value="0" name="should_autoassign" class="minimal" {{ (old('remote', $user->should_autoassign)) }} aria-label="should_autoassign">
+                                      {{ trans('admin/users/general.auto_assign_label') }}
+
+                                  </label>
+                                  <p class="help-block">{{ trans('admin/users/general.auto_assign_help') }}
+                                  </p>
+                              </div>
+                          </div>
+
                           <!-- Location -->
                           @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'location_id'])
 

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -380,7 +380,7 @@
                           <div class="form-group">
                               <div class="col-md-7 col-md-offset-3">
                                   <label for="should_autoassign">
-                                      <input type="checkbox" value="1" name="should_autoassign" class="minimal" {{ (old('should_autoassign', $user->should_autoassign)) }} aria-label="should_autoassign">
+                                      <input type="checkbox" value="1" name="should_autoassign" class="minimal" {{ (old('should_autoassign', $user->should_autoassign)) == '1' ? ' checked="checked"' : '' }} aria-label="should_autoassign">
                                       {{ trans('admin/users/general.auto_assign_label') }}
 
                                   </label>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -380,7 +380,7 @@
                           <div class="form-group">
                               <div class="col-md-7 col-md-offset-3">
                                   <label for="should_autoassign">
-                                      <input type="checkbox" value="0" name="should_autoassign" class="minimal" {{ (old('remote', $user->should_autoassign)) }} aria-label="should_autoassign">
+                                      <input type="checkbox" value="1" name="should_autoassign" class="minimal" {{ (old('should_autoassign', $user->should_autoassign)) }} aria-label="should_autoassign">
                                       {{ trans('admin/users/general.auto_assign_label') }}
 
                                   </label>


### PR DESCRIPTION
# Description

Adds an `should_autoassign` boolean to the users table to prevent certain users from being auto assigned licenses.

User Edit page:
<img width="707" alt="image" src="https://user-images.githubusercontent.com/47435081/202049840-a92d7c15-16e7-4585-ab28-7bb8d6091b41.png">


Fixes #sc 16946

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
