### PR TITLE
Checkin/out info on side bar

### DIFF
--- a/resources/lang/en/admin/hardware/general.php
+++ b/resources/lang/en/admin/hardware/general.php
@@ -19,7 +19,7 @@ return [
     'requestable'               => 'Requestable',
     'requested'				    => 'Requested',
     'not_requestable'           => 'Not Requestable',
-    'requestable_status_warning' => 'Do not change  requestable status',
+    'requestable_status_warning' => 'Do not change requestable status',
     'restore'  					=> 'Restore Asset',
     'pending'  					=> 'Pending',
     'undeployable'  			=> 'Undeployable',

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -934,6 +934,14 @@
                                                     {{ $asset->location->state }} {{ $asset->location->zip }}
                                                 </li>
                                             @endif
+                                                <li>
+                                                    <i class="fas fa-calendar"></i> {{ trans('admin/hardware/form.checkout_date') }}: {{ Helper::getFormattedDateObject($asset->last_checkout, 'date', false) }}
+                                                </li>
+                                            @if (isset($asset->expected_checkin))
+                                                <li>
+                                                    <i class="fas fa-calendar"></i> {{ trans('admin/hardware/form.expected_checkin') }}: {{ Helper::getFormattedDateObject($asset->expected_checkin, 'date', false) }}
+                                                </li>
+                                            @endif
                                         </ul>
 
                                 @endif


### PR DESCRIPTION
From #7928 the information on checkout date and expected checkin date has been added to the side bar on the right of an asset view.  This should allow for faster/simmpler parsing of checkout information when viewing an asset.  These values will  also still show in their original locations upon scrolling down the `Info` tab.

The `Expected Checkin` line will not show if that date has not been set.  Users can edit an asset to enter this info in which the line will then show. Editing an asset to update this field, will also update the new line.


- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested on local instance


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
