### PR TITLE
Fixed #12249: fix csv importer for serial_number field

### DIFF
--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -90,7 +90,7 @@ class ItemImporter extends Importer
         $this->item['qty'] = $this->findCsvMatch($row, 'quantity');
         $this->item['requestable'] = $this->findCsvMatch($row, 'requestable');
         $this->item['user_id'] = $this->user_id;
-        $this->item['serial'] = $this->findCsvMatch($row, 'serial number');
+        $this->item['serial'] = $this->findCsvMatch($row, 'serial');
         // NO need to call this method if we're running the user import.
         // TODO: Merge these methods.
         $this->item['checkout_class'] = $this->findCsvMatch($row, 'checkout_class');
@@ -222,11 +222,11 @@ class ItemImporter extends Importer
             $item = $this->sanitizeItemForStoring($asset_model, $editingModel);
             $item['name'] = $asset_model_name;
             $item['notes'] = $this->findCsvMatch($row, 'model_notes');
-            
+
             if(!empty($asset_modelNumber)){
                 $item['model_number'] = $asset_modelNumber;
             }
-            
+
             $asset_model->update($item);
             $asset_model->save();
             $this->log('Asset Model Updated');


### PR DESCRIPTION
# Description

The importer does not work to map the serial_number field because it is searching for a KEY that does not exist.

Fixes #12249

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```csv
Asset Tag,Manufacturer,Category,Model Name,Serial
1,Lenovo,Laptop,ThinkPad X13 Gen 3,ABCDEFG
```

1. Upload a CSV
2. Select "Import type" as "Asset"
3. Select "Serial" as "Serial Number"
4. Click "Import" button

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
