### PR TITLE
WIP: Reset database GUI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,8 +71,15 @@ IMAGE_LIB=gd
 MAIL_BACKUP_NOTIFICATION_DRIVER=null
 MAIL_BACKUP_NOTIFICATION_ADDRESS=null
 BACKUP_ENV=true
+
+# --------------------------------------------
+# OPTIONAL: HIGH RISK SETTINGS
+# These should be enabled as-needed and set to false
+# when not actively being used for better security
+# --------------------------------------------
 ALLOW_BACKUP_DELETE=false
 ALLOW_DATA_PURGE=false
+ALLOW_TABLE_TRUNCATE=false
 
 # --------------------------------------------
 # OPTIONAL: SESSION SETTINGS

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1435,6 +1435,7 @@ class SettingsController extends Controller
         \Log::warning('User '.Auth::user()->username.' (ID'.Auth::user()->id.') is committing a TABLE TRUNCATE');
 
         if (config('app.allow_table_truncate')=='true') {
+            Artisan::call('snipeit:backup', ['--filename' => 'reset-backup-'.date('Y-m-d-H:i:s')]);
             return view('settings.index');
         }
 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1367,6 +1367,81 @@ class SettingsController extends Controller
             ->with('error', trans('general.purge_not_allowed'));
     }
 
+
+    /**
+     * Return a form to allow a superadmin to delete data from selected tables
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     *
+     * @since [v6.1.1]
+     *
+     * @return View
+     */
+    public function getReset()
+    {
+
+        \Log::warning('User '.Auth::user()->username.' (ID'.Auth::user()->id.') is attempting a TABLE TRUNCATE');
+
+        if (config('app.allow_table_truncate')=='true') {
+
+            // List all the tables in the database so we don't have to worry about missing some as the app grows
+            $tables = \DB::connection()->getDoctrineSchemaManager()->listTableNames();
+
+            // We will ONLY allow these tables to be touched - we cannot give users the ability to clear join tables.
+            // We'll decide what join tables to truncate based on their selections
+            $only_tables = [
+                'accessories',
+                'assets',
+                'users',
+                'kits',
+                'components',
+                'consumables',
+                'categories',
+                'custom_fields',
+                'custom_fieldsets',
+                'licenses',
+                'manufacturers',
+                'models',
+                'locations',
+                'depreciations',
+                'permission_groups',
+                'status_labels',
+                'suppliers',
+                'companies',
+                'checkout_requests',
+                'departments',
+            ];
+
+            return view('settings.reset')
+                ->with('only_tables', $only_tables)
+                ->with('tables', $tables);
+        }
+
+        return redirect()->route('settings.index')->with('error', trans('general.reset_not_allowed'));
+
+    }
+
+
+    /**
+     * Return a form to allow a superadmin to delete data from selected tables
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     *
+     * @since [v6.1.1]
+     *
+     * @return View
+     */
+    public function postReset()
+    {
+
+        \Log::warning('User '.Auth::user()->username.' (ID'.Auth::user()->id.') is committing a TABLE TRUNCATE');
+
+        if (config('app.allow_table_truncate')=='true') {
+            return view('settings.index');
+        }
+
+        return redirect()->route('settings.index')->with('error', trans('general.reset_not_allowed'));
+
+    }
+
     /**
      * Returns a page with the API token generation interface.
      *

--- a/config/app.php
+++ b/config/app.php
@@ -406,18 +406,30 @@ return [
     'allow_backup_delete' => env('ALLOW_BACKUP_DELETE', false),
 
 
-  /*
-  |--------------------------------------------------------------------------
-  | Escape Excel formulas in CSV exports
-  |--------------------------------------------------------------------------
-  |
-  | This determins whether or not we should escape Excel formulas in CSV exports.
-  | This can be UNSAFE in untrusted environments, and therefore defaults to true
-  | so that Excel forumals WILL be escaped in CSV exports, however if your workflow
-  | is designed around using formulas in your fields, you
-  | you can set CSV_ESCAPE_FORMULAS to 'false' in your .env.
-  |
-  */
+    /*
+    |--------------------------------------------------------------------------
+    | Allow Table Resets
+    |--------------------------------------------------------------------------
+    |
+    | This sets whether or not to allow superadmins to hard-delete table contents
+    |
+    */
+
+    'allow_table_truncate' => env('ALLOW_TABLE_TRUNCATE', false),
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Escape Excel formulas in CSV exports
+    |--------------------------------------------------------------------------
+    |
+    | This determins whether or not we should escape Excel formulas in CSV exports.
+    | This can be UNSAFE in untrusted environments, and therefore defaults to true
+    | so that Excel forumals WILL be escaped in CSV exports, however if your workflow
+    | is designed around using formulas in your fields, you
+    | you can set CSV_ESCAPE_FORMULAS to 'false' in your .env.
+    |
+    */
 
     'escape_formulas' => env('CSV_ESCAPE_FORMULAS', true),
 

