### PR TITLE
Add GitHub Action to push translation sources to Crowdin

### DIFF
--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,0 +1,21 @@
+name: Crowdin Action
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  upload-sources-to-crowdin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Crowdin push
+        uses: crowdin/github-action@v1
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
+          token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
# Description
This PR adds the [Crowdin GitHub Action](https://github.com/crowdin/github-action) to push language source changes to Crowdin.

In detail:
- If merged, pushes to `develop` will kick off the included GitHub Action and push any changes in the source translation files (`/lang/en/**/*.php` as defined in `crowdin.yml`) to Crowdin.
- Only new or modified keys will be pushed to Crowdin. Keys that are removed will not be removed from Crowdin.
	- For instance, if `/lang/en/auth.php` contained a key that is removed in a commit to `develop`, Crowdin would still contain that key even though it is no longer used in the app. 
	- If we would like to remove keys that have been deleted we can add `upload_sources_args: '--delete-obsolete'` to the `with` section.
- Changing a source string (`/lang/en/**/*.php`) that has previously been translated and marked as Approved in Crowdin will mark the string as untranslated in once the change is merged to develop (see note below).

## Adding Secrets
This action requires adding keys to the repository's [Actions Secrets Variables](https://github.com/snipe/snipe-it/settings/secrets/actions) (via the `New repository secret` button)
- `CROWDIN_PROJECT_ID`: displayed publicly on Snipe-IT's [Crowdin page](https://crowdin.com/project/snipe-it): `67597`
- `CROWDIN_PERSONAL_TOKEN`: Acquired from the [personal account settings api page](https://crowdin.com/settings#api-key). 
	- The permissions required for the token is unfortunately broad: `Projects > Projects (List, Get, Create, Edit)` and `Projects > Source files & strings` but you can click the option for `Granular access` and `Grant access to selected projects` to scope the token to this project.
![image](https://user-images.githubusercontent.com/1141514/221927343-335822b3-5d4c-4a5e-8672-322d1036f2bd.png)

## How This Was Tested
To avoid winging it in this repo and accidentally screwing up the existing translations I created a [sample repository](https://github.com/marcusmoore/translation-playground) and [Crowdin project](https://crowdin.com/project/translation-playground) to test on that you can view if curious. I copied snipe-it's `/resources/lang` directory into the project in `/lang` (Laravel 10's folder structure) and pushed a bunch of commits to confirm the behavior listed above.

## Updating Sources...
A little more clarification on the note about strings being marked as untranslated:

Taking the key:value `auth.failed:These credentials do not match our records.` as an example and assuming the string is marked as approved in Crowdin. If a subsequent PR gets merged that changes `These credentials do not match our records.`  to `These credentials do not match our records!!` the string will be marked as untranslated and require re-approval.

## Potential Future Improvements
This action only handles pushing source changes to Crowdin but not pulling translations into the app. We can look into using an Action to create pull requests with translation changes on a schedule, when a release is tagged, or [manually](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) (check the [Triggers](https://github.com/crowdin/github-action/blob/master/EXAMPLES.md#triggers) section of the Action's docs for details).

---

Please question any hesitations that pop up. I really don't want to invalid our existing translations (although any mistakes should be able to be reverted in the project's [Activity Stream](https://crowdin.com/project/snipe-it/activity-stream) 🤞🏾)