### PR TITLE
Bulk Consumable Checkout

### DIFF
--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -57,8 +57,14 @@ class ConsumableCheckoutController extends Controller
 
         $this->authorize('checkout', $consumable);
 
+        // If the quantity is not present in the request or is not a positive integer, set it to 1
+        $quantity = $request->input('qty');
+        if (!isset($quantity) || !ctype_digit((string)$quantity) || $quantity <= 0) {
+            $quantity = 1;
+        }
+
         // Make sure there is at least one available to checkout
-        if ($consumable->numRemaining() <= 0 || $request->qty > $consumable->numRemaining()) {
+        if ($consumable->numRemaining() <= 0 || $quantity > $consumable->numRemaining()) {
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.checkout.unavailable'));
         }
 
@@ -75,7 +81,7 @@ class ConsumableCheckoutController extends Controller
         // Update the consumable data
         $consumable->assigned_to = e($request->input('assigned_to'));
 
-        for($i = 0; $i < $request->qty; $i++){
+        for($i = 0; $i < $quantity; $i++){
         $consumable->users()->attach($consumable->id, [
             'consumable_id' => $consumable->id,
             'user_id' => $admin_user->id,

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -58,7 +58,7 @@ class ConsumableCheckoutController extends Controller
         $this->authorize('checkout', $consumable);
 
         // Make sure there is at least one available to checkout
-        if ($consumable->numRemaining() <= 0) {
+        if ($consumable->numRemaining() <= 0 || $request->qty > $consumable->numRemaining()) {
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.checkout.unavailable'));
         }
 
@@ -75,13 +75,14 @@ class ConsumableCheckoutController extends Controller
         // Update the consumable data
         $consumable->assigned_to = e($request->input('assigned_to'));
 
+        for($i = 0; $i < $request->qty; $i++){
         $consumable->users()->attach($consumable->id, [
             'consumable_id' => $consumable->id,
             'user_id' => $admin_user->id,
             'assigned_to' => e($request->input('assigned_to')),
             'note' => $request->input('note'),
         ]);
-
+        }
         event(new CheckoutableCheckedOut($consumable, $user, Auth::user(), $request->input('note')));
 
         // Redirect to the new consumable page

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -66,6 +66,18 @@
                 </div>
               </div>
             @endif
+
+          <!-- Checkout QTY -->
+          <div class="form-group {{ $errors->has('qty') ? 'error' : '' }} ">
+              <label for="qty" class="col-md-3 control-label">{{ trans('general.qty') }}</label>
+              <div class="col-md-7 col-sm-12 required">
+                  <div class="col-md-2" style="padding-left:0px">
+                    <input class="form-control" type="number" name="qty" id="qty" value="1" min="1" max="{{$consumable->numRemaining()}}" />
+                  </div>
+              </div>
+              {!! $errors->first('qty', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+          </div>
+          
           <!-- Note -->
           <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
             <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>


### PR DESCRIPTION
# Description

This PR implements the 'bulk checkout' feature for consumable items in the inventory management system. This feature allows users to check out multiple units of a consumable item at once, instead of checking out one item at a time. It addresses feature request #12892 and is motivated by the need to streamline and improve the efficiency of the checkout process. Screenshots are provided in the related issue thread.

Before:
<img width="1338" alt="image" src="https://github.com/snipe/snipe-it/assets/88882041/75da0ca2-56d7-41e5-8e61-49f6cf4eaa17">

After:
<img width="1338" alt="image" src="https://github.com/snipe/snipe-it/assets/88882041/d04eee51-90da-4bdf-b695-e62100f18658">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

This feature has been tested manually, following these steps:

1. Log in as a user who has permissions to check out consumable items.
2. Navigate to the checkout page of a consumable item.
3. Enter a quantity in the new 'Quantity' field and submit the form.
4. Confirm that the quantity of the item in the inventory is decreased by the correct amount.
5. Confirm that an error message is displayed when trying to checkout more of an item than is available.

- [x] Test A: Checkout a valid quantity of a consumable item.
- [x] Test B: Attempt to checkout more of a consumable item than is available.

**Test Configuration**:
* PHP version: 8.0
* MySQL version: 8.1.17
* Webserver version: Apache/2.4.56 (Debian)
* OS version: Mac OS


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
