### PR TITLE
Fixed: Change license_seat changing method to properly 'true up' license seats

### DIFF
--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -123,12 +123,20 @@ class License extends Depreciable
         static::created(function ($license) {
             $newSeatCount = $license->getAttributes()['seats'];
 
-            return static::adjustSeatCount($license, $oldSeatCount = 0, $newSeatCount);
+            return static::adjustSeatCount($license, 0, $newSeatCount);
         });
         // However, we listen for updating to be able to prevent the edit if we cannot delete enough seats.
         static::updating(function ($license) {
             $newSeatCount = $license->getAttributes()['seats'];
-            $oldSeatCount = isset($license->getOriginal()['seats']) ? $license->getOriginal()['seats'] : 0;
+            //$oldSeatCount = isset($license->getOriginal()['seats']) ? $license->getOriginal()['seats'] : 0;
+            /*
+               That previous method *did* mostly work, but if you ever managed to get your $license->seats value out of whack
+               with your actual count of license_seats *records*, you would never manage to get back 'into whack'.
+               The below method actually grabs a count of existing license_seats records, so it will be more accurate.
+               This means that if your license_seats are out of whack, you can change the quantity and hit 'save' and it
+               will manage to 'true up' and make your counts line up correctly.
+            */
+            $oldSeatCount = $license->license_seats_count;
 
             return static::adjustSeatCount($license, $oldSeatCount, $newSeatCount);
         });


### PR DESCRIPTION
A customer reported that the number of license seats that they had defined for the license didn't match up with the number of license seats reported when they clicked the 'seats' tab.

Somehow, they managed to have only 5 empty `license_seat` records, even though they had defined 6 as the number of seats that are in the license.

I realized that, no matter how I adjust the seat count in the license, the issue will never get rectified - when I changed the seat count to 7, it correctly added a new blank seat - but there were still only 6 of them. So nothing I was going to be able to do was going to fix their data barring manually editing their database.

I've modified our callback hooks to instead take the 'true' seat count (from literally counting the number of records in the `license_seats` table) instead of the 'previous' seat count. This means that if any other user has a license_seat count vs. `$license->seats` mismatch, they can just do an edit to the seat count, and it should correct the issue and 'true up' the database to match.