### PR TITLE
Fixes where clause operator in artisan checkout command

### DIFF
--- a/app/Console/Commands/CheckoutLicenseToAllUsers.php
+++ b/app/Console/Commands/CheckoutLicenseToAllUsers.php
@@ -56,7 +56,7 @@ class CheckoutLicenseToAllUsers extends Command
             return false;
         }
 
-        $users = User::whereNull('deleted_at')->where('autoassign_licenses', '==', 1)->with('licenses')->get();
+        $users = User::whereNull('deleted_at')->where('autoassign_licenses', '=', 1)->with('licenses')->get();
 
         if ($users->count() > $license->getAvailSeatsCountAttribute()) {
             $this->info('You do not have enough free seats to complete this task, so we will check out as many as we can. ');


### PR DESCRIPTION
# Description

This PR fixes the operator in a where clause used query users that are eligible to have licenses auto-assigned to them in the `CheckoutLicenseToAllUsers` artisan command. 

Previous output:
```
php artisan snipeit:checkout-to-all --license_id=2 --notify
Checking out 0 of 10 seats for Acrobat
```

Current output:
```
php artisan snipeit:checkout-to-all --license_id=2 --notify
You do not have enough free seats to complete this task, so we will check out as many as we can.
Checking out 58 of 10 seats for Acrobat
10 seats left
License 2 seat 11 checked out to admin
9 seats left
License 2 seat 12 checked out to snipe
8 seats left
License 2 seat 13 checked out to helmer.braun
7 seats left
License 2 seat 14 checked out to kstehr
6 seats left
License 2 seat 15 checked out to tatyana.cole
5 seats left
License 2 seat 16 checked out to roberto.kshlerin
4 seats left
License 2 seat 17 checked out to fcartwright
3 seats left
License 2 seat 18 checked out to gabrielle60
2 seats left
License 2 seat 19 checked out to towne.glen
1 seats left
License 2 seat 20 checked out to kuhlman.jadyn
ERROR: No available seats
```

---

**Side note:** It seems like the `--notify` flag doesn't actually send email notifications to users...I think that is on purpose to avoid sending what could end up being a _lot_ of emails at one time?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)