### PR TITLE
Fixed Component factory

### DIFF
--- a/database/factories/ComponentFactory.php
+++ b/database/factories/ComponentFactory.php
@@ -38,7 +38,7 @@ class ComponentFactory extends Factory
             'serial'   => $this->faker->uuid,
             'qty' => $this->faker->numberBetween(3, 10),
             'order_number' => $this->faker->numberBetween(1000000, 50000000),
-            'purchase_date' => $this->faker->dateTime(),
+            'purchase_date' => $this->faker->dateTime()->format('Y-m-d'),
             'purchase_cost' => $this->faker->randomFloat(2),
             'min_amt' => $this->faker->numberBetween($min = 1, $max = 2),
             'company_id' => function () {


### PR DESCRIPTION
# Description

Follow up to #12672. The component factory was also silently failing and needed a format applied to the purchase_date field.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)