### PR TITLE
Silence E_WARNING "exceptions"

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -41,7 +41,9 @@ class Handler extends ExceptionHandler
     public function report(Throwable $exception)
     {
         if ($this->shouldReport($exception)) {
-            \Log::error($exception);
+            if (class_exists(\Log::class)) {
+                \Log::error($exception);
+            }
             return parent::report($exception);
         }
     }

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,4 @@
 <?php
-
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -114,7 +113,7 @@ $config = [
             'access_token' => env('ROLLBAR_TOKEN'),
             'level' => env('ROLLBAR_LEVEL', 'error'),
             'check_ignore' => function($isUncaught, $args, $payload) {
-                if (App::environment('production') && get_class($args) == Rollbar\ErrorWrapper::class && $args->errorLevel == E_WARNING ) {
+                if (App::environment('production') && is_object($args) && get_class($args) == Rollbar\ErrorWrapper::class && $args->errorLevel == E_WARNING ) {
                     \Log::info("IGNORING E_WARNING in production mode: ".$args->getMessage());
                     return true; // "TRUE - you should ignore it!"
                 }

--- a/config/logging.php
+++ b/config/logging.php
@@ -114,10 +114,10 @@ $config = [
             'access_token' => env('ROLLBAR_TOKEN'),
             'level' => env('ROLLBAR_LEVEL', 'error'),
             'check_ignore' => function($isUncaught, $args, $payload) {
-                if (method_exists($args, 'getMessage') && strstr($args->getMessage(), 'Declaration of')) {
-                    return true;
+                if (App::environment('production') && get_class($args) == Rollbar\ErrorWrapper::class && $args->errorLevel == E_WARNING ) {
+                    \Log::info("IGNORING E_WARNING in production mode: ".$args->getMessage());
+                    return true; // "TRUE - you should ignore it!"
                 }
-
                 return false;
             },
         ],

--- a/config/logging.php
+++ b/config/logging.php
@@ -113,6 +113,13 @@ $config = [
             'handler' => \Rollbar\Laravel\MonologHandler::class,
             'access_token' => env('ROLLBAR_TOKEN'),
             'level' => env('ROLLBAR_LEVEL', 'error'),
+            'check_ignore' => function($isUncaught, $args, $payload) {
+                if (method_exists($args, 'getMessage') && strstr($args->getMessage(), 'Declaration of')) {
+                    return true;
+                }
+
+                return false;
+            },
         ],
     ],
 


### PR DESCRIPTION
This is really only going to affect people who use Rollbar - which is probably mostly just us.

The background for this issue is complicated, so I'll tl;dr it here and say - "This fix makes it so that error-suppressed things like `@$array['nonexistent_element']` will no longer send to Rollbar when in Production-mode". 

I tested that with and without the `@` in front of it. And **without** the `@`, it still alerts Rollbar (and, also, fails to render the page, showing an error screen instead). With the '@' it prints a message to the Log. Full-fledged Exceptions continue to alert Rollbar normally.

~~One concern I have - and I really have no idea how to 'fix' this concern - is that things like Parse errors are going to show weird error messages like "class \Log not found" which is going to look funny. Maybe I can find a way to detect parse errors in Pure PHP and do an early-return of `true` so "normal" PHP error handling catches it all? Happy to discuss it, because it definitely will throw us for a loop at some point.~~ - RESOLVED!

## Long Explanation

There's a lot of complicated stuff going on here. Regular 'exceptions' work _just fine_. Really. They do pretty much what you want them to. However, "old-school" PHP "errors" and such are not. Modern frameworks like Laravel will typically patch in a `set_error_handler()` callback that will turn those errors and warnings into Exceptions, which will filter their way up the stack. Furthermore, Rollbar itself does the same thing - in order to report them to Rollbar. So I can't really tell which error handler is messing up which, here - but it's very confusing.

The best solution I could come up with is to figure out how to use Rollbar's `check_ignore` config option, and find things that were originally `E_WARNING` and filter those out - only when in Production, though.