### PR TITLE
Refactor category API for fewer queries

### DIFF
--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -10,6 +10,7 @@ use App\Models\Category;
 use Illuminate\Http\Request;
 use App\Http\Requests\ImageUploadRequest;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
 
 class CategoriesController extends Controller
 {
@@ -107,7 +108,7 @@ class CategoriesController extends Controller
     public function show($id)
     {
         $this->authorize('view', Category::class);
-        $category = Category::findOrFail($id);
+        $category = Category::withCount('assets as assets_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'licenses as licenses_count')->findOrFail($id);
         return (new CategoriesTransformer)->transformCategory($category);
 
     }
@@ -126,9 +127,17 @@ class CategoriesController extends Controller
     {
         $this->authorize('update', Category::class);
         $category = Category::findOrFail($id);
+
+        if ($category->category_type !== $request->input('category_type')) {
+            return response()->json(
+                Helper::formatStandardApiResponse('error', null,  trans('admin/categories/message.update.cannot_change_category_type'))
+            );
+        }
         $category->fill($request->all());
-        $category->category_type = strtolower($request->input('category_type'));
+
         $category = $request->handleImages($category);
+
+
 
         if ($category->save()) {
             return response()->json(Helper::formatStandardApiResponse('success', $category, trans('admin/categories/message.update.success')));
@@ -148,7 +157,7 @@ class CategoriesController extends Controller
     public function destroy($id)
     {
         $this->authorize('delete', Category::class);
-        $category = Category::findOrFail($id);
+        $category = Category::withCount('assets as assets_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'licenses as licenses_count')->findOrFail($id);
 
         if (! $category->isDeletable()) {
             return response()->json(

--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -128,16 +128,14 @@ class CategoriesController extends Controller
         $this->authorize('update', Category::class);
         $category = Category::findOrFail($id);
 
-        if ($category->category_type !== $request->input('category_type')) {
+        // Don't allow the user to change the category_type once it's been created
+        if (($request->filled('category_type')) && ($category->category_type != $request->input('category_type'))) {
             return response()->json(
                 Helper::formatStandardApiResponse('error', null,  trans('admin/categories/message.update.cannot_change_category_type'))
             );
         }
         $category->fill($request->all());
-
         $category = $request->handleImages($category);
-
-
 
         if ($category->save()) {
             return response()->json(Helper::formatStandardApiResponse('success', $category, trans('admin/categories/message.update.success')));

--- a/app/Http/Transformers/CategoriesTransformer.php
+++ b/app/Http/Transformers/CategoriesTransformer.php
@@ -22,6 +22,24 @@ class CategoriesTransformer
 
     public function transformCategory(Category $category = null)
     {
+
+        switch ($category->category_type) {
+            case 'asset':
+                $category->item_count = $category->assets_count;
+                break;
+            case 'accessory':
+                $category->item_count = $category->accessories_count;
+                break;
+            case 'consumable':
+                $category->item_count = $category->consumables_count;
+                break;
+            case 'component':
+                $category->item_count = $category->components_count;
+                break;
+            default:
+                $category->item_count = 0;
+        }
+
         if ($category) {
             $array = [
                 'id' => (int) $category->id,
@@ -33,7 +51,7 @@ class CategoriesTransformer
                 'eula' => ($category->getEula()),
                 'checkin_email' => ($category->checkin_email == '1'),
                 'require_acceptance' => ($category->require_acceptance == '1'),
-                'item_count' => (int) $category->itemCount(),
+                'item_count' => (int) $category->item_count,
                 'assets_count' => (int) $category->assets_count,
                 'accessories_count' => (int) $category->accessories_count,
                 'consumables_count' => (int) $category->consumables_count,

--- a/app/Http/Transformers/CategoriesTransformer.php
+++ b/app/Http/Transformers/CategoriesTransformer.php
@@ -23,6 +23,8 @@ class CategoriesTransformer
     public function transformCategory(Category $category = null)
     {
 
+        // We only ever use item_count for categories in this transformer, so it makes sense to keep it
+        // simple and do this switch here.
         switch ($category->category_type) {
             case 'asset':
                 $category->item_count = $category->assets_count;

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -100,7 +100,7 @@ class Category extends SnipeModel
     {
 
         return Gate::allows('delete', $this)
-            && ($this->itemCount() == 0);
+                && ($this->itemCount() == 0);
     }
 
     /**
@@ -155,7 +155,7 @@ class Category extends SnipeModel
      * Get the number of items in the category. This should NEVER be used in
      * a collection of categories, as you'll end up with an n+1 query problem.
      *
-     * It should only be used in a single categoiry context.
+     * It should only be used in a single category context.
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v2.0]

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -179,7 +179,8 @@ class Category extends SnipeModel
                 return $this->consumables()->count();
             case 'license':
                 return $this->licenses()->count();
-            default: 0;
+            default:
+                return 0;
         }
 
     }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Gate;
 use Watson\Validating\ValidatingTrait;
 use App\Helpers\Helper;
+use Illuminate\Support\Str;
 
 /**
  * Model for Categories. Categories are a higher-level group
@@ -97,8 +98,11 @@ class Category extends SnipeModel
      */
     public function isDeletable()
     {
-        return Gate::allows('delete', $this)
-                && ($this->itemCount() == 0);
+        if (Gate::allows('delete', $this)) {
+            $category_type_var = Str::plural($this->category_type).'_count';
+            return  $this->{$category_type_var};
+        }
+
     }
 
     /**
@@ -148,31 +152,7 @@ class Category extends SnipeModel
     {
         return $this->hasMany(\App\Models\Component::class);
     }
-
-    /**
-     * Get the number of items in the category
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v2.0]
-     * @return int
-     */
-    public function itemCount()
-    {
-        switch ($this->category_type) {
-            case 'asset':
-                return $this->assets()->count();
-            case 'accessory':
-                return $this->accessories()->count();
-            case 'component':
-                return $this->components()->count();
-            case 'consumable':
-                return $this->consumables()->count();
-            case 'license':
-                return $this->licenses()->count();
-        }
-
-        return '0';
-    }
+    
 
     /**
      * Establishes the category -> assets relationship

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -98,11 +98,8 @@ class Category extends SnipeModel
      */
     public function isDeletable()
     {
-        if (Gate::allows('delete', $this)) {
-            $category_type_var = Str::plural($this->category_type).'_count';
-            return  $this->{$category_type_var};
-        }
-
+        return Gate::allows('delete', $this)
+            && ($this->{Str::plural($this->category_type).'_count'} == 0);
     }
 
     /**
@@ -152,7 +149,34 @@ class Category extends SnipeModel
     {
         return $this->hasMany(\App\Models\Component::class);
     }
-    
+
+    /**
+     * Get the number of items in the category. This should NEVER be used in
+     * a collection of cartegories, as you'll end up with an n+1 query problem.
+     *
+     * It should only be used in a single categoiry context.
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v2.0]
+     * @return int
+     */
+    public function itemCount()
+    {
+        switch ($this->category_type) {
+            case 'asset':
+                return $this->assets()->count();
+            case 'accessory':
+                return $this->accessories()->count();
+            case 'component':
+                return $this->components()->count();
+            case 'consumable':
+                return $this->consumables()->count();
+            case 'license':
+                return $this->licenses()->count();
+        }
+
+        return '0';
+    }
 
     /**
      * Establishes the category -> assets relationship

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -98,8 +98,9 @@ class Category extends SnipeModel
      */
     public function isDeletable()
     {
+
         return Gate::allows('delete', $this)
-            && ($this->{Str::plural($this->category_type).'_count'} == 0);
+            && ($this->itemCount() == 0);
     }
 
     /**
@@ -152,7 +153,7 @@ class Category extends SnipeModel
 
     /**
      * Get the number of items in the category. This should NEVER be used in
-     * a collection of cartegories, as you'll end up with an n+1 query problem.
+     * a collection of categories, as you'll end up with an n+1 query problem.
      *
      * It should only be used in a single categoiry context.
      *
@@ -162,6 +163,11 @@ class Category extends SnipeModel
      */
     public function itemCount()
     {
+
+        if (isset($this->{Str::plural($this->category_type).'_count'})) {
+            return $this->{Str::plural($this->category_type).'_count'};
+        }
+
         switch ($this->category_type) {
             case 'asset':
                 return $this->assets()->count();
@@ -173,9 +179,9 @@ class Category extends SnipeModel
                 return $this->consumables()->count();
             case 'license':
                 return $this->licenses()->count();
+            default: 0;
         }
 
-        return '0';
     }
 
     /**

--- a/resources/lang/en/admin/categories/message.php
+++ b/resources/lang/en/admin/categories/message.php
@@ -13,7 +13,8 @@ return array(
 
     'update' => array(
         'error'   => 'Category was not updated, please try again',
-        'success' => 'Category updated successfully.'
+        'success' => 'Category updated successfully.',
+        'cannot_change_category_type'   => 'You cannot change the category type once it has been created',
     ),
 
     'delete' => array(

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -15,10 +15,15 @@
 <div class="form-group {{ $errors->has('category_type') ? ' has-error' : '' }}">
     <label for="category_type" class="col-md-3 control-label">{{ trans('general.type') }}</label>
     <div class="col-md-7 required">
-        {{ Form::select('category_type', $category_types , old('category_type', $item->category_type), array('class'=>'select2', 'style'=>'min-width:350px', 'aria-label'=>'category_type', $item->itemCount() > 0 ? 'disabled' : '')) }}
+        {{ Form::select('category_type', $category_types , old('category_type', $item->category_type), array('class'=>'select2', 'style'=>'min-width:350px', 'aria-label'=>'category_type', ($item->category_type!='') || ($item->itemCount() > 0) ? 'disabled' : '')) }}
         {!! $errors->first('category_type', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
+    <div class="col-md-7 col-md-offset-3">
+        <p class="help-block">{!! trans('admin/categories/message.update.cannot_change_category_type') !!} </p>
+    </div>
 </div>
+
+
 
 <!-- EULA text -->
 <div class="form-group {{ $errors->has('eula_text') ? 'error' : '' }}">


### PR DESCRIPTION
I just happened to notice that we had a bit of an n+1 query issue on the categories page, due to the `itemCount()` method on the Category model, which was trying to be clever with it's polymorphic-ness, but meant we ended up doing counts for each category, instead of using the `withCount()` that were already doing in the Category index controller. 

In the API transformer, we were using `itemCount()` twice, once for the generic item counter that we use to display the results on the screen via bootstrap tables, and then again in `isDeletable()`.

This change reduced the number of queries on the Categories listing API call on the listing page from 32 to 6 (and I only had 15 categories - the original number would definitely get higher with more categories. 😬)

The refactor on the `itemCount()` method basically checks for a field that matches the counts that we usually eager load, and uses them instead of a new count query each time. 

I've also made it so that once a category has been created, even if it has no items in it, the `category_type` cannot be changed. Previously, it would have been possible to create a category, add items, delete items, and change the category type, which could lead to some misleading asset history. 

While the additional eager loading will cause a little overhead, we're only adding those in places where a single category would be looked up, so this seems like a price worth paying to speed up the category listings.