### PR TITLE
Fixed #12635 - dashboard category should not show archived

### DIFF
--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -51,7 +51,7 @@ class CategoriesController extends Controller
             'require_acceptance',
             'checkin_email',
             'image'
-            ])->withCount('showableAssets as assets_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'licenses as licenses_count');
+            ])->withCount('accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'licenses as licenses_count');
 
 
         /*

--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -24,10 +24,50 @@ class CategoriesController extends Controller
     public function index(Request $request)
     {
         $this->authorize('view', Category::class);
-        $allowed_columns = ['id', 'name', 'category_type', 'category_type', 'use_default_eula', 'eula_text', 'require_acceptance', 'checkin_email', 'assets_count', 'accessories_count', 'consumables_count', 'components_count', 'licenses_count', 'image'];
+        $allowed_columns = [
+            'id',
+            'name',
+            'category_type',
+            'category_type',
+            'use_default_eula',
+            'eula_text',
+            'require_acceptance',
+            'checkin_email',
+            'assets_count',
+            'accessories_count',
+            'consumables_count',
+            'components_count',
+            'licenses_count',
+            'image',
+        ];
 
-        $categories = Category::select(['id', 'created_at', 'updated_at', 'name', 'category_type', 'use_default_eula', 'eula_text', 'require_acceptance', 'checkin_email', 'image'])
-            ->withCount('assets as assets_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'licenses as licenses_count');
+        $categories = Category::select([
+            'id',
+            'created_at',
+            'updated_at',
+            'name', 'category_type',
+            'use_default_eula',
+            'eula_text',
+            'require_acceptance',
+            'checkin_email',
+            'image'
+            ])->withCount('showableAssets as assets_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'licenses as licenses_count');
+
+
+        /*
+         * This checks to see if we should override the Admin Setting to show archived assets in list.
+         * We don't currently use it within the Snipe-IT GUI, but will be useful for API integrations where they
+         * may actually need to fetch assets that are archived.
+         *
+         * @see \App\Models\Category::showableAssets()
+         */
+        if ($request->input('archived')=='true') {
+            $categories = $categories->withCount('assets as assets_count');
+        } else {
+            $categories = $categories->withCount('showableAssets as assets_count');
+        }
+
+
 
         if ($request->filled('search')) {
             $categories = $categories->TextSearch($request->input('search'));

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -194,7 +194,25 @@ class Category extends SnipeModel
      */
     public function assets()
     {
-        return $this->hasManyThrough(\App\Models\Asset::class, \App\Models\AssetModel::class, 'category_id', 'model_id');
+        return $this->hasManyThrough(Asset::class, \App\Models\AssetModel::class, 'category_id', 'model_id');
+    }
+
+    /**
+     * Establishes the category -> assets relationship but also takes into consideration
+     * the setting to show archived in lists.
+     *
+     * We could have complicated the assets() method above, but keeping this separate
+     * should give us more flexibility if we need to return actually archived assets
+     * by their category.
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v6.1.0]
+     * @see \App\Models\Asset::scopeAssetsForShow()
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function showableAssets()
+    {
+        return $this->hasManyThrough(Asset::class, \App\Models\AssetModel::class, 'category_id', 'model_id')->AssetsForShow();
     }
 
     /**

--- a/resources/views/categories/view.blade.php
+++ b/resources/views/categories/view.blade.php
@@ -39,7 +39,7 @@
                     <li class="active">
                         <a href="#items" data-toggle="tab" title="{{ trans('general.items') }}"> {{ ucwords($category_type_route) }}
                             @if ($category->category_type=='asset')
-                            <badge class="badge badge-secondary"> {{ $category->assets()->AssetsForShow()->count() }}</badge>
+                            <badge class="badge badge-secondary"> {{ $category->showableAssets()->count() }}</badge>
                             @endif
                         </a>
                     </li>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -274,7 +274,7 @@
 </div> <!--/row-->
 <div class="row">
     <div class="col-md-6">
-         <!-- Categories -->
+         <!-- Locations -->
          <div class="box box-default">
             <div class="box-header with-border">
                 <h2 class="box-title">{{ trans('general.asset') }} {{ trans('general.locations') }}</h2>


### PR DESCRIPTION
This fixed #12635, where the number of assets by category was not reflecting the `Admin Settings > General > Show Archived in Lists` setting. 