### PR TITLE
Fixed #12151 Quantity statistics in Parent Location

### DIFF
--- a/app/Http/Transformers/LocationsTransformer.php
+++ b/app/Http/Transformers/LocationsTransformer.php
@@ -24,12 +24,23 @@ class LocationsTransformer
     {
         if ($location) {
             $children_arr = [];
+            $children_counts = [
+                'assigned_assets_count' => 0,
+                'assets_count' => 0,
+                'rtd_assets_count' => 0,
+                'users_count' => 0,
+            ];
+
             if (! is_null($location->children)) {
                 foreach ($location->children as $child) {
                     $children_arr[] = [
                         'id' => (int) $child->id,
                         'name' => $child->name,
                     ];
+                    $children_counts['assigned_assets_count'] += $child->assignedAssets()->count();
+                    $children_counts['assets_count'] += $child->assets()->count();
+                    $children_counts['rtd_assets_count'] += $child->rtd_assets()->count();
+                    $children_counts['users_count'] += $child->users()->count();
                 }
             }
 
@@ -43,10 +54,10 @@ class LocationsTransformer
                 'state' =>  ($location->state) ? e($location->state) : null,
                 'country' => ($location->country) ? e($location->country) : null,
                 'zip' => ($location->zip) ? e($location->zip) : null,
-                'assigned_assets_count' => (int) $location->assigned_assets_count,
-                'assets_count'    => (int) $location->assets_count,
-                'rtd_assets_count'    => (int) $location->rtd_assets_count,
-                'users_count'    => (int) $location->users_count,
+                'assigned_assets_count' => (int) $location->assigned_assets_count + (int) $children_counts['assigned_assets_count'],
+                'assets_count'    => (int) $location->assets_count + (int) $children_counts['assets_count'],
+                'rtd_assets_count'    => (int) $location->rtd_assets_count + (int) $children_counts['rtd_assets_count'],
+                'users_count'    => (int) $location->users_count + (int) $children_counts['users_count'],
                 'currency' =>  ($location->currency) ? e($location->currency) : null,
                 'ldap_ou' =>  ($location->ldap_ou) ? e($location->ldap_ou) : null,
                 'created_at' => Helper::getFormattedDateObject($location->created_at, 'datetime'),


### PR DESCRIPTION
# Description
In the Locations view, where we show the number of assets assigned per location, some user report that the number of assets assigned to the parent location should be the sum of the children locations in there. Like in this Screenshot they posted:

![image](https://user-images.githubusercontent.com/653557/219254643-22beefdb-6b60-4898-a55d-230775da99c1.png)

This PR adjust the calculation to show the number as this user think it should be, but I'm not sure about this fix, because once we click on the parent location, the reality is no asset, or user is in it but in the children... so I'm open to comments on how this should behave.

Fixes #12151

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version:8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
