### PR TITLE
Handle already-deleted license files more gracefully

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseFilesController.php
+++ b/app/Http/Controllers/Licenses/LicenseFilesController.php
@@ -91,29 +91,30 @@ class LicenseFilesController extends Controller
      */
     public function destroy($licenseId = null, $fileId = null)
     {
-        $license = License::find($licenseId);
+        if ($license = License::find($licenseId)) {
 
-        // the asset is valid
-        if (isset($license->id)) {
             $this->authorize('update', $license);
-            $log = Actionlog::find($fileId);
 
-            // Remove the file if one exists
-            if (Storage::exists('licenses/'.$log->filename)) {
-                try {
-                    Storage::delete('licenses/'.$log->filename);
-                } catch (\Exception $e) {
-                    \Log::debug($e);
+            if ($log = Actionlog::find($fileId)) {
+
+                // Remove the file if one exists
+                if (Storage::exists('licenses/'.$log->filename)) {
+                    try {
+                        Storage::delete('licenses/'.$log->filename);
+                    } catch (\Exception $e) {
+                        \Log::debug($e);
+                    }
                 }
+                
+                $log->delete();
+
+                return redirect()->back()
+                    ->with('success', trans('admin/hardware/message.deletefile.success'));
             }
 
-            $log->delete();
-
-            return redirect()->back()
-                ->with('success', trans('admin/hardware/message.deletefile.success'));
+            return redirect()->route('licenses.index')->with('error', trans('general.log_does_not_exist'));
         }
 
-        // Redirect to the licence management page
         return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.does_not_exist'));
     }
 
@@ -129,7 +130,6 @@ class LicenseFilesController extends Controller
      */
     public function show($licenseId = null, $fileId = null, $download = true)
     {
-        \Log::info('Private filesystem is: '.config('filesystems.default'));
         $license = License::find($licenseId);
 
         // the license is valid

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -407,7 +407,7 @@ return [
     'true'                  => 'True',
     'false'                 => 'False',
     'integration_option'    => 'Integration Option',
-
+    'log_does_not_exist'    => 'No matching log record exists.',
 
 
 ];


### PR DESCRIPTION
Edge case, but accidentally trying to delete a license file that was already deleted would trigger a 500.