### PR TITLE
Bulk Restore from Deleted

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -334,10 +334,14 @@ class BulkAssetsController extends Controller
     }
     public function restore(Request $request) {
        $assetIds = $request->get('ids');
-       foreach ($assetIds as $key => $assetId) {
-              $asset = Asset::withTrashed()->find($assetId);
-              $asset->restore(); 
-       } 
-      return redirect()->route('hardware.index')->with('success', 'Assets Restored');
+      if (empty($assetIds)) {
+          return redirect()->route('hardware.index')->with('error', 'No Assets Selected');
+        } else {
+            foreach ($assetIds as $key => $assetId) {
+                    $asset = Asset::withTrashed()->find($assetId);
+                    $asset->restore(); 
+            } 
+        return redirect()->route('hardware.index')->with('success', 'Assets Restored');
+        }
     }
 }

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -335,13 +335,13 @@ class BulkAssetsController extends Controller
     public function restore(Request $request) {
        $assetIds = $request->get('ids');
       if (empty($assetIds)) {
-          return redirect()->route('hardware.index')->with('error', 'No Assets Selected');
+          return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.restore.nothing_updated'));
         } else {
             foreach ($assetIds as $key => $assetId) {
                     $asset = Asset::withTrashed()->find($assetId);
                     $asset->restore(); 
             } 
-        return redirect()->route('hardware.index')->with('success', 'Assets Restored');
+        return redirect()->route('hardware.index')->with('success', trans('admin/hardware/message.restore.success'));
         }
     }
 }

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -49,6 +49,7 @@ class BulkAssetsController extends Controller
                         ->with('settings', Setting::getSettings())
                         ->with('bulkedit', true)
                         ->with('count', 0);
+
                 case 'delete':
                     $assets = Asset::with('assignedTo', 'location')->find($asset_ids);
                     $assets->each(function ($asset) {
@@ -58,12 +59,13 @@ class BulkAssetsController extends Controller
                     return view('hardware/bulk-delete')->with('assets', $assets);
                    
                 case 'restore': 
-                    $assets = Asset::with('assignedTo', 'location')->find($asset_ids);
+                    $assets = Asset::withTrashed()->find($asset_ids); 
                     $assets->each(function ($asset) {
-                        $this->authorize('restore', $asset);
+                        $this->authorize('delete', $asset);
                     });
 
                     return view('hardware/bulk-restore')->with('assets', $assets);
+
                 case 'edit':
                     return view('hardware/bulk')
                         ->with('assets', $asset_ids)
@@ -336,5 +338,6 @@ class BulkAssetsController extends Controller
               $asset = Asset::withTrashed()->find($assetId);
               $asset->restore(); 
        } 
+      return redirect()->route('hardware.index')->with('success', 'Assets Restored');
     }
 }

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -56,6 +56,14 @@ class BulkAssetsController extends Controller
                     });
 
                     return view('hardware/bulk-delete')->with('assets', $assets);
+                   
+                case 'restore': 
+                    $assets = Asset::with('assignedTo', 'location')->find($asset_ids);
+                    $assets->each(function ($asset) {
+                        $this->authorize('restore', $asset);
+                    });
+
+                    return view('hardware/bulk-restore')->with('assets', $assets);
                 case 'edit':
                     return view('hardware/bulk')
                         ->with('assets', $asset_ids)
@@ -320,5 +328,13 @@ class BulkAssetsController extends Controller
         } catch (ModelNotFoundException $e) {
             return redirect()->route('hardware.bulkcheckout.show')->with('error', $e->getErrors());
         }
+        
+    }
+    public function restore(Request $request) {
+       $assetIds = $request->get('ids');
+       foreach ($assetIds as $key => $assetId) {
+              $asset = Asset::withTrashed()->find($assetId);
+              $asset->restore(); 
+       } 
     }
 }

