### PR TITLE
Use `heroku-redis:mini` instead of `hobby` as It is deprecated

### DIFF
--- a/app.json
+++ b/app.json
@@ -148,7 +148,7 @@
     "image": "heroku/php",
     "addons": [
       "cleardb:ignite",
-      "heroku-redis:hobby-dev",
+      "heroku-redis:mini",
       "papertrail:choklad"
     ]
   }


### PR DESCRIPTION
Heroku has renamed it's plan to `mini` so we are updating the `app.json` file to use the correct add-on name.