### PR TITLE
Added missing case for licenses for item_count

### DIFF
--- a/app/Http/Transformers/CategoriesTransformer.php
+++ b/app/Http/Transformers/CategoriesTransformer.php
@@ -38,6 +38,9 @@ class CategoriesTransformer
             case 'component':
                 $category->item_count = $category->components_count;
                 break;
+            case 'license':
+                $category->item_count = $category->licenses_count;
+                break;
             default:
                 $category->item_count = 0;
         }


### PR DESCRIPTION
We were missing a switch case for licenses to determine `item_count`. This was added, so viewing license categories should show the correct number of licenses now.