### PR TITLE
Fixed "Backup before importing?" checkbox on import page

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -127,7 +127,7 @@ class ImportController extends Controller
         $this->authorize('import');
 
         // Run a backup immediately before processing
-        if ($request->has('run-backup')) {
+        if ($request->get('run-backup')) {
             \Log::debug('Backup manually requested via importer');
             Artisan::call('backup:run');
         } else {


### PR DESCRIPTION
# Description

We were always taking backups before import, no matter the status of
this box.

Turns out we were testing for the presence of the property defined by
the checkbox, rather than the value of the property, and as such were
always doing a backup.

We're now checking the status, and it behaves as expected

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tried import with and without the box checked, and observed backups
being made and not being made... additionally turned up the logs and
noted the correct log output for each state.