### PR TITLE
Added serial number to emailed inventory report

### DIFF
--- a/resources/views/notifications/markdown/user-inventory.blade.php
+++ b/resources/views/notifications/markdown/user-inventory.blade.php
@@ -9,9 +9,9 @@
 ## {{ $assets->count() }} {{ trans('general.assets') }}
 
 <table width="100%">
-<tr><th align="left">{{ trans('mail.name') }} </th><th align="left">{{ trans('mail.asset_tag') }}</th></tr>
+<tr><th align="left">{{ trans('mail.name') }} </th><th align="left">{{ trans('mail.asset_tag') }}</th><th align="left">{{ trans('admin/hardware/table.serial') }}</th></tr>
 @foreach($assets as $asset)
-<tr><td>{{ $asset->present()->name }}</td><td> {{ $asset->asset_tag }} </td></tr>
+<tr><td>{{ $asset->present()->name }}</td><td> {{ $asset->asset_tag }} </td><td> {{ $asset->serial }} </td></tr>
 @endforeach
 </table>
 @endif


### PR DESCRIPTION
This just adds the asset serial number to the emailed inventory report that provides the user a list of everything assigned to them. 