### PR TITLE
Use environment variable and default to PHP's sendmail_path

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -140,8 +140,8 @@ return [
     |
     */
 
-    'sendmail' => '/usr/sbin/sendmail -bs',
-
+    'sendmail' => env('SENDMAIL_PATH', ini_get('sendmail_path')),
+ 
     'markdown' => [
         'theme' => 'default',
         'paths' => [


### PR DESCRIPTION
Use sendmail_path in PHP instead of hardcoded path and options

# Description

We use mailhog in our DDEV local development with sendmail and in staging we change the sendmail enviroment variable to dump email in the garbage (/tmp).

Instead of using a hardcoded path and options for the sendmail command you can use an environment variable and default to another environment variable provided by PHP.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

We use this configuration to capture emails in local dev and staging.

**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0
* Webserver version: Apache 2.4
* OS version: Ubuntu/Redhat/macOS


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
