### PR TITLE
Fixed Trying to access array offset on value of type null [sc-20528]

### DIFF
--- a/resources/views/notifications/markdown/report-expiring-assets.blade.php
+++ b/resources/views/notifications/markdown/report-expiring-assets.blade.php
@@ -10,7 +10,7 @@ $expires = Helper::getFormattedDateObject($asset->present()->warranty_expires, '
 $diff = round(abs(strtotime($asset->present()->warranty_expires) - strtotime(date('Y-m-d')))/86400);
 $icon = ($diff <= ($threshold / 2)) ? '🚨' : (($diff <= $threshold) ? '⚠️' : ' ');
 @endphp
-<tr><td>{{ $icon }} </td><td> <a href="{{ route('hardware.show', $asset->id) }}">{{ $asset->present()->name }}</a> </td><td> {{ $diff }} {{ trans('mail.Days') }} </td><td> {{ $expires['formatted'] }} </td><td> {{ ($asset->supplier ? e($asset->supplier->name) : '') }} </td><td> {{ ($asset->assignedTo ? e($asset->assignedTo->present()->name()) : '') }} </td></tr>
+<tr><td>{{ $icon }} </td><td> <a href="{{ route('hardware.show', $asset->id) }}">{{ $asset->present()->name }}</a> </td><td> {{ $diff }} {{ trans('mail.Days') }} </td><td> {{ !is_null($expires) ? $expires['formatted'] : '' }} </td><td> {{ ($asset->supplier ? e($asset->supplier->name) : '') }} </td><td> {{ ($asset->assignedTo ? e($asset->assignedTo->present()->name()) : '') }} </td></tr>
 @endforeach
 </table>
 @endcomponent


### PR DESCRIPTION
# Description
The expiring alerts report can reach a state in which the variable containing the asset's expiring date is null, as that variable comes in the form of array, an exception is thrown when this happens. 

I can't reproduce this 'organically', so I think it's kind of an edge case when this happen... but I added a ternary to mitigate this issue. 

Fixes [sc-20528]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
