### PR TITLE
Fixes slack settings submit button availability

### DIFF
--- a/app/Http/Livewire/SlackSettingsForm.php
+++ b/app/Http/Livewire/SlackSettingsForm.php
@@ -11,6 +11,7 @@ class SlackSettingsForm extends Component
     public $slack_endpoint;
     public $slack_channel;
     public $slack_botname;
+    public $isDisabled ='disabled' ;
 
     public Setting $setting;
 
@@ -35,6 +36,9 @@ class SlackSettingsForm extends Component
 
     public function render()
     {
+        if(empty($this->slack_channel || $this->slack_endpoint)){
+            $this->isDisabled= 'disabled';
+        }
         return view('livewire.slack-settings-form');
     }
 
@@ -57,9 +61,11 @@ class SlackSettingsForm extends Component
 
         try {
             $slack->post($this->slack_endpoint, ['body' => $payload]);
+            $this->isDisabled='';
             return session()->flash('success' , 'Your Slack Integration works!');
 
         } catch (\Exception $e) {
+            $this->isDisabled= 'disabled';
             return session()->flash('error' , trans('admin/settings/message.slack.error', ['error_message' => $e->getMessage()]));
         }
 

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -34,9 +34,9 @@
             <div class="col-md-8 required">
                 @if (config('app.lock_passwords')===true)
                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-                    <input type="text" wire:model.lazy="slack_endpoint" class= 'form-control' placeholder="https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXX" {{old('slack_endpoint', $slack_endpoint)}}>
+                    <input type="text" wire:model="slack_endpoint" class= 'form-control' placeholder="https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXX" {{old('slack_endpoint', $slack_endpoint)}}>
                 @else
-                    <input type="text" wire:model.lazy="slack_endpoint" class= 'form-control' placeholder="https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXX" {{old('slack_endpoint', $slack_endpoint)}}>
+                    <input type="text" wire:model="slack_endpoint" class= 'form-control' placeholder="https://hooks.slack.com/services/XXXXXXXXXXXXXXXXXXXXX" {{old('slack_endpoint', $slack_endpoint)}}>
                 @endif
                 {!! $errors->first('slack_endpoint', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
             </div>
@@ -49,11 +49,11 @@
             </div>
             <div class="col-md-8 required">
                 @if (config('app.lock_passwords')===true)
-                    <input type="text" wire:model.lazy="slack_channel" class='form-control' placeholder="#IT-Ops" value="{{old('slack_channel', $slack_channel)}}">
+                    <input type="text" wire:model="slack_channel" class='form-control' placeholder="#IT-Ops" value="{{old('slack_channel', $slack_channel)}}">
                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
 
                 @else
-                    <input type="text" wire:model.lazy="slack_channel" class= 'form-control' placeholder="#IT-Ops" value="{{old('slack_channel', $slack_channel)}}">
+                    <input type="text" wire:model="slack_channel" class= 'form-control' placeholder="#IT-Ops" value="{{old('slack_channel', $slack_channel)}}">
                 @endif
                 {!! $errors->first('slack_channel', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
             </div>
@@ -66,18 +66,18 @@
             </div>
             <div class="col-md-8">
                 @if (config('app.lock_passwords')===true)
-                    <input type="text" wire:model.lazy="slack_botname" class= 'form-control' placeholder="Snipe-Bot" {{old('slack_botname', $slack_botname)}}>
+                    <input type="text" wire:model="slack_botname" class= 'form-control' placeholder="Snipe-Bot" {{old('slack_botname', $slack_botname)}}>
                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
 
                 @else
-                    <input type="text" wire:model.lazy="slack_botname" class= 'form-control' placeholder="Snipe-Bot" {{old('slack_botname', $slack_botname)}}>
+                    <input type="text" wire:model="slack_botname" class= 'form-control' placeholder="Snipe-Bot" {{old('slack_botname', $slack_botname)}}>
                 @endif
                 {!! $errors->first('slack_botname', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
             </div><!--col-md-10-->
         </div>
 
         <!--Slack Integration Test-->
-            @if($slack_endpoint != null && $slack_channel != null && $slack_botname != null)
+            @if($slack_endpoint != null && $slack_channel != null)
         <div class="form-group">
                 <div class="col-md-offset-2 col-md-8">
                     <a href="#" wire:click.prevent="testSlack" class="btn btn-default btn-sm pull-left"><span>{!! trans('admin/settings/general.slack_test') !!}</span></a>

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -64,7 +64,7 @@
             <div class="col-md-2">
                 {{ Form::label('slack_botname', trans('admin/settings/general.slack_botname')) }}
             </div>
-            <div class="col-md-8 required">
+            <div class="col-md-8">
                 @if (config('app.lock_passwords')===true)
                     <input type="text" wire:model.lazy="slack_botname" class= 'form-control' placeholder="Snipe-Bot" {{old('slack_botname', $slack_botname)}}>
                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
@@ -89,7 +89,7 @@
         <div class="box-footer" style="margin-top: 45px;">
             <div class="text-right col-md-12">
                 <a class="btn btn-link text-left" href="{{ route('settings.index') }}">{{ trans('button.cancel') }}</a>
-                <button type="submit" class="btn btn-primary"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('general.save') }}</button>
+                <button type="submit" {{$isDisabled}} class="btn btn-primary"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('general.save') }}</button>
             </div>
         </div><!--box-footer-->
         </form>


### PR DESCRIPTION
# Description

This greys out the submit button if `slack_endpoint` or `slack_channel` are not filled in. Also greys it out if the integration 
test fails or hasn't been run.
Fixes #SC-20041

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
