### PR TITLE
Fixed #12822 - Missing translation on bulk edit user submit button 

### DIFF
--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -178,7 +178,7 @@
 
                         <button type="submit" class="btn btn-success"{{ (config('app.lock_passwords') ? ' disabled' : '') }}>
                             <i class="fas fa-check icon-white" aria-hidden="true"></i>
-                            {{ trans('button.update') }}
+                            {{ trans('general.update') }}
                         </button>
 
                     </div><!-- /.box-footer -->


### PR DESCRIPTION
Wrong button label for bulk edit users. Fixed #12822