### PR TITLE
Fixes back-in-time Slack v slack migration

### DIFF
--- a/database/migrations/2023_03_21_215218_update_slack_setting.php
+++ b/database/migrations/2023_03_21_215218_update_slack_setting.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Setting;
+
+class UpdateSlackSetting extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        /*
+         * This is a dumb migration that would only affect a few people that would have been caught in the back-in-time
+         * migration change to change Slack to slack
+         */
+        $settings = Setting::where('webhook_selected', '=', 'Slack')->get();
+
+        foreach($settings as $setting){
+            $setting->update(['webhook_selected' => 'slack']);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
In #12663, we inadvertently made a back in time migration, setting the default to "Ssack" (versus "Slack", which it originally was.) This ends up breaking anyone's webhook settings page if they HAPPENED to deploy and run migrations during that small window when the default was "Slack".