### PR TITLE
Fixed misplaced div when saml is disabled

### DIFF
--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -92,9 +92,10 @@
                                     <p class="help-block">
                                         <a href="{{ route('saml.metadata') }}" target="_blank" class="btn btn-default" style="margin-right: 5px;">{{ trans('admin/settings/general.saml_download') }}</a>
                                     </p>
+                                    </div>
                                 @endif
                                 {!! $errors->first('saml_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                            </div>
+
                         </div>
 
 


### PR DESCRIPTION
Looks like we had a misplaced div that was causing the layout to be weird if you didn't have SAML enabled. 

<img width="1097" alt="Screenshot 2023-05-08 at 11 22 14 AM" src="https://user-images.githubusercontent.com/197404/236901275-07e87718-bbb5-4c99-91ba-cd4bfcd1b92a.png">
