### PR TITLE
fix: Typo on the barcode settings page

### DIFF
--- a/resources/lang/en-GB/admin/settings/general.php
+++ b/resources/lang/en-GB/admin/settings/general.php
@@ -51,7 +51,7 @@ return [
     'display_asset_name'        => 'Display Asset Name',
     'display_checkout_date'     => 'Display Checkout Date',
     'display_eol'               => 'Display EOL in table view',
-    'display_qr'                => 'Display 3D Codes',
+    'display_qr'                => 'Display 2D Codes',
     'display_alt_barcode'		=> 'Display 1D barcode',
     'email_logo'                => 'Email Logo',
     'barcode_type'				=> '2D Barcode Type',


### PR DESCRIPTION
# Description

On the barcode settings page, the checkbox for QR codes was labelled as "3D" when I believe it should be "2D"

![Screenshot 2023-01-23 at 10 09 06](https://user-images.githubusercontent.com/168025/214014992-0ab8532f-4627-4828-85d7-3657a39ce016.png)

This looks to only be an issue in the `en-GB` language.


## Type of change

Please delete options that are not relevant.

- [*] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Have ran my branch locally and verified the copy has changed. There are no tests covering this screen as far as I can tell.

![Screenshot 2023-01-23 at 10 16 07](https://user-images.githubusercontent.com/168025/214015156-e4a133b0-dc10-4465-a526-0273c0396e99.png)



**Test Configuration**:
* PHP version: 8.1.2
* MySQL version: 15.1
* Webserver version: 2.4.52
* OS version: Ubuntu 22.04.1


# Checklist:

- [*] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [*] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] I have made corresponding changes to the documentation
- [*] My changes generate no new warnings
- [*] I have added tests that prove my fix is effective or that my feature works
- [*] New and existing unit tests pass locally with my changes
