### PR TITLE
Fixed background color for readonly date picker fields

### DIFF
--- a/resources/views/partials/forms/edit/datepicker.blade.php
+++ b/resources/views/partials/forms/edit/datepicker.blade.php
@@ -3,7 +3,7 @@
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
     <div class="input-group col-md-4">
         <div class="input-group date" data-provide="datepicker" data-date-clear-btn="true" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old($fieldname, ($item->{$fieldname}) ? $item->{$fieldname}->format('Y-m-d') : '') }}" readonly>
+            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old($fieldname, ($item->{$fieldname}) ? $item->{$fieldname}->format('Y-m-d') : '') }}" readonly style="background-color:inherit">
             <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
         </div>
         {!! $errors->first($fieldname, '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}


### PR DESCRIPTION
This just enhances the UI to display the fields to the user as "not readonly" when using the datepicker. It's set as readonly to disallow people from free-typing, but it also makes for a confusing UX, since it doesn't *look* like you can change it even though you can. 

<img width="554" alt="Screen Shot 2022-11-22 at 8 48 36 AM" src="https://user-images.githubusercontent.com/197404/203375004-c8f8aed6-01b4-4de4-89db-88640a1983e1.png">
