### PR TITLE
Fixed Undefined array key 266 rollbar 17086

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -334,7 +334,11 @@ class Helper
             '#92896B',
         ];
 
+        $total_colors = count($colors);
 
+        if ($index >= $total_colors) {
+            $index = $index - $total_colors;
+        }
 
         return $colors[$index];
     }


### PR DESCRIPTION
# Description

When a user have a lot of status labels to show in the dashboard's pie chart (the one above), if the statuses are more than the colors we have by default (266) the pie chart doesn't show because of this index out of range.

I don't know if it's the proper solution, but I just added a condition to 'restart' the color index, making that the colors repeat from the beginning when show in the pie chart. This makes for 532 statuses, that seems plenty but with enough status labels the system can get to crash again... but I'm unsure how to handle it because I don't know how to return an error to the dashboard...

Fixes rollbar 17086

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP Dev Server
* OS version: Debian 11
