### PR TITLE
Fixed #12671: Re-enable config:cache when there's no Rollbar

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -112,27 +112,31 @@ $config = [
             'handler' => \Rollbar\Laravel\MonologHandler::class,
             'access_token' => env('ROLLBAR_TOKEN'),
             'level' => env('ROLLBAR_LEVEL', 'error'),
-            'check_ignore' => function($isUncaught, $args, $payload) {
-                if (App::environment('production') && is_object($args) && get_class($args) == Rollbar\ErrorWrapper::class && $args->errorLevel == E_WARNING ) {
-                    \Log::info("IGNORING E_WARNING in production mode: ".$args->getMessage());
-                    return true; // "TRUE - you should ignore it!"
-                }
-                $needle = "ArieTimmerman\\Laravel\\SCIMServer\\Exceptions\\SCIMException";
-                if (App::environment('production') && is_string($args) && strncmp($args, $needle, strlen($needle) ) === 0 ) {
-                    \Log::info("String: '$args' looks like a SCIM Exception; ignoring error");
-                    return true; //yes, *do* ignore it
-                }
-                return false;
-            },
         ],
     ],
 
 ];
 
 
-// Only add rollbar if the .env has a rollbar token
 if ((env('APP_ENV')=='production') && (env('ROLLBAR_TOKEN'))) {
+    // Only add rollbar if the .env has a rollbar token
     $config['channels']['stack']['channels'] = ['single', 'rollbar'];
+
+    // and only add the rollbar filter under the same conditions
+    // Note: it will *not* be cacheable
+    $config['channels']['rollbar']['check_ignore'] = function ($isUncaught, $args, $payload) {
+        if (App::environment('production') && is_object($args) && get_class($args) == Rollbar\ErrorWrapper::class && $args->errorLevel == E_WARNING ) {
+            \Log::info("IGNORING E_WARNING in production mode: ".$args->getMessage());
+            return true; // "TRUE - you should ignore it!"
+        }
+        $needle = "ArieTimmerman\\Laravel\\SCIMServer\\Exceptions\\SCIMException";
+        if (App::environment('production') && is_string($args) && strncmp($args, $needle, strlen($needle) ) === 0 ) {
+            \Log::info("String: '$args' looks like a SCIM Exception; ignoring error");
+            return true; //yes, *do* ignore it
+        }
+        return false;
+    };
+
 }
 
 


### PR DESCRIPTION
Fixes #12671 

It turns out the new Rollbar filters I added to suppress error messages that weren't really errors also rendered our configurations to be uncacheable with `php artisan config:cache`.

Apparently, that command doesn't like serializing closures into the config-cache, which makes sense.

I tried extracting out the function into a named function, and that didn't work, and I tried setting up as a variable-named function (`$a = function () { /* blah */ }`), and few other tricks. None worked.

So, finally, I took @snipe 's advice and figured out a way to dynamically insert the closure into the config *only* if you are actually using it. Otherwise the closure isn't included.

The end result is that, so long as you *don't* run Rollbar, you can now run `php artisan config:cache` again. However, if you *are* running Rollbar, you *cannot* config:cache it. If I can eventually manage to figure out how to 'hoist' the closure into some AppServiceProvider or something, I certainly will, but this is the best I could come up with for now.

For testing, this is what I did:
- [x] When Rollbar is disabled (I just commented-out the keys in my `.env`), I can cache the config.
- [x] When Rollbar is enabled (and the cache is cleared), exceptions still throw to Rollbar.
- [ ] However, when Rollbar is enabled, `php artisan config:cache` won't run.

This is the best compromise I can come up with until I can figure out a better solution. There *are* some docs on how to dynamically load/unload Rollbar in the AppServiceProvider, but that still looks like it wants to read the same config, which would still have the same problem.