### PR TITLE
min amt and model number are mappable

### DIFF
--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -81,6 +81,7 @@ class Importer extends Component
     static $accessories = [
         'model_number' => 'Model Number',
         'notes' => 'Notes',
+        'min_amt' => 'Min Qty',
     ];
 
     static $assets = [


### PR DESCRIPTION
# Description
Makes minimum quantity mappable for import, Model number was already mappable. I also noticed the import table is unreadable. Another PR will be coming soon for that.
<img width="736" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/bfdd2281-a1ac-4d5f-9816-3b544631ccfe">

Fixes #sc-15952
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
