### PR TITLE
Pass filename to pre-import backup

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -160,7 +160,7 @@ class ImportController extends Controller
         // Run a backup immediately before processing
         if ($request->get('run-backup')) {
             \Log::debug('Backup manually requested via importer');
-            Artisan::call('backup:run');
+            Artisan::call('snipeit:backup', ['--filename' => 'pre-import-backup-'.date('Y-m-d-H:i:s')]);
         } else {
             \Log::debug('NO BACKUP requested via importer');
         }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1094,7 +1094,7 @@ class SettingsController extends Controller
     public function postBackups()
     {
         if (! config('app.lock_passwords')) {
-            Artisan::call('backup:run');
+            Artisan::call('snipeit:backup', ['--filename' => 'manual-backup-'.date('Y-m-d-H:i:s')]);
             $output = Artisan::output();
 
             // Backup completed


### PR DESCRIPTION
This adds a filename to the backup that we generate before an import so it can be visually differentiated from a regular old backup, and changes the filename from a manual backup as well.

<img width="508" alt="Backups____Snipe-IT_Demo" src="https://user-images.githubusercontent.com/197404/236948298-c3b892f6-c534-45ac-9ac6-7ce026b1cd92.png">
