### PR TITLE
Update CrowdIn configuration to allow nested translations

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -3,6 +3,7 @@
 "files": [
   {
     "source" : "/resources/lang/en/**/*.php",
-    "translation" : "/resources/lang/%locale%/%original_file_name%"
+    # https://developer.crowdin.com/configuration-file/#placeholders
+    "translation" : "/resources/lang/%locale%/**/%original_file_name%"
   }
 ]


### PR DESCRIPTION
# Description

This PR updates the app's CrowdIn configuration so that directories are included when Building and Downloading translations from [CrowdIn's UI](https://crowdin.com/project/snipe-it/translations).

Currently, the generated zip file only contains the `.php` files at the top level of each language directory.
![current output](https://user-images.githubusercontent.com/1141514/229938048-e86ad07f-22f7-49de-9119-b594e33f0ace.png)

With this PR, the directories for each language, `account`, `admin`, and `auth`, are included when the translations are [built and downloaded](https://crowdin.com/project/snipe-it/translations):
![output with this PR](https://user-images.githubusercontent.com/1141514/229938199-ee00332a-b3c9-48f9-9c6a-cda6337a4f40.png)

**Note:** the issue where the most of the resulting translations are keyed by locale (`en-US` instead of `en`) is still present and will be addressed in the near future.