### PR TITLE
Fixed #12947 Accessory image in checkin email when Show images in emails is disabled

### DIFF
--- a/resources/views/notifications/markdown/checkin-accessory.blade.php
+++ b/resources/views/notifications/markdown/checkin-accessory.blade.php
@@ -3,7 +3,7 @@
 
 {{ trans('mail.the_following_item') }}
 
-@if ($item->getImageUrl())
+@if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
 <center><img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;"></center>
 @endif
 


### PR DESCRIPTION
# Description
In the notification sent when an accessory is checked in, the markdown always shown images even if the setting for that is deactivated in the system.

In this PR I just add a condition to shown when required only.

Fixes #12947 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP Dev server
* OS version: Debian 11
