### PR TITLE
Temp fix for the seeders

### DIFF
--- a/database/seeders/AssetSeeder.php
+++ b/database/seeders/AssetSeeder.php
@@ -29,26 +29,26 @@ class AssetSeeder extends Seeder
         $this->locationIds = Location::all()->pluck('id');
         $this->supplierIds = Supplier::all()->pluck('id');
 
-        Asset::factory()->count(1000)->laptopMbp()->state(new Sequence($this->getState()))->create();
+        Asset::factory()->count(2000)->laptopMbp()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(50)->laptopMbpPending()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(50)->laptopMbpArchived()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(50)->laptopAir()->state(new Sequence($this->getState()))->create();
-        Asset::factory()->count(5)->laptopSurface()->state(new Sequence($this->getState()))->create();
+        Asset::factory()->count(50)->laptopSurface()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(5)->laptopXps()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(5)->laptopSpectre()->state(new Sequence($this->getState()))->create();
-        Asset::factory()->count(5)->laptopZenbook()->state(new Sequence($this->getState()))->create();
-        Asset::factory()->count(3)->laptopYoga()->state(new Sequence($this->getState()))->create();
+        Asset::factory()->count(50)->laptopZenbook()->state(new Sequence($this->getState()))->create();
+        Asset::factory()->count(30)->laptopYoga()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(30)->desktopMacpro()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(30)->desktopLenovoI5()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(30)->desktopOptiplex()->state(new Sequence($this->getState()))->create();
-        Asset::factory()->count(5)->confPolycom()->state(new Sequence($this->getState()))->create();
-        Asset::factory()->count(2)->confPolycomcx()->state(new Sequence($this->getState()))->create();
-        Asset::factory()->count(12)->tabletIpad()->state(new Sequence($this->getState()))->create();
-        Asset::factory()->count(4)->tabletTab3()->state(new Sequence($this->getState()))->create();
+        Asset::factory()->count(50)->confPolycom()->state(new Sequence($this->getState()))->create();
+        Asset::factory()->count(20)->confPolycomcx()->state(new Sequence($this->getState()))->create();
+        Asset::factory()->count(30)->tabletIpad()->state(new Sequence($this->getState()))->create();
+        Asset::factory()->count(10)->tabletTab3()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(27)->phoneIphone11()->state(new Sequence($this->getState()))->create();
         Asset::factory()->count(40)->phoneIphone12()->state(new Sequence($this->getState()))->create();
-        Asset::factory()->count(10)->ultrafine()->state(new Sequence($this->getState()))->create();
-        Asset::factory()->count(10)->ultrasharp()->state(new Sequence($this->getState()))->create();
+        Asset::factory()->count(20)->ultrafine()->state(new Sequence($this->getState()))->create();
+        Asset::factory()->count(20)->ultrasharp()->state(new Sequence($this->getState()))->create();
 
         $del_files = Storage::files('assets');
         foreach ($del_files as $del_file) { // iterate files


### PR DESCRIPTION
This is a very temporary fix for the SC-23108. I'm not sure why partway through, it's not finding the RTD locations to checkout in the factory:

```php
Call to a member function update() on null

  at database/factories/ActionlogFactory.php:43
     39▕         return $this->state(function () {
     40▕             $target = User::inRandomOrder()->first();
     41▕             $asset = Asset::RTD()->inRandomOrder()->first();
     42▕
  ➜  43▕             $asset->update(
     44▕                     [
     45▕                         'assigned_to' => $target->id,
     46▕                         'assigned_type' => User::class,
     47▕                         'location_id' => $target->location_id,

      +8 vendor frames
  9   [internal]:0
      Illuminate\Database\Eloquent\Factories\Factory::Illuminate\Database\Eloquent\Factories\{closure}()

      +3 vendor frames
  13  database/seeders/ActionlogSeeder.php:30
      Illuminate\Database\Eloquent\Factories\Factory::create([])
```

But creating more of them seems to help for now. We can try to figure this out further on Monday.