### PR TITLE
Added dynamic warranty URL to manufacturers

### DIFF
--- a/app/Http/Controllers/Api/ManufacturersController.php
+++ b/app/Http/Controllers/Api/ManufacturersController.php
@@ -23,10 +23,10 @@ class ManufacturersController extends Controller
     public function index(Request $request)
     {
         $this->authorize('view', Manufacturer::class);
-        $allowed_columns = ['id', 'name', 'url', 'support_url', 'support_email', 'support_phone', 'created_at', 'updated_at', 'image', 'assets_count', 'consumables_count', 'components_count', 'licenses_count'];
+        $allowed_columns = ['id', 'name', 'url', 'support_url', 'support_email', 'warranty_lookup_url', 'support_phone', 'created_at', 'updated_at', 'image', 'assets_count', 'consumables_count', 'components_count', 'licenses_count'];
 
         $manufacturers = Manufacturer::select(
-            ['id', 'name', 'url', 'support_url', 'support_email', 'support_phone', 'created_at', 'updated_at', 'image', 'deleted_at']
+            ['id', 'name', 'url', 'support_url', 'warranty_lookup_url', 'support_email', 'support_phone', 'created_at', 'updated_at', 'image', 'deleted_at']
         )->withCount('assets as assets_count')->withCount('licenses as licenses_count')->withCount('consumables as consumables_count')->withCount('accessories as accessories_count');
 
         if ($request->input('deleted') == 'true') {
@@ -47,6 +47,10 @@ class ManufacturersController extends Controller
 
         if ($request->filled('support_url')) {
             $manufacturers->where('support_url', '=', $request->input('support_url'));
+        }
+
+        if ($request->filled('warranty_lookup_url')) {
+            $manufacturers->where('warranty_lookup_url', '=', $request->input('warranty_lookup_url'));
         }
 
         if ($request->filled('support_phone')) {

--- a/app/Http/Controllers/ManufacturersController.php
+++ b/app/Http/Controllers/ManufacturersController.php
@@ -68,6 +68,7 @@ class ManufacturersController extends Controller
         $manufacturer->user_id = Auth::id();
         $manufacturer->url = $request->input('url');
         $manufacturer->support_url = $request->input('support_url');
+        $manufacturer->warranty_lookup_url = $request->input('warranty_lookup_url');
         $manufacturer->support_phone = $request->input('support_phone');
         $manufacturer->support_email = $request->input('support_email');
         $manufacturer = $request->handleImages($manufacturer);
@@ -127,6 +128,7 @@ class ManufacturersController extends Controller
         $manufacturer->name = $request->input('name');
         $manufacturer->url = $request->input('url');
         $manufacturer->support_url = $request->input('support_url');
+        $manufacturer->warranty_lookup_url = $request->input('warranty_lookup_url');
         $manufacturer->support_phone = $request->input('support_phone');
         $manufacturer->support_email = $request->input('support_email');
 

--- a/app/Http/Transformers/ManufacturersTransformer.php
+++ b/app/Http/Transformers/ManufacturersTransformer.php
@@ -29,6 +29,7 @@ class ManufacturersTransformer
                 'url' => e($manufacturer->url),
                 'image' =>   ($manufacturer->image) ? Storage::disk('public')->url('manufacturers/'.e($manufacturer->image)) : null,
                 'support_url' => e($manufacturer->support_url),
+                'warranty_lookup_url' => e($manufacturer->warranty_lookup_url),
                 'support_phone' => e($manufacturer->support_phone),
                 'support_email' => e($manufacturer->support_email),
                 'assets_count' => (int) $manufacturer->assets_count,

--- a/app/Models/Manufacturer.php
+++ b/app/Models/Manufacturer.php
@@ -25,6 +25,7 @@ class Manufacturer extends SnipeModel
         'url'   => 'url|nullable',
         'support_email'   => 'email|nullable',
         'support_url'   => 'starts_with:http://,https://,afp://,facetime://,file://,irc://','nullable',
+        'warranty_lookup_url' => 'starts_with:http://,https://,afp://,facetime://,file://,irc://','nullable'
     ];
 
     protected $hidden = ['user_id'];
@@ -51,6 +52,7 @@ class Manufacturer extends SnipeModel
         'support_phone',
         'support_url',
         'url',
+        'warranty_lookup_url',
     ];
 
     use Searchable;

--- a/app/Models/Manufacturer.php
+++ b/app/Models/Manufacturer.php
@@ -24,7 +24,7 @@ class Manufacturer extends SnipeModel
         'name'   => 'required|min:2|max:255|unique:manufacturers,name,NULL,id,deleted_at,NULL',
         'url'   => 'url|nullable',
         'support_email'   => 'email|nullable',
-        'support_url'   => 'starts_with:http://,https://,afp://,facetime://,file://,irc://','nullable',
+        'support_url'   => 'nullable|url',
         'warranty_lookup_url' => 'starts_with:http://,https://,afp://,facetime://,file://,irc://','nullable'
     ];
 

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -538,14 +538,12 @@ class AssetPresenter extends Presenter
      * Used to take user created warranty URL and dynamically fill in the needed values per asset
      * @return string
      */
