### PR TITLE
Disable browser tests in ChipperCI

### DIFF
--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -41,19 +41,18 @@ pipeline:
     cmd: |
       # php artisan test --testsuite Feature
 
-  - name: Browser Tests
-    cmd: |
-      cp -v .env.dusk.example .env.dusk.ci
-      sed -i "s@APP_ENV=.*@APP_ENV=ci@g" .env.dusk.ci
-      sed -i "s@APP_URL=.*@APP_URL=http://$BUILD_HOST:8000@g" .env.dusk.ci
-      #sed -i "s@DB_HOST=.*@DB_HOST=mysql@g" .env.dusk.ci
-      sed -i "s@DB_HOST=.*@DB_HOST=$DB_HOST@g" .env.dusk.ci
-      sed -i "s@DB_USERNAME=.*@DB_USERNAME=chipperci@g" .env.dusk.ci
-      sed -i "s@DB_DATABASE=.*@DB_DATABASE=chipperci@g" .env.dusk.ci
-      sed -i "s@DB_PASSWORD=.*@DB_PASSWORD=secret@g" .env.dusk.ci
-      
-      php -S [::0]:8000 -t public 2>server.log &
-      sleep 2
-      php artisan dusk:chrome-driver $CHROME_DRIVER
-      php artisan dusk --env=ci
-
+#  - name: Browser Tests
+#    cmd: |
+#      cp -v .env.dusk.example .env.dusk.ci
+#      sed -i "s@APP_ENV=.*@APP_ENV=ci@g" .env.dusk.ci
+#      sed -i "s@APP_URL=.*@APP_URL=http://$BUILD_HOST:8000@g" .env.dusk.ci
+#      #sed -i "s@DB_HOST=.*@DB_HOST=mysql@g" .env.dusk.ci
+#      sed -i "s@DB_HOST=.*@DB_HOST=$DB_HOST@g" .env.dusk.ci
+#      sed -i "s@DB_USERNAME=.*@DB_USERNAME=chipperci@g" .env.dusk.ci
+#      sed -i "s@DB_DATABASE=.*@DB_DATABASE=chipperci@g" .env.dusk.ci
+#      sed -i "s@DB_PASSWORD=.*@DB_PASSWORD=secret@g" .env.dusk.ci
+#
+#      php -S [::0]:8000 -t public 2>server.log &
+#      sleep 2
+#      php artisan dusk:chrome-driver $CHROME_DRIVER
+#      php artisan dusk --env=ci


### PR DESCRIPTION
# Description

This PR disables Dusk tests in Chipper for the time being. The configuration isn't set correctly and needs some debugging but I don't want our builds to be red in the meantime.

Related: #12989 and #13000