### PR TITLE
Updates the Gate “use” statement to be more specific

### DIFF
--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use Laravel\Passport\TokenRepository;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use DB;
 
 class ProfileController extends Controller

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -16,7 +16,7 @@ use App\Models\User;
 use Auth;
 use Carbon\Carbon;
 use DB;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -8,7 +8,7 @@ use App\Models\Setting;
 use App\Models\User;
 use App\Notifications\CurrentInventory;
 use Illuminate\Support\Facades\Auth;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;

--- a/app/Http/Middleware/CheckPermissions.php
+++ b/app/Http/Middleware/CheckPermissions.php
@@ -3,7 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 
 class CheckPermissions
 {

--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Accessory;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Storage;
 

--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -5,7 +5,7 @@ namespace App\Http\Transformers;
 use App\Helpers\Helper;
 use App\Models\Asset;
 use App\Models\AssetMaintenance;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 
 class AssetMaintenancesTransformer

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -5,7 +5,7 @@ namespace App\Http\Transformers;
 use App\Helpers\Helper;
 use App\Models\Asset;
 use App\Models\Setting;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 
 

--- a/app/Http/Transformers/CategoriesTransformer.php
+++ b/app/Http/Transformers/CategoriesTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Category;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Storage;
 

--- a/app/Http/Transformers/CompaniesTransformer.php
+++ b/app/Http/Transformers/CompaniesTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Company;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Storage;
 

--- a/app/Http/Transformers/ComponentsAssetsTransformer.php
+++ b/app/Http/Transformers/ComponentsAssetsTransformer.php
@@ -3,7 +3,7 @@
 namespace App\Http\Transformers;
 
 use App\Models\Asset;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 
 class ComponentsAssetsTransformer

--- a/app/Http/Transformers/ComponentsTransformer.php
+++ b/app/Http/Transformers/ComponentsTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Component;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Storage;
 

--- a/app/Http/Transformers/ConsumablesTransformer.php
+++ b/app/Http/Transformers/ConsumablesTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Consumable;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Storage;
 

--- a/app/Http/Transformers/DepartmentsTransformer.php
+++ b/app/Http/Transformers/DepartmentsTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Department;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Storage;
 

--- a/app/Http/Transformers/DepreciationsTransformer.php
+++ b/app/Http/Transformers/DepreciationsTransformer.php
@@ -5,7 +5,7 @@ namespace App\Http\Transformers;
 use App\Helpers\Helper;
 use App\Models\Depreciable;
 use App\Models\Depreciation;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 
 class DepreciationsTransformer

--- a/app/Http/Transformers/GroupsTransformer.php
+++ b/app/Http/Transformers/GroupsTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Group;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 
 class GroupsTransformer

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Models\License;
 use App\Models\LicenseSeat;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 
 class LicenseSeatsTransformer

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\License;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 
 class LicensesTransformer

--- a/app/Http/Transformers/ManufacturersTransformer.php
+++ b/app/Http/Transformers/ManufacturersTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Manufacturer;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Storage;
 

--- a/app/Http/Transformers/PredefinedKitsTransformer.php
+++ b/app/Http/Transformers/PredefinedKitsTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Models\PredefinedKit;
 use App\Models\SnipeModel;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 
 /**

--- a/app/Http/Transformers/StatuslabelsTransformer.php
+++ b/app/Http/Transformers/StatuslabelsTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Statuslabel;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 
 class StatuslabelsTransformer

--- a/app/Http/Transformers/SuppliersTransformer.php
+++ b/app/Http/Transformers/SuppliersTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Supplier;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Storage;
 

--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -4,7 +4,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\User;
-use Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
 
 class UsersTransformer


### PR DESCRIPTION
This just makes it so that we're using `use Illuminate\Support\Facades\Gate;` instead of `use Gate` in our controllers. It wasn't *wrong*, this is just more right. 