-    public function supportUrl()
+    public function dynamicVariableUrl()
     {
-        $tempurl = $this->model->model->manufacturer->support_url;
-
-        $tempurl = (str_replace('{LOCALE}',\App\Models\Setting::getSettings()->locale,$tempurl));
-        $tempurl = (str_replace('{SERIAL}',$this->model->serial,$tempurl));
-
-        return $tempurl;
+        $warranty_lookup_url = $this->model->model->manufacturer->warranty_lookup_url;
+        $url = (str_replace('{LOCALE}',\App\Models\Setting::getSettings()->locale,$warranty_lookup_url));
+        $url = (str_replace('{SERIAL}',$this->model->serial,$url));
+        return $url;
     }
 
     /**

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -538,7 +538,7 @@ class AssetPresenter extends Presenter
      * Used to take user created warranty URL and dynamically fill in the needed values per asset
      * @return string
      */
-    public function dynamicVariableUrl()
+    public function dynamicWarrantyUrl()
     {
         $warranty_lookup_url = $this->model->model->manufacturer->warranty_lookup_url;
         $url = (str_replace('{LOCALE}',\App\Models\Setting::getSettings()->locale,$warranty_lookup_url));

--- a/app/Presenters/ManufacturerPresenter.php
+++ b/app/Presenters/ManufacturerPresenter.php
@@ -78,6 +78,15 @@ class ManufacturerPresenter extends Presenter
                 'visible' => true,
                 'formatter' => 'emailFormatter',
             ],
+            [
+                'field' => 'warranty_lookup_url',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('admin/manufacturers/table.warranty_lookup_url'),
+                'visible' => false,
+                'formatter' => 'linkFormatter',
+            ],
 
             [
                 'field' => 'assets_count',

--- a/database/factories/ManufacturerFactory.php
+++ b/database/factories/ManufacturerFactory.php
@@ -38,6 +38,7 @@ class ManufacturerFactory extends Factory
                 'name' => 'Apple',
                 'url' => 'https://apple.com',
                 'support_url' => 'https://support.apple.com',
+                'warranty_lookup_url' => 'https://checkcoverage.apple.com',
                 'image' => 'apple.jpg',
             ];
         });
@@ -50,6 +51,7 @@ class ManufacturerFactory extends Factory
                 'name' => 'Microsoft',
                 'url' => 'https://microsoft.com',
                 'support_url' => 'https://support.microsoft.com',
+                'warranty_lookup_url' => 'https://account.microsoft.com/devices',
                 'image' => 'microsoft.png',
             ];
         });
@@ -62,6 +64,7 @@ class ManufacturerFactory extends Factory
                 'name' => 'Dell',
                 'url' => 'https://dell.com',
                 'support_url' => 'https://support.dell.com',
+                'warranty_lookup_url' => 'https://www.dell.com/support/home/en-us/Products/?app=warranty',
                 'image' => 'dell.png',
             ];
         });

--- a/database/migrations/2023_04_26_160235_add_warranty_url_to_manufacturers.php
+++ b/database/migrations/2023_04_26_160235_add_warranty_url_to_manufacturers.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddWarrantyUrlToManufacturers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('manufacturers', function (Blueprint $table) {
+            $table->string('warranty_lookup_url')->after('support_url')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('manufacturers', function (Blueprint $table) {
+            $table->dropColumn('warranty_lookup_url');
+        });
+    }
+}

