### PR TITLE
Fixed #12236 - Determine which transformer to use based on number of assets in byTag and bySerial API endpoint

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -379,17 +379,19 @@ class AssetsController extends Controller
             $assets = $assets->withTrashed();
         }
 
-        $assets = $assets->get();
+        if (($assets = $assets->get()) && ($assets->count()) > 0) {
 
-        // If there is only one result, we should pull the first (and only) asset from the returned collection, since
-        // transformAsset() expects an Asset object, NOT a collection
-        if (($assets) && ($assets->count() == 1)) {
-            return (new AssetsTransformer)->transformAsset($assets->first());
+            // If there is only one result, we should pull the first (and only) asset from the returned collection, since
+            // transformAsset() expects an Asset object, NOT a collection
+            if ($assets->count() == 1) {
+                return (new AssetsTransformer)->transformAsset($assets->first());
 
-        // If there is more than one result - which would probably never show up in the UI, since it would only happen if
-        //  there are multiple deleted assets with the same tag, pass the collection normally
-        } elseif (($assets) && ($assets->count() > 1)) {
-            return (new AssetsTransformer)->transformAssets($assets, $assets->count());
+            // If there is more than one result OR if the endpoint is requesting deleted items (even if there is only one
+            // match, return the normal collection transformed.
+            } elseif (($assets->count() > 1) || ($request->input('deleted') == 'true')) {
+                return (new AssetsTransformer)->transformAssets($assets, $assets->count());
+            }
+
         }
 
         // If there are 0 results, return the "no such asset" response
@@ -418,15 +420,19 @@ class AssetsController extends Controller
 
         $assets = $assets->get();
 
-        // If there is only one result, we should pull the first (and only) asset from the returned collection, since
-        // transformAsset() expects an Asset object, NOT a collection
-        if (($assets) && ($assets->count() == 1)) {
-            return (new AssetsTransformer)->transformAsset($assets->first());
+        if (($assets = $assets->get()) && ($assets->count()) > 0) {
 
-            // If there is more than one result - which would probably never show up in the UI, since it would only happen if
-            //  there are multiple deleted assets with the same tag, pass the collection normally
-        } elseif (($assets) && ($assets->count() > 1)) {
-            return (new AssetsTransformer)->transformAssets($assets, $assets->count());
+            // If there is exactly one result, we should pull the first (and only) asset from the returned collection, since
+            // transformAsset() expects an Asset object, NOT a collection
+            if ($assets->count() == 1) {
+                return (new AssetsTransformer)->transformAsset($assets->first());
+
+                // If there is more than one result OR if the endpoint is requesting deleted items (even if there is only one
+                // match, return the normal collection transformed.
+            } elseif (($assets->count() > 1) || ($request->input('deleted') == 'true')) {
+                return (new AssetsTransformer)->transformAssets($assets, $assets->count());
+            }
+
         }
 
         // If there are 0 results, return the "no such asset" response

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -381,11 +381,20 @@ class AssetsController extends Controller
 
         $assets = $assets->get();
 
-        if (($assets) && ($assets->count() > 0)) {
+        // If there is only one result, we should pull the first (and only) asset from the returned collection, since
+        // transformAsset() expects an Asset object, NOT a collection
+        if (($assets) && ($assets->count() == 1)) {
+            return (new AssetsTransformer)->transformAsset($assets->first());
+
+        // If there is more than one result - which would probably never show up in the UI, since it would only happen if
+        //  there are multiple deleted assets with the same tag, pass the collection normally
+        } elseif (($assets) && ($assets->count() > 1)) {
             return (new AssetsTransformer)->transformAssets($assets, $assets->count());
-        } else {
-            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/hardware/message.does_not_exist')), 200);
         }
+
+        // If there are 0 results, return the "no such asset" response
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/hardware/message.does_not_exist')), 200);
+
 
     }
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -381,22 +381,18 @@ class AssetsController extends Controller
 
         if (($assets = $assets->get()) && ($assets->count()) > 0) {
 
-            // If there is only one result, we should pull the first (and only) asset from the returned collection, since
-            // transformAsset() expects an Asset object, NOT a collection
-            if ($assets->count() == 1) {
+            // If there is exactly one result and the deleted parameter is not passed, we should pull the first (and only)
+            // asset from the returned collection, since transformAsset() expects an Asset object, NOT a collection
+            if (($assets->count() == 1) && ($request->input('deleted') != 'true')) {
                 return (new AssetsTransformer)->transformAsset($assets->first());
 
-            // If there is more than one result OR if the endpoint is requesting deleted items (even if there is only one
-            // match, return the normal collection transformed.
-            } elseif (($assets->count() > 1) || ($request->input('deleted') == 'true')) {
+                // If there is more than one result OR if the endpoint is requesting deleted items (even if there is only one
+                // match, return the normal collection transformed.
+            } else {
                 return (new AssetsTransformer)->transformAssets($assets, $assets->count());
             }
 
         }
-
-        // If there are 0 results, return the "no such asset" response
-        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/hardware/message.does_not_exist')), 200);
-
 
     }
 
@@ -422,14 +418,14 @@ class AssetsController extends Controller
 
         if (($assets = $assets->get()) && ($assets->count()) > 0) {
 
-            // If there is exactly one result, we should pull the first (and only) asset from the returned collection, since
-            // transformAsset() expects an Asset object, NOT a collection
-            if ($assets->count() == 1) {
+            // If there is exactly one result and the deleted parameter is not passed, we should pull the first (and only)
+            // asset from the returned collection, since transformAsset() expects an Asset object, NOT a collection
+            if (($assets->count() == 1) && ($request->input('deleted') != 'true')) {
                 return (new AssetsTransformer)->transformAsset($assets->first());
 
-                // If there is more than one result OR if the endpoint is requesting deleted items (even if there is only one
-                // match, return the normal collection transformed.
-            } elseif (($assets->count() > 1) || ($request->input('deleted') == 'true')) {
+            // If there is more than one result OR if the endpoint is requesting deleted items (even if there is only one
+            // match, return the normal collection transformed.
+            } else {
                 return (new AssetsTransformer)->transformAssets($assets, $assets->count());
             }
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -418,11 +418,20 @@ class AssetsController extends Controller
 
         $assets = $assets->get();
 
-        if (($assets) && ($assets->count() > 0)) {
+        // If there is only one result, we should pull the first (and only) asset from the returned collection, since
+        // transformAsset() expects an Asset object, NOT a collection
+        if (($assets) && ($assets->count() == 1)) {
+            return (new AssetsTransformer)->transformAsset($assets->first());
+
+            // If there is more than one result - which would probably never show up in the UI, since it would only happen if
+            //  there are multiple deleted assets with the same tag, pass the collection normally
+        } elseif (($assets) && ($assets->count() > 1)) {
             return (new AssetsTransformer)->transformAssets($assets, $assets->count());
-        } else {
-            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/hardware/message.does_not_exist')), 200);
         }
+
+        // If there are 0 results, return the "no such asset" response
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/hardware/message.does_not_exist')), 200);
+
     }
 
     /**

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -394,6 +394,9 @@ class AssetsController extends Controller
 
         }
 
+        // If there are 0 results, return the "no such asset" response
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/hardware/message.does_not_exist')), 200);
+
     }
 
     /**


### PR DESCRIPTION
When we added the ability to pass a deleted flag to the `showByTag()` method in the Assets API controller, we inadvertently broke compatibility with barcode scanners that were configured to use the old response. 

The reason for this is that it's NOW possible to get more than one asset returned in the current API call. Previously, we were looking for an __exact__ match on asset tag, and since (undeleted) asset tags are unique, we never needed to worry about passing more than one asset back to you as a result. With the deleted flag, it IS possible to have more than one result there, so we'd have to funnel it through the `transformAssets()` (plural) transformer, which expects a collection. 

By using `$assets->first()` on results where there is only one result, it passes an Asset object to the `transformAsset()` (singular) which expects an Asset Object and cannot take a collection. This should restore the old behavior without breaking the new.

This should fix the regression discovered in #12236.