### PR TITLE
Update Dockerfile to Ubuntu 22.04 and PHP 8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL maintainer="Brady Wetherington <bwetherington@grokability.com>"
 
 # No need to add `apt-get clean` here, reference:
@@ -14,16 +14,16 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
 apt-utils \
 apache2 \
 apache2-bin \
-libapache2-mod-php7.4 \
-php7.4-curl \
-php7.4-ldap \
-php7.4-mysql \
-php7.4-gd \
-php7.4-xml \
-php7.4-mbstring \
-php7.4-zip \
-php7.4-bcmath \
-php7.4-redis \
+libapache2-mod-php8.1 \
+php8.1-curl \
+php8.1-ldap \
+php8.1-mysql \
+php8.1-gd \
+php8.1-xml \
+php8.1-mbstring \
+php8.1-zip \
+php8.1-bcmath \
+php8.1-redis \
 php-memcached \
 patch \
 curl \
@@ -40,7 +40,7 @@ autoconf \
 libc-dev \
 pkg-config \
 libmcrypt-dev \
-php7.4-dev \
+php8.1-dev \
 ca-certificates \
 unzip \
 dnsutils \
@@ -50,16 +50,16 @@ dnsutils \
 RUN curl -L -O https://github.com/pear/pearweb_phars/raw/master/go-pear.phar
 RUN php go-pear.phar
 
-RUN pecl install mcrypt-1.0.3
+RUN pecl install mcrypt
 
-RUN bash -c "echo extension=/usr/lib/php/20190902/mcrypt.so > /etc/php/7.4/mods-available/mcrypt.ini"
+RUN bash -c "echo extension=/usr/lib/php/20210902/mcrypt.so > /etc/php/8.1/mods-available/mcrypt.ini"
 
 RUN phpenmod mcrypt
 RUN phpenmod gd
 RUN phpenmod bcmath
 
-RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/7.4/apache2/php.ini
-RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/7.4/cli/php.ini
+RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/8.1/apache2/php.ini
+RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/8.1/cli/php.ini
 
 RUN useradd -m --uid 1000 --gid 50 docker
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,34 +1,34 @@
-FROM alpine:3.14.2
+FROM alpine:3.17.3
 # Apache + PHP
 RUN  apk add --no-cache \
         apache2 \
-        php7 \
-        php7-common \
-        php7-apache2 \
-        php7-curl \
-        php7-ldap \
-        php7-mysqli \
-        php7-gd \
-        php7-xml \
-        php7-mbstring \
-        php7-zip \
-        php7-ctype \
-        php7-tokenizer \
-        php7-pdo_mysql \
-        php7-openssl \
-        php7-bcmath \
-        php7-phar \
-        php7-json \
-        php7-iconv \
-        php7-fileinfo \
-        php7-simplexml \
-        php7-session \
-        php7-dom \
-        php7-xmlwriter \
-        php7-xmlreader \
-        php7-sodium \
-        php7-redis \
-        php7-pecl-memcached \
+        php81 \
+        php81-common \
+        php81-apache2 \
+        php81-curl \
+        php81-ldap \
+        php81-mysqli \
+        php81-gd \
+        php81-xml \
+        php81-mbstring \
+        php81-zip \
+        php81-ctype \
+        php81-tokenizer \
+        php81-pdo_mysql \
+        php81-openssl \
+        php81-bcmath \
+        php81-phar \
+        php81-json \
+        php81-iconv \
+        php81-fileinfo \
+        php81-simplexml \
+        php81-session \
+        php81-dom \
+        php81-xmlwriter \
+        php81-xmlreader \
+        php81-sodium \
+        php81-redis \
+        php81-pecl-memcached \
         curl \
         wget \
         vim \
@@ -41,7 +41,7 @@ COPY docker/column-statistics.cnf /etc/mysql/conf.d/column-statistics.cnf
 # Where apache's PID lives
 RUN mkdir -p /run/apache2 && chown apache:apache /run/apache2
 
-RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php7/php.ini
+RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php81/php.ini
 COPY  docker/000-default-2.4.conf /etc/apache2/conf.d/default.conf
 
 # Enable mod_rewrite

--- a/Dockerfile.fpm-alpine
+++ b/Dockerfile.fpm-alpine
@@ -1,8 +1,8 @@
 ARG ENVIRONMENT=production
