### PR TITLE
Adding ability to see boolean values when using normal table export

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -403,6 +403,8 @@ return [
     'toggle_navigation'     => 'Toggle navigation',
     'alerts'                => 'Alerts',
     'tasks_view_all'        => 'View all tasks',
+    'true'                  => 'True',
+    'false'                 => 'False',
 
 
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -570,9 +570,9 @@
 
     function trueFalseFormatter(value) {
         if ((value) && ((value == 'true') || (value == '1'))) {
-            return '<i class="fas fa-check text-success"></i>';
+            return '<i class="fas fa-check text-success"></i><span class="sr-only">{{ trans('general.true') }}</span>';
         } else {
-            return '<i class="fas fa-times text-danger"></i>';
+            return '<i class="fas fa-times text-danger"></i><span class="sr-only">{{ trans('general.false') }}</span>';
         }
     }
 


### PR DESCRIPTION
# Description

This adds the ability for users to see boolean values when exporting using the normal exporting option. (Not custom reports)

Boolean values we show as a check/x mark were showing up blank upon export.
They will now show TRUE/FALSE in the exported file.
For loading those reports into Excel or Gsheets, a simple format to a checkbox will return the report to that checkbox view.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested locally by exporting reports to verify the boolean fields are populated


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
