### PR TITLE
Fixed #12918 - wrong route for clone location

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -50,7 +50,7 @@ Route::group(['middleware' => 'auth'], function () {
         
         Route::get('{locationId}/clone',
             [LocationsController::class, 'getClone']
-        )->name('clone/license');
+        )->name('clone/location');
 
         Route::get(
             '{locationId}/printassigned',


### PR DESCRIPTION
Fixed #12918 where we had the wrong name in the routes file for cloning locations, which was causing the clone license to fail on the View License page.