### PR TITLE
Allow users to set a blank asset name during checkout

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -316,13 +316,9 @@ class Asset extends Depreciable
         }
 
         $this->last_checkout = $checkout_at;
+        $this->name = $name;
 
         $this->assignedTo()->associate($target);
-
-
-        if ($name != null) {
-            $this->name = $name;
-        }
 
         if ($location != null) {
             $this->location_id = $location;


### PR DESCRIPTION
# Description

This PR allows users to set a blank string for an assets name when checking it out. Previously, clearing the text field for an assets name and submitting the form did not set the name to `null` like expected and instead ignored the field so the name remained.

From what I can tell, removing the `if` condition shouldn't be a problem but for reference, the modified `checkOut` method is used in the following places:
- Passes name value from `$request` (which can be null)
	- `App\Http\Controllers\Api\AssetsController::store`
	- `App\Http\Controllers\Api\AssetsController::update`
	- `App\Http\Controllers\Api\AssetsController::checkout`
	- `App\Http\Controllers\Assets\AssetCheckoutController::store`
	- `App\Http\Controllers\Assets\AssetsController::store`
- Explicitly passes null
	- `Assets\BulkAssetsController::storeCheckout`
- Does not pass name into method
	- `App\Importer\AssetImporter::createAssetIfNotExists`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)