### PR TITLE
Fix: Ensure users editing themselves do not deactivate their account

### DIFF
--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -210,7 +210,6 @@ class UsersController extends Controller
      */
     public function update(SaveUserRequest $request, $id = null)
     {
-
         // We need to reverse the UI specific logic for our
         // permissions here before we update the user.
         $permissions = $request->input('permissions', []);
@@ -268,7 +267,8 @@ class UsersController extends Controller
         $user->city = $request->input('city', null);
         $user->state = $request->input('state', null);
         $user->country = $request->input('country', null);
-        $user->activated = $request->input('activated', 0);
+        // if a user is editing themselves we should always keep activated true
+        $user->activated = $request->input('activated', $request->user()->is($user) ? 1 : 0);
         $user->zip = $request->input('zip', null);
         $user->remote = $request->input('remote', 0);
         $user->vip = $request->input('vip', 0);

--- a/tests/Feature/Users/UpdateUserTest.php
+++ b/tests/Feature/Users/UpdateUserTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Users;
+
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class UpdateUserTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testUsersCanBeActivated()
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['activated' => false]);
+
+        $this->actingAs($admin)
+            ->put(route('users.update', $user), [
+                'first_name' => $user->first_name,
+                'username' => $user->username,
+                'activated' => 1,
+            ]);
+
+        $this->assertTrue($user->refresh()->activated);
+    }
+
+    public function testUsersCanBeDeactivated()
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create(['activated' => true]);
+
+        $this->actingAs($admin)
+            ->put(route('users.update', $user), [
+                'first_name' => $user->first_name,
+                'username' => $user->username,
+                // checkboxes that are not checked are
+                // not included in the request payload
+                // 'activated' => 0,
+            ]);
+
+        $this->assertFalse($user->refresh()->activated);
+    }
+
+    public function testUsersUpdatingThemselvesDoNotDeactivateTheirAccount()
+    {
+        $admin = User::factory()->admin()->create(['activated' => true]);
+
+        $this->actingAs($admin)
+            ->put(route('users.update', $admin), [
+                'first_name' => $admin->first_name,
+                'username' => $admin->username,
+                // checkboxes that are disabled are not
+                // included in the request payload
+                // even if they are checked
+                // 'activated' => 0,
+            ]);
+
+        $this->assertTrue($admin->refresh()->activated);
+    }
+}


### PR DESCRIPTION
# Description

When a user is editing themselves they are shown the following in the form:
<img width="349" alt="image" src="https://user-images.githubusercontent.com/1141514/233544928-52a483cd-0f91-4d00-8b7f-0cbf3c7e2df8.png">

Upon submitting the form they are logged out because we accidentally marked their account as inactive. This is because checkboxes that are disabled, even when they are "checked", are not included in the form submission.

This PR fixes the issue and ensures that a user editing themselves doesn't deactivate their account in the process.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)