### PR TITLE
Added acceptance PDF filename to asset endpoint

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -190,8 +190,8 @@ class AssetsTransformer
                     'email'=> ($asset->assigned->email) ? e($asset->assigned->email) : null,
                     'employee_number' =>  ($asset->assigned->employee_num) ? e($asset->assigned->employee_num) : null,
                     'type' => 'user',
-                    'eula_pdf' => e($asset->lastAcceptedLog->last()->filename),
-                    'signature_file' => e($asset->lastAcceptedLog->last()->accept_signature),
+                    'eula_pdf' => e($asset->acceptanceLog->last()->filename),
+                    'signature_file' => e($asset->acceptanceLog->last()->accept_signature),
                 ] : null;
         }
 

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -190,6 +190,8 @@ class AssetsTransformer
                     'email'=> ($asset->assigned->email) ? e($asset->assigned->email) : null,
                     'employee_number' =>  ($asset->assigned->employee_num) ? e($asset->assigned->employee_num) : null,
                     'type' => 'user',
+                    'eula_pdf' => e($asset->lastAcceptedLog->last()->filename),
+                    'signature_file' => e($asset->lastAcceptedLog->last()->accept_signature),
                 ] : null;
         }
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -106,7 +106,6 @@ class Asset extends Depreciable
         'physical'        => 'numeric|max:1|nullable',
         'checkout_date'   => 'date|max:10|min:10|nullable',
         'checkin_date'    => 'date|max:10|min:10|nullable',
-        'supplier_id'     => 'exists:suppliers,id|numeric|nullable',
         'location_id'     => 'exists:locations,id|nullable',
         'rtd_location_id' => 'exists:locations,id|nullable',
         'asset_tag'       => 'required|min:1|max:255|unique_undeleted',

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -596,7 +596,7 @@ class Asset extends Depreciable
      * @since [v6.0.14]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function lastAcceptedLog()
+    public function acceptanceLog()
     {
         return $this->hasMany(\App\Models\Actionlog::class, 'item_id')
             ->where('item_type', '=', self::class)

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -588,6 +588,24 @@ class Asset extends Depreciable
     }
 
     /**
+     * Get the log info for acceptances on this asset.
+     * To use this as a single record, invoke it using ->last(), for
+     * example, $asset->lastAcceptedLog->last().
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v6.0.14]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function lastAcceptedLog()
+    {
+        return $this->hasMany(\App\Models\Actionlog::class, 'item_id')
+            ->where('item_type', '=', self::class)
+            ->where('action_type', '=', 'accepted')
+            ->orderBy('created_at', 'desc')
+            ->withTrashed();
+    }
+
+    /**
      * Get the list of checkouts for this asset
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]


### PR DESCRIPTION
If a user has accepted an asset and they had to sign the EULA, this simply returns the EULA and signature filename to the `assigned_to` payload.

```json
"assigned_to": {
        "id": 2,
        "username": "snipe",
        "name": "Snipe E. Head",
        "first_name": "Snipe E.",
        "last_name": "Head",
        "email": "snipe@snipe.net",
        "employee_number": "22890",
        "type": "user",
        "eula_pdf": "accepted-eula-2023-01-10-11-11-40.pdf",
        "signature_file": "siglog-60e5c56c-5205-4abe-834c-01c97131bb06-2023-01-10-111140.png"
    },
```

While this isn't immediately useful to us on the UI side, it can be helpful for automations, and may help us convert some of the few non-API based screens within the UI.

I also fixed a duplicate validation, since I was in there, tho it should probably have been a separate PR.