### PR TITLE
Dynamically determine target route for expected checkin emails

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -547,6 +547,28 @@ class Asset extends Depreciable
         return strtolower(class_basename($this->assigned_type));
     }
 
+
+
+    /**
+     * This is annoying, but because we don't say "assets" in our route names, we have to make an exception here
+     * @todo - normalize the route names - API endpoint URLS can stay the same
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v6.1.0]
+     * @return string
+     */
+    public function targetShowRoute()
+    {
+        $route = str_plural($this->assignedType());
+        if ($route=='assets') {
+            return 'hardware';
+        }
+
+        return $route;
+
+    }
+
+
     /**
      * Get the asset's location based on default RTD location
      *

--- a/resources/views/notifications/markdown/report-expected-checkins.blade.php
+++ b/resources/views/notifications/markdown/report-expected-checkins.blade.php
@@ -10,7 +10,7 @@
 @php
 $checkin = Helper::getFormattedDateObject($asset->expected_checkin, 'date');
 @endphp
-| [{{ $asset->present()->name }}]({{ route('hardware.show', ['hardware' => $asset->id]) }}) | [{{ $asset->assigned->present()->fullName }}]({{ route('users.show', ['user'=>$asset->assigned->id]) }})  | {{ $checkin['formatted'] }}
+| [{{ $asset->present()->name }}]({{ route('hardware.show', ['hardware' => $asset->id]) }}) | [{{ $asset->assigned->present()->fullName }}]({{ route($asset->targetShowRoute().'.show', [$asset->assigned->id]) }})  | {{ $checkin['formatted'] }}
 @endforeach
 @endcomponent
 


### PR DESCRIPTION
This is a janky fix, but it should work until we go through and rename all of the routes to use "assets" instead of hardware. Calling it "hardware" is a legacy leftover from when Laravel forced you to publish CSS/JS/etc assets into the `public/assets` directory.

It's a little too clever for my taste, but should get the job done for now. 