### PR TITLE
Properly close tag in mail template

### DIFF
--- a/resources/views/notifications/markdown/user-inventory.blade.php
+++ b/resources/views/notifications/markdown/user-inventory.blade.php
@@ -47,7 +47,7 @@
 ## {{ $licenses->count() }} {{ trans('general.licenses') }}
 
 <table width="100%">
-<tr><th align="left"{{ trans('mail.name') }} </th></tr>
+<tr><th align="left">{{ trans('mail.name') }} </th></tr>
 @foreach($licenses as $license)
 <tr>
     <td>{{ $license->name }}</td>


### PR DESCRIPTION
# Description
This PR properly closes a `th` tag.

With this change the `Name` label is presented as expected as well.

| Before | After |
| - | - |
| ![Before](https://user-images.githubusercontent.com/1141514/220805028-b29f30a8-4897-4681-8e04-6d96e052a548.png) | ![After](https://user-images.githubusercontent.com/1141514/220805145-b6f96efe-7168-47a7-8b34-3156998e2bf8.png) |

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally by checking out a license to a user and running `php artisan snipeit:user-inventory` and checking the results in MailTrap.