### PR TITLE
Fixed Column not found: 1054 Unknown column '0' in 'field list' [sc-20004]

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -20,6 +20,7 @@ use Auth;
 use Illuminate\Http\Request;
 use App\Http\Requests\ImageUploadRequest;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
 
 class UsersController extends Controller
 {
@@ -452,11 +453,12 @@ class UsersController extends Controller
 
             // Check if the request has groups passed and has a value
             if ($request->filled('groups')) {
-                try{
-                    $user->groups()->sync($request->input('groups'));
-                } catch (\Exception $exception){
-                    return response()->json(Helper::formatStandardApiResponse('error', null, $exception));
-                }
+                $validator = Validator::make($request->input('groups'), [
+                    'groups' => 'array',
+                    'groups.*' => 'integer',
+                ]);
+
+                $user->groups()->sync($request->input('groups'));
             // The groups field has been passed but it is null, so we should blank it out
             } elseif ($request->has('groups')) {
                 $user->groups()->sync([]);

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -459,11 +459,7 @@ class UsersController extends Controller
                 }
             // The groups field has been passed but it is null, so we should blank it out
             } elseif ($request->has('groups')) {
-                try{
-                    $user->groups()->sync([]);
-                } catch (\Exception $exception){
-                    return response()->json(Helper::formatStandardApiResponse('error', null, $exception));
-                }
+                $user->groups()->sync([]);
             }
 
 

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -452,10 +452,18 @@ class UsersController extends Controller
 
             // Check if the request has groups passed and has a value
             if ($request->filled('groups')) {
-                $user->groups()->sync($request->input('groups'));
+                try{
+                    $user->groups()->sync($request->input('groups'));
+                } catch (\Exception $exception){
+                    return response()->json(Helper::formatStandardApiResponse('error', null, $exception));
+                }
             // The groups field has been passed but it is null, so we should blank it out
             } elseif ($request->has('groups')) {
-                $user->groups()->sync([]);
+                try{
+                    $user->groups()->sync([]);
+                } catch (\Exception $exception){
+                    return response()->json(Helper::formatStandardApiResponse('error', null, $exception));
+                }
             }
 
 

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -453,11 +453,14 @@ class UsersController extends Controller
 
             // Check if the request has groups passed and has a value
             if ($request->filled('groups')) {
-                $validator = Validator::make($request->input('groups'), [
-                    'groups' => 'array',
-                    'groups.*' => 'integer',
+                $validator = Validator::make($request->all(), [
+                    'groups' => 'integer|exists:permission_groups,id',
+                    'groups.*' => 'integer|exists:permission_groups,id',
                 ]);
-
+                
+                if ($validator->fails()){
+                    return response()->json(Helper::formatStandardApiResponse('error', null, $user->getErrors()));
+                }
                 $user->groups()->sync($request->input('groups'));
             // The groups field has been passed but it is null, so we should blank it out
             } elseif ($request->has('groups')) {

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -454,7 +454,6 @@ class UsersController extends Controller
             // Check if the request has groups passed and has a value
             if ($request->filled('groups')) {
                 $validator = Validator::make($request->all(), [
-                    'groups' => 'integer|exists:permission_groups,id',
                     'groups.*' => 'integer|exists:permission_groups,id',
                 ]);
                 


### PR DESCRIPTION
# Description
The API call to Users with method PATCH accepts arrays for the `groups` parameter. But if the array is weirdly formed the users making the call got an error 500. I found hard to validate that the array is properly formed, since this is in the API and a client could pass whatever value they want... so I use a Try/Catch block to the method causing this error, that way the system doesn't crash and returns the exception as an API error.

Fixes [sc-20004]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11