### PR TITLE
Pulled in latest upstream changes for improved standards-compliance

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -78,19 +78,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/grokability/laravel-scim-server.git",
-                "reference": "8eba81d36a32077ab45ef60290cad817d07b6224"
+                "reference": "2c7ecc450eee59234e059ec2e7724b2d8f3a8369"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/8eba81d36a32077ab45ef60290cad817d07b6224",
-                "reference": "8eba81d36a32077ab45ef60290cad817d07b6224",
+                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/2c7ecc450eee59234e059ec2e7724b2d8f3a8369",
+                "reference": "2c7ecc450eee59234e059ec2e7724b2d8f3a8369",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "^6.0|^7.0|^8.0",
-                "illuminate/database": "^6.0|^7.0|^8.0",
-                "illuminate/support": "^6.0|^7.0|^8.0",
-                "php": "^7.4|^8.0",
+                "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
+                "illuminate/database": "^6.0|^7.0|^8.0|^9.0",
+                "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
+                "php": "^7.0|^8.0",
                 "tmilos/scim-filter-parser": "^1.3",
                 "tmilos/scim-schema": "^0.1.0"
             },
@@ -133,7 +133,7 @@
             "support": {
                 "source": "https://github.com/grokability/laravel-scim-server/tree/master"
             },
-            "time": "2022-11-09T17:01:45+00:00"
+            "time": "2022-11-22T20:26:54+00:00"
         },
         {
             "name": "asm89/stack-cors",

--- a/config/scim.php
+++ b/config/scim.php
@@ -3,6 +3,6 @@
 return [
     "trace" => env("SCIM_TRACE",false),
     // below, if we ever get 'sure' that we can change this default to 'true' we should
-    "standards_compliance" => env('SCIM_STANDARDS_COMPLIANCE', false),
+    "omit_main_schema_in_return" => env('SCIM_STANDARDS_COMPLIANCE', false),
     "publish_routes" => false,
 ];


### PR DESCRIPTION
The original version of the laravel-scim-server package that we use for our SCIM support has made a few updates that I wanted to take in. Furthermore, our SCIM support with the new `.env` var for `SCIM_STANDARDS_COMPLIANCE` had a few bugs that dropped 500-series errors. So this change goes along with those updates to our fork of the library, so it uses the new config variable (upstream chose a different config variable name), and the new functionality (which is much less hacky than what I built before).