### PR TITLE
Restrict PHP version to <8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": ">=7.4 <8.3",
+    "php": ">=7.4.3 <8.2",
     "ext-curl": "*",
     "ext-fileinfo": "*",
     "ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "590171872e4a6a29c78efde99fbbf00e",
+    "content-hash": "c0444af6de1d16a70c7e5520db745170",
     "packages": [
         {
             "name": "alek13/slack",
@@ -2673,6 +2673,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2022-02-23T14:25:13+00:00"
         },
         {
@@ -3803,6 +3804,7 @@
                 "issues": "https://github.com/LaravelCollective/html/issues",
                 "source": "https://github.com/LaravelCollective/html"
             },
+            "abandoned": "spatie/laravel-html",
             "time": "2022-02-08T21:02:54+00:00"
         },
         {
@@ -5007,6 +5009,10 @@
                 "source": "https://github.com/maennchen/ZipStream-PHP/tree/2.2.1"
             },
             "funding": [
+                {
+                    "url": "https://github.com/maennchen",
+                    "type": "github"
+                },
                 {
                     "url": "https://opencollective.com/zipstream",
                     "type": "open_collective"
@@ -13984,6 +13990,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-12-07T05:51:20+00:00"
         },
         {
@@ -16410,7 +16417,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4 <8.3",
+        "php": ">=7.4.3 <8.2",
         "ext-curl": "*",
         "ext-fileinfo": "*",
         "ext-json": "*",
@@ -16418,5 +16425,5 @@
         "ext-pdo": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
# Description

We're aware of some issues that occur when the app is running PHP 8.2 so this PR restricts PHP in composer for the time-being.

## Type of change

- [x] Bug fix (~~non-breaking change~~ which fixes an issue)
- [x] Breaking change