### PR TITLE
Fixed #9949 - PATCH to custom fields failing on validation (alt approach to #12011)

### DIFF
--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -50,7 +50,7 @@ class CustomField extends Model
      */
     protected $rules = [
         'name' => 'required|unique:custom_fields',
-        'element' => 'required','in:text,listbox,textarea,checkbox,radio',
+        'element' => 'required|in:text,listbox,textarea,checkbox,radio',
         'field_encrypted' => 'nullable|boolean',
     ];
 

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -48,7 +48,11 @@ class CustomField extends Model
      *
      * @var array
      */
-    protected $rules = [];
+    protected $rules = [
+        'name' => 'required|unique:custom_fields',
+        'element' => 'required','in:text,listbox,textarea,checkbox,radio',
+        'field_encrypted' => 'nullable|boolean',
+    ];
 
     /**
      * The attributes that are mass assignable.
@@ -357,15 +361,9 @@ class CustomField extends Model
     public function validationRules($regex_format = null)
     {
         return [
-            'name' => 'required|unique:custom_fields',
-            'element' => [
-                'required',
-                Rule::in(['text', 'listbox',  'textarea', 'checkbox', 'radio']),
-            ],
             'format' => [
                 Rule::in(array_merge(array_keys(self::PREDEFINED_FORMATS), self::PREDEFINED_FORMATS, [$regex_format])),
-            ],
-            'field_encrypted' => 'nullable|boolean',
+            ]
         ];
     }
 


### PR DESCRIPTION
This is an alternate solution to the issue where patches to the custom fields API would require you to pass the name (and would fail if it wasn't unique). @inietov had a proposed solution in #12011 which is meant to fix #9949, but this is a slightly different angle which may or may not be more consistent with how we handle this issue elsewhere. We still have to use `$validator = Validator::make($data, $field->validationRules($regex_format));` in the controllers since we have to pass some dynamic info (regex) into that validator and the `protected $rules` won't allow that. 

I'd love some eyeballs on this though, from both @uberbrady and @inietov <3