### PR TITLE
Added users total cost of assets to user profile

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -767,23 +767,25 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return $this->locale;
     }
     public function getUserTotalCost(){
-        $total_cost= array();
         $asset_cost= 0;
         $license_cost= 0;
         $accessory_cost= 0;
         foreach ($this->assets as $asset){
             $asset_cost += $asset->purchase_cost;
-            array_push($total_cost, $asset_cost);
+            $this->asset_cost = $asset_cost;
         }
         foreach ($this->licenses as $license){
             $license_cost += $license->purchase_cost;
-            array_push($total_cost, $license_cost);
+            $this->license_cost = $license_cost;
         }
         foreach ($this->accessories as $accessory){
             $accessory_cost += $accessory->purchase_cost;
-            array_push($total_cost, $accessory_cost);
+            $this->accessory_cost = $accessory_cost;
         }
 
-        return $total_cost;
+        $this->total_user_cost = ($asset_cost + $accessory_cost + $license_cost);
+
+
+        return $this;
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -766,4 +766,24 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     {
         return $this->locale;
     }
+    public function getUserTotalCost(){
+        $total_cost= array();
+        $asset_cost= 0;
+        $license_cost= 0;
+        $accessory_cost= 0;
+        foreach ($this->assets as $asset){
+            $asset_cost += $asset->purchase_cost;
+            array_push($total_cost, $asset_cost);
+        }
+        foreach ($this->licenses as $license){
+            $license_cost += $license->purchase_cost;
+            array_push($total_cost, $license_cost);
+        }
+        foreach ($this->accessories as $accessory){
+            $accessory_cost += $accessory->purchase_cost;
+            array_push($total_cost, $accessory_cost);
+        }
+
+        return $total_cost;
+    }
 }

--- a/resources/lang/en/admin/users/table.php
+++ b/resources/lang/en/admin/users/table.php
@@ -29,6 +29,7 @@ return array(
     'show_deleted'          => 'Show Deleted Users',
     'title' 				=> 'Title',
 	'to_restore_them'		=> 'to restore them.',
+    'total_assets_cost'     => "Total Assets Cost",
     'updateuser' 			=> 'Update User',
     'username' 				=> 'Username',
 	'user_deleted_text' 	=> 'This user has been marked as deleted.',

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -638,6 +638,26 @@
 
                     </div>
                     @endif
+                   <div class="row">
+
+                       <div class="col-md-3">
+                           {{ trans('admin/users/table.total_assets_cost') }}
+                       </div>
+                       <div class="col-md-9">
+                           {{Helper::formatCurrencyOutput(array_sum(array ($user->getUserTotalCost())))}}
+                           <a id="optional_info" class="text-primary">
+                               <i class="fa fa-caret-right fa-2x" id="optional_info_icon"></i>
+                               <strong>{{ trans('admin/hardware/form.optional_infos') }}</strong>
+                           </a>
+                       </div>
+                       <div id="optional_details" class="col-md-12" style="display:none">
+                           <br>
+                           <div class="col-md-9">
+
+                           </div>
+
+                       </div>
+                   </div>
 
                   </div> <!--/end striped container-->
                 </div> <!-- end col-md-9 -->
@@ -1108,6 +1128,12 @@ $(function () {
 
 
         }
+    });
+    $("#optional_info").on("click",function(){
+        $('#optional_details').fadeToggle(100);
+        $('#optional_info_icon').toggleClass('fa-caret-right fa-caret-down');
+        var optional_info_open = $('#optional_info_icon').hasClass('fa-caret-down');
+        document.cookie = "optional_info_open="+optional_info_open+'; path=/';
     });
 });
 </script>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -650,15 +650,14 @@
                                <strong>{{ trans('admin/hardware/form.optional_infos') }}</strong>
                            </a>
                        </div>
-                       <div id="optional_details" class="col-md-12" style="display:none">
-                           <br>
-                           <div class="col-md-9">
-                               Asset: {{$user->getUserTotalCost()->asset_cost}}
-                              License: {{$user->getUserTotalCost()->license_cost}}
-                               Accessory: {{$user->getUserTotalCost()->accessory_cost}}
+                           <div id="optional_details" class="col-md-12" style="display:none">
+                               <div class="col-md-3" style="border-top:none;"></div>
+                               <div class="col-md-9" style="border-top:none;">
+                               {{trans('general.assets').': '. Helper::formatCurrencyOutput($user->getUserTotalCost()->asset_cost)}}<br>
+                               {{trans('general.licenses').': '. Helper::formatCurrencyOutput($user->getUserTotalCost()->license_cost)}}<br>
+                               {{trans('general.accessories').': '.Helper::formatCurrencyOutput($user->getUserTotalCost()->accessory_cost)}}<br>
+                               </div>
                            </div>
-
-                       </div>
                    </div>
 
                   </div> <!--/end striped container-->

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -644,7 +644,7 @@
                            {{ trans('admin/users/table.total_assets_cost') }}
                        </div>
                        <div class="col-md-9">
-                           {{Helper::formatCurrencyOutput(array_sum(array ($user->getUserTotalCost())))}}
+                           {{Helper::formatCurrencyOutput($user->getUserTotalCost()->total_user_cost)}}
                            <a id="optional_info" class="text-primary">
                                <i class="fa fa-caret-right fa-2x" id="optional_info_icon"></i>
                                <strong>{{ trans('admin/hardware/form.optional_infos') }}</strong>
@@ -653,7 +653,9 @@
                        <div id="optional_details" class="col-md-12" style="display:none">
                            <br>
                            <div class="col-md-9">
-
+                               Asset: {{$user->getUserTotalCost()->asset_cost}}
+                              License: {{$user->getUserTotalCost()->license_cost}}
+                               Accessory: {{$user->getUserTotalCost()->accessory_cost}}
                            </div>
 
                        </div>


### PR DESCRIPTION
# Description
This adds a users total cost of assets they current use to the user profile. It also breaks down into Assets, Licenses, and Accessories.
<img width="846" alt="image" src="https://user-images.githubusercontent.com/47435081/234056311-e9b4f983-568a-4736-8be3-3ce6993cb4e9.png">

Fixes #sc-19399

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
