### PR TITLE
Echo out the array values in withInput()

### DIFF
--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -18,10 +18,14 @@
   <!-- Asset Tag -->
   <div class="form-group {{ $errors->has('asset_tag') ? ' has-error' : '' }}">
     <label for="asset_tag" class="col-md-3 control-label">{{ trans('admin/hardware/form.tag') }}</label>
-    
-      <!-- we are editing an existing asset -->
+
+
+
       @if  ($item->id)
+          <!-- we are editing an existing asset,  there will be only one asset tag -->
           <div class="col-md-7 col-sm-12{{  (Helper::checkIfRequired($item, 'asset_tag')) ? ' required' : '' }}">
+
+
           <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ old('asset_tag', $item->asset_tag) }}" data-validation="required">
               {!! $errors->first('asset_tags', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
               {!! $errors->first('asset_tag', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
@@ -29,7 +33,7 @@
       @else
           <!-- we are creating a new asset - let people use more than one asset tag -->
           <div class="col-md-7 col-sm-12{{  (Helper::checkIfRequired($item, 'asset_tag')) ? ' required' : '' }}">
-              <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ old('asset_tag', \App\Models\Asset::autoincrement_asset()) }}" data-validation="required">
+              <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ old('asset_tags.1', \App\Models\Asset::autoincrement_asset()) }}" data-validation="required">
               {!! $errors->first('asset_tags', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
               {!! $errors->first('asset_tag', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
           </div>
@@ -40,11 +44,8 @@
           </div>
       @endif
   </div>
-    
 
-
-
-    @include ('partials.forms.edit.serial', ['fieldname'=> 'serials[1]', 'translated_serial' => trans('admin/hardware/form.serial')])
+    @include ('partials.forms.edit.serial', ['fieldname'=> 'serials[1]', 'old_val_name' => 'serials.1', 'translated_serial' => trans('admin/hardware/form.serial')])
 
     <div class="input_fields_wrap">
     </div>

--- a/resources/views/partials/forms/edit/serial.blade.php
+++ b/resources/views/partials/forms/edit/serial.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('serial') ? ' has-error' : '' }}">
     <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ trans('admin/hardware/form.serial') }} </label>
     <div class="col-md-7 col-sm-12{{  (Helper::checkIfRequired($item, 'serial')) ? ' required' : '' }}">
-        <input class="form-control" type="text" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old('serial', $item->serial) }}" />
+        <input class="form-control" type="text" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old((isset($old_val_name) ? $old_val_name : $fieldname), $item->serial) }}" />
         {!! $errors->first('serial', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>


### PR DESCRIPTION
This was brought to my attention on Discord today - if you fail validation from a custom field requirement (which isn't included in the JS validation stuff, which is why it's possible to submit the form with missing/wrong fields for custom fields only), the form gets echoed back without the asset tag (if you're not using auto-incrementing tags) or serial. 

This is because of how Laravel handles the `old()` stuff in `withInput()` when you're using array inputs (we use array inputs because you can create several assets on that screen, each with their own asset tag and serial number.)

While the fieldname is `asset_tags[1]`, the `old()` input helper wants it in dot-notation, as in `old('asset_tags.1')` and it won't echo it our properly if you use the standard array format. This fix is hopefully temporary, as we convert as much of the asset form into livewire as we can, but this seems to do the trick.

### To test:

- Turn off auto-incrementing tags
- Create an asset and leave out a required custom field (or bungle the format for mac address, etc)
- See if the page maintains your asset tag and serial number on the re-presented create form with errors
- Repeat with editing an asset

Note: this is not expected to re-populate additional asset tags and serials if you tried to create multiple - but it never worked that way, so this is still better than it was. That seems like a job for Livewire. 

We do use that serial partial in one other place (components) and I tested that and it seems to be fine.