### PR TITLE
Fixed #12647: fix translation and adds icon on property reassignable

### DIFF
--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -358,7 +358,7 @@
                       </strong>
                     </div>
                     <div class="col-md-9">
-                      {{ $license->reassignable ? 'Yes' : 'No' }}
+                      {!! $license->reassignable ? '<i class="fas fa-check text-success" aria-hidden="true"></i> '.trans('general.yes') : '<i class="fas fa-times text-danger" aria-hidden="true"></i> '.trans('general.no') !!}
                     </div>
                   </div>
 


### PR DESCRIPTION
# Description

Fixes #12647
On the individual license pages, the property Reassignable is not translated and the icon (red cross or green checkmark) is missing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Not tested.


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
