### PR TITLE
Introduced improved way to interact with settings in tests

### DIFF
--- a/app/Observers/SettingObserver.php
+++ b/app/Observers/SettingObserver.php
@@ -17,6 +17,5 @@ class SettingObserver
     public function saved(Setting $setting)
     {
         Cache::forget(Setting::SETUP_CHECK_KEY);
-        Setting::$_cache = null;
     }
 }

--- a/app/Observers/SettingObserver.php
+++ b/app/Observers/SettingObserver.php
@@ -17,5 +17,6 @@ class SettingObserver
     public function saved(Setting $setting)
     {
         Cache::forget(Setting::SETUP_CHECK_KEY);
+        Setting::$_cache = null;
     }
 }

--- a/database/factories/SettingFactory.php
+++ b/database/factories/SettingFactory.php
@@ -34,13 +34,4 @@ class SettingFactory extends Factory
             'email_domain' => 'test.com',
         ];
     }
-
-    public function withMultipleFullCompanySupport()
-    {
-        return $this->state(function () {
-            return [
-                'full_multiple_companies_support' => 1,
-            ];
-        });
-    }
 }

--- a/tests/Feature/Api/Assets/AssetIndexTest.php
+++ b/tests/Feature/Api/Assets/AssetIndexTest.php
@@ -6,10 +6,13 @@ use App\Models\Asset;
 use App\Models\User;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Passport\Passport;
