### PR TITLE
Fixed #11699 and #12065 Email issues

### DIFF
--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -7,7 +7,7 @@
 
 @if (isset($snipeSettings) && ($snipeSettings::setupCompleted()))
 
-    @if ($snipeSettings->show_url_in_email=='1' )
+    @if ($snipeSettings->show_url_in_emails=='1' )
         @component('mail::header', ['url' => config('app.url')])
     @else
         @component('mail::header', ['url' => ''])

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -1,12 +1,17 @@
 @component('mail::layout')
 {{-- Header --}}
 @slot('header')
-@component('mail::header', ['url' => config('app.url')])
 
 {{-- Check that the $snipeSettings variable is set, images are set to be shown, and setup is complete --}}
 
 
 @if (isset($snipeSettings) && ($snipeSettings::setupCompleted()))
+
+    @if ($snipeSettings->show_url_in_email=='1' )
+        @component('mail::header', ['url' => config('app.url')])
+    @else
+        @component('mail::header', ['url' => ''])
+    @endif
 
     {{-- Show images in email!  --}}
     @if (($snipeSettings->show_images_in_email=='1' ) && (($snipeSettings->brand == '3') || ($snipeSettings->brand == '2')))

--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -73,16 +73,26 @@ $style = [
                         <td style="{{ $style['email-masthead'] }}">
 
                             @if (($snipeSettings->show_images_in_email=='1' ) && ($snipeSettings::setupCompleted()))
+                                @php
+                                    $logo = '';
+                                    if ($snipeSettings->logo != ''){
+                                        $logo = $snipeSettings->logo;
+                                    }
+
+                                    if ($snipeSettings->email_logo != ''){
+                                        $logo = $snipeSettings->email_logo;
+                                    }
+                                @endphp
 
                                 @if ($snipeSettings->brand == '3')
-                                    @if ($snipeSettings->logo!='')
-                                        <img class="navbar-brand-img logo" style="max-width: 50px;" src="{{ url('/') }}/uploads/{{ $snipeSettings->logo }}">
+                                    @if ($logo!='')
+                                        <img class="navbar-brand-img logo" style="max-width: 50px;" src="{{ url('/') }}/uploads/{{ $logo }}">
                                     @endif
                                     {{ $snipeSettings->site_name }}
 
                                 @elseif ($snipeSettings->brand == '2')
-                                    @if ($snipeSettings->logo!='')
-                                        <img class="navbar-brand-img logo" style="max-width: 50px;" src="{{ url('/') }}/uploads/{{ $snipeSettings->logo }}">
+                                    @if ($logo!='')
+                                        <img class="navbar-brand-img logo" style="max-width: 50px;" src="{{ url('/') }}/uploads/{{ $logo }}">
                                     @endif
                                 @else
                                     {{ $snipeSettings->site_name }}


### PR DESCRIPTION
# Description
Fixes a couple of settings. The email logo is not respected in forgotten password emails and if user have links deactivated email notifications still have the link active to click on.

Fixes #11699 and #12065

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
