### PR TITLE
Added max results limit to report index

### DIFF
--- a/app/Http/Controllers/Api/ReportsController.php
+++ b/app/Http/Controllers/Api/ReportsController.php
@@ -57,8 +57,12 @@ class ReportsController extends Controller
         $sort = in_array($request->input('sort'), $allowed_columns) ? e($request->input('sort')) : 'created_at';
         $order = ($request->input('order') == 'asc') ? 'asc' : 'desc';
         $offset = request('offset', 0);
-        $limit = request('limit', 50);
         $total = $actionlogs->count();
+
+        // Check to make sure the limit is not higher than the max allowed
+        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+
+
         $actionlogs = $actionlogs->orderBy($sort, $order)->skip($offset)->take($limit)->get();
 
         return response()->json((new ActionlogsTransformer)->transformActionlogs($actionlogs, $total), 200, ['Content-Type' => 'application/json;charset=utf8'], JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
In all other places in the API, we force the API results to return a maximum of x results per API response page, as documented [here](https://snipe-it.readme.io/reference/api-throttling). This can be overridden via .env config, but it's designed to prevent memory crashes, as many of our endpoints are querying a LOT of tables at once.

This PR simply enforces that same constraint here. 