### PR TITLE
Use `heroku-redis:mini` since `hobby-dev` is deprecated

### DIFF
--- a/app.json
+++ b/app.json
@@ -148,7 +148,7 @@
     "image": "heroku/php",
     "addons": [
       "cleardb:ignite",
-      "heroku-redis:hobby-dev",
+      "heroku-redis:mini",
       "papertrail:choklad"
     ]
   }


### PR DESCRIPTION
hobby-dev plan is removed. Replacing it with the same `mini` plan