### PR TITLE
Fixes the migration of sqlite databases

### DIFF
--- a/database/migrations/2021_04_14_180125_add_ids_to_tables.php
+++ b/database/migrations/2021_04_14_180125_add_ids_to_tables.php
@@ -22,7 +22,7 @@ class AddIdsToTables extends Migration
 
         Schema::table('password_resets', function (Blueprint $table) {
             // Add the id column to the password_resets table if it doesn't yet have one
-            if (! Schema::hasColumn('password_resets', 'id')) {
+            if (! Schema::hasColumn('password_resets', 'id') && $this->notUsingSqlite()) {
                 $table->increments('id');
             }
         });
@@ -46,5 +46,10 @@ class AddIdsToTables extends Migration
                 $table->dropColumn('id');
             }
         });
+    }
+
+    private function notUsingSqlite()
+    {
+        return Schema::connection($this->getConnection())->getConnection()->getDriverName() !== 'sqlite';
     }
 }

--- a/database/migrations/2023_02_28_173527_adds_webhook_option_to_settings_table.php
+++ b/database/migrations/2023_02_28_173527_adds_webhook_option_to_settings_table.php
@@ -13,12 +13,27 @@ class AddsWebhookOptionToSettingsTable extends Migration
      */
     public function up()
     {
+        /**
+         * So...you're probably wondering why this isn't all in one Schema::table()...
+         * Turns out we'll get the following error:
+         * "SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification."
+         * if we're running sqlite so a solution is to make multiple calls.
+         * ¯\_(ツ)_/¯
+         */
         Schema::table('settings', function (Blueprint $table) {
-                $table->string('webhook_selected')->after('slack_botname')->default('slack')->nullable();
-                $table->renameColumn('slack_botname', 'webhook_botname');
-                $table->renameColumn('slack_endpoint', 'webhook_endpoint');
-                $table->renameColumn('slack_channel', 'webhook_channel');
+            $table->string('webhook_selected')->after('slack_botname')->default('slack')->nullable();
+        });
 
+        Schema::table('settings', function (Blueprint $table) {
+            $table->renameColumn('slack_botname', 'webhook_botname');
+        });
+
+        Schema::table('settings', function (Blueprint $table) {
+            $table->renameColumn('slack_endpoint', 'webhook_endpoint');
+        });
+
+        Schema::table('settings', function (Blueprint $table) {
+            $table->renameColumn('slack_channel', 'webhook_channel');
         });
     }
 


### PR DESCRIPTION
# Description

Although we don't officially support sqlite the app can (mostly?) run just fine on it. There are two migrations that sqlite doesn't like and throws exceptions for:
- `General error: 1 Cannot add a PRIMARY KEY column (SQL: alter table "password_resets" add column "id" integer not null primary key autoincrement)`
- `SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.`

This paves the way for running local tests faster 😄 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)