### PR TITLE
Added BYOD to assets

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -191,7 +191,7 @@ class AssetsController extends Controller
         }
 
         if ($request->filled('byod')) {
-            $assets->ByDepreciationId($request->input('byod'));
+            $assets->where('assets.byod', '=', $request->input('byod'));
         }
 
         $request->filled('order_number') ? $assets = $assets->where('assets.order_number', '=', e($request->get('order_number'))) : '';

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -271,6 +271,11 @@ class AssetsController extends Controller
                 // more sad, horrible workarounds for laravel bugs when doing full text searches
                 $assets->where('assets.assigned_to', '>', '0');
                 break;
+            case 'byod':
+                // This is kind of redundant, since we already check for byod=1 above, but this keeps the
+                // sidebar nav links a little less chaotic
+                $assets->where('assets.byod', '=', '1');
+                break;
             default:
 
                 if ((! $request->filled('status_id')) && ($settings->show_archived_in_list != '1')) {

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -100,6 +100,7 @@ class AssetsController extends Controller
             'checkout_counter',
             'checkin_counter',
             'requests_counter',
+            'byod',
         ];
 
         $filter = [];
@@ -187,6 +188,10 @@ class AssetsController extends Controller
 
         if ($request->filled('depreciation_id')) {
             $assets->ByDepreciationId($request->input('depreciation_id'));
+        }
+
+        if ($request->filled('byod')) {
+            $assets->ByDepreciationId($request->input('byod'));
         }
 
         $request->filled('order_number') ? $assets = $assets->where('assets.order_number', '=', e($request->get('order_number'))) : '';

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -146,6 +146,7 @@ class AssetsController extends Controller
             $asset->supplier_id             = request('supplier_id', null);
             $asset->requestable             = request('requestable', 0);
             $asset->rtd_location_id         = request('rtd_location_id', null);
+            $asset->byod                    = request('byod', 0);
 
             if (! empty($settings->audit_interval)) {
                 $asset->next_audit_date = Carbon::now()->addMonths($settings->audit_interval)->toDateString();
@@ -318,6 +319,7 @@ class AssetsController extends Controller
         // If the box isn't checked, it's not in the request at all.
         $asset->requestable = $request->filled('requestable');
         $asset->rtd_location_id = $request->input('rtd_location_id', null);
+        $asset->byod = $request->input('byod', 0);
 
         if ($asset->assigned_to == '') {
             $asset->location_id = $request->input('rtd_location_id', null);

--- a/app/Http/Middleware/AssetCountForSidebar.php
+++ b/app/Http/Middleware/AssetCountForSidebar.php
@@ -52,6 +52,13 @@ class AssetCountForSidebar
             \Log::debug($e);
         }
 
+        try {
+            $total_byod_sidebar = Asset::where('byod', '=', '1')->count();
+            view()->share('total_byod_sidebar', $total_byod_sidebar);
+        } catch (\Exception $e) {
+            \Log::debug($e);
+        }
+
         return $next($request);
     }
 }

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -35,6 +35,8 @@ class AssetsTransformer
                 'id' => (int) $asset->model->id,
                 'name'=> e($asset->model->name),
             ] : null,
+            'byod' => ($asset->byod ? true : false),
+
             'model_number' => (($asset->model) && ($asset->model->model_number)) ? e($asset->model->model_number) : null,
             'eol' => ($asset->purchase_date != '') ? Helper::getFormattedDateObject($asset->present()->eol_date(), 'date') : null,
             'status_label' => ($asset->assetstatus) ? [

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -95,6 +95,7 @@ class Asset extends Depreciable
         'location_id'    => 'integer',
         'rtd_company_id' => 'integer',
         'supplier_id'    => 'integer',
+        'byod'           => 'boolean',
     ];
 
     protected $rules = [
@@ -106,7 +107,6 @@ class Asset extends Depreciable
         'physical'        => 'numeric|max:1|nullable',
         'checkout_date'   => 'date|max:10|min:10|nullable',
         'checkin_date'    => 'date|max:10|min:10|nullable',
-        'supplier_id'     => 'exists:suppliers,id|numeric|nullable',
         'location_id'     => 'exists:locations,id|nullable',
         'rtd_location_id' => 'exists:locations,id|nullable',
         'asset_tag'       => 'required|min:1|max:255|unique_undeleted',
@@ -144,6 +144,7 @@ class Asset extends Depreciable
         'requestable',
         'last_checkout',
         'expected_checkin',
+        'byod',
     ];
 
     use Searchable;

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -250,6 +250,14 @@ class AssetPresenter extends Presenter
                 'visible' => false,
                 'title' => trans('general.next_audit_date'),
                 'formatter' => 'dateDisplayFormatter',
+            ], [
+                'field' => 'byod',
+                'searchable' => false,
+                'sortable' => true,
+                'visible' => false,
+                'title' => trans('general.byod'),
+                'formatter' => 'trueFalseFormatter',
+
             ],
         ];
 

