### PR TITLE
Feature/snipe 12567 asset delete

### DIFF
--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -57,8 +57,14 @@ class ConsumableCheckoutController extends Controller
 
         $this->authorize('checkout', $consumable);
 
+        // If the quantity is not present in the request or is not a positive integer, set it to 1
+        $quantity = $request->input('qty');
+        if (!isset($quantity) || !ctype_digit((string)$quantity) || $quantity <= 0) {
+            $quantity = 1;
+        }
+
         // Make sure there is at least one available to checkout
-        if ($consumable->numRemaining() <= 0 || $request->qty > $consumable->numRemaining()) {
+        if ($consumable->numRemaining() <= 0 || $quantity > $consumable->numRemaining()) {
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.checkout.unavailable'));
         }
 
@@ -75,7 +81,7 @@ class ConsumableCheckoutController extends Controller
         // Update the consumable data
         $consumable->assigned_to = e($request->input('assigned_to'));
 
-        for($i = 0; $i < $request->qty; $i++){
+        for($i = 0; $i < $quantity; $i++){
         $consumable->users()->attach($consumable->id, [
             'consumable_id' => $consumable->id,
             'user_id' => $admin_user->id,

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -58,7 +58,7 @@ class ConsumableCheckoutController extends Controller
         $this->authorize('checkout', $consumable);
 
         // Make sure there is at least one available to checkout
-        if ($consumable->numRemaining() <= 0) {
+        if ($consumable->numRemaining() <= 0 || $request->qty > $consumable->numRemaining()) {
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.checkout.unavailable'));
         }
 
@@ -75,13 +75,14 @@ class ConsumableCheckoutController extends Controller
         // Update the consumable data
         $consumable->assigned_to = e($request->input('assigned_to'));
 
+        for($i = 0; $i < $request->qty; $i++){
         $consumable->users()->attach($consumable->id, [
             'consumable_id' => $consumable->id,
             'user_id' => $admin_user->id,
             'assigned_to' => e($request->input('assigned_to')),
             'note' => $request->input('note'),
         ]);
-
+        }
         event(new CheckoutableCheckedOut($consumable, $user, Auth::user(), $request->input('note')));
 
         // Redirect to the new consumable page

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -66,6 +66,18 @@
                 </div>
               </div>
             @endif
+
+          <!-- Checkout QTY -->
+          <div class="form-group {{ $errors->has('qty') ? 'error' : '' }} ">
+              <label for="qty" class="col-md-3 control-label">{{ trans('general.qty') }}</label>
+              <div class="col-md-7 col-sm-12 required">
+                  <div class="col-md-2" style="padding-left:0px">
+                    <input class="form-control" type="number" name="qty" id="qty" value="1" min="1" max="{{$consumable->numRemaining()}}" />
+                  </div>
+              </div>
+              {!! $errors->first('qty', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+          </div>
+          
           <!-- Note -->
           <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
             <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -937,6 +937,17 @@
                                         </ul>
 
                                 @endif
+                                @can('delete', $asset)
+                                  <form class="form-horizontal" method="post" action="{{ route('hardware/bulkdelete') }}" autocomplete="off" role="form">
+                                    {{csrf_field()}}
+                                      <div class="box-body">
+                                          <input type="hidden" name="ids[]" value="{{ $asset->id }}">
+                                      </div>
+                                      <div class="box-footer text-right">
+                                        <button style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('button.delete')}}</button>
+                                    </div>
+                                  </form>
+                                @endcan
                             </div> <!-- div.col-md-4 -->
                         </div><!-- /row -->
                     </div><!-- /.tab-pane asset details -->


### PR DESCRIPTION
# Description

This change introduces a "delete" button on an individual Asset view. The initial request was driven by the inconvenience of having to navigate back to the Asset List to delete an asset, especially when the user only has the asset tag available. The proposed solution should enhance the user experience by streamlining the asset management process.

This addresses Feature Request  #12567 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A:  Attempting to delete an asset from its individual view, confirming the deletion 

**Test Configuration**:
* PHP version: 8.0
* MySQL version 8.1.17
* Webserver version Apache/2.4.56 (Debian)
* OS version Mac OS


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
