### PR TITLE
Fixed Integrity Constraint Violation: Column `requestable` Cannot be Null [sc-20566]

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -115,6 +115,7 @@ class Asset extends Depreciable
         'purchase_cost'   => 'numeric|nullable|gte:0',
         'supplier_id'     => 'exists:suppliers,id|nullable',
         'asset_eol_date'  => 'date|max:10|min:10|nullable',
+        'requestable'     => 'required',
     ];
 
   /**

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -115,7 +115,7 @@ class Asset extends Depreciable
         'purchase_cost'   => 'numeric|nullable|gte:0',
         'supplier_id'     => 'exists:suppliers,id|nullable',
         'asset_eol_date'  => 'date|max:10|min:10|nullable',
-        'requestable'     => 'required',
+        'requestable'     => 'required|boolean',
     ];
 
   /**


### PR DESCRIPTION
# Description
In the AssetsController:store method from the API when we get the `requestable` parameter, we guard against the parameter to not be present, so we save a falsy value in the database (0 in that case). But if the user pass a `{"requestable": null}` to the JSON data the system crash. So in this PR I added a rule to the Asset Model that makes it required, making the API return an error if this happens.

Also I noted that the docs say `requestable` is a boolean field so I added that rule to the Asset Model too. I tested with values evaluated as boolean (1, 0, true, false) and the functionality is the same, but before it also accept whatever kind of integer value.

Fixes [sc-20566]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
