### PR TITLE
Fixed #11980 Submit button deactivated in Users' Bulk Checkin if no status selected

### DIFF
--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -115,3 +115,18 @@
 </div>
 
 @stop
+
+@section('moar_scripts')
+<script>
+    $(":submit").attr("disabled", "disabled");
+    $("[name='status_id']").on('select2:select', function (e) {
+        if (e.params.data.id != ""){
+            console.log(e.params.data.id);
+            $(":submit").removeAttr("disabled");
+        }
+        else {
+            $(":submit").attr("disabled", "disabled");
+        }
+    });
+</script>
+@stop


### PR DESCRIPTION
# Description
Someone was annoyed because in the users bulk-checkin view, if you didn't selected one status for all the assets that got checked in, the system came back into the users list with an error and no users selection is preserved.

I can see how, although little, this change is an enhancement to the current workflow if for some reason you didn't pay attention to the status and just click submit. This PR disables the submit button until the selected status is a valid one.

Fixes #11980 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
