### PR TITLE
Fix checkouts during asset imports

### DIFF
--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -107,13 +107,14 @@ class ItemImporter extends Importer
      */
     protected function determineCheckout($row)
     {
+        // If we are importing a location then there is nothing to checkout.
+        if (get_class($this) === LocationImporter::class) {
+            return;
+        }
+
         // We only support checkout-to-location for asset, so short circuit otherwise.
         if (get_class($this) != AssetImporter::class) {
             return $this->createOrFetchUser($row);
-        }
-
-        if (get_class($this) != LocationImporter::class) {
-            return;
         }
 
         if (strtolower($this->item['checkout_class']) === 'location' && $this->findCsvMatch($row, 'checkout_location') != null ) {


### PR DESCRIPTION
# Description

This PR fixes an issue where assets were not being checked out to users during the import process. Previously, we were dropping into the removed `if` conditional and returning nothing but now the check has been moved to the top of the method and returns early for location imports.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)