### PR TITLE
Fixed #12133 - Added job title to header in print assets view

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -49,7 +49,7 @@
     @endif
 @endif
 
-<h2>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }}</h4>
+<h3>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} {{ ($show_user->jobtitle!='' ? ' - '.$show_user->jobtitle : '') }}</h3>
 
     @if ($assets->count() > 0)
         @php


### PR DESCRIPTION
This PR adds the user's job title (if one is present) to the header of the print all assigned screen.