### PR TITLE
Fixed #12252 Quotes in Custom Field regex are being HTML-escaped

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -109,9 +109,9 @@ class CustomFieldsController extends Controller
 
 
         if ($request->filled('custom_format')) {
-            $field->format = e($request->get('custom_format'));
+            $field->format = $request->get('custom_format');
         } else {
-            $field->format = e($request->get('format'));
+            $field->format = $request->get('format');
         }
 
         if ($field->save()) {

--- a/database/migrations/2023_02_12_224353_fix_unescaped_customfields_format.php
+++ b/database/migrations/2023_02_12_224353_fix_unescaped_customfields_format.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\CustomField;
+
+class FixUnescapedCustomfieldsFormat extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $customfields = CustomField::where('format', 'LIKE', '%&%')->get();
+
+        foreach($customfields as $customfield){
+            $customfield->update(['format' => html_entity_decode($customfield->format)]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
# Description
When a user needs to use a Custom Field with a custom regex format, if they need to use single or double quotes, the system save in the DB the HTML entity escaped for security reasons. But we prefer to save the user input unescaped and then escape the value where needed.

So this PR gets rid of the `e()` function used to escape the user input in the Custom Regex, and also adds a migration to update the format field in the database if there's already escaped values in there.

Fixes #12252 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11