### PR TITLE
Remove auto-link from from manufacturer warranty

### DIFF
--- a/app/Presenters/ManufacturerPresenter.php
+++ b/app/Presenters/ManufacturerPresenter.php
@@ -56,7 +56,7 @@ class ManufacturerPresenter extends Presenter
                 'switchable' => true,
                 'title' => trans('admin/manufacturers/table.support_url'),
                 'visible' => true,
-                'formatter' => 'linkFormatter',
+                'formatter' => 'externalLinkFormatter',
             ],
 
             [
@@ -85,7 +85,7 @@ class ManufacturerPresenter extends Presenter
                 'switchable' => true,
                 'title' => trans('admin/manufacturers/table.warranty_lookup_url'),
                 'visible' => false,
-                'formatter' => 'linkFormatter',
+                'formatter' => 'externalLinkFormatter',
             ],
 
             [

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -597,7 +597,7 @@
 
                                                 @if (($asset->model->manufacturer) && ($asset->model->manufacturer->warranty_lookup_url!=''))
                                                     <a href="{{ $asset->present()->dynamicWarrantyUrl() }}" target="_blank">
-                                                        <i class="fa fa-external-link"><span class="sr-only">{{ trans('hardware/general.mfg_warranty_lookup') }}</span></i>
+                                                        <i class="fa fa-external-link"><span class="sr-only">{{ trans('admin/hardware/general.mfg_warranty_lookup', ['manufacturer' => $asset->model->manufacturer->name]) }}</span></i>
                                                     </a>
                                                 @endif
                                             </div>

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -511,8 +511,12 @@
     }
 
     function externalLinkFormatter(value) {
+
         if (value) {
-            return '<a href="' + value + '" target="_blank">' + value + '</a>';
+            if ((value.indexOf("{") === -1) || (value.indexOf("}") ===-1)) {
+                return '<a href="' + value + '" target="_blank">' + value + ' <i class="fa fa-external-link"><span class="sr-only">{{ trans('hardware/general.mfg_warranty_lookup') }}</span></i></a>';
+            }
+            return value;
         }
     }
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -514,7 +514,7 @@
 
         if (value) {
             if ((value.indexOf("{") === -1) || (value.indexOf("}") ===-1)) {
-                return '<a href="' + value + '" target="_blank">' + value + ' <i class="fa fa-external-link"><span class="sr-only">{{ trans('hardware/general.mfg_warranty_lookup') }}</span></i></a>';
+                return '<a href="' + value + '" target="_blank">' + value + ' <i class="fa fa-external-link"></i></a>';
             }
             return value;
         }


### PR DESCRIPTION
This is an improvement on the new `warranty_lookup_url` functionality, where if there are NO dynamic fields detected (`{`) or `}`) we will link it, if we find dynamic variables in there, we'll just make it text, since without those placeholder variables filled in, that link from the manufacturers listing page will never work. 

I've also implemented the `externalLinkFormatter` on the support and warranty URL so that we include the "external link" icon where appropriate.

<img width="747" alt="Asset_Manufacturers____Snipe-IT_Demo" src="https://user-images.githubusercontent.com/197404/234738196-5a9807c6-5e18-4fd8-802b-1749fe1d0e46.png">
