### PR TITLE
Small tooltip improvements for undeployable items in table view

### DIFF
--- a/resources/lang/en/admin/hardware/general.php
+++ b/resources/lang/en/admin/hardware/general.php
@@ -23,6 +23,7 @@ return [
     'restore'  					=> 'Restore Asset',
     'pending'  					=> 'Pending',
     'undeployable'  			=> 'Undeployable',
+    'undeployable_tooltip'  	=> 'This asset has a status label that is undeployable and cannot be checked out at this time.',
     'view'  					=> 'View Asset',
     'csv_error' => 'You have an error in your CSV file:',
     'import_text' => '

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -446,5 +446,6 @@ return [
     'no_autoassign_licenses_help' => 'Do not include user for bulk-assigning through the license UI or cli tools.',
     'modal_confirm_generic'      => 'Are you sure?',
     'cannot_be_deleted'      => 'This item cannot be deleted',
+    'undeployable_tooltip'      => 'This item cannot be checked out. Check the quantity remaining.',
 
 ];

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -384,7 +384,7 @@
 
                 // We use slightly different language for assets versus other things, since they are the only
                 // item that has a status label
-                if (destination =='assets') {
+                if (destination =='hardware') {
                     return '<span  data-tooltip="true" title="{{ trans('admin/hardware/general.undeployable_tooltip') }}"><a class="btn btn-sm bg-maroon disabled">{{ trans('general.checkout') }}</a></span>';
                 } else {
                     return '<span  data-tooltip="true" title="{{ trans('general.undeployable_tooltip') }}"><a class="btn btn-sm bg-maroon disabled">{{ trans('general.checkout') }}</a></span>';

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -376,11 +376,19 @@
 
             // The user is allowed to check items out, AND the item is deployable
             if ((row.available_actions.checkout == true) && (row.user_can_checkout == true) && ((!row.asset_id) && (!row.assigned_to))) {
+
                     return '<a href="{{ config('app.url') }}/' + destination + '/' + row.id + '/checkout" class="btn btn-sm bg-maroon" data-tooltip="true" title="{{ trans('general.checkout_tooltip') }}">{{ trans('general.checkout') }}</a>';
 
-            // The user is allowed to check items out, but the item is not deployable
+            // The user is allowed to check items out, but the item is not able to be checked out
             } else if (((row.user_can_checkout == false)) && (row.available_actions.checkout == true) && (!row.assigned_to)) {
-                return '<span  data-tooltip="true" title="This item has a status label that is undeployable and cannot be checked out at this time."><a class="btn btn-sm bg-maroon disabled">{{ trans('general.checkout') }}</a></span>';
+
+                // We use slightly different language for assets versus other things, since they are the only
+                // item that has a status label
+                if (destination =='assets') {
+                    return '<span  data-tooltip="true" title="{{ trans('admin/hardware/general.undeployable_tooltip') }}"><a class="btn btn-sm bg-maroon disabled">{{ trans('general.checkout') }}</a></span>';
+                } else {
+                    return '<span  data-tooltip="true" title="{{ trans('general.undeployable_tooltip') }}"><a class="btn btn-sm bg-maroon disabled">{{ trans('general.checkout') }}</a></span>';
+                }
 
             // The user is allowed to check items in
             } else if (row.available_actions.checkin == true)  {


### PR DESCRIPTION
Since tooltips for disabled "checkout" buttons were previously not working, we hadn't noticed that the language was a little confusing in the tooltip if the item was not an asset, as it references status labels. This fix localizes the strings, and also carves out a special case for assets.

### Before
<img width="1160" alt="Screenshot 2023-04-18 at 12 55 09 PM" src="https://user-images.githubusercontent.com/197404/232891011-25836b14-cf90-47eb-8456-26a73b21d788.png">

### After
<img width="1166" alt="Screenshot 2023-04-18 at 12 55 40 PM" src="https://user-images.githubusercontent.com/197404/232891024-6451b375-32b9-40b0-9858-ca7d70000b77.png">
