### PR TITLE
Check that the `$use_db_field` has a value before attempting a delete

### DIFF
--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -146,7 +146,7 @@ class ImageUploadRequest extends Request
                 }
 
                  // Remove Current image if exists
-                if (Storage::disk('public')->exists($path.'/'.$item->{$use_db_field})) {
+                if (($item->{$use_db_field}!='') && (Storage::disk('public')->exists($path.'/'.$item->{$use_db_field}))) {
                     \Log::debug('A file already exists that we are replacing - we should delete the old one.');
                     try {
                          Storage::disk('public')->delete($path.'/'.$item->{$use_db_field});


### PR DESCRIPTION
This normally doesn't cause any issues since PHP won't be able to delete a directory, but we weren't previously checking to see if the `$item->{$use_db_field}` has a value before trying to delete the "old" file. 

To reproduce: Create a category/manufacturer, etc *without* an image, then edit the category/manugacturer, etc to add an image. This should no longer trigger the deletion action. 

This should quiet down the rollbars we've been getting in production.