--- a/resources/lang/en/admin/hardware/form.php
+++ b/resources/lang/en/admin/hardware/form.php
@@ -2,8 +2,11 @@
 
 return [
     'bulk_delete'		=> 'Confirm Bulk Delete Assets',
+    'bulk_restore'      => 'Confirm Bulk Restore Assets', 
   'bulk_delete_help'	=> 'Review the assets for bulk deletion below. Once deleted, these assets can be restored, but they will no longer be associated with any users they are currently assigned to.',
+  'bulk_restore_help'	=> 'Review the assets for bulk restoration below. Once restored, these assets will not be associated with any users they were previously assigned to.',
   'bulk_delete_warn'	=> 'You are about to delete :asset_count assets.',
+  'bulk_restore_warn'	=> 'You are about to restore :asset_count assets.',
     'bulk_update'		=> 'Bulk Update Assets',
     'bulk_update_help'	=> 'This form allows you to update multiple assets at once. Only fill in the fields you need to change. Any fields left blank will remain unchanged. ',
     'bulk_update_warn'	=> 'You are about to edit the properties of a single asset.|You are about to edit the properties of :asset_count assets.',

--- a/resources/lang/en/admin/hardware/form.php
+++ b/resources/lang/en/admin/hardware/form.php
@@ -2,11 +2,8 @@
 
 return [
     'bulk_delete'		=> 'Confirm Bulk Delete Assets',
-    'bulk_restore'		=> 'Confirm Bulk Restore Assets',
   'bulk_delete_help'	=> 'Review the assets for bulk deletion below. Once deleted, these assets can be restored, but they will no longer be associated with any users they are currently assigned to.',
-  'bulk_restore_help'	=> 'Review the assets for bulk deletion below. Once deleted, these assets can be restored, but they will no longer be associated with any users they are currently assigned to.',
   'bulk_delete_warn'	=> 'You are about to delete :asset_count assets.',
-  'bulk_restore_warn'	=> 'You are about to restore :asset_count assets.',
     'bulk_update'		=> 'Bulk Update Assets',
     'bulk_update_help'	=> 'This form allows you to update multiple assets at once. Only fill in the fields you need to change. Any fields left blank will remain unchanged. ',
     'bulk_update_warn'	=> 'You are about to edit the properties of a single asset.|You are about to edit the properties of :asset_count assets.',

--- a/resources/lang/en/admin/hardware/form.php
+++ b/resources/lang/en/admin/hardware/form.php
@@ -2,8 +2,11 @@
 
 return [
     'bulk_delete'		=> 'Confirm Bulk Delete Assets',
+    'bulk_restore'		=> 'Confirm Bulk Restore Assets',
   'bulk_delete_help'	=> 'Review the assets for bulk deletion below. Once deleted, these assets can be restored, but they will no longer be associated with any users they are currently assigned to.',
+  'bulk_restore_help'	=> 'Review the assets for bulk deletion below. Once deleted, these assets can be restored, but they will no longer be associated with any users they are currently assigned to.',
   'bulk_delete_warn'	=> 'You are about to delete :asset_count assets.',
+  'bulk_restore_warn'	=> 'You are about to restore :asset_count assets.',
     'bulk_update'		=> 'Bulk Update Assets',
     'bulk_update_help'	=> 'This form allows you to update multiple assets at once. Only fill in the fields you need to change. Any fields left blank will remain unchanged. ',
     'bulk_update_warn'	=> 'You are about to edit the properties of a single asset.|You are about to edit the properties of :asset_count assets.',

--- a/resources/lang/en/admin/hardware/message.php
+++ b/resources/lang/en/admin/hardware/message.php
@@ -23,6 +23,8 @@ return [
     'restore' => [
         'error'   		=> 'Asset was not restored, please try again',
         'success' 		=> 'Asset restored successfully.',
+        'bulk_success' 		=> 'Asset restored successfully.',
+        'nothing_updated'   => 'No assets were selected, so nothing was restored.', 
     ],
 
     'audit' => [

--- a/resources/views/hardware/bulk-restore.blade.php
+++ b/resources/views/hardware/bulk-restore.blade.php
@@ -1,0 +1,62 @@
+@extends('layouts/default')
+
+{{-- Page title --}}
+@section('title')
+{{ trans('admin/hardware/form.bulk_delete') }}
+@parent
+@stop
+
+@section('header_right')
+<a href="{{ URL::previous() }}" class="btn btn-primary pull-right">
+  {{ trans('general.back') }}</a>
+@stop
+
+{{-- Page content --}}
+@section('content')
+<div class="row">
+  <!-- left column -->
+  <div class="col-md-12">
+    <p>{{ trans('admin/hardware/form.bulk_delete_help') }}</p>
+    <form class="form-horizontal" method="post" action="{{ route('hardware/bulkrestore') }}" autocomplete="off" role="form">
+      {{csrf_field()}}
+      <div class="box box-default">
+        <div class="box-header with-border">
+          <h2 class="box-title" style="color: red">{{ trans('admin/hardware/form.bulk_restore_warn', ['asset_count' => count($assets)]) }}</h2>
+        </div>
+
+        <div class="box-body">
+          <table class="table table-striped table-condensed">
+            <thead>
+              <tr>
+                <td></td>
+                <td>{{ trans('admin/hardware/table.id') }}</td>
+                <td>{{ trans('admin/hardware/table.name') }}</td>
+                <td>{{ trans('admin/hardware/table.location')}}</td>
+              </tr>
+            </thead>
+            <tbody>
+              @foreach ($assets as $asset)
+              <tr>
+                <td><input type="checkbox" name="ids[]" value="{{ $asset->id }}" checked="checked"></td>
+                <td>{{ $asset->id }}</td>
+                <td>{{ $asset->present()->name() }}</td>
+                <td>
+                  @if ($asset->location)
+                  {{ $asset->location->name }}
+                  @endif
+                </td>
+              </tr>
+              @endforeach
+            </tbody>
+          </table>
+        </div><!-- /.box-body -->
+
+        <div class="box-footer text-right">
+          <a class="btn btn-link" href="{{ URL::previous() }}" method="post" enctype="multipart/form-data">{{ trans('button.cancel') }}</a>
+          <button type="submit" class="btn btn-success" id="submit-button"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('button.delete') }}</button>
+        </div><!-- /.box-footer -->
+      </div><!-- /.box -->
+    </form>
+  </div> <!-- .col-md-12-->
+</div><!--.row-->
+@stop

--- a/resources/views/hardware/bulk-restore.blade.php
+++ b/resources/views/hardware/bulk-restore.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Page title --}}
 @section('title')
-{{ trans('admin/hardware/form.bulk_delete') }}
+{{ trans('admin/hardware/form.bulk_restore') }}
 @parent
 @stop
 
@@ -16,7 +16,7 @@
 <div class="row">
   <!-- left column -->
   <div class="col-md-12">
-    <p>{{ trans('admin/hardware/form.bulk_delete_help') }}</p>
+    <p>{{ trans('admin/hardware/form.bulk_restore_help') }}</p>
     <form class="form-horizontal" method="post" action="{{ route('hardware/bulkrestore') }}" autocomplete="off" role="form">
       {{csrf_field()}}
       <div class="box box-default">
@@ -53,7 +53,7 @@
 
         <div class="box-footer text-right">
           <a class="btn btn-link" href="{{ URL::previous() }}" method="post" enctype="multipart/form-data">{{ trans('button.cancel') }}</a>
-          <button type="submit" class="btn btn-success" id="submit-button"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('button.delete') }}</button>
+          <button type="submit" class="btn btn-success" id="submit-button"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('button.restore') }}</button>
         </div><!-- /.box-footer -->
       </div><!-- /.box -->
     </form>

