### PR TITLE
Fixed #12559 Unable to import Purchase Date field

### DIFF
--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -74,7 +74,7 @@ class ItemImporter extends Importer
 
         $this->item['purchase_date'] = null;
         if ($this->findCsvMatch($row, 'purchase_date') != '') {
-            $this->item['purchase_date'] = date('Y-m-d 00:00:01', strtotime($this->findCsvMatch($row, 'purchase_date')));
+            $this->item['purchase_date'] = date('Y-m-d', strtotime($this->findCsvMatch($row, 'purchase_date')));
         }
 
         $this->item['last_audit_date'] = null;


### PR DESCRIPTION
# Description
The importer fails to parse the `purchase_date` field because it was converting the value in the CSV as 'Y-m-d H:i:s' instead of the newly enforced 'Y-m-d'. The PR just adjust the format as needed.

Fixes #12559 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**: 
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
