### PR TITLE
Fixed ErrorException: Undefined array key 0 [sc-20424]

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1024,7 +1024,11 @@ class ReportsController extends Controller
         if (is_null($acceptance->created_at)){
             return redirect()->route('reports/unaccepted_assets')->with('error', trans('general.bad_data'));
         } else {
-            $logItem = $assetItem->checkouts()->where('created_at', '=', $acceptance->created_at)->get()[0];
+            $logItem_res = $assetItem->checkouts()->where('created_at', '=', $acceptance->created_at)->get();
+            if ($logItem_res->isEmpty()){
+                return redirect()->route('reports/unaccepted_assets')->with('error', trans('general.bad_data'));
+            }
+            $logItem = $logItem_res[0];
         }
 
         if(!$assetItem->assignedTo->locale){


### PR DESCRIPTION
# Description
When some admin user want to resend unaccepted assets reminders, so the user with the asset checkout to them can accept it, sometimes if the system can't find the asset log where the info of that user resides, it fails with a 500. 

This PR check if the collection of assets reported in the acceptance report is not empty, if it is we don't try to access that index.

Fixes [sc-20424]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
