### PR TITLE
Added unavailable message to prevent over-checkout of Consumables

### DIFF
--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -70,10 +70,10 @@ class ConsumableCheckoutController extends Controller
             'note' => $request->input('note'),
         ]);
 
-        $checkedout=DB::table('consumables_users')->where('consumable_id', '=', $consumable->id)->count();
-        $available=DB::table('consumables')->where('id', '=', $consumable->id)->first('qty');
+        $checkedout= DB::table('consumables_users')->where('consumable_id', '=', $consumable->id)->count();
+        $available= new Consumable();
 
-        if($checkedout >= $available->qty){
+        if($checkedout >= $available->numRemaining()){
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.checkout.unavailable'));
         }
         event(new CheckoutableCheckedOut($consumable, $user, Auth::user(), $request->input('note')));

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -8,6 +8,7 @@ use App\Models\Consumable;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Input;
 
 class ConsumableCheckoutController extends Controller
@@ -69,6 +70,12 @@ class ConsumableCheckoutController extends Controller
             'note' => $request->input('note'),
         ]);
 
+        $checkedout=DB::table('consumables_users')->where('consumable_id', '=', $consumable->id)->count();
+        $available=DB::table('consumables')->where('id', '=', $consumable->id)->first('qty');
+
+        if($checkedout >= $available->qty){
+            return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.checkout.unavailable'));
+        }
         event(new CheckoutableCheckedOut($consumable, $user, Auth::user(), $request->input('note')));
 
         // Redirect to the new consumable page

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -70,10 +70,9 @@ class ConsumableCheckoutController extends Controller
             'note' => $request->input('note'),
         ]);
 
-        $checkedout= DB::table('consumables_users')->where('consumable_id', '=', $consumable->id)->count();
         $available= new Consumable();
 
-        if($checkedout >= $available->numRemaining()){
+        if($available->numRemaining()<=0){
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.checkout.unavailable'));
         }
         event(new CheckoutableCheckedOut($consumable, $user, Auth::user(), $request->input('note')));

--- a/resources/lang/en/admin/consumables/message.php
+++ b/resources/lang/en/admin/consumables/message.php
@@ -23,6 +23,7 @@ return array(
      'checkout' => array(
         'error'   		=> 'Consumable was not checked out, please try again',
         'success' 		=> 'Consumable checked out successfully.',
+        'unavailable'   => 'Consumable is not available for checkout. Check quantity available',
         'user_does_not_exist' => 'That user is invalid. Please try again.'
     ),
 


### PR DESCRIPTION
# Description
It seems it was possible to checkout if available quantity for an consumable was 0 or below. This applies a redirect and an unavailable message
<img width="1765" alt="image" src="https://user-images.githubusercontent.com/47435081/230161078-5918c3d8-9ca4-4086-b76b-2afe2633adef.png">

This fixes Consumables. checking the remaining.
Fixes #12778

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
