### PR TITLE
Resolved Rollbar error 16746 - missing array key 'extension'

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -149,7 +149,7 @@ class RestoreFromBackup extends Command
                 $boring_files[] = $raw_path;
                 continue;
             }
-            if (@pathinfo($raw_path)['extension'] == 'sql') {
+            if (@pathinfo($raw_path, PATHINFO_EXTENSION) == 'sql') {
                 \Log::debug("Found a sql file!");
                 $sqlfiles[] = $raw_path;
                 $sqlfile_indices[] = $i;


### PR DESCRIPTION
So we've been getting a lot of these Rollbar errors lately - "missing array key 'extension'"

It turns out that `pathinfo()` doesn't even *return* the extension on files that don't have one. While doing an `array_key_exists()` call is always an option, it turns out there's a flag we can pass that will make it return the extension instead. So I used that.

I confirmed the bug by doing:

```sh
php artisan tinker
Psy Shell v0.11.7 (PHP 7.4.33 — cli) by Justin Hileman
>>> pathinfo('fart')['extension']
PHP Notice:  Undefined index: extension in /Users/uberbrady/Documents/grokability/snipe-iteval()'d code on line 1
=> null

>>> pathinfo('fart', PATHINFO_EXTENSION)
=> ""

>>> 
```
I tested this by running a CLI restore on my local, which worked.