### PR TITLE
Remove start/end dates from casts array

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -76,8 +76,6 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         'created_at'   => 'datetime',
         'updated_at'   => 'datetime',
         'deleted_at'   => 'datetime',
-        'start_date'   => 'datetime:Y-m-d',
-        'end_date'     => 'datetime:Y-m-d',
     ];
 
     /**


### PR DESCRIPTION
We're not exactly sure why we needed to do this, but start_date and end_date on users was throwing a validation error even on a valid YYYY-MM-DD date. We'll figure out the why and have a better plan shortly, but this fixes it for now. 