### PR TITLE
Fixed: Grey out password reset button for consistency

### DIFF
--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -203,16 +203,18 @@
                 @endcan
 
                 @can('update', $user)
-                <div class="col-md-12" style="padding-top: 5px;">
-                  @if (($user->activated == '1') && ($user->email != '') && ($user->ldap_import == '0'))
+                  @if (($user->activated == '1') && ($user->ldap_import == '0'))
+                  <div class="col-md-12" style="padding-top: 5px;">
+                    @if($user->email != '')
                       <form action="{{ route('users.password',['userId'=> $user->id]) }}" method="POST">
                           {{ csrf_field() }}
                       <button style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('button.send_password_link') }}</button>
                       </form>
-                  @elseif(($user->activated == '1') && ($user->ldap_import == '0'))
+                    @else
                       <button style="width: 100%;" class="btn btn-sm btn-primary hidden-print" rel="noopener" disabled title="{{ trans('admin/users/message.user_has_no_email') }}">{{ trans('button.send_password_link') }}</button> 
-                  @endif
+                    @endif
                   </div>
+                  @endif
                 @endcan
 
                 @can('delete', $user)

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -203,14 +203,16 @@
                 @endcan
 
                 @can('update', $user)
+                <div class="col-md-12" style="padding-top: 5px;">
                   @if (($user->activated == '1') && ($user->email != '') && ($user->ldap_import == '0'))
-                      <div class="col-md-12" style="padding-top: 5px;">
-                        <form action="{{ route('users.password',['userId'=> $user->id]) }}" method="POST">
+                      <form action="{{ route('users.password',['userId'=> $user->id]) }}" method="POST">
                           {{ csrf_field() }}
-                          <button style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('button.send_password_link') }}</button>
-                        </form>
-                      </div>
+                      <button style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('button.send_password_link') }}</button>
+                      </form>
+                  @elseif(($user->activated == '1') && ($user->ldap_import == '0'))
+                      <button style="width: 100%;" class="btn btn-sm btn-primary hidden-print" rel="noopener" disabled title="{{ trans('admin/users/message.user_has_no_email') }}">{{ trans('button.send_password_link') }}</button> 
                   @endif
+                  </div>
                 @endcan
 
                 @can('delete', $user)


### PR DESCRIPTION
When user has no email in their profile, the box is greyed out for consistency accross all buttons on the user profile

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in local instance


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
