### PR TITLE
Pass the existing asset name to the bulk checkout form

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -288,7 +288,8 @@ class BulkAssetsController extends Controller
                 foreach ($asset_ids as $asset_id) {
                     $asset = Asset::findOrFail($asset_id);
                     $this->authorize('checkout', $asset);
-                    $error = $asset->checkOut($target, $admin, $checkout_at, $expected_checkin, e($request->get('note')), null);
+
+                    $error = $asset->checkOut($target, $admin, $checkout_at, $expected_checkin, e($request->get('note')), $asset->name, null);
 
                     if ($target->location_id != '') {
                         $asset->location_id = $target->location_id;


### PR DESCRIPTION
This should fix an issue where the asset name was being nulled out on bulk checkout.