### PR TITLE
Better handling for weird data passed to the API via limit and offset

### DIFF
--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -80,12 +80,9 @@ class AccessoriesController extends Controller
             $accessories->where('notes','=',$request->input('notes'));
         }
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($accessories) && ($request->get('offset') > $accessories->count())) ? $accessories->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $accessories->count()) ? $accessories->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort_override =  $request->input('sort');

--- a/app/Http/Controllers/Api/AssetMaintenancesController.php
+++ b/app/Http/Controllers/Api/AssetMaintenancesController.php
@@ -55,12 +55,9 @@ class AssetMaintenancesController extends Controller
         }
 
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($maintenances) && ($request->get('offset') > $maintenances->count())) ? $maintenances->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $maintenances->count()) ? $maintenances->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $allowed_columns = [
                                 'id',

--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -78,12 +78,9 @@ class AssetModelsController extends Controller
             $assetmodels->TextSearch($request->input('search'));
         }
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($assetmodels) && ($request->get('offset') > $assetmodels->count())) ? $assetmodels->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $assetmodels->count()) ? $assetmodels->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'models.created_at';

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -199,13 +199,9 @@ class AssetsController extends Controller
 
         $request->filled('order_number') ? $assets = $assets->where('assets.order_number', '=', e($request->get('order_number'))) : '';
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($assets) && ($request->get('offset') > $assets->count())) ? $assets->count() : $request->get('offset', 0);
-
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $assets->count()) ? $assets->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
 

--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -95,12 +95,9 @@ class CategoriesController extends Controller
 
 
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($categories) && ($request->get('offset') > $categories->count())) ? $categories->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $categories->count()) ? $categories->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'assets_count';

--- a/app/Http/Controllers/Api/CompaniesController.php
+++ b/app/Http/Controllers/Api/CompaniesController.php
@@ -48,12 +48,9 @@ class CompaniesController extends Controller
         }
 
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($companies) && ($request->get('offset') > $companies->count())) ? $companies->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $companies->count()) ? $companies->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';

--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -72,12 +72,9 @@ class ComponentsController extends Controller
             $components->where('notes','=',$request->input('notes'));
         }
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($components) && ($request->get('offset') > $components->count())) ? $components->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $components->count()) ? $components->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -84,12 +84,9 @@ class ConsumablesController extends Controller
         }
 
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($consumables) && ($request->get('offset') > $consumables->count())) ? $consumables->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $consumables->count()) ? $consumables->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $allowed_columns = ['id', 'name', 'order_number', 'min_amt', 'purchase_date', 'purchase_cost', 'company', 'category', 'model_number', 'item_no', 'manufacturer', 'location', 'qty', 'image'];
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';

--- a/app/Http/Controllers/Api/DepartmentsController.php
+++ b/app/Http/Controllers/Api/DepartmentsController.php
@@ -58,12 +58,9 @@ class DepartmentsController extends Controller
             $departments->where('location_id', '=', $request->input('location_id'));
         }
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($departments) && ($request->get('offset') > $departments->count())) ? $departments->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $departments->count()) ? $departments->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';

--- a/app/Http/Controllers/Api/DepreciationsController.php
+++ b/app/Http/Controllers/Api/DepreciationsController.php
@@ -28,12 +28,9 @@ class DepreciationsController extends Controller
             $depreciations = $depreciations->TextSearch($request->input('search'));
         }
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($depreciations) && ($request->get('offset') > $depreciations->count())) ? $depreciations->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $depreciations->count()) ? $depreciations->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';

--- a/app/Http/Controllers/Api/GroupsController.php
+++ b/app/Http/Controllers/Api/GroupsController.php
@@ -35,12 +35,9 @@ class GroupsController extends Controller
             $groups->where('name', '=', $request->input('name'));
         }
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($groups) && ($request->get('offset') > $groups->count())) ? $groups->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $groups->count()) ? $groups->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';

--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -39,8 +39,11 @@ class LicenseSeatsController extends Controller
             }
 
             $total = $seats->count();
-            $offset = (($seats) && (request('offset') >= $total)) ? 0 : request('offset', 0);
-            $limit = request('limit', 50);
+
+            // Make sure the offset and limit are actually integers and do not exceed system limits
+            $offset = ($request->input('offset') > $seats->count()) ? $seats->count() : intval(request('offset'));
+            $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
+
 
             $seats = $seats->skip($offset)->take($limit)->get();
 

--- a/app/Http/Controllers/Api/LicensesController.php
+++ b/app/Http/Controllers/Api/LicensesController.php
@@ -94,12 +94,9 @@ class LicensesController extends Controller
             $licenses->onlyTrashed();
         }
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($licenses) && ($request->get('offset') > $licenses->count())) ? $licenses->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $licenses->count()) ? $licenses->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
 

