### PR TITLE
Added more granular permissions on bulk actions for assets

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -29,7 +29,7 @@ class BulkAssetsController extends Controller
      */
     public function edit(Request $request)
     {
-        $this->authorize('update', Asset::class);
+        $this->authorize('view', Asset::class);
 
         if (! $request->filled('ids')) {
             return redirect()->back()->with('error', trans('admin/hardware/message.update.no_assets_selected'));
@@ -44,6 +44,7 @@ class BulkAssetsController extends Controller
         if ($request->filled('bulk_actions')) {
             switch ($request->input('bulk_actions')) {
                 case 'labels':
+                    $this->authorize('view', Asset::class);
                     return view('hardware/labels')
                         ->with('assets', Asset::find($asset_ids))
                         ->with('settings', Setting::getSettings())
@@ -51,6 +52,7 @@ class BulkAssetsController extends Controller
                         ->with('count', 0);
 
                 case 'delete':
+                    $this->authorize('delete', Asset::class);
                     $assets = Asset::with('assignedTo', 'location')->find($asset_ids);
                     $assets->each(function ($asset) {
                         $this->authorize('delete', $asset);
@@ -58,7 +60,8 @@ class BulkAssetsController extends Controller
 
                     return view('hardware/bulk-delete')->with('assets', $assets);
                    
-                case 'restore': 
+                case 'restore':
+                    $this->authorize('update', Asset::class);
                     $assets = Asset::withTrashed()->find($asset_ids); 
                     $assets->each(function ($asset) {
                         $this->authorize('delete', $asset);
@@ -67,6 +70,7 @@ class BulkAssetsController extends Controller
                     return view('hardware/bulk-restore')->with('assets', $assets);
 
                 case 'edit':
+                    $this->authorize('update', Asset::class);
                     return view('hardware/bulk')
                         ->with('assets', $asset_ids)
                         ->with('statuslabel_list', Helper::statusLabelList());

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -337,6 +337,7 @@ class BulkAssetsController extends Controller
         
     }
     public function restore(Request $request) {
+        $this->authorize('update', Asset::class);
        $assetIds = $request->get('ids');
       if (empty($assetIds)) {
           return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.restore.nothing_updated'));


### PR DESCRIPTION
In a use case where a user only has view permission, if they were trying to create labels, they would get our sad panda permission denied page, since the bulk edit controller was checking for edit permissions, not view permissions. This fixes that.