### PR TITLE
Tightened up some layout issues, checkbox issues in LDAP settings

### DIFF
--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -60,12 +60,33 @@
                         <!-- Enable LDAP -->
                         <div class="form-group {{ $errors->has('ldap_integration') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_integration', trans('admin/settings/general.ldap_integration')) }}
+                                {{ Form::label('ldap_enabled', trans('admin/settings/general.ldap_integration')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
 
-                                {{ Form::checkbox('ldap_enabled', '1', Request::old('ldap_enabled', $setting->ldap_enabled), [((config('app.lock_passwords')===true)) ? 'disabled ': '', 'class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                <label class="form-control">
+                                    {{ Form::checkbox('ldap_enabled', '1', old('ldap_enabled', $setting->ldap_enabled), [((config('app.lock_passwords')===true)) ? 'disabled ': '', 'class' => 'form-control '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('admin/settings/general.ldap_enabled') }}
+                                </label>
+                                @if (config('app.lock_passwords')===true)
+                                    <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
+                                @endif
+                            </div>
+                        </div>
+
+
+                        <!-- AD Flag -->
+                        <div class="form-group">
+                            <div class="col-md-3">
+                                {{ Form::label('is_ad', trans('admin/settings/general.ad')) }}
+                            </div>
+                            <div class="col-md-8">
+                                <label class="form-control">
+                                {{ Form::checkbox('is_ad', '1', Request::old('is_ad', $setting->is_ad), [((config('app.lock_passwords')===true)) ? 'disabled ': '', 'class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                {{ trans('admin/settings/general.is_ad') }}
+                                </label>
+                                {!! $errors->first('is_ad', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
                                 @endif
@@ -77,10 +98,11 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_pw_sync', trans('admin/settings/general.ldap_pw_sync')) }}
                             </div>
-                            <div class="col-md-9">
-
+                            <div class="col-md-8">
+                                <label class="form-control">
                                 {{ Form::checkbox('ldap_pw_sync', '1', Request::old('ldap_pw_sync', $setting->ldap_pw_sync), [((config('app.lock_passwords')===true)) ? 'disabled ': '', 'class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('general.yes') }}
+                                </label>
 
                                 <p class="help-block">{{ trans('admin/settings/general.ldap_pw_sync_help') }}</p>
                                 {!! $errors->first('ldap_pw_sync_help', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -91,75 +113,12 @@
                             </div>
                         </div>
 
-                        <!--  Default LDAP Permissions Group Select -->
-
-                        <div class="form-group{{ $errors->has('group') ? ' has-error' : '' }}">
-                            <div class="col-md-3">
-                                {{ Form::label('ldap_default_group', trans('admin/settings/general.ldap_default_group')) }}
-                            </div>
-
-                            <div class="col-md-9">
-
-                                @if ($groups->count())
-                                    @if ((Config::get('app.lock_passwords') || (!Auth::user()->isSuperUser())))
-                                        <ul>
-                                            @foreach ($groups as $id => $group)
-                                                {!! '<li>'.e($group).'</li>' !!}
-                                            @endforeach
-                                        </ul>
-
-
-                                        <span class="help-block">{{ trans('admin/users/general.group_memberships_helpblock') }}</span>
-                                    @else
-                                        <div class="controls">
-                                            <select
-                                                    name="ldap_default_group"
-                                                    aria-label="ldap_default_group"
-                                                    id="ldap_default_group"
-                                                    class="form-control select2"
-                                            >
-                                                <option value="">{{ trans('admin/settings/general.no_default_group') }}</option>
-                                                @foreach ($groups as $id => $group)
-                                                    <option value="{{ $id }}" {{ $setting->ldap_default_group == $id ? 'selected' : '' }}>
-                                                        {{ $group }}
-                                                    </option>
-                                                @endforeach
-                                            </select>
-
-                                            <span class="help-block">
-                                      {{ trans('admin/settings/general.ldap_default_group_info') }}
-                                    </span>
-                                        </div>
-                                    @endif
-                                @else
-                                    <p>No groups have been created yet. Visit <code>Admin Settings > Permission Groups</code> to add one.</p>
-                                @endif
-
-                            </div>
-                        </div>
-
-                        <!-- AD Flag -->
-                        <div class="form-group">
-                            <div class="col-md-3">
-                                {{ Form::label('is_ad', trans('admin/settings/general.ad')) }}
-                            </div>
-                            <div class="col-md-9">
-                                {{ Form::checkbox('is_ad', '1', Request::old('is_ad', $setting->is_ad), [((config('app.lock_passwords')===true)) ? 'disabled ': '', 'class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
-                                {{ trans('admin/settings/general.is_ad') }}
-                                {!! $errors->first('is_ad', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-
-                                @if (config('app.lock_passwords')===true)
-                                    <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
-                                @endif
-                            </div>
-                        </div>
-
                         <!-- AD Domain -->
                         <div class="form-group {{ $errors->has('ad_domain') ? 'error' : '' }}">
                             <div class="col-md-3">
                                 {{ Form::label('ad_domain', trans('admin/settings/general.ad_domain')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ad_domain', Request::old('ad_domain', $setting->ad_domain), ['class' => 'form-control','placeholder' => trans('general.example') .'example.com', $setting->demoMode]) }}
                                 <p class="help-block">{{ trans('admin/settings/general.ad_domain_help') }}</p>
                                 {!! $errors->first('ad_domain', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -174,7 +133,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ad_append_domain', trans('admin/settings/general.ad_append_domain_label')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::checkbox('ad_append_domain', '1', Request::old('ad_append_domain', $setting->ad_append_domain),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('admin/settings/general.ad_append_domain') }}
                                 <p class="help-block">{{ trans('admin/settings/general.ad_append_domain_help') }}</p>
@@ -190,7 +149,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_client_tls_key', trans('admin/settings/general.ldap_client_tls_key')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::textarea('ldap_client_tls_key', Request::old('ldap_client_tls_key', $setting->ldap_client_tls_key), ['class' => 'form-control','placeholder' =>  trans('general.example') .'-----BEGIN RSA PRIVATE KEY-----'."\r\n1234567890\r\n-----END RSA PRIVATE KEY-----
 ", $setting->demoMode]) }}
                                 {!! $errors->first('ldap_client_tls_key', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -205,7 +164,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_client_tls_cert', trans('admin/settings/general.ldap_client_tls_cert')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::textarea('ldap_client_tls_cert', Request::old('ldap_client_tls_cert', $setting->ldap_client_tls_cert), ['class' => 'form-control','placeholder' =>  trans('general.example') .'-----BEGIN CERTIFICATE-----'."\r\n1234567890\r\n-----END CERTIFICATE-----", $setting->demoMode]) }}
                                 <p class="help-block">{{ trans('admin/settings/general.ldap_client_tls_cert_help') }}</p>
                                 {!! $errors->first('ldap_client_tls_cert', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -220,7 +179,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_server', trans('admin/settings/general.ldap_server')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_server', Request::old('ldap_server', $setting->ldap_server), ['class' => 'form-control','placeholder' =>  trans('general.example') .'ldap://ldap.example.com', $setting->demoMode]) }}
                                 <p class="help-block">{{ trans('admin/settings/general.ldap_server_help') }}</p>
                                 {!! $errors->first('ldap_server', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -235,9 +194,11 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_tls', trans('admin/settings/general.ldap_tls')) }}
                             </div>
-                            <div class="col-md-9">
-                                {{ Form::checkbox('ldap_tls', '1', Request::old('ldap_tls', $setting->ldap_tls),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
-                                {{ trans('admin/settings/general.ldap_tls_help') }}
+                            <div class="col-md-8">
+                                <label class="form-control">
+                                    {{ Form::checkbox('ldap_tls', '1', Request::old('ldap_tls', $setting->ldap_tls),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                    {{ trans('admin/settings/general.ldap_tls_help') }}
+                                </label>
                                 {!! $errors->first('ldap_tls', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -250,9 +211,11 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_server_cert_ignore', trans('admin/settings/general.ldap_server_cert')) }}
                             </div>
-                            <div class="col-md-9">
-                                {{ Form::checkbox('ldap_server_cert_ignore', '1', Request::old('ldap_server_cert_ignore', $setting->ldap_server_cert_ignore),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
-                                {{ trans('admin/settings/general.ldap_server_cert_ignore') }}
+                            <div class="col-md-8">
+                                <label class="form-control">
+                                    {{ Form::checkbox('ldap_server_cert_ignore', '1', Request::old('ldap_server_cert_ignore', $setting->ldap_server_cert_ignore),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                    {{ trans('admin/settings/general.ldap_server_cert_ignore') }}
+                                </label>
                                 {!! $errors->first('ldap_server_cert_ignore', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 <p class="help-block">{{ trans('admin/settings/general.ldap_server_cert_help') }}</p>
                                 @if (config('app.lock_passwords')===true)
@@ -266,7 +229,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_uname', trans('admin/settings/general.ldap_uname')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_uname', Request::old('ldap_uname', $setting->ldap_uname), ['class' => 'form-control','placeholder' => trans('general.example') .'binduser@example.com', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_uname', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -280,7 +243,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_pword', trans('admin/settings/general.ldap_pword')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::password('ldap_pword', ['class' => 'form-control','placeholder' => trans('general.example') .' binduserpassword', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_pword', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -294,7 +257,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_basedn', trans('admin/settings/general.ldap_basedn')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_basedn', Request::old('ldap_basedn', $setting->ldap_basedn), ['class' => 'form-control', 'placeholder' => trans('general.example') .'cn=users/authorized,dc=example,dc=com', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_basedn', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -308,7 +271,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_filter', trans('admin/settings/general.ldap_filter')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_filter', Request::old('ldap_filter', $setting->ldap_filter), ['class' => 'form-control','placeholder' => trans('general.example') .'&(cn=*)', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_filter', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -322,7 +285,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_username_field', trans('admin/settings/general.ldap_username_field')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_username_field', Request::old('ldap_username_field', $setting->ldap_username_field), ['class' => 'form-control','placeholder' => trans('general.example') .'samaccountname', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_username_field', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -336,7 +299,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_lname_field', trans('admin/settings/general.ldap_lname_field')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_lname_field', Request::old('ldap_lname_field', $setting->ldap_lname_field), ['class' => 'form-control','placeholder' => trans('general.example') .'sn', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_lname_field', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -350,7 +313,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_fname_field', trans('admin/settings/general.ldap_fname_field')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_fname_field', Request::old('ldap_fname_field', $setting->ldap_fname_field), ['class' => 'form-control', 'placeholder' => trans('general.example') .'givenname', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_fname_field', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -364,7 +327,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_auth_filter_query', trans('admin/settings/general.ldap_auth_filter_query')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_auth_filter_query', Request::old('ldap_auth_filter_query', $setting->ldap_auth_filter_query), ['class' => 'form-control','placeholder' => trans('general.example') .'uid=', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_auth_filter_query', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -373,17 +336,45 @@
                             </div>
                         </div>
 
-                        <!-- LDAP Version -->
-                        <div class="form-group {{ $errors->has('ldap_version') ? 'error' : '' }}">
+                        <!--  Default LDAP Permissions Group Select -->
+
+                        <div class="form-group{{ $errors->has('group') ? ' has-error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_version', trans('admin/settings/general.ldap_version')) }}
+                                {{ Form::label('ldap_default_group', trans('admin/settings/general.ldap_default_group')) }}
                             </div>
-                            <div class="col-md-9">
-                                {{ Form::text('ldap_version', Request::old('ldap_version', $setting->ldap_version), ['class' => 'form-control','placeholder' => '3', $setting->demoMode]) }}
-                                {!! $errors->first('ldap_version', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                @if (config('app.lock_passwords')===true)
-                                    <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
+
+                            <div class="col-md-8">
+
+                                @if ($groups->count())
+                                    @if ((Config::get('app.lock_passwords') || (!Auth::user()->isSuperUser())))
+                                        <ul>
+                                            @foreach ($groups as $id => $group)
+                                                {!! '<li>'.e($group).'</li>' !!}
+                                            @endforeach
+                                        </ul>
+
+
+                                        <span class="help-block">{{ trans('admin/users/general.group_memberships_helpblock') }}</span>
+                                    @else
+                                        <div class="controls">
+                                            <select name="ldap_default_group" aria-label="ldap_default_group" id="ldap_default_group" class="form-control select2">
+                                                <option value="">{{ trans('admin/settings/general.no_default_group') }}</option>
+                                                @foreach ($groups as $id => $group)
+                                                    <option value="{{ $id }}" {{ $setting->ldap_default_group == $id ? 'selected' : '' }}>
+                                                        {{ $group }}
+                                                    </option>
+                                                @endforeach
+                                            </select>
+
+                                            <span class="help-block">
+                                                {{ trans('admin/settings/general.ldap_default_group_info') }}
+                                            </span>
+                                        </div>
+                                    @endif
+                                @else
+                                    <p>No groups have been created yet. Visit <code>Admin Settings > Permission Groups</code> to add one.</p>
                                 @endif
+
                             </div>
                         </div>
 
@@ -392,7 +383,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_active_flag', trans('admin/settings/general.ldap_active_flag')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_active_flag', Request::old('ldap_active_flag', $setting->ldap_active_flag), ['class' => 'form-control', $setting->demoMode]) }}
 
                                 <p class="help-block">{!! trans('admin/settings/general.ldap_activated_flag_help') !!}</p>
@@ -409,7 +400,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_emp_num', trans('admin/settings/general.ldap_emp_num')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_emp_num', Request::old('ldap_emp_num', $setting->ldap_emp_num), ['class' => 'form-control','placeholder' => trans('general.example') .'employeenumber/employeeid', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_emp_num', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -422,7 +413,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_dept', trans('admin/settings/general.ldap_dept')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_dept', Request::old('ldap_dept', $setting->ldap_dept), ['class' => 'form-control','placeholder' => trans('general.example') .'department', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_dept', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -435,7 +426,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_dept', trans('admin/settings/general.ldap_manager')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_manager', Request::old('ldap_manager', $setting->ldap_manager), ['class' => 'form-control','placeholder' => trans('general.example') .'manager', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_manager', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -449,7 +440,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_email', trans('admin/settings/general.ldap_email')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_email', Request::old('ldap_email', $setting->ldap_email), ['class' => 'form-control','placeholder' => trans('general.example') .'mail', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_email', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -463,7 +454,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_phone', trans('admin/settings/general.ldap_phone')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_phone', Request::old('ldap_phone', $setting->ldap_phone_field), ['class' => 'form-control','placeholder' => trans('general.example') .'telephonenumber', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_phone', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -477,7 +468,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_jobtitle', trans('admin/settings/general.ldap_jobtitle')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_jobtitle', Request::old('ldap_jobtitle', $setting->ldap_jobtitle), ['class' => 'form-control','placeholder' => trans('general.example') .'title', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_jobtitle', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -491,7 +482,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_country', trans('admin/settings/general.ldap_country')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_country', Request::old('ldap_country', $setting->ldap_country), ['class' => 'form-control','placeholder' => trans('general.example') .'c', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_country', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -504,7 +495,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('ldap_location', trans('admin/settings/general.ldap_location')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('ldap_location', Request::old('ldap_location', $setting->ldap_location), ['class' => 'form-control','placeholder' => trans('general.example') .'physicaldeliveryofficename', $setting->demoMode]) }}
                                 <p class="help-block">{!! trans('admin/settings/general.ldap_location_help') !!}</p>
                                 {!! $errors->first('ldap_location', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -520,14 +511,14 @@
                                 <div class="col-md-3">
                                     {{ Form::label('test_ldap_sync', 'Test LDAP Sync') }}
                                 </div>
-                                <div class="col-md-9" id="ldaptestrow">
+                                <div class="col-md-8" id="ldaptestrow">
                                     <a {{ $setting->demoMode }} class="btn btn-default btn-sm pull-left" id="ldaptest" style="margin-right: 10px;">{{ trans('admin/settings/general.ldap_test_sync') }}</a>
                                 </div>
-                                <div class="col-md-9 col-md-offset-3">
+                                <div class="col-md-8 col-md-offset-3">
                                     <br />
                                     <div id="ldapad_test_results" class="hidden well well-sm"></div>
                                 </div>
-                                <div class="col-md-9 col-md-offset-3">
+                                <div class="col-md-8 col-md-offset-3">
                                     <p class="help-block">{{ trans('admin/settings/general.ldap_login_sync_help') }}</p>
                                     @if (config('app.lock_passwords')===true)
                                         <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -541,7 +532,7 @@
                                 <div class="col-md-3">
                                     {{ Form::label('test_ldap_login', 'Test LDAP Login') }}
                                 </div>
-                                <div class="col-md-9">
+                                <div class="col-md-8">
                                     <div class="row">
                                     <div class="col-md-4">
                                         <input type="text" name="ldaptest_user" id="ldaptest_user"  class="form-control" placeholder="LDAP username">
@@ -556,12 +547,12 @@
 
                                 </div>
                                 </div>
-                                <div class="col-md-9 col-md-offset-3">
+                                <div class="col-md-8 col-md-offset-3">
                                     <span id="ldaptestloginicon"></span>
                                     <span id="ldaptestloginresult"></span>
                                     <span id="ldaptestloginstatus"></span>
                                 </div>
-                                <div class="col-md-9 col-md-offset-3">
+                                <div class="col-md-8 col-md-offset-3">
                                     <p class="help-block">{{ trans('admin/settings/general.ldap_login_test_help') }}</p>
                                 </div>
 
@@ -575,7 +566,7 @@
                             <div class="col-md-3">
                                 {{ Form::label('custom_forgot_pass_url', trans('admin/settings/general.custom_forgot_pass_url')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-8">
                                 {{ Form::text('custom_forgot_pass_url', Request::old('custom_forgot_pass_url', $setting->custom_forgot_pass_url), ['class' => 'form-control','placeholder' => trans('general.example') .'https://my.ldapserver-forgotpass.com', $setting->demoMode]) }}
                                 <p class="help-block">{{ trans('admin/settings/general.custom_forgot_pass_url_help') }}</p>
                                 {!! $errors->first('custom_forgot_pass_url', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -610,6 +601,8 @@
 @push('js')
     <script nonce="{{ csrf_token() }}">
 
+
+
         /**
          * Check to see if is_ad is checked, if not disable the ad_domain field
          */
@@ -619,6 +612,15 @@
             } else {
                 //$('#ldap_server').prop('disabled', 'disabled');
             }
+        });
+
+        $("#is_ad").change(function() {
+            $('#ad_domain').prop('disabled', 'disabled');
+
+            if (this.checked) {
+                $('#ad_domain').toggleDisabled();
+            }
+
         });
 
         /**


### PR DESCRIPTION
This just fixes the layout for the checkboxes in the LDAP settings page and moves the default group down closer to where it makes a little more sense. 

### Before
<img width="1067" alt="Screenshot 2023-05-09 at 10 36 15 PM" src="https://github.com/snipe/snipe-it/assets/197404/3dbcca61-589e-4a4c-88ca-910ef0ab2e92">

### After

<img width="1070" alt="Screenshot 2023-05-09 at 10 36 32 PM" src="https://github.com/snipe/snipe-it/assets/197404/c4de79ff-d1aa-47b8-bbfc-2759266f835c">
