### PR TITLE
Fixed #8208, #8896, #8985 and #9789:  Currency issues when using non-english locales (resubmission)

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -77,7 +77,7 @@ class AccessoriesController extends Controller
         $accessory->manufacturer_id         = request('manufacturer_id');
         $accessory->model_number            = request('model_number');
         $accessory->purchase_date           = request('purchase_date');
-        $accessory->purchase_cost           = Helper::ParseCurrency(request('purchase_cost'));
+        $accessory->purchase_cost           = request('purchase_cost');
         $accessory->qty                     = request('qty');
         $accessory->user_id                 = Auth::user()->id;
         $accessory->supplier_id             = request('supplier_id');
@@ -180,7 +180,7 @@ class AccessoriesController extends Controller
             $accessory->order_number = request('order_number');
             $accessory->model_number = request('model_number');
             $accessory->purchase_date = request('purchase_date');
-            $accessory->purchase_cost = Helper::ParseCurrency(request('purchase_cost'));
+            $accessory->purchase_cost = request('purchase_cost');
             $accessory->qty = request('qty');
             $accessory->supplier_id = request('supplier_id');
             $accessory->notes = request('notes');

--- a/app/Http/Controllers/Api/AssetMaintenancesController.php
+++ b/app/Http/Controllers/Api/AssetMaintenancesController.php
@@ -121,7 +121,7 @@ class AssetMaintenancesController extends Controller
         $assetMaintenance = new AssetMaintenance();
         $assetMaintenance->supplier_id = $request->input('supplier_id');
         $assetMaintenance->is_warranty = $request->input('is_warranty');
-        $assetMaintenance->cost =  Helper::ParseCurrency($request->input('cost'));
+        $assetMaintenance->cost =  $request->input('cost');
         $assetMaintenance->notes = e($request->input('notes'));
         $asset = Asset::find(e($request->input('asset_id')));
 
@@ -178,7 +178,7 @@ class AssetMaintenancesController extends Controller
 
         $assetMaintenance->supplier_id = e($request->input('supplier_id'));
         $assetMaintenance->is_warranty = e($request->input('is_warranty'));
-        $assetMaintenance->cost =  Helper::ParseCurrency($request->input('cost'));
+        $assetMaintenance->cost =  $request->input('cost');
         $assetMaintenance->notes = e($request->input('notes'));
 
         $asset = Asset::find(request('asset_id'));

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -554,7 +554,7 @@ class AssetsController extends Controller
         $asset->depreciate              = '0';
         $asset->status_id               = $request->get('status_id', 0);
         $asset->warranty_months         = $request->get('warranty_months', null);
-        $asset->purchase_cost           = Helper::ParseCurrency($request->get('purchase_cost')); // this is the API's store method, so I don't know that I want to do this? Confusing. FIXME (or not?!)
+        $asset->purchase_cost           = $request->get('purchase_cost'); // this is the API's store method, so I don't know that I want to do this? Confusing. FIXME (or not?!)
         $asset->purchase_date           = $request->get('purchase_date', null);
         $asset->assigned_to             = $request->get('assigned_to', null);
         $asset->supplier_id             = $request->get('supplier_id');

--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -101,7 +101,7 @@ class AssetMaintenancesController extends Controller
         $assetMaintenance = new AssetMaintenance();
         $assetMaintenance->supplier_id = $request->input('supplier_id');
         $assetMaintenance->is_warranty = $request->input('is_warranty');
-        $assetMaintenance->cost = Helper::ParseCurrency($request->input('cost'));
+        $assetMaintenance->cost = $request->input('cost');
         $assetMaintenance->notes = $request->input('notes');
         $asset = Asset::find($request->input('asset_id'));
 
@@ -211,7 +211,7 @@ class AssetMaintenancesController extends Controller
 
         $assetMaintenance->supplier_id = $request->input('supplier_id');
         $assetMaintenance->is_warranty = $request->input('is_warranty');
-        $assetMaintenance->cost =  Helper::ParseCurrency($request->input('cost'));
+        $assetMaintenance->cost =  $request->input('cost');
         $assetMaintenance->notes = $request->input('notes');
 
         $asset = Asset::find(request('asset_id'));

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -140,7 +140,7 @@ class AssetsController extends Controller
             $asset->depreciate              = '0';
             $asset->status_id               = request('status_id');
             $asset->warranty_months         = request('warranty_months', null);
-            $asset->purchase_cost           = Helper::ParseCurrency($request->get('purchase_cost'));
+            $asset->purchase_cost           = $request->get('purchase_cost');
             $asset->purchase_date           = request('purchase_date', null);
             $asset->asset_eol_date          = request('asset_eol_date', null);
             $asset->assigned_to             = request('assigned_to', null);
@@ -312,7 +312,7 @@ class AssetsController extends Controller
 
         $asset->status_id = $request->input('status_id', null);
         $asset->warranty_months = $request->input('warranty_months', null);
