### PR TITLE
Fixed: Dashboard user count scoping when full company support is enabled

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -34,7 +34,7 @@ class DashboardController extends Controller
             $counts['license'] = \App\Models\License::assetcount();
             $counts['consumable'] = \App\Models\Consumable::count();
             $counts['component'] = \App\Models\Component::count();
-            $counts['user'] = \App\Models\User::count();
+            $counts['user'] = \App\Models\Company::scopeCompanyables(Auth::user())->count();
             $counts['grand_total'] = $counts['asset'] + $counts['accessory'] + $counts['license'] + $counts['consumable'];
 
             if ((! file_exists(storage_path().'/oauth-private.key')) || (! file_exists(storage_path().'/oauth-public.key'))) {


### PR DESCRIPTION
# Description
I found a small issue in the Dashboard where the system counts all people in the system, even if Full Company Support is enabled. This PR takes care of that and only count the users that have the same company assigned.

For clarity, this is where the number was wrong.

![image](https://user-images.githubusercontent.com/653557/208793872-61da3c77-f466-43a5-81f6-5a9d9ab6ba34.png)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version. 8.0.22
* Webserver version: nginx/1.19.8
* OS version: Debian 10
