### PR TITLE
Fixed: Bug with BS tables' select-all which showed an incorrect list of elements

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -129,7 +129,10 @@
         var tableId =  $(this).data('id-table');
 
         for (var i in rowsAfter) {
-            $(buttonName).after('<input id="' + tableId + '_checkbox_' + rowsAfter[i].id + '" type="hidden" name="ids[]" value="' + rowsAfter[i].id + '">');
+            // Do not select things that were already selected
+            if($('#'+ tableId + '_checkbox_' + rowsAfter[i].id).length == 0) {
+                $(buttonName).after('<input id="' + tableId + '_checkbox_' + rowsAfter[i].id + '" type="hidden" name="ids[]" value="' + rowsAfter[i].id + '">');
+            }
         }
     });
 


### PR DESCRIPTION
On a call with a customer, we noticed that if you select-all, then unselect a few items, then select-all again, then *un*-select-all, and then select a few items, then go to 'bulk checkin' - it would show you a big giant list of users, not just the ones you picked.

It turns out the 'select-all' functionality didn't check if something had already been selected, so it would insert a *second* hidden element (with the exact same ID, which is a violation of the HTML spec). So when you un-select things it would only yank the *first* element with that ID, leaving the second one.

This change just makes sure that the hidden form input doesn't already exist before it tries to add a new one.

I suspect you could also trigger this bug by selecting a few things, then clicking select-all, then clicking un-select all, and finally picking one element and hitting 'checkin' bulk action - same thing would've probably happened.

I've included a video of the behavior before the change.


https://user-images.githubusercontent.com/36335/208783160-dbd64877-1ff2-4783-bfcb-5e1d823c5cf1.mov

