### PR TITLE
The 'download activity report' displayed the wrong value for 'admin' (fixes FD-33368)

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -284,7 +284,7 @@ class ReportsController extends Controller
 
                     $row = [
                         $actionlog->created_at,
-                        ($actionlog->user) ? e($actionlog->user->getFullNameAttribute()) : '',
+                        ($actionlog->admin) ? e($actionlog->admin->getFullNameAttribute()) : '',
                         $actionlog->present()->actionType(),
                         e($actionlog->itemType()),
                         ($actionlog->itemType() == 'user') ? $actionlog->filename : $item_name,


### PR DESCRIPTION
In the Activity report _view_ we correctly display who the Admin is who performed an action that resulted in 'activity'.

However, in the Activity report 'download all' screen, we do *not*, and instead just re-display the user who the action 'happened to'.

This fixes that. I tested by making the fix and downloading the activity report on my local workstation, and it now correctly display's the Admin's name in that column.