### PR TITLE
Use named route with params for requestable asset model links

### DIFF
--- a/resources/views/account/requestable-assets.blade.php
+++ b/resources/views/account/requestable-assets.blade.php
@@ -113,7 +113,7 @@
 
                                                 <td>
                                                     @can('view', \App\Models\AssetModel::class)
-                                                        <a href="{{ url('/') }}'/models/'.{{ $requestableModel->id }}) }}">{{ $requestableModel->name }}</a>
+                                                        <a href="{{ route('models.show', ['model' => $requestableModel->id]) }}">{{ $requestableModel->name }}</a>
                                                     @else
                                                         {{ $requestableModel->name }}
                                                     @endcan


### PR DESCRIPTION
This fixes #12742 where we were improperly constructing the model URL in the requestable asset models tab.