### PR TITLE
Fixed Call to a member function present() on null [sc-20594]

### DIFF
--- a/resources/views/account/accept/index.blade.php
+++ b/resources/views/account/accept/index.blade.php
@@ -1,11 +1,8 @@
 @extends('layouts/default')
-@php
-  !empty($user) ? $full_name = $user->present()->full_name : $full_name = '';
-@endphp 
 
 {{-- Page title --}}
 @section('title')
-{{ trans('general.accept_assets', array('name' => $full_name)) }}
+{{ trans('general.accept_assets', array('name' => empty($user) ? '' : $user->present()->full_name)) }}
 @parent
 @stop
 

--- a/resources/views/account/accept/index.blade.php
+++ b/resources/views/account/accept/index.blade.php
@@ -1,8 +1,11 @@
 @extends('layouts/default')
+@php
+  !empty($user) ? $full_name = $user->present()->full_name : $full_name = '';
+@endphp 
 
 {{-- Page title --}}
 @section('title')
-{{ trans('general.accept_assets', array('name' => $user->present()->fullName())) }}
+{{ trans('general.accept_assets', array('name' => $full_name)) }}
 @parent
 @stop
 


### PR DESCRIPTION
# Description
For some weird reason, the `$user` variable used in the `account/accept/index.blade` view doesn't got assigned and was causing the system to crash. This variable is referring the current logged in user, so I think this error doesn't happen too frequently.

As I couldn't find the place where this variable is set, I just add an extra variable to contain the full name of the user if exists and if not an empty string. That way the view is not crashing anymore.

Fixes [sc-20594]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
