### PR TITLE
Check that the file exists before trying to stat it for filesize

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -126,7 +126,12 @@ class ImportController extends Controller
                 }
                 $file_name = date('Y-m-d-his').'-'.$fixed_filename;
                 $import->file_path = $file_name;
-                $import->filesize = filesize($path.'/'.$file_name);
+                $import->filesize = null;
+
+                if (file_exists($path.'/'.$file_name)) {
+                    $import->filesize = filesize($path.'/'.$file_name);
+                }
+                
                 $import->save();
                 $results[] = $import;
             }

--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -128,9 +128,11 @@ class ImportController extends Controller
                 $import->file_path = $file_name;
                 $import->filesize = null;
 
-                if (file_exists($path.'/'.$file_name)) {
-                    $import->filesize = filesize($path.'/'.$file_name);
+                if (!file_exists($path.'/'.$file_name)) {
+                    return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.file_not_found')), 500);
                 }
+
+                $import->filesize = filesize($path.'/'.$file_name);
                 
                 $import->save();
                 $results[] = $import;

--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -271,7 +271,7 @@ class SettingsController extends Controller
             $headers = ['ContentType' => 'application/zip'];
             return Storage::download($path.'/'.$file, $file, $headers);
         } else {
-            return response()->json(Helper::formatStandardApiResponse('error', null, 'File not found'));
+            return response()->json(Helper::formatStandardApiResponse('error', null,  trans('general.file_not_found')));
         }
 
     }

--- a/resources/lang/de/general.php
+++ b/resources/lang/de/general.php
@@ -395,7 +395,7 @@ return [
     'end_date'            => 'Enddatum',
     'alt_uploaded_image_thumbnail' => 'Hochgeladene Miniaturansicht',
     'placeholder_kit'       => 'Kit auswählen',
-    'file_not_found'        => 'File not found',
+    'file_not_found'        => 'File not found on server',
     'preview_not_available' => '(no preview)',
     'setup'                 => 'Setup',
     'pre_flight'            => 'Pre-Flight',


### PR DESCRIPTION
This just does a check that the file exists before we try to get the file size. Eventually, we'll want to use the `Storage::` facades here (and everywhere else in the importer), but this will at least prevent errors if the import upload failed for some reason. 