### PR TITLE
Cleanup some small UI bugaboos (padding, etc)

### DIFF
--- a/resources/views/layouts/edit-form.blade.php
+++ b/resources/views/layouts/edit-form.blade.php
@@ -35,24 +35,22 @@
 
                 @if ((isset($topSubmit) && ($topSubmit=='true')) || (isset($item->id)))
 
-                <div class="col-md-12 box-title text-right">
-                    <div class="col-md-12">
+                <div class="col-md-12 box-title text-right" style="padding: 0px; margin: 0px;">
                         <div class="col-md-9 text-left">
                             @if ($item->id)
-                                <h2 class="box-title text-left" style="padding-top: 8px;">
+                                <h2 class="box-title" style="padding-top: 8px; padding-bottom: 7px;">
                                     {{ $item->display_name }}
                                 </h2>
                             @endif
                         </div>
                         @if (isset($topSubmit) && ($topSubmit=='true'))
-                        <div class="col-md-3 text-right" style="padding-right: 10px;">
-                            <button type="submit" class="btn btn-primary">
+                        <div class="col-md-3 text-right" style="padding-right: 0px;">
+                            <button type="submit" class="btn btn-primary pull-right">
                                 <i class="fas fa-check icon-white" aria-hidden="true"></i>
                                 {{ trans('general.save') }}
                             </button>
                         </div>
                         @endif
-                    </div>
                 </div>
             </div><!-- /.box-header -->
             @endif

--- a/resources/views/layouts/edit-form.blade.php
+++ b/resources/views/layouts/edit-form.blade.php
@@ -41,7 +41,7 @@
                             @if ($item->id)
                                 <h2 class="box-title text-left" style="padding-top: 8px;">
                                     {{ $item->display_name }}
-                                </h2> ;
+                                </h2>
                             @endif
                         </div>
                         @if (isset($topSubmit) && ($topSubmit=='true'))

--- a/resources/views/layouts/edit-form.blade.php
+++ b/resources/views/layouts/edit-form.blade.php
@@ -44,7 +44,7 @@
                             @endif
                         </div>
                         @if (isset($topSubmit) && ($topSubmit=='true'))
-                        <div class="col-md-3 text-right" style="padding-right: 0px;">
+                        <div class="col-md-3 text-right" style="padding-right: 10px;">
                             <button type="submit" class="btn btn-primary pull-right">
                                 <i class="fas fa-check icon-white" aria-hidden="true"></i>
                                 {{ trans('general.save') }}

--- a/resources/views/layouts/edit-form.blade.php
+++ b/resources/views/layouts/edit-form.blade.php
@@ -31,35 +31,36 @@
         <!-- box -->
         <div class="box box-default">
             <!-- box-header -->
-            <div class="box-header with-border text-right">
+            <div class="box-header with-border">
 
-                <div class="col-md-12 box-title text-right" style="padding: 0px; margin: 0px;">
+                @if ((isset($topSubmit) && ($topSubmit=='true')) || (isset($item->id)))
 
-                    <div class="col-md-12" style="padding: 0px; margin: 0px;">
+                <div class="col-md-12 box-title text-right">
+                    <div class="col-md-12">
                         <div class="col-md-9 text-left">
                             @if ($item->id)
                                 <h2 class="box-title text-left" style="padding-top: 8px;">
                                     {{ $item->display_name }}
-                                </h2>
+                                </h2> ;
                             @endif
                         </div>
+                        @if (isset($topSubmit) && ($topSubmit=='true'))
                         <div class="col-md-3 text-right" style="padding-right: 10px;">
-                            <a class="btn btn-link text-left" href="{{ URL::previous() }}">
-                                {{ trans('button.cancel') }}
-                            </a>
                             <button type="submit" class="btn btn-primary">
                                 <i class="fas fa-check icon-white" aria-hidden="true"></i>
                                 {{ trans('general.save') }}
                             </button>
                         </div>
+                        @endif
                     </div>
                 </div>
-
             </div><!-- /.box-header -->
+            @endif
 
             <!-- box-body -->
             <div class="box-body">
 
+                <div style="padding-top: 30px;">
                     @if ($item->id)
                     {{ method_field('PUT') }}
                     @endif
@@ -68,6 +69,7 @@
                     {{ csrf_field() }}
                     @yield('inputFields')
                     @include('partials.forms.edit.submit')
+                </div>
 
             </div> <!-- ./box-body -->
         </div> <!-- box -->

--- a/resources/views/partials/forms/edit/submit.blade.php
+++ b/resources/views/partials/forms/edit/submit.blade.php
@@ -1,7 +1,7 @@
 <!-- partials/forms/edit/submit.blade.php -->
 
-<div class="box-footer text-right">
-    <a class="btn btn-link text-left" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>
+<div class="box-footer text-right" style="padding-bottom: 0px;">
+    <a class="btn btn-link pull-left" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>
     <button type="submit" accesskey="s" class="btn btn-primary"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('general.save') }}</button>
 </div>
 <!-- / partials/forms/edit/submit.blade.php -->


### PR DESCRIPTION
Just some small tweaks to padding, and some regressions (that the cancel button is too close to the submit, which can end in tears from a UX perspective) and also the top save button on really small forms. I also added some padding to the top of the forms so that it doesn't feel quite so cramped, and we now (once again) respect the `$topSubmit` variable.

For example, in the categories edit form, we start with this:

```php
@extends('layouts/edit-form', [
    'createText' => trans('admin/categories/general.create') ,
    'updateText' => trans('admin/categories/general.update'),
    'helpPosition'  => 'right',
    'helpText' => trans('help.categories'),
    'formAction' => (isset($item->id)) ? route('categories.update', ['category' => $item->id]) : route('categories.store'),
])
```

If we wanted a top submit button there (which we would only do if the form is longer, and it looks weird if we have a very small form - manufacturers, for example - we can just add in this line into the edit blade:

```php
    'topSubmit'  => 'true',
```

So it would look like:

```php
@extends('layouts/edit-form', [
    'createText' => trans('admin/categories/general.create') ,
    'updateText' => trans('admin/categories/general.update'),
    'helpPosition'  => 'right',
    'helpText' => trans('help.categories'),
    'topSubmit'  => 'true',
    'formAction' => (isset($item->id)) ? route('categories.update', ['category' => $item->id]) : route('categories.store'),
])
```

### Before
<img width="1040" alt="Screenshot 2023-02-15 at 5 21 44 PM" src="https://user-images.githubusercontent.com/197404/219237374-6b71ba8f-b4ef-4d42-bb30-9b07425155d4.png">

### After
<img width="1038" alt="Screenshot 2023-02-15 at 5 22 03 PM" src="https://user-images.githubusercontent.com/197404/219237504-2ae329f3-0831-4760-a5d8-28d73276028c.png">
