### PR TITLE
Handle missing userfiles more gracefully

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -390,7 +390,8 @@ return [
     'start_date'            => 'Start Date',
     'end_date'            => 'End Date',
     'alt_uploaded_image_thumbnail' => 'Uploaded thumbnail',
-    'placeholder_kit'       => 'Select a kit'
+    'placeholder_kit'       => 'Select a kit',
+    'file_not_found'        => 'File not found',
 
 
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -869,16 +869,19 @@
                             </td>
                             <td>
                                 @if ($file->filename)
-                                    @if ( Helper::checkUploadIsImage($file->get_src('users')))
+                                    @if ((Storage::exists('private_uploads/users/'.$file->filename)) && ( Helper::checkUploadIsImage($file->get_src('users'))))
                                         <a href="{{ route('show/userfile', ['userId' => $user->id, 'fileId' => $file->id, 'download' => 'false']) }}" data-toggle="lightbox" data-type="image"><img src="{{ route('show/userfile', ['userId' => $user->id, 'fileId' => $file->id]) }}" class="img-thumbnail" style="max-width: 50px;"></a>
+                                    @else
+                                        <i class="fa fa-times text-danger" aria-hidden="true"></i>
+                                        {{ trans('general.file_not_found') }}
                                     @endif
                                 @endif
                             </td>
                             <td>
                                 {{ $file->filename }}
                             </td>
-                            <td>
-                                {{ Helper::formatFilesizeUnits(Storage::size('private_uploads/users/'.$file->filename)) }}
+                            <td data-value="{{ (Storage::exists('private_uploads/users/'.$file->filename)) ? Storage::size('private_uploads/users/'.$file->filename) : '' }}">
+                                {{ (Storage::exists('private_uploads/users/'.$file->filename)) ? Helper::formatFilesizeUnits(Storage::size('private_uploads/users/'.$file->filename)) : '' }}
                             </td>
 
                             <td>
@@ -888,10 +891,12 @@
                             </td>
                             <td>
                                 @if ($file->filename)
-                                    <a href="{{ route('show/userfile', [$user->id, $file->id]) }}" class="btn btn-default">
-                                        <i class="fas fa-download" aria-hidden="true"></i>
-                                        <span class="sr-only">{{ trans('general.download') }}</span>
-                                    </a>
+                                    @if ((Storage::exists('private_uploads/users/'.$file->filename)) && ( Helper::checkUploadIsImage($file->get_src('users'))))
+                                        <a href="{{ route('show/userfile', [$user->id, $file->id]) }}" class="btn btn-default">
+                                            <i class="fas fa-download" aria-hidden="true"></i>
+                                            <span class="sr-only">{{ trans('general.download') }}</span>
+                                        </a>
+                                    @endif
                                 @endif
                             </td>
                             <td>{{ $file->created_at }}</td>


### PR DESCRIPTION
Previously, if an uploaded user file (not avatar, but uploaded via the "Files" tab on the user page) was missing from the server, the entire user page would crash. This change handles it a bit more gracefully and does not 500. 

While this scenario *shouldn't* happen, it could, if a file was manually deleted, or if some files were lost.

Fixes RB-16844.

<img width="1314" alt="Screenshot 2023-02-02 at 10 50 11 AM" src="https://user-images.githubusercontent.com/197404/216421849-b2d455e9-d92f-4aed-b2f2-c68feae79d37.png">