-        $asset->purchase_cost = Helper::ParseCurrency($request->input('purchase_cost', null));
+        $asset->purchase_cost = $request->input('purchase_cost', null);
         $asset->asset_eol_date  = request('asset_eol_date', null);
 
         $asset->purchase_date = $request->input('purchase_date', null);

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -135,7 +135,7 @@ class BulkAssetsController extends Controller
                 }
 
                 if ($request->filled('purchase_cost')) {
-                    $this->update_array['purchase_cost'] =  Helper::ParseCurrency($request->input('purchase_cost'));
+                    $this->update_array['purchase_cost'] =  $request->input('purchase_cost');
                 }
 
                 if ($request->filled('company_id')) {

--- a/app/Http/Controllers/Components/ComponentsController.php
+++ b/app/Http/Controllers/Components/ComponentsController.php
@@ -77,7 +77,7 @@ class ComponentsController extends Controller
         $component->min_amt                = $request->input('min_amt', null);
         $component->serial                 = $request->input('serial', null);
         $component->purchase_date          = $request->input('purchase_date', null);
-        $component->purchase_cost          = Helper::ParseCurrency($request->input('purchase_cost', null));
+        $component->purchase_cost          = $request->input('purchase_cost', null);
         $component->qty                    = $request->input('qty');
         $component->user_id                = Auth::id();
         $component->notes                  = $request->input('notes');
@@ -151,7 +151,7 @@ class ComponentsController extends Controller
         $component->min_amt                = $request->input('min_amt');
         $component->serial                 = $request->input('serial');
         $component->purchase_date          = $request->input('purchase_date');
-        $component->purchase_cost          = Helper::ParseCurrency(request('purchase_cost'));
+        $component->purchase_cost          = request('purchase_cost');
         $component->qty                    = $request->input('qty');
         $component->notes                  = $request->input('notes');
 

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -76,7 +76,7 @@ class ConsumablesController extends Controller
         $consumable->model_number           = $request->input('model_number');
         $consumable->item_no                = $request->input('item_no');
         $consumable->purchase_date          = $request->input('purchase_date');
-        $consumable->purchase_cost          = Helper::ParseCurrency($request->input('purchase_cost'));
+        $consumable->purchase_cost          = $request->input('purchase_cost');
         $consumable->qty                    = $request->input('qty');
         $consumable->user_id                = Auth::id();
         $consumable->notes                  = $request->input('notes');
@@ -152,7 +152,7 @@ class ConsumablesController extends Controller
         $consumable->model_number           = $request->input('model_number');
         $consumable->item_no                = $request->input('item_no');
         $consumable->purchase_date          = $request->input('purchase_date');
-        $consumable->purchase_cost          = Helper::ParseCurrency($request->input('purchase_cost'));
+        $consumable->purchase_cost          = $request->input('purchase_cost');
         $consumable->qty                    = Helper::ParseFloat($request->input('qty'));
         $consumable->notes                  = $request->input('notes');
 

--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -86,7 +86,7 @@ class LicensesController extends Controller
         $license->name              = $request->input('name');
         $license->notes             = $request->input('notes');
         $license->order_number      = $request->input('order_number');
-        $license->purchase_cost     = Helper::ParseCurrency($request->input('purchase_cost'));
+        $license->purchase_cost     = $request->input('purchase_cost');
         $license->purchase_date     = $request->input('purchase_date');
         $license->purchase_order    = $request->input('purchase_order');
         $license->purchase_order    = $request->input('purchase_order');
@@ -164,7 +164,7 @@ class LicensesController extends Controller
         $license->name              = $request->input('name');
         $license->notes             = $request->input('notes');
         $license->order_number      = $request->input('order_number');
-        $license->purchase_cost     = Helper::ParseCurrency($request->input('purchase_cost'));
+        $license->purchase_cost     = $request->input('purchase_cost');
         $license->purchase_date     = $request->input('purchase_date');
         $license->purchase_order    = $request->input('purchase_order');
         $license->reassignable      = $request->input('reassignable', 0);

--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -95,8 +95,8 @@ class AssetMaintenance extends Model implements ICompanyableChild
      */
     public function setCostAttribute($value)
     {
-        $value = Helper::ParseFloat($value);
-        if ($value == '0.0') {
+        $value = Helper::ParseCurrency($value);
+        if ($value == 0) {
             $value = null;
         }
         $this->attributes['cost'] = $value;

--- a/app/Models/SnipeModel.php
+++ b/app/Models/SnipeModel.php
@@ -21,9 +21,9 @@ class SnipeModel extends Model
      */
     public function setPurchaseCostAttribute($value)
     {
-        $value = Helper::ParseFloat($value);
+        $value = Helper::ParseCurrency($value);
 
-        if ($value == '0.0') {
+        if ($value == 0) {
             $value = null;
         }
         $this->attributes['purchase_cost'] = $value;


### PR DESCRIPTION
# Description

Resubmission of #11511 now with develop branch.

Uberbrady created a `ParseCurrency` method in the `Helper` class that was introduced through [pull request 10141](https://github.com/snipe/snipe-it/pull/10141). Sadly, we still had issues saving cent prices in our company and others also had these problems (#8208, #8896, #8985 and #9789)

What I noticed was that the `SnipeModel` and `AssetMaintenance` models already have setter methods (`setCostAttribute` and `setPurchaseCostAttribute` that format the input using the `ParseFloat` Helper method). So sending all the cost values from the form inputs through `Helper::ParseCurrency` in the Controllers did not help, because inside the model the values were reformatted a second time using the `Helper::ParseFloat`.

Therefore I removed all calls to `Helper::ParseCurrency` inside the controllers and instead switched the formatting methods in the `setCostAttribute` and `setPurchaseCostAttribute` methods in the models `SnipeModel` and `AssetMaintenance`.

Fixes #8208
Fixes #8896
Fixes #8985
Fixes #9789

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Saved different objects using all kind of prices.

**Test Configuration**:
* PHP version: 7.4.29
* MySQL version: MariaDB 10.4.24
* Webserver version: Apache 2.4.53
* OS version: Windows 10