### PR TITLE
Fixed #12064 Mail-Template missing translation strings

### DIFF
--- a/app/Notifications/CurrentInventory.php
+++ b/app/Notifications/CurrentInventory.php
@@ -44,7 +44,7 @@ class CurrentInventory extends Notification
                 'accessories'  => $this->user->accessories,
                 'licenses'  => $this->user->licenses,
             ])
-            ->subject('Inventory Report');
+            ->subject(trans('mail.inventory_report'));
 
         return $message;
     }

--- a/resources/lang/en/mail.php
+++ b/resources/lang/en/mail.php
@@ -43,6 +43,7 @@ return [
     'login_first_admin' => 'Login to your new Snipe-IT installation using the credentials below:',
     'login' => 'Login:',
     'Low_Inventory_Report' => 'Low Inventory Report',
+    'inventory_report' => 'Inventory Report',
     'min_QTY' => 'Min QTY',
     'name' => 'Name',
     'new_item_checked' => 'A new item has been checked out under your name, details are below.',
@@ -79,4 +80,5 @@ return [
     'Expected_Checkin_Notification' => 'Reminder: :name checkin deadline approaching',
     'Expected_Checkin_Date' => 'An asset checked out to you is due to be checked back in on :date',
     'your_assets' => 'View Your Assets',
+    'rights_reserved' => 'All rights reserved.',
 ];

--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -204,7 +204,7 @@ $style = [
                                         <p style="{{ $style['paragraph-sub'] }}">
                                             &copy; {{ date('Y') }}
                                             <a style="{{ $style['anchor'] }}" href="{{ url('/') }}" target="_blank">{{ $snipeSettings->site_name }}</a>.
-                                            All rights reserved.
+                                            {{ trans('mail.rights_reserved') }}
                                         </p>
 
                                         @if ($snipeSettings->privacy_policy_link!='')


### PR DESCRIPTION
# Description
Just added a couple of translation strings that an user report as missing.

Fixes #12064 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP Dev server
* OS version: Debian 11