### PR TITLE
Added categories to default visiable set on asset models

### DIFF
--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -88,7 +88,7 @@ class AssetModelPresenter extends Presenter
                 'sortable' => true,
                 'switchable' => true,
                 'title' => trans('general.category'),
-                'visible' => false,
+                'visible' => true,
                 'formatter' => 'categoriesLinkObjFormatter',
             ],
             [


### PR DESCRIPTION
This is largely a personal/workflow preference, but it seems harmless.