### PR TITLE
Added help text to the now-dynamic manufacturer URLS

### DIFF
--- a/resources/lang/en/admin/manufacturers/message.php
+++ b/resources/lang/en/admin/manufacturers/message.php
@@ -2,6 +2,7 @@
 
 return array(
 
+    'support_url_help' => 'Use <code>{LOCALE}</code> and <code>{SERIAL}</code> in your URL as variables to have those values auto-populate when viewing assets.',
     'does_not_exist' => 'Manufacturer does not exist.',
     'assoc_users'	 => 'This manufacturer is currently associated with at least one model and cannot be deleted. Please update your models to no longer reference this manufacturer and try again. ',
 

--- a/resources/views/manufacturers/edit.blade.php
+++ b/resources/views/manufacturers/edit.blade.php
@@ -26,6 +26,7 @@
         </label>
         <div class="col-md-6">
             <input class="form-control" type="text" name="support_url" id="support_url" value="{{ old('support_url', $item->support_url) }}" />
+            <p class="help-block">{!! trans('admin/manufacturers/message.support_url_help') !!}</p>
             {!! $errors->first('support_url', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>


### PR DESCRIPTION
This just adds some help text to manufacture's support url form to indicate the new variables

<img width="1133" alt="Screenshot 2023-04-26 at 2 54 27 PM" src="https://user-images.githubusercontent.com/197404/234714608-a21b029c-0851-4723-bf37-c70f887f3ff2.png">
