### PR TITLE
Add eager loading to Asset Models controller

### DIFF
--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -63,7 +63,7 @@ class AssetModelsController extends Controller
             'models.deleted_at',
             'models.updated_at',
          ])
-            ->with('category', 'depreciation', 'manufacturer', 'fieldset')
+            ->with('category', 'depreciation', 'manufacturer', 'fieldset.fields.defaultValues')
             ->withCount('assets as assets_count');
 
         if ($request->input('status')=='deleted') {


### PR DESCRIPTION
# Description

This PR adds eager loading to the api endpoint controller method that returns a list of asset models.

Before returning the asset models, they are passed to the `AssetModelsTransformer` which in turn references the nested `defaultValues` relationship.

Before this PR, on my system listing 10 asset models resulted in 
- 105 statements being executed
  - 64 being duplicated
  - 41 being unique
- 49MB of memory being used
- 109 seconds

After adding the eager loading in the PR it's
- 12 statements being executed
  - 2 being duplicated
  - 10 being unique
- 29MB of memory being used
- 209ms

Bumping this to listing 200 asset models results in the same number of statements being executed with 44MB of memory being used. This is in contrast to 517 duplicate/116 unique queries with 242MB of memory being used prior to this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
