### PR TITLE
Use translation strings for importer exceptions

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -73,7 +73,7 @@ class ImportController extends Controller
                         Helper::formatStandardApiResponse(
                             'error',
                             null,
-                            'One or more attributes in the header row contain malformed UTF-8 characters'
+                            trans('admin/hardware/message.import.header_row_has_malformed_characters')
                         ),
                         422
                     );
@@ -106,7 +106,7 @@ class ImportController extends Controller
                         Helper::formatStandardApiResponse(
                             'error',
                             null,
-                            'One or more attributes in row 2 contain malformed UTF-8 characters'
+                            trans('admin/hardware/message.import.content_row_has_malformed_characters')
                         ),
                         422
                     );

--- a/resources/lang/en/admin/hardware/message.php
+++ b/resources/lang/en/admin/hardware/message.php
@@ -49,6 +49,8 @@ return [
         'success'               => 'Your file has been imported',
         'file_delete_success'   => 'Your file has been been successfully deleted',
         'file_delete_error'      => 'The file was unable to be deleted',
+        'header_row_has_malformed_characters' => 'One or more attributes in the header row contain malformed UTF-8 characters',
+        'content_row_has_malformed_characters' => 'One or more attributes in row 2 contain malformed UTF-8 characters',
     ],
 
 

--- a/resources/lang/en/admin/hardware/message.php
+++ b/resources/lang/en/admin/hardware/message.php
@@ -50,7 +50,7 @@ return [
         'file_delete_success'   => 'Your file has been been successfully deleted',
         'file_delete_error'      => 'The file was unable to be deleted',
         'header_row_has_malformed_characters' => 'One or more attributes in the header row contain malformed UTF-8 characters',
-        'content_row_has_malformed_characters' => 'One or more attributes in row 2 contain malformed UTF-8 characters',
+        'content_row_has_malformed_characters' => 'One or more attributes in the first row of content contain malformed UTF-8 characters',
     ],
 
 


### PR DESCRIPTION
# Description
This PR updates the error messages added in #12489 to use translation strings instead of hard-coded english strings.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
 