### PR TITLE
The cache system in getSettings() cached values "forever." That's bad.

### DIFF
--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -21,11 +21,10 @@ class Setting extends Model
     use Notifiable, ValidatingTrait;
 
     /**
-     * The app settings cache key name.
-     *
-     * @var string
+     * The cache property so that multiple invocations of this will only load the Settings record from disk only once
+     * @var self
      */
-    const APP_SETTINGS_KEY = 'snipeit_app_settings';
+    public static ?self $_cache = null;
 
     /**
      * The setup check cache key name.
@@ -98,14 +97,15 @@ class Setting extends Model
      */
     public static function getSettings(): ?self
     {
-        return Cache::rememberForever(self::APP_SETTINGS_KEY, function () {
+        if (!self::$_cache) {
             // Need for setup as no tables exist
             try {
-                return self::first();
+                self::$_cache = self::first();
             } catch (\Throwable $th) {
                 return null;
             }
-        });
+        }
+        return self::$_cache;
     }
 
     /**

--- a/app/Observers/SettingObserver.php
+++ b/app/Observers/SettingObserver.php
@@ -16,7 +16,6 @@ class SettingObserver
      */
     public function saved(Setting $setting)
     {
-        Cache::forget(Setting::APP_SETTINGS_KEY);
         Cache::forget(Setting::SETUP_CHECK_KEY);
     }
 }


### PR DESCRIPTION
The `Cache::rememberForever()` invocation we were doing was way, way too aggressive - literally caching forever. Newly-updated Settings would end up not reflecting changes in the settings table until you could run `php artisan cache:clear`.

This changes that caching system to use a simple static property as an in-memory cache so that multiple invocations of `Setting::getSettings()` would only hit the disk once - per request. On the next request, it will hit the disk again - but, again, only once.

I tested this in Tinker multiple times by changing the database directly and repeatedly re-invoking `getSettings()` - which seemed to work as expected.