### PR TITLE
Fixed Call to a member function totalSeatsByLicenseID() on null 

### DIFF
--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -235,28 +235,29 @@ class LicensesController extends Controller
     {
         $license = License::with('assignedusers')->find($licenseId);
 
-        if ($license) {
-            $users_count = User::where('autoassign_licenses', '1')->count();
-            $total_seats_count = $license->totalSeatsByLicenseID();
-            $available_seats_count = $license->availCount()->count();
-            $checkedout_seats_count = ($total_seats_count - $available_seats_count);
-
-            \Log::debug('Total: '.$total_seats_count);
-            \Log::debug('Users: '.$users_count);
-            \Log::debug('Available: '.$available_seats_count);
-            \Log::debug('Checkedout: '.$checkedout_seats_count);
-
-
-            $this->authorize('view', $license);
-            return view('licenses.view', compact('license'))
-                ->with('users_count', $users_count)
-                ->with('total_seats_count', $total_seats_count)
-                ->with('available_seats_count', $available_seats_count)
-                ->with('checkedout_seats_count', $checkedout_seats_count);
+        if (!$license) {
+            return redirect()->route('licenses.index')
+            ->with('error', trans('admin/licenses/message.does_not_exist'));
         }
 
-        return redirect()->route('licenses.index')
-            ->with('error', trans('admin/licenses/message.does_not_exist'));
+        $users_count = User::where('autoassign_licenses', '1')->count();
+        $total_seats_count = $license->totalSeatsByLicenseID();
+        $available_seats_count = $license->availCount()->count();
+        $checkedout_seats_count = ($total_seats_count - $available_seats_count);
+
+        \Log::debug('Total: '.$total_seats_count);
+        \Log::debug('Users: '.$users_count);
+        \Log::debug('Available: '.$available_seats_count);
+        \Log::debug('Checkedout: '.$checkedout_seats_count);
+
+
+        $this->authorize('view', $license);
+        return view('licenses.view', compact('license'))
+            ->with('users_count', $users_count)
+            ->with('total_seats_count', $total_seats_count)
+            ->with('available_seats_count', $available_seats_count)
+            ->with('checkedout_seats_count', $checkedout_seats_count);
+
     }
 
 

--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -234,18 +234,19 @@ class LicensesController extends Controller
     public function show($licenseId = null)
     {
         $license = License::with('assignedusers')->find($licenseId);
-        $users_count = User::where('autoassign_licenses', '1')->count();
-        $total_seats_count = $license->totalSeatsByLicenseID();
-        $available_seats_count = $license->availCount()->count();
-        $checkedout_seats_count = ($total_seats_count - $available_seats_count);
-
-        \Log::debug('Total: '.$total_seats_count);
-        \Log::debug('Users: '.$users_count);
-        \Log::debug('Available: '.$available_seats_count);
-        \Log::debug('Checkedout: '.$checkedout_seats_count);
-
 
         if ($license) {
+            $users_count = User::where('autoassign_licenses', '1')->count();
+            $total_seats_count = $license->totalSeatsByLicenseID();
+            $available_seats_count = $license->availCount()->count();
+            $checkedout_seats_count = ($total_seats_count - $available_seats_count);
+
+            \Log::debug('Total: '.$total_seats_count);
+            \Log::debug('Users: '.$users_count);
+            \Log::debug('Available: '.$available_seats_count);
+            \Log::debug('Checkedout: '.$checkedout_seats_count);
+
+
             $this->authorize('view', $license);
             return view('licenses.view', compact('license'))
                 ->with('users_count', $users_count)
@@ -254,7 +255,7 @@ class LicensesController extends Controller
                 ->with('checkedout_seats_count', $checkedout_seats_count);
         }
 
-        return redirect()->route('licenses.view')
+        return redirect()->route('licenses.index')
             ->with('error', trans('admin/licenses/message.does_not_exist'));
     }
 


### PR DESCRIPTION
# Description
When trying to view a license that doesn't exist, the system crashes instead of return the error. For example in the screenshot I don't have a license with ID 300.
![image](https://user-images.githubusercontent.com/653557/233427381-d4bb4e38-d6a1-4f91-a87d-dae63818cbce.png)

I put the variable declaration inside of the true part of the condition if the license is found. And if not, I redirect to the licenses index with the error.

Fixes rollbar #3516

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.32
* Webserver version: PHP dev server
* OS version: Debian 11
