### PR TITLE
Fixed Rollbar 16883 Error: Attempt to assign property "assigned_to" on null

### DIFF
--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -80,6 +80,11 @@ class LicenseImporter extends ItemImporter
                 $checkout_target = $this->item['checkout_target'];
                 $asset = Asset::where('asset_tag', $asset_tag)->first();
                 $targetLicense = $license->freeSeat();
+
+                if (is_null($targetLicense)){
+                    return;
+                }
+
                 if ($checkout_target) {
                     $targetLicense->assigned_to = $checkout_target->id;
                     $targetLicense->user_id = Auth::id();


### PR DESCRIPTION
# Description
In the License Importer, we try to get a free license seat to assign as required, but if we don't have any the system fails with ` Attempt to assign property "assigned_to" on null` error. This PR takes care of that adding a guard clause to return early if no empty seat is found, ignoring that assignation.

We can make the system to fail if no empty license seat is found, but looking at the code I understood that the Importer ignores the assignation if no seat is found and I thought this makes the Importer consistent in both error cases (no seats left or no empty seat found). Let me know if you think it's better to return the error instead.

Fixes Rollbar 16883

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
