### PR TITLE
Maintain activated state on editing a user

### DIFF
--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -74,7 +74,6 @@ class UsersController extends Controller
         $permissions = $this->filterDisplayable($permissions);
 
         $user = new User;
-        $user->activated = 1;
 
         return view('users/edit', compact('groups', 'userGroups', 'permissions', 'userPermissions'))
             ->with('user', $user);

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -227,7 +227,7 @@
                               @else
                                   <!-- everything is normal - as you were -->
                                   <label class="form-control">
-                                      {{ Form::checkbox('activated', '1', old('activated'), ['id' => 'activated', 'checked'=> 'checked', 'aria-label'=>'update_real_loc']) }}
+                                      <input type="checkbox" value="1" name="activated"{{ ((old('activated') == '1') || ($user->activated) == '1') ? ' checked="checked"' : '' }} aria-label="activated" id="activated">
                                       {{ trans('admin/users/general.activated_help_text') }}
                                   </label>
                               @endif


### PR DESCRIPTION
This fixes an issue where editing the user would re-check the checkbox for login enabled. 