### PR TITLE
Fixed #12288 - LDAP default group feature refactor

### DIFF
--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -77,6 +77,7 @@ return [
     'ldap'                      => 'LDAP',
     'ldap_default_group'        => 'Default Permissions Group',
     'ldap_default_group_info'   => 'Select a group to assign to newly synced users. Remember that a user takes on the permissions of the group they are assigned.',
+    'no_default_group'          => 'No Default Group',
     'ldap_help'                 => 'LDAP/Active Directory',
     'ldap_client_tls_key'       => 'LDAP Client TLS Key',
     'ldap_client_tls_cert'      => 'LDAP Client-Side TLS Certificate',

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -116,11 +116,11 @@
                                                     name="ldap_default_group"
                                                     aria-label="ldap_default_group"
                                                     id="ldap_default_group"
-                                                    class="form-control"
+                                                    class="form-control select2"
                                             >
-                                                <option></option>
+                                                <option value="">{{ trans('admin/settings/general.no_default_group') }}</option>
                                                 @foreach ($groups as $id => $group)
-                                                    <option value="{{ $id }}">
+                                                    <option value="{{ $id }}" {{ $setting->ldap_default_group == $id ? 'selected' : '' }}>
                                                         {{ $group }}
                                                     </option>
                                                 @endforeach


### PR DESCRIPTION
In issue #12288, it seemed that:

 - if you have a default group selected for LDAP users, and then that group got deleted, then the LDAP sync would crash out.

Furthermore, there were a couple of other issues:

- We were repeatedly looking up the group by ID within the for loop, when one single lookup outside of the loop would be enough.
- We were just copying the permissions over from the group, instead of 'attaching' the group to the many-to-many relationship
- We were assigned the group to all users, not just the newly-created ones.
- The select2 styling wasn't applied to the drop-down menu in the settings
- The previous selection wasn't being reflected in the settings screen - if you set a default LDAP group, and reload the settings page, you couldn't see that the group was actually 'set'.