### PR TITLE
Fixed: Checkin limit string translation for components

### DIFF
--- a/resources/lang/en/admin/components/general.php
+++ b/resources/lang/en/admin/components/general.php
@@ -12,5 +12,5 @@ return array(
     'remaining' 			             => 'Remaining',
     'total' 			                 => 'Total',
     'update'                            => 'Update Component',
-    'checkin_limit'            => 'Amount checked in must be equal to or less than this amount'
+    'checkin_limit'            => 'Amount checked in must be equal to or less than :assigned_qty'
 );

--- a/resources/lang/en/admin/components/general.php
+++ b/resources/lang/en/admin/components/general.php
@@ -12,4 +12,5 @@ return array(
     'remaining' 			             => 'Remaining',
     'total' 			                 => 'Total',
     'update'                            => 'Update Component',
+    'checkin_limit'            => 'Amount checked in must be equal to or less than this amount'
 );

--- a/resources/views/components/checkin.blade.php
+++ b/resources/views/components/checkin.blade.php
@@ -42,7 +42,7 @@
                                 <input type="text" class="form-control" name="checkin_qty" aria-label="checkin_qty" value="{{ old('assigned_qty', $component_assets->assigned_qty) }}">
                             </div>
                             <div class="col-md-9 col-md-offset-2">
-                            <p class="help-block">{{ trans(admin/components/general.checkin_limit, ['assigned_qty' => '$component_assets->assigned_qty']) }}</p>
+                            <p class="help-block">{{ trans('admin/components/general.checkin_limit', ['assigned_qty' => $component_assets->assigned_qty]) }}</p>
                             {!! $errors->first('checkin_qty', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i>
                             :message</span>') !!}
                             </div>

--- a/resources/views/components/checkin.blade.php
+++ b/resources/views/components/checkin.blade.php
@@ -42,7 +42,7 @@
                                 <input type="text" class="form-control" name="checkin_qty" aria-label="checkin_qty" value="{{ old('assigned_qty', $component_assets->assigned_qty) }}">
                             </div>
                             <div class="col-md-9 col-md-offset-2">
-                            <p class="help-block">Must be {{ $component_assets->assigned_qty }} or less.</p>
+                            <p class="help-block">{{ trans(admin/components/general.checkin_limit) }}: {{ $component_assets->assigned_qty }}</p>
                             {!! $errors->first('checkin_qty', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i>
                             :message</span>') !!}
                             </div>

--- a/resources/views/components/checkin.blade.php
+++ b/resources/views/components/checkin.blade.php
@@ -42,7 +42,7 @@
                                 <input type="text" class="form-control" name="checkin_qty" aria-label="checkin_qty" value="{{ old('assigned_qty', $component_assets->assigned_qty) }}">
                             </div>
                             <div class="col-md-9 col-md-offset-2">
-                            <p class="help-block">{{ trans(admin/components/general.checkin_limit) }}: {{ $component_assets->assigned_qty }}</p>
+                            <p class="help-block">{{ trans(admin/components/general.checkin_limit, ['assigned_qty' => '$component_assets->assigned_qty']) }}</p>
                             {!! $errors->first('checkin_qty', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i>
                             :message</span>') !!}
                             </div>


### PR DESCRIPTION
# Description
Translating the string informing users of the limit to how many components can be checked in.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
