### PR TITLE
Fixed Undefined variable `$total`

### DIFF
--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -196,6 +196,7 @@ class StatuslabelsController extends Controller
     {
         $this->authorize('view', Statuslabel::class);
         $statuslabels = Statuslabel::withCount('assets')->get();
+        $total = Array();
 
         foreach ($statuslabels as $statuslabel) {
 


### PR DESCRIPTION
# Description
Noticed a rollbar complaining about a `$total` variable in the `StatusLabelController`, I only can reproduce this deleting all the status labels in my local environment, and that should never happen... but I declare the variable as an empty array so if for some reason the error case is reached, it doesn't hard fail like this.

Fixes rollbar 16988

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
