### PR TITLE
Refactor of #12955

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -573,9 +573,6 @@ class AssetsController extends Controller
         // Update custom fields in the database.
         // Validation for these fields is handled through the AssetRequest form request
         $model = AssetModel::find($request->get('model_id'));
-        if (!$model) {
-            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/models/message.does_not_exist')), 200);
-        }
 
         if (($model) && ($model->fieldset)) {
             foreach ($model->fieldset->fields as $field) {

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -90,7 +90,7 @@ class Asset extends Depreciable
 
     protected $rules = [
         'name'            => 'max:255|nullable',
-        'model_id'        => 'required|integer|exists:models,id',
+        'model_id'        => 'required|integer|exists:models,id,deleted_at,NULL',
         'status_id'       => 'required|integer|exists:status_labels,id',
         'company_id'      => 'integer|nullable',
         'warranty_months' => 'numeric|nullable|digits_between:0,240',


### PR DESCRIPTION
# Description
A couple days ago I submit the following PR https://github.com/snipe/snipe-it/pull/12955. Which made an early return so if we try to assign a `model_id` of a model that's soft-deleted on the system, it returns an error.

This PR refactor those changes and made the validation in the `model_id: exists` rule over the `Model\Asset.php` file, which is a change suggested by @snipe, and I agree that make the code a lot simpler and better.

## Type of change
- [x] Refactor

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.2
* MySQL version: 8.0.31
* Webserver version: PHP Dev server
* OS version: Debian 11
