### PR TITLE
Fixed UX issue where assets sidenav would collapse if custom status label is selected

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -403,7 +403,7 @@
             </li>
             @endcan
             @can('index', \App\Models\Asset::class)
-            <li class="treeview{{ (Request::is('hardware*') ? ' active' : '') }}">
+            <li class="treeview{{ ((Request::is('statuslabels/*') || Request::is('hardware*')) ? ' active' : '') }}">
                 <a href="#"><i class="fas fa-barcode fa-fw" aria-hidden="true"></i>
                   <span>{{ trans('general.assets') }}</span>
                   <i class="fa fa-angle-left pull-right"></i>
@@ -419,7 +419,7 @@
                     <?php $status_navs = \App\Models\Statuslabel::where('show_in_nav', '=', 1)->withCount('assets as asset_count')->get(); ?>
                     @if (count($status_navs) > 0)
                         @foreach ($status_navs as $status_nav)
-                            <li><a href="{{ route('statuslabels.show', ['statuslabel' => $status_nav->id]) }}">
+                            <li{!! (Request::is('statuslabels/'.$status_nav->id) == 'Deployed' ? ' class="active"' : '') !!}><a href="{{ route('statuslabels.show', ['statuslabel' => $status_nav->id]) }}">
                                 <i class="fas fa-circle text-grey fa-fw" aria-hidden="true"{!!  ($status_nav->color!='' ? ' style="color: '.e($status_nav->color).'"' : '') !!}></i>
                                  {{ $status_nav->name }} ({{ $status_nav->asset_count }})</a></li>
                         @endforeach

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -419,7 +419,7 @@
                     <?php $status_navs = \App\Models\Statuslabel::where('show_in_nav', '=', 1)->withCount('assets as asset_count')->get(); ?>
                     @if (count($status_navs) > 0)
                         @foreach ($status_navs as $status_nav)
-                            <li{!! (Request::is('statuslabels/'.$status_nav->id) == 'Deployed' ? ' class="active"' : '') !!}><a href="{{ route('statuslabels.show', ['statuslabel' => $status_nav->id]) }}">
+                            <li{!! (Request::is('statuslabels/'.$status_nav->id) ? ' class="active"' : '') !!}><a href="{{ route('statuslabels.show', ['statuslabel' => $status_nav->id]) }}">
                                 <i class="fas fa-circle text-grey fa-fw" aria-hidden="true"{!!  ($status_nav->color!='' ? ' style="color: '.e($status_nav->color).'"' : '') !!}></i>
                                  {{ $status_nav->name }} ({{ $status_nav->asset_count }})</a></li>
                         @endforeach


### PR DESCRIPTION
This is a bit of an awkward fix tbh. To reproduce this:

1. Create a custom status label and mark it as shown in the nav. 
2. Using the hamburger menu, expand the sidenav so it's not the compact version
3. When you click on the custom status label in the sidenav in the Assets section, the asset top level menu collapses

The reason for this is because custom status labels don't actually point to the `/hardware` sections, instead they point to the status labels listing, since the non-custom ones are working with the meta status, while the custom ones are a specific status ID. This is a sort of visual workaround which I don't love, but I think should solve the problem for most people.

### Before

![Screen Recording 2023-01-10 at 1 36 11 AM 2023-01-10 01_44_07](https://user-images.githubusercontent.com/197404/211517323-8077d075-1e21-44d8-9405-c697e56c6c55.gif)


### After

![Screen Recording 2023-01-10 at 1 38 57 AM 2023-01-10 01_45_08](https://user-images.githubusercontent.com/197404/211517407-80524b42-52d6-4c9c-a9cc-742110d93ba9.gif)



