### PR TITLE
fix : missing translation & invalid color for bulk update button

### DIFF
--- a/resources/lang/en/button.php
+++ b/resources/lang/en/button.php
@@ -21,4 +21,5 @@ return [
     'add_maintenance'           => 'Add Maintenance',
     'append'                    => 'Append',
     'new'                       => 'New',
+    'update'                    => 'Update'
 ];

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -176,7 +176,7 @@
                     <div class="box-footer text-right">
                         <a class="btn btn-link pull-left" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>
 
-                        <button type="submit" class="btn btn-success"{{ (config('app.lock_passwords') ? ' disabled' : '') }}>
+                        <button type="submit" class="btn btn-primary"{{ (config('app.lock_passwords') ? ' disabled' : '') }}>
                             <i class="fas fa-check icon-white" aria-hidden="true"></i>
                             {{ trans('button.update') }}
                         </button>


### PR DESCRIPTION
# Description

Fixing missing translation string for update button in bulk edit

![image](https://user-images.githubusercontent.com/3839381/232947083-46d028ac-e19d-47a3-a5ef-6229a0c27321.png)

to

![image](https://user-images.githubusercontent.com/3839381/232947113-fd3177ae-5faf-48b6-8f09-52f7c3220f51.png)


Fixes # issue ticket not created yet

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Check if update properly implemented

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
