### PR TITLE
Change protected $dates to casts

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -70,19 +70,6 @@ class Asset extends Depreciable
     */
     protected $injectUniqueIdentifier = true;
 
-    // We set these as protected dates so that they will be easily accessible via Carbon
-    protected $dates = [
-        'created_at',
-        'updated_at',
-        'deleted_at',
-        'purchase_date',
-        'last_checkout',
-        'expected_checkin',
-        'last_audit_date',
-        'next_audit_date'
-    ];
-
-
     protected $casts = [
         'purchase_date' => 'date',
         'last_checkout' => 'datetime',
@@ -96,6 +83,14 @@ class Asset extends Depreciable
         'rtd_company_id' => 'integer',
         'supplier_id'    => 'integer',
         'byod'           => 'boolean',
+        'created_at'     => 'datetime',
+        'updated_at'   => 'datetime',
+        'deleted_at'  => 'datetime',
+        'purchase_date' => 'datetime',
+        'last_checkout' => 'datetime',
+        'expected_checkin'  => 'datetime',
+        'last_audit_date'  => 'datetime',
+        'next_audit_date' => 'datetime',
     ];
 
     protected $rules = [

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -86,11 +86,6 @@ class Asset extends Depreciable
         'created_at'     => 'datetime',
         'updated_at'   => 'datetime',
         'deleted_at'  => 'datetime',
-        'purchase_date' => 'datetime',
-        'last_checkout' => 'datetime',
-        'expected_checkin'  => 'datetime',
-        'last_audit_date'  => 'datetime',
-        'next_audit_date' => 'datetime',
     ];
 
     protected $rules = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -73,17 +73,12 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         'location_id'  => 'integer',
         'company_id'   => 'integer',
         'vip'      => 'boolean',
+        'created_at'   => 'datetime',
+        'updated_at'   => 'datetime',
+        'deleted_at'   => 'datetime',
+        'start_date'   => 'datetime:Y-m-d',
+        'end_date'     => 'datetime:Y-m-d',
     ];
-
-
-    protected $dates = [
-        'created_at',
-        'updated_at',
-        'deleted_at',
-        'start_date' => 'date_format:Y-m-d',
-        'end_date' => 'date_format:Y-m-d',
-    ];
-
 
     /**
      * Model validation rules


### PR DESCRIPTION
# Description
Move `protected $dates` to `protected $casts` in prep for Laravel 9 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Asset and user views + api post and get for each, I can't tell any difference in data or response before and after the change. 
