### PR TITLE
Added unavailable message to prevent over-checkout of Accessories

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -78,9 +78,11 @@ class AccessoryCheckoutController extends Controller
         ]);
 
         $checkedout=DB::table('accessories_users')->where('accessory_id', '=', $accessory->id)->count();
-        $available=DB::table('accessories')->where('id', '=', $accessory->id)->first('qty');
+        $available= new Accessory();
 
-        if($checkedout >= $available->qty){
+
+
+        if($checkedout >= $available->numRemaining()){
 
             return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.unavailable'));
         }

--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -77,12 +77,11 @@ class AccessoryCheckoutController extends Controller
             'note' => $request->input('note'),
         ]);
 
-        $checkedout=DB::table('accessories_users')->where('accessory_id', '=', $accessory->id)->count();
         $available= new Accessory();
 
 
 
-        if($checkedout >= $available->numRemaining()){
+        if($available->numRemaining()<=0){
 
             return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.unavailable'));
         }

--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -77,6 +77,14 @@ class AccessoryCheckoutController extends Controller
             'note' => $request->input('note'),
         ]);
 
+        $checkedout=DB::table('accessories_users')->where('accessory_id', '=', $accessory->id)->count();
+        $available=DB::table('accessories')->where('id', '=', $accessory->id)->first('qty');
+
+        if($checkedout >= $available->qty){
+
+            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.unavailable'));
+        }
+
         DB::table('accessories_users')->where('assigned_to', '=', $accessory->assigned_to)->where('accessory_id', '=', $accessory->id)->first();
 
         event(new CheckoutableCheckedOut($accessory, $user, Auth::user(), $request->input('note')));

--- a/resources/lang/en/admin/accessories/message.php
+++ b/resources/lang/en/admin/accessories/message.php
@@ -24,6 +24,7 @@ return array(
      'checkout' => array(
         'error'   		=> 'Accessory was not checked out, please try again',
         'success' 		=> 'Accessory checked out successfully.',
+        'unavailable'   => 'Accessory is not available for checkout. Check quantity available',
         'user_does_not_exist' => 'That user is invalid. Please try again.'
     ),
 


### PR DESCRIPTION
# Description
It seems it was possible to checkout if available quantity for an accessory was 0 or below. This applies a redirect and an  unavailable message 
<img width="1765" alt="image" src="https://user-images.githubusercontent.com/47435081/230151931-00dd4b40-0313-4739-a4eb-57c3517c893c.png">

This fixes Accessories, I will be checking other categories and pushing accordingly.


Fixes #12778

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
