### PR TITLE
Added table aliases to fix ambiguous SQL clause

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1641,9 +1641,9 @@ class Asset extends Depreciable
      */
     public function scopeOrderManufacturer($query, $order)
     {
-        return $query->join('models', 'assets.model_id', '=', 'models.id')
-            ->join('manufacturers', 'models.manufacturer_id', '=', 'manufacturers.id')
-            ->orderBy('manufacturers.name', $order);
+        return $query->join('models as order_asset_model', 'assets.model_id', '=', 'order_asset_model.id')
+            ->join('manufacturers as manufacturer_order', 'order_asset_model.manufacturer_id', '=', 'manufacturer_order.id')
+            ->orderBy('manufacturer_order.name', $order);
     }
 
    /**


### PR DESCRIPTION
This fixes SC-19834 and RB-16814. We didn't catch it before, since it's a bit of an odd use-case, where you're including a manufacturer ID *and also* sorting on the manufacturer (which wouldn't make sense, since you'll only have one manufacturer in the results.)


### To reproduce:
`/api/v1/hardware?manufacturer_id=3&itemtype=assets&search=&sort=manufacturer&order=asc&offset=0&limit=200`

