### PR TITLE
Add throttle for password reset form

### DIFF
--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -41,6 +41,7 @@ class ResetPasswordController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
+        $this->middleware('throttle:10,1');
     }
 
     protected function rules()
@@ -116,7 +117,7 @@ class ResetPasswordController extends Controller
             }
 
             \Log::debug('Password reset for '.$user->username.' FAILED - this user exists but the token is not valid');
-            return redirect()->back()->withInput($request->only('email'))->with('error', trans('passwords.token'));
+            return redirect()->back()->withInput($request->only('email'))->with('success', trans('passwords.reset'));
 
         }
 


### PR DESCRIPTION
I personally HATE this fix. It was brought up as a CVE issue because IF you have the wrong token, it tells you that the token is wrong. This changes it so that you get a success message even if the token it wrong and adds throttling to the reset password routes.

It's one of those "better security but shittier UX" compromises and I'm not sure I even want to take this PR. We'll discuss offline. 