### PR TITLE
Fixed missing translation string

### DIFF
--- a/app/Http/Requests/ItemImportRequest.php
+++ b/app/Http/Requests/ItemImportRequest.php
@@ -49,7 +49,7 @@ class ItemImportRequest extends FormRequest
                 $errorMessage = null;
 
                 if (is_null($fieldValue)) {
-                    $errorMessage = trans('validation.import_field_empty');
+                    $errorMessage = trans('validation.import_field_empty', ['fieldname' => $field]);
                     $this->errorCallback($import, $field, $errorMessage);
 
                     return $this->errors;

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -43,6 +43,7 @@ return [
     'file'                 => 'The :attribute must be a file.',
     'filled'               => 'The :attribute field must have a value.',
     'image'                => 'The :attribute must be an image.',
+    'import_field_empty'    => 'The value for :fieldname cannot be null.',
     'in'                   => 'The selected :attribute is invalid.',
     'in_array'             => 'The :attribute field does not exist in :other.',
     'integer'              => 'The :attribute must be an integer.',


### PR DESCRIPTION
To be honest, I'm kinda not sure when this switch would actually fire - perhaps a weirdly formatted CSV where the value is being passed as null instead of `''`? Either way though, the validation string doesn't exist, so it currently (unfixed) returned `Notes: validation.import_field_empty`. 