### PR TITLE
Fixed awkward checkout text in checkedout side panel

### DIFF
--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -91,7 +91,7 @@
     <div class="box box-primary">
       <div class="box-header with-border">
         <h2 class="box-title">{{ trans('admin/users/general.current_assets') }}</h2>
-      </div>
+          </div>
       <div class="box-body">
         <div id="current_assets_content">
         </div>

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -91,7 +91,7 @@
     <div class="box box-primary">
       <div class="box-header with-border">
         <h2 class="box-title">{{ trans('admin/users/general.current_assets') }}</h2>
-          </div>
+      </div>
       <div class="box-body">
         <div id="current_assets_content">
         </div>

--- a/resources/views/partials/assets-assigned.blade.php
+++ b/resources/views/partials/assets-assigned.blade.php
@@ -60,7 +60,7 @@
                                 table_html += "</tr>";
                             }
                         } else {
-                            table_html += '<tr><td colspan="4">No assets checked out to this user yet!</td></tr>';
+                            table_html += '<tr><td colspan="4">{{ trans('admin/users/message.user_has_no_assets_assigned') }}</td></tr>';
                         }
                         $('#current_assets_content').html(table_html + '</tbody></table></div></div>');
 

--- a/resources/views/partials/assets-assigned.blade.php
+++ b/resources/views/partials/assets-assigned.blade.php
@@ -60,7 +60,7 @@
                                 table_html += "</tr>";
                             }
                         } else {
-                            table_html += '<tr><td colspan="4">No assets checked out to '+ $('.js-data-user-ajax').find('option:selected').text() + ' yet!</td></tr>';
+                            table_html += '<tr><td colspan="4">No assets checked out to this user yet!</td></tr>';
                         }
                         $('#current_assets_content').html(table_html + '</tbody></table></div></div>');
 


### PR DESCRIPTION
# Description
When checking out an asset, and no asset assigned to the user selected, the page was trying to add the user's name into a line stating no assets assigned for that user. This was bugged and this PR removes that bit of code to make the line read correctly.

Fixes SC-19909

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

tested locally with new wording

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
