### PR TITLE
Show signature column in asset history regardless of “require sig” state

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1170,10 +1170,8 @@
                   <th class="col-sm-2" data-visible="true" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>
                   <th class="col-sm-2" data-visible="true" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.target') }}</th>
                   <th class="col-sm-2" data-field="note">{{ trans('general.notes') }}</th>
-                    @if  ($snipeSettings->require_accept_signature=='1')
-                        <th class="col-md-3" data-field="signature_file" data-visible="false"  data-formatter="imageFormatter">{{ trans('general.signature') }}</th>
-                    @endif
-                    <th class="col-md-3" data-visible="false" data-field="file" data-visible="false"  data-formatter="fileUploadFormatter">{{ trans('general.download') }}</th>
+                  <th class="col-md-3" data-field="signature_file" data-visible="false"  data-formatter="imageFormatter">{{ trans('general.signature') }}</th>
+                  <th class="col-md-3" data-visible="false" data-field="file" data-visible="false"  data-formatter="fileUploadFormatter">{{ trans('general.download') }}</th>
                   <th class="col-sm-2" data-field="log_meta" data-visible="true" data-formatter="changeLogFormatter">{{ trans('admin/hardware/table.changed')}}</th>
                 </tr>
                 </thead>


### PR DESCRIPTION
Previously, we would only show the signature column in asset history if the Require Signature option was checked in `Admin > Settings`. We did this to remove unnecessary cruft from the UI for folks who were never (and never intended to) use signatures on asset acceptance. This could be a little confusing however, since the history tab is a look back through time, where the Require Signature option is real-time. So as a compromise to make it clearer, we are no longer checking to see whether or not the Require Signature option is checked - we just make that column available by default no matter what. It's hidden by default so it doesn't clutter the screen, but superadmins should now be able to toggle that option in their settings and while it will impact whether or not a signature is actually required, it will not affect visibility on the asset history page. 