### PR TITLE
Fixed #13074 [API] Remaining accessories quantity not correct

### DIFF
--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -150,7 +150,7 @@ class AccessoriesController extends Controller
     public function show($id)
     {
         $this->authorize('view', Accessory::class);
-        $accessory = Accessory::findOrFail($id);
+        $accessory = Accessory::withCount('users as users_count')->findOrFail($id);
 
         return (new AccessoriesTransformer)->transformAccessory($accessory);
     }


### PR DESCRIPTION
# Description
When we calculate the remaining accessories we need to know how many users have that accessory checked out to them. So I add the `users_count` to the eloquent query executed when the user wants to see info about determined accessory via API.

Fixes #13074 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**: 
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP Dev Server
* OS version: Debian 11
