### PR TITLE
Fixed #12161 500 error when accepting assets

### DIFF
--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -21,7 +21,7 @@ class CheckoutAcceptance extends Model
     {
         // At this point the endpoint is the same for everything.
         //  In the future this may want to be adapted for individual notifications.
-        return config('mail.reply_to.address');
+        return (config('mail.reply_to.address')) ? config('mail.reply_to.address') : '' ;
     }
 
     /**


### PR DESCRIPTION
# Description

When a user tries to accept an assigned asset, if no MAIL_REPLYTO_ADDR environment variable is setted in their .env file, the system shows a 500 error because the return type of the function `routeNotificationForMail()` is a string.

This PR I checks first if the variable is setted and if it is, returns the address, if don't exists just returns an empty string so the system don't crash.

Fixes #12161 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: nginx/1.19.8
* OS version: Debian 10


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
