### PR TITLE
Fixed #12682 - add default location to maintenance report

### DIFF
--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -45,6 +45,10 @@ class AssetMaintenancesTransformer
                 'name'=> e($assetmaintenance->asset->location->name),
 
             ] : null,
+            'rtd_location' => ($assetmaintenance->asset->defaultLoc) ? [
+                'id' => (int) $assetmaintenance->asset->defaultLoc->id,
+                'name'=> e($assetmaintenance->asset->defaultLoc->name),
+            ] : null,
             'notes'         => ($assetmaintenance->notes) ? e($assetmaintenance->notes) : null,
             'supplier'      => ($assetmaintenance->supplier) ? ['id' => $assetmaintenance->supplier->id, 'name'=> e($assetmaintenance->supplier->name)] : null,
             'cost'          => Helper::formatCurrencyOutput($assetmaintenance->cost),

--- a/resources/views/reports/asset_maintenances.blade.php
+++ b/resources/views/reports/asset_maintenances.blade.php
@@ -46,6 +46,8 @@
                     <th data-searchable="true" data-sortable="true" data-field="completion_date" data-formatter="dateDisplayFormatter">{{ trans('admin/asset_maintenances/form.completion_date') }}</th>
                     <th data-searchable="true" data-sortable="true" data-field="asset_maintenance_time">{{ trans('admin/asset_maintenances/form.asset_maintenance_time') }}</th>
                     <th data-searchable="true" data-sortable="true" data-field="cost" class="text-right" data-footer-formatter="sumFormatter">{{ trans('admin/asset_maintenances/form.cost') }}</th>
+                    <th data-sortable="true" data-field="location" data-formatter="deployedLocationFormatter" data-visible="false">{{ trans('general.location') }}</th>
+                    <th data-sortable="true" data-field="rtd_location" data-formatter="deployedLocationFormatter" data-visible="false">{{ trans('admin/hardware/form.default_location') }}</th>
                     <th data-searchable="true" data-sortable="true" data-field="user_id" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
                     <th data-searchable="true" data-sortable="true" data-field="notes" data-visible="false">{{ trans('admin/asset_maintenances/form.notes') }}</th>
                 </tr>


### PR DESCRIPTION
Fixed #12682 - this just adds location and default location to the asset maintenance report.

Down the line, we probably want to store those values in the maintenances table itself, so that the locations are locked to where it was at the time of the maintenance, NOT wherever it might end up moving forward.