### PR TITLE
adds a red icon next to the  undeployable status

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -243,8 +243,6 @@
                                                         <i class="fas fa-circle text-green"></i>
                                                     @elseif (($asset->assetstatus) && ($asset->assetstatus->pending=='1'))
                                                         <i class="fas fa-circle text-orange"></i>
-                                                    @elseif (($asset->assetstatus) && ($asset->assetstatus->archived=='1'))
-                                                        <i class="fas fa-times text-red"></i>
                                                     @else
                                                         <i class="fas fa-times text-red"></i>
                                                     @endif

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -245,7 +245,10 @@
                                                         <i class="fas fa-circle text-orange"></i>
                                                     @elseif (($asset->assetstatus) && ($asset->assetstatus->archived=='1'))
                                                         <i class="fas fa-times text-red"></i>
+                                                    @elseif (($asset->assetstatus) && ($asset->assetstatus->name =="Broken - Not Fixable"))
+                                                        <i class="fas fa-times text-red"></i>
                                                     @endif
+
                                                     <a href="{{ route('statuslabels.show', $asset->assetstatus->id) }}">
                                                         {{ $asset->assetstatus->name }}</a>
                                                     <label class="label label-default">{{ $asset->present()->statusMeta }}</label>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -245,7 +245,7 @@
                                                         <i class="fas fa-circle text-orange"></i>
                                                     @elseif (($asset->assetstatus) && ($asset->assetstatus->archived=='1'))
                                                         <i class="fas fa-times text-red"></i>
-                                                    @elseif (($asset->assetstatus) && ($asset->assetstatus->deployable=='0'))
+                                                    @else
                                                         <i class="fas fa-times text-red"></i>
                                                     @endif
                                                     <a href="{{ route('statuslabels.show', $asset->assetstatus->id) }}">

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -245,10 +245,9 @@
                                                         <i class="fas fa-circle text-orange"></i>
                                                     @elseif (($asset->assetstatus) && ($asset->assetstatus->archived=='1'))
                                                         <i class="fas fa-times text-red"></i>
-                                                    @elseif (($asset->assetstatus) && ($asset->assetstatus->name =="Broken - Not Fixable"))
+                                                    @elseif (($asset->assetstatus) && ($asset->assetstatus->deployable=='0'))
                                                         <i class="fas fa-times text-red"></i>
                                                     @endif
-
                                                     <a href="{{ route('statuslabels.show', $asset->assetstatus->id) }}">
                                                         {{ $asset->assetstatus->name }}</a>
                                                     <label class="label label-default">{{ $asset->present()->statusMeta }}</label>


### PR DESCRIPTION
# Description

adds a red X to undeployable items  in the Asset View blade. Making it consistent with how status labels appear elsewhere 
<img width="679" alt="image" src="https://user-images.githubusercontent.com/47435081/218820775-c2e72eb4-b9bb-4061-ba35-85fb67ec49b2.png">

Fixes #12493 

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
