### PR TITLE
Suppress SCIMExceptions from cluttering up Rollbar

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -117,6 +117,11 @@ $config = [
                     \Log::info("IGNORING E_WARNING in production mode: ".$args->getMessage());
                     return true; // "TRUE - you should ignore it!"
                 }
+                $needle = "ArieTimmerman\\Laravel\\SCIMServer\\Exceptions\\SCIMException";
+                if (App::environment('production') && is_string($args) && strncmp($args, $needle, strlen($needle) ) === 0 ) {
+                    \Log::info("String: '$args' looks like a SCIM Exception; ignoring error");
+                    return true; //yes, *do* ignore it
+                }
                 return false;
             },
         ],


### PR DESCRIPTION
This requires two changes, rather than one, for some reason that I still don't fully understand. First off, within Rollbar itself it seems like we have to add SCIMExceptions to our custom ignore method.

Next, within our Universal Snipe-IT Exception handler, we need to also mark these exceptions to *not* get reported, and try to return a reasonable error message when an improper SCIM payload is detected.

I decided to go with the generic `400` style of error, because if we're firing off SCIM exceptions, it generally means you sent us something we aren't able to process, so that's your fault, not ours.