### PR TITLE
Fixed: Active Directory "not-delegated+dont-expire-password+normal-accounts" can now login

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -303,17 +303,18 @@ class LdapSync extends Command
                         $user->activated = 0;
                     } */
                     $enabled_accounts = [
-                    '512',    // 0x200    NORMAL_ACCOUNT
-                    '544',    // 0x220    NORMAL_ACCOUNT, PASSWD_NOTREQD
-                    '66048',  // 0x10200  NORMAL_ACCOUNT, DONT_EXPIRE_PASSWORD
-                    '66080',  // 0x10220  NORMAL_ACCOUNT, PASSWD_NOTREQD, DONT_EXPIRE_PASSWORD
-                    '262656', // 0x40200  NORMAL_ACCOUNT, SMARTCARD_REQUIRED
-                    '262688', // 0x40220  NORMAL_ACCOUNT, PASSWD_NOTREQD, SMARTCARD_REQUIRED
-                    '328192', // 0x50200  NORMAL_ACCOUNT, SMARTCARD_REQUIRED, DONT_EXPIRE_PASSWORD
-                    '328224', // 0x50220  NORMAL_ACCOUNT, PASSWD_NOT_REQD, SMARTCARD_REQUIRED, DONT_EXPIRE_PASSWORD
-                    '4194816',// 0x400200 NORMAL_ACCOUNT, DONT_REQ_PREAUTH
+                    '512',    //     0x200 NORMAL_ACCOUNT
+                    '544',    //     0x220 NORMAL_ACCOUNT, PASSWD_NOTREQD
+                    '66048',  //   0x10200 NORMAL_ACCOUNT, DONT_EXPIRE_PASSWORD
+                    '66080',  //   0x10220 NORMAL_ACCOUNT, PASSWD_NOTREQD, DONT_EXPIRE_PASSWORD
+                    '262656', //   0x40200 NORMAL_ACCOUNT, SMARTCARD_REQUIRED
+                    '262688', //   0x40220 NORMAL_ACCOUNT, PASSWD_NOTREQD, SMARTCARD_REQUIRED
+                    '328192', //   0x50200 NORMAL_ACCOUNT, SMARTCARD_REQUIRED, DONT_EXPIRE_PASSWORD
+                    '328224', //   0x50220 NORMAL_ACCOUNT, PASSWD_NOT_REQD, SMARTCARD_REQUIRED, DONT_EXPIRE_PASSWORD
+                    '4194816',//  0x400200 NORMAL_ACCOUNT, DONT_REQ_PREAUTH
                     '4260352', // 0x410200 NORMAL_ACCOUNT, DONT_EXPIRE_PASSWORD, DONT_REQ_PREAUTH
                     '1049088', // 0x100200 NORMAL_ACCOUNT, NOT_DELEGATED
+                    '1114624', // 0x110200 NORMAL_ACCOUNT, DONT_EXPIRE_PASSWORD, NOT_DELEGATED,
                   ];
                     $user->activated = (in_array($results[$i]['useraccountcontrol'][0], $enabled_accounts)) ? 1 : 0;
 


### PR DESCRIPTION
We list a bunch of `UserAccountControl` values as being permitted to log in (e.g. have an `active` flag of `1`). One of the permutations we have not taken account of is when a user is: 

- a regular user
- whose password doesn't expire
- who cannot be delegated from

This PR permits those users to log in, and also cleans up some of the formatting of the list of UserAccountControl values to be a little more readable.

There might be another, easier way to approach this - without going completely into doing the whole 'bitwise math' thing - where we use binary logic to say "these particular attributes are okay" - then we won't have to add quite as many permutations as we list here - for instance, we probably can't handle `SMARTCARD_REQUIRED` + `NOT_DELEGATED`, and when that one comes up, we'll have to add that permutation as well. Let me know if you want me to try and take a swing at that.