### PR TITLE
Fixed #12388 - Add CSS to the div to correct the weird indenting

### DIFF
--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -13,7 +13,7 @@
             </div>
     </div>
     @if ($this->add_default_values ) {{-- 'if the checkbox is enabled *AND* there are more than 0 fields in the fieldsset' --}}
-    <div>
+    <div style="padding-left: 10px; padding-bottom: 0px; margin-bottom: -15px;">
         <div class="form-group">
             @if ($fields)
                 @foreach ($fields as $field)


### PR DESCRIPTION
Small HTML/CSS change to fix the weird indenting within the livewire div on asset models with default custom fields. 

<img width="553" alt="Notification_Center-3" src="https://user-images.githubusercontent.com/197404/213897794-91fd7e86-0bdf-4a9e-bf9b-24ebf6ee8ef6.png">
