### PR TITLE
Return QR Code public URL's instead of going through a controller

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -471,21 +471,12 @@ class AssetsController extends Controller
         if ($settings->qr_code == '1') {
             $asset = Asset::withTrashed()->find($assetId);
             if ($asset) {
-                $size = Helper::barcodeDimensions($settings->barcode_type);
-                $qr_file = public_path().'/uploads/barcodes/qr-'.str_slug($asset->asset_tag).'-'.str_slug($asset->id).'.png';
+                $qr_file = $asset->getQrCodeUrl(); // NOTE - this will generate the QR code if it didn't exist
 
-                if (isset($asset->id, $asset->asset_tag)) {
-                    if (file_exists($qr_file)) {
-                        $header = ['Content-type' => 'image/png'];
+                if ($qr_file) {
+                    $header = ['Content-type' => 'image/png'];
 
-                        return response()->file($qr_file, $header);
-                    } else {
-                        $barcode = new \Com\Tecnick\Barcode\Barcode();
-                        $barcode_obj = $barcode->getBarcodeObj($settings->barcode_type, route('hardware.show', $asset->id), $size['height'], $size['width'], 'black', [-2, -2, -2, -2]);
-                        file_put_contents($qr_file, $barcode_obj->getPngData());
-
-                        return response($barcode_obj->getPngData())->header('Content-type', 'image/png');
-                    }
+                    return response()->file($qr_file, $header);
                 }
             }
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -569,6 +569,36 @@ class Asset extends Depreciable
         return false;
     }
 
+    /**
+     * Get the image URL for the QR Code, creating it beforehand if necessary.
+     *
+     * @author [B. Wetherington] [<bwetherington@grokability.com>]
+     * @since [v6.0.14
+     * @return string | false
+     */
+
+    public function getQrCodeUrl()
+    {
+        $settings = Setting::getSettings();
+
+        if ($settings->qr_code == '1') {
+            $size = Helper::barcodeDimensions($settings->barcode_type);
+            $qr_file = 'barcodes/qr-'.str_slug($this->asset_tag).'-'.str_slug($this->id).'.png';
+
+            if (isset($this->id, $this->asset_tag)) {
+                if (!Storage::disk('public')->exists($qr_file)) { // TODO - if the file is out-of-date relative to the asset, regenerate it?
+                    $barcode = new \Com\Tecnick\Barcode\Barcode();
+                    $barcode_obj = $barcode->getBarcodeObj($settings->barcode_type, route('hardware.show', $this->id), $size['height'], $size['width'], 'black', [-2, -2, -2, -2]);
+                    Storage::disk('public')->put($qr_file, $barcode_obj->getPngData());
+                }
+                return Storage::disk('public')->url($qr_file);
+
+            }
+
+        }
+        return false;
+    }
+
 
     /**
      * Get the asset's logs

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -112,7 +112,9 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->alt_barcode!='')
 
         @if ($settings->qr_code=='1')
             <div class="qr_img">
-                <img src="{{ config('app.url') }}/hardware/{{ $asset->id }}/qr_code" class="qr_img">
+                @if($asset->getQrCodeUrl())
+                    <img src="{{ $asset->getQrCodeUrl() }}" class="qr_img">
+                @endif
             </div>
         @endif
 


### PR DESCRIPTION
Well, I *thought* this was going to solve one of our customers' problems - but it doesn't look like it did. I still like the code and would prefer that it be 'out in the world' though.

Right now, on the labels page, we repeatedly hit `hardware/{assetId}/qr_code` - for each QR-code-able label.

This means it eats a PHP process in order to do that. But the files already live on the disk, can't we just serve them out directly?

Well, turns out we can!

This code has a couple of features - 
- It uses the Storage facade to enable us to better-support other filesystems (like S3)
- It serves the asset image files directly from the public directory, bypassing a PHP process
- Even though the '/hardware/{assetId}/qr_code' route should probably not be used anymore, this back-fills that with an implementation that *ought* to work - but I haven't tested yet.

Possible future things that this might be able to do -
- Automatically regenerate QR Codes when the `updated_at` is older than the `mtime` on the image file
- Eventually, embed the image directly into the generated web page with: `<img src="data:image/png;base64,` (etc). Substantial reduction in round-trips to the server! <-- I like this one a lot
- We could definitely do the same thing to barcodes?

Since I **haven't** properly tested the back-fill on the original AssetController method, and I'm not 100% convinced about the `getQrCodeUrl()` method name I've chosen, I'm going to leave this in draft for a little bit though.