### PR TITLE
Fix seeder so assets are checked out to users

### DIFF
--- a/database/factories/ActionlogFactory.php
+++ b/database/factories/ActionlogFactory.php
@@ -55,7 +55,7 @@ class ActionlogFactory extends Factory
                     [
                         'assigned_to' => $target->id,
                         'assigned_type' => \App\Models\User::class,
-                        'assigned_to' => $target->location_id,
+                        'location_id' => $target->location_id,
                     ]
                 );
     
@@ -84,7 +84,7 @@ class ActionlogFactory extends Factory
                     [
                         'assigned_to' => $target->id,
                         'assigned_type' => \App\Models\Location::class,
-                        'assigned_to' => $target->id,
+                        'location_id' => $target->id,
                     ]
                 );
 


### PR DESCRIPTION
# Description

Currently, our seeders do not "check out" assets to users properly (see `ActionlogSeeder`). This PR fixes that by ensuring `assigned_to` is set as expected (it was being overwritten). In addition, I set `location_id` for both assets checked out to users and locations, which I believe was the original intention.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)