### PR TITLE
Fixed 500 when admin erroneously tries to upload a tiff as logo, cleaned up logo upload layout

### DIFF
--- a/public/js/build/app.js
+++ b/public/js/build/app.js
@@ -2152,10 +2152,13 @@ $(document).ready(function () {
     var id = '#' + $this.attr('id');
     var status = id + '-status';
     var $status = $(status);
+    var delete_id = $(id + '-deleteCheckbox');
+    var preview_container = $(id + '-previewContainer');
     $status.removeClass('text-success').removeClass('text-danger');
     $(status + ' .goodfile').remove();
     $(status + ' .badfile').remove();
     $(status + ' .previewSize').hide();
+    preview_container.hide();
     $(id + '-info').html('');
     var max_size = $this.data('maxsize');
     var total_size = 0;
@@ -2165,9 +2168,6 @@ $(document).ready(function () {
       $(id + '-info').append('<span class="label label-default">' + htmlEntities(this.files[i].name) + ' (' + formatBytes(this.files[i].size) + ')</span> ');
     }
 
-    console.log('Max size is: ' + max_size);
-    console.log('Real size is: ' + total_size);
-
     if (total_size > max_size) {
       $status.addClass('text-danger').removeClass('help-block').prepend('<i class="badfile fas fa-times"></i> ').append('<span class="previewSize"> Upload is ' + formatBytes(total_size) + '.</span>');
     } else {
@@ -2175,6 +2175,8 @@ $(document).ready(function () {
       var $preview = $(id + '-imagePreview');
       readURL(this, $preview);
       $preview.fadeIn();
+      preview_container.fadeIn();
+      delete_id.hide();
     }
   });
 });

--- a/public/js/dist/all.js
+++ b/public/js/dist/all.js
@@ -61281,10 +61281,13 @@ $(document).ready(function () {
     var id = '#' + $this.attr('id');
     var status = id + '-status';
     var $status = $(status);
+    var delete_id = $(id + '-deleteCheckbox');
+    var preview_container = $(id + '-previewContainer');
     $status.removeClass('text-success').removeClass('text-danger');
     $(status + ' .goodfile').remove();
     $(status + ' .badfile').remove();
     $(status + ' .previewSize').hide();
+    preview_container.hide();
     $(id + '-info').html('');
     var max_size = $this.data('maxsize');
     var total_size = 0;
@@ -61294,9 +61297,6 @@ $(document).ready(function () {
       $(id + '-info').append('<span class="label label-default">' + htmlEntities(this.files[i].name) + ' (' + formatBytes(this.files[i].size) + ')</span> ');
     }
 
-    console.log('Max size is: ' + max_size);
-    console.log('Real size is: ' + total_size);
-
     if (total_size > max_size) {
       $status.addClass('text-danger').removeClass('help-block').prepend('<i class="badfile fas fa-times"></i> ').append('<span class="previewSize"> Upload is ' + formatBytes(total_size) + '.</span>');
     } else {
@@ -61304,6 +61304,8 @@ $(document).ready(function () {
       var $preview = $(id + '-imagePreview');
       readURL(this, $preview);
       $preview.fadeIn();
+      preview_container.fadeIn();
+      delete_id.hide();
     }
   });
 });

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/js/build/app.js": "/js/build/app.js?id=790387868822daaa28dcc3722928b7b1",
+    "/js/build/app.js": "/js/build/app.js?id=da037f537476ebca094531163cb611f5",
     "/css/dist/skins/skin-blue.css": "/css/dist/skins/skin-blue.css?id=f677207c6cf9678eb539abecb408c374",
     "/css/build/overrides.css": "/css/build/overrides.css?id=d9175e3d9b9074397343dddebfe23888",
     "/css/build/app.css": "/css/build/app.css?id=dcb8aa9f4501a370214a67442e88daf0",
@@ -34,7 +34,7 @@
     "/css/dist/bootstrap-table.css": "/css/dist/bootstrap-table.css?id=ee4896df8b8f008ce73a9a0c2549aefd",
     "/js/build/vendor.js": "/js/build/vendor.js?id=47ecbb4bb3b0e02315f391caadbdf971",
     "/js/dist/bootstrap-table.js": "/js/dist/bootstrap-table.js?id=14d9a2affec7b066d20fcba2e6e67ad2",
-    "/js/dist/all.js": "/js/dist/all.js?id=93f3ed97355821b50ee5bbd4f658dd05",
+    "/js/dist/all.js": "/js/dist/all.js?id=758f256419ccaf4b4266da3bbc742b0b",
     "/css/dist/skins/skin-green.min.css": "/css/dist/skins/skin-green.min.css?id=0a82a6ae6bb4e58fe62d162c4fb50397",
     "/css/dist/skins/skin-green-dark.min.css": "/css/dist/skins/skin-green-dark.min.css?id=c0d21166315b7c2cdd4819fa4a5e4d1e",
     "/css/dist/skins/skin-black.min.css": "/css/dist/skins/skin-black.min.css?id=76482123f6c70e866d6b971ba91de7bb",

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -540,10 +540,16 @@ $(document).ready(function () {
         var id = '#' + $this.attr('id');
         var status = id + '-status';
         var $status = $(status);
+        var delete_id = $(id + '-deleteCheckbox');
+        var preview_container = $(id + '-previewContainer');
+
+
+
         $status.removeClass('text-success').removeClass('text-danger');
         $(status + ' .goodfile').remove();
         $(status + ' .badfile').remove();
         $(status + ' .previewSize').hide();
+        preview_container.hide();
         $(id + '-info').html('');
 
         var max_size = $this.data('maxsize');
@@ -554,17 +560,15 @@ $(document).ready(function () {
             $(id + '-info').append('<span class="label label-default">' + htmlEntities(this.files[i].name) + ' (' + formatBytes(this.files[i].size) + ')</span> ');
         }
 
-        console.log('Max size is: ' + max_size);
-        console.log('Real size is: ' + total_size);
-
         if (total_size > max_size) {
             $status.addClass('text-danger').removeClass('help-block').prepend('<i class="badfile fas fa-times"></i> ').append('<span class="previewSize"> Upload is ' + formatBytes(total_size) + '.</span>');
         } else {
-
             $status.addClass('text-success').removeClass('help-block').prepend('<i class="goodfile fas fa-check"></i> ');
             var $preview =  $(id + '-imagePreview');
             readURL(this, $preview);
             $preview.fadeIn();
+            preview_container.fadeIn();
+            delete_id.hide();
         }
 
 

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -148,6 +148,7 @@ return [
     'filetypes_accepted_help'    => 'Accepted filetype is :types. Max upload size allowed is :size.|Accepted filetypes are :types. Max upload size allowed is :size.',
     'filetypes_size_help'   => 'Max upload size allowed is :size.',
     'image_filetypes_help'  => 'Accepted filetypes are jpg, webp, png, gif, and svg. Max upload size allowed is :size.',
+    'unaccepted_image_type'  => 'This image file was not readable. Accepted filetypes are jpg, webp, png, gif, and svg. The mimetype of this file is :mimetype.',
     'import'         	    => 'Import',
     'importing'         	=> 'Importing',
     'importing_help'        => 'You can import assets, accessories, licenses, components, consumables, and users via CSV file. <br><br>The CSV should be comma-delimited and formatted with headers that match the ones in the <a href="https://snipe-it.readme.io/docs/importing" target="_new">sample CSVs in the documentation</a>.',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -148,7 +148,7 @@ return [
     'filetypes_accepted_help'    => 'Accepted filetype is :types. Max upload size allowed is :size.|Accepted filetypes are :types. Max upload size allowed is :size.',
     'filetypes_size_help'   => 'Max upload size allowed is :size.',
     'image_filetypes_help'  => 'Accepted filetypes are jpg, webp, png, gif, and svg. Max upload size allowed is :size.',
-    'unaccepted_image_type'  => 'This image file was not readable. Accepted filetypes are jpg, webp, png, gif, and svg. The mimetype of this file is :mimetype.',
+    'unaccepted_image_type'  => 'This image file was not readable. Accepted filetypes are jpg, webp, png, gif, and svg. The mimetype of this file is: :mimetype.',
     'import'         	    => 'Import',
     'importing'         	=> 'Importing',
     'importing_help'        => 'You can import assets, accessories, licenses, components, consumables, and users via CSV file. <br><br>The CSV should be comma-delimited and formatted with headers that match the ones in the <a href="https://snipe-it.readme.io/docs/importing" target="_new">sample CSVs in the documentation</a>.',

--- a/resources/views/partials/forms/edit/uploadLogo.blade.php
+++ b/resources/views/partials/forms/edit/uploadLogo.blade.php
@@ -1,57 +1,57 @@
-<div class="form-group {{ $errors->has($logoVariable) ? 'has-error' : '' }}">
+<div class="form-group">
     <div class="col-md-3">
-        <strong>{{ $logoLabel }}</strong>
+        <label{!!  $errors->has($logoVariable) ? ' class="alert-msg"' : '' !!} for="{{ $logoVariable }}">{{ ucwords(str_replace('_', ' ', $logoVariable)) }}</label>
     </div>
-
-        @if (($setting->$logoVariable!='') && (Storage::disk('public')->exists(e($snipeSettings->$logoVariable))))
-        <div class="col-md-9">
-
-            <label for="{{ $logoClearVariable }}" style="font-weight: normal">
-                {{ Form::checkbox($logoClearVariable, '1', Request::old($logoClearVariable),array('class' => 'minimal')) }}
-                Remove current {{ str_replace('_', ' ', $logoVariable) }} image
-
-            </label>
-
-
-                <br>
-                @if ($logoVariable!='favicon')
-                    <a href="{{ Storage::disk('public')->url(e($snipeSettings->$logoVariable)) }}" data-toggle="lightbox">
-                        <img style="max-height: 60px; padding-top: 10px; padding-bottom: 10px; " alt="" src="{{ Storage::disk('public')->url(e($snipeSettings->$logoVariable)) }}">
-                    </a>
-                @else
-                    <img style="max-height: 50px; padding-top: 10px; padding-bottom: 10px; " alt="" src="{{ Storage::disk('public')->url(e($snipeSettings->$logoVariable)) }}">
-                @endif
-
-        </div>
-        <div class="col-md-9 col-md-offset-3">
-            @else
-                <div class="col-md-9">
-        @endif
-
-
-
-
+    <div class="col-md-9">
         <label class="btn btn-default">
             {{ trans('button.select_file')  }}
             <input type="file" name="{{ $logoVariable }}" class="js-uploadFile" id="{{ $logoId }}"
-                data-maxsize="{{ $maxSize ?? Helper::file_upload_max_size() }}"
-                accept="{{ $allowedTypes ?? 'image/gif,image/jpeg,image/png,image/svg,image/svg+xml'}}" style="display:none; max-width: 90%">
+                   data-maxsize="{{ $maxSize ?? Helper::file_upload_max_size() }}"
+                   style="display:none; max-width: 90%">
         </label>
+
         <span class='label label-default' id="{{ $logoId }}-info"></span>
 
-        <p class="help-block" id="{{ $logoId }}-status">
+        {!! $errors->first($logoVariable, '<span class="alert-msg">:message</span>') !!}
+
+
+        <p class="help-block" style="!important" id="{{ $logoId }}-status">
             {{ $helpBlock }}
         </p>
 
         @if (config('app.lock_passwords')===true)
             <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
         @endif
-        {!! $errors->first($logoVariable, '<span class="alert-msg">:message</span>') !!}
+    </div>
+
+    <div class="col-md-9 col-md-offset-3">
+        <div class="col-md-6 no-padding">
+
+            @if (($setting->$logoVariable!='') && (Storage::disk('public')->exists(e($snipeSettings->$logoVariable))))
+
+            <a href="{{ Storage::disk('public')->url(e($snipeSettings->$logoVariable)) }}" {{ ($logoVariable!='favicon') ? ' data-toggle="lightbox"' : '' }}>
+                <img id="{{ $logoId }}-imagePreview" style="max-height: 80px;" alt="" src="{{ Storage::disk('public')->url(e($snipeSettings->$logoVariable)) }}">
+            </a>
+
+            <label for="{{ $logoClearVariable }}" style="font-weight: normal">
+                {{ Form::checkbox($logoClearVariable, '1', Request::old($logoClearVariable),array('class' => 'minimal')) }}
+                Remove current {{ ucwords(str_replace('_', ' ', $logoVariable)) }} image
+            </label>
+           @else
+                <img id="{{ $logoId }}-imagePreview" style="max-height: 80px;" alt="" src="{{ Storage::disk('public')->url(e($snipeSettings->$logoVariable)) }}">
+           @endif
+
+        </div>
 
     </div>
-    <div class="col-md-9 col-md-offset-3">
-        <img id="{{ $logoId }}-imagePreview" style="max-width: 500px; max-height: 50px;">
-    </div>
+
 
 
 </div>
+
+
+
+
+
+
+

--- a/resources/views/partials/forms/edit/uploadLogo.blade.php
+++ b/resources/views/partials/forms/edit/uploadLogo.blade.php
@@ -1,12 +1,15 @@
+<!-- {{ $logoVariable }}logo image upload -->
+
 <div class="form-group">
     <div class="col-md-3">
-        <label{!!  $errors->has($logoVariable) ? ' class="alert-msg"' : '' !!} for="{{ $logoVariable }}">{{ ucwords(str_replace('_', ' ', $logoVariable)) }}</label>
+        <label {!! $errors->has($logoVariable) ? 'class="alert-msg"' : '' !!} for="{{ $logoVariable }}">
+        {{ ucwords(str_replace('_', ' ', $logoVariable)) }}
+        </label>
     </div>
     <div class="col-md-9">
         <label class="btn btn-default">
             {{ trans('button.select_file')  }}
-            <input type="file" name="{{ $logoVariable }}" class="js-uploadFile" id="{{ $logoId }}"
-                   data-maxsize="{{ $maxSize ?? Helper::file_upload_max_size() }}"
+            <input type="file" name="{{ $logoVariable }}" class="js-uploadFile" id="{{ $logoId }}" accept="image/gif,image/jpeg,image/webp,image/png,image/svg,image/svg+xml" data-maxsize="{{ $maxSize ?? Helper::file_upload_max_size() }}"
                    style="display:none; max-width: 90%">
         </label>
 
@@ -25,25 +28,31 @@
     </div>
 
     <div class="col-md-9 col-md-offset-3">
-        <div class="col-md-6 no-padding">
 
             @if (($setting->$logoVariable!='') && (Storage::disk('public')->exists(e($snipeSettings->$logoVariable))))
+            <div class="pull-left" style="padding-right: 20px;">
+                <a href="{{ Storage::disk('public')->url(e($snipeSettings->$logoVariable)) }}"{!! ($logoVariable!='favicon') ? ' data-toggle="lightbox"' : '' !!}>
+                    <img id="{{ $logoId }}-imagePreview" style="height: 80px; padding-bottom: 5px;" alt="" src="{{ Storage::disk('public')->url(e($snipeSettings->$logoVariable)) }}">
+                </a>
+            </div>
+            @endif
 
-            <a href="{{ Storage::disk('public')->url(e($snipeSettings->$logoVariable)) }}" {{ ($logoVariable!='favicon') ? ' data-toggle="lightbox"' : '' }}>
-                <img id="{{ $logoId }}-imagePreview" style="max-height: 80px;" alt="" src="{{ Storage::disk('public')->url(e($snipeSettings->$logoVariable)) }}">
-            </a>
+            <div id="{{ $logoId }}-previewContainer" style="display: none;">
+                <img id="{{ $logoId }}-imagePreview" style="height: 80px;">
+            </div>
 
-            <label for="{{ $logoClearVariable }}" style="font-weight: normal">
-                {{ Form::checkbox($logoClearVariable, '1', Request::old($logoClearVariable),array('class' => 'minimal')) }}
-                Remove current {{ ucwords(str_replace('_', ' ', $logoVariable)) }} image
-            </label>
-           @else
-                <img id="{{ $logoId }}-imagePreview" style="max-height: 80px;" alt="" src="{{ Storage::disk('public')->url(e($snipeSettings->$logoVariable)) }}">
-           @endif
 
-        </div>
 
     </div>
+    @if (($setting->$logoVariable!='') && (Storage::disk('public')->exists(e($snipeSettings->$logoVariable))))
+
+    <div class="col-md-9 col-md-offset-3">
+        <label id="{{ $logoId }}-deleteCheckbox" for="{{ $logoClearVariable }}" style="font-weight: normal">
+            {{ Form::checkbox($logoClearVariable, '1', Request::old($logoClearVariable),array('class' => 'minimal')) }}
+            Remove current {{ ucwords(str_replace('_', ' ', $logoVariable)) }} image
+        </label>
+    </div>
+    @endif
 
 
 


### PR DESCRIPTION
Okay, I admit I ended up down a rabbit hole here. I had intended just to fix SC-20332, which was tied to a Rollbar where an admin somehow was managing to try to upload a .tiff file. Those changes are in the initial commit, in the `app/Http/Requests/ImageUploadRequest.php`:

https://user-images.githubusercontent.com/197404/223609064-28777c7d-68f1-4f20-92c4-f62e30a6e57f.mov

### Where it Started

What's interesting is that the file picker shouldn't have allowed that tiff to be selected, since we use `accept="image/gif,image/jpeg,image/webp,image/png,image/svg,image/svg+xml"` in the HTML. It's certainly possible someone is using a funky-ass browser or with an image with a weird mime-type that "passes" as a non-tuff image, or they twiddled the HTML to remove that constraint because they *really really* wanted to upload a tiff, but either way, rather than 500ing, it now at least gives a good error response. (We don't allow tiffs just because not every browser supports them, we can't resize them using Intervention, and they're usually gigantic.)

We now handle that "unreadable" exception and pass that back to the user (in branding or anywhere else that image uploads are handled) in the form context.


### How it's Going

But then as I had to test 1000x, the layout started to bug me too, since the errors were highlighting the entire block of the each logo section they were triggered in, which looked awful.

So I ended up rewriting the `resources/views/partials/forms/edit/uploadLogo.blade.php` file to make the layout a little more compact and intuitive. I know I should have made that it's own PR, but I was on a roll. Sorry :( 

https://user-images.githubusercontent.com/197404/223608658-5a449f6f-c8fa-4ea9-94f0-43d2c3a4f771.mov

TYSM for the 🐥🐥 with the jquery brainfarts, @uberbrady!



