### PR TITLE
Fixed #12340  Deleting imported files visually drops first element in table.

### DIFF
--- a/resources/views/importer/import.blade.php
+++ b/resources/views/importer/import.blade.php
@@ -73,7 +73,7 @@
                                         <th class="col-md-1 text-right"><span class="sr-only">{{ trans('general.actions') }}</span></th>
                                     </tr>
 
-                                    <template v-for="currentFile in files">
+                                    <template v-for="(currentFile, index) in files">
                                     		<tr>
                                     			<td class="col-md-6">@{{ currentFile.file_path }}</td>
                                     			<td class="col-md-3">@{{ currentFile.created_at }} </td>
@@ -84,7 +84,7 @@
                                                         <span class="sr-only">{{ trans('general.import') }}</span>
                                                     </button>
 
-                                                    <button class="btn btn-sm btn-danger" @click="deleteFile(currentFile)">
+                                                    <button class="btn btn-sm btn-danger" @click="deleteFile(currentFile, index)">
                                                         <i class="fas fa-trash icon-white" aria-hidden="true"></i><span class="sr-only"></span></button>
                                     			</td>
                                     		</tr>


### PR DESCRIPTION
# Description
Add index value to deleteFile() function call in `import-blade` view, so it knows what element delete from the files array in the frontend. 


Fixes #12340 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: N/A
* OS version: Debian 11
