### PR TITLE
Not For Merge - SQLite Setup Issues Repro

### DIFF
--- a/Dockerfile.sqlite
+++ b/Dockerfile.sqlite
@@ -103,7 +103,7 @@ RUN \
       && rm -rf "/var/www/html/public/uploads" && ln -fs "/var/lib/snipeit/data/uploads" "/var/www/html/public/uploads" \
       && rm -r "/var/www/html/storage/app/backups" && ln -fs "/var/lib/snipeit/dumps" "/var/www/html/storage/app/backups" \
       && rm -r "/var/www/html/storage/logs" && ln -fs "/var/lib/snipeit/logs" "/var/www/html/storage/logs" \
-      && rm -r "/var/www/html/database" && mkdir -p "/var/www/html/database" && ln -fs "/var/lib/snipeit/database" "/var/www/html/database" \
+      && rm -r "/var/www/html/database" && mkdir -p "/var/lib/snipeit/database" && ln -fs "/var/lib/snipeit/database" "/var/www/html/database" \
       && mkdir -p "/var/lib/snipeit/keys" && ln -fs "/var/lib/snipeit/keys/oauth-private.key" "/var/www/html/storage/oauth-private.key" \
       && ln -fs "/var/lib/snipeit/keys/oauth-public.key" "/var/www/html/storage/oauth-public.key" \
       && ln -fs "/var/lib/snipeit/keys/ldap_client_tls.cert" "/var/www/html/storage/ldap_client_tls.cert" \

--- a/Dockerfile.sqlite
+++ b/Dockerfile.sqlite
@@ -1,0 +1,148 @@
+FROM ubuntu:20.04
+LABEL maintainer="Brady Wetherington <bwetherington@grokability.com>"
+
+# No need to add `apt-get clean` here, reference:
+# - https://github.com/snipe/snipe-it/pull/9201
+# - https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
+
+RUN export DEBIAN_FRONTEND=noninteractive; \
+    export DEBCONF_NONINTERACTIVE_SEEN=true; \
+    echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections; \
+    echo 'tzdata tzdata/Zones/Etc select UTC' | debconf-set-selections; \
+    apt-get update -qqy \
+ && apt-get install -qqy --no-install-recommends \
+apt-utils \
+apache2 \
+apache2-bin \
+libapache2-mod-php7.4 \
+php7.4-curl \
+php7.4-ldap \
+php7.4-mysql \
+php7.4-sqlite3 \
+php7.4-gd \
+php7.4-xml \
+php7.4-mbstring \
+php7.4-zip \
+php7.4-bcmath \
+php7.4-redis \
+php-memcached \
+patch \
+curl \
+wget  \
+vim \
+git \
+cron \
+mysql-client \
+sqlite3 \
+supervisor \
+cron \
+gcc \
+make \
+autoconf \
+libc-dev \
+pkg-config \
+libmcrypt-dev \
+php7.4-dev \
+ca-certificates \
+unzip \
+dnsutils \
+&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
+RUN curl -L -O https://github.com/pear/pearweb_phars/raw/master/go-pear.phar
+RUN php go-pear.phar
+
+RUN pecl install mcrypt-1.0.3
+
+RUN bash -c "echo extension=/usr/lib/php/20190902/mcrypt.so > /etc/php/7.4/mods-available/mcrypt.ini"
+
+RUN phpenmod mcrypt
+RUN phpenmod gd
+RUN phpenmod bcmath
+
+RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/7.4/apache2/php.ini
+RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/7.4/cli/php.ini
+
+RUN useradd -m --uid 1000 --gid 50 docker
+
+RUN echo export APACHE_RUN_USER=docker >> /etc/apache2/envvars
+RUN echo export APACHE_RUN_GROUP=staff >> /etc/apache2/envvars
+
+COPY docker/000-default.conf /etc/apache2/sites-enabled/000-default.conf
+
+#SSL
+RUN mkdir -p /var/lib/snipeit/ssl
+#COPY docker/001-default-ssl.conf /etc/apache2/sites-enabled/001-default-ssl.conf
+COPY docker/001-default-ssl.conf /etc/apache2/sites-available/001-default-ssl.conf
+
+RUN a2enmod ssl
+RUN a2ensite 001-default-ssl.conf
+
+COPY . /var/www/html
+
+RUN a2enmod rewrite
+
+COPY docker/column-statistics.cnf /etc/mysql/conf.d/column-statistics.cnf
+
+############ INITIAL APPLICATION SETUP #####################
+
+WORKDIR /var/www/html
+
+#Append to bootstrap file (less brittle than 'patch')
+# RUN sed -i 's/return $app;/$env="production";\nreturn $app;/' bootstrap/start.php
+
+#copy all configuration files
+# COPY docker/*.php /var/www/html/app/config/production/
+COPY docker/docker.env /var/www/html/.env
+
+RUN chown -R docker /var/www/html
+
+
+RUN \
+	rm -r "/var/www/html/storage/private_uploads" && ln -fs "/var/lib/snipeit/data/private_uploads" "/var/www/html/storage/private_uploads" \
+      && rm -rf "/var/www/html/public/uploads" && ln -fs "/var/lib/snipeit/data/uploads" "/var/www/html/public/uploads" \
+      && rm -r "/var/www/html/storage/app/backups" && ln -fs "/var/lib/snipeit/dumps" "/var/www/html/storage/app/backups" \
+      && rm -r "/var/www/html/storage/logs" && ln -fs "/var/lib/snipeit/logs" "/var/www/html/storage/logs" \
+      && rm -r "/var/www/html/database" && mkdir -p "/var/www/html/database" && ln -fs "/var/lib/snipeit/database" "/var/www/html/database" \
+      && mkdir -p "/var/lib/snipeit/keys" && ln -fs "/var/lib/snipeit/keys/oauth-private.key" "/var/www/html/storage/oauth-private.key" \
+      && ln -fs "/var/lib/snipeit/keys/oauth-public.key" "/var/www/html/storage/oauth-public.key" \
+      && ln -fs "/var/lib/snipeit/keys/ldap_client_tls.cert" "/var/www/html/storage/ldap_client_tls.cert" \
+      && ln -fs "/var/lib/snipeit/keys/ldap_client_tls.key" "/var/www/html/storage/ldap_client_tls.key" \
+      && chown docker "/var/lib/snipeit/keys/" \
+      && chown -h docker "/var/www/html/storage/" \
+      && chmod +x /var/www/html/artisan \
+      && echo "Finished setting up application in /var/www/html"
+
+############## DEPENDENCIES via COMPOSER ###################
+
+#global install of composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Get dependencies
+USER docker
+RUN composer install --no-dev --working-dir=/var/www/html
+USER root
+
+############### APPLICATION INSTALL/INIT #################
+
+#RUN php artisan app:install
+# too interactive! Try something else
+
+#COPY docker/app_install.exp /tmp/app_install.exp
+#RUN chmod +x /tmp/app_install.exp
+#RUN /tmp/app_install.exp
+
+############### DATA VOLUME #################
+
+VOLUME ["/var/lib/snipeit"]
+
+##### START SERVER
+
+COPY docker/startup.sh docker/supervisord.conf /
+COPY docker/supervisor-exit-event-listener /usr/bin/supervisor-exit-event-listener
+RUN chmod +x /startup.sh /usr/bin/supervisor-exit-event-listener
+
+CMD ["/startup.sh"]
+
+EXPOSE 80
+EXPOSE 443