--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -62,14 +62,16 @@
        
           <div class="row">
             <div class="col-md-12">
+
+
               
-              @if (Request::get('status')!='Deleted')
+              {{-- @if (Request::get('status')!='Deleted') --}}
 
 
 
-                @include('partials.asset-bulk-actions')
+                @include('partials.asset-bulk-actions', ['status' => Request::get('status')])
                    
-              @endif
+              {{-- @endif --}}
 
               <table
                 data-advanced-search="true"

--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -63,16 +63,8 @@
           <div class="row">
             <div class="col-md-12">
 
-
-              
-              {{-- @if (Request::get('status')!='Deleted') --}}
-
-
-
                 @include('partials.asset-bulk-actions', ['status' => Request::get('status')])
                    
-              {{-- @endif --}}
-
               <table
                 data-advanced-search="true"
                 data-click-to-select="true"

--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -13,8 +13,10 @@
         </span>
     </label>
     <select name="bulk_actions" class="form-control select2" aria-label="bulk_actions" style="min-width: 350px;">
-        @if($status == 'Deleted')
+        @if($status ?? '' == 'Deleted')
+        @can('delete', \App\Models\Asset::class)
             <option value="restore">{{trans('button.restore')}}</option> 
+        @endcan
         @else 
         @can('update', \App\Models\Asset::class)
             <option value="edit">{{ trans('button.edit') }}</option>

--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -13,6 +13,9 @@
         </span>
     </label>
     <select name="bulk_actions" class="form-control select2" aria-label="bulk_actions" style="min-width: 350px;">
+        @if($status == 'Deleted')
+            <option value="restore">{{trans('button.restore')}}</option> 
+        @else 
         @can('update', \App\Models\Asset::class)
             <option value="edit">{{ trans('button.edit') }}</option>
         @endcan
@@ -20,6 +23,7 @@
             <option value="delete">{{ trans('button.delete') }}</option>
         @endcan
         <option value="labels" accesskey="l">{{ trans_choice('button.generate_labels', 2) }}</option>
+        @endif
     </select>
 
     <button class="btn btn-primary" id="{{ (isset($id_button)) ? $id_button : 'bulkAssetEditButton' }}" disabled>{{ trans('button.go') }}</button>

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -161,6 +161,11 @@ Route::group(
         )->name('hardware/bulkdelete');
 
         Route::post(
+            'bulkrestore',
+            [BulkAssetsController::class, 'restore']
+        )->name('hardware/bulkrestore');
+
+        Route::post(
             'bulksave',
             [BulkAssetsController::class, 'update']
         )->name('hardware/bulksave');


### PR DESCRIPTION
# Description
Translations done, this allows users to bulk restore deleted assets from the deleted view. Permission is set to users who can delete assets. 

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/7305753/228937342-7e39ab1c-acb7-43e7-bed4-e6a00860a570.png">

Restore action was added to `asset-bulk-actions.blade.php` partial - as well as an optional parameter to determine what page the partial is being called from (because displaying the restore option only makes sense on the deleted page). It's also the _only_ option that shows up on that page. 

Fixes #12613 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
Tested locally

**Test Configuration**:
* PHP version: 8.0.28
* MySQL version: 8.0.32
* Webserver version
* OS version