+use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
 class AssetIndexTest extends TestCase
 {
+    use InteractsWithSettings;
+
     public function testAssetIndexReturnsExpectedAssets()
     {
         Asset::factory()->count(3)->create();

--- a/tests/Feature/Api/Assets/AssetIndexTest.php
+++ b/tests/Feature/Api/Assets/AssetIndexTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature\Api\Assets;
 
 use App\Models\Asset;
-use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Passport\Passport;
@@ -13,8 +12,6 @@ class AssetIndexTest extends TestCase
 {
     public function testAssetIndexReturnsExpectedAssets()
     {
-        Setting::factory()->create();
-
         Asset::factory()->count(3)->create();
 
         Passport::actingAs(User::factory()->superuser()->create());

--- a/tests/Feature/Api/Users/UsersForSelectListTest.php
+++ b/tests/Feature/Api/Users/UsersForSelectListTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature\Api\Users;
 
 use App\Models\Company;
-use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Passport\Passport;
@@ -13,8 +12,6 @@ class UsersForSelectListTest extends TestCase
 {
     public function testUsersAreReturned()
     {
-        Setting::factory()->create();
-
         $users = User::factory()->superuser()->count(3)->create();
 
         Passport::actingAs($users->first());
@@ -32,7 +29,7 @@ class UsersForSelectListTest extends TestCase
 
     public function testUsersScopedToCompanyWhenMultipleFullCompanySupportEnabled()
     {
-        Setting::factory()->withMultipleFullCompanySupport()->create();
+        $this->settings->enableMultipleFullCompanySupport();
 
         $jedi = Company::factory()->has(User::factory()->count(3)->sequence(
             ['first_name' => 'Luke', 'last_name' => 'Skywalker', 'username' => 'lskywalker'],
@@ -60,7 +57,7 @@ class UsersForSelectListTest extends TestCase
 
     public function testUsersScopedToCompanyDuringSearchWhenMultipleFullCompanySupportEnabled()
     {
-        Setting::factory()->withMultipleFullCompanySupport()->create();
+        $this->settings->enableMultipleFullCompanySupport();
 
         $jedi = Company::factory()->has(User::factory()->count(3)->sequence(
             ['first_name' => 'Luke', 'last_name' => 'Skywalker', 'username' => 'lskywalker'],

--- a/tests/Feature/Api/Users/UsersForSelectListTest.php
+++ b/tests/Feature/Api/Users/UsersForSelectListTest.php
@@ -6,10 +6,13 @@ use App\Models\Company;
 use App\Models\User;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Laravel\Passport\Passport;
+use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
 class UsersForSelectListTest extends TestCase
 {
+    use InteractsWithSettings;
+
     public function testUsersAreReturned()
     {
         $users = User::factory()->superuser()->count(3)->create();

--- a/tests/Support/InteractsWithSettings.php
+++ b/tests/Support/InteractsWithSettings.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Support;
+
+trait InteractsWithSettings
+{
+
+}

--- a/tests/Support/InteractsWithSettings.php
+++ b/tests/Support/InteractsWithSettings.php
@@ -4,5 +4,10 @@ namespace Tests\Support;
 
 trait InteractsWithSettings
 {
+    protected Settings $settings;
 
+    public function setUpSettings()
+    {
+        $this->settings = Settings::initialize();
+    }
 }

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -31,5 +31,6 @@ class Settings
     private function update(array $attributes)
     {
         Setting::unguarded(fn() => $this->setting->update($attributes));
+        Setting::$_cache = null;
     }
 }

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Support;
+
+use App\Models\Setting;
+
+class Settings
+{
+    private Setting $setting;
+    
+    public function __construct()
+    {
+        $this->setting = Setting::factory()->create();
+    }
+
+    public function enableMultipleFullCompanySupport()
+    {
+        $this->update(['full_multiple_companies_support' => 1]);
+    }
+
+    public function disableMultipleFullCompanySupport()
+    {
+        $this->update(['full_multiple_companies_support' => 0]);
+    }
+
+    private function update(array $attributes)
+    {
+        Setting::unguarded(fn() => $this->setting->update($attributes));
+    }
+}

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -18,22 +18,24 @@ class Settings
         return new self();
     }
 
-    public function enableMultipleFullCompanySupport(): void
+    public function enableMultipleFullCompanySupport(): Settings
     {
-        $this->update(['full_multiple_companies_support' => 1]);
+        return $this->update(['full_multiple_companies_support' => 1]);
     }
 
     /**
      * @param array $attributes Attributes to modify in the application's settings.
      */
-    public function set(array $attributes): void
+    public function set(array $attributes): Settings
     {
-        $this->update($attributes);
+        return $this->update($attributes);
     }
 
-    private function update(array $attributes): void
+    private function update(array $attributes): Settings
     {
         Setting::unguarded(fn() => $this->setting->update($attributes));
         Setting::$_cache = null;
+
+        return $this;
     }
 }

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -7,28 +7,31 @@ use App\Models\Setting;
 class Settings
 {
     private Setting $setting;
-    
+
     private function __construct()
     {
         $this->setting = Setting::factory()->create();
     }
 
-    public static function initialize()
+    public static function initialize(): Settings
     {
         return new self();
     }
 
-    public function enableMultipleFullCompanySupport()
+    public function enableMultipleFullCompanySupport(): void
     {
         $this->update(['full_multiple_companies_support' => 1]);
     }
 
-    public function set(array $attributes)
+    /**
+     * @param array $attributes Attributes to modify in the application's settings.
+     */
+    public function set(array $attributes): void
     {
         $this->update($attributes);
     }
 
-    private function update(array $attributes)
+    private function update(array $attributes): void
     {
         Setting::unguarded(fn() => $this->setting->update($attributes));
         Setting::$_cache = null;

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -23,6 +23,11 @@ class Settings
         $this->update(['full_multiple_companies_support' => 1]);
     }
 
+    public function set(array $attributes)
+    {
+        $this->update($attributes);
+    }
+
     private function update(array $attributes)
     {
         Setting::unguarded(fn() => $this->setting->update($attributes));

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -8,9 +8,14 @@ class Settings
 {
     private Setting $setting;
     
-    public function __construct()
+    private function __construct()
     {
         $this->setting = Setting::factory()->create();
+    }
+
+    public static function initialize()
+    {
+        return new self();
     }
 
     public function enableMultipleFullCompanySupport()

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -18,11 +18,6 @@ class Settings
         $this->update(['full_multiple_companies_support' => 1]);
     }
 
-    public function disableMultipleFullCompanySupport()
-    {
-        $this->update(['full_multiple_companies_support' => 0]);
-    }
-
     private function update(array $attributes)
     {
         Setting::unguarded(fn() => $this->setting->update($attributes));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,14 +3,16 @@
 namespace Tests;
 
 use App\Http\Middleware\SecurityHeaders;
-use App\Models\Setting;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Tests\Support\Settings;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
     use LazilyRefreshDatabase;
+
+    protected Settings $settings;
 
     private array $globallyDisabledMiddleware = [
         SecurityHeaders::class,
@@ -20,8 +22,8 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        $this->beforeApplicationDestroyed(fn() => Setting::$_cache = null);
-
         $this->withoutMiddleware($this->globallyDisabledMiddleware);
+
+        $this->settings = new Settings();
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,14 +6,11 @@ use App\Http\Middleware\SecurityHeaders;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Tests\Support\InteractsWithSettings;
-use Tests\Support\Settings;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
     use LazilyRefreshDatabase;
-
-    protected Settings $settings;
 
     private array $globallyDisabledMiddleware = [
         SecurityHeaders::class,
@@ -25,8 +22,8 @@ abstract class TestCase extends BaseTestCase
 
         $this->withoutMiddleware($this->globallyDisabledMiddleware);
 
-        if (in_array(InteractsWithSettings::class, class_uses_recursive($this))) {
-            $this->settings = Settings::initialize();
+        if (collect(class_uses_recursive($this))->contains(InteractsWithSettings::class)) {
+            $this->setUpSettings();
         }
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Tests;
 use App\Http\Middleware\SecurityHeaders;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Tests\Support\InteractsWithSettings;
 use Tests\Support\Settings;
 
 abstract class TestCase extends BaseTestCase
@@ -24,6 +25,8 @@ abstract class TestCase extends BaseTestCase
 
         $this->withoutMiddleware($this->globallyDisabledMiddleware);
 
-        $this->settings = Settings::initialize();
+        if (in_array(InteractsWithSettings::class, class_uses_recursive($this))) {
+            $this->settings = Settings::initialize();
+        }
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,6 +24,6 @@ abstract class TestCase extends BaseTestCase
 
         $this->withoutMiddleware($this->globallyDisabledMiddleware);
 
-        $this->settings = new Settings();
+        $this->settings = Settings::initialize();
     }
 }


### PR DESCRIPTION
# Description

This PR improves the way settings are interacted with in tests. Previously, in most feature tests we would have to set up app settings by adding the following to the top of each test:
```php
Setting::factory()->create()

// or something like
Setting::factory()->withMultipleFullCompanySupport()->create()
```
> Another approach could be to put it in the universal `setUp()` method but that would nullify our usage of `LazilyRefreshDatabase` since each test would be refreshing the database regardless of the actual test code needing it.

In addition, subsequent changes to settings had the possibility of not talking practical effect if `Setting::getSettings()` was called prior to the changes since that method caches settings in a static variable.

This PR introduces a trait and fluent interface for interacting with settings in a similar manner as Laravel's `WithFaker` trait. 

Tests that need to interact with the application's settings should add the `InteractsWithSettings` trait to the class. Our base `TestCase`'s `setUp` method checks for this trait and will initialize the app's settings using the Setting factory. It will also allow tests to use the following syntax for updating application settings within tests:
```php
$this->settings->enableMultipleFullCompanySupport();

$this->settings->set(['some' => 'thing']);
```
> Using these methods will clear the settings cache that may have been stored if `Setting::getSettings()` was called.

Additional helper methods like `enableMultipleFullCompanySupport()` can be added to the `Settings` class as they are needed.

Note: I'm avoiding updating the testing docs to document this because I want to use it in other pieces of work a bit to make sure the API is solid.