### PR TITLE
Removed loading and reduced chunking to 10

### DIFF
--- a/database/migrations/2023_01_21_225350_add_eol_date_on_assets_table.php
+++ b/database/migrations/2023_01_21_225350_add_eol_date_on_assets_table.php
@@ -23,7 +23,7 @@ class AddEolDateOnAssetsTable extends Migration
         });
 
         // Chunk the model query to get the models that do have an EOL date
-        AssetModel::whereNotNull('eol')->with('assets')->chunk(200, function ($models) {
+        AssetModel::whereNotNull('eol')->chunk(10, function ($models) {
             foreach ($models as $model) {
                 foreach ($model->assets as $asset) {
 


### PR DESCRIPTION
If I'm honest, I don't really know why this is necessary, but it did come up during a customer upgrade. We had an issue where a customer had ~15k assets with ~1.9k asset models, and it was exhausting memory for some inexplicable reason. Even without an index on `model_id`, those numbers aren't really enough to make MySQL fart out. But with these changes, I was able to get their migration to run successfully. The smaller chunking does make it run a little slower, but at least we don't cap out memory. :-/