### PR TITLE
Check for array in linux setup

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -111,17 +111,17 @@ class SettingsController extends Controller
             $start_settings['prod'] = true;
         }
 
+        $start_settings['owner'] = '';
+
         if (function_exists('posix_getpwuid')) { // Probably Linux
             $owner = posix_getpwuid(fileowner($_SERVER['SCRIPT_FILENAME']));
-            $start_settings['owner'] = $owner['name'];
-        } else { // Windows
-            // TODO: Is there a way of knowing if a windows user has elevated permissions
-            // This just gets the user name, which likely isn't 'root'
-            // $start_settings['owner'] = getenv('USERNAME');
-            $start_settings['owner'] = '';
+            // This *shouldn't* be boolean, but we've seen this in come chrooted environments
+            if (!is_bool($owner)) {
+                $start_settings['owner'] = $owner['name'];
+            }
         }
 
-        if (('root' === $start_settings['owner']) || ('0' === $start_settings['owner'])) {
+        if (($start_settings['owner'] === 'root') || ($start_settings['owner'] === '0')) {
             $start_settings['owner_is_admin'] = true;
         } else {
             $start_settings['owner_is_admin'] = false;

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -115,7 +115,7 @@ class SettingsController extends Controller
 
         if (function_exists('posix_getpwuid')) { // Probably Linux
             $owner = posix_getpwuid(fileowner($_SERVER['SCRIPT_FILENAME']));
-            // This *shouldn't* be boolean, but we've seen this in come chrooted environments
+            // This *should* be an array, but we've seen this return a bool in some chrooted environments
             if (is_array($owner)) {
                 $start_settings['owner'] = $owner['name'];
             }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -116,7 +116,7 @@ class SettingsController extends Controller
         if (function_exists('posix_getpwuid')) { // Probably Linux
             $owner = posix_getpwuid(fileowner($_SERVER['SCRIPT_FILENAME']));
             // This *shouldn't* be boolean, but we've seen this in come chrooted environments
-            if (!is_bool($owner)) {
+            if (is_array($owner)) {
                 $start_settings['owner'] = $owner['name'];
             }
         }


### PR DESCRIPTION
I'm not sure if this is the right fix here and it's damned hard to reproduce, but we're seeing this on the hosted platform occasionally. Granted, a hosted user should never see the setup screen, but it *will* try to redirect back to the setup screen if something went catawampus during a restore from a backup.

I *suspect* the reason we don't see this often is because of our chrooted environment, but I'm honestly not sure. This relates to RB-16992 and SC-20220, `ErrorException: Trying to access array offset on value of type bool`