--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -78,13 +78,13 @@ class LocationsController extends Controller
             $locations->where('locations.country', '=', $request->input('country'));
         }
 
-        $offset = (($locations) && (request('offset') > $locations->count())) ? $locations->count() : request('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $locations->count()) ? $locations->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';
+
 
         switch ($request->input('sort')) {
             case 'parent':

--- a/app/Http/Controllers/Api/ManufacturersController.php
+++ b/app/Http/Controllers/Api/ManufacturersController.php
@@ -57,12 +57,9 @@ class ManufacturersController extends Controller
             $manufacturers->where('support_email', '=', $request->input('support_email'));
         }
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($manufacturers) && ($request->get('offset') > $manufacturers->count())) ? $manufacturers->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $manufacturers->count()) ? $manufacturers->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';

--- a/app/Http/Controllers/Api/PredefinedKitsController.php
+++ b/app/Http/Controllers/Api/PredefinedKitsController.php
@@ -29,8 +29,10 @@ class PredefinedKitsController extends Controller
             $kits = $kits->TextSearch($request->input('search'));
         }
 
-        $offset = $request->input('offset', 0);
-        $limit = $request->input('limit', 50);
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $kits->count()) ? $kits->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
+
         $order = $request->input('order') === 'desc' ? 'desc' : 'asc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'name';
         $kits->orderBy($sort, $order);

--- a/app/Http/Controllers/Api/ReportsController.php
+++ b/app/Http/Controllers/Api/ReportsController.php
@@ -54,14 +54,14 @@ class ReportsController extends Controller
             'note',
         ];
 
+
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $actionlogs->count()) ? $actionlogs->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
+
         $sort = in_array($request->input('sort'), $allowed_columns) ? e($request->input('sort')) : 'created_at';
         $order = ($request->input('order') == 'asc') ? 'asc' : 'desc';
-        $offset = request('offset', 0);
         $total = $actionlogs->count();
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
-
 
         $actionlogs = $actionlogs->orderBy($sort, $order)->skip($offset)->take($limit)->get();
 

--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -50,12 +50,9 @@ class StatuslabelsController extends Controller
             }
         }
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($statuslabels) && ($request->get('offset') > $statuslabels->count())) ? $statuslabels->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $statuslabels->count()) ? $statuslabels->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';

--- a/app/Http/Controllers/Api/SuppliersController.php
+++ b/app/Http/Controllers/Api/SuppliersController.php
@@ -74,12 +74,9 @@ class SuppliersController extends Controller
             $suppliers->where('notes', '=', $request->input('notes'));
         }
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($suppliers) && ($request->get('offset') > $suppliers->count())) ? $suppliers->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $suppliers->count()) ? $suppliers->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'created_at';

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -193,12 +193,9 @@ class UsersController extends Controller
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
 
