### PR TITLE
Fixed Address in mailbox given does not comply with RFC 2822, 3.6.2. [sc-202022]

### DIFF
--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -25,7 +25,10 @@ class CheckoutAcceptance extends Model
     {
         // At this point the endpoint is the same for everything.
         //  In the future this may want to be adapted for individual notifications.
-        return Setting::getSettings()->alert_email;
+        $recipients_string = explode(',', Setting::getSettings()->alert_email);
+        $recipients = array_map('trim', $recipients_string);
+
+        return array_filter($recipients);
     }
 
     /**


### PR DESCRIPTION
# Description
When the user accepts/declines an asset if the setting `alert_email` is set, and that value is formed of multiple emails comma separated, the system fails.

To fix this issue I convert that string value into an array of strings (emails) on the CheckoutAcceptance model function that return those addresses.

Fixes  shortcut sc-20202 and rollbar 16977

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP Dev Server
* OS version: Debian 11
