### PR TITLE
Fixed ErrorException: A non-numeric value encountered in app/Models/License [sc-20187]

### DIFF
--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -36,7 +36,6 @@ class License extends Depreciable
         'purchase_date' => 'datetime',
         'expiration_date' => 'datetime',
         'termination_date' => 'datetime',
-        'seats'   => 'integer',
         'category_id'  => 'integer',
         'company_id'   => 'integer',
     ];


### PR DESCRIPTION
# Description
When a license is updated the license->seats value can try to assign non numeric values because we are casting whatever the user puts in the input to an integer value, so if the user puts a `2+` the casting makes it an integer `2` so the validation pass , but in a static function of the License model, we recalculate the seats assigned (checking if we are substracting more seats that we have available for example)  and in that function we access whatever value the user pass. no casting, so the `2+` makes the app fails.

I deleted the casting from the License model, so the user is enforced to always put an integer value in the input format.

Fixes [sc-20187]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
