### PR TITLE
Slack webhook UI tweaks, added select2

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1155,10 +1155,10 @@ class Helper
      * This makes it cleanly available in blades and in controllers, e.g.
      *
      * Blade:
-     * {{ app('demo_mode') ? ' disabled' : ''}} for form blades where we need to disable a form
+     * {{ Helper::isDemoMode() ? ' disabled' : ''}} for form blades where we need to disable a form
      *
      * Controller:
-     * if (app('demo_mode')) {
+     * if (Helper::isDemoMode()) {
      *      // don't allow the thing
      * }
      * @todo - use this everywhere else in the app where we have very long if/else config('app.lock_passwords') stuff

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1148,12 +1148,37 @@ class Helper
 
     }
 
+
+     /*
+     * This is a shorter way to see if the app is in demo mode.
+     *
+     * This makes it cleanly available in blades and in controllers, e.g.
+     *
+     * Blade:
+     * {{ app('demo_mode') ? ' disabled' : ''}} for form blades where we need to disable a form
+     *
+     * Controller:
+     * if (app('demo_mode')) {
+     *      // don't allow the thing
+     * }
+     * @todo - use this everywhere else in the app where we have very long if/else config('app.lock_passwords') stuff
+     */
+    public function isDemoMode() {
+        if (config('app.lock_passwords') === true) {
+            return true;
+            \Log::debug('app locked!');
+        }
+
+        return false;
+    }
+
+
     /*
      * I know it's gauche  to return a shitty HTML string, but this is just a helper and since it will be the same every single time,
      * it seemed pretty safe to do here. Don't you judge me.
      */
     public function showDemoModeFieldWarning() {
-        if (app('demo_mode')) {
+        if (Helper::isDemoMode()) {
             return "<p class=\"text-warning\"><i class=\"fas fa-lock\"></i>" . trans('general.feature_disabled') . "</p>";
         }
     }

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1147,4 +1147,14 @@ class Helper
         return $age;
 
     }
+
+    /*
+     * I know it's gauche  to return a shitty HTML string, but this is just a helper and since it will be the same every single time,
+     * it seemed pretty safe to do here. Don't you judge me.
+     */
+    public function showDemoModeFieldWarning() {
+        if (app('demo_mode')) {
+            return "<p class=\"text-warning\"><i class=\"fas fa-lock\"></i>" . trans('general.feature_disabled') . "</p>";
+        }
+    }
 }

--- a/app/Http/Livewire/SlackSettingsForm.php
+++ b/app/Http/Livewire/SlackSettingsForm.php
@@ -28,7 +28,7 @@ class SlackSettingsForm extends Component
         'webhook_botname'                       => 'string|nullable',
     ];
 
