### PR TITLE
Fixes calls to changed webhook properties names

### DIFF
--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -83,9 +83,9 @@ class Setting extends Model
         'email_domain',
         'email_format',
         'username_format',
-        'slack_endpoint',
-        'slack_channel',
-        'slack_botname',
+        'webhook_endpoint',
+        'webhook_channel',
+        'webhook_botname',
     ];
 
     /**
@@ -265,7 +265,7 @@ class Setting extends Model
     {
         // At this point the endpoint is the same for everything.
         //  In the future this may want to be adapted for individual notifications.
-        return self::getSettings()->slack_endpoint;
+        return self::getSettings()->webhook_endpoint;
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -272,7 +272,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     {
         // At this point the endpoint is the same for everything.
         //  In the future this may want to be adapted for individual notifications.
-        $this->endpoint = \App\Models\Setting::getSettings()->slack_endpoint;
+        $this->endpoint = \App\Models\Setting::getSettings()->webhook_endpoint;
 
         return $this->endpoint;
     }

--- a/app/Notifications/AuditNotification.php
+++ b/app/Notifications/AuditNotification.php
@@ -34,7 +34,7 @@ class AuditNotification extends Notification
     public function via()
     {
         $notifyBy = [];
-        if (Setting::getSettings()->slack_endpoint) {
+        if (Setting::getSettings()->webhook_endpoint) {
             $notifyBy[] = 'slack';
         }
 

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -39,11 +39,7 @@ class CheckinAccessoryNotification extends Notification
         \Log::debug('via called');
         $notifyBy = [];
 
-        if (Setting::getSettings()->slack_endpoint) {
-            $notifyBy[] = 'slack';
-        }
-
-        if (Setting::getSettings()->slack_endpoint != '') {
+        if (Setting::getSettings()->webhook_endpoint != '') {
             $notifyBy[] = 'slack';
         }
 
@@ -95,7 +91,7 @@ class CheckinAccessoryNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->slack_botname) ? $this->settings->slack_botname : 'Snipe-Bot';
+        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
 
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -43,9 +43,8 @@ class CheckinAssetNotification extends Notification
     public function via()
     {
         $notifyBy = [];
-
-        if (Setting::getSettings()->slack_endpoint != '') {
-            \Log::debug('use slack');
+        if (Setting::getSettings()->webhook_endpoint != '') {
+            \Log::debug('use webhook');
             $notifyBy[] = 'slack';
         }
 
@@ -65,7 +64,7 @@ class CheckinAssetNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->slack_botname != '') ? $this->settings->slack_botname : 'Snipe-Bot';
+        $botname = ($this->settings->webhook_botname != '') ? $this->settings->webhook_botname : 'Snipe-Bot';
 
         $fields = [
             trans('general.administrator') => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',

--- a/app/Notifications/CheckinLicenseSeatNotification.php
+++ b/app/Notifications/CheckinLicenseSeatNotification.php
@@ -41,7 +41,7 @@ class CheckinLicenseSeatNotification extends Notification
     {
         $notifyBy = [];
 
-        if (Setting::getSettings()->slack_endpoint != '') {
+        if (Setting::getSettings()->webhook_endpoint != '') {
             $notifyBy[] = 'slack';
         }
 
@@ -62,7 +62,7 @@ class CheckinLicenseSeatNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->slack_botname) ? $this->settings->slack_botname : 'Snipe-Bot';
+        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
 
         if ($admin) {
             $fields = [

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -37,7 +37,7 @@ class CheckoutAccessoryNotification extends Notification
     {
         $notifyBy = [];
 
-        if (Setting::getSettings()->slack_endpoint != '') {
+        if (Setting::getSettings()->webhook_endpoint != '') {
             $notifyBy[] = 'slack';
         }
 
@@ -78,7 +78,7 @@ class CheckoutAccessoryNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->slack_botname) ? $this->settings->slack_botname : 'Snipe-Bot';
+        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
 
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -53,8 +53,8 @@ class CheckoutAssetNotification extends Notification
     {
         $notifyBy = [];
 
-        if ((Setting::getSettings()) && (Setting::getSettings()->slack_endpoint != '')) {
-            \Log::debug('use slack');
+        if ((Setting::getSettings()) && (Setting::getSettings()->webhook_endpoint != '')) {
+            \Log::debug('use webhook');
             $notifyBy[] = 'slack';
         }
 
@@ -95,7 +95,7 @@ class CheckoutAssetNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->slack_botname) ? $this->settings->slack_botname : 'Snipe-Bot';
+        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
 
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -43,7 +43,7 @@ class CheckoutConsumableNotification extends Notification
     {
         $notifyBy = [];
 
-        if (Setting::getSettings()->slack_endpoint != '') {
+        if (Setting::getSettings()->webhook_endpoint != '') {
             $notifyBy[] = 'slack';
         }
 
@@ -84,7 +84,7 @@ class CheckoutConsumableNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->slack_botname) ? $this->settings->slack_botname : 'Snipe-Bot';
+        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
 
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',

--- a/app/Notifications/CheckoutLicenseSeatNotification.php
+++ b/app/Notifications/CheckoutLicenseSeatNotification.php
@@ -43,7 +43,7 @@ class CheckoutLicenseSeatNotification extends Notification
     {
         $notifyBy = [];
 
-        if (Setting::getSettings()->slack_endpoint != '') {
+        if (Setting::getSettings()->webhook_endpoint != '') {
             $notifyBy[] = 'slack';
         }
 
@@ -84,7 +84,7 @@ class CheckoutLicenseSeatNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->slack_botname) ? $this->settings->slack_botname : 'Snipe-Bot';
+        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
 
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',

--- a/app/Notifications/RequestAssetCancelation.php
+++ b/app/Notifications/RequestAssetCancelation.php
@@ -57,8 +57,8 @@ class RequestAssetCancelation extends Notification
     {
         $notifyBy = [];
 
-        if (Setting::getSettings()->slack_endpoint != '') {
-            \Log::debug('use slack');
+        if (Setting::getSettings()->webhook_endpoint != '') {
+            \Log::debug('use webhook');
             $notifyBy[] = 'slack';
         }
 
@@ -73,7 +73,7 @@ class RequestAssetCancelation extends Notification
         $item = $this->item;
         $note = $this->note;
         $qty = $this->item_quantity;
-        $botname = ($this->settings->slack_botname) ? $this->settings->slack_botname : 'Snipe-Bot';
+        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
 
         $fields = [
             'QTY' => $qty,

--- a/app/Notifications/RequestAssetNotification.php
+++ b/app/Notifications/RequestAssetNotification.php
@@ -58,7 +58,7 @@ class RequestAssetNotification extends Notification
     {
         $notifyBy = [];
 
-        if (Setting::getSettings()->slack_endpoint != '') {
+        if (Setting::getSettings()->webhook_endpoint != '') {
             $notifyBy[] = 'slack';
         }
 
@@ -73,7 +73,7 @@ class RequestAssetNotification extends Notification
         $qty = $this->item_quantity;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->slack_botname) ? $this->settings->slack_botname : 'Snipe-Bot';
+        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
 
         $fields = [
             'QTY' => $qty,

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -253,7 +253,7 @@ return [
     'signature'             => 'Signature',
     'signed_off_by'         => 'Signed Off By',
     'skin'       			=> 'Skin',
-    'webhook_msg_note'        => 'A :app message will be sent',
+    'webhook_msg_note'        => 'A notification will be sent via webhook',
     'webhook_test_msg'        => 'Oh hai! Looks like your :app integration with Snipe-IT is working!',
     'some_features_disabled' => 'DEMO MODE: Some features are disabled for this installation.',
     'site_name'				=> 'Site Name',

--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -54,7 +54,7 @@
           @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_to'])
 
 
-             @if ($accessory->requireAcceptance() || $accessory->getEula() || ($snipeSettings->slack_endpoint!=''))
+             @if ($accessory->requireAcceptance() || $accessory->getEula() || ($snipeSettings->webhook_endpoint!=''))
                  <div class="form-group notification-callout">
                      <div class="col-md-8 col-md-offset-3">
                          <div class="callout callout-info">
@@ -71,9 +71,9 @@
                                  <br>
                              @endif
 
-                             @if ($snipeSettings->slack_endpoint!='')
+                             @if ($snipeSettings->webhook_endpoint!='')
                                  <i class="fab fa-slack"></i>
-                                 A slack message will be sent
+                                 {{ trans('general.webhook_msg_note') }}
                              @endif
                          </div>
                      </div>

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -41,7 +41,7 @@
             @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_to', 'required'=> 'true'])
 
 
-            @if ($consumable->requireAcceptance() || $consumable->getEula() || ($snipeSettings->slack_endpoint!=''))
+            @if ($consumable->requireAcceptance() || $consumable->getEula() || ($snipeSettings->webhook_endpoint!=''))
               <div class="form-group notification-callout">
                 <div class="col-md-8 col-md-offset-3">
                   <div class="callout callout-info">
@@ -58,9 +58,9 @@
                         <br>
                     @endif
 
-                    @if ($snipeSettings->slack_endpoint!='')
+                    @if ($snipeSettings->webhook_endpoint!='')
                         <i class="fab fa-slack"></i>
-                        {{ trans('general.slack_msg_note') }}
+                        {{ trans('general.webhook_msg_note') }}
                     @endif
                   </div>
                 </div>

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -114,7 +114,7 @@
                             </div>
                         </div>
 
-                        @if ($asset->requireAcceptance() || $asset->getEula() || ($snipeSettings->slack_endpoint!=''))
+                        @if ($asset->requireAcceptance() || $asset->getEula() || ($snipeSettings->webhook_endpoint!=''))
                             <div class="form-group notification-callout">
                                 <div class="col-md-8 col-md-offset-3">
                                     <div class="callout callout-info">
@@ -131,9 +131,9 @@
                                             <br>
                                         @endif
 
-                                        @if ($snipeSettings->slack_endpoint!='')
+                                        @if ($snipeSettings->webhook_endpoint!='')
                                             <i class="fab fa-slack" aria-hidden="true"></i>
-                                            {{ trans('general.slack_msg_note')}}
+                                            {{ trans('general.webhook_msg_note') }}
                                         @endif
                                     </div>
                                 </div>

--- a/resources/views/licenses/checkout.blade.php
+++ b/resources/views/licenses/checkout.blade.php
@@ -65,7 +65,7 @@
                 </div>
 
 
-                @if ($license->requireAcceptance() || $license->getEula() || ($snipeSettings->slack_endpoint!=''))
+                @if ($license->requireAcceptance() || $license->getEula() || ($snipeSettings->webhook_endpoint!=''))
                     <div class="form-group notification-callout">
                         <div class="col-md-8 col-md-offset-3">
                             <div class="callout callout-info">
@@ -88,9 +88,9 @@
                                     <br>
                                 @endif
 
-                                @if ($snipeSettings->slack_endpoint!='')
+                                @if ($snipeSettings->webhook_endpoint!='')
                                     <i class="fab fa-slack"></i>
-                                    {{ trans('general.slack_msg_note') }}
+                                    {{ trans('general.webhook_msg_note') }}
                                 @endif
                             </div>
                         </div>


### PR DESCRIPTION
# Description

This PR follows up on #12570 and updates references to `slack_*` to `webhook_*`.

In the process I updated the message that displays when checking out an accessory, asset, consumable, or license to be more general and say "A notification will be sent via webhook" instead of attempting to specify the application it will be sent to. This is because my first attempt was to run `webhook_selected` through `Str::title()` to show "Slack" but that doesn't work when the setting is "General". This was just easier for now.

![changed message](https://user-images.githubusercontent.com/1141514/227295829-4ea10bf9-d31c-44ab-915d-a2dc9b9303d3.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)