### PR TITLE
Increase state from 3 chars

### DIFF
--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -26,11 +26,12 @@ class Location extends SnipeModel
     protected $table = 'locations';
     protected $rules = [
         'name'          => 'required|min:2|max:255|unique_undeleted',
-        'city'          => 'min:2|max:255|nullable',
-        'country'       => 'min:2|max:255|nullable',
-        'address'       => 'max:80|nullable',
-        'address2'      => 'max:80|nullable',
-        'zip'           => 'min:3|max:12|nullable',
+        'address'       => 'max:191|nullable',
+        'address2'      => 'max:191|nullable',
+        'city'          => 'max:191|nullable',
+        'state'         => 'min:2|max:191|nullable',
+        'country'       => 'min:2|max:191|nullable',
+        'zip'           => 'max:10|nullable',
         'manager_id'    => 'exists:users,id|nullable',
         'parent_id'     => 'non_circular:locations,id',
     ];

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -16,17 +16,17 @@ class Supplier extends SnipeModel
     protected $table = 'suppliers';
 
     protected $rules = [
-        'name'              => 'required|min:1|max:255|unique_undeleted',
-        'address'           => 'max:250|nullable',
-        'address2'          => 'max:250|nullable',
-        'city'              => 'max:255|nullable',
-        'state'             => 'max:32|nullable',
-        'country'           => 'max:3|nullable',
+        'name'               => 'required|min:1|max:255|unique_undeleted',
         'fax'               => 'min:7|max:35|nullable',
         'phone'             => 'min:7|max:35|nullable',
         'contact'           => 'max:100|nullable',
         'notes'             => 'max:191|nullable', // Default string length is 191 characters..
         'email'             => 'email|max:150|nullable',
+        'address'            => 'max:250|nullable',
+        'address2'           => 'max:250|nullable',
+        'city'               => 'max:191|nullable',
+        'state'              => 'min:2|max:191|nullable',
+        'country'            => 'min:2|max:191|nullable',
         'zip'               => 'max:10|nullable',
         'url'               => 'sometimes|nullable|string|max:250',
     ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -98,6 +98,11 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         'start_date'              => 'nullable|date_format:Y-m-d',
         'end_date'                => 'nullable|date_format:Y-m-d|after_or_equal:start_date',
         'autoassign_licenses'     => 'boolean',
+        'address'                 => 'max:191|nullable',
+        'city'                    => 'max:191|nullable',
+        'state'                   => 'min:2|max:191|nullable',
+        'country'                 => 'min:2|max:191|nullable',
+        'zip'                     => 'max:10|nullable',
     ];
 
     /**

--- a/database/migrations/2023_05_08_132921_increase_state_to_more_than_3.php
+++ b/database/migrations/2023_05_08_132921_increase_state_to_more_than_3.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class IncreaseStateToMoreThan3 extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('state', 191)->nullable()->default(null)->change();
+        });
+
+        Schema::table('suppliers', function (Blueprint $table) {
+            $table->string('state', 191)->nullable()->default(null)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('state', 3)->nullable()->default(null)->change();
+        });
+
+        Schema::table('suppliers', function (Blueprint $table) {
+            $table->string('state', 32)->nullable()->default(null)->change();
+        });
+    }
+}

--- a/resources/views/partials/forms/edit/address.blade.php
+++ b/resources/views/partials/forms/edit/address.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group {{ $errors->has('address') ? ' has-error' : '' }}">
     {{ Form::label('address', trans('general.address'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-        {{Form::text('address', old('address', $item->address), array('class' => 'form-control', 'aria-label'=>'address')) }}
+        {{Form::text('address', old('address', $item->address), array('class' => 'form-control', 'aria-label'=>'address', 'maxlength'=>'191')) }}
         {!! $errors->first('address', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
@@ -9,13 +9,13 @@
 <div class="form-group {{ $errors->has('address2') ? ' has-error' : '' }}">
     <label class="sr-only " for="address2">{{  trans('general.address')  }}</label>
     <div class="col-md-7 col-md-offset-3">
-        {{Form::text('address2', old('address2', $item->address2), array('class' => 'form-control', 'aria-label'=>'address2')) }}
+        {{Form::text('address2', old('address2', $item->address2), array('class' => 'form-control', 'aria-label'=>'address2', 'maxlength'=>'191')) }}
         {!! $errors->first('address2', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
 <div class="form-group {{ $errors->has('city') ? ' has-error' : '' }}">
-    {{ Form::label('city', trans('general.city'), array('class' => 'col-md-3 control-label')) }}
+    {{ Form::label('city', trans('general.city'), array('class' => 'col-md-3 control-label', 'maxlength'=>'191')) }}
     <div class="col-md-7">
     {{Form::text('city', old('city', $item->city), array('class' => 'form-control', 'aria-label'=>'city')) }}
         {!! $errors->first('city', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
@@ -23,7 +23,7 @@
 </div>
 
 <div class="form-group {{ $errors->has('state') ? ' has-error' : '' }}">
-    {{ Form::label('state', trans('general.state'), array('class' => 'col-md-3 control-label')) }}
+    {{ Form::label('state', trans('general.state'), array('class' => 'col-md-3 control-label', 'maxlength'=>'191')) }}
     <div class="col-md-7">
     {{Form::text('state', old('state', $item->state), array('class' => 'form-control', 'aria-label'=>'state')) }}
         {!! $errors->first('state', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
@@ -40,7 +40,7 @@
 </div>
 
 <div class="form-group {{ $errors->has('zip') ? ' has-error' : '' }}">
-    {{ Form::label('zip', trans('general.zip'), array('class' => 'col-md-3 control-label')) }}
+    {{ Form::label('zip', trans('general.zip'), array('class' => 'col-md-3 control-label', 'maxlength'=>'10')) }}
     <div class="col-md-7">
     {{Form::text('zip', old('zip', $item->zip), array('class' => 'form-control')) }}
         {!! $errors->first('zip', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -441,7 +441,7 @@
                           <div class="form-group{{ $errors->has('state') ? ' has-error' : '' }}">
                               <label class="col-md-3 control-label" for="state">{{ trans('general.state') }}</label>
                               <div class="col-md-6">
-                                  <input class="form-control" type="text" name="state" id="state" value="{{ old('state', $user->state) }}" maxlength="3" />
+                                  <input class="form-control" type="text" name="state" id="state" value="{{ old('state', $user->state) }}" maxlength="191" />
                                   {!! $errors->first('state', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                               </div>
                           </div>


### PR DESCRIPTION
We have a user who is using longer `state` names in their directory, and we were limiting the `state` field to 3 characters, causing those field values to get cut off in SCIM. This makes the `state` field longer, adds some model level validation for those (and other) address fields which coincides with the size of the field in the database, and adds some form `maxlength` values to enforce that on the UI side.