### PR TITLE
Fixed bySerial endpoint to always return a list

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -416,22 +416,9 @@ class AssetsController extends Controller
         if ($request->input('deleted', 'false') == 'true') {
             $assets = $assets->withTrashed();
         }
-
-        $assets = $assets->get();
-
+        
         if (($assets = $assets->get()) && ($assets->count()) > 0) {
-
-            // If there is exactly one result and the deleted parameter is not passed, we should pull the first (and only)
-            // asset from the returned collection, since transformAsset() expects an Asset object, NOT a collection
-            if (($assets->count() == 1) && ($request->input('deleted') != 'true')) {
-                return (new AssetsTransformer)->transformAsset($assets->first());
-
-            // If there is more than one result OR if the endpoint is requesting deleted items (even if there is only one
-            // match, return the normal collection transformed.
-            } else {
-                return (new AssetsTransformer)->transformAssets($assets, $assets->count());
-            }
-
+             return (new AssetsTransformer)->transformAssets($assets, $assets->count());
         }
 
         // If there are 0 results, return the "no such asset" response


### PR DESCRIPTION
Looks like in the older versions of `showBySerial()` we were always returning a list (collection) so this reverts that behavior back.