### PR TITLE
Fixed #10779: Add Reverse Proxy support to Pre-Flight URL check

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -65,12 +65,22 @@ class SettingsController extends Controller
             $start_settings['db_error'] = $e->getMessage();
         }
 
-        $protocol = array_key_exists('HTTPS', $_SERVER) && ('on' == $_SERVER['HTTPS']) ? 'https://' : 'http://';
+        if (array_key_exists("HTTP_X_FORWARDED_PROTO", $_SERVER)) {
+            $protocol = $_SERVER["HTTP_X_FORWARDED_PROTO"] . "://";
+        } elseif (array_key_exists('HTTPS', $_SERVER) && ('on' == $_SERVER['HTTPS'])) {
+            $protocol = "https://";
+        } else {
+            $protocol = "http://";
+        }
 
-        $host = array_key_exists('SERVER_NAME', $_SERVER) ? $_SERVER['SERVER_NAME'] : null;
-        $port = array_key_exists('SERVER_PORT', $_SERVER) ? $_SERVER['SERVER_PORT'] : null;
-        if (('http://' === $protocol && '80' != $port) || ('https://' === $protocol && '443' != $port)) {
-            $host .= ':'.$port;
+        if (array_key_exists("HTTP_X_FORWARDED_HOST", $_SERVER)) {
+            $host = $_SERVER["HTTP_X_FORWARDED_HOST"];
+        } else {
+            $host = array_key_exists('SERVER_NAME', $_SERVER) ? $_SERVER['SERVER_NAME'] : null;
+            $port = array_key_exists('SERVER_PORT', $_SERVER) ? $_SERVER['SERVER_PORT'] : null;
+            if (('http://' === $protocol && '80' != $port) || ('https://' === $protocol && '443' != $port)) {
+                $host .= ':'.$port;
+            }
         }
         $pageURL = $protocol.$host.$_SERVER['REQUEST_URI'];
 


### PR DESCRIPTION
# Description

Before this change, the Pre-Flight URL check would inevitably fail whenever Snipe-IT was running behind a reverse proxy or load balancer.

The URL check tries to ensure that the configured application URL matches the URL that is actually used to reach the application. However, when running behind an HTTP intermediary (like a reverse proxy or a load balancer) the HTTP connection that Snipe-IT receives is not the _real_ connection from the user anymore, but a connection from the HTTP intermediary. The scheme, host and port that Snipe-IT would obtain from that incoming intermediary connection wouldn't match what is configured as application URL and, therefore, the URL check would fail.

This commit solves the situation by making Snipe-IT's Pre-Flight URL check aware of the `X-Forwarded-Proto` and `X-Forwarded-Host` HTTP headers. These headers represent the _de-facto_ standard used by reverse proxies and other HTTP intermediary components to convey information about the incoming HTTP connection to the upstream application. Being the upstream application, Snipe-IT can then make use of this information to correctly evaluate the validity of the configured application URL.

Fixes #10779

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested it by running Snipe-IT behind Caddy as reverse proxy and configured with a fake `snipeit.local` domain that I just added to my `/etc/hosts`. I visited https://snipeit.local in my browser, which immediately redirects to https://snipeit.local/setup (the Pre-Flight checks), and there I observed the result of the URL check. These are screenshots of the before and after:

> Uh oh! Snipe-IT thinks your URL is https://snipeit.local, but your real URL is http://snipeit.local/setup Please update your APP_URL settings in your .env file

![2023-03-05-193755_1133x64_scrot](https://user-images.githubusercontent.com/1827568/222979366-064b61d0-e58c-4a87-a743-0499d7526cd5.png)

> That URL looks right! Good job!

![2023-03-05-193827_1140x39_scrot](https://user-images.githubusercontent.com/1827568/222979372-548a7f6a-794d-4b81-9853-2ba6347f8078.png)


In terms of how to reproduce it, in https://github.com/manuteleco/snipe-it/commit/5491dbb16c619f9e3ce682b76d3db2798f37e767 you have the Caddy setup I used, including a modified copy of the `docker-compose.yml`. The default `.env.docker` environment didn't work for me out of the box, so I provided my own modifications for the sake of doing this local test, by combining pieces from the `.env.docker` and from the `.env` that I used to set up Snipe-IT in production (behind Caddy as well).

From the environment I used, particularly relevant for testing this might be not to provide (i.e., comment out) `APP_TRUSTED_PROXIES` in the environment. I simply didn't look further into what value should go there otherwise.

**Test Configuration**:
Probably irrelevant for this PR, but here are the versions I used (basically the `Dockerfile` as it was defined in the `develop` branch):
* PHP version: 7.4.3
* MySQL version: MariaDB 10.6.4
* Webserver version: Apache 2.4.41
* OS version: Ubuntu 20.04

All of it running inside:
* Docker: 23.0.1
* docker-compose: 2.16.0
* ArchLinux

# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
  - Relatively small change. Didn't consider it requires comments. Also, the commit message already includes plenty of information (discoverable with `git blame` or `git log -S`/`git log -G`).
- [ ] I have made corresponding changes to the documentation
  - Bugfix. Didn't consider it required documentation changes.
- [ ] My changes generate no new warnings
  - Unclear to me how I would check this (I'm not a PHP developer, BTW, in case this is something obvious to anyone familiar with PHP). Also, if there is automation for this, I wasn't able to make it work (see next point).
- [ ] I have added tests that prove my fix is effective or that my feature works
  - I didn't find any existing tests for the Pre-Flight functionality that I could adapt. Also, I wasn't able to get the tests working. From what I can tell, the CI build is currently broken. I only tested this manually, as described above.
- [ ] New and existing unit tests pass locally with my changes
  - See previous bullet point.
