### PR TITLE
Fixed #9148 Checking Out Consumables doesn't decrease starting quantity

### DIFF
--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -278,6 +278,8 @@ class ConsumablesController extends Controller
                 'note' => $request->input('note'),
             ]);
 
+            $consumable->newQuery()->where(['id' => $consumable->id])->update(['qty' => $consumable->qty - 1]);
+
             // Log checkout event
             $logaction = $consumable->logCheckout(e($request->input('note')), $user);
             $data['log_id'] = $logaction->id;

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -69,6 +69,8 @@ class ConsumableCheckoutController extends Controller
             'note' => $request->input('note'),
         ]);
 
+        $consumable->newQuery()->where(['id' => $consumable->id])->update(['qty' => $consumable->qty - 1]);
+
         event(new CheckoutableCheckedOut($consumable, $user, Auth::user(), $request->input('note')));
 
         // Redirect to the new consumable page

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -317,11 +317,9 @@ class Consumable extends SnipeModel
      */
     public function numRemaining()
     {
-        $checkedout = $this->users->count();
         $total = $this->qty;
-        $remaining = $total - $checkedout;
 
-        return $remaining;
+        return $total;
     }
 
     /**

--- a/app/Presenters/ConsumablePresenter.php
+++ b/app/Presenters/ConsumablePresenter.php
@@ -69,13 +69,7 @@ class ConsumablePresenter extends Presenter
                 'sortable' => false,
                 'title' => trans('admin/components/general.total'),
                 'visible' => true,
-            ], [
-                'field' => 'remaining',
-                'searchable' => false,
-                'sortable' => false,
-                'title' => trans('admin/components/general.remaining'),
-                'visible' => true,
-            ], [
+            ],  [
                 'field' => 'min_amt',
                 'searchable' => false,
                 'sortable' => false,

--- a/database/migrations/2023_02_09_015832_adjust_consumables_quantities.php
+++ b/database/migrations/2023_02_09_015832_adjust_consumables_quantities.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Consumable;
+
+class AdjustConsumablesQuantities extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $consumables_checkedout = DB::table('consumables_users')->select('consumable_id', DB::raw('count(*) as total_checkedout'))->groupBy('consumable_id')->get();
+
+        foreach ($consumables_checkedout as $consumable){
+            $consumable_qty = Consumable::select('qty')->where(['id' => $consumable->consumable_id])->value('qty');
+            $total = $consumable_qty - $consumable->total_checkedout;
+
+            Consumable::where('id', $consumable->consumable_id)->update(['qty' => $total]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2023_02_09_015832_adjust_consumables_quantities.php
+++ b/database/migrations/2023_02_09_015832_adjust_consumables_quantities.php
@@ -18,7 +18,12 @@ class AdjustConsumablesQuantities extends Migration
 
         foreach ($consumables_checkedout as $consumable){
             $consumable_qty = Consumable::select('qty')->where(['id' => $consumable->consumable_id])->value('qty');
-            $total = $consumable_qty - $consumable->total_checkedout;
+            $total = (int) $consumable_qty - (int) $consumable->total_checkedout;
+
+            // Control that the $total is never negative 
+            if ($total < 0){
+                $total = 0;
+            }
 
             Consumable::where('id', $consumable->consumable_id)->update(['qty' => $total]);
         }


### PR DESCRIPTION
# Description
A long time ago an user ask about some changes on the quantity of consumables that seems reasonable: The consumables doesn't need to be checkedin again, so the total and remaining quantities kinda made sense in the way they're implemented.

I adjusted the quantity to get decreased everytime a consumable is checked out. In the API and the GUI.
Alter a numRemaining function to return the `Consumable->qty` value directly.
Added a migration to adjust the previous consumables totals if consumables already used.
In the consumables index view, remove the remaining column, as doesn't really make sense anymore.

Fixes #9148

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11

1. 