--- a/config/database.php
+++ b/config/database.php
@@ -56,7 +56,7 @@ return [
 
         'sqlite' => [
             'driver'   => 'sqlite',
-            'database' => database_path('database.sqlite'),
+            'database' => env('DB_PATH', database_path('database.sqlite')),
             'prefix'   => '',
         ],
 

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -39,10 +39,16 @@ for dir in \
   'data/uploads/models' \
   'data/uploads/suppliers' \
   'dumps' \
+  'database' \
+  'logs' \
   'keys'
 do
   [ ! -d "/var/lib/snipeit/$dir" ] && mkdir -p "/var/lib/snipeit/$dir"
 done
+
+# Fix sqlite to run properly. It seems that the db framework won't create a new sqlite db file unless
+# it already exists so this creates the files needed.
+sqlite3 /var/lib/snipeit/database/database.sqlite "CREATE TABLE t(x INTEGER PRIMARY KEY ASC, y, z)"
 
 chown -R docker:root /var/lib/snipeit/data/*
 chown -R docker:root /var/lib/snipeit/dumps

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -47,6 +47,8 @@ done
 chown -R docker:root /var/lib/snipeit/data/*
 chown -R docker:root /var/lib/snipeit/dumps
 chown -R docker:root /var/lib/snipeit/keys
+chown -R docker:root /var/lib/snipeit/logs
+chown -R docker:root /var/lib/snipeit/database
 chown -R docker:root /var/www/html/storage/framework/cache
 
 # Fix php settings


### PR DESCRIPTION
This isn't really intended for merging, but to help @marcusmoore with some of the sqlite issues. With the rebase to develop I was able to get past some of the other migration issues we were hitting. 

Generally there are some changes to make sqlite setup easier, and to work around the issue where on first run laravel (?) can't create sqlite by default (set startup.sh). 

At this point I can get through all the migrations 🎉 but then I hit issues with user creation, but it's progress! 

To run the container:

```
 docker build -t local/snipe-it:test -f Dockerfile.sqlite .
 docker run --rm -i -t -p 8080:80 --name="snipeit" --env-file=./env --mount source=snipe-vol,dst=/var/lib/snipeit local/snipe-it:test
```

error during user create phase

```
Illuminate\Database\QueryException
SQLSTATE[HY000]: General error: 1 no such table: users (SQL: select count(*) as aggregate from "users" where "username" = jsmith)

vendor/laravel/framework/src/Illuminate/Database/Connection.php:712
```

Hopefully this allows you to reproduce locally to make it a bit easier :) 


laravel issue where unable to create db automatically

```
   Illuminate\Database\QueryException

  Database (/var/www/html/database/database.sqlite) does not exist. (SQL: select * from sqlite_master where type = 'table' and name = migrations)

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:712
    708▕         // If an exception occurs when attempting to run a query, we'll format the error
    709▕         // message to include the bindings with SQL, which will make this exception a
    710▕         // lot more helpful to the developer instead of just the database's errors.
    711▕         catch (Exception $e) {
  ➜ 712▕             throw new QueryException(
    713▕                 $query, $this->prepareBindings($bindings), $e
    714▕             );
    715▕         }
    716▕     }

      +30 vendor frames
  31  artisan:35
      Illuminate\Foundation\Console\Kernel::handle()



```