### PR TITLE
Fixed #12503 - asset names being removed during API checkout requests

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -857,6 +857,7 @@ class AssetsController extends Controller
         $checkout_at = request('checkout_at', date('Y-m-d H:i:s'));
         $expected_checkin = request('expected_checkin', null);
         $note = request('note', null);
+        // Using `->has` preserves the asset name if the name parameter was not included in request.
         $asset_name = request()->has('name') ? request('name') : $asset->name;
 
         // Set the location ID to the RTD location id if there is one

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -857,7 +857,7 @@ class AssetsController extends Controller
         $checkout_at = request('checkout_at', date('Y-m-d H:i:s'));
         $expected_checkin = request('expected_checkin', null);
         $note = request('note', null);
-        $asset_name = request('name', null);
+        $asset_name = request()->has('name') ? request('name') : $asset->name;
 
         // Set the location ID to the RTD location id if there is one
         // Wait, why are we doing this? This overrides the stuff we set further up, which makes no sense.


### PR DESCRIPTION
# Description
This PR fixes a bug introduced in #12378 and reported in #12503 where an asset name is cleared by checkout requests when the `name` parameter is not provided. Now, for API requests we check if the request includes a `name` parameter and use it if it does. If it does not then we simply use the existing name.

Fixes #12503

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?