### PR TITLE
Clear the settings cache on app destruction

### DIFF
--- a/tests/Support/InteractsWithSettings.php
+++ b/tests/Support/InteractsWithSettings.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Support;
 
+use App\Models\Setting;
+
 trait InteractsWithSettings
 {
     protected Settings $settings;
@@ -9,5 +11,7 @@ trait InteractsWithSettings
     public function setUpSettings()
     {
         $this->settings = Settings::initialize();
+
+        $this->beforeApplicationDestroyed(fn() => Setting::$_cache = null);
     }
 }

--- a/tests/Support/InteractsWithSettings.php
+++ b/tests/Support/InteractsWithSettings.php
@@ -8,7 +8,7 @@ trait InteractsWithSettings
 {
     protected Settings $settings;
 
-    public function setUpSettings()
+    public function initializeSettings()
     {
         $this->settings = Settings::initialize();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,7 +23,7 @@ abstract class TestCase extends BaseTestCase
         $this->withoutMiddleware($this->globallyDisabledMiddleware);
 
         if (collect(class_uses_recursive($this))->contains(InteractsWithSettings::class)) {
-            $this->setUpSettings();
+            $this->initializeSettings();
         }
     }
 }

--- a/tests/Unit/AssetMaintenanceTest.php
+++ b/tests/Unit/AssetMaintenanceTest.php
@@ -3,10 +3,13 @@ namespace Tests\Unit;
 
 use App\Models\AssetMaintenance;
 use Carbon\Carbon;
+use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
 class AssetMaintenanceTest extends TestCase
 {
+    use InteractsWithSettings;
+
     public function testZerosOutWarrantyIfBlank()
     {
         $c = new AssetMaintenance;

--- a/tests/Unit/AssetModelTest.php
+++ b/tests/Unit/AssetModelTest.php
@@ -4,10 +4,13 @@ namespace Tests\Unit;
 use App\Models\Asset;
 use App\Models\Category;
 use App\Models\AssetModel;
+use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
 class AssetModelTest extends TestCase
 {
+    use InteractsWithSettings;
+
     public function testAnAssetModelZerosOutBlankEols()
     {
         $am = new AssetModel;

--- a/tests/Unit/AssetTest.php
+++ b/tests/Unit/AssetTest.php
@@ -5,10 +5,13 @@ use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Category;
 use Carbon\Carbon;
+use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
 class AssetTest extends TestCase
 {
+    use InteractsWithSettings;
+
     // public function testAutoIncrementMixed()
     // {
     //     $expected = '123411';

--- a/tests/Unit/CategoryTest.php
+++ b/tests/Unit/CategoryTest.php
@@ -4,10 +4,13 @@ namespace Tests\Unit;
 use App\Models\Category;
 use App\Models\AssetModel;
 use App\Models\Asset;
+use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
 class CategoryTest extends TestCase
 {
+    use InteractsWithSettings;
+
     public function testFailsEmptyValidation()
     {
         // An Asset requires a name, a qty, and a category_id.

--- a/tests/Unit/ComponentTest.php
+++ b/tests/Unit/ComponentTest.php
@@ -5,10 +5,13 @@ use App\Models\Category;
 use App\Models\Company;
 use App\Models\Component;
 use App\Models\Location;
+use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
 class ComponentTest extends TestCase
 {
+    use InteractsWithSettings;
+
     public function testAComponentBelongsToACompany()
     {
         $component = Component::factory()

--- a/tests/Unit/DepreciationTest.php
+++ b/tests/Unit/DepreciationTest.php
@@ -5,10 +5,13 @@ use App\Models\Depreciation;
 use App\Models\Category;
 use App\Models\License;
 use App\Models\AssetModel;
+use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
 class DepreciationTest extends TestCase
 {
+    use InteractsWithSettings;
+
     public function testADepreciationHasModels()
     {
         $depreciation = Depreciation::factory()->create();

--- a/tests/Unit/NotificationTest.php
+++ b/tests/Unit/NotificationTest.php
@@ -8,10 +8,13 @@ use App\Models\Category;
 use Carbon\Carbon;
 use App\Notifications\CheckoutAssetNotification;
 use Illuminate\Support\Facades\Notification;
+use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
 class NotificationTest extends TestCase
 {
+    use InteractsWithSettings;
+
     public function testAUserIsEmailedIfTheyCheckoutAnAssetWithEULA()
     {
         $admin = User::factory()->superuser()->create();

--- a/tests/Unit/SnipeModelTest.php
+++ b/tests/Unit/SnipeModelTest.php
@@ -2,10 +2,13 @@
 namespace Tests\Unit;
 
 use App\Models\SnipeModel;
+use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
 class SnipeModelTest extends TestCase
 {
+    use InteractsWithSettings;
+
     public function testSetsPurchaseDatesAppropriately()
     {
         $c = new SnipeModel;


### PR DESCRIPTION
# Description

This PR gets the test suite back to green by adding the `InteractsWithSettings` trait to some unit tests that expect settings to be initialized. (A recent [PR](https://github.com/snipe/snipe-it/pull/12756) moved some logic that relies on the app's currency to model setters and getters)

In addition, I added a hook to clear the settings cache in between tests to avoid leaking state.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)