### PR TITLE
Small visual tweaks to slack/webhook UI

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -406,6 +406,7 @@ return [
     'tasks_view_all'        => 'View all tasks',
     'true'                  => 'True',
     'false'                 => 'False',
+    'integration_option'    => 'Integration Option',
 
 
 

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -1,25 +1,27 @@
+{{-- Page title --}}
+@section('title')
+{{ trans('admin/settings/general.webhook_title') }}
+@parent
+@stop
 
-    {{-- Page title --}}
-    @section('title')
-        {{ trans('admin/settings/general.webhook_title') }}
-        @parent
-    @stop
-
-    @section('header_right')
-        <a href="{{ route('settings.index') }}" class="btn btn-primary"> {{ trans('general.back') }}</a>
-    @stop
+@section('header_right')
+<a href="{{ route('settings.index') }}" class="btn btn-primary"> {{ trans('general.back') }}</a>
+@stop
 
 
-    {{-- Page content --}}
-    @section('content')
+{{-- Page content --}}
+@section('content')
 
 <div>
+    <form class="form-horizontal" role="form" wire:submit.prevent="submit">
+        {{csrf_field()}}
+
         <div class="row">
             <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
     <div class="panel box box-default">
         <div class="box-header with-border">
             <h2 class="box-title">
-                <i class="{{$webhook_icon}}"></i> {{ trans('admin/settings/general.webhook', ['app'=>$webhook_name] ) }}
+                <i class="{{$webhook_icon}}"></i> {{ trans('admin/settings/general.webhook', ['app' => $webhook_name] ) }}
             </h2>
         </div>
         <div class="box-body">
@@ -32,7 +34,7 @@
                 <br>
             </div>
 
-                    <div class="col-md-12" style="border-top: 0px;">
+                    <div class="col-md-12">
                         @if (session()->has('save'))
                             <div class="alert alert-success fade in">
                                 {{session('save')}}
@@ -55,84 +57,77 @@
                             </div>
                         @endif
 
-                        <div class="form-group" style="margin-left:-14px;">
-                            <div class="col-md-2">
-                                <label>Integration Option</label>
+
+                        <div class="form-group col-md-12 required">
+                            <div class="col-md-3">
+                                <label for="webhook_selected">
+                                    {{ trans('general.integration_option') }}
+                                </label>
                             </div>
-                            <div class="col-md-8"style="margin-left: 2px;">
-                                <select wire:model="webhook_selected"
-                                        aria-label="webhook_selected"
-                                        class="form-control "
-                                >
-                                    <option value="slack">{{trans('admin/settings/general.slack')}}</option>
-{{--                                    <option value="Discord">Discord</option>--}}
-                                    <option value="general">{{trans('admin/settings/general.general_webhook')}}</option>
+
+                            <div class="col-md-9">
+                                <select wire:model="webhook_selected" aria-label="webhook_selected" class="form-control">
+                                    <option value="slack">{{ trans('admin/settings/general.slack') }}</option>
+                                    <option value="general">{{ trans('admin/settings/general.general_webhook') }}</option>
                                 </select>
                             </div>
-                            <br><br><br>
 
                         </div>
-                        <form class="form-horizontal" role="form" wire:submit.prevent="submit">
-                            {{csrf_field()}}
 
-                            <!--Webhook endpoint-->
-                            <div class="form-group{{ $errors->has('webhook_endpoint') ? ' error' : '' }}">
-                                <div class="col-md-2">
-                                    {{ Form::label('webhook_endpoint', trans('admin/settings/general.webhook_endpoint',['app' => $webhook_selected ])) }}
-                                </div>
-                                <div class="col-md-8 required">
-                                    @if (config('app.lock_passwords')===true)
-                                        <p class="text-warning"><i
-                                                    class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-                                        <input type="text" wire:model="webhook_endpoint" class='form-control'
-                                               placeholder="{{$webhook_placeholder}}"
-                                                value="{{old('webhook_endpoint', $webhook_endpoint)}}">
-                                    @else
-                                        <input type="text" wire:model="webhook_endpoint" class='form-control'
-                                               placeholder="{{$webhook_placeholder}}"
-                                                value="{{old('webhook_endpoint', $webhook_endpoint)}}">
-                                    @endif
-                                    {!! $errors->first('webhook_endpoint', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                </div>
+                        <!--Webhook endpoint-->
+                        <div class="form-group col-md-12 required{{ $errors->has('webhook_endpoint') ? ' error' : '' }}">
+
+                            <div class="col-md-3">
+                                {{ Form::label('webhook_endpoint', trans('admin/settings/general.webhook_endpoint',['app' => ucwords($webhook_selected) ])) }}
                             </div>
 
-                            <!-- Webhook channel -->
-                            <div class="form-group{{ $errors->has('webhook_channel') ? ' error' : '' }}">
-                                <div class="col-md-2">
-                                    {{ Form::label('webhook_channel', trans('admin/settings/general.webhook_channel',['app' => $webhook_selected ])) }}
-                                </div>
-                                <div class="col-md-8 required">
-                                    @if (config('app.lock_passwords')===true)
-                                        <input type="text" wire:model="webhook_channel" class='form-control'
-                                               placeholder="#IT-Ops"
-                                               value="{{old('webhook_channel', $webhook_channel)}}">
-                                        <p class="text-warning"><i
-                                                    class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-
-                                    @else
-                                        <input type="text" wire:model="webhook_channel" class='form-control'
-                                               placeholder="#IT-Ops"
-                                               value="{{old('webhook_channel', $webhook_channel)}}">
-                                    @endif
-                                    {!! $errors->first('webhook_channel', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                </div>
+                            <div class="col-md-9">
+                                @if (config('app.lock_passwords')===true)
+                                    <p class="text-warning">
+                                        <i class="fas fa-lock" aria-hidden="true"></i>
+                                        {{ trans('general.feature_disabled') }}
+                                    </p>
+                                    <input type="text" wire:model="webhook_endpoint" class="form-control" placeholder="{{ $webhook_placeholder }}" value="{{ old('webhook_endpoint', $webhook_endpoint) }}">
+                                @else
+                                    <input type="text" wire:model="webhook_endpoint" class="form-control" placeholder="{{ $webhook_placeholder }}" value="{{ old('webhook_endpoint', $webhook_endpoint) }}">
+                                @endif
+                                {!! $errors->first('webhook_endpoint', '<span class="alert-msg">:message</span>') !!}
                             </div>
+                        </div>
+
+                        <!-- Webhook channel -->
+                        <div class="col-md-12 form-group required{{ $errors->has('webhook_channel') ? ' error' : '' }}">
+                            <div class="col-md-3">
+                                {{ Form::label('webhook_channel', trans('admin/settings/general.webhook_channel',['app' => ucwords($webhook_selected) ])) }}
+                            </div>
+                            <div class="col-md-9">
+
+                                @if (config('app.lock_passwords')===true)
+                                    <input type="text" wire:model="webhook_channel" class="form-control" placeholder="#IT-Ops" value="{{ old('webhook_channel', $webhook_channel) }}">
+                                    <p class="text-warning">
+                                        <i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
+                                @else
+                                    <input type="text" wire:model="webhook_channel" class="form-control" placeholder="#IT-Ops" value="{{ old('webhook_channel', $webhook_channel) }}">
+                                @endif
+                                {!! $errors->first('webhook_channel', '<span class="alert-msg">:message</span>') !!}
+                            </div>
+
+                        </div>
 
                             <!-- Webhook botname -->
-                            <div class="form-group{{ $errors->has('webhook_botname') ? ' error' : '' }}">
-                                <div class="col-md-2">
-                                    {{ Form::label('webhook_botname', trans('admin/settings/general.webhook_botname',['app' => $webhook_selected ])) }}
+                            <div class="col-md-12 form-group required{{ $errors->has('webhook_botname') ? ' error' : '' }}">
+                                <div class="col-md-3">
+                                    {{ Form::label('webhook_botname', trans('admin/settings/general.webhook_botname',['app' => ucwords($webhook_selected) ])) }}
                                 </div>
-                                <div class="col-md-8">
+                                <div class="col-md-9">
                                     @if (config('app.lock_passwords')===true)
                                         <input type="text" wire:model="webhook_botname" class='form-control'
                                                placeholder="Snipe-Bot" {{old('webhook_botname', $webhook_botname)}}>
-                                        <p class="text-warning"><i
-                                                    class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-
+                                        <p class="text-warning"><i class="fas fa-lock"></i>
+                                            {{ trans('general.feature_disabled') }}
+                                        </p>
                                     @else
-                                        <input type="text" wire:model="webhook_botname" class='form-control'
-                                               placeholder="Snipe-Bot" {{old('webhook_botname', $webhook_botname)}}>
+                                        <input type="text" wire:model="webhook_botname" class="form-control" placeholder="Snipe-Bot" {{old('webhook_botname', $webhook_botname)}}>
                                     @endif
                                     {!! $errors->first('webhook_botname', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 </div><!--col-md-10-->
@@ -141,12 +136,20 @@
                             <!--Webhook Integration Test-->
                             @if($webhook_selected == 'Slack' || $webhook_selected == 'Discord')
                                 @if($webhook_endpoint != null && $webhook_channel != null)
-                                    <div class="form-group">
-                                        <div class="col-md-offset-2 col-md-8">
+                                    <div class="form-group col-md-12">
+                                        <div class="col-md-offset-3 col-md-9">
+
                                             <a href="#" wire:click.prevent="testWebhook"
-                                               class="btn btn-default btn-sm pull-left"><span><i class="{{$webhook_icon}}"></i>  {!! trans('admin/settings/general.webhook_test',['app' => $webhook_selected ]) !!}</span></a>
-                                            <div wire:loading><span style="padding-left: 5px; font-size: 20px"><i
-                                                            class="fas fa-spinner fa-spin"></i></span></div>
+                                               class="btn btn-default btn-sm pull-left">
+                                                <i class="{{$webhook_icon}}" aria-hidden="true"></i>
+                                                    {!! trans('admin/settings/general.webhook_test',['app' => ucwords($webhook_selected) ]) !!}
+                                            </a>
+                                            <div wire:loading>
+                                                <span style="padding-left: 5px; font-size: 20px">
+                                                    <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+                                                </span>
+                                            </div>
+
                                         </div>
                                     </div>
                                 @endif
@@ -161,8 +164,10 @@
                                                 aria-hidden="true"></i> {{ trans('general.save') }}</button>
                                 </div>
                             </div><!--box-footer-->
-                        </form>
-
                     </div> <!-- /box -->
                 </div> <!-- /.col-md-8-->
+        </div>
+    </div>
+    </form>
+</div>
 

--- a/resources/views/settings/slack.blade.php
+++ b/resources/views/settings/slack.blade.php
@@ -1,11 +1,5 @@
 @extends('layouts/default')
-
-
-                    @livewire('slack-settings-form')
-        </div> <!-- /.col-md-8-->
-    </div> <!-- /.row-->
-
-
+    @livewire('slack-settings-form')
 @stop
 
 


### PR DESCRIPTION
These are just some small tweaks - possibly not the last - for the new Livewire webhook form. @Godmartinz - as far as I know, this doesn't break anything new. (See the video in Slack) It just cleans up some of the HTML. We were missing (and I may not have hit them all) some aria label/accessibility stuff, etc. I just wanted to put this out there so you could work from this and not have a giant mess of conflicts to deal with later today.