### PR TITLE
Bug/sc 23260 multi select example text

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -841,6 +841,9 @@ input[type="radio"]:checked::before {
   grid-template-columns: .1em auto;
   gap: 1.5em;
 }
+.multi-select-fix {
+  padding-left:10px;
+}
 
 /** --------------------------------------- **/
 /** End checkbox styles to replace iCheck   **/

--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -841,8 +841,8 @@ input[type="radio"]:checked::before {
   grid-template-columns: .1em auto;
   gap: 1.5em;
 }
-.multi-select-fix {
-  padding-left:10px;
+.select2-container .select2-search--inline .select2-search__field{
+  padding-left:15px;
 }
 
 /** --------------------------------------- **/

--- a/resources/views/partials/forms/edit/department-select.blade.php
+++ b/resources/views/partials/forms/edit/department-select.blade.php
@@ -3,7 +3,7 @@
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
 
     <div class="col-md-6">
-        <select class="js-data-ajax" data-endpoint="departments" data-placeholder="{{ trans('general.select_department') }}" name="{{ $fieldname }}" style="width: 100%" id="department_select" aria-label="{{ $fieldname }}"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+        <select class="js-data-ajax {{(isset($multiple) && ($multiple=='true')) ? "multi-select-fix" : ''}}" data-endpoint="departments" data-placeholder="{{ trans('general.select_department') }}" name="{{ $fieldname }}" style="width: 100%" id="department_select" aria-label="{{ $fieldname }}"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
             @if ($department_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $department_id }}" selected="selected" role="option" aria-selected="true"  role="option">
                     {{ (\App\Models\Department::find($department_id)) ? \App\Models\Department::find($department_id)->name : '' }}

--- a/resources/views/partials/forms/edit/department-select.blade.php
+++ b/resources/views/partials/forms/edit/department-select.blade.php
@@ -3,7 +3,7 @@
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
 
     <div class="col-md-6">
-        <select class="js-data-ajax {{(isset($multiple) && ($multiple=='true')) ? "multi-select-fix" : ''}}" data-endpoint="departments" data-placeholder="{{ trans('general.select_department') }}" name="{{ $fieldname }}" style="width: 100%" id="department_select" aria-label="{{ $fieldname }}"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+        <select class="js-data-ajax" data-endpoint="departments" data-placeholder="{{ trans('general.select_department') }}" name="{{ $fieldname }}" style="width: 100%" id="department_select" aria-label="{{ $fieldname }}"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
             @if ($department_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $department_id }}" selected="selected" role="option" aria-selected="true"  role="option">
                     {{ (\App\Models\Department::find($department_id)) ? \App\Models\Department::find($department_id)->name : '' }}


### PR DESCRIPTION
# Description
This adds some padding left to the input field so they look consistent with the rest of the form.
Before:
![image](https://github.com/snipe/snipe-it/assets/47435081/25443b85-88c6-4f92-b394-3c47688ccf1d)
After:
<img width="318" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/d034c9be-9be5-459c-960c-05378aac71ec">

Fixes #sc-23260

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
