### PR TITLE
Change from a standard Eloquent mapping for ID to a custom setRead

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -70,7 +70,11 @@ class SnipeSCIMConfig extends \ArieTimmerman\Laravel\SCIMServer\SCIMConfig
             // Map a SCIM attribute to an attribute of the object.
             'mapping' => [
 
-                'id' => AttributeMapping::eloquent("id")->disableWrite(),
+                'id' => (new AttributeMapping())->setRead(
+                    function (&$object) {
+                        return (string)$object->id;
+                    }
+                )->disableWrite(),
 
                 'externalId' => AttributeMapping::eloquent('scim_externalid'), // FIXME - I have a PR that changes a lot of this.
 
@@ -174,7 +178,6 @@ class SnipeSCIMConfig extends \ArieTimmerman\Laravel\SCIMServer\SCIMConfig
                         '$ref' => null,
                         'display' => null,
                         'type' => null,
-                        'type' => null
                     ]],
 
                     'entitlements' => null,


### PR DESCRIPTION
A customer reports that they were having problems with JumpCloud integration with our SCIM endpoint. JumpCloud eventually told us (indirectly) that the problem was because we were returning the 'id' attribute as an integer, not a string. Interestingly enough, it turns out that most of the other identity providers can handle that, but apparently JumpCloud could not.

After reviewing the specs, it turns out that this **is** actually a spec violation, so I thought it was important enough to fix. I also took the opportunity to review the rest of our SCIM output to see if there were any other 'bare' integers where strings should be being returned, and I didn't see any. So I felt like this change would be sufficient for what we need for now.

I'm going to be submitting a PR up to the upstream library as well, so as to be Good Open Source Citizens :)

Here is some of my test data - **BEFORE** the change:

```json
{
  "totalResults": 1369,
  "itemsPerPage": 10,
  "startIndex": 1,
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:ListResponse"
  ],
  "Resources": [
    {
      "id": 1,
      "meta": {
        "created": "2022-09-12T19:48:10+00:00",
        "lastModified": "2023-04-17T23:18:07+00:00",
        "location": "http://snipe-it.test/scim/v2/Users/1",
        "resourceType": "User"
      },
/* ... */
```

**AFTER** : 

```json
{
  "totalResults": 1369,
  "itemsPerPage": 10,
  "startIndex": 1,
  "schemas": [
    "urn:ietf:params:scim:api:messages:2.0:ListResponse"
  ],
  "Resources": [
    {
      "id": "1",
      "meta": {
        "created": "2022-09-12T19:48:10+00:00",
        "lastModified": "2023-04-17T23:18:07+00:00",
        "location": "http://snipe-it.test/scim/v2/Users/1",
        "resourceType": "User"
      },
/* ... */
```

(please note that this output is 'simulated' - because I cleared my screen after my initial testing, but I saw similar output to this during my tests)