### PR TITLE
Updated - Refactored ImageHandler request to be more re-usable, and checkboxes with missing `minimal` class for iCheck

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -67,37 +67,9 @@ class ProfileController extends Controller
             $user->location_id = $request->input('location_id');
         }
 
+        // Handle the avatar upload and/or delete if necessary
+        app('\App\Http\Requests\ImageUploadRequest')->handleImages($user, 600, 'avatar', 'avatars', 'avatar');
 
-        if ($request->input('avatar_delete') == 1) {
-            $user->avatar = null;
-        }
-
-
-        if ($request->hasFile('avatar')) {
-            $path = 'avatars';
-
-            if (! Storage::disk('public')->exists($path)) {
-                Storage::disk('public')->makeDirectory($path, 775);
-            }
-
-            $upload = $image = $request->file('avatar');
-            $ext = $image->getClientOriginalExtension();
-            $file_name = 'avatar-'.str_random(18).'.'.$ext;
-
-            if ($image->getClientOriginalExtension() != 'svg') {
-                $upload = Image::make($image->getRealPath())->resize(84, 84);
-            }
-
-            // This requires a string instead of an object, so we use ($string)
-            Storage::disk('public')->put($path.'/'.$file_name, (string) $upload->encode());
-
-            // Remove Current image if exists
-            if (($user->avatar) && (Storage::disk('public')->exists($path.'/'.$user->avatar))) {
-                Storage::disk('public')->delete($path.'/'.$user->avatar);
-            }
-
-            $user->avatar = $file_name;
-        }
 
         if ($user->save()) {
             return redirect()->route('profile')->with('success', 'Account successfully updated');

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -131,7 +131,7 @@ class UsersController extends Controller
         $user->permissions = json_encode($permissions_array);
 
         // we have to invoke the
-        app(\App\Http\Requests\ImageUploadRequest::class)->handleImages($user, 600, 'image', 'avatars', 'avatar');
+        app(\App\Http\Requests\ImageUploadRequest::class)->handleImages($user, 600, 'avatar', 'avatars', 'avatar');
 
         if ($user->save()) {
             if ($request->filled('groups')) {

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -131,7 +131,7 @@ class UsersController extends Controller
         $user->permissions = json_encode($permissions_array);
 
         // we have to invoke the
-        app(\App\Http\Requests\ImageUploadRequest::class)->handleImages($user, 600, 'avatar', 'avatars', 'avatar');
+        app(ImageUploadRequest::class)->handleImages($user, 600, 'avatar', 'avatars', 'avatar');
 
         if ($user->save()) {
             if ($request->filled('groups')) {
@@ -296,7 +296,7 @@ class UsersController extends Controller
         $user->permissions = json_encode($permissions_array);
 
         // Handle uploaded avatar
-        app(\App\Http\Requests\ImageUploadRequest::class)->handleImages($user, 600, 'avatar', 'avatars', 'avatar');
+        app(ImageUploadRequest::class)->handleImages($user, 600, 'avatar', 'avatars', 'avatar');
 
         //\Log::debug(print_r($user, true));
 

--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -63,11 +63,13 @@ class ImageUploadRequest extends Request
      * @param string $path  location for uploaded images, defaults to uploads/plural of item type.
      * @return SnipeModel        Target asset is being checked out to.
      */
-    public function handleImages($item, $w = 600, $form_fieldname = null, $path = null, $db_fieldname = 'image')
+    public function handleImages($item, $w = 600, $form_fieldname = 'image', $path = null, $db_fieldname = 'image')
     {
+
         $type = strtolower(class_basename(get_class($item)));
 
         if (is_null($path)) {
+
             $path = str_plural($type);
 
             if ($type == 'assetmodel') {
@@ -79,42 +81,31 @@ class ImageUploadRequest extends Request
             }
         }
 
-        if (is_null($form_fieldname)) {
-            $form_fieldname = 'image';
-        }
-
-        // This is dumb, but we need it for overriding field names for exceptions like avatars and logo uploads
-        if (is_null($db_fieldname)) {
-            $use_db_field = $form_fieldname;
-        } else {
-            $use_db_field = $db_fieldname;
-        }
-
-        
-        // ConvertBase64ToFiles just changes object type, 
-        // as it cannot currently insert files to $this->files
         if ($this->offsetGet($form_fieldname) instanceof UploadedFile) {
-           $image=$this->offsetGet($form_fieldname);
+           $image = $this->offsetGet($form_fieldname);
+           \Log::debug('Image is an instance of UploadedFile');
+        } elseif ($this->hasFile($form_fieldname)) {
+            $image = $this->file($form_fieldname);
+            \Log::debug('Just use regular upload for '.$form_fieldname);
         } else {
-            if ($this->hasFile($form_fieldname)) {
-                $image = $this->file($form_fieldname);
-            }
+            \Log::debug('No image found for form fieldname: '.$form_fieldname);
         }
 
         if (isset($image)) {
-            \Log::debug($image);
 
             if (!config('app.lock_passwords')) {
 
                 $ext = $image->getClientOriginalExtension();
-                $file_name = $type.'-'.$form_fieldname.'-'.str_random(10).'.'.$ext;
+                $file_name = $type.'-'.$form_fieldname.'-'.$item->id.'-'.str_random(10).'.'.$ext;
 
                 \Log::info('File name will be: '.$file_name);
                 \Log::debug('File extension is: '.$ext);
 
                 if (($image->getClientOriginalExtension() !== 'webp') && ($image->getClientOriginalExtension() !== 'svg')) {
+
                     \Log::debug('Not an SVG or webp - resize');
                     \Log::debug('Trying to upload to: '.$path.'/'.$file_name);
+
                     $upload = Image::make($image->getRealPath())->resize(null, $w, function ($constraint) {
                         $constraint->aspectRatio();
                         $constraint->upsize();
@@ -122,6 +113,7 @@ class ImageUploadRequest extends Request
 
                     // This requires a string instead of an object, so we use ($string)
                     Storage::disk('public')->put($path.'/'.$file_name, (string) $upload->encode());
+
                 } else {
                     // If the file is a webp, we need to just move it since webp support
                     // needs to be compiled into gd for resizing to be available
@@ -146,30 +138,30 @@ class ImageUploadRequest extends Request
                 }
 
                  // Remove Current image if exists
-                if (($item->{$use_db_field}!='') && (Storage::disk('public')->exists($path.'/'.$item->{$use_db_field}))) {
+                if (($item->{$form_fieldname}!='') && (Storage::disk('public')->exists($path.'/'.$item->{$db_fieldname}))) {
                     \Log::debug('A file already exists that we are replacing - we should delete the old one.');
                     try {
-                         Storage::disk('public')->delete($path.'/'.$item->{$use_db_field});
+                         Storage::disk('public')->delete($path.'/'.$item->{$form_fieldname});
                          \Log::debug('Old file '.$path.'/'.$file_name.' has been deleted.');
                     } catch (\Exception $e) {
                         \Log::debug('Could not delete old file. '.$path.'/'.$file_name.' does not exist?');
                     }
                 }
 
-                $item->{$use_db_field} = $file_name;
+                $item->{$db_fieldname} = $file_name;
             }
 
+
         // If the user isn't uploading anything new but wants to delete their old image, do so
-        } else {
-            if ($this->input('image_delete') == '1') {
-                \Log::debug('Deleting image');
-                try {
-                    Storage::disk('public')->delete($path.'/'.$item->{$use_db_field});
-                        $item->{$use_db_field} = null;
-                } catch (\Exception $e) {
-                    \Log::debug($e);
-                }
+        } elseif ($this->input('image_delete') == '1') {
+            \Log::debug('Deleting image');
+            try {
+                Storage::disk('public')->delete($path.'/'.$item->{$db_fieldname});
+                    $item->{$db_fieldname} = null;
+            } catch (\Exception $e) {
+                \Log::debug($e);
             }
+
         }
 
         return $item;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -61,7 +61,9 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         'remote',
         'start_date',
         'end_date',
-        'scim_externalid'
+        'scim_externalid',
+        'avatar',
+        'gravatar',
     ];
 
     protected $casts = [

--- a/resources/views/accessories/edit.blade.php
+++ b/resources/views/accessories/edit.blade.php
@@ -24,13 +24,20 @@
 @include ('partials.forms.edit.notes')
 
 <!-- Image -->
-@if ($item->image)
-    <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-        <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-        <div class="col-md-5">
-            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
-            <img src="{{  Storage::disk('public')->url('accessories/'.e($item->image)) }}" class="img-responsive" />
-            {!! $errors->first('image_delete', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+@if (($item->image) && ($item->image!=''))
+    <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+        <div class="col-md-9 col-md-offset-3">
+            <label for="image_delete">
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                {{ trans('general.image_delete') }}
+                {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+            </label>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-md-9 col-md-offset-3">
+            <img src="{{ Storage::disk('public')->url(app('accessories_upload_path').e($item->image)) }}" class="img-responsive">
+            {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
         </div>
     </div>
 @endif

--- a/resources/views/accessories/edit.blade.php
+++ b/resources/views/accessories/edit.blade.php
@@ -21,21 +21,19 @@
 @include ('partials.forms.edit.purchase_cost')
 @include ('partials.forms.edit.quantity')
 @include ('partials.forms.edit.minimum_quantity')
-
+@include ('partials.forms.edit.notes')
 
 <!-- Image -->
 @if ($item->image)
     <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
         <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
         <div class="col-md-5">
-            {{ Form::checkbox('image_delete') }}
+            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
             <img src="{{  Storage::disk('public')->url('accessories/'.e($item->image)) }}" class="img-responsive" />
             {!! $errors->first('image_delete', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
         </div>
     </div>
 @endif
-
-@include ('partials.forms.edit.notes')
 
 @include ('partials.forms.edit.image-upload')
 

--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -104,16 +104,20 @@
 
         <!-- Avatar -->
 
-        @if ($user->avatar)
-          <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-            <label class="col-md-3 control-label" for="avatar_delete">{{ trans('general.image_delete') }}</label>
-            <div class="col-md-9">
-              <label for="avatar_delete">
-                {{ Form::checkbox('avatar_delete', '1', old('avatar_delete'), array('class' => 'minimal')) }}
+        @if (($user->avatar) && ($user->avatar!=''))
+          <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+            <div class="col-md-9 col-md-offset-3">
+              <label for="image_delete">
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                {{ trans('general.image_delete') }}
+                {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
               </label>
-              <br>
-              <img src="{{ url('/') }}/uploads/avatars/{{  $user->avatar }}" alt="{{ $user->present()->fullName() }} avatar image">
-              {!! $errors->first('avatar_delete', '<span class="alert-msg" aria-hidden="true"><br>:message</span>') !!}
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-md-9 col-md-offset-3">
+              <img src="{{ Storage::disk('public')->url(app('users_upload_path').e($user->avatar)) }}" class="img-responsive">
+              {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
             </div>
           </div>
         @endif

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -91,7 +91,7 @@
     <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
         <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
         <div class="col-md-9">
-            {{ Form::checkbox('image_delete') }}
+            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
             <img src="{{ Storage::disk('public')->url(app('categories_upload_path').e($item->image)) }}" class="img-responsive" />
             {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
         </div>

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -74,9 +74,7 @@
 
 <!-- Email on Checkin -->
 <div class="form-group">
-    <div class="col-md-3">
-    </div>
-    <div class="col-md-9">
+    <div class="col-md-9 col-md-offset-3">
         <label for="checkin_email">
         {{ Form::checkbox('checkin_email', '1', old('checkin_email', $item->checkin_email), ['class'=>'minimal','aria-label'=>'checkin_email']) }}
         {{ trans('admin/categories/general.checkin_email') }}
@@ -87,12 +85,19 @@
 
 
 <!-- Image -->
-@if ($item->image)
-    <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-        <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-        <div class="col-md-9">
-            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
-            <img src="{{ Storage::disk('public')->url(app('categories_upload_path').e($item->image)) }}" class="img-responsive" />
+@if (($item->image) && ($item->image!=''))
+    <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+        <div class="col-md-9 col-md-offset-3">
+            <label for="image_delete">
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                {{ trans('general.image_delete') }}
+                {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+            </label>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-md-9 col-md-offset-3">
+            <img src="{{ Storage::disk('public')->url(app('companies_upload_path').e($item->image)) }}" class="img-responsive">
             {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
         </div>
     </div>

--- a/resources/views/companies/edit.blade.php
+++ b/resources/views/companies/edit.blade.php
@@ -15,7 +15,7 @@
     <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
         <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
         <div class="col-md-5">
-            {{ Form::checkbox('image_delete') }}
+            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
             <img src="{{ Storage::disk('public')->url(app('companies_upload_path').e($item->image)) }}" class="img-responsive" />
             {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
         </div>

--- a/resources/views/companies/edit.blade.php
+++ b/resources/views/companies/edit.blade.php
@@ -10,13 +10,19 @@
 @section('inputFields')
 @include ('partials.forms.edit.name', ['translated_name' => trans('admin/companies/table.name')])
 
-<!-- Image -->
-@if ($item->image)
-    <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-        <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-        <div class="col-md-5">
-            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
-            <img src="{{ Storage::disk('public')->url(app('companies_upload_path').e($item->image)) }}" class="img-responsive" />
+@if (($item->image) && ($item->image!=''))
+    <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+        <div class="col-md-9 col-md-offset-3">
+            <label for="image_delete">
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                {{ trans('general.image_delete') }}
+                {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+            </label>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-md-9 col-md-offset-3">
+            <img src="{{ Storage::disk('public')->url(app('companies_upload_path').e($item->image)) }}" class="img-responsive">
             {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
         </div>
     </div>

--- a/resources/views/components/edit.blade.php
+++ b/resources/views/components/edit.blade.php
@@ -26,7 +26,7 @@
     <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
         <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
         <div class="col-md-5">
-            {{ Form::checkbox('image_delete') }}
+            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
             <img src="{{ Storage::disk('public')->url(app('components_upload_path').e($item->image)) }}"  class="img-responsive" />
             {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
         </div>

--- a/resources/views/components/edit.blade.php
+++ b/resources/views/components/edit.blade.php
@@ -22,12 +22,19 @@
 @include ('partials.forms.edit.purchase_cost')
 
 <!-- Image -->
-@if ($item->image)
-    <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-        <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-        <div class="col-md-5">
-            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
-            <img src="{{ Storage::disk('public')->url(app('components_upload_path').e($item->image)) }}"  class="img-responsive" />
+@if (($item->image) && ($item->image!=''))
+    <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+        <div class="col-md-9 col-md-offset-3">
+            <label for="image_delete">
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                {{ trans('general.image_delete') }}
+                {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+            </label>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-md-9 col-md-offset-3">
+            <img src="{{ Storage::disk('public')->url(app('components_upload_path').e($item->image)) }}" class="img-responsive">
             {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
         </div>
     </div>

--- a/resources/views/consumables/edit.blade.php
+++ b/resources/views/consumables/edit.blade.php
@@ -20,20 +20,21 @@
 @include ('partials.forms.edit.purchase_cost')
 @include ('partials.forms.edit.quantity')
 @include ('partials.forms.edit.minimum_quantity')
+@include ('partials.forms.edit.notes')
 
 <!-- Image -->
 @if ($item->image)
     <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
         <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
         <div class="col-md-5">
-            {{ Form::checkbox('image_delete') }}
+            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
             <img src="{{ Storage::disk('public')->url(app('consumables_upload_path').e($item->image)) }}"  class="img-responsive" />
             {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
         </div>
     </div>
 @endif
 
-@include ('partials.forms.edit.notes')
+
 
 @include ('partials.forms.edit.image-upload')
 @stop

--- a/resources/views/consumables/edit.blade.php
+++ b/resources/views/consumables/edit.blade.php
@@ -23,12 +23,19 @@
 @include ('partials.forms.edit.notes')
 
 <!-- Image -->
-@if ($item->image)
-    <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-        <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-        <div class="col-md-5">
-            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
-            <img src="{{ Storage::disk('public')->url(app('consumables_upload_path').e($item->image)) }}"  class="img-responsive" />
+@if (($item->image) && ($item->image!=''))
+    <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+        <div class="col-md-9 col-md-offset-3">
+            <label for="image_delete">
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                {{ trans('general.image_delete') }}
+                {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+            </label>
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-md-9 col-md-offset-3">
+            <img src="{{ Storage::disk('public')->url(app('consumables_upload_path').e($item->image)) }}" class="img-responsive">
             {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
         </div>
     </div>

--- a/resources/views/departments/edit.blade.php
+++ b/resources/views/departments/edit.blade.php
@@ -28,7 +28,7 @@
         <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
             <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
             <div class="col-md-5">
-                {{ Form::checkbox('image_delete') }}
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
                 <img src="{{ Storage::disk('public')->url(app('departments_upload_path').e($item->image)) }}" class="img-responsive" />
                 {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
             </div>

--- a/resources/views/departments/edit.blade.php
+++ b/resources/views/departments/edit.blade.php
@@ -24,12 +24,19 @@
     @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'location_id'])
 
     <!-- Image -->
-    @if ($item->image)
-        <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-            <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-            <div class="col-md-5">
-                {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
-                <img src="{{ Storage::disk('public')->url(app('departments_upload_path').e($item->image)) }}" class="img-responsive" />
+    @if (($item->image) && ($item->image!=''))
+        <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+            <div class="col-md-9 col-md-offset-3">
+                <label for="image_delete">
+                    {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                    {{ trans('general.image_delete') }}
+                    {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+                </label>
+            </div>
+        </div>
+        <div class="form-group">
+            <div class="col-md-9 col-md-offset-3">
+                <img src="{{ Storage::disk('public')->url(app('departments_upload_path').e($item->image)) }}" class="img-responsive">
                 {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
             </div>
         </div>

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -68,19 +68,22 @@
     @include ('partials.forms.edit.requestable', ['requestable_text' => trans('admin/hardware/general.requestable')])
 
     <!-- Image -->
-    @if ($item->image)
-    <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-        <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-        <div class="col-md-5">
-            <label class="control-label" for="image_delete">
-            <input type="checkbox" value="1" name="image_delete" id="image_delete" class="minimal" {{ Request::old('image_delete') == '1' ? ' checked="checked"' : '' }}>
-            {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
-            </label>
-            <div style="margin-top: 0.5em">
-                <img src="{{ Storage::disk('public')->url(app('assets_upload_path').e($item->image)) }}" class="img-responsive" />
+    @if (($item->image) && ($item->image!=''))
+        <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+            <div class="col-md-9 col-md-offset-3">
+                <label for="image_delete">
+                    {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                    {{ trans('general.image_delete') }}
+                    {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+                </label>
             </div>
         </div>
-    </div>
+        <div class="form-group">
+            <div class="col-md-9 col-md-offset-3">
+                <img src="{{ Storage::disk('public')->url(app('assets_upload_path').e($item->image)) }}" class="img-responsive">
+                {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+            </div>
+        </div>
     @endif
 
     @include ('partials.forms.edit.image-upload')

--- a/resources/views/locations/edit.blade.php
+++ b/resources/views/locations/edit.blade.php
@@ -45,15 +45,19 @@
 
 <!-- Image -->
 @if (($item->image) && ($item->image!=''))
-    <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-        <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-        <div class="col-md-9">
+    <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+        <div class="col-md-9 col-md-offset-3">
             <label for="image_delete">
-                {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                {{ trans('general.image_delete') }}
+                {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
             </label>
-            <br>
-            <img src="{{ url('/') }}/uploads/locations/{{ $item->image }}" alt="Image for {{ $item->name }}">
-            {!! $errors->first('image_delete', '<span class="alert-msg" aria-hidden="true"><br>:message</span>') !!}
+        </div>
+    </div>
+    <div class="form-group">
+        <div class="col-md-9 col-md-offset-3">
+            <img src="{{ Storage::disk('public')->url(app('locations_upload_path').e($item->image)) }}" class="img-responsive">
+            {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
         </div>
     </div>
 @endif

--- a/resources/views/locations/edit.blade.php
+++ b/resources/views/locations/edit.blade.php
@@ -49,7 +49,7 @@
         <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
         <div class="col-md-9">
             <label for="image_delete">
-                {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'required')) }}
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
             </label>
             <br>
             <img src="{{ url('/') }}/uploads/locations/{{ $item->image }}" alt="Image for {{ $item->name }}">

--- a/resources/views/manufacturers/edit.blade.php
+++ b/resources/views/manufacturers/edit.blade.php
@@ -56,7 +56,7 @@
         <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
         <div class="col-md-5">
             <label for="image_delete">
-                {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'required')) }}
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
             </label>
             <br>
             <img src="{{ url('/') }}/uploads/manufacturers/{{ $item->image }}" alt="Image for {{ $item->name }}" class="img-responsive">

--- a/resources/views/manufacturers/edit.blade.php
+++ b/resources/views/manufacturers/edit.blade.php
@@ -51,19 +51,16 @@
     </div>
 
 <!-- Image -->
-    @if (($item->image) && ($item->image!=''))
+@if ($item->image)
     <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
         <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
         <div class="col-md-5">
-            <label for="image_delete">
-                {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
-            </label>
-            <br>
-            <img src="{{ url('/') }}/uploads/manufacturers/{{ $item->image }}" alt="Image for {{ $item->name }}" class="img-responsive">
-            {!! $errors->first('image_delete', '<span class="alert-msg" aria-hidden="true"><br>:message</span>') !!}
+            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
+            <img src="{{ Storage::disk('public')->url(app('manufacturers_upload_path').e($item->image)) }}"  class="img-responsive" />
+            {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
         </div>
     </div>
-    @endif
+@endif
 
 
     @include ('partials.forms.edit.image-upload')

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -41,19 +41,21 @@
 
 <!-- Image -->
 @if (($item->image) && ($item->image!=''))
-<div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-    <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-    <div class="col-md-5">
-        <label for="image_delete">
-            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
-        </label>
-        <br>
-        <img src="{{ Storage::disk('public')->url(app('models_upload_path').e($item->image )) }}" alt="Image for {{ $item->name }}" class="img-responsive">
-        {!! $errors->first('image_delete', '<span class="alert-msg" aria-hidden="true"><br>:message</span>') !!}
+    <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+        <div class="col-md-9 col-md-offset-3">
+            <label for="image_delete">
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                {{ trans('general.image_delete') }}
+                {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+            </label>
+        </div>
     </div>
-</div>
-
-
+    <div class="form-group">
+        <div class="col-md-9 col-md-offset-3">
+            <img src="{{ Storage::disk('public')->url(app('models_upload_path').e($item->image)) }}" class="img-responsive">
+            {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+        </div>
+    </div>
 @endif
 
 @include ('partials.forms.edit.image-upload')

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -45,7 +45,7 @@
     <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
     <div class="col-md-5">
         <label for="image_delete">
-            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'required')) }}
+            {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
         </label>
         <br>
         <img src="{{ Storage::disk('public')->url(app('models_upload_path').e($item->image )) }}" alt="Image for {{ $item->name }}" class="img-responsive">

--- a/resources/views/partials/forms/edit/image-upload.blade.php
+++ b/resources/views/partials/forms/edit/image-upload.blade.php
@@ -1,8 +1,8 @@
 <div class="form-group {{ $errors->has((isset($fieldname) ? $fieldname : 'image')) ? 'has-error' : '' }}">
-    <label class="col-md-3 control-label" for="image">{{ trans('general.image_upload') }}</label>
+    <label class="col-md-3 control-label" for="{{ (isset($fieldname) ? $fieldname : 'image') }}">{{ trans('general.image_upload') }}</label>
     <div class="col-md-9">
 
-        <input type="file" id="image" name="{{ (isset($fieldname) ? $fieldname : 'image') }}" aria-label="{{ (isset($fieldname) ? $fieldname : 'image') }}" class="sr-only">
+        <input type="file" id="{{ (isset($fieldname) ? $fieldname : 'image') }}" name="{{ (isset($fieldname) ? $fieldname : 'image') }}" aria-label="{{ (isset($fieldname) ? $fieldname : 'image') }}" class="sr-only">
 
         <label class="btn btn-default" aria-hidden="true">
             {{ trans('button.select_file')  }}
@@ -14,7 +14,7 @@
         {!! $errors->first('image', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
     </div>
     <div class="col-md-4 col-md-offset-3" aria-hidden="true">
-        <img id="uploadFile-imagePreview" style="max-width: 200px; display: none;" alt="{{ trans('partials/forms/general.alt_uploaded_image_thumbnail') }}">
+        <img id="uploadFile-imagePreview" style="max-width: 300px; display: none;" alt="{{ trans('partials/forms/general.alt_uploaded_image_thumbnail') }}">
     </div>
 </div>
 

--- a/resources/views/partials/forms/edit/image-upload.blade.php
+++ b/resources/views/partials/forms/edit/image-upload.blade.php
@@ -2,11 +2,11 @@
     <label class="col-md-3 control-label" for="image">{{ trans('general.image_upload') }}</label>
     <div class="col-md-9">
 
-        <input type="file" id="image" name="{{ (isset($fieldname) ? $fieldname : 'image') }}" aria-label="image" class="sr-only">
+        <input type="file" id="image" name="{{ (isset($fieldname) ? $fieldname : 'image') }}" aria-label="{{ (isset($fieldname) ? $fieldname : 'image') }}" class="sr-only">
 
         <label class="btn btn-default" aria-hidden="true">
             {{ trans('button.select_file')  }}
-            <input type="file" name="{{ (isset($fieldname) ? $fieldname : 'image') }}" class="js-uploadFile" id="uploadFile" data-maxsize="{{ Helper::file_upload_max_size() }}" accept="image/gif,image/jpeg,image/webp,image/png,image/svg,image/svg+xml" style="display:none; max-width: 90%" aria-label="image" aria-hidden="true">
+            <input type="file" name="{{ (isset($fieldname) ? $fieldname : 'image') }}" class="js-uploadFile" id="uploadFile" data-maxsize="{{ Helper::file_upload_max_size() }}" accept="image/gif,image/jpeg,image/webp,image/png,image/svg,image/svg+xml" style="display:none; max-width: 90%" aria-label="{{ (isset($fieldname) ? $fieldname : 'image') }}" aria-hidden="true">
         </label>
         <span class='label label-default' id="uploadFile-info"></span>
 

--- a/resources/views/suppliers/edit.blade.php
+++ b/resources/views/suppliers/edit.blade.php
@@ -45,19 +45,21 @@
 
 <!-- Image -->
 @if (($item->image) && ($item->image!=''))
-    <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-        <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-        <div class="col-md-5">
+    <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+        <div class="col-md-9 col-md-offset-3">
             <label for="image_delete">
-                {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                {{ trans('general.image_delete') }}
+                {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
             </label>
-            <br>
-            <img src="{{ url('/') }}/uploads/suppliers/{{ $item->image }}" alt="Image for {{ $item->name }}" class="img-responsive">
-            {!! $errors->first('image_delete', '<span class="alert-msg" aria-hidden="true"><br>:message</span>') !!}
         </div>
     </div>
-
-
+    <div class="form-group">
+        <div class="col-md-9 col-md-offset-3">
+            <img src="{{ Storage::disk('public')->url(app('suppliers_upload_path').e($item->image)) }}" class="img-responsive">
+            {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+        </div>
+    </div>
 @endif
 
 @include ('partials.forms.edit.image-upload')

--- a/resources/views/suppliers/edit.blade.php
+++ b/resources/views/suppliers/edit.blade.php
@@ -49,7 +49,7 @@
         <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
         <div class="col-md-5">
             <label for="image_delete">
-                {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'required')) }}
+                {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
             </label>
             <br>
             <img src="{{ url('/') }}/uploads/suppliers/{{ $item->image }}" alt="Image for {{ $item->name }}" class="img-responsive">

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -272,12 +272,13 @@
                           </div>
                       </div> <!--/form-group-->
                   @endif
+
                   <!-- Image -->
                   @if ($user->avatar)
                       <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
                           <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
                           <div class="col-md-5">
-                              {{ Form::checkbox('image_delete') }}
+                              {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
                               <img src="{{ Storage::disk('public')->url(app('users_upload_path').e($user->avatar)) }}" class="img-responsive" />
                               {!! $errors->first('image_delete', '<span class="alert-msg"><br>:message</span>') !!}
                           </div>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -274,13 +274,20 @@
                   @endif
 
                   <!-- Image -->
-                  @if ($user->avatar)
-                      <div class="form-group {{ $errors->has('image_delete') ? 'has-error' : '' }}">
-                          <label class="col-md-3 control-label" for="image_delete">{{ trans('general.image_delete') }}</label>
-                          <div class="col-md-5">
-                              {{ Form::checkbox('image_delete', '1', old('image_delete'), array('class' => 'minimal', 'aria-label'=>'image_delete')) }}
-                              <img src="{{ Storage::disk('public')->url(app('users_upload_path').e($user->avatar)) }}" class="img-responsive" />
-                              {!! $errors->first('image_delete', '<span class="alert-msg"><br>:message</span>') !!}
+                  @if (($user->avatar) && ($user->avatar!=''))
+                      <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
+                          <div class="col-md-9 col-md-offset-3">
+                              <label for="image_delete">
+                                  {{ Form::checkbox('image_delete', '1', old('image_delete'), ['class'=>'minimal','aria-label'=>'image_delete']) }}
+                                  {{ trans('general.image_delete') }}
+                                  {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
+                              </label>
+                          </div>
+                      </div>
+                      <div class="form-group">
+                          <div class="col-md-9 col-md-offset-3">
+                              <img src="{{ Storage::disk('public')->url(app('users_upload_path').$user->avatar) }}" class="img-responsive">
+                              {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
                           </div>
                       </div>
                   @endif


### PR DESCRIPTION
This just makes the UI a little more consistent on edit screens, so that the notes field is above the image delete/upload section, and all checkboxes use the correct CSS style (`minimal`, which is used by iCheck) and corrected the incorrect `aria-label`.

This also ended up fixing a few small bugs with uploads (avatars) on new user creation.