### PR TITLE
Fixes translation strong for "group not found" error

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -92,7 +92,7 @@ class GroupsController extends Controller
             return view('groups.edit', compact('group', 'permissions', 'selected_array', 'groupPermissions'));
         }
 
-        return redirect()->route('groups.index')->with('error', trans('admin/groups/message.group_not_found'));
+        return redirect()->route('groups.index')->with('error', trans('admin/groups/message.group_not_found', ['id' => $id]));
     }
 
     /**
@@ -107,7 +107,7 @@ class GroupsController extends Controller
     public function update(Request $request, $id = null)
     {
         if (! $group = Group::find($id)) {
-            return redirect()->route('groups.index')->with('error', trans('admin/groups/message.group_not_found', compact('id')));
+            return redirect()->route('groups.index')->with('error', trans('admin/groups/message.group_not_found', ['id' => $id]));
         }
         $group->name = $request->input('name');
         $group->permissions = json_encode($request->input('permission'));
@@ -133,14 +133,13 @@ class GroupsController extends Controller
      * @return \Illuminate\Http\RedirectResponse
      * @throws \Exception
      */
-    public function destroy($id = null)
+    public function destroy($id)
     {
         if (! config('app.lock_passwords')) {
             if (! $group = Group::find($id)) {
-                return redirect()->route('groups.index')->with('error', trans('admin/groups/message.group_not_found', compact('id')));
+                return redirect()->route('groups.index')->with('error', trans('admin/groups/message.group_not_found', ['id' => $id]));
             }
             $group->delete();
-            // Redirect to the group management page
             return redirect()->route('groups.index')->with('success', trans('admin/groups/message.success.delete'));
         }
 
@@ -164,6 +163,6 @@ class GroupsController extends Controller
             return view('groups/view', compact('group'));
         }
 
-        return redirect()->route('groups.index')->with('error', trans('admin/groups/message.group_not_found', compact('id')));
+        return redirect()->route('groups.index')->with('error', trans('admin/groups/message.group_not_found', ['id' => $id]));
     }
 }

--- a/resources/lang/en/admin/groups/message.php
+++ b/resources/lang/en/admin/groups/message.php
@@ -3,7 +3,7 @@
 return array(
 
     'group_exists'        => 'Group already exists!',
-    'group_not_found'     => 'Group [:id] does not exist.',
+    'group_not_found'     => 'Group ID :id does not exist.',
     'group_name_required' => 'The name field is required',
 
     'success' => array(

--- a/resources/views/groups/index.blade.php
+++ b/resources/views/groups/index.blade.php
@@ -43,7 +43,7 @@
               <tr>
                <th data-switchable="true" data-sortable="true" data-field="id" data-visible="false">{{ trans('general.id') }}</th>
                <th data-switchable="true" data-sortable="true" data-field="name" data-formatter="groupsAdminLinkFormatter" data-visible="true">{{ trans('admin/groups/table.name') }}</th>
-               <th data-switchable="true" data-sortable="true" data-field="users_count" data-visible="true">{{ trans('admin/groups/table.users') }}</th>
+                  <th data-switchable="true" data-sortable="true" data-field="users_count" data-visible="true"><i class="fas fa-user" aria-hidden="true"></i><span class="sr-only">{{ trans('admin/groups/table.users') }}</span></th>
                <th data-switchable="true" data-sortable="true" data-field="created_at" data-visible="true" data-formatter="dateDisplayFormatter">{{ trans('general.created_at') }}</th>
                <th data-switchable="false" data-searchable="false" data-sortable="false" data-field="actions"   data-formatter="groupsActionsFormatter">{{ trans('table.actions') }}</th>
               </tr>


### PR DESCRIPTION
This corrects the language string that displays when a group is not found, and also switches to use a user icon in the header to make it more consistent with the rest of the Snipe-IT UI.

### Before:
<img width="313" alt="Screenshot 2023-03-28 at 4 36 28 PM" src="https://user-images.githubusercontent.com/197404/228390729-ce4133d4-dc23-4d5f-a6a4-cda86d5b87b6.png">

### After:
<img width="362" alt="Screenshot 2023-03-28 at 4 36 21 PM" src="https://user-images.githubusercontent.com/197404/228390726-14bab42c-7193-4662-829a-1f7a320dc82b.png">

