### PR TITLE
Fixed #12046 #12137 Custom field checkboxes not holding value

### DIFF
--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -19,7 +19,7 @@
                   @foreach ($field->formatFieldValuesAsArray() as $key => $value)
                       <div>
                           <label>
-                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" class="minimal" {{  isset($item) ? (in_array($value, preg_split('/[, |,]/', $item->{$field->db_column_name()})) ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, preg_split('/[, |,]/', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
+                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" class="minimal" {{  isset($item) ? (in_array($value, array_map('trim', explode(',', $item->{$field->db_column_name()}))) ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, array_map('trim', explode(',', $field->defaultValue($model->id)))) ? ' checked="checked"' : '')) }}>
                               {{ $value }}
                           </label>
                       </div>


### PR DESCRIPTION
# Description
Some time ago (https://github.com/snipe/snipe-it/pull/11925) I tried to address an issue with custom field values when they are setted via API, and in doing so I broke the GUI functionality :(

Lucky that our users / customers are awesome to detect this kind of things quickly, the slow response was my fault, sorry.

I do tested the feature, but with one-word values (apples, bananas, pears) and not with multi word values (the apple, the bananas, the pears) so my regex (never sure about using that anyway) broke the view when trying to retrieve selected multiword values. Anyway, this PR returns to the explode function but now it maps a trim to every value so it eliminates spaces that can affect the view, which made it compatible with tha API and with the standard GUI.

Fixes #12046 #12137

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
