### PR TITLE
Fixed: Translated the QuickStart screens

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -397,6 +397,12 @@ return [
     'placeholder_kit'       => 'Select a kit',
     'file_not_found'        => 'File not found',
     'preview_not_available' => '(no preview)',
+    'setup'                 => 'Setup',
+    'pre_flight'            => 'Pre-Flight',
+    'skip_to_main_content'  => 'Skip to main content',
+    'toggle_navigation'     => 'Toggle navigation',
+    'alerts'                => 'Alerts',
+    'tasks_view_all'        => 'View all tasks',
 
 
 

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -88,7 +88,7 @@
       <body class="sidebar-mini skin-{{ $snipeSettings->skin!='' ? $snipeSettings->skin : 'blue' }} {{ (session('menu_state')!='open') ? 'sidebar-mini sidebar-collapse' : ''  }}">
   @endif
 
-  <a class="skip-main" href="#main">Skip to main content</a>
+  <a class="skip-main" href="#main">{{ trans('general.skip_to_main_content') }}</a>
     <div class="wrapper">
 
       <header class="main-header">
@@ -100,7 +100,7 @@
         <nav class="navbar navbar-static-top" role="navigation">
           <!-- Sidebar toggle button above the compact sidenav -->
           <a href="#" style="color: white" class="sidebar-toggle btn btn-white" data-toggle="push-menu" role="button">
-            <span class="sr-only">Toggle navigation</span>
+            <span class="sr-only">{{ trans('general.toggle_navigation') }}</span>
           </a>
           <div class="nav navbar-nav navbar-left">
               <div class="left-navblock">
@@ -256,7 +256,7 @@
                <li class="dropdown tasks-menu">
                  <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                    <i class="far fa-flag" aria-hidden="true"></i>
-                     <span class="sr-only">Alerts</span>
+                     <span class="sr-only">{{ trans('general.alerts') }}</span>
                    @if (count($alert_items))
                     <span class="label label-danger">{{ count($alert_items) }}</span>
                    @endif
@@ -288,12 +288,13 @@
                      </ul>
                    </li>
                    {{-- <li class="footer">
-                     <a href="#">View all tasks</a>
+                     <a href="#">{{ trans('general.tasks_view_all') }}</a>
                    </li> --}}
                  </ul>
                </li>
                @endcan
                @endif
+
 
 
                <!-- User Account: style can be found in dropdown.less -->

--- a/resources/views/layouts/setup.blade.php
+++ b/resources/views/layouts/setup.blade.php
@@ -4,10 +4,11 @@
     <head>
       <title>
         @section('title')
-         Snipe-IT Setup
+         Snipe-IT {{ trans('general.setup') }}
         @show
       </title>
         <link rel="stylesheet" href="{{ url(mix('css/dist/all.css')) }}">
+
 
 
         <script nonce="{{ csrf_token() }}">
@@ -57,7 +58,7 @@
           <div class="container">
               <div class="row">
                   <div class="col-lg-10 col-lg-offset-1">
-                    <h1 class="page-header">Snipe-IT Pre-Flight</h1>
+                    <h1 class="page-header">Snipe-IT {{ trans('general.pre_flight') }}</h1>
                   </div>
                   <div class="col-lg-11 col-lg-offset-1">
 


### PR DESCRIPTION
# Description
During initial setup, a number of items were hardcoded. This adds translations to that. While the pages during setup get less overall views, they do get some of the _first_ views from a new user.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