--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -330,4 +330,8 @@ return [
     'setup_migration_create_user' => 'Next: Create User',
     'ldap_settings_link' => 'LDAP Settings Page',
     'slack_test' => 'Test <i class="fab fa-slack"></i> Integration',
+    'reset' => 'Reset Data',
+    'reset_keywords' => 'reset, database, clear',
+    'reset_help' => 'Clear delete data from selected tables',
+    'reset_not_allowed' => 'Resetting data is not permitted on t',
 ];

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -381,6 +381,7 @@ return [
     'maintenance_mode_title' => 'System Temporarily Unavailable',
     'ldap_import'           => 'User password should not be managed by LDAP. (This allows you to send forgotten password requests.)',
     'purge_not_allowed'     => 'Purging deleted data has been disabled in the .env file. Contact support or your systems administrator.',
+    'reset_not_allowed'     => 'Resetting data has been disabled in the .env file. Contact support or your systems administrator.',
     'backup_delete_not_allowed'     => 'Deleting backups has been disabled in the .env file. Contact support or your systems administrator.',
     'additional_files'           => 'Additional Files',
     'shitty_browser'        => 'No signature detected. If you are using an older browser, please use a more modern browser to complete your asset acceptance.',

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -316,6 +316,7 @@
 
 
     <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
+
       <div class="box box-danger">
         <div class="box-body text-center">
           <h5>
@@ -330,6 +331,24 @@
         </div>
       </div>
     </div>
+
+      <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
+
+        <div class="box box-danger">
+          <div class="box-body text-center">
+            <h5>
+              <a href="{{ route('settings.reset.index') }}" class="link-danger">
+                <i class="fa-solid fa-house-fire fa-4x" aria-hidden="true"></i>
+                <br><br>
+                <span class="name">{{ trans('admin/settings/general.reset') }}</span>
+                <span class="keywords" aria-hidden="true" style="display:none">{{ trans('admin/settings/general.reset_keywords') }}</span>
+              </a>
+            </h5>
+            <p class="help-block">{{ trans('admin/settings/general.reset_help') }}</p>
+          </div>
+        </div>
+      </div>
+
   </div>
 
 

--- a/resources/views/settings/reset.blade.php
+++ b/resources/views/settings/reset.blade.php
@@ -1,0 +1,78 @@
+@extends('layouts/default')
+
+{{-- Page title --}}
+@section('title')
+    {{ trans('admin/settings/general.reset') }}
+    @parent
+@stop
+
+@section('header_right')
+    <a href="{{ route('settings.index') }}" class="btn btn-default"> {{ trans('general.back') }}</a>
+@stop
+
+
+{{-- Page content --}}
+@section('content')
+
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="box box-solid box-danger">
+                <div class="box-header with-border">
+                    <h1 class="box-title"><i class="fa-solid fa-house-fire" aria-hidden="true"></i> {{ trans('admin/settings/general.reset') }}</h1>
+                </div>
+                {{ Form::open(['method' => 'POST', 'files' => false, 'autocomplete' => 'off', 'class' => 'form-horizontal', 'role' => 'form' ]) }}
+                <!-- CSRF Token -->
+                {{csrf_field()}}
+                <div class="box-body">
+                    <div class="col-md-12">
+                        <p>Select the tables you would like to empty from the list below. This generally should ONLY be needed if you have imported sample data and need to start again from "scratch".
+                        </p>
+
+                        <div class="alert alert-danger">
+                            <i class="fas fa-exclamation-triangle faa-pulse animated" aria-hidden="true"></i>
+                            <strong>{{ trans('general.notification_warning') }}</strong>
+                            It cannot be overstated enough that anything you do here is data-destructive and should be used with extreme caution.
+                        </div>
+
+                        <p>Unselectable tables will have corresponding table entries automatically removed.</p>
+
+                        <div class="form-group">
+
+                            @foreach ($tables as $table)
+                                <div class="col-md-4">
+                                    <label class="form-control{{ (!in_array($table, $only_tables)) ? ' form-control--disabled' : '' }}">
+                                        <input name="{{ $table }}" value="{{ $table }}" type="checkbox"{{ (!in_array($table, $only_tables)) ? ' disabled' : '' }}>{{ str_replace('_', ' ', $table) }}
+                                    </label>
+                                </div>
+                            @endforeach
+
+                        </div>
+
+                        <p>{{ trans('admin/settings/general.confirm_purge_help') }}</p>
+                        <div class="col-md-3{{ $errors->has('confirm_purge') ? 'error' : '' }}">
+                            {{ Form::label('confirm_purge', trans('admin/settings/general.confirm_purge')) }}
+                        </div>
+                        <div class="col-md-9{{ $errors->has('confirm_purge') ? 'error' : '' }}">
+                            @if (config('app.lock_passwords')===true)
+                                {{ Form::text('confirm_purge', Request::old('confirm_purge'), array('class' => 'form-control', 'disabled'=>'true')) }}
+                            @else
+                                {{ Form::text('confirm_purge', Request::old('confirm_purge'), array('class' => 'form-control')) }}
+                            @endif
+
+                            @if (config('app.lock_passwords')===true)
+                                <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+                <div class="box-footer text-right">
+                    <button type="submit" class="btn btn-danger" {{ (config('app.lock_passwords')===true) ? ' disabled' : '' }}>{{ trans('admin/settings/general.purge') }}</button>
+                </div> <!--/box-footer-->
+                {{ Form::close() }}
+            </div> <!--/.box-solid-->
+        </div><!-- /.col-md-8-->
+    </div><!--/.row-->
+
+    {{Form::close()}}
+
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -197,6 +197,9 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth', 'authorize:superuser
 
     Route::get('login-attempts', [SettingsController::class, 'getLoginAttempts'])->name('settings.logins.index');
 
+    Route::get('reset', [SettingsController::class, 'getReset'])->name('settings.reset.index');
+    Route::post('reset', [SettingsController::class, 'postReset'])->name('settings.reset.save');
+
     // Backups
     Route::group(['prefix' => 'backups', 'middleware' => 'auth'], function () {
         Route::get('download/{filename}',


### PR DESCRIPTION
This introduces a new GUI screen that will allow super admins to clear tables (and the associated joins). This is meant for folks to be able to do a hard reset after mucking around a bit uploading CSVs and creating a bunch of bad data, and it will bring them back to a potentially "fresh install" state. I had considered making this more simple, the way the `snipeit:paveit` command works, but we do get a lot of requests of "Reset me back to when I first signed up, EXCEPT for the `blah` section."

This is a first run, and there's definitely some clever stuff we can do in the UI, but I think this will save support time overall. 

This was added to the Admin Settings page:

<img width="366" alt="Screenshot 2023-05-08 at 5 12 18 PM" src="https://user-images.githubusercontent.com/197404/236980274-a889ec53-fdef-42a5-b87e-1b83920f9347.png">

<img width="1515" alt="Screenshot 2023-05-08 at 7 41 03 PM" src="https://user-images.githubusercontent.com/197404/236980318-17325d71-0791-4607-9cc4-02f0d62d0bd0.png">

<img width="1032" alt="Screenshot 2023-05-08 at 7 40 09 PM" src="https://user-images.githubusercontent.com/197404/236980346-2fff33a5-299d-4850-a5e3-536f2b852f66.png">

This UI is a bit WIP - I might end up hiding the un-selectable tables altogether, but right now I don't mind showing them, just so folks can see the connections involved. 

This also may be a fool's errand, since you can't delete categories and have licenses, assets, etc still work. I might have just overthought this and we could maybe just use a simple variation of the pave script :( 

### To Do:

- [x] Add backup 
- [ ] Wire up the actual truncate methods
- [ ] Massage the language
- [ ] Fully translate strings