### PR TITLE
Fixed #11800: Include path in the expected URL during Pre-Flight

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -74,9 +74,8 @@ class SettingsController extends Controller
         }
         $pageURL = $protocol.$host.$_SERVER['REQUEST_URI'];
 
-        $start_settings['url_valid'] = (url('/').'/setup' === $pageURL);
-
-        $start_settings['url_config'] = url('/');
+        $start_settings['url_config'] = url('/').'/setup';
+        $start_settings['url_valid'] = ($start_settings['url_config'] === $pageURL);
         $start_settings['real_url'] = $pageURL;
         $start_settings['php_version_min'] = true;
 


### PR DESCRIPTION
# Description

Include path in the expected URL during Pre-Flight, so that the message displayed to the user when the URL Pre-Flight check fails is:

> Snipe-IT thinks your URL is SCHEME://DOMAIN, but your real
  URL is SCHEME://DOMAIN/setup

instead of:

> Snipe-IT thinks your URL is SCHEME://DOMAIN/setup, but your real
  URL is SCHEME://DOMAIN/setup

Having a missing "/setup" in the expected URL might confuse the user into thinking that it is an additional configuration problem they need to fix.

With this change, the comparison between the expected and actual URL will not contain any accidental difference anymore. Only those that the user really needs to be aware of and fix in their setup.

Fixes #11800. Kind of. It probably fixes what the issue title describes. But the failed URL check was probably caused by the explicit ":443", not by the missing "/setup". This PR hopefully prevents future confusion.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

In exactly the same way as https://github.com/snipe/snipe-it/pull/12611, refer to the description there for all the details.

But basically by forcing the URL check to fail and looking at the displayed error message, before and after:

> Uh oh! Snipe-IT thinks your URL is https://snipeit.local, but your real URL is http://snipeit.local/setup Please update your APP_URL settings in your .env file

![2023-03-05-193755_1133x64_scrot](https://user-images.githubusercontent.com/1827568/222981310-17edf5a9-2674-4aa5-977b-a527cd122f26.png)

> Uh oh! Snipe-IT thinks your URL is https://snipeit.local/setup, but your real URL is http://snipeit.local/setup Please update your APP_URL settings in your .env file

![2023-03-05-202323_1135x68_scrot](https://user-images.githubusercontent.com/1827568/222981314-5aa324f4-afbf-4de3-8834-2ad615b4105e.png)

**Test Configuration**:
Probably irrelevant for this PR, but here are the versions I used (basically the `Dockerfile` as it was defined in the `develop` branch):
* PHP version: 7.4.3
* MySQL version: MariaDB 10.6.4
* Webserver version: Apache 2.4.41
* OS version: Ubuntu 20.04

All of it running inside:
* Docker: 23.0.1
* docker-compose: 2.16.0
* ArchLinux


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
  - Relatively small change. Didn't consider it requires comments. Also, the commit message already includes plenty of information (discoverable with `git blame` or `git log -S`/`git log -G`).
- [ ] I have made corresponding changes to the documentation
  - Bugfix. Didn't consider it required documentation changes.
- [ ] My changes generate no new warnings
  - Unclear to me how I would check this (I'm not a PHP developer, BTW, in case this is something obvious to anyone familiar with PHP). Also, if there is automation for this, I wasn't able to make it work (see next point).
- [ ] I have added tests that prove my fix is effective or that my feature works
  - I didn't find any existing tests for the Pre-Flight functionality that I could adapt. Also, I wasn't able to get the tests working. From what I can tell, the CI build is currently broken. I only tested this manually, as described above.
- [ ] New and existing unit tests pass locally with my changes
  - See previous bullet point.