--- a/database/migrations/2023_01_18_122534_add_byod_to_assets.php
+++ b/database/migrations/2023_01_18_122534_add_byod_to_assets.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddByodToAssets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->boolean('byod')->nullable()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            if (Schema::hasColumn('assets', 'byod')) {
+                $table->dropColumn('byod');
+            }
+        });
+    }
+}

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -39,6 +39,8 @@ return [
     'bulk_delete'           => 'Bulk Delete',
     'bulk_actions'          => 'Bulk Actions',
     'bulk_checkin_delete'   => 'Bulk Checkin Items from Users',
+    'byod'                  => 'BYOD',
+    'byod_help'             => 'This device is owned by the user',
     'bystatus'              => 'by Status',
     'cancel'  				=> 'Cancel',
     'categories'			=> 'Categories',

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -120,6 +120,19 @@
         <br>
             @include ('partials.forms.edit.name', ['translated_name' => trans('admin/hardware/form.name')])
             @include ('partials.forms.edit.warranty')
+
+            <!-- byod checkbox -->
+            <div class="form-group">
+                <div class="col-md-7 col-md-offset-3">
+                    <label for="byod">
+                        <input type="checkbox" value="1" name="byod" class="minimal" {{ (old('remote', $item->byod)) == '1' ? ' checked="checked"' : '' }} aria-label="byod">
+                        {{ trans('general.byod') }}
+
+                    </label>
+                    <p class="help-block">{{ trans('general.byod_help') }}
+                    </p>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -25,6 +25,8 @@
     {{ trans('general.archived') }}
   @elseif (Request::get('status')=='Deleted')
     {{ trans('general.deleted') }}
+  @elseif (Request::get('status')=='byod')
+    {{ trans('general.byod') }}
   @endif
 @else
 {{ trans('general.all') }}

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -289,7 +289,6 @@
                                         </div>
                                     @endif
 
-
                                     @if ((isset($audit_log)) && ($audit_log->created_at))
                                         <div class="row">
                                             <div class="col-md-2">
@@ -435,6 +434,16 @@
                                         </div>
                                         <div class="col-md-6">
                                             {{ ($asset->model) ? $asset->model->model_number : ''}}
+                                        </div>
+                                    </div>
+
+                                    <!-- byod -->
+                                    <div class="row">
+                                        <div class="col-md-2">
+                                            <strong>{{ trans('general.byod') }}</strong>
+                                        </div>
+                                        <div class="col-md-9">
+                                            {!! ($asset->byod=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"></i> '.trans('general.yes') : '<i class="fas fa-times text-danger" aria-hidden="true"></i> '.trans('general.no')  !!}
                                         </div>
                                     </div>
 

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -454,6 +454,12 @@
                           ({{ (isset($total_undeployable_sidebar)) ? $total_undeployable_sidebar : '' }})
                       </a>
                   </li>
+                    <li{!! (Request::query('status') == 'byod' ? ' class="active"' : '') !!}><a href="{{ url('hardware?status=byod') }}"><i class="fas fa-times text-red fa-fw"></i>
+                            {{ trans('general.all') }}
+                            {{ trans('general.byod') }}
+                            ({{ (isset($total_byod_sidebar)) ? $total_byod_sidebar : '' }})
+                        </a>
+                    </li>
                   <li{!! (Request::query('status') == 'Archived' ? ' class="active"' : '') !!}><a href="{{ url('hardware?status=Archived') }}"><i class="fas fa-times text-red fa-fw"></i>
                           {{ trans('general.all') }}
                           {{ trans('admin/hardware/general.archived') }}


### PR DESCRIPTION
This is, for now, just a boolean field to indicate that an asset is BYOD. While each organization will likely handle that differently (track it, don't track it, etc), at least offering this field up gives folks more to work with, and as we get subsequent requests for additional business logic or berhavior around that, we can continue to build on it. 

This *could* be a little confusing, having BYOD as a "status" in the sidebar, but it's not really a status. In the same way "Overdue for audit" isn't really a status, but we include that link there to make it easy to get to.

I'll probably end up changing that icon in the sidenav to something that's a little clearer.

<img width="1041" alt="Screenshot 2023-01-18 at 12 58 04 PM" src="https://user-images.githubusercontent.com/197404/213298452-19d481dc-0194-4eac-98bb-f8bd660b2d87.png">
<img width="406" alt="Screenshot 2023-01-18 at 1 15 50 PM" src="https://user-images.githubusercontent.com/197404/213298461-098c4888-17a8-4c8b-af0b-415ac05bdcf0.png">
<img width="783" alt="Screenshot 2023-01-18 at 1 00 16 PM" src="https://user-images.githubusercontent.com/197404/213298487-3c3d5e56-f0ac-4ce8-a726-49554aebae8a.png">
<img width="448" alt="Screenshot 2023-01-18 at 1 02 53 PM" src="https://user-images.githubusercontent.com/197404/213298505-84ab9e3a-1a37-4fb8-becf-ad46b9972af5.png">
