### PR TITLE
Adds asset age to asset index and asset view pages

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -12,6 +12,7 @@ use App\Models\Statuslabel;
 use Crypt;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Image;
+use Carbon\Carbon;
 
 class Helper
 {
@@ -1125,5 +1126,25 @@ class Helper
 
         return $settings;
         }
+    public static function AgeFormat($date) {
+        $year = Carbon::parse($date)
+            ->diff(now())->y;
+        $month = Carbon::parse($date)
+            ->diff(now())->m;
+        $days = Carbon::parse($date)
+            ->diff(now())->d;
+        $age='';
+        if ($year) {
+            $age .= $year.'y ';
+        }
+        if ($month) {
+            $age .= $month.'m ';
+        }
+        if ($days) {
+            $age .= $days.'d';
+        }
 
+        return $age;
+
+    }
 }

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -81,7 +81,7 @@ class AssetsTransformer
             'next_audit_date' => Helper::getFormattedDateObject($asset->next_audit_date, 'date'),
             'deleted_at' => Helper::getFormattedDateObject($asset->deleted_at, 'datetime'),
             'purchase_date' => Helper::getFormattedDateObject($asset->purchase_date, 'date'),
-            'age' => $asset->purchase_date ? Helper::AgeFormat($asset->purhcase_date) : '',
+            'age' => $asset->purchase_date ? Helper::AgeFormat($asset->purchase_date) : '',
             'last_checkout' => Helper::getFormattedDateObject($asset->last_checkout, 'datetime'),
             'expected_checkin' => Helper::getFormattedDateObject($asset->expected_checkin, 'date'),
             'purchase_cost' => Helper::formatCurrencyOutput($asset->purchase_cost),

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -7,7 +7,7 @@ use App\Models\Asset;
 use App\Models\Setting;
 use Gate;
 use Illuminate\Database\Eloquent\Collection;
-use Carbon\Carbon;
+
 
 class AssetsTransformer
 {
@@ -81,7 +81,7 @@ class AssetsTransformer
             'next_audit_date' => Helper::getFormattedDateObject($asset->next_audit_date, 'date'),
             'deleted_at' => Helper::getFormattedDateObject($asset->deleted_at, 'datetime'),
             'purchase_date' => Helper::getFormattedDateObject($asset->purchase_date, 'date'),
-            'age' => Carbon::parse($asset->purchase_date)->diff(Carbon::now())->format('%y years, %m months and %d days'),
+            'age' => $asset->purchase_date ? Helper::AgeFormat($asset->purhcase_date) : '',
             'last_checkout' => Helper::getFormattedDateObject($asset->last_checkout, 'datetime'),
             'expected_checkin' => Helper::getFormattedDateObject($asset->expected_checkin, 'date'),
             'purchase_cost' => Helper::formatCurrencyOutput($asset->purchase_cost),

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -7,6 +7,7 @@ use App\Models\Asset;
 use App\Models\Setting;
 use Gate;
 use Illuminate\Database\Eloquent\Collection;
+use Carbon\Carbon;
 
 class AssetsTransformer
 {
@@ -80,6 +81,7 @@ class AssetsTransformer
             'next_audit_date' => Helper::getFormattedDateObject($asset->next_audit_date, 'date'),
             'deleted_at' => Helper::getFormattedDateObject($asset->deleted_at, 'datetime'),
             'purchase_date' => Helper::getFormattedDateObject($asset->purchase_date, 'date'),
+            'age' => Carbon::parse($asset->purchase_date)->diff(Carbon::now())->format('%y years, %m months and %d days'),
             'last_checkout' => Helper::getFormattedDateObject($asset->last_checkout, 'datetime'),
             'expected_checkin' => Helper::getFormattedDateObject($asset->expected_checkin, 'date'),
             'purchase_cost' => Helper::formatCurrencyOutput($asset->purchase_cost),

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -141,6 +141,12 @@ class AssetPresenter extends Presenter
                 'title' => trans('general.purchase_date'),
                 'formatter' => 'dateDisplayFormatter',
             ], [
+                'field' => 'age',
+                'searchable' => true,
+                'sortable' => true,
+                'visible' => false,
+                'title' => trans('general.age'),
+            ], [
                 'field' => 'purchase_cost',
                 'searchable' => true,
                 'sortable' => true,

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -11,6 +11,7 @@ return [
     'admin'					=> 'Admin',
     'administrator'			=> 'Administrator',
     'add_seats'             => 'Added seats',
+    'age'                   => "Age",
     'all_assets'			=> 'All Assets',
     'all'       			=> 'All',
     'archived'              => 'Archived',

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -495,6 +495,9 @@
                                             </div>
                                             <div class="col-md-6">
                                                 {{ Helper::getFormattedDateObject($asset->purchase_date, 'date', false) }}
+                                                -
+                                                {{ Carbon::parse($asset->purchase_date)->diff(Carbon::now())->format('%y years, %m months and %d days')}}
+
                                             </div>
                                         </div>
                                     @endif


### PR DESCRIPTION
# Description
This adds the age of an asset next to the purchase date on the view asset blade.
<img width="1456" alt="image" src="https://user-images.githubusercontent.com/47435081/204356397-f32d9b69-7498-4e83-aa3b-e66f47bc31e5.png">

Also adds age to the asset index page.  with a more abbreviated format, it is hidden by default.
<img width="351" alt="image" src="https://user-images.githubusercontent.com/47435081/207127455-3ea5568e-b25e-44c0-b66e-1fd9cb700704.png">



Fixes #12163 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