-        // Set the offset to the API call's offset, unless the offset is higher than the actual count of items in which
-        // case we override with the actual count, so we should return 0 items.
-        $offset = (($users) && ($request->get('offset') > $users->count())) ? $users->count() : $request->get('offset', 0);
-
-        // Check to make sure the limit is not higher than the max allowed
-        ((config('app.max_results') >= $request->input('limit')) && ($request->filled('limit'))) ? $limit = $request->input('limit') : $limit = config('app.max_results');
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $users->count()) ? $users->count() : intval(request('offset'));
+        $limit = ($request->input('limit') > config('app.max_results')) ? config('app.max_results') : max(intval(request('offset')),  config('app.max_results'));
 
 
         switch ($request->input('sort')) {


### PR DESCRIPTION
So, every now and then, people think they're cute and they start passing bad data to the API to see how it breaks. Currently it will just return a 500 error, which is fine I suppose, but it tends to poop all over our logging system. 

This should set us up with sane default, while also still making sure that you're never going to get more results than the `MAX_RESULTS` in the `.env`.

When I had some debugging code in there, I tested this with multiple different URL parameters, and the numbers all look the way I'd expect:

```
[2023-04-12 11:58:32] local.DEBUG: Max Results: 200
[2023-04-12 11:58:32] local.DEBUG: Original Requested Limit: 10
[2023-04-12 11:58:32] local.DEBUG: Intval Limit: 10
[2023-04-12 11:58:32] local.DEBUG: Modified Limit: 10
[2023-04-12 11:58:32] local.DEBUG: Original Requested Offset: -2
[2023-04-12 11:58:32] local.DEBUG: Modified Offset: 0
[2023-04-12 11:58:32] local.DEBUG: Total Results: 209
[2023-04-12 11:58:32] local.DEBUG: -----------------------------
[2023-04-12 11:58:35] local.DEBUG: Max Results: 200
[2023-04-12 11:58:35] local.DEBUG: Original Requested Limit: 10
[2023-04-12 11:58:35] local.DEBUG: Intval Limit: 10
[2023-04-12 11:58:35] local.DEBUG: Modified Limit: 10
[2023-04-12 11:58:35] local.DEBUG: Original Requested Offset: -20
[2023-04-12 11:58:35] local.DEBUG: Modified Offset: 0
[2023-04-12 11:58:35] local.DEBUG: Total Results: 209
[2023-04-12 11:58:35] local.DEBUG: -----------------------------
[2023-04-12 11:58:37] local.DEBUG: Max Results: 200
[2023-04-12 11:58:37] local.DEBUG: Original Requested Limit: 100
[2023-04-12 11:58:37] local.DEBUG: Intval Limit: 100
[2023-04-12 11:58:37] local.DEBUG: Modified Limit: 100
[2023-04-12 11:58:37] local.DEBUG: Original Requested Offset: -20
[2023-04-12 11:58:37] local.DEBUG: Modified Offset: 0
[2023-04-12 11:58:37] local.DEBUG: Total Results: 209
[2023-04-12 11:58:37] local.DEBUG: -----------------------------
[2023-04-12 11:58:40] local.DEBUG: Max Results: 200
[2023-04-12 11:58:40] local.DEBUG: Original Requested Limit: 1000
[2023-04-12 11:58:40] local.DEBUG: Intval Limit: 1000
[2023-04-12 11:58:40] local.DEBUG: Modified Limit: 200
[2023-04-12 11:58:40] local.DEBUG: Original Requested Offset: -20
[2023-04-12 11:58:40] local.DEBUG: Modified Offset: 0
[2023-04-12 11:58:40] local.DEBUG: Total Results: 209
[2023-04-12 11:58:40] local.DEBUG: -----------------------------
[2023-04-12 11:58:43] local.DEBUG: Max Results: 200
[2023-04-12 11:58:43] local.DEBUG: Original Requested Limit: -1000
[2023-04-12 11:58:43] local.DEBUG: Intval Limit: -1000
[2023-04-12 11:58:43] local.DEBUG: Modified Limit: 1
[2023-04-12 11:58:43] local.DEBUG: Original Requested Offset: -20
[2023-04-12 11:58:43] local.DEBUG: Modified Offset: 0
[2023-04-12 11:58:43] local.DEBUG: Total Results: 209
[2023-04-12 11:58:43] local.DEBUG: -----------------------------
[2023-04-12 11:58:47] local.DEBUG: Max Results: 200
[2023-04-12 11:58:47] local.DEBUG: Original Requested Limit: -1000
[2023-04-12 11:58:47] local.DEBUG: Intval Limit: -1000
[2023-04-12 11:58:47] local.DEBUG: Modified Limit: 1
[2023-04-12 11:58:47] local.DEBUG: Original Requested Offset: farts
[2023-04-12 11:58:47] local.DEBUG: Modified Offset: 0
[2023-04-12 11:58:47] local.DEBUG: Total Results: 209
[2023-04-12 11:58:47] local.DEBUG: -----------------------------
[2023-04-12 11:58:53] local.DEBUG: Max Results: 200
[2023-04-12 11:58:53] local.DEBUG: Original Requested Limit: -5) OR 584=(SELECT 584 FROM PG_SLEEP(15))--
[2023-04-12 11:58:53] local.DEBUG: Intval Limit: -5
[2023-04-12 11:58:53] local.DEBUG: Modified Limit: 1
[2023-04-12 11:58:53] local.DEBUG: Original Requested Offset: 20
[2023-04-12 11:58:53] local.DEBUG: Modified Offset: 20
[2023-04-12 11:58:53] local.DEBUG: Total Results: 209
[2023-04-12 11:58:53] local.DEBUG: -----------------------------
[2023-04-12 11:59:15] local.DEBUG: Max Results: 200
[2023-04-12 11:59:15] local.DEBUG: Original Requested Limit: -5) OR 584=(SELECT 584 FROM PG_SLEEP(15))--
[2023-04-12 11:59:15] local.DEBUG: Intval Limit: -5
[2023-04-12 11:59:15] local.DEBUG: Modified Limit: 1
[2023-04-12 11:59:15] local.DEBUG: Original Requested Offset: farts
[2023-04-12 11:59:15] local.DEBUG: Modified Offset: 0
[2023-04-12 11:59:15] local.DEBUG: Total Results: 209
[2023-04-12 11:59:15] local.DEBUG: -----------------------------
```

I've tested this and all looks well, however this touches basically every major listing endpoint we have, so I'd appreciate some additional testing :)