### PR TITLE
Fixed accessories verifying that enough remain to be checked out

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -25,11 +25,16 @@ class AccessoryCheckoutController extends Controller
     public function create($accessoryId)
     {
         // Check if the accessory exists
-        if (is_null($accessory = Accessory::find($accessoryId))) {
+        if (is_null($accessory = Accessory::withCount('users as users_count')->find($accessoryId))) {
             // Redirect to the accessory management page with error
             return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.not_found'));
         }
 
+        // Make sure there is at least one available to checkout
+        if ($accessory->numRemaining() <= 0){
+            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.unavailable'));
+        }
+        
         if ($accessory->category) {
             $this->authorize('checkout', $accessory);
 
@@ -55,16 +60,22 @@ class AccessoryCheckoutController extends Controller
     public function store(Request $request, $accessoryId)
     {
         // Check if the accessory exists
-        if (is_null($accessory = Accessory::find($accessoryId))) {
+        if (is_null($accessory = Accessory::withCount('users as users_count')->find($accessoryId))) {
             // Redirect to the accessory management page with error
             return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.user_not_found'));
         }
 
         $this->authorize('checkout', $accessory);
 
-        if (! $user = User::find($request->input('assigned_to'))) {
+        if (!$user = User::find($request->input('assigned_to'))) {
             return redirect()->route('accessories.checkout.show', $accessory->id)->with('error', trans('admin/accessories/message.checkout.user_does_not_exist'));
         }
+
+        // Make sure there is at least one available to checkout
+        if ($accessory->numRemaining() <= 0){
+            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.unavailable'));
+        }
+
 
         // Update the accessory data
         $accessory->assigned_to = e($request->input('assigned_to'));
@@ -76,15 +87,6 @@ class AccessoryCheckoutController extends Controller
             'assigned_to' => $request->get('assigned_to'),
             'note' => $request->input('note'),
         ]);
-
-        $available= new Accessory();
-
-
-
-        if($available->numRemaining()<=0){
-
-            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.unavailable'));
-        }
 
         DB::table('accessories_users')->where('assigned_to', '=', $accessory->assigned_to)->where('accessory_id', '=', $accessory->id)->first();
 

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -330,7 +330,11 @@ class Accessory extends SnipeModel
 
 
     /**
-     * Check how many items of an accessory remain
+     * Check how many items of an accessory remain.
+     *
+     * In order to use this model method, you MUST call withCount('users as users_count')
+     * on the eloquent query in the controller, otherwise $this->>users_count will be null and
+     * bad things happen.
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v3.0]


### PR DESCRIPTION
This fixed a bug introduced earlier today. If we forget to pass `users_count` to the `numRemaining()` method on the accessory, the value for `$this->users_count` will be 0 or null, which means it thinks it has no users. 