### PR TITLE
Fixed Consumable Factory Seeder

### DIFF
--- a/database/factories/ConsumableFactory.php
+++ b/database/factories/ConsumableFactory.php
@@ -33,7 +33,7 @@ class ConsumableFactory extends Factory
             'user_id' => 1,
             'item_no' => $this->faker->numberBetween(1000000, 50000000),
             'order_number' => $this->faker->numberBetween(1000000, 50000000),
-            'purchase_date' => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get()),
+            'purchase_date' => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get())->format('Y-m-d'),
             'purchase_cost' => $this->faker->randomFloat(2, 1, 50),
             'qty' => $this->faker->numberBetween(5, 10),
             'min_amt' => $this->faker->numberBetween($min = 1, $max = 2),


### PR DESCRIPTION
# Description
As with other items, the Consumable seeder was silently failing because of the purchase date format. This PR added the expected format, so now the seeder can create consumables to test.

Fixes N/A

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 
# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
