### PR TITLE
Fixed UI bug where download button was missing for non-images

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -396,6 +396,7 @@ return [
     'alt_uploaded_image_thumbnail' => 'Uploaded thumbnail',
     'placeholder_kit'       => 'Select a kit',
     'file_not_found'        => 'File not found',
+    'preview_not_available' => '(no preview)',
 
 
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -868,13 +868,15 @@
 
                             </td>
                             <td>
-                                @if ($file->filename)
-                                    @if ((Storage::exists('private_uploads/users/'.$file->filename)) && ( Helper::checkUploadIsImage($file->get_src('users'))))
+                                @if (($file->filename) && (Storage::exists('private_uploads/users/'.$file->filename)))
+                                   @if (Helper::checkUploadIsImage($file->get_src('users')))
                                         <a href="{{ route('show/userfile', ['userId' => $user->id, 'fileId' => $file->id, 'download' => 'false']) }}" data-toggle="lightbox" data-type="image"><img src="{{ route('show/userfile', ['userId' => $user->id, 'fileId' => $file->id]) }}" class="img-thumbnail" style="max-width: 50px;"></a>
                                     @else
-                                        <i class="fa fa-times text-danger" aria-hidden="true"></i>
-                                        {{ trans('general.file_not_found') }}
+                                        {{ trans('general.preview_not_available') }}
                                     @endif
+                                @else
+                                    <i class="fa fa-times text-danger" aria-hidden="true"></i>
+                                        {{ trans('general.file_not_found') }}
                                 @endif
                             </td>
                             <td>
@@ -891,7 +893,7 @@
                             </td>
                             <td>
                                 @if ($file->filename)
-                                    @if ((Storage::exists('private_uploads/users/'.$file->filename)) && ( Helper::checkUploadIsImage($file->get_src('users'))))
+                                    @if (Storage::exists('private_uploads/users/'.$file->filename))
                                         <a href="{{ route('show/userfile', [$user->id, $file->id]) }}" class="btn btn-default">
                                             <i class="fas fa-download" aria-hidden="true"></i>
                                             <span class="sr-only">{{ trans('general.download') }}</span>


### PR DESCRIPTION
Reported via discord. I had grouped together the image check and the file exists check into one statement, which ignored a case where an uploaded file might be a non-image (PDF, etc) which resulted in the download button not being presented, and an erroneous "file not found" message displayed in the preview column. 

<img width="1502" alt="Screenshot 2023-02-07 at 6 41 12 PM" src="https://user-images.githubusercontent.com/197404/217415059-dc7fb12d-af15-4894-bc34-7ed07ee9feaa.png">
