### PR TITLE
Fixed file uploads for accessories, components, and consumables

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -114,6 +114,12 @@ class AuthServiceProvider extends ServiceProvider
             }
         });
 
+        Gate::define('components.files', function ($user) {
+            if ($user->hasAccess('components.files')) {
+                return true;
+            }
+        });
+
         // Can the user import CSVs?
         Gate::define('import', function ($user) {
             if ($user->hasAccess('import')) {

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -126,6 +126,12 @@ class AuthServiceProvider extends ServiceProvider
             }
         });
 
+        Gate::define('consumables.files', function ($user) {
+            if ($user->hasAccess('consumables.files')) {
+                return true;
+            }
+        });
+
         // Can the user import CSVs?
         Gate::define('import', function ($user) {
             if ($user->hasAccess('import')) {

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -114,6 +114,12 @@ class AuthServiceProvider extends ServiceProvider
             }
         });
 
+        Gate::define('accessories.files', function ($user) {
+            if ($user->hasAccess('accessories.files')) {
+                return true;
+            }
+        });
+
         Gate::define('components.files', function ($user) {
             if ($user->hasAccess('components.files')) {
                 return true;

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -84,7 +84,7 @@
                         </li>
                     @endcan
 
-                    @can('update', \App\Models\Accessory::class)
+                    @can('update', $accessory)
                         <li class="pull-right">
                             <a href="#" data-toggle="modal" data-target="#uploadFileModal">
                                 <i class="fas fa-paperclip" aria-hidden="true"></i> {{ trans('button.upload') }}

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -265,14 +265,14 @@
                                     </tbody>
                                 </table>
                             </div>
+                        </div>
+                        </div>
                         </div> <!-- /.tab-pane -->
                     @endcan
 
                         </div>
                     </div>
                 </div>
-            </div>
-        </div>
 
 
 <!-- side address column -->

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -84,8 +84,7 @@
                         </li>
                     @endcan
 
-                    @can('update', Component::class)
-
+                    @can('update', \App\Models\Accessory::class)
                         <li class="pull-right">
                             <a href="#" data-toggle="modal" data-target="#uploadFileModal">
                                 <i class="fas fa-paperclip" aria-hidden="true"></i> {{ trans('button.upload') }}

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -98,7 +98,7 @@
                     <div class="tab-pane active" id="checkedout">
                         <div class="table table-responsive">
                           <div class="row">
-                              <div class="col-md-9">
+                              <div class="col-md-12">
                                 <table
                                     data-cookie-id-table="usersTable"
                                     data-pagination="true"
@@ -135,7 +135,7 @@
                      <div class="tab-pane fade" id="history">
                          <div class="table table-responsive">
                              <div class="row">
-                                 <div class="col-md-9">
+                                 <div class="col-md-12">
                                 <table
                                         class="table table-striped snipe-table"
                                         data-cookie-id-table="AccessoryHistoryTable"

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -344,9 +344,6 @@
               </div>
           @endcan
 
-                    </div><!--col-md-3-->
-                </div><!--row-->
-            </div><!--tab-pane details-->
 
         <div class="tab-pane fade" id="history">
             <div class="row">
@@ -386,8 +383,8 @@
                 </div> <!-- /.col-md-12-->
             </div> <!-- /.row-->
         </div><!--tab history-->
-    </div><!--tab-content-->
-</div><!--/.nav-tabs-custom-->
+    </div><!--col-md-3-->
+</div><!--row-->
 
 
 

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -80,8 +80,7 @@
           </li>
         @endcan
 
-        @can('update', Component::class)
-
+        @can('components.files', $component)
           <li class="pull-right">
             <a href="#" data-toggle="modal" data-target="#uploadFileModal">
               <i class="fas fa-paperclip" aria-hidden="true"></i> {{ trans('button.upload') }}

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -45,7 +45,7 @@
           </li>
         @endcan
 
-        @can('update', \App\Models\Consumable::class)
+        @can('update', $consumable)
           <li class="pull-right">
             <a href="#" data-toggle="modal" data-target="#uploadFileModal">
               <i class="fas fa-paperclip" aria-hidden="true"></i> {{ trans('button.upload') }}

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -45,8 +45,7 @@
           </li>
         @endcan
 
-        @can('update', Consumable::class)
-
+        @can('update', \App\Models\Consumable::class)
           <li class="pull-right">
             <a href="#" data-toggle="modal" data-target="#uploadFileModal">
               <i class="fas fa-paperclip" aria-hidden="true"></i> {{ trans('button.upload') }}
@@ -200,7 +199,7 @@
             <div class="row">
               <div class="col-md-12">
 
-          
+
                 @if ($consumable->image!='')
                 <div class="col-md-12 text-center">
                   <a href="{{ Storage::disk('public')->url('consumables/'.e($consumable->image)) }}" data-toggle="lightbox">
@@ -269,7 +268,7 @@
     @endcan
 
     @if ($consumable->notes)
-       
+
     <div class="col-md-12">
       <strong>
         {{ trans('general.notes') }}:
@@ -282,7 +281,7 @@
   @endif
 
     </div>
-    
+
   </div> <!-- /.col-md-3-->
 </div> <!-- /.row-->
 

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -259,7 +259,7 @@
             {{ trans('general.checkout') }}
           </a>
         @else
-          <button style="margin-bottom:10px; width:100%"" class="btn btn-primary btn-sm disabled">
+          <button style="margin-bottom:10px; width:100%" class="btn btn-primary btn-sm disabled">
             {{ trans('general.checkout') }}
           </button>
         @endif


### PR DESCRIPTION
# Description

This PR adds the previously missing file upload tab and file upload button on the accessories, components, and  consumables show pages for users that have the ability to view and modify files for those respective entities. For non-super-users this means the following permissions have been granted:
- View and Modify Accessory Files
- View and Modify Component Files
- View and Modify Consumable Files

This is accomplished by registering the gates that are already being checked in the templates:
- `accessories.files`
- `components.files`
- `consumables.files`

In addition, minor template changes were made on the accessory show page so the bottom bar is constrained to the content area, and the layout is consistent for users regardless of if they have access to accessory files.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Before and After

Assuming the user has been granted the "View and Modify x Files" mentioned above.

## Accessories

| Before  | After |
| - | - |
| ![Accessories before](https://user-images.githubusercontent.com/1141514/213303801-16ebec68-84bc-452a-9ad5-9d5e5edb5c6b.png) |  ![Accessories after](https://user-images.githubusercontent.com/1141514/213304188-d4778c7a-5f26-4492-9117-5c0b93e82379.png) |

## Components

| Before  | After |
| - | - |
| ![Components before](https://user-images.githubusercontent.com/1141514/213304001-0848120a-e4a9-4caa-9e86-099e6749e05c.png) | ![Components after](https://user-images.githubusercontent.com/1141514/213305019-85d3a14b-88da-4024-b324-e203012cf03e.png) |


## Consumables

| Before  | After |
| - | - |
| ![Consumables before](https://user-images.githubusercontent.com/1141514/213304018-bc0ab08a-f733-4df2-a998-7c8a60b7efc7.png) | ![Consumables after](https://user-images.githubusercontent.com/1141514/213305097-46d76a0f-85f6-4064-a22b-0e00bfeca18d.png) |