### PR TITLE
Check that the filename we pass ends in zip, add it if not

### DIFF
--- a/app/Console/Commands/SystemBackup.php
+++ b/app/Console/Commands/SystemBackup.php
@@ -38,7 +38,14 @@ class SystemBackup extends Command
     public function handle()
     {
         if ($this->option('filename')) {
-            $this->call('backup:run', ['--filename' => $this->option('filename')]);
+            $filename = $this->option('filename');
+
+            // Make sure the filename ends in .zip
+            if (!ends_with($filename, '.zip')) {
+                $filename = $filename.'.zip';
+            }
+
+            $this->call('backup:run', ['--filename' => $filename]);
         } else {
             $this->call('backup:run');
         }


### PR DESCRIPTION
This just checks that the `--filename` that's passed (if one is passed) ends in `.zip` and adds it if it doesn't. 

Note: The filename passed should be unique, for example including a timestamp, which will throw a spate backup error: `Copying zip failed because: File already exists at path: backups/snipe-it-fresh.zip.`