### PR TITLE
Importer fix for non-Location imports

### DIFF
--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -103,17 +103,17 @@ class ItemImporter extends Importer
     /**
      * Parse row to determine what (if anything) we should checkout to.
      * @param  array $row CSV Row being parsed
-     * @return SnipeModel      Model to be checked out to
+     * @return ?SnipeModel      Model to be checked out to
      */
     protected function determineCheckout($row)
     {
+        if (get_class($this) == LocationImporter::class) {
+            return;
+        }
+
         // We only support checkout-to-location for asset, so short circuit otherwise.
         if (get_class($this) != AssetImporter::class) {
             return $this->createOrFetchUser($row);
-        }
-
-        if (get_class($this) != LocationImporter::class) {
-            return;
         }
 
         if (strtolower($this->item['checkout_class']) === 'location' && $this->findCsvMatch($row, 'checkout_location') != null ) {


### PR DESCRIPTION
A customer reported that an import that also does a "checkout to Location" in it seemed to stop working after a recent release.

I was able to track it down to the new fixes that enable the Location importer - there's one piece of logic that's incorrect in there - `!=` instead of `==`. Also, the check should probably be earlier.

So I fixed those two things. Additionally, my IDE was yelling at me about the return type on the method, so I adjusted it.