### PR TITLE
Fixed #12607 - Datestamp on "Print All Assigned" generated form

### DIFF
--- a/resources/lang/en/admin/users/general.php
+++ b/resources/lang/en/admin/users/general.php
@@ -50,4 +50,5 @@ return [
     'email_credentials' => 'Email credentials',
     'email_credentials_text' => 'Email my credentials to the email address above',
     'next_save_user' => 'Next: Save User',
+    'all_assigned_list_generation' => 'Generated on:'
 ];

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -49,8 +49,7 @@
     @endif
 @endif
 
-<h3>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} {{ ($show_user->jobtitle!='' ? ' - '.$show_user->jobtitle : '') }}<div style='text-align:right'><div style='color:red'>{{ trans('admin/users/general.all_assigned_list_generation')}} {{ date('d-M-Y H:i', time()) }}
-</div></div>
+<h3>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} {{ ($show_user->jobtitle!='' ? ' - '.$show_user->jobtitle : '') }}
 </h3>
     @if ($assets->count() > 0)
         @php
@@ -242,7 +241,15 @@
         </table>
     @endif
 
+    @php
+    $currenttime = Helper::getFormattedDateObject(now(), 'date', false);
+    @endphp
+
     <br>
+    <br>
+    //needs to fix string/int error
+    <div style='text-align:left'><div style='color:black'>{{ trans('admin/users/general.all_assigned_list_generation')}} {{ date('d-M-Y H:i', $currenttime) }}
+</div></div>
     <br>
     <br>
     <table>

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -241,15 +241,9 @@
         </table>
     @endif
 
-    @php
-    $currenttime = Helper::getFormattedDateObject(now(), 'date', false);
-    @endphp
-
     <br>
     <br>
-    //needs to fix string/int error
-    <div style='text-align:left'><div style='color:black'>{{ trans('admin/users/general.all_assigned_list_generation')}} {{ date('d-M-Y H:i', $currenttime) }}
-</div></div>
+    {{ trans('admin/users/general.all_assigned_list_generation')}} {{ Helper::getFormattedDateObject(now(), 'datetime', false) }}
     <br>
     <br>
     <table>

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -2,7 +2,7 @@
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <title>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} - {{ date('Y-m-d', time()) }}</title>
+    <title>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} - {{ date('Y-m-d H:i', time()) }}</title>
     <style>
         body {
             font-family: "Arial, Helvetica", sans-serif;
@@ -49,7 +49,7 @@
     @endif
 @endif
 
-<h3>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} {{ ($show_user->jobtitle!='' ? ' - '.$show_user->jobtitle : '') }}<div style='text-align:right'><div style='color:red'>{{ trans('admin/users/general.all_assigned_list_generation')}} {{ date('d-M-Y', time()) }}
+<h3>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} {{ ($show_user->jobtitle!='' ? ' - '.$show_user->jobtitle : '') }}<div style='text-align:right'><div style='color:red'>{{ trans('admin/users/general.all_assigned_list_generation')}} {{ date('d-M-Y H:i', time()) }}
 </div></div>
 </h3>
     @if ($assets->count() > 0)

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -49,8 +49,9 @@
     @endif
 @endif
 
-<h3>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} {{ ($show_user->jobtitle!='' ? ' - '.$show_user->jobtitle : '') }}</h3>
-
+<h3>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} {{ ($show_user->jobtitle!='' ? ' - '.$show_user->jobtitle : '') }}<div style='text-align:right'><div style='color:red'>{{ trans('admin/users/general.all_assigned_list_generation')}} {{ date('d-M-Y', time()) }}
+</div></div>
+</h3>
     @if ($assets->count() > 0)
         @php
             $counter = 1;

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -2,7 +2,7 @@
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <title>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }}</title>
+    <title>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} - {{ date('Y-m-d', time()) }}</title>
     <style>
         body {
             font-family: "Arial, Helvetica", sans-serif;


### PR DESCRIPTION
# Description
Added a datestamp onto the form generated when a user selects "Print All Assigned" from the user detail view window.  It is calling the users local time, so will stay relevant to where the user is when they generate the form.
Date formatting is chosen to improve usability around the world as different date formats are common.

<img width="302" alt="Screen Shot 2023-03-08 at 2 57 57 PM" src="https://user-images.githubusercontent.com/116301219/223834026-2a8dd891-afbb-4bf8-bae6-7d6d38da4ceb.png">


## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested locally.


**Test Configuration**:
* PHP version: 8.0

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Fixes #12607 