### PR TITLE
Fixed #12004: Snipe-IT restore didn't work on Windows

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -214,7 +214,7 @@ class RestoreFromBackup extends Command
         $env_vars['MYSQL_PWD'] = config('database.connections.mysql.password');
         // TODO notes: we are stealing the dump_binary_path (which *probably* also has your copy of the mysql binary in it. But it might not, so we might need to extend this)
         //             we unilaterally prepend a slash to the `mysql` command. This might mean your path could look like /blah/blah/blah//mysql - which should be fine. But maybe in some environments it isn't?
-        $mysql_binary = config('database.connections.mysql.dump.dump_binary_path').'/mysql';
+        $mysql_binary = config('database.connections.mysql.dump.dump_binary_path').\DIRECTORY_SEPARATOR.'mysql'.(\DIRECTORY_SEPARATOR == '\\' ? ".exe" : "");
         if( ! file_exists($mysql_binary) ) {
             return $this->error("mysql tool at: '$mysql_binary' does not exist, cannot restore. Please edit DB_DUMP_PATH in your .env to point to a directory that contains the mysqldump and mysql binary");
         }


### PR DESCRIPTION
When I built the Snipe-IT restore command, I didn't take Windows into account. This uses the `DIRECTORY_SEPARATOR` constant to determine how to assemble the path to the mysql binary, and then uses it again to determine if we want to add `.exe` to the end.

This definitely still works on my Mac (I just did a test restore), but I'm waiting for confirmation that it works on Windows, as well. I've reached out to the customer who mentioned it, as well as to the GH issue (#12004 ) about it. Hopefully someone can confirm that for us soon and we can put this to bed.

Once someone confirms this works, I'll take this out of 'DRAFT' mode. Or, as I'm thinking about it - since Windows is already busted on restores, maybe we should just YOLO it?