--- a/resources/lang/en/admin/manufacturers/table.php
+++ b/resources/lang/en/admin/manufacturers/table.php
@@ -10,6 +10,7 @@ return array(
     'support_email'   		=> 'Support Email',
     'support_phone'   		=> 'Support Phone',
     'support_url'   		=> 'Support URL',
+    'warranty_lookup_url'   => 'Warranty Lookup URL',
     'update'				=> 'Update Manufacturer',
     'url'   				=> 'URL',
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -595,9 +595,9 @@
                                                 {{ $asset->warranty_months }}
                                                 {{ trans('admin/hardware/form.months') }}
 
-                                                @if ($asset->serial && $asset->model->manufacturer)
-                                                    <a href="{{ $asset->present()->supportUrl() }}" target="_blank">
-                                                        <i class="fa fa-external-link" style="width:25px;height:25px;"><span class="sr-only">{{ trans('hardware/general.mfg_warranty_lookup') }}</span></i>
+                                                @if (($asset->model->manufacturer) && ($asset->model->manufacturer->warranty_lookup_url!=''))
+                                                    <a href="{{ $asset->present()->dynamicVariableUrl() }}" target="_blank">
+                                                        <i class="fa fa-external-link"><span class="sr-only">{{ trans('hardware/general.mfg_warranty_lookup') }}</span></i>
                                                     </a>
                                                 @endif
                                             </div>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -596,7 +596,7 @@
                                                 {{ trans('admin/hardware/form.months') }}
 
                                                 @if (($asset->model->manufacturer) && ($asset->model->manufacturer->warranty_lookup_url!=''))
-                                                    <a href="{{ $asset->present()->dynamicVariableUrl() }}" target="_blank">
+                                                    <a href="{{ $asset->present()->dynamicWarrantyUrl() }}" target="_blank">
                                                         <i class="fa fa-external-link"><span class="sr-only">{{ trans('hardware/general.mfg_warranty_lookup') }}</span></i>
                                                     </a>
                                                 @endif

--- a/resources/views/manufacturers/edit.blade.php
+++ b/resources/views/manufacturers/edit.blade.php
@@ -26,7 +26,6 @@
         </label>
         <div class="col-md-6">
             <input class="form-control" type="text" name="support_url" id="support_url" value="{{ old('support_url', $item->support_url) }}" />
-            <p class="help-block">{!! trans('admin/manufacturers/message.support_url_help') !!}</p>
             {!! $errors->first('support_url', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>

--- a/resources/views/manufacturers/edit.blade.php
+++ b/resources/views/manufacturers/edit.blade.php
@@ -31,6 +31,17 @@
         </div>
     </div>
 
+    <!-- Warranty Lookup URL -->
+    <div class="form-group {{ $errors->has('warranty_lookup_url') ? ' has-error' : '' }}">
+        <label for="support_url" class="col-md-3 control-label">{{ trans('admin/manufacturers/table.warranty_lookup_url') }}
+        </label>
+        <div class="col-md-6">
+            <input class="form-control" type="text" name="warranty_lookup_url" id="warranty_lookup_url" value="{{ old('warranty_lookup_url', $item->warranty_lookup_url) }}" />
+            <p class="help-block">{!! trans('admin/manufacturers/message.support_url_help') !!}</p>
+            {!! $errors->first('warranty_lookup_url', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        </div>
+    </div>
+
     <!-- Support Phone -->
     <div class="form-group {{ $errors->has('support_phone') ? ' has-error' : '' }}">
         <label for="support_phone" class="col-md-3 control-label">{{ trans('admin/manufacturers/table.support_phone') }}


### PR DESCRIPTION
This takes the great work by @akemidx on adding variables to the support url on manufacturers and adds a warranty lookup URL that can use `{LOCALE}` and `{SERIAL}` as variables in the URL.

This *does* switch us back to non-dynamic support URLs, but I think those *tend* to be more static anyway. I think probably we'll want to eventually move this into a url helper that's global so we can expand this functionality over time. 