### PR TITLE
Fixes PR #12831 use array bracket for multi select company

### DIFF
--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -237,7 +237,7 @@
 
             {!! trans('general.report_fields_info') !!}
 
-            @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'),'multiple' => 'multiple', 'fieldname' => 'by_company_id', 'hide_new' => 'true'])
+            @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'),'multiple' => 'multiple', 'fieldname' => 'by_company_id[]', 'hide_new' => 'true'])
             @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'by_location_id', 'hide_new' => 'true'])
             @include ('partials.forms.edit.location-select', ['translated_name' => trans('admin/hardware/form.default_location'), 'fieldname' => 'by_rtd_location_id', 'hide_new' => 'true'])
           @include ('partials.forms.edit.department-select', ['translated_name' => trans('general.department'), 'fieldname' => 'by_dept_id', 'hide_new' => 'true'])


### PR DESCRIPTION
When we're passing an array via HTML, the field name must include brackets, otherwise the HTML will only send the last value selected in a multi-select box. Addresses #12831.