### PR TITLE
Fix purchase date field in asset seeder

### DIFF
--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -44,7 +44,7 @@ class AssetFactory extends Factory
             'user_id' => 1,
             'asset_tag' => $this->faker->unixTime('now'),
             'notes'   => 'Created by DB seeder',
-            'purchase_date' => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get()),
+            'purchase_date' => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get())->format('Y-m-d'),
             'purchase_cost' => $this->faker->randomFloat(2, '299.99', '2999.99'),
             'order_number' => $this->faker->numberBetween(1000000, 50000000),
             'supplier_id' => Supplier::all()->random()->id,


### PR DESCRIPTION
# Description

Currently the `AssetSeeder` does not run properly because the rules in the Asset model define the format for the `purchase_date` field in a way that faker does not adhere to by default. This PR fixes that by applying formatting in the factory.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)