### PR TITLE
Adds a checkout range for custom asset reports

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -641,6 +641,9 @@ class ReportsController extends Controller
             if (($request->filled('created_start')) && ($request->filled('created_end'))) {
                 $assets->whereBetween('assets.created_at', [$request->input('created_start'), $request->input('created_end')]);
             }
+            if (($request->filled('checkout_date_start')) && ($request->filled('checkout_date_end'))) {
+                $assets->whereBetween('assets.last_checkout', [$request->input('checkout_date_start'), $request->input('checkout_date_end')]);
+            }
 
             if (($request->filled('expected_checkin_start')) && ($request->filled('expected_checkin_end'))) {
                 $assets->whereBetween('assets.expected_checkin', [$request->input('expected_checkin_start'), $request->input('expected_checkin_end')]);

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -283,6 +283,16 @@
               </div>
             </div>
 
+          <!-- Created Date -->
+          <div class="form-group purchase-range">
+              <label for="checkout_date" class="col-md-3 control-label">{{ trans('general.checkout') }} {{  trans('general.range') }}</label>
+              <div class="input-daterange input-group col-md-6" id="datepicker">
+                  <input type="text" class="form-control" name="checkout_date_start" aria-label="checkout_date_start">
+                  <span class="input-group-addon">to</span>
+                  <input type="text" class="form-control" name="checkout_date_end" aria-label="checkout_date_end">
+              </div>
+          </div>
+
             <!-- Expected Checkin Date -->
             <div class="form-group expected_checkin-range">
               <label for="expected_checkin_start" class="col-md-3 control-label">{{ trans('admin/hardware/form.expected_checkin') }}</label>

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -284,7 +284,7 @@
             </div>
 
           <!-- Checkout Date -->
-          <div class="form-group purchase-range">
+          <div class="form-group checkout-range">
               <label for="checkout_date" class="col-md-3 control-label">{{ trans('general.checkout') }} {{  trans('general.range') }}</label>
               <div class="input-daterange input-group col-md-6" id="datepicker">
                   <input type="text" class="form-control" name="checkout_date_start" aria-label="checkout_date_start">
@@ -373,6 +373,12 @@
   <script>
 
       $('.purchase-range .input-daterange').datepicker({
+          clearBtn: true,
+          todayHighlight: true,
+          endDate: '0d',
+          format: 'yyyy-mm-dd'
+      });
+      $('.checkout-range .input-daterange').datepicker({
           clearBtn: true,
           todayHighlight: true,
           endDate: '0d',

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -283,7 +283,7 @@
               </div>
             </div>
 
-          <!-- Created Date -->
+          <!-- Checkout Date -->
           <div class="form-group purchase-range">
               <label for="checkout_date" class="col-md-3 control-label">{{ trans('general.checkout') }} {{  trans('general.range') }}</label>
               <div class="input-daterange input-group col-md-6" id="datepicker">


### PR DESCRIPTION
# Description

Adds checkout range inputs for custom asset reports.
<img width="549" alt="image" src="https://user-images.githubusercontent.com/47435081/233136238-4c15996e-4d01-4c60-8ba1-27e77bb6f8e4.png">

Fixes # 23130

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
