### PR TITLE
Added standardized colors to the importer

### DIFF
--- a/resources/assets/less/skins/skin-red-dark.less
+++ b/resources/assets/less/skins/skin-red-dark.less
@@ -385,6 +385,10 @@ input[type=text], input[type=search] {
 .box-header.with-border {
   border-bottom: #000;
 }
+#upload-table tbody > tr.warning > td,#upload-table h3,#upload-table p{
+  background-color:#fcf8e3;
+  color:#000;
+}
 
 a {
   color: var(--link);


### PR DESCRIPTION
# Description
The importer table now stays the same color scheme no matter what the theme being used is.
<img width="665" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/2aefa0a5-7b64-4f40-ae69-6266cf08c4f6">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
