### PR TITLE
Fixed #12449 - Added checkout/checkin  note to user history

### DIFF
--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -954,7 +954,8 @@
                   @endif
                   <th class="col-sm-3" data-field="item.serial" data-visible="false">{{ trans('admin/hardware/table.serial') }}</th>
                   <th class="col-sm-3" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>
-                <th class="col-sm-2" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.target') }}</th>
+                  <th class="col-sm-3" data-field="note">{{ trans('general.notes') }}</th>
+                  <th class="col-sm-2" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.target') }}</th>
               </tr>
               </thead>
             </table>


### PR DESCRIPTION
This includes the checkout/checkin note to the user history page.

<img width="1238" alt="Screenshot 2023-02-02 at 11 27 09 AM" src="https://user-images.githubusercontent.com/197404/216430445-98b02f73-d417-40cc-8dd9-fbd110195ab8.png">
