### PR TITLE
Fixed #12252 Quotes in Custom Field regex are being HTML-escaped

### DIFF
--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -90,7 +90,7 @@ class CustomFieldset extends Model
                     $rule[] = 'unique_undeleted';
             }
 
-            array_push($rule, $field->attributes['format']);
+            array_push($rule, html_entity_decode($field->attributes['format']));
             $rules[$field->db_column_name()] = $rule;
         }
 

--- a/resources/views/custom_fields/fieldsets/view.blade.php
+++ b/resources/views/custom_fields/fieldsets/view.blade.php
@@ -53,7 +53,7 @@
               @endcan
               <td class="index">{{$field->pivot->order}}</td>
               <td>{{$field->name}}</td>
-              <td>{{$field->format}}</td>
+              <td>{!! $field->format !!}</td>
               <td>{{$field->element}}</td>
               <td>{{ $field->field_encrypted=='1' ?  trans('general.yes') : trans('general.no') }}</td>
                 <td>

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -166,7 +166,7 @@
                   {!! trans('admin/custom_fields/general.db_convert_warning',['db_column' => $field->db_column, 'expected' => $field->convertUnicodeDbSlug()]) !!}
                 @endif
               </td>
-              <td>{{ $field->format }}</td>
+              <td>{!! $field->format !!}</td>
               <td>{!!  ($field->field_encrypted=='1' ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times text-danger"></i>') !!}</td>
               <td>{!!  ($field->display_in_user_view=='1' ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times text-danger"></i>') !!}</td>
               <td class='text-center'>{!! ($field->show_in_email=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"><span class="sr-only">'.trans('general.yes').'</span></i>' : '<i class="fas fa-times text-danger" aria-hidden="true"><span class="sr-only">'.trans('general.no').'</span></i>'  !!}</td>

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -54,7 +54,7 @@
 
                 @else
                     @if (($field->field_encrypted=='0') || (Gate::allows('admin')))
-                    <input type="text" value="{{ Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}" id="{{ $field->db_column_name() }}" class="form-control" name="{{ $field->db_column_name() }}" placeholder="Enter {{ strtolower($field->format) }} text">
+                    <input type="text" value="{{ Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}" id="{{ $field->db_column_name() }}" class="form-control" name="{{ $field->db_column_name() }}" placeholder="Enter {!! strtolower($field->format) !!} text">
                         @else
                             <input type="text" value="{{ strtoupper(trans('admin/custom_fields/general.encrypted')) }}" class="form-control disabled" disabled>
                     @endif


### PR DESCRIPTION
# Description
When a user needs to use a Custom Field with a custom regex format, if they need to use single or double quotes, the system save in the DB the HTML entity  escaped for security reasons.

But when they try to actually put a value on that field, as we don't decode back the format value in the rules array, they can't save a matching regex. This PR decodes back from the database the values so we can use it to validate the custom field as we normally do.

Fixes #12252 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
