### PR TITLE
Fixed ErrorException:  Attempt to read property "id" on null [sc-19855]

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -60,12 +60,14 @@ class ActionlogsTransformer
             if ($actionlog->action_type == 'accepted') {
                 $file_url = route('log.storedeula.download', ['filename' => $actionlog->filename]);
             } else {
-                if ($actionlog->itemType() == 'asset') {
-                    $file_url = route('show/assetfile', ['assetId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
-                } elseif ($actionlog->itemType() == 'license') {
-                    $file_url = route('show.licensefile', ['licenseId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
-                } elseif ($actionlog->itemType() == 'user') {
-                    $file_url = route('show/userfile', ['userId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
+                if ($actionlog->item) {
+                    if ($actionlog->itemType() == 'asset') {
+                        $file_url = route('show/assetfile', ['assetId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
+                    } elseif ($actionlog->itemType() == 'license') {
+                        $file_url = route('show.licensefile', ['licenseId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
+                    } elseif ($actionlog->itemType() == 'user') {
+                        $file_url = route('show/userfile', ['userId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description
We didn't check if the item assigned in some Action Logs still exists, making that when passing its data to the ActionLogsTransformer if it doesn't exist, we try to get some properties from an non-existent object and the system fails.

Fixes Internal shortcut [sc-19855]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
