### PR TITLE
Env-ify hashing variables, setting the normal defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,6 +176,15 @@ API_THROTTLE_PER_MINUTE=120
 CSV_ESCAPE_FORMULAS=true
 
 # --------------------------------------------
+# OPTIONAL: HASHING
+# --------------------------------------------
+HASHING_DRIVER='bcrypt'
+BCRYPT_ROUNDS=10
+ARGON_MEMORY=1024
+ARGON_THREADS=2
+ARGON_TIME=2
+
+# --------------------------------------------
 # OPTIONAL: SCIM
 # --------------------------------------------
 SCIM_TRACE=false

--- a/config/hashing.php
+++ b/config/hashing.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'driver' => 'bcrypt',
+    'driver' => env('HASHING_DRIVER', 'bcrypt'),
 
     /*
     |--------------------------------------------------------------------------
@@ -44,9 +44,9 @@ return [
     */
 
     'argon' => [
-        'memory' => 1024,
-        'threads' => 2,
-        'time' => 2,
+        'memory' => env('ARGON_MEMORY', 1024),
+        'threads' => env('ARGON_THREADS', 2),
+        'time' => env('ARGON_TIME', 2),
     ],
 
 ];


### PR DESCRIPTION
We were using the normal Laravel defaults for hashing driver, work rounds, etc - but this way it will allow Snipe-IT admins to define that from the .env