-    public function mount(){
+    public function mount() {
         $this->webhook_text= [
             "slack" => array(
                 "name" => trans('admin/settings/general.slack') ,
@@ -63,12 +63,14 @@ class SlackSettingsForm extends Component
         }
 
     }
-    public function updated($field){
+    public function updated($field) {
+
         if($this->webhook_selected != 'general') {
             $this->validateOnly($field, $this->rules);
         }
     }
-    public function updatedWebhookSelected(){
+
+    public function updatedWebhookSelected() {
         $this->webhook_name = $this->webhook_text[$this->webhook_selected]['name'];
         $this->webhook_icon = $this->webhook_text[$this->webhook_selected]["icon"]; ;
         $this->webhook_placeholder = $this->webhook_text[$this->webhook_selected]["placeholder"];
@@ -79,7 +81,7 @@ class SlackSettingsForm extends Component
         }
     }
 
-    private function isButtonDisabled(){
+    private function isButtonDisabled() {
         if($this->webhook_selected == 'slack') {
             if (empty($this->webhook_endpoint)) {
                 $this->isDisabled = 'disabled';
@@ -92,6 +94,7 @@ class SlackSettingsForm extends Component
         }
 
     }
+
     public function render()
     {
         $this->isButtonDisabled();
@@ -116,12 +119,14 @@ class SlackSettingsForm extends Component
             ]);
 
         try {
+
             $webhook->post($this->webhook_endpoint, ['body' => $payload]);
             $this->isDisabled='';
             $this->save_button = trans('general.save');
             return session()->flash('success' , 'Your '.$this->webhook_name.' Integration works!');
 
         } catch (\Exception $e) {
+
             $this->isDisabled= 'disabled';
             return session()->flash('error' , trans('admin/settings/message.webhook.error', ['error_message' => $e->getMessage(), 'app' => $this->webhook_name]));
         }
@@ -131,6 +136,7 @@ class SlackSettingsForm extends Component
     }
 
     public function clearSettings(){
+
         if (Helper::isDemoMode()) {
             session()->flash('error',trans('general.feature_disabled'));
         } else {

--- a/app/Http/Livewire/SlackSettingsForm.php
+++ b/app/Http/Livewire/SlackSettingsForm.php
@@ -126,7 +126,7 @@ class SlackSettingsForm extends Component
         }
 
         //}
-        return session()->flash('message' , trans('admin/settings/message.webhook.error_misc'));
+        return session()->flash('error' , trans('admin/settings/message.webhook.error_misc'));
 
     }
 
@@ -140,23 +140,28 @@ class SlackSettingsForm extends Component
 
         $this->setting->save();
 
-        session()->flash('save',trans('admin/settings/message.update.success'));
+        session()->flash('success',trans('admin/settings/message.update.success'));
     }
 
     public function submit()
     {
-        if($this->webhook_selected != 'general') {
-            $this->validate($this->rules);
+        if (app('demo_mode')) {
+            session()->flash('error',trans('general.feature_disabled'));
+        } else {
+            if ($this->webhook_selected != 'general') {
+                $this->validate($this->rules);
+            }
+
+            $this->setting->webhook_selected = $this->webhook_selected;
+            $this->setting->webhook_endpoint = $this->webhook_endpoint;
+            $this->setting->webhook_channel = $this->webhook_channel;
+            $this->setting->webhook_botname = $this->webhook_botname;
+
+            $this->setting->save();
+
+            session()->flash('success',trans('admin/settings/message.update.success'));
+
         }
-
-        $this->setting->webhook_selected = $this->webhook_selected;
-        $this->setting->webhook_endpoint = $this->webhook_endpoint;
-        $this->setting->webhook_channel = $this->webhook_channel;
-        $this->setting->webhook_botname = $this->webhook_botname;
-
-        $this->setting->save();
-
-        session()->flash('save',trans('admin/settings/message.update.success'));
 
     }
 }

--- a/app/Http/Livewire/SlackSettingsForm.php
+++ b/app/Http/Livewire/SlackSettingsForm.php
@@ -131,21 +131,25 @@ class SlackSettingsForm extends Component
     }
 
     public function clearSettings(){
-        $this->webhook_endpoint = '';
-        $this->webhook_channel = '';
-        $this->webhook_botname = '';
-        $this->setting->webhook_endpoint = '';
-        $this->setting->webhook_channel = '';
-        $this->setting->webhook_botname = '';
+        if (Helper::isDemoMode()) {
+            session()->flash('error',trans('general.feature_disabled'));
+        } else {
+            $this->webhook_endpoint = '';
+            $this->webhook_channel = '';
+            $this->webhook_botname = '';
+            $this->setting->webhook_endpoint = '';
+            $this->setting->webhook_channel = '';
+            $this->setting->webhook_botname = '';
 
-        $this->setting->save();
+            $this->setting->save();
 
-        session()->flash('success',trans('admin/settings/message.update.success'));
+            session()->flash('success', trans('admin/settings/message.update.success'));
+        }
     }
 
     public function submit()
     {
-        if (app('demo_mode')) {
+        if (Helper::isDemoMode()) {
             session()->flash('error',trans('general.feature_disabled'));
         } else {
             if ($this->webhook_selected != 'general') {

--- a/app/Http/Livewire/SlackSettingsForm.php
+++ b/app/Http/Livewire/SlackSettingsForm.php
@@ -5,6 +5,7 @@ namespace App\Http\Livewire;
 use GuzzleHttp\Client;
 use Livewire\Component;
 use App\Models\Setting;
+use App\Helpers\Helper;
 
 class SlackSettingsForm extends Component
 {
@@ -125,7 +126,6 @@ class SlackSettingsForm extends Component
             return session()->flash('error' , trans('admin/settings/message.webhook.error', ['error_message' => $e->getMessage(), 'app' => $this->webhook_name]));
         }
 
-        //}
         return session()->flash('error' , trans('admin/settings/message.webhook.error_misc'));
 
     }

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -150,6 +150,32 @@ class SettingsServiceProvider extends ServiceProvider
         // Set the monetary locale to the configured locale to make helper::parseFloat work.
         setlocale(LC_MONETARY, config('app.locale'));
         setlocale(LC_NUMERIC, config('app.locale'));
+
+
+        /*
+         * This is a shorter way to see if the app is in demo mode.
+         *
+         * This makes it cleanly available in blades and in controllers, e.g.
+         *
+         * Blade:
+         * {{ app('demo_mode') ? ' disabled' : ''}} for form blades where we need to disable a form
+         *
+         * Controller:
+         * if (app('demo_mode')) {
+         *      // don't allow the thing
+         * }
+         * @todo - use this everywhere else in the app where we have very long if/else config('app.lock_passwords') stuff
+         */
+        \App::singleton('demo_mode', function () {
+            if (config('app.lock_passwords') === true) {
+                return true;
+            }
+            return false;
+        });
+
+
+
+
     }
 
     /**

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -152,30 +152,6 @@ class SettingsServiceProvider extends ServiceProvider
         setlocale(LC_NUMERIC, config('app.locale'));
 
 
-        /*
-         * This is a shorter way to see if the app is in demo mode.
-         *
-         * This makes it cleanly available in blades and in controllers, e.g.
-         *
-         * Blade:
-         * {{ app('demo_mode') ? ' disabled' : ''}} for form blades where we need to disable a form
-         *
-         * Controller:
-         * if (app('demo_mode')) {
-         *      // don't allow the thing
-         * }
-         * @todo - use this everywhere else in the app where we have very long if/else config('app.lock_passwords') stuff
-         */
-        \App::singleton('demo_mode', function () {
-            if (config('app.lock_passwords') === true) {
-                return true;
-            }
-            return false;
-        });
-
-
-
-
     }
 
     /**

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -150,8 +150,7 @@ class SettingsServiceProvider extends ServiceProvider
         // Set the monetary locale to the configured locale to make helper::parseFloat work.
         setlocale(LC_MONETARY, config('app.locale'));
         setlocale(LC_NUMERIC, config('app.locale'));
-
-
+        
     }
 
     /**

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -417,6 +417,6 @@ return [
     'merged'                => 'merged',
     'merged_log_this_user_into' => 'Merged this user (ID :to_id - :to_username) into user ID :from_id (:from_username) ',
     'merged_log_this_user_from' => 'Merged user ID :from_id (:from_username) into this user (ID :to_id - :to_username)',
-
+    'clear_and_save'            => 'Clear & Save',
 
 ];

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -141,7 +141,7 @@
                 <div class="box-footer">
                     <div class="text-right col-md-12">
 
-                        <button type="reset" wire:click.prevent="clearSettings" class="col-md-2 text-left btn btn-danger pull-left">{{ trans('general.clear_and_save') }}</button>
+                        <button type="reset" wire:click.prevent="clearSettings" class="col-md-2 text-left btn btn-danger pull-left"{{ Helper::isDemoMode() ? ' disabled' : ''}}>{{ trans('general.clear_and_save') }}</button>
 
                         <a class="btn btn-link pull-left" href="{{ route('settings.index') }}">{{ trans('button.cancel') }}</a>
 

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -58,14 +58,14 @@
                                 </label>
                             </div>
                             <div class="col-md-9 required">
-                                <select wire:model="webhook_selected" aria-label="webhook_selected" class="form-control"{{ app('demo_mode') ? ' disabled' : ''}}>
+                                <select wire:model="webhook_selected" aria-label="webhook_selected" class="form-control"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
                                     <option value="slack">{{ trans('admin/settings/general.slack') }}</option>
                                     <option value="general">{{ trans('admin/settings/general.general_webhook') }}</option>
                                 </select>
                             </div>
                         </div>
 
-                        @if (app('demo_mode'))
+                        @if (Helper::isDemoMode())
                             @include('partials.forms.demo-mode')
                         @endif
 
@@ -75,12 +75,12 @@
                                 {{ Form::label('webhook_endpoint', trans('admin/settings/general.webhook_endpoint',['app' => $webhook_name ])) }}
                             </div>
                             <div class="col-md-9 required">
-                                    <input type="text" wire:model="webhook_endpoint" class="form-control" placeholder="{{$webhook_placeholder}}" value="{{old('webhook_endpoint', $webhook_endpoint)}}"{{ app('demo_mode') ? ' disabled' : ''}}>
+                                    <input type="text" wire:model="webhook_endpoint" class="form-control" placeholder="{{$webhook_placeholder}}" value="{{old('webhook_endpoint', $webhook_endpoint)}}"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
                                 {!! $errors->first('webhook_endpoint', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
                         </div>
 
-                        @if (app('demo_mode'))
+                        @if (Helper::isDemoMode())
                             @include('partials.forms.demo-mode')
                         @endif
 
@@ -91,13 +91,13 @@
                                 {{ Form::label('webhook_channel', trans('admin/settings/general.webhook_channel',['app' => $webhook_name ])) }}
                             </div>
                             <div class="col-md-9 required">
-                                    <input type="text" wire:model="webhook_channel" class="form-control" placeholder="#IT-Ops" value="{{ old('webhook_channel', $webhook_channel) }}"{{ app('demo_mode') ? ' disabled' : ''}}>
+                                    <input type="text" wire:model="webhook_channel" class="form-control" placeholder="#IT-Ops" value="{{ old('webhook_channel', $webhook_channel) }}"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
 
                                 {!! $errors->first('webhook_channel', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
                         </div>
 
-                        @if (!app('demo_mode'))
+                        @if (Helper::isDemoMode())
                             @include('partials.forms.demo-mode')
                         @endif
 
@@ -107,12 +107,12 @@
                                 {{ Form::label('webhook_botname', trans('admin/settings/general.webhook_botname',['app' => $webhook_name ])) }}
                             </div>
                             <div class="col-md-9">
-                                    <input type="text" wire:model="webhook_botname" class='form-control' placeholder="Snipe-Bot" {{ old('webhook_botname', $webhook_botname)}}{{ app('demo_mode') ? ' disabled' : ''}}>
+                                    <input type="text" wire:model="webhook_botname" class='form-control' placeholder="Snipe-Bot" {{ old('webhook_botname', $webhook_botname)}}{{ Helper::isDemoMode() ? ' disabled' : ''}}>
                                 {!! $errors->first('webhook_botname', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div><!--col-md-10-->
                         </div>
 
-                        @if (app('demo_mode'))
+                        @if (!Helper::isDemoMode())
                             @include('partials.forms.demo-mode')
                         @endif
 
@@ -140,13 +140,13 @@
 
                 <div class="box-footer">
                     <div class="text-right col-md-12">
-                        
+
                         <button type="reset" wire:click.prevent="clearSettings" class="col-md-2 text-left btn btn-danger pull-left">{{ trans('general.clear_and_save') }}</button>
 
                         <a class="btn btn-link pull-left" href="{{ route('settings.index') }}">{{ trans('button.cancel') }}</a>
 
 
-                        <button type="submit" {{$isDisabled}} class="btn btn-primary"{{ app('demo_mode') ? ' disabled' : ''}}>
+                        <button type="submit" {{$isDisabled}} class="btn btn-primary"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
                         <i class="fas fa-check icon-white" aria-hidden="true"></i> {{ $save_button }}</button>
 
                     </div> <!-- /.col-md-12 -->

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -55,13 +55,14 @@
                             <div class="col-md-2">
                                 <label for="webhook_selected">
                                     {{ trans('general.integration_option') }}
-                                </label>
+
+								</label>
                             </div>
                             <div class="col-md-9 required" wire:ignore>
-                                <select aria-label="webhook_selected" id="select2" class="select2 form-control"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
-                                    <option value="slack">{{ trans('admin/settings/general.slack') }}</option>
-                                    <option value="general">{{ trans('admin/settings/general.general_webhook') }}</option>
-                                </select>
+
+								{{ Form::select('webhook_selected', array('slack' => trans('admin/settings/general.slack'), 'general' => trans('admin/settings/general.general_webhook')), old('webhook_selected', $webhook_selected), array('class'=>'select2 form-control', 'aria-label' => 'webhook_selected', 'id' => 'select2', 'style'=>'width:90%')) }}
+
+
                             </div>
                         </div>
 

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -168,7 +168,7 @@
         $('#select2').select2();
         $('#select2').on('change', function (e) {
             var data = $('#select2').select2("val");
-        @this.set('webhook_selected', data);
+            @this.set('webhook_selected', data);
         });
 
         // Re-render select2

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -12,33 +12,33 @@
 {{-- Page content --}}
 @section('content')
 
-<div>
+<div><!-- livewire div - do not remove -->
     <form class="form-horizontal" role="form" wire:submit.prevent="submit">
         {{csrf_field()}}
+
         <div class="row">
+
             <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
-    <div class="panel box box-default">
-        <div class="box-header with-border">
-            <h2 class="box-title">
-                <i class="{{$webhook_icon}}"></i> {{ trans('admin/settings/general.webhook', ['app' => $webhook_name] ) }}
-            </h2>
-        </div>
-        <div class="box-body">
-            <div class="col-md-12">
-                @if($webhook_selected != 'general')
-                <p>
-                    {!! trans('admin/settings/general.webhook_integration_help',array('webhook_link' => $webhook_link, 'app' => $webhook_name)) !!}
-                </p>
-                @endif
-                <br>
-            </div>
+
+                <div class="panel box box-default">
+
+                    <div class="box-header with-border">
+                        <h2 class="box-title">
+                            <i class="{{$webhook_icon}}"></i> {{ trans('admin/settings/general.webhook', ['app' => $webhook_name] ) }}
+                        </h2>
+                    </div>
+
+                <div class="box-body">
+                    @if($webhook_selected != 'general')
+                    <div class="col-md-12">
+                            <p>
+                                {!! trans('admin/settings/general.webhook_integration_help',array('webhook_link' => $webhook_link, 'app' => $webhook_name)) !!}
+                            </p>
+                        <br>
+                    </div>
+                    @endif
 
                     <div class="col-md-12" style="border-top: 0px;">
-                        @if (session()->has('save'))
-                            <div class="alert alert-success fade in">
-                                {{session('save')}}
-                            </div>
-                        @endif
 
                         @if(session()->has('success'))
                             <div class="alert alert-success fade in">
@@ -50,130 +50,112 @@
                                 {{session('error')}}
                             </div>
                         @endif
-                        @if(session()->has('message'))
-                            <div class="alert alert-danger fade in">
-                                {{session('message')}}
-                            </div>
-                        @endif
 
-
-                        <div class="form-group" style="margin-left:-14px;">
-                            <div class="col-md-3">
+                        <div class="form-group">
+                            <div class="col-md-2">
                                 <label for="webhook_selected">
                                     {{ trans('general.integration_option') }}
                                 </label>
                             </div>
-
-                            <div class="col-md-8" style="margin-left: -62px;">
-                                <select wire:model="webhook_selected" aria-label="webhook_selected" class="form-control">
+                            <div class="col-md-9 required">
+                                <select wire:model="webhook_selected" aria-label="webhook_selected" class="form-control"{{ app('demo_mode') ? ' disabled' : ''}}>
                                     <option value="slack">{{ trans('admin/settings/general.slack') }}</option>
                                     <option value="general">{{ trans('admin/settings/general.general_webhook') }}</option>
                                 </select>
                             </div>
-                            <br><br><br>
-
                         </div>
-                        <form class="form-horizontal" role="form" wire:submit.prevent="submit">
-                            {{csrf_field()}}
 
-                            <!--Webhook endpoint-->
-                            <div class="form-group{{ $errors->has('webhook_endpoint') ? ' error' : '' }}">
-                                <div class="col-md-2">
-                                    {{ Form::label('webhook_endpoint', trans('admin/settings/general.webhook_endpoint',['app' => $webhook_name ])) }}
-                                </div>
-                                <div class="col-md-8 required">
-                                    @if (config('app.lock_passwords')===true)
-                                        <p class="text-warning"><i
-                                                    class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-                                        <input type="text" wire:model="webhook_endpoint" class='form-control'
-                                               placeholder="{{$webhook_placeholder}}"
-                                                value="{{old('webhook_endpoint', $webhook_endpoint)}}">
-                                    @else
-                                        <input type="text" wire:model="webhook_endpoint" class='form-control'
-                                               placeholder="{{$webhook_placeholder}}"
-                                                value="{{old('webhook_endpoint', $webhook_endpoint)}}">
-                                    @endif
-                                    {!! $errors->first('webhook_endpoint', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                </div>
+                        @if (app('demo_mode'))
+                            @include('partials.forms.demo-mode')
+                        @endif
+
+                        <!--Webhook endpoint-->
+                        <div class="form-group{{ $errors->has('webhook_endpoint') ? ' error' : '' }}">
+                            <div class="col-md-2">
+                                {{ Form::label('webhook_endpoint', trans('admin/settings/general.webhook_endpoint',['app' => $webhook_name ])) }}
                             </div>
-
-                            <!-- Webhook channel -->
-                            <div class="form-group{{ $errors->has('webhook_channel') ? ' error' : '' }}">
-                                <div class="col-md-2">
-                                    {{ Form::label('webhook_channel', trans('admin/settings/general.webhook_channel',['app' => $webhook_name ])) }}
-                                </div>
-                                <div class="col-md-8 required">
-                                    @if (config('app.lock_passwords')===true)
-                                        <input type="text" wire:model="webhook_channel" class='form-control'
-                                               placeholder="#IT-Ops"
-                                               value="{{old('webhook_channel', $webhook_channel)}}">
-                                        <p class="text-warning"><i
-                                                    class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-                                    @else
-                                        <input type="text" wire:model="webhook_channel" class='form-control'
-                                               placeholder="#IT-Ops"
-                                               value="{{old('webhook_channel', $webhook_channel)}}">
-                                    @endif
-                                    {!! $errors->first('webhook_channel', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                </div>
+                            <div class="col-md-9 required">
+                                    <input type="text" wire:model="webhook_endpoint" class="form-control" placeholder="{{$webhook_placeholder}}" value="{{old('webhook_endpoint', $webhook_endpoint)}}"{{ app('demo_mode') ? ' disabled' : ''}}>
+                                {!! $errors->first('webhook_endpoint', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
+                        </div>
 
-                            <!-- Webhook botname -->
-                            <div class="form-group{{ $errors->has('webhook_botname') ? ' error' : '' }}">
-                                <div class="col-md-2">
-                                    {{ Form::label('webhook_botname', trans('admin/settings/general.webhook_botname',['app' => $webhook_name ])) }}
-                                </div>
-                                <div class="col-md-8">
-                                    @if (config('app.lock_passwords')===true)
-                                        <input type="text" wire:model="webhook_botname" class='form-control'
-                                               placeholder="Snipe-Bot" {{old('webhook_botname', $webhook_botname)}}>
-                                        <p class="text-warning"><i class="fas fa-lock"></i>
-                                            {{ trans('general.feature_disabled') }}
-                                        </p>
-                                    @else
-                                        <input type="text" wire:model="webhook_botname" class='form-control'
-                                               placeholder="Snipe-Bot" {{old('webhook_botname', $webhook_botname)}}>
-                                    @endif
-                                    {!! $errors->first('webhook_botname', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                </div><!--col-md-10-->
+                        @if (app('demo_mode'))
+                            @include('partials.forms.demo-mode')
+                        @endif
+
+
+                        <!-- Webhook channel -->
+                        <div class="form-group{{ $errors->has('webhook_channel') ? ' error' : '' }}">
+                            <div class="col-md-2">
+                                {{ Form::label('webhook_channel', trans('admin/settings/general.webhook_channel',['app' => $webhook_name ])) }}
                             </div>
+                            <div class="col-md-9 required">
+                                    <input type="text" wire:model="webhook_channel" class="form-control" placeholder="#IT-Ops" value="{{ old('webhook_channel', $webhook_channel) }}"{{ app('demo_mode') ? ' disabled' : ''}}>
 
-                            <!--Webhook Integration Test-->
-                            @if($webhook_selected == 'slack')
-                                @if($webhook_endpoint != null && $webhook_channel != null)
-                                    <div class="form-group">
-                                        <div class="col-md-offset-2 col-md-8">
-                                            <a href="#" wire:click.prevent="testWebhook"
-                                               class="btn btn-default btn-sm pull-left">
-                                                <i class="{{$webhook_icon}}" aria-hidden="true"></i>
-                                                    {!! trans('admin/settings/general.webhook_test',['app' => ucwords($webhook_selected) ]) !!}
-                                            </a>
-                                            <div wire:loading>
-                                                <span style="padding-left: 5px; font-size: 20px">
-                                                    <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
-                                                </span>
-                                            </div>
+                                {!! $errors->first('webhook_channel', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                            </div>
+                        </div>
+
+                        @if (!app('demo_mode'))
+                            @include('partials.forms.demo-mode')
+                        @endif
+
+                        <!-- Webhook botname -->
+                        <div class="form-group{{ $errors->has('webhook_botname') ? ' error' : '' }}">
+                            <div class="col-md-2">
+                                {{ Form::label('webhook_botname', trans('admin/settings/general.webhook_botname',['app' => $webhook_name ])) }}
+                            </div>
+                            <div class="col-md-9">
+                                    <input type="text" wire:model="webhook_botname" class='form-control' placeholder="Snipe-Bot" {{ old('webhook_botname', $webhook_botname)}}{{ app('demo_mode') ? ' disabled' : ''}}>
+                                {!! $errors->first('webhook_botname', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                            </div><!--col-md-10-->
+                        </div>
+
+                        @if (app('demo_mode'))
+                            @include('partials.forms.demo-mode')
+                        @endif
+
+                        <!--Webhook Integration Test-->
+                        @if($webhook_selected == 'slack')
+                            @if($webhook_endpoint != null && $webhook_channel != null)
+                                <div class="form-group">
+                                    <div class="col-md-offset-2 col-md-9">
+                                        <a href="#" wire:click.prevent="testWebhook"
+                                           class="btn btn-default btn-sm pull-left">
+                                            <i class="{{$webhook_icon}}" aria-hidden="true"></i>
+                                                {!! trans('admin/settings/general.webhook_test',['app' => ucwords($webhook_selected) ]) !!}
+                                        </a>
+                                        <div wire:loading>
+                                            <span style="padding-left: 5px; font-size: 20px">
+                                                <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+                                            </span>
                                         </div>
                                     </div>
-                                @endif
-                            @endif
-
-                            <div class="box-footer" style="margin-top: 45px;">
-                                <div class="text-right col-md-12">
-                                    <button type="reset" wire:click.prevent="clearSettings" class="col-md-2 text-left btn btn-danger">Clear & Save</button>
-
-                                    <a class="btn btn-link text-left"
-                                       href="{{ route('settings.index') }}">{{ trans('button.cancel') }}</a>
-                                    <button type="submit" {{$isDisabled}} class="btn btn-primary"><i
-                                                class="fas fa-check icon-white"
-                                                aria-hidden="true"></i> {{ $save_button }}</button>
                                 </div>
-                            </div><!--box-footer-->
+                            @endif
+                        @endif
+                    </div><!-- /.col-md-12 -->
+               </div><!-- /.box-body -->
 
-                    </div> <!-- /box -->
-                </div> <!-- /.col-md-8-->
-    </div>
-            </div>
-        </div>
-    </form>
-</div>
+                <div class="box-footer">
+                    <div class="text-right col-md-12">
+                        
+                        <button type="reset" wire:click.prevent="clearSettings" class="col-md-2 text-left btn btn-danger pull-left">{{ trans('general.clear_and_save') }}</button>
+
+                        <a class="btn btn-link pull-left" href="{{ route('settings.index') }}">{{ trans('button.cancel') }}</a>
+
+
+                        <button type="submit" {{$isDisabled}} class="btn btn-primary"{{ app('demo_mode') ? ' disabled' : ''}}>
+                        <i class="fas fa-check icon-white" aria-hidden="true"></i> {{ $save_button }}</button>
+
+                    </div> <!-- /.col-md-12 -->
+                </div><!--box-footer-->
+
+           </div> <!-- /.box -->
+       </div> <!-- /.col-md-8-->
+    </div> <!-- /.row -->
+</form>
+</div>  <!-- /livewire div -->
+
+

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -57,8 +57,8 @@
                                     {{ trans('general.integration_option') }}
                                 </label>
                             </div>
-                            <div class="col-md-9 required">
-                                <select wire:model="webhook_selected" aria-label="webhook_selected" class="form-control"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
+                            <div class="col-md-9 required" wire:ignore>
+                                <select aria-label="webhook_selected" id="select2" class="select2 form-control"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
                                     <option value="slack">{{ trans('admin/settings/general.slack') }}</option>
                                     <option value="general">{{ trans('admin/settings/general.general_webhook') }}</option>
                                 </select>
@@ -157,5 +157,27 @@
     </div> <!-- /.row -->
 </form>
 </div>  <!-- /livewire div -->
+
+
+
+
+@section('moar_scripts')
+<script>
+    $(document).ready(function () {
+        $('#select2').select2();
+        $('#select2').on('change', function (e) {
+            var data = $('#select2').select2("val");
+        @this.set('webhook_selected', data);
+        });
+
+        // Re-render select2
+        window.livewire.hook('message.processed', function (el, component) {
+            $('.select2').select2();
+        });
+    });
+
+
+</script>
+@endsection
 
 

--- a/resources/views/partials/forms/demo-mode.blade.php
+++ b/resources/views/partials/forms/demo-mode.blade.php
@@ -1,0 +1,5 @@
+<div class="row">
+    <div class="col-md-10 col-md-offset-2">
+        {!! Helper::showDemoModeFieldWarning() !!}
+    </div>
+</div>


### PR DESCRIPTION
This just tightens up the UI a little from the great work @Godmartinz did in #12703 (and many others) for the slack (and generic webhook) Livewire stuff, and styles the select box in our standard select2 formatting. It also prevents the user from submitting the form if the app is in demo mode (on both client side and server side), and adds a helper method to make it easier to handle ternary operators in blades for demo mode disabling things (which can get long and messy and hard to read.) I tried to make it a singleton but @uberbrady overrode me there.

Quick summary of changes:

- removed some of the extra padding, etc that was throwing the layout off
- re-added the `required` class to show that the integration option is required
- moved the "demo mode" text below the field, to make it consistent with the rest of the UI
- fixed the box footer, which was not spanning the full width of the box, resulting in the thin grey line above the box footer to not span the width of the footer
- shifted the footer buttons around a bit (more below on that)
- added `select2` to the webhook type selection box
- fixed a few unmatched `<div>` tags
- removed duplicated, unclosed opening `<form>` tag
- made the input fields disabled in demo mode
- switched to using the `success` (versus `save`) convention that's universal for our success/error conditions. (This wasn't broken, this just makes it more consistent with how we do it elsewhere.)

We do have an unusual UI case here (two, actually, but we're going to run into one of them in every Livewire form we have, sigh):

- Normally, we have the "save" button on the far right in the box footer, and the cancel link (much less prominent) link on the far left, to prevent users from spending forever on a form and then accidentally clicking cancel and losing all of their changes (which I loathe). In this case, since we don't have a "turn on / turn off" toggle, if you want to disable slack altogether, we have to offer an option that lets you clear and save the form - which  we don't have *anywhere* else in the system. To keep it as consistent with the rest of the UI as possible, I moved the "cancel" link where it normally should be, and placed the "clear and save" option to the right. We'll see if this works longer term, or if we need to rethink this.

- Normally, we have success and confirmation alerts show up *above* the box and the content within. In Livewire forms, so far, the alert (success/error) messages happen inside the form, since that's where the livewire hotness is. (This isn't anyone's fault, it's just how Livewire works out of the box.) IMHO, we need to figure out a long-term solution for this. There should not be any visual difference to the user between a Livewire form and a non-Livewire form. I'm okay shipping this behavior for now, but we'll have to sit down and think through how we want to handle this UI inconsistency moving forward. 

I will remain slightly salty that the generic "webhook" font awesome icon is only available in the pro version, which we wouldn't be allowed to distribute. Harrumph.

### Before

<img width="532" alt="Screenshot_2023-03-21_at_5_03_03_PM" src="https://user-images.githubusercontent.com/197404/226791915-eabab388-1435-4408-b47f-05556fba315f.png">

### After
<img width="535" alt="Update_Webhook_Settings____Snipe-IT_Demo-3" src="https://user-images.githubusercontent.com/197404/226798361-fc5ccfdb-89eb-4179-91f8-7e1a85482b5e.png">
<img width="527" alt="Update_Webhook_Settings____Snipe-IT_Demo-4" src="https://user-images.githubusercontent.com/197404/226792130-7f204363-0a74-4f33-8a6b-32dc41006dc9.png">
<img width="531" alt="Notification_Center-4" src="https://user-images.githubusercontent.com/197404/226792121-c6ac8fa2-81d8-4a63-b2c2-45cdaa2c9cd3.png">
<img width="531" alt="Update_Webhook_Settings____Snipe-IT_Demo-6" src="https://user-images.githubusercontent.com/197404/226792133-b998c129-80e5-439d-8561-07e3895086c8.png">
<img width="532" alt="Update_Webhook_Settings____Snipe-IT_Demo-2" src="https://user-images.githubusercontent.com/197404/226795578-c95d1bb4-05af-4018-89ad-11780297fdfe.png">


