### PR TITLE
Have acceptance result notifications adhere to alerts enabled setting

### DIFF
--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -21,7 +21,7 @@ class CheckoutAcceptance extends Model
     {
         // At this point the endpoint is the same for everything.
         //  In the future this may want to be adapted for individual notifications.
-        return (config('mail.reply_to.address')) ? config('mail.reply_to.address') : '' ;
+        return Setting::getSettings()['alert_email'];
     }
 
     /**

--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -16,8 +16,12 @@ class CheckoutAcceptance extends Model
         'declined_at' => 'datetime',
     ];
 
-    // Get the mail recipient from the config
-    public function routeNotificationForMail(): string
+    /**
+     * Get the mail recipient from the config
+     *
+     * @return mixed|string|null
+     */
+    public function routeNotificationForMail()
     {
         // At this point the endpoint is the same for everything.
         //  In the future this may want to be adapted for individual notifications.

--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -21,7 +21,7 @@ class CheckoutAcceptance extends Model
     {
         // At this point the endpoint is the same for everything.
         //  In the future this may want to be adapted for individual notifications.
-        return Setting::getSettings()['alert_email'];
+        return Setting::getSettings()->alert_email;
     }
 
     /**

--- a/app/Notifications/AcceptanceAssetAcceptedNotification.php
+++ b/app/Notifications/AcceptanceAssetAcceptedNotification.php
@@ -46,6 +46,11 @@ class AcceptanceAssetAcceptedNotification extends Notification
 
     }
 
+    public function shouldSend($notifiable, $channel)
+    {
+        return $this->settings->alerts_enabled && ! empty($this->settings->alert_email);
+    }
+
     /**
      * Get the mail representation of the notification.
      *

--- a/app/Notifications/AcceptanceAssetDeclinedNotification.php
+++ b/app/Notifications/AcceptanceAssetDeclinedNotification.php
@@ -44,6 +44,11 @@ class AcceptanceAssetDeclinedNotification extends Notification
 
     }
 
+    public function shouldSend($notifiable, $channel)
+    {
+        return $this->settings->alerts_enabled && ! empty($this->settings->alert_email);
+    }
+
     /**
      * Get the mail representation of the notification.
      *


### PR DESCRIPTION
# Description

Currently, notifications are sent when a user accepts or declines an asset checkout without checking to see if the admin has turned off email alerts. This PR checks to see if alerts are enabled and cancels sending the notification if they have been disabled.

It also routes the notification to the email that is set in notification settings.

This PR is scoped to just the notifications around asset acceptance but other notifications should probably be checked for the setting as well. I can follow up with that in the future if that makes sense.

---

- [x] Bug fix (non-breaking change which fixes an issue)