### PR TITLE
Fixes potential unwanted overwrites in asset imports

### DIFF
--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -3,6 +3,7 @@
 namespace App\Http\Livewire;
 
 use App\Models\CustomField;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
 use App\Models\Import;
@@ -15,6 +16,8 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 class Importer extends Component
 {
     use AuthorizesRequests;
+
+    public bool $userIsSuperUser;
 
     public $files;
 
@@ -250,6 +253,7 @@ class Importer extends Component
     public function mount()
     {
         $this->authorize('import');
+        $this->userIsSuperUser = Auth::user()->isSuperUser();
         $this->progress = -1; // '-1' means 'don't show the progressbar'
         $this->progress_bar_class = 'progress-bar-warning';
         \Log::debug("Hey, we are calling MOUNT (in the importer-file) !!!!!!!!"); //fcuk

--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -17,8 +17,6 @@ class Importer extends Component
 {
     use AuthorizesRequests;
 
-    public bool $userIsSuperUser;
-
     public $files;
 
     public $progress; //upload progress - '-1' means don't show
@@ -253,7 +251,6 @@ class Importer extends Component
     public function mount()
     {
         $this->authorize('import');
-        $this->userIsSuperUser = Auth::user()->isSuperUser();
         $this->progress = -1; // '-1' means 'don't show the progressbar'
         $this->progress_bar_class = 'progress-bar-warning';
         \Log::debug("Hey, we are calling MOUNT (in the importer-file) !!!!!!!!"); //fcuk

--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -3,7 +3,6 @@
 namespace App\Http\Livewire;
 
 use App\Models\CustomField;
-use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
 use App\Models\Import;

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -60,7 +60,7 @@ class AssetImporter extends ItemImporter
             $asset_tag = Asset::autoincrement_asset();
         }
 
-        $asset = Asset::where(['asset_tag'=> $asset_tag])->first();
+        $asset = Asset::where(['asset_tag'=> (string) $asset_tag])->first();
         if ($asset) {
             if (! $this->updating) {
                 $this->log('A matching Asset '.$asset_tag.' already exists');

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -422,6 +422,8 @@ return [
     'merged_log_this_user_from' => 'Merged user ID :from_id (:from_username) into this user (ID :to_id - :to_username)',
     'clear_and_save'            => 'Clear & Save',
     'update_existing_values'    => 'Update Existing Values?',
+    'auto_incrementing_asset_tags_disabled_so_tags_required' => 'Generating auto-incrementing asset tags is disabled so all rows need to have the "Asset Tag" column populated.',
+    'auto_incrementing_asset_tags_enabled_so_now_assets_will_be_created' => 'Note: Generating auto-incrementing asset tags is enabled so assets will be created for rows that do not have "Asset Tag" populated. Rows that do have "Asset Tag" populated will be updated with the provided information.',
     'send_welcome_email_to_users'   => ' Send Welcome Email for new Users?',
     'back_before_importing'     => 'Backup before importing?',
     'csv_header_field'          => 'CSV Header Field',

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -354,7 +354,7 @@
                             'import-update': !!@this.update,
                             'send-welcome': !!@this.send_welcome,
                             'import-type': @this.activeFile.import_type,
-                            'A': !!@this.run_backup,
+                            'run-backup': !!@this.run_backup,
                             'column-mappings': mappings
                         }),
                         headers: {

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -156,6 +156,11 @@
                                                                         'data-minimum-results-for-search' => '-1', // Remove this if the list gets long enough that we need to search
                                                                         'data-livewire-component' => $_instance->id
                                                                     ]) }}
+                                                                    @if ($activeFile->import_type === 'asset' && $snipeSettings->auto_increment_assets == 0)
+                                                                        <span class="help-block">
+                                                                            Generating auto-incrementing asset tags is @if ($userIsSuperUser)<a href="{{ route('settings.asset_tags.index') }}">disabled</a> @else disabled @endif so all rows need to have the "Asset Tag" column populated.
+                                                                        </span>
+                                                                    @endif
                                                                 </div>
                                                             </div>
 
@@ -163,6 +168,11 @@
                                                                 <label for="update" class="col-md-9 col-md-offset-3 col-xs-12">
                                                                     <input type="checkbox" class="minimal livewire-icheck" name="update" data-livewire-component="{{ $_instance->id }}" wire:model="update">
                                                                     {{ trans('general.update_existing_values') }}
+                                                                    @if ($activeFile->import_type === 'asset' && $snipeSettings->auto_increment_assets == 1 && $update)
+                                                                        <span class="help-block">
+                                                                            Note: Generating auto-incrementing asset tags is @if ($userIsSuperUser)<a href="{{ route('settings.asset_tags.index') }}">disabled</a> @else enabled @endif so assets will be created for rows that do not have "Asset Tag" populated. Rows that do have "Asset Tag" populated will be updated with the provided information.
+                                                                        </span>
+                                                                    @endif
                                                                 </label>
                                                             </div>
 
@@ -344,7 +354,7 @@
                             'import-update': !!@this.update,
                             'send-welcome': !!@this.send_welcome,
                             'import-type': @this.activeFile.import_type,
-                            'run-backup': !!@this.run_backup,
+                            'A': !!@this.run_backup,
                             'column-mappings': mappings
                         }),
                         headers: {

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -160,22 +160,22 @@
                                                             </div>
 
                                                             <div class="form-group col-md-12">
-                                                                <label for="update" class="col-md-9 col-md-offset-3 col-xs-12" wire:ignore>
-                                                                    <input type="checkbox" class="minimal livewire-icheck" name="update" data-livewire-component="{{ $_instance->id }}">
+                                                                <label for="update" class="col-md-9 col-md-offset-3 col-xs-12">
+                                                                    <input type="checkbox" class="minimal livewire-icheck" name="update" data-livewire-component="{{ $_instance->id }}" wire:model="update">
                                                                     {{ trans('general.update_existing_values') }}
                                                                 </label>
                                                             </div>
 
                                                             <div class="form-group col-md-12">
-                                                                <label for="send_welcome" class="col-md-9 col-md-offset-3 col-xs-12" wire:ignore>
-                                                                    <input type="checkbox" class="minimal livewire-icheck" name="send_welcome" data-livewire-component="{{ $_instance->id }}">
+                                                                <label for="send_welcome" class="col-md-9 col-md-offset-3 col-xs-12">
+                                                                    <input type="checkbox" class="minimal livewire-icheck" name="send_welcome" data-livewire-component="{{ $_instance->id }}" wire:model="send_welcome">
                                                                     {{ trans('general.send_welcome_email_to_users') }}
                                                                 </label>
                                                             </div>
 
                                                             <div class="form-group col-md-12">
-                                                                <label for="run_backup" class="col-md-9 col-md-offset-3 col-xs-12" wire:ignore>
-                                                                    <input type="checkbox" class="minimal livewire-icheck" name="run_backup" data-livewire-component="{{ $_instance->id }}">
+                                                                <label for="run_backup" class="col-md-9 col-md-offset-3 col-xs-12">
+                                                                    <input type="checkbox" class="minimal livewire-icheck" name="run_backup" data-livewire-component="{{ $_instance->id }}" wire:model="run_backup">
                                                                     {{ trans('general.back_before_importing') }}
                                                                 </label>
                                                             </div>

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -158,7 +158,7 @@
                                                                     ]) }}
                                                                     @if ($activeFile->import_type === 'asset' && $snipeSettings->auto_increment_assets == 0)
                                                                         <span class="help-block">
