### PR TITLE
Only add rollbar to the logging array if the app is in production

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -120,7 +120,7 @@ $config = [
 
 
 // Only add rollbar if the .env has a rollbar token
-if (env('ROLLBAR_TOKEN')) {
+if ((env('APP_ENV')=='production') && (env('ROLLBAR_TOKEN'))) {
     $config['channels']['stack']['channels'] = ['single', 'rollbar'];
 }
 


### PR DESCRIPTION
This updates the bit at the end of the `config/logging.php` config file to only add Rollbar to the logging config is the app is in production. (This was causing errors in the laravel log when running with `APP_ENV="local"` and `APP_DEBUG=true`, so would only have affected dev environments. Because we dynamically load the rollbar library in the AppServiceProvider, where we DO check for production, this was resulting in local environments never loading the Rollbar library.