### PR TITLE
Fixed issue where View Assigned Assets would crash if there are no custom fields for any assigned models

### DIFF
--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -42,12 +42,16 @@ class ViewAssetsController extends Controller
 
         // Loop through all the custom fields that are applied to any model the user has assigned
         foreach ($user->assets as $asset) {
+
+            // Make sure the model has a custom fieldset before trying to loop through the associated fields
             if ($asset->model->fieldset) {
+
                 foreach ($asset->model->fieldset->fields as $field) {
                     // check and make sure they're allowed to see the value of the custom field
                     if ($field->display_in_user_view == '1') {
                         $field_array[$field->db_column] = $field->name;
                     }
+                    
                 }
             }
 

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -38,14 +38,19 @@ class ViewAssetsController extends Controller
             'licenses',
         )->find(Auth::user()->id);
 
+        $field_array = array();
+
         // Loop through all the custom fields that are applied to any model the user has assigned
         foreach ($user->assets as $asset) {
-            foreach ($asset->model->fieldset->fields as $field) {
-                // check and make sure they're allowed to see the value of the custom field
-                if ($field->display_in_user_view == '1') {
-                    $field_array[$field->db_column] = $field->name;
+            if ($asset->model->fieldset) {
+                foreach ($asset->model->fieldset->fields as $field) {
+                    // check and make sure they're allowed to see the value of the custom field
+                    if ($field->display_in_user_view == '1') {
+                        $field_array[$field->db_column] = $field->name;
+                    }
                 }
             }
+
         }
 
         // Since some models may re-use the same fieldsets/fields, let's make the array unique so we don't repeat columns


### PR DESCRIPTION
If none of a user's assigned assets have any custom fields, this will cause the View Assigned Assets page to crash. This fixes that regression.