### PR TITLE
Improve error messaging around invalid characters in import

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -36,7 +36,7 @@ class ImportController extends Controller
      * Process and store a CSV upload file.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function store()
     {
@@ -132,9 +132,9 @@ class ImportController extends Controller
             }
             $results = (new ImportsTransformer)->transformImports($results);
 
-            return [
+            return response()->json([
                 'files' => $results,
-            ];
+            ]);
         }
 
         return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.feature_disabled')), 500);

--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -73,7 +73,8 @@ class ImportController extends Controller
                         Helper::formatStandardApiResponse(
                             'error',
                             null,
-                            'One or more attributes in the header row contain malformed UTF-8 characters'),
+                            'One or more attributes in the header row contain malformed UTF-8 characters'
+                        ),
                         500
                     );
                 }
@@ -105,7 +106,8 @@ class ImportController extends Controller
                         Helper::formatStandardApiResponse(
                             'error',
                             null,
-                            'One or more attributes in row 2 contain malformed UTF-8 characters'),
+                            'One or more attributes in row 2 contain malformed UTF-8 characters'
+                        ),
                         500
                     );
                 }

--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -57,7 +57,7 @@ class ImportController extends Controller
                     'text/tsv', ])) {
                     $results['error'] = 'File type must be CSV. Uploaded file is '.$file->getMimeType();
 
-                    return response()->json(Helper::formatStandardApiResponse('error', null, $results['error']), 500);
+                    return response()->json(Helper::formatStandardApiResponse('error', null, $results['error']), 422);
                 }
 
                 //TODO: is there a lighter way to do this?
@@ -75,7 +75,7 @@ class ImportController extends Controller
                             null,
                             'One or more attributes in the header row contain malformed UTF-8 characters'
                         ),
-                        500
+                        422
                     );
                 }
 
@@ -95,7 +95,7 @@ class ImportController extends Controller
                     }
                 }
                 if (count($duplicate_headers) > 0) {
-                    return response()->json(Helper::formatStandardApiResponse('error', null, implode('; ', $duplicate_headers)), 500); //should this be '4xx'?
+                    return response()->json(Helper::formatStandardApiResponse('error', null, implode('; ', $duplicate_headers)),422);
                 }
 
                 try {
@@ -108,7 +108,7 @@ class ImportController extends Controller
                             null,
                             'One or more attributes in row 2 contain malformed UTF-8 characters'
                         ),
-                        500
+                        422
                     );
                 }
 
@@ -137,7 +137,7 @@ class ImportController extends Controller
             ]);
         }
 
-        return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.feature_disabled')), 500);
+        return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.feature_disabled')), 422);
     }
 
     /**


### PR DESCRIPTION
# Description

This PR improves the error messaging around characters that cannot be encoded during the beginning of the import process.

Currently, if an import contains a character that cannot be encoded to JSON in the header or first content rows the status bar turns red but the user is not given a message telling them what went wrong:
![image](https://user-images.githubusercontent.com/1141514/217665426-1a9480d7-6818-4f64-ba52-70edee39cf41.png)

With this PR, a message is shown to the user indicating what happened and pointing them to either the header or content row:
![image](https://user-images.githubusercontent.com/1141514/217665435-2afe4652-c03e-47a8-9bd1-5e904aec8535.png)
![image](https://user-images.githubusercontent.com/1141514/217665445-fe41c1db-a413-4e24-badb-6d9f0eef7ffc.png)

This also includes returning `422` status codes when the import is in an invalid state instead of `500` and correcting the `store` method's return type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
This was tested by pasting an invalid 3 octet sequence into a field in the header and first content rows of an import template.
The invalid character I used was: `"\xe2\x28\xa1"` (`â(¡`)
