### PR TITLE
Fixed Error 500 after sign and accept asset

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -159,6 +159,9 @@ class AcceptanceController extends Controller
                 case 'App\Models\Asset':
                         $pdf_view_route ='account.accept.accept-asset-eula';
                         $asset_model = AssetModel::find($item->model_id);
+                        if (!$asset_model) {
+                            return redirect()->back()->with('error', trans('admin/models/message.does_not_exist'));
+                        }
                         $display_model = $asset_model->name;
                         $assigned_to = User::find($acceptance->assigned_to_id)->present()->fullName;
                 break;

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -573,6 +573,10 @@ class AssetsController extends Controller
         // Update custom fields in the database.
         // Validation for these fields is handled through the AssetRequest form request
         $model = AssetModel::find($request->get('model_id'));
+        if (!$model) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/models/message.does_not_exist')), 200);
+        }
+
         if (($model) && ($model->fieldset)) {
             foreach ($model->fieldset->fields as $field) {
 


### PR DESCRIPTION
# Description
A customer reported that when a user accepts an Asset a 500 is triggered.

I found that this was happening because the asset that is being assigned have associated a model that is soft-deleted. Which is something that doesn't supposed to happen. I discovered that using the API is possible to assign a model that doesn't exist when creating a new asset. So instead of patching the already occurred error I fix the root cause in the API. 

I'm also adding a little conditional to the code retrieving the model name, so it doesn't hard crashes to users that already have models soft-deleted assigned to their assets, but that shouldn't be a problem from now on.

Fixes internal freshdesk 35225

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP Dev Server
* OS version: Debian 11


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
