### PR TITLE
Actually display name of company in Accessories Report

### DIFF
--- a/resources/views/reports/accessories.blade.php
+++ b/resources/views/reports/accessories.blade.php
@@ -35,7 +35,7 @@
 
                             <thead>
                             <tr>
-                                <th class="col-sm-1" data-field="company">{{ trans('admin/companies/table.title') }}</th>
+                                <th class="col-sm-1" data-field="company.name">{{ trans('admin/companies/table.title') }}</th>
                                 <th class="col-sm-1" data-field="name">{{ trans('admin/accessories/table.title') }}</th>
                                 <th class="col-sm-1" data-field="model_number">{{ trans('general.model_no') }}</th>
                                 <th class="col-sm-1" data-field="qty">{{ trans('admin/accessories/general.total') }}</th>


### PR DESCRIPTION
My previous fix to the Accessories report did not correctly parse the Company name, and instead just spat out `[object Object]` for that column, which is very poopy.

This makes it not do that.

I was able to replicate this problem on my local workstation, and then, with this fix, the problem went away.