### PR TITLE
Handle mismatch in action_logs and asset assigned_type

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -474,7 +474,7 @@ class Asset extends Depreciable
      */
     public function assignedTo()
     {
-        return $this->morphTo('assigned', 'assigned_type', 'assigned_to')->withTrashed();
+        return $this->morphTo('assigned', 'assigned_type', 'assigned_to')->whereNotNull('assigned_type')->withTrashed();
     }
 
     /**


### PR DESCRIPTION
This should fix an issue where the `assets` table still has an `assigned_to` value but does not have an `assigned_type` value. I'm not sure *why* we'd ever see this, but I've seen it in the wild.

This would cause an error like:

```
[Column not found: 1054 Unknown column 'assets.' in 'where clause' (SQL: select * from assets where assets.`` = 299 limit 1) (View: /resources/views/hardware/view.blade.php)](
```

since it's trying to do the `morphTo()` but has no type to map to. I still need to figure out HOW that data would occur in the first place. Either way, we shouldn't be allowing it to save that way.

Fixes RB-16793