### PR TITLE
Use the asset tag instead of asset name if no name is given on delete modal

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -269,12 +269,19 @@
             }
 
             if ((row.available_actions) && (row.available_actions.delete === true)) {
+
+                // use the asset tag if no name is provided
+                var name_for_box = row.name
+                if (row.name=='') {
+                    var name_for_box = row.asset_tag
+                }
+                
                 actions += '<a href="{{ config('app.url') }}/' + dest + '/' + row.id + '" '
                     + ' class="btn btn-danger btn-sm delete-asset" data-tooltip="true"  '
                     + ' data-toggle="modal" '
-                    + ' data-content="{{ trans('general.sure_to_delete') }} ' + row.name + '?" '
+                    + ' data-content="{{ trans('general.sure_to_delete') }} ' + name_for_box + '?" '
                     + ' data-title="{{  trans('general.delete') }}" onClick="return false;">'
-                    + '<i class="fas fa-trash" aria-hidden="true"></i><span class="sr-only">Delete</span></a>&nbsp;';
+                    + '<i class="fas fa-trash" aria-hidden="true"></i><span class="sr-only">{{ trans('general.delete') }}</span></a>&nbsp;';
             } else {
                 actions += '<span data-tooltip="true" title="{{ trans('general.cannot_be_deleted') }}"><a class="btn btn-danger btn-sm delete-asset disabled" onClick="return false;"><i class="fas fa-trash"></i></a></span>&nbsp;';
             }


### PR DESCRIPTION
This fixes a small UI quirk where if the asset's name is not populated - and it doesn't have to be - it will return an awkward looking message.

### Data:
<img width="1723" alt="Screenshot 2023-04-26 at 2 42 09 PM" src="https://user-images.githubusercontent.com/197404/234709650-6f44b550-1089-4506-a15d-eea59c3b3266.png">

### Before:
<img width="736" alt="Screenshot 2023-04-26 at 2 42 14 PM" src="https://user-images.githubusercontent.com/197404/234709729-f2b2dd6f-e914-4c33-b300-72aac987c7c8.png">
<img width="726" alt="Screenshot 2023-04-26 at 2 42 22 PM" src="https://user-images.githubusercontent.com/197404/234709732-60fbceaf-80ee-4309-93a9-22bcf973e888.png">


### After:
<img width="736" alt="Screenshot 2023-04-26 at 2 42 14 PM" src="https://user-images.githubusercontent.com/197404/234709787-7d79d5b6-d536-45e5-a367-e55fe3b12c0b.png">
<img width="724" alt="Screenshot 2023-04-26 at 2 42 50 PM" src="https://user-images.githubusercontent.com/197404/234709788-5d7c311c-d10e-4460-bebc-b031f4141cb0.png">

Assets are the only thing in the system where name is optional, and I tested this fix on users, etc and all seems fine.