### PR TITLE
Fixed: TypeError: get_class(): Argument #1 ($object) must be of type object, null given

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -59,6 +59,12 @@ class LicenseCheckinController extends Controller
         }
 
         $license = License::find($licenseSeat->license_id);
+
+        // LicenseSeat is not assigned, it can't be checked in
+        if (is_null($licenseSeat->assignedTo) && is_null($licenseSeat->asset_id)) {
+            return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.checkin.error'));
+        }
+
         $this->authorize('checkout', $license);
 
         if (! $license->reassignable) {

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -93,8 +93,12 @@ trait Loggable
     {
         $settings = Setting::getSettings();
         $log = new Actionlog;
-        $log->target_type = get_class($target);
-        $log->target_id = $target->id;
+
+        if($target != null){
+            $log->target_type = get_class($target);
+            $log->target_id = $target->id;
+
+        }
 
         if (static::class == LicenseSeat::class) {
             $log->item_type = License::class;


### PR DESCRIPTION
# Description
For some reason some customers where trying to checkin license seats that aren't checked out (API call maybe? who knows), I could replicate the issue going to the route `http://localhost:8080/licenses/license_seat_id/checkin` for example, where the `license_seat_id` part is a license seat I didn't have assigned.

In the PR I first checked if the license seat is assigned to a user or another asset, and if it's not then I return showing an error. Which can be enough probably, but to be sure, I also added a condition in the Loggable model, and if the variable `$target` is null (the license seat is not assigned) I just ignore it. It should never come down to that.... but just in case.

Fixes rollbar 16819

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
