### PR TITLE
Maintain asset name during import with checkout

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -137,7 +137,7 @@ class AssetImporter extends ItemImporter
             //-- user_id is a property of the abstract class Importer, which this class inherits from and it's setted by
             //-- the class that needs to use it (command importer or GUI importer inside the project).
             if (isset($target)) {
-                $asset->fresh()->checkOut($target, $this->user_id, date('Y-m-d H:i:s'));
+                $asset->fresh()->checkOut($target, $this->user_id, date('Y-m-d H:i:s'), null, $asset->notes, $asset->name);
             }
 
             return;


### PR DESCRIPTION
# Description

This PR fixes an issue where asset names were not being populated (or being removed) when importing assets that are checked out (have a check out location defined in the import).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)