### PR TITLE
Fixed db seeder when company id is not present

### DIFF
--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -218,7 +218,7 @@ class ValidationServiceProvider extends ServiceProvider
 
         Validator::extend('is_unique_department', function ($attribute, $value, $parameters, $validator) {
             $data = $validator->getData();
-            if ($data['location_id'] != null && $data['company_id'] != null) {
+            if ((array_key_exists('location_id', $data) && $data['location_id'] != null) && (array_key_exists('company_id', $data) && $data['company_id'] != null)) {
                 $count = Department::where('name', $data['name'])
                     ->where('location_id', $data['location_id'])
                     ->where('company_id', $data['company_id'])


### PR DESCRIPTION
Small fix to check whether or not `company_id ` is included in the `$data` payload. This should fix the develop demo no seeding properly.