### PR TITLE
Fixed ErrorException: A non-numeric value encountered in app/Models/License [sc-20187]

### DIFF
--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -170,8 +170,8 @@ class LicensesController extends Controller
         $license->reassignable      = $request->input('reassignable', 0);
         $license->serial            = $request->input('serial');
         $license->termination_date  = $request->input('termination_date');
-        $license->seats             = e($request->input('seats'));
-        $license->manufacturer_id   =  $request->input('manufacturer_id');
+        $license->seats             = $request->input('seats');
+        $license->manufacturer_id   = $request->input('manufacturer_id');
         $license->supplier_id       = $request->input('supplier_id');
         $license->category_id       = $request->input('category_id');
 

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -155,7 +155,7 @@ class License extends Depreciable
     public static function adjustSeatCount($license, $oldSeats, $newSeats)
     {
         if(!is_numeric($newSeats)){
-            Session::flash('error', trans('admin/licenses/message.update.error'));
+            Session::flash('error', trans('admin/licenses/message.seats_format_value'));
 
             return false;
         }

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -154,6 +154,11 @@ class License extends Depreciable
      */
     public static function adjustSeatCount($license, $oldSeats, $newSeats)
     {
+        if(!is_numeric($newSeats)){
+            Session::flash('error', trans('admin/licenses/message.update.error'));
+
+            return false;
+        }
         // If the seats haven't changed, continue on happily.
         if ($oldSeats == $newSeats) {
             return true;

--- a/resources/lang/en/admin/licenses/message.php
+++ b/resources/lang/en/admin/licenses/message.php
@@ -9,6 +9,7 @@ return array(
     'assoc_users'	 => 'This license is currently checked out to a user and cannot be deleted. Please check the license in first, and then try deleting again. ',
     'select_asset_or_person' => 'You must select an asset or a user, but not both.',
     'not_found' => 'License not found',
+    'seats_format_value' => 'The \'Seats\' format value is not numeric',
 
 
     'create' => array(


### PR DESCRIPTION
# Description
When a license is updated, as we recalculate the seats assigned (checking if we are substracting more seats that we have available for example) the `license->seats` value can try to assign non numeric values. I tried to add an early return if the string doesn't appear as numeric and that fixes the update issue, but affects the creation of new Licenses. So I left it as a WIP while I further investigate this. 

Fixes internal shortcut [sc-20187]

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
