### PR TITLE
Fixed User start and end date throws validation error [sc-20228]

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -80,8 +80,8 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         'created_at',
         'updated_at',
         'deleted_at',
-        'start_date',
-        'end_date',
+        'start_date' => 'date_format:Y-m-d',
+        'end_date' => 'date_format:Y-m-d',
     ];
 
 


### PR DESCRIPTION
# Description
Format added to `start_date` and `end_date` User model, so the validation gets trough.

Fixes [sc-20228]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
