### PR TITLE
Fixed #12641 - added JSON to mimes

### DIFF
--- a/app/Http/Requests/AssetFileRequest.php
+++ b/app/Http/Requests/AssetFileRequest.php
@@ -24,7 +24,7 @@ class AssetFileRequest extends Request
         $max_file_size = \App\Helpers\Helper::file_upload_max_size();
 
         return [
-          'file.*' => 'required|mimes:png,gif,jpg,svg,jpeg,doc,docx,pdf,txt,zip,rar,xls,xlsx,lic,xml,rtf,webp|max:'.$max_file_size,
+          'file.*' => 'required|mimes:png,gif,jpg,svg,jpeg,doc,docx,pdf,txt,zip,rar,xls,xlsx,lic,xml,rtf,json,webp|max:'.$max_file_size,
         ];
     }
 }

--- a/resources/views/modals/upload-file.blade.php
+++ b/resources/views/modals/upload-file.blade.php
@@ -19,7 +19,7 @@
 
                         <label class="btn btn-default">
                             {{ trans('button.select_file')  }}
-                            <input type="file" name="file[]" multiple="true" class="js-uploadFile" id="uploadFile" data-maxsize="{{ Helper::file_upload_max_size() }}" accept="image/*,.csv,.zip,.rar,.doc,.docx,.xls,.xlsx,.xml,.lic,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/plain,.pdf,application/rtf" style="display:none" required>
+                            <input type="file" name="file[]" multiple="true" class="js-uploadFile" id="uploadFile" data-maxsize="{{ Helper::file_upload_max_size() }}" accept="image/*,.csv,.zip,.rar,.doc,.docx,.xls,.xlsx,.xml,.lic,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/plain,.pdf,application/rtf,application/json" style="display:none" required>
                         </label>
 
                     </div>


### PR DESCRIPTION
Although JSON is often a `text/plain` MIME type, according to [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml), the official MIME type for JSON is `application/json`. This *should* explicitly allow JSON files as an upload type. Fixes #12641.