### PR TITLE
Fixed: Deleting custom fieldsets actually deletes custom fields

### DIFF
--- a/app/Http/Controllers/CustomFieldsetsController.php
+++ b/app/Http/Controllers/CustomFieldsetsController.php
@@ -169,7 +169,7 @@ class CustomFieldsetsController extends Controller
      */
     public function destroy($id)
     {
-        $fieldset = CustomField::find($id);
+        $fieldset = CustomFieldset::find($id);
 
         $this->authorize('delete', $fieldset);
 


### PR DESCRIPTION
# Description

This fixes deleting custom fieldsets. Currently trying to delete fieldsets will delete custom **fields** with the same id as the fieldset, and leaves the fieldset unchanged.


## Type of change

Oneliner 


