### PR TITLE
Catch Duplicate Headers in Asset History Import 

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -627,7 +627,11 @@ class AssetsController extends Controller
         $csv->setHeaderOffset(0);
         $header = $csv->getHeader();
         $isCheckinHeaderExplicit = in_array('checkin date', (array_map('strtolower', $header)));
-        $results = $csv->getRecords();
+        try {
+            $results = $csv->getRecords();
+        } catch (\Exception $e) {
+            return back()->with('error', 'There was an error reading the CSV file: '.$e->getMessage());
+        } 
         $item = [];
         $status = [];
         $status['error'] = [];


### PR DESCRIPTION
# Description
When importing an asset history csv, an exception is thrown if there are duplicate headers. 

Fixes # (issue)
[sc-20437](https://app.shortcut.com/grokability/story/20437/league-csv-syntaxerror-the-header-record-contains-duplicate-column-names)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 8.2.3
* MySQL version 8.0.32
* Webserver version Valet
* OS version macOS 13.1