### PR TITLE
Uses actions text in backups table

### DIFF
--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -49,7 +49,7 @@
               <th data-sortable="true" data-field="modified_display" data-sort-name="modified_value">{{ trans('admin/settings/table.created') }}</th>
               <th data-field="modified_value" data-visible="false"></th>
               <th data-sortable="true">{{ trans('admin/settings/table.size') }}</th>
-              <th><span class="sr-only">{{ trans('general.delete') }}</span></th>
+              <th>{{ trans('table.actions') }}</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Fixes a weird layout issue on backups with dark skin

<img width="1063" alt="Screenshot 2023-05-16 at 4 04 20 PM" src="https://github.com/snipe/snipe-it/assets/197404/c0f9578d-94d4-4958-94b8-f9f3ecb68e3b">

<img width="1048" alt="Screenshot 2023-05-16 at 4 04 26 PM" src="https://github.com/snipe/snipe-it/assets/197404/80bb3e39-3671-4eb9-b19b-2cd0a3380bf3">

