### PR TITLE
Added images to emailed user inventory report [sc-19801]

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -285,7 +285,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function assets()
     {
-        return $this->morphMany(\App\Models\Asset::class, 'assigned', 'assigned_type', 'assigned_to')->withTrashed();
+        return $this->morphMany(\App\Models\Asset::class, 'assigned', 'assigned_type', 'assigned_to')->withTrashed()->orderBy('id');
     }
 
     /**
@@ -313,7 +313,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     public function accessories()
     {
         return $this->belongsToMany(\App\Models\Accessory::class, 'accessories_users', 'assigned_to', 'accessory_id')
-            ->withPivot('id', 'created_at', 'note')->withTrashed();
+            ->withPivot('id', 'created_at', 'note')->withTrashed()->orderBy('accessory_id');
     }
 
     /**

--- a/resources/views/notifications/markdown/user-inventory.blade.php
+++ b/resources/views/notifications/markdown/user-inventory.blade.php
@@ -9,7 +9,7 @@
 ## {{ $assets->count() }} {{ trans('general.assets') }}
 
 <table width="100%">
-    <tr><th align="left">{{ trans('mail.name') }} </th><th align="left">{{ trans('mail.asset_tag') }}</th><th align="left">{{ trans('admin/hardware/table.serial') }}</th></tr><tr></tr>>
+    <tr><th align="left">{{ trans('mail.name') }} </th><th align="left">{{ trans('mail.asset_tag') }}</th><th align="left">{{ trans('admin/hardware/table.serial') }}</th> <th></th> </tr>
 @foreach($assets as $asset)
 <tr>
     <td>{{ $asset->present()->name }}</td>

--- a/resources/views/notifications/markdown/user-inventory.blade.php
+++ b/resources/views/notifications/markdown/user-inventory.blade.php
@@ -29,7 +29,7 @@
 ## {{ $accessories->count() }} {{ trans('general.accessories') }}
 
 <table width="100%">
-<tr><th align="left">{{ trans('mail.name') }} </th></tr>
+    <tr><th align="left">{{ trans('mail.name') }} </th> <th></th> </tr>
 @foreach($accessories as $accessory)
 <tr>
     <td>{{ $accessory->name }}</td>

--- a/resources/views/notifications/markdown/user-inventory.blade.php
+++ b/resources/views/notifications/markdown/user-inventory.blade.php
@@ -9,9 +9,18 @@
 ## {{ $assets->count() }} {{ trans('general.assets') }}
 
 <table width="100%">
-<tr><th align="left">{{ trans('mail.name') }} </th><th align="left">{{ trans('mail.asset_tag') }}</th><th align="left">{{ trans('admin/hardware/table.serial') }}</th></tr>
+    <tr><th align="left">{{ trans('mail.name') }} </th><th align="left">{{ trans('mail.asset_tag') }}</th><th align="left">{{ trans('admin/hardware/table.serial') }}</th></tr><tr></tr>>
 @foreach($assets as $asset)
-<tr><td>{{ $asset->present()->name }}</td><td> {{ $asset->asset_tag }} </td><td> {{ $asset->serial }} </td></tr>
+<tr>
+    <td>{{ $asset->present()->name }}</td>
+    <td> {{ $asset->asset_tag }} </td>
+    <td> {{ $asset->serial }} </td>
+    @if (($snipeSettings->show_images_in_email =='1') && $asset->getImageUrl())
+    <td>
+        <img src="{{ asset($asset->getImageUrl()) }}" alt="Asset" style="max-width: 64px;">
+    </td>
+    @endif
+</tr>
 @endforeach
 </table>
 @endif
@@ -22,7 +31,14 @@
 <table width="100%">
 <tr><th align="left">{{ trans('mail.name') }} </th></tr>
 @foreach($accessories as $accessory)
-<tr><td>{{ $accessory->name }}</td></tr>
+<tr>
+    <td>{{ $accessory->name }}</td>
+    @if (($snipeSettings->show_images_in_email =='1') && $accessory->getImageUrl())
+    <td>
+        <img src="{{ asset($accessory->getImageUrl()) }}" alt="Accessory" style="max-width: 64px;">
+    </td>
+    @endif
+</tr>
 @endforeach
 </table>
 @endif
@@ -33,7 +49,9 @@
 <table width="100%">
 <tr><th align="left"{{ trans('mail.name') }} </th></tr>
 @foreach($licenses as $license)
-<tr><td>{{ $license->name }}</td></tr>
+<tr>
+    <td>{{ $license->name }}</td>
+</tr>
 @endforeach
 </table>
 @endif


### PR DESCRIPTION
# Description
In the internal freshdesk a customer asks for imeges in the Email List of All Assigned option per user. In this PR I add the images of the assigned assets and accessories (licenses doesn't have images). I have found that some mail clients doesn't show every image if repeated, so I added a order by clause in the query that retrieves the items, to always appear in order, that way if some images aren't displayed they are the same for every item that are the same.

Fixes [sc-19801]

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11