### PR TITLE
Allow checkout of available components down to zero stock (fixes #12854)

### DIFF
--- a/app/Http/Controllers/Components/ComponentCheckoutController.php
+++ b/app/Http/Controllers/Components/ComponentCheckoutController.php
@@ -64,8 +64,8 @@ class ComponentCheckoutController extends Controller
 
         $max_to_checkout = $component->numRemaining();
 
-        // Make sure there is at least one available to checkout
-        if ($max_to_checkout <= $request->get('assigned_qty')) {
+        // Make sure there are at least the requested number of components available to checkout
+        if ($max_to_checkout < $request->get('assigned_qty')) {
             return redirect()->back()->withInput()->with('error', trans('admin/components/message.checkout.unavailable', ['remaining' => $max_to_checkout, 'requested' => $request->get('assigned_qty')]));
         }
 


### PR DESCRIPTION
# Description

The previous code forced that at least 1 item of a component stays available. My change makes it possible to checkout also the last item of a component, so that the stock can go down to 0.

Fixes #12854 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test A: Checkout 1 item when 1 available should succeed
Before:
![2023-04-17_11-39](https://user-images.githubusercontent.com/915514/232447642-f19dc4c8-e5de-42ba-b1ab-67f7f5faf303.png)
After:
![2023-04-17_11-42](https://user-images.githubusercontent.com/915514/232447785-61b946d4-9e41-4d83-9a37-0bc5441563f5.png)

- [x] Test B: Checkout 2 items when 1 available should fail
Before: 
![2023-04-17_11-40](https://user-images.githubusercontent.com/915514/232447664-ddd76d30-0c8f-480d-89b4-b1a7697f8af2.png)
After:
![2023-04-17_11-41](https://user-images.githubusercontent.com/915514/232447836-4c6ca6fa-aa27-434e-9e9c-635ff508b3f3.png)


**Test Configuration**:
Official Docker Image in Debug mode, where I edited the file inside the running container.
* PHP version: 7.4.3
* MySQL version: MariaDB 10.7
* Webserver version: Apache2 2.4.41
* OS version: Ubuntu 22.04.6


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
