### PR TITLE
Fixed: username doubles on 'checked-out-to' column if display is resized [sc-19869], [fd-33242]

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -327,8 +327,8 @@
                 item_icon = '';
             }
 
-            // display the username if it's checked out to a user
-            if (value.username) {
+            // display the username if it's checked out to a user, but don't do it if the username's there already
+            if (value.username && !value.name.match('\\(') && !value.name.match('\\)')) {
                 value.name = value.name + ' (' + value.username + ')';
             }
 


### PR DESCRIPTION
It turns out that Bootstrap Tables will re-run `polymorphicItemFormatter` repeatedly, whenever the layout changes - by adding a column, removing one, or even resizing the screen.

This meant that a user's name would get repeated additions of their username added over and over and over again as you mess with the table layout, looking like:

> Firstname Lastname (username) (username) (username) (username)

If you did it for long enough.

This is the dumbest possible way to fix it, the only thing dumber would be to not fix it.

We check if a `(` and a `)` are *not* present, and append the username only if so.