### PR TITLE
Fixed Undefined array key 266 rollbar 17086

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -334,7 +334,11 @@ class Helper
             '#92896B',
         ];
 
+        $total_colors = count($colors);
 
+        if ($index >= $total_colors) {
+            $index = $index - $total_colors;
+        }
 
         return $colors[$index];
     }
@@ -1092,15 +1096,6 @@ class Helper
         return $file_name;
     }
 
-
-    /**
-     * Universal helper to show file size in human-readable formats
-     *
-     * @author A. Gianotto <snipe@snipe.net>
-     * @since 5.0
-     *
-     * @return string[]
-     */
     public static function formatFilesizeUnits($bytes)
     {
         if ($bytes >= 1073741824)
@@ -1130,91 +1125,30 @@ class Helper
 
         return $bytes;
     }
-
-    /**
-     * This is weird but used by the side nav to determine which URL to point the user to
-     *
-     * @author A. Gianotto <snipe@snipe.net>
-     * @since 5.0
-     *
-     * @return string[]
-     */
     public static function SettingUrls(){
         $settings=['#','fields.index', 'statuslabels.index', 'models.index', 'categories.index', 'manufacturers.index', 'suppliers.index', 'departments.index', 'locations.index', 'companies.index', 'depreciations.index'];
 
         return $settings;
         }
-
-
-    /**
-     * Generic helper (largely used by livewire right now) that returns the font-awesome icon
-     * for the object type.
-     *
-     * @author A. Gianotto <snipe@snipe.net>
-     * @since 6.1.0
-     *
-     * @return string
-     */
-    public static function iconTypeByItem($item) {
-
-        switch ($item) {
-            case 'asset':
-                return 'fas fa-barcode';
-                break;
-            case 'accessory':
-                return 'fas fa-keyboard';
-                break;
-            case 'component':
-                return 'fas fa-hdd';
-                break;
-            case 'consumable':
-                return 'fas fa-tint';
-                break;
-            case 'license':
-                return 'far fa-save';
-                break;
-            case 'location':
-                return 'fas fa-map-marker-alt';
-                break;
-            case 'user':
-                return 'fas fa-user';
-                break;
+    public static function AgeFormat($date) {
+        $year = Carbon::parse($date)
+            ->diff(now())->y;
+        $month = Carbon::parse($date)
+            ->diff(now())->m;
+        $days = Carbon::parse($date)
+            ->diff(now())->d;
+        $age='';
+        if ($year) {
+            $age .= $year.'y ';
+        }
+        if ($month) {
+            $age .= $month.'m ';
+        }
+        if ($days) {
+            $age .= $days.'d';
         }
 
-    }
+        return $age;
 
-
-     /*
-     * This is a shorter way to see if the app is in demo mode.
-     *
-     * This makes it cleanly available in blades and in controllers, e.g.
-     *
-     * Blade:
-     * {{ Helper::isDemoMode() ? ' disabled' : ''}} for form blades where we need to disable a form
-     *
-     * Controller:
-     * if (Helper::isDemoMode()) {
-     *      // don't allow the thing
-     * }
-     * @todo - use this everywhere else in the app where we have very long if/else config('app.lock_passwords') stuff
-     */
-    public static function isDemoMode() {
-        if (config('app.lock_passwords') === true) {
-            return true;
-            \Log::debug('app locked!');
-        }
-
-        return false;
-    }
-
-
-    /*
-     * I know it's gauche  to return a shitty HTML string, but this is just a helper and since it will be the same every single time,
-     * it seemed pretty safe to do here. Don't you judge me.
-     */
-    public static function showDemoModeFieldWarning() {
-        if (Helper::isDemoMode()) {
-            return "<p class=\"text-warning\"><i class=\"fas fa-lock\"></i>" . trans('general.feature_disabled') . "</p>";
-        }
     }
 }


### PR DESCRIPTION
# Description
When a user have a lot of status labels to show in the dashboard's pie chart (the one above), if the statuses are more than the colors we have by default (266) the pie chart doesn't show because of this out of 

I don't know if it's the proper solution, but I just added a condition to 'restart' the color index, making that the colors repeat from the beginning when show in the pie chart. This makes for 532 statuses, that seems plenty but with enough status labels the system can get to crash again... but I'm unsure how to handle it because I don't know how to return an error to the dashboard...

Fixes rollbar 17086

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP Dev server
* OS version: Debian 11