### PR TITLE
Fixed #12601 Error checkin license seats

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -61,7 +61,7 @@ class LicenseCheckinController extends Controller
         $license = License::find($licenseSeat->license_id);
 
         // LicenseSeat is not assigned, it can't be checked in
-        if (is_null($licenseSeat->assignedTo) && is_null($licenseSeat->asset_id)) {
+        if (is_null($licenseSeat->assigned_to) && is_null($licenseSeat->asset_id)) {
             return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.checkin.error'));
         }
 


### PR DESCRIPTION
# Description
I was using the `$licenseSeat->assignedTo` property to check if the license is assigned, but I needed to use `$licenseSeat->assigned_to`, I can blame my IDE dumb autocomplete... but I should test this properly. Sorry for the problems caused.

Fixes #12601 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
