### PR TITLE
Added setting for username display, reworked API responses for "user" details

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -340,6 +340,7 @@ class SettingsController extends Controller
         $setting->email_format = $request->input('email_format');
         $setting->username_format = $request->input('username_format');
         $setting->require_accept_signature = $request->input('require_accept_signature');
+        $setting->display_username = $request->input('display_username', 0);
         $setting->show_assigned_assets = $request->input('show_assigned_assets', '0');
         if (! config('app.lock_passwords')) {
             $setting->login_note = $request->input('login_note');

--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -4,6 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Accessory;
+use App\Models\Setting;
 use Gate;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Storage;
@@ -22,6 +23,7 @@ class AccessoriesTransformer
 
     public function transformAccessory(Accessory $accessory)
     {
+
         $array = [
             'id' => $accessory->id,
             'name' => e($accessory->name),
@@ -66,6 +68,8 @@ class AccessoriesTransformer
 
     public function transformCheckedoutAccessory($accessory, $accessory_users, $total)
     {
+        $setting = Setting::getSettings();
+
         $array = [];
 
         foreach ($accessory_users as $user) {
@@ -74,7 +78,7 @@ class AccessoriesTransformer
                 'assigned_pivot_id' => $user->pivot->id,
                 'id' => (int) $user->id,
                 'username' => e($user->username),
-                'name' => e($user->getFullNameAttribute()),
+                'name' => ($setting->display_username == '1') ? e($user->getCompleteNameAttribute()) : e($user->getFullNameAttribute()),
                 'first_name'=> e($user->first_name),
                 'last_name'=> e($user->last_name),
                 'employee_number' =>  e($user->employee_num),

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -4,6 +4,7 @@ namespace App\Http\Transformers;
 use App\Helpers\Helper;
 use App\Models\Actionlog;
 use App\Models\Setting;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 
 class ActionlogsTransformer
@@ -113,9 +114,7 @@ class ActionlogsTransformer
             'log_meta'          => ((isset($clean_meta)) && (is_array($clean_meta))) ? $clean_meta: null,
             'action_date'   => ($actionlog->action_date) ? Helper::getFormattedDateObject($actionlog->action_date, 'datetime'): Helper::getFormattedDateObject($actionlog->created_at, 'datetime'),
         ];
-        //\Log::info("Clean Meta is: ".print_r($clean_meta,true));
 
-        //dd($array);
         return $array;
     }
 
@@ -126,7 +125,7 @@ class ActionlogsTransformer
 
         $array = array();
         foreach ($accessories_users as $user) {
-            $array[] = (new UsersTransformer)->transformUser($user);
+            $array[] = (new UsersTransformer)->transformUserCompact($user);
         }
         return (new DatatablesTransformer)->transformDatatables($array, $total);
     }

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -74,7 +74,7 @@ class AssetsTransformer
             'image' => ($asset->getImageUrl()) ? $asset->getImageUrl() : null,
             'qr' => ($setting->qr_code=='1') ? config('app.url').'/uploads/barcodes/qr-'.str_slug($asset->asset_tag).'-'.str_slug($asset->id).'.png' : null,
             'alt_barcode' => ($setting->alt_barcode_enabled=='1') ? config('app.url').'/uploads/barcodes/'.str_slug($setting->alt_barcode).'-'.str_slug($asset->asset_tag).'.png' : null,
-            'assigned_to' => $this->transformAssignedTo($asset),
+            'assigned_to' => $this->transformAssignedTo($asset, $setting),
             'warranty_months' =>  ($asset->warranty_months > 0) ? e($asset->warranty_months.' '.trans('admin/hardware/form.months')) : null,
             'warranty_expires' => ($asset->warranty_months > 0) ? Helper::getFormattedDateObject($asset->warranty_expires, 'date') : null,
             'created_at' => Helper::getFormattedDateObject($asset->created_at, 'datetime'),
@@ -180,19 +180,10 @@ class AssetsTransformer
         return (new DatatablesTransformer)->transformDatatables($assets);
     }
 
-    public function transformAssignedTo($asset)
+    public function transformAssignedTo($asset, $setting)
     {
         if ($asset->checkedOutToUser()) {
-            return $asset->assigned ? [
-                    'id' => (int) $asset->assigned->id,
-                    'username' => e($asset->assigned->username),
-                    'name' => e($asset->assigned->getFullNameAttribute()),
-                    'first_name'=> e($asset->assigned->first_name),
-                    'last_name'=> ($asset->assigned->last_name) ? e($asset->assigned->last_name) : null,
-                    'email'=> ($asset->assigned->email) ? e($asset->assigned->email) : null,
-                    'employee_number' =>  ($asset->assigned->employee_num) ? e($asset->assigned->employee_num) : null,
-                    'type' => 'user',
-                ] : null;
+            return (new UsersTransformer)->transformUserCompact($asset->assigned);
         }
 
         return $asset->assigned ? [

--- a/app/Http/Transformers/ConsumablesTransformer.php
+++ b/app/Http/Transformers/ConsumablesTransformer.php
@@ -60,11 +60,11 @@ class ConsumablesTransformer
         return $array;
     }
 
-    public function transformCheckedoutConsumables(Collection $consumables_users, $total)
+    public function transformCheckedoutConsumables(Consumable $consumable, $consumables_users, $total)
     {
         $array = [];
-        foreach ($consumables_users as $user) {
-            $array[] = (new UsersTransformer)->transformUser($user);
+        foreach ($consumables_users as $consumables_user) {
+            $array[] = (new UsersTransformer)->transformUserCompact($consumables_user);
         }
 
         return (new DatatablesTransformer)->transformDatatables($array, $total);

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -4,6 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Models\License;
 use App\Models\LicenseSeat;
+use App\Models\Setting;
 use Gate;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -23,19 +24,12 @@ class LicenseSeatsTransformer
 
     public function transformLicenseSeat(LicenseSeat $seat, $seat_count = 0)
     {
+        $setting = Setting::getSettings();
+
         $array = [
             'id' => (int) $seat->id,
             'license_id' => (int) $seat->license->id,
-            'assigned_user' => ($seat->user) ? [
-                'id' => (int) $seat->user->id,
-                'name'=> e($seat->user->present()->fullName),
-                'department'=> ($seat->user->department) ?
-                        [
-                            'id' => (int) $seat->user->department->id,
-                            'name' => e($seat->user->department->name),
-
-                        ] : null,
-            ] : null,
+            'assigned_user' => ($seat->user) ?  (new UsersTransformer)->transformUserCompact($seat->user) : null,
             'assigned_asset' => ($seat->asset) ? [
                 'id' => (int) $seat->asset->id,
                 'name'=> e($seat->asset->present()->fullName),

--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -3,6 +3,7 @@
 namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
+use App\Models\Setting;
 use App\Models\User;
 use Gate;
 use Illuminate\Database\Eloquent\Collection;
@@ -21,6 +22,7 @@ class UsersTransformer
 
     public function transformUser(User $user)
     {
+
         $array = [
                 'id' => (int) $user->id,
                 'avatar' => e($user->present()->gravatar),
@@ -99,6 +101,34 @@ class UsersTransformer
         }
 
         return $array;
+    }
+
+    public function transformUserCompact(User $user) {
+        $setting = Setting::getSettings();
+        return  [
+            'new' => 'yep', // remove me
+            'id' => (int) $user->id,
+            'avatar' => e($user->present()->gravatar),
+            'username' => e($user->username),
+            'name' => ($setting->display_username == '1') ? e($user->getCompleteNameAttribute()) : e($user->getFullNameAttribute()),
+            'first_name'=> e($user->first_name),
+            'last_name'=> ($user->last_name) ? e($user->last_name) : null,
+            'email'=> ($user->email) ? e($user->email) : null,
+            'employee_num' => ($user->employee_num) ? e($user->employee_num) : null,
+            'manager' => ($user->manager) ? [
+                'id' => (int) $user->manager->id,
+                'name'=> e($user->manager->first_name).' '.e($user->manager->last_name),
+            ] : null,
+            'department' => ($user->department) ? [
+                'id' => (int) $user->department->id,
+                'name'=> e($user->department->name),
+            ] : null,
+            'location' => ($user->userloc) ? [
+                'id' => (int) $user->userloc->id,
+                'name'=> e($user->userloc->name),
+            ] : null,
+            'type' => 'user',
+        ];
     }
 
     public function transformUsersDatatable($users)

--- a/database/migrations/2023_02_08_123912_add_username_display_to_settings.php
+++ b/database/migrations/2023_02_08_123912_add_username_display_to_settings.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUsernameDisplayToSettings extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->boolean('display_username')->after('show_archived_in_list')->default(1)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            if (Schema::hasColumn('assets', 'display_username_in_list')) {
+                $table->dropColumn('display_username');
+            }
+        });
+    }
+}

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -397,6 +397,8 @@ return [
     'placeholder_kit'       => 'Select a kit',
     'file_not_found'        => 'File not found',
     'preview_not_available' => '(no preview)',
+    'display_username'      => 'Display Username',
+    'display_username_help_text'    => 'Checking this box will cause listings to display the username in addition to the first and last name for users on listing pages.',
 
 
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -327,10 +327,6 @@
                 item_icon = '';
             }
 
-            // display the username if it's checked out to a user, but don't do it if the username's there already
-            if (value.username && !value.name.match('\\(') && !value.name.match('\\)')) {
-                value.name = value.name + ' (' + value.username + ')';
-            }
 
             return '<nobr><a href="{{ url('/') }}/' + item_destination +'/' + value.id + '" data-tooltip="true" title="' + value.type + '"><i class="' + item_icon + ' text-{{ $snipeSettings->skin!='' ? $snipeSettings->skin : 'blue' }} "></i> ' + value.name + '</a></nobr>';
 

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -114,6 +114,22 @@
                         </div>
                     </div>
 
+                       <!-- Include username in listings -->
+                       <div class="form-group {{ $errors->has('display_username') ? 'error' : '' }}">
+                           <div class="col-md-3">
+                               {{ Form::label('display_username',
+                                              trans('general.display_username')) }}
+                           </div>
+                           <div class="col-md-9">
+                               {{ Form::checkbox('display_username', '1', Request::old('display_username', $setting->display_username),array('class' => 'minimal')) }}
+                               {{ trans('general.yes') }}
+                               {!! $errors->first('display_username', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                               <p class="help-block">{{ trans('general.display_username_help_text') }}</p>
+                           </div>
+                       </div>
+                       <!-- /.form-group -->
+
+
                        <!-- Load images in emails -->
                        <div class="form-group {{ $errors->has('show_images_in_email') ? 'error' : '' }}">
                            <div class="col-md-3">

--- a/routes/api.php
+++ b/routes/api.php
@@ -283,7 +283,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
         Route::get('{id}/users',
             [
                 Api\ConsumablesController::class, 
-                'userCheckouts'
+                'checkedout'
             ]
         )->name('api.consumables.showUsers');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -283,17 +283,8 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
         Route::get('{id}/users',
             [
                 Api\ConsumablesController::class, 
-                'getDataView'
+                'userCheckouts'
             ]
-        )->name('api.consumables.showUsers');
-
-
-        // This is LEGACY endpoint URL and should be removed in the next major release
-        Route::get('view/{id}/users',
-              [
-                  Api\ConsumablesController::class,
-                  'getDataView'
-              ]
         )->name('api.consumables.showUsers');
 
         Route::post('{consumable}/checkout',


### PR DESCRIPTION
This is a WIP - it started as a small (hah!) change to add a setting to the settings table to allow admins to select which way they want usernames displayed, and while going down this rabbit hole, I realized that we have a lot of inconsistencies in our API responses. As we brace for 6.1, this WILL bring breaking changes, but I also think this will make things more sane in the long run, as the user object we return in the payload varies pretty wildly, and this would at least standardize it. It of course uncovered some very old code in consumables that was written in v1 of Snipe-IT, and hasn't been changed since 2017, so it needs some work, hence the WIP. 😬