### PR TITLE
Fixed regression with the custom report export user fields

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -763,7 +763,7 @@ class ReportsController extends Controller
                     if ($request->filled('username')) {
                         // Only works if we're checked out to a user, not anything else.
                         if ($asset->checkedOutToUser()) {
-                            $row[] = ($asset->assignedTo) ? $asset->assignedTo->username : '';
+                            $row[] = ($asset->assignedto) ? $asset->assignedto->username : '';
                         } else {
                             $row[] = ''; // Empty string if unassigned
                         }
@@ -772,7 +772,7 @@ class ReportsController extends Controller
                     if ($request->filled('employee_num')) {
                         // Only works if we're checked out to a user, not anything else.
                         if ($asset->checkedOutToUser()) {
-                            $row[] = ($asset->assignedTo) ? $asset->assignedTo->employee_num : '';
+                            $row[] = ($asset->assignedto) ? $asset->assignedto->employee_num : '';
                         } else {
                             $row[] = ''; // Empty string if unassigned
                         }
@@ -780,7 +780,7 @@ class ReportsController extends Controller
 
                     if ($request->filled('manager')) {
                         if ($asset->checkedOutToUser()) {
-                            $row[] = (($asset->assignedTo) && ($asset->assignedTo->manager)) ? $asset->assignedTo->manager->present()->fullName : '';
+                            $row[] = (($asset->assignedto) && ($asset->assignedto->manager)) ? $asset->assignedto->manager->present()->fullName : '';
                         } else {
                             $row[] = ''; // Empty string if unassigned
                         }
@@ -788,7 +788,7 @@ class ReportsController extends Controller
 
                     if ($request->filled('department')) {
                         if ($asset->checkedOutToUser()) {
-                            $row[] = (($asset->assignedTo) && ($asset->assignedTo->department)) ? $asset->assignedTo->department->name : '';
+                            $row[] = (($asset->assignedto) && ($asset->assignedto->department)) ? $asset->assignedto->department->name : '';
                         } else {
                             $row[] = ''; // Empty string if unassigned
                         }
@@ -796,7 +796,7 @@ class ReportsController extends Controller
 
                     if ($request->filled('title')) {
                         if ($asset->checkedOutToUser()) {
-                            $row[] = ($asset->assignedTo) ? $asset->assignedTo->jobtitle : '';
+                            $row[] = ($asset->assignedto) ? $asset->assignedto->jobtitle : '';
                         } else {
                             $row[] = ''; // Empty string if unassigned
                         }


### PR DESCRIPTION
# Description
The 'Checked Out To Fields" under custom asset reports were not populating. They did at one point. Works again now.
<img width="732" alt="image" src="https://user-images.githubusercontent.com/47435081/202325239-adb25d9a-c3fc-4f23-8afb-cc0fd1ffdc83.png">


Fixes #FD-31833


## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
