### PR TITLE
Fix #9326: Warranty Expires should be also sortable

### DIFF
--- a/app/Console/Commands/SendExpirationAlerts.php
+++ b/app/Console/Commands/SendExpirationAlerts.php
@@ -52,7 +52,7 @@ class SendExpirationAlerts extends Command
             });
 
             // Expiring Assets
-            $assets = Asset::getExpiringWarrantee($threshold);
+            $assets = Asset::getExpiringWarranty($threshold);
             if ($assets->count() > 0) {
                 $this->info(trans_choice('mail.assets_warrantee_alert', $assets->count(), ['count' => $assets->count(), 'threshold' => $threshold]));
                 \Notification::send($recipients, new ExpiringAssetsNotification($assets, $threshold));

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -97,6 +97,7 @@ class AssetsController extends Controller
             'last_audit_date',
             'next_audit_date',
             'warranty_months',
+            'warranty_expires',
             'checkout_counter',
             'checkin_counter',
             'requests_counter',

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -680,10 +680,10 @@ class Asset extends Depreciable
             ->whereNotNull('warranty_months')
             ->whereNotNull('purchase_date')
             ->whereNull('deleted_at')
-            ->whereRaw('DATE_ADD(`purchase_date`,INTERVAL `warranty_months` MONTH) <= DATE(NOW() + INTERVAL '
+            ->whereRaw('`warranty_expires` <= DATE(NOW() + INTERVAL '
                                  . $days
-                                 . ' DAY) AND DATE_ADD(`purchase_date`, INTERVAL `warranty_months` MONTH) > NOW()')
-            ->orderByRaw('DATE_ADD(`purchase_date`,INTERVAL `warranty_months` MONTH)')
+                                 . ' DAY) AND `warranty_expires` > NOW()')
+            ->orderBy('warranty_expires')
             ->get();
     }
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -224,26 +224,6 @@ class Asset extends Depreciable
         return $this->present()->name();
     }
 
-    /**
-     * Returns the warranty expiration date as Carbon object
-     * @return \Carbon|null
-     */
-    public function getWarrantyExpiresAttribute()
-    {
-        if (isset($this->attributes['warranty_months']) && isset($this->attributes['purchase_date'])) {
-            if (is_string($this->attributes['purchase_date']) || is_string($this->attributes['purchase_date'])) {
-                $purchase_date = \Carbon\Carbon::parse($this->attributes['purchase_date']);
-            } else {
-                $purchase_date = \Carbon\Carbon::instance($this->attributes['purchase_date']);
-            }
-            $purchase_date->setTime(0, 0, 0);
-
-            return $purchase_date->addMonths((int) $this->attributes['warranty_months']);
-        }
-
-        return null;
-    }
-
 
     /**
      * Establishes the asset -> company relationship

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -672,7 +672,7 @@ class Asset extends Depreciable
      * @since [v2.0]
      * @return mixed
      */
-    public static function getExpiringWarrantee($days = 30)
+    public static function getExpiringWarranty($days = 30)
     {
         $days = (is_null($days)) ? 30 : $days;
 

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -170,7 +170,7 @@ class AssetPresenter extends Presenter
             ], [
                 'field' => 'warranty_expires',
                 'searchable' => false,
-                'sortable' => false,
+                'sortable' => true,
                 'visible' => false,
                 'title' => trans('admin/hardware/form.warranty_expires'),
                 'formatter' => 'dateDisplayFormatter',

--- a/database/migrations/2022_12_02_170921_add_warranty_expires_to_assets.php
+++ b/database/migrations/2022_12_02_170921_add_warranty_expires_to_assets.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddWarrantyExpiresToAssets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->date('warranty_expires')->virtualAs('DATE_ADD(`purchase_date`, INTERVAL `warranty_months` MONTH)')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            //
+            $table->dropColumn('warranty_expires');
+        });
+    }
+}


### PR DESCRIPTION
# Description

This adds the ability to sort by the warranty expires field. I added a generated column to the database that still calculates the warranty expires date on the fly, but allows it to be accessed like a normal database column. That change led to some redundancy in other places, so I cleaned that up. 

Also I changed the spelling of Warrantee in the name of getExpiringWarantee to Warranty to be consistent with the other parts of the project.

Regarding compatibility: generated columns are supported in MySQL since 5.7.1 and MariaDB since 10.2. I'm not totally sure from the requirements in the documentation whether this will be a problem.

Fixes #9326, but also slightly affects #5905. If #5925 or #524 are ever addressed, this shouldn't hurt anything.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I unfortunately couldn't figure out how to get the automated tests running, but I tested by hand with seeded data in Firefox and Chrome. I added a variety of warranty info (this isn't seeded by default) and made sure it sorted correctly. It works with null values and updates correctly when a purchase date or warranty month field is modified.

There is one existing test in tests/Unit/AssetTest.php for the old warranty_expires mutator that should still cover this.

I also don't have email alerts set up, but I put a a breakpoint in the getExpiringWarranty function and it successfully found the assets that were expiring within the threshold I set.

**Test Configuration**:
* PHP version: 8.1.2
* MySQL version: 8.0.31
* Webserver version: built in artisan serve with laravel 8.83.22  
* OS version Ubuntu 22.04

# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes