### PR TITLE
Fixed 500 if `format` is not passed to the create custom field endpoint payload

### DIFF
--- a/app/Http/Controllers/Api/CustomFieldsController.php
+++ b/app/Http/Controllers/Api/CustomFieldsController.php
@@ -96,7 +96,7 @@ class CustomFieldsController extends Controller
         $data = $request->all();
         $regex_format = null;
 
-        if (str_contains($data['format'], 'regex:')) {
+        if ((array_key_exists('format', $data)) && (str_contains($data['format'], 'regex:'))) {
             $regex_format = $data['format'];
         }
 


### PR DESCRIPTION
Previously, if you did not include `format` in your new custom field API call, the call would fail with a 500 error that looks like this:

```
"message": "Undefined index: format",
    "exception": "ErrorException",
    "file": "/Users/snipe/Sites/snipe-it/snipe-it/app/Http/Controllers/Api/CustomFieldsController.php",
    "line": 99,
```

This fix corrects that behavior and checks to see that the `format` index actually exists in the `$data` payload.