### PR TITLE
Fixed #12366 #10074 #11763 Encrypted Customfields Issues

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -598,6 +598,10 @@ class AssetsController extends Controller
                         if (($field_val == null) && ($request->has('model_id') != '')) {
                             $field_val = \Crypt::encrypt($field->defaultValue($request->get('model_id')));
                         } else {
+                            $validated = $request->validate([
+                                $field->db_column => $model->fieldset->validation_rules()[$field->db_column],
+                            ]);
+                            
                             $field_val = \Crypt::encrypt($request->input($field->db_column));
                         }
                     }
@@ -672,6 +676,10 @@ class AssetsController extends Controller
                     if ($request->has($field->db_column)) {
                         if ($field->field_encrypted == '1') {
                             if (Gate::allows('admin')) {
+                                $validated = $request->validate([
+                                    $field->db_column => $model->fieldset->validation_rules()[$field->db_column],
+                                ]);
+                                
                                 $asset->{$field->db_column} = \Crypt::encrypt($request->input($field->db_column));
                             }
                         } else {

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -364,6 +364,10 @@ class AssetsController extends Controller
                         if (is_array($request->input($field->db_column))) {
                             $asset->{$field->db_column} = \Crypt::encrypt(implode(', ', $request->input($field->db_column)));
                         } else {
+                            $validated = $request->validate([
+                                $field->db_column => $model->fieldset->validation_rules()[$field->db_column],
+                            ]);
+
                             $asset->{$field->db_column} = \Crypt::encrypt($request->input($field->db_column));
                         }
                     }

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -173,6 +173,10 @@ class AssetsController extends Controller
                             if (is_array($request->input($field->db_column))) {
                                 $asset->{$field->db_column} = \Crypt::encrypt(implode(', ', $request->input($field->db_column)));
                             } else {
+                                $validated = $request->validate([
+                                    $field->db_column => $model->fieldset->validation_rules()[$field->db_column],
+                                ]);
+                                
                                 $asset->{$field->db_column} = \Crypt::encrypt($request->input($field->db_column));
                             }
                         }

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -4,6 +4,7 @@ namespace App\Importer;
 
 use App\Models\Asset;
 use App\Models\Statuslabel;
+use App\Models\AssetModel;
 
 class AssetImporter extends ItemImporter
 {
@@ -21,11 +22,23 @@ class AssetImporter extends ItemImporter
         parent::handle($row);
 
         if ($this->customFields) {
+            $input = array();
             foreach ($this->customFields as $customField) {
                 $customFieldValue = $this->array_smart_custom_field_fetch($row, $customField);
 
                 if ($customFieldValue) {
                     if ($customField->field_encrypted == 1) {
+                        $model = AssetModel::where('name', $this->findCsvMatch($row, 'asset_model'))->first();
+                        $input[$customField->db_column_name()]  = $customFieldValue;
+
+                        $validator = \Validator::make($input, [
+                            $customField->db_column_name() => $model->fieldset->validation_rules()[$customField->db_column_name()],
+                        ]);
+
+                        if ($validator->fails()){
+                            $this->logError($validator, "error");
+                        }
+
                         $this->item['custom_fields'][$customField->db_column_name()] = \Crypt::encrypt($customFieldValue);
                         $this->log('Custom Field '.$customField->name.': '.\Crypt::encrypt($customFieldValue));
                     } else {

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -224,7 +224,6 @@ class Asset extends Depreciable
                     // Encrypted Fields are validated in the controller, we remove the validation rule here
                     if ($field->field_encrypted == 1){
                         unset($this->rules[$field->db_column]);
-                        dd($this->rules);
                     }
                 }
             }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -221,6 +221,11 @@ class Asset extends Depreciable
                     if($field->format == 'BOOLEAN'){
                         $this->{$field->db_column} = filter_var($this->{$field->db_column}, FILTER_VALIDATE_BOOLEAN);
                     }
+                    // Encrypted Fields are validated in the controller, we remove the validation rule here
+                    if ($field->field_encrypted == 1){
+                        unset($this->rules[$field->db_column]);
+                        dd($this->rules);
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description
We have different errors with Customfields validation that reduces to the order encryption takes place in our system. 

Let's take this workflow as an example:

- User creates a Customfield and want it to be of numeric format.
- Then marks that customfield to save its value encrypted.
- When the user tries to assigne a value to that field the system first encrypts it, then validate, then save it.
- As the encrypted field is a hashed value that can be of the form: 'eyJpdiI6IkNQcWZQa08xdzdrS0lGMFFGR3FRZ2c9PSIsInZhbHVlIjoicnNPQm10ejFrd3ppVndvOXdCSEhnQT09IiwibWFjIjoiZTE2MmVkZDA0MzM1ZDQ5ZTQ5OWZmNTU2MTNmMGUxMTgyNDNhYmEwY2E1ODBkZTk1ZjgwMDk5ZjY1NjUxMzZmMyIsInRhZyI6IiJ9' then the field does not pass the numeric validation.

The same applies if it's validated and nullable, the empty string never got accepted because of the hashed value. This problem is hard and I struggle to come with this solution, so it probably is not the best solution, but it's a first approach. 

This PR only validate single values for now, I'm ok to mark it as WIP if we need all the functionality implemented, but I think the array of values ( used by radiobuttons, checkboxes, etc) can be a separate PR because it's not as usual as this case.

Fixes #12366 #10074 #11763

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP Dev server
* OS version: Debian 11