-                                                                            Generating auto-incrementing asset tags is @if ($userIsSuperUser)<a href="{{ route('settings.asset_tags.index') }}">disabled</a> @else disabled @endif so all rows need to have the "Asset Tag" column populated.
+                                                                            {{ trans('general.auto_incrementing_asset_tags_disabled_so_tags_required') }}
                                                                         </span>
                                                                     @endif
                                                                 </div>
@@ -170,7 +170,7 @@
                                                                     {{ trans('general.update_existing_values') }}
                                                                     @if ($activeFile->import_type === 'asset' && $snipeSettings->auto_increment_assets == 1 && $update)
                                                                         <span class="help-block">
-                                                                            Note: Generating auto-incrementing asset tags is @if ($userIsSuperUser)<a href="{{ route('settings.asset_tags.index') }}">disabled</a> @else enabled @endif so assets will be created for rows that do not have "Asset Tag" populated. Rows that do have "Asset Tag" populated will be updated with the provided information.
+                                                                            {{ trans('general.auto_incrementing_asset_tags_enabled_so_now_assets_will_be_created') }}
                                                                         </span>
                                                                     @endif
                                                                 </label>


### PR DESCRIPTION
# Description

There were certain situations where querying an Asset by the tag in the importer would return an unexpected asset. 

This is because `Asset::autoincrement_asset()` returns `false` if "Generate auto-incrementing asset tags" is disabled and the subsequent call to `Asset::where(['asset_tag'=> $asset_tag])->first();` (when `$asset_tag` is `false`) would cause the `false` to be implicit converted to `0` and fire the following query:
```sql
SELECT
	*
FROM
	`assets`
WHERE (`asset_tag` = 0)
	AND `assets`.`deleted_at` IS NULL
LIMIT 1
```
which could potentially return a row where the `asset_tag` has a combination of strings and integers. To avoid this I explicitly cast the `$asset_tag` to a string.

This PR also adds `wire:model` to the checkboxes in the importer to ensure they are passed when the import is submitted to be processed.
<img width="280" alt="Checkboxes in import form" src="https://user-images.githubusercontent.com/1141514/228707259-20fd3713-54d7-45fa-9d2a-23688805c2c9.png">

Finally, a couple error messages have been added when importing assets to clarify behavior:
![Help message](https://user-images.githubusercontent.com/1141514/228707419-20116237-60bd-47d3-af8f-fc9e2413380e.png)

![Help message](https://user-images.githubusercontent.com/1141514/228708321-314134f8-4cba-4c09-8c73-85a54006f6c4.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)