### PR TITLE
feature: add button delete page view asset

### DIFF
--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -146,7 +146,38 @@ var baseUrl = $('meta[name="baseUrl"]').attr('content');
         };
     };
 
+    // confirm delete modal single
+    Components.modals.confirmDeleteSingle = function () {
+        var $el = $(document);
 
+        var events = {
+            'click': function (evnt) {
+                var $context = $(this);
+                var $dataConfirmModal = $('#dataConfirmModal');
+                var href = $context.attr('href');
+                var message = $context.attr('data-content');
+                var title = $context.attr('data-title');
+
+                $('#myModalLabel').text(title);
+                $dataConfirmModal.find('.modal-body').text(message);
+                $('#deleteForm').attr('action', href);
+                $dataConfirmModal.modal({
+                    show: true
+                });
+                return false;
+            }
+        };
+
+        var render = function () {
+            $el.on('click', '.delete-asset-single', events['click']);
+        };
+
+        return {
+            render: render
+        };
+    };
+
+    
     /**
      * Application start point
      * Component definition stays out of load event, execution only happens.
@@ -154,6 +185,7 @@ var baseUrl = $('meta[name="baseUrl"]').attr('content');
     $(function() {
         new Components.modals.confirmRestore().render();
         new Components.modals.confirmDelete().render();
+        new Components.modals.confirmDeleteSingle().render();
     });
 }(jQuery, window.snipeit.settings));
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -61,6 +61,19 @@
                         </a>
                     </li>
                 @endcan
+                
+                @can('delete', \App\Models\Asset::class)
+                    @if ($asset->deleted_at == '' && $asset->assigned_to == '')
+                        <li role="menuitem">
+                            <a href="{{ route('hardware.destroy', $asset->id) }}" class="delete-asset-single"
+                                data-content="{{ trans('general.sure_to_delete') }}@if ($asset->name) {{ $asset->name }} @else {{ $asset->asset_tag }} @endif?"
+                                data-title="{{ trans('general.delete') }}" onClick="return false;">
+                                {{ trans('general.delete') }}
+                            </a>
+                        </li>
+                    @endif
+                @endcan
+                
             </ul>
         </div>
         @endif


### PR DESCRIPTION
# Description

### Feature: added delete asset button when user is in assets detail page
### It will also ask for confirmation before deletion.
I added a button for delete asset, made a call to API for Delete And added a confirmation popup to confirm delete.

![image](https://github.com/snipe/snipe-it/assets/111287779/f408cbe9-0551-4c64-8448-d96da58b00db)


Fixes #12567

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Test A: Go to any Asset, Click on actions and click Delete.
- [x] Test B: a Red Confirmation message will popup asking to confirm delete. Click Delete to delete the asset.


**Test Configuration**:
* PHP version:  PHP 8.0.28
* MySQL version: 10.4.28-MariaDB
* Webserver version: Apache/2.4.56
* OS version: Windows 11

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