-ARG SNIPEIT_RELEASE=5.1.3
-ARG PHP_VERSION=7.4.16
-ARG PHP_ALPINE_VERSION=3.13
-ARG COMPOSER_VERSION=2.0.11
+ARG SNIPEIT_RELEASE=6.1.0
+ARG PHP_VERSION=8.2
+ARG PHP_ALPINE_VERSION=3.17
+ARG COMPOSER_VERSION=2
 
 # Cannot use arguments with 'COPY --from' workaround
 # https://github.com/moby/moby/issues/34482#issuecomment-454716952
@@ -52,7 +52,7 @@ RUN { \
 
 # Install php extensions inside docker containers easily
 # https://github.com/mlocati/docker-php-extension-installer
-COPY --from=mlocati/php-extension-installer:1.2.19 /usr/bin/install-php-extensions /usr/local/bin/
+COPY --from=mlocati/php-extension-installer:2.1.15 /usr/bin/install-php-extensions /usr/local/bin/
 RUN set -eux; \
     install-php-extensions \
         bcmath \


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Was suspiciously easy, here's the build on my machine:

```
┌─(~/Code/snipe-it)(develop M:1 S:14)
└─(1)─ docker build .
[+] Building 20.8s (37/37) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                          0.0s
 => => transferring dockerfile: 4.43kB                                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 35B                                                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                             0.3s
 => => transferring context: 541.26kB                                                                                                                                                                         0.3s
 => CACHED FROM docker.io/library/composer:latest                                                                                                                                                             0.0s
 => => resolve docker.io/library/composer:latest                                                                                                                                                              0.9s
 => [stage-0  1/31] FROM docker.io/library/ubuntu:22.04                                                                                                                                                       0.0s
 => CACHED [stage-0  2/31] RUN export DEBIAN_FRONTEND=noninteractive;     export DEBCONF_NONINTERACTIVE_SEEN=true;     echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections;     echo 'tzdata tzda  0.0s
 => CACHED [stage-0  3/31] RUN curl -L -O https://github.com/pear/pearweb_phars/raw/master/go-pear.phar                                                                                                       0.0s
 => CACHED [stage-0  4/31] RUN php go-pear.phar                                                                                                                                                               0.0s
 => CACHED [stage-0  5/31] RUN pecl install mcrypt                                                                                                                                                            0.0s
 => [stage-0  6/31] RUN bash -c "echo extension=/usr/lib/php/20210902/mcrypt.so > /etc/php/8.1/mods-available/mcrypt.ini"                                                                                     0.3s
 => [stage-0  7/31] RUN phpenmod mcrypt                                                                                                                                                                       0.2s
 => [stage-0  8/31] RUN phpenmod gd                                                                                                                                                                           0.3s
 => [stage-0  9/31] RUN phpenmod bcmath                                                                                                                                                                       0.3s
 => [stage-0 10/31] RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/8.1/apache2/php.ini                                                                                               0.3s
 => [stage-0 11/31] RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/8.1/cli/php.ini                                                                                                   0.3s
 => [stage-0 12/31] RUN useradd -m --uid 1000 --gid 50 docker                                                                                                                                                 0.3s
 => [stage-0 13/31] RUN echo export APACHE_RUN_USER=docker >> /etc/apache2/envvars                                                                                                                            0.3s
 => [stage-0 14/31] RUN echo export APACHE_RUN_GROUP=staff >> /etc/apache2/envvars                                                                                                                            0.3s
 => [stage-0 15/31] COPY docker/000-default.conf /etc/apache2/sites-enabled/000-default.conf                                                                                                                  0.0s
 => [stage-0 16/31] RUN mkdir -p /var/lib/snipeit/ssl                                                                                                                                                         0.2s
 => [stage-0 17/31] COPY docker/001-default-ssl.conf /etc/apache2/sites-available/001-default-ssl.conf                                                                                                        0.0s
 => [stage-0 18/31] RUN a2enmod ssl                                                                                                                                                                           0.2s
 => [stage-0 19/31] RUN a2ensite 001-default-ssl.conf                                                                                                                                                         0.3s
 => [stage-0 20/31] COPY . /var/www/html                                                                                                                                                                      0.6s
 => [stage-0 21/31] RUN a2enmod rewrite                                                                                                                                                                       0.2s
 => [stage-0 22/31] COPY docker/column-statistics.cnf /etc/mysql/conf.d/column-statistics.cnf                                                                                                                 0.0s
 => [stage-0 23/31] WORKDIR /var/www/html                                                                                                                                                                     0.0s
 => [stage-0 24/31] COPY docker/docker.env /var/www/html/.env                                                                                                                                                 0.0s
 => [stage-0 25/31] RUN chown -R docker /var/www/html                                                                                                                                                         5.6s
 => [stage-0 26/31] RUN  rm -r "/var/www/html/storage/private_uploads" && ln -fs "/var/lib/snipeit/data/private_uploads" "/var/www/html/storage/private_uploads"       && rm -rf "/var/www/html/public/uploa  0.4s
 => [stage-0 27/31] COPY --from=composer:latest /usr/bin/composer /usr/bin/composer                                                                                                                           0.0s
 => [stage-0 28/31] RUN composer install --no-dev --working-dir=/var/www/html                                                                                                                                 9.3s
 => [stage-0 29/31] COPY docker/startup.sh docker/supervisord.conf /                                                                                                                                          0.0s
 => [stage-0 30/31] COPY docker/supervisor-exit-event-listener /usr/bin/supervisor-exit-event-listener                                                                                                        0.0s
 => [stage-0 31/31] RUN chmod +x /startup.sh /usr/bin/supervisor-exit-event-listener                                                                                                                          0.1s
 => exporting to image                                                                                                                                                                                        0.9s
 => => exporting layers                                                                                                                                                                                       0.9s
 => => writing image sha256:e2b299f282bb10ba0f0fa9dee400b6525ae6b56fd6fa70e0b8c83b7b86089746
```

Testing PHP CLI version:

```
docker run -it e2b299f282bb10ba0f0fa9dee400b6525ae6b56fd6fa70e0b8c83b7b86089746 /bin/php -v
PHP 8.1.2-1ubuntu2.11 (cli) (built: Feb 22 2023 22:56:18) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.2, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.2-1ubuntu2.11, Copyright (c), by Zend Technologies
```

Building Alpine images

### alpine

```
docker build . -f Dockerfile.alpine
[+] Building 0.5s (23/23) FINISHED
 => [internal] load build definition from Dockerfile.alpine                                                                                                                                                   0.0s
 => => transferring dockerfile: 44B                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 35B                                                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/alpine:3.17.3                                                                                                                                              0.0s
 => [internal] load build context                                                                                                                                                                             0.2s
 => => transferring context: 536.86kB                                                                                                                                                                         0.2s
 => [stage-0  1/17] FROM docker.io/library/alpine:3.17.3                                                                                                                                                      0.0s
 => FROM docker.io/library/composer:latest                                                                                                                                                                    0.4s
 => => resolve docker.io/library/composer:latest                                                                                                                                                              0.4s
 => CACHED [stage-0  2/17] RUN  apk add --no-cache         apache2         php81         php81-common         php81-apache2         php81-curl         php81-ldap         php81-mysqli         php81-gd       0.0s
 => CACHED [stage-0  3/17] COPY docker/column-statistics.cnf /etc/mysql/conf.d/column-statistics.cnf                                                                                                          0.0s
 => CACHED [stage-0  4/17] RUN mkdir -p /run/apache2 && chown apache:apache /run/apache2                                                                                                                      0.0s
 => CACHED [stage-0  5/17] RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php81/php.ini                                                                                                  0.0s
 => CACHED [stage-0  6/17] COPY  docker/000-default-2.4.conf /etc/apache2/conf.d/default.conf                                                                                                                 0.0s
 => CACHED [stage-0  7/17] RUN sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf                                                                                                            0.0s
 => CACHED [stage-0  8/17] COPY . /var/www/html                                                                                                                                                               0.0s
 => CACHED [stage-0  9/17] WORKDIR /var/www/html                                                                                                                                                              0.0s
 => CACHED [stage-0 10/17] COPY docker/docker.env /var/www/html/.env                                                                                                                                          0.0s
 => CACHED [stage-0 11/17] RUN chown -R apache:apache /var/www/html                                                                                                                                           0.0s
 => CACHED [stage-0 12/17] RUN  rm -r "/var/www/html/storage/private_uploads"  && mkdir -p "/var/lib/snipeit/data/private_uploads" && ln -fs "/var/lib/snipeit/data/private_uploads" "/var/www/html/storage/  0.0s
 => CACHED [stage-0 13/17] COPY --from=composer:latest /usr/bin/composer /usr/bin/composer                                                                                                                    0.0s
 => CACHED [stage-0 14/17] RUN mkdir -p /var/www/.composer && chown apache /var/www/.composer                                                                                                                 0.0s
 => CACHED [stage-0 15/17] RUN COMPOSER_CACHE_DIR=/dev/null composer install --no-dev --working-dir=/var/www/html                                                                                             0.0s
 => CACHED [stage-0 16/17] COPY docker/entrypoint_alpine.sh /entrypoint.sh                                                                                                                                    0.0s
 => CACHED [stage-0 17/17] RUN chmod +x /entrypoint.sh                                                                                                                                                        0.0s
 => exporting to image                                                                                                                                                                                        0.0s
 => => exporting layers                                                                                                                                                                                       0.0s
 => => writing image sha256:faac9118a1579bca79124757f66a10359c523af55ec0b8a8c41881880bf90945
```

### fpm-alpine

```
└─(1)─ docker build . -f Dockerfile.fpm-alpine
[+] Building 70.2s (18/18) FINISHED
 => [internal] load build definition from Dockerfile.fpm-alpine                                                                                                                                               0.0s
 => => transferring dockerfile: 3.69kB                                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 35B                                                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/php:8.2-fpm-alpine3.17                                                                                                                                     0.5s
 => [internal] load metadata for docker.io/library/composer:2                                                                                                                                                 0.9s
 => [source  1/10] FROM docker.io/library/php:8.2-fpm-alpine3.17@sha256:f20c9409b660e20b0a3a13c61448d51e4b4bb1055a4dca897d9490aa8e3e087d                                                                      0.0s
 => [internal] load build context                                                                                                                                                                             0.0s
 => => transferring context: 167B                                                                                                                                                                             0.0s
 => FROM docker.io/mlocati/php-extension-installer:2.1.15                                                                                                                                                     0.3s
 => => resolve docker.io/mlocati/php-extension-installer:2.1.15                                                                                                                                               0.9s
 => => sha256:e183edc7b3d663c7ab317c68f01db9bf7f4bfb0217f5d750faece9a65b2b7dd2 526B / 526B                                                                                                                    0.0s
 => => sha256:e86a3b551ced0de2e6a23519dd353414ad2df8f4cd10edd5a8f058c408098098 1.25kB / 1.25kB                                                                                                                0.0s
 => => sha256:0d827fbc0d5bdcb179dd195ff2deb1a07f4951117a4c08ebe955ad1dd78de9c5 28.24kB / 28.24kB                                                                                                              0.2s
 => => extracting sha256:0d827fbc0d5bdcb179dd195ff2deb1a07f4951117a4c08ebe955ad1dd78de9c5                                                                                                                     0.0s
 => CACHED [composer 1/1] FROM docker.io/library/composer:2@sha256:622effa24be2e4c4099c2e655d6f88652fa0294605503b41288469bf71e1c198                                                                           0.0s
 => CACHED [source  2/10] RUN set -eux;  docker-php-ext-enable opcache;  {   echo 'opcache.memory_consumption=128';   echo 'opcache.interned_strings_buffer=8';   echo 'opcache.max_accelerated_files=4000';  0.0s
 => CACHED [source  3/10] RUN {   echo 'error_reporting = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING | E_RECOVERABLE_ERROR';   echo 'display_errors  0.0s
 => [source  4/10] COPY --from=mlocati/php-extension-installer:2.1.15 /usr/bin/install-php-extensions /usr/local/bin/                                                                                         0.0s
 => [source  5/10] RUN set -eux;     install-php-extensions         bcmath         gd         ldap         mysqli         pdo_mysql         zip;     rm -f /usr/local/bin/install-php-extensions;     apk a  42.9s
 => [source  6/10] COPY --from=composer /usr/bin/composer /usr/local/bin                                                                                                                                      0.0s
 => [source  7/10] RUN set -eux;  curl -o snipeit.tar.gz -fL "https://github.com/snipe/snipe-it/archive/v6.1.0.tar.gz";  tar -xzf snipeit.tar.gz --strip-components=1 -C /var/www/html/;  rm snipeit.tar.gz  23.9s
 => [source  8/10] COPY --chown=www-data:www-data docker/docker-secrets.env /var/www/html/.env                                                                                                                0.0s
 => [source  9/10] COPY --chmod=655 docker/docker-entrypoint.sh /usr/local/bin/docker-snipeit-entrypoint                                                                                                      0.0s
 => [source 10/10] COPY docker/column-statistics.cnf /etc/mysql/conf.d/column-statistics.cnf                                                                                                                  0.0s
 => exporting to image                                                                                                                                                                                        1.1s
 => => exporting layers                                                                                                                                                                                       1.1s
 => => writing image sha256:3463643f742649d9964ee7b84bc9f3d3c528418125aaffa6c7d5925998997b5e                                                                                                                  0.0s
docker build . -f Dockerfile.fpm-alpine: 01:10
```

# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

