### PR TITLE
Fixed: Short-circuit the LDAP sync if LDAP is disabled

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -44,12 +44,17 @@ class LdapSync extends Command
      */
     public function handle()
     {
+
+        // If LDAP enabled isn't set to 1 (ldap_enabled!=1) then we should cut this short immediately without going any further
+        if (Setting::getSettings()->ldap_enabled!='1') {
+            $this->error('LDAP is not enabled. Aborting. See Settings > LDAP to enable it.');
+        }
+
         ini_set('max_execution_time', env('LDAP_TIME_LIM', 600)); //600 seconds = 10 minutes
         ini_set('memory_limit', env('LDAP_MEM_LIM', '500M'));
         $ldap_result_username = Setting::getSettings()->ldap_username_field;
         $ldap_result_last_name = Setting::getSettings()->ldap_lname_field;
         $ldap_result_first_name = Setting::getSettings()->ldap_fname_field;
-
         $ldap_result_active_flag = Setting::getSettings()->ldap_active_flag;
         $ldap_result_emp_num = Setting::getSettings()->ldap_emp_num;
         $ldap_result_email = Setting::getSettings()->ldap_email;


### PR DESCRIPTION
Previously, even if LDAP was disabled in the LDAP settings, if a cron was set up to sync, we would still sync, since we weren't checking to see if LDAP was enabled. This should resolve that issue. 