### PR TITLE
Fixes state leak between tests

### DIFF
--- a/tests/Feature/Users/UpdateUserTest.php
+++ b/tests/Feature/Users/UpdateUserTest.php
@@ -12,7 +12,7 @@ class UpdateUserTest extends TestCase
 
     public function testUsersCanBeActivated()
     {
-        $admin = User::factory()->admin()->create();
+        $admin = User::factory()->superuser()->create();
         $user = User::factory()->create(['activated' => false]);
 
         $this->actingAs($admin)
@@ -27,7 +27,7 @@ class UpdateUserTest extends TestCase
 
     public function testUsersCanBeDeactivated()
     {
-        $admin = User::factory()->admin()->create();
+        $admin = User::factory()->superuser()->create();
         $user = User::factory()->create(['activated' => true]);
 
         $this->actingAs($admin)
@@ -44,7 +44,7 @@ class UpdateUserTest extends TestCase
 
     public function testUsersUpdatingThemselvesDoNotDeactivateTheirAccount()
     {
-        $admin = User::factory()->admin()->create(['activated' => true]);
+        $admin = User::factory()->superuser()->create(['activated' => true]);
 
         $this->actingAs($admin)
             ->put(route('users.update', $admin), [


### PR DESCRIPTION
# Description

I noticed that running the test case included in #12887 in isolation works as expected but there is some state leaking that causes failures when running the entire test suite. This PR switches from using the `admin` to the `superuser` state on the user factory which fixes the issue.

I'll investigate the issue with the `admin` state in the future.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)