### PR TITLE
Fixed #12531 Expected Checkin Date on Asset Checkout throws an error

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -186,6 +186,14 @@ class Asset extends Depreciable
         'model.manufacturer' => ['name'],
     ];
 
+    // To properly set the expected checkin as Y-m-d
+    public function setExpectedCheckinAttribute($value)
+    {
+        if ($value == '') {
+            $value = null;
+        }
+        $this->attributes['expected_checkin'] = $value;
+    }
 
     /**
      * This handles the custom field validation for assets


### PR DESCRIPTION
# Description
When an asset get checkout, the user can set a date for the day they expected the asset to got checkin. We made a couple days ago that the `expexted_checkin` value came in the form `Y-m-d` but whenever this value is set, the validation always fails. This was caused because for some reason, Laravel put the asset object together with that date as format `Y-m-d H:i:s`
![image](https://user-images.githubusercontent.com/653557/219972408-177bfea7-f02a-4347-93cd-3b2f67ff1db3.png)
 So I tested various forms to make this works as expected. And my results where this:

- Change the validation rule from: `'expected_checkin' => 'date_format:Y-m-d|nullable',` to `'expected_checkin' => 'date_format:Y-m-d H:i:s|nullable',`. This way the validation pass and the date still is saved as `Y-m-d` in the database, but I don't like that we are expressing in the code something we really don't like.
- Remove the `expected_checkin` field from the `protected $dates` array. This way the validation pass but I don't like that we are not putting a date field with the others, and also we have dates in this array that fulfill the needed format.
- Put a setter in the Asset model class, as the `purchase_date` have in SnipeModel model class. I read the code and see this field have the same format as we need. It's defined in the Snipe model class because the `purchase_date` field is common to a lot of types of assets. So I put it in the Asset model class because the `expected_checkin` field only is used in asset types. We can see that using the setter, the object is formed with this attribute in the correct format.
![image](https://user-images.githubusercontent.com/653557/219972838-5a0195ea-661b-491d-9e85-4a92f214f6e9.png)

As always let me know if there is a more elegant/simpler solution. This was the only way I could figure out.

Fixes #12531 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
