### PR TITLE
Fix minor visual bug on asset show page

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -442,7 +442,7 @@
                                         <div class="col-md-2">
                                             <strong>{{ trans('general.byod') }}</strong>
                                         </div>
-                                        <div class="col-md-9">
+                                        <div class="col-md-6">
                                             {!! ($asset->byod=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"></i> '.trans('general.yes') : '<i class="fas fa-times text-danger" aria-hidden="true"></i> '.trans('general.no')  !!}
                                         </div>
                                     </div>


### PR DESCRIPTION
# Description

This PR sets the BYOD column width on the view asset page the same as the surrounding rows to fix a divider that is a little too long.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

| Before | After |
|-|-|
| ![Before](https://user-images.githubusercontent.com/1141514/213575401-8e248cf0-d86b-4742-bffe-9dbe64170087.png) | ![After](https://user-images.githubusercontent.com/1141514/213575435-d848056f-c76a-4216-8f9d-a40d72dd1c93.png) |

