### PR TITLE
Dynamically adapt concatenation searches for MySQL and sqlite

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -947,13 +947,10 @@ class Asset extends Depreciable
                 ->orWhere('assets_users.first_name', 'LIKE', '%'.$term.'%')
                 ->orWhere('assets_users.last_name', 'LIKE', '%'.$term.'%')
                 ->orWhere('assets_users.username', 'LIKE', '%'.$term.'%')
-                ->orWhereRaw(
-                    $this->buildMultipleColumnSearch([
-                        DB::getTablePrefix().'assets_users.first_name',
-                        DB::getTablePrefix().'assets_users.last_name',
-                    ]),
-                    ["%{$term}%"]
-                );
+                ->orWhereMultipleColumns([
+                    DB::getTablePrefix() . 'assets_users.first_name',
+                    DB::getTablePrefix() . 'assets_users.last_name',
+                ], $term);
         }
 
         /**
@@ -1348,13 +1345,10 @@ class Asset extends Depreciable
                 })->orWhere(function ($query) use ($search) {
                     $query->where('assets_users.first_name', 'LIKE', '%'.$search.'%')
                         ->orWhere('assets_users.last_name', 'LIKE', '%'.$search.'%')
-                        ->orWhereRaw(
-                            $this->buildMultipleColumnSearch([
-                                DB::getTablePrefix().'assets_users.first_name',
-                                DB::getTablePrefix().'assets_users.last_name',
-                            ]),
-                            ["%{$search}%"]
-                        )
+                        ->orWhereMultipleColumns([
+                            DB::getTablePrefix() . 'assets_users.first_name',
+                            DB::getTablePrefix() . 'assets_users.last_name',
+                        ], $search)
                         ->orWhere('assets_users.username', 'LIKE', '%'.$search.'%')
                         ->orWhere('assets_locations.name', 'LIKE', '%'.$search.'%')
                         ->orWhere('assigned_assets.name', 'LIKE', '%'.$search.'%');

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -948,8 +948,8 @@ class Asset extends Depreciable
                 ->orWhere('assets_users.last_name', 'LIKE', '%'.$term.'%')
                 ->orWhere('assets_users.username', 'LIKE', '%'.$term.'%')
                 ->orWhereMultipleColumns([
-                    DB::getTablePrefix() . 'assets_users.first_name',
-                    DB::getTablePrefix() . 'assets_users.last_name',
+                    'assets_users.first_name',
+                    'assets_users.last_name',
                 ], $term);
         }
 
@@ -1346,8 +1346,8 @@ class Asset extends Depreciable
                     $query->where('assets_users.first_name', 'LIKE', '%'.$search.'%')
                         ->orWhere('assets_users.last_name', 'LIKE', '%'.$search.'%')
                         ->orWhereMultipleColumns([
-                            DB::getTablePrefix() . 'assets_users.first_name',
-                            DB::getTablePrefix() . 'assets_users.last_name',
+                            'assets_users.first_name',
+                            'assets_users.last_name',
                         ], $search)
                         ->orWhere('assets_users.username', 'LIKE', '%'.$search.'%')
                         ->orWhere('assets_locations.name', 'LIKE', '%'.$search.'%')

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -947,8 +947,13 @@ class Asset extends Depreciable
                 ->orWhere('assets_users.first_name', 'LIKE', '%'.$term.'%')
                 ->orWhere('assets_users.last_name', 'LIKE', '%'.$term.'%')
                 ->orWhere('assets_users.username', 'LIKE', '%'.$term.'%')
-                ->orWhereRaw('CONCAT('.DB::getTablePrefix().'assets_users.first_name," ",'.DB::getTablePrefix().'assets_users.last_name) LIKE ?', ["%$term%"]);
-
+                ->orWhereRaw(
+                    $this->buildMultipleColumnSearch([
+                        DB::getTablePrefix().'assets_users.first_name',
+                        DB::getTablePrefix().'assets_users.last_name',
+                    ]),
+                    ["%{$term}%"]
+                );
         }
 
         /**

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1348,7 +1348,13 @@ class Asset extends Depreciable
                 })->orWhere(function ($query) use ($search) {
                     $query->where('assets_users.first_name', 'LIKE', '%'.$search.'%')
                         ->orWhere('assets_users.last_name', 'LIKE', '%'.$search.'%')
-                        ->orWhereRaw('CONCAT('.DB::getTablePrefix().'assets_users.first_name," ",'.DB::getTablePrefix().'assets_users.last_name) LIKE ?', ["%$search%"])
+                        ->orWhereRaw(
+                            $this->buildMultipleColumnSearch([
+                                DB::getTablePrefix().'assets_users.first_name',
+                                DB::getTablePrefix().'assets_users.last_name',
+                            ]),
+                            ["%{$search}%"]
+                        )
                         ->orWhere('assets_users.username', 'LIKE', '%'.$search.'%')
                         ->orWhere('assets_locations.name', 'LIKE', '%'.$search.'%')
                         ->orWhere('assigned_assets.name', 'LIKE', '%'.$search.'%');

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -265,6 +265,12 @@ trait Searchable
         return $related->getTable();
     }
 
+    /**
+     * Builds a search string for either MySQL or sqlite by separating the provided columns with a space.
+     *
+     * @param array $columns Columns to include in search string.
+     * @return string
+     */
     private function buildMultipleColumnSearch(array $columns): string
     {
         $driver = config('database.connections.' . config('database.default') . '.driver');

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -282,4 +282,9 @@ trait Searchable
         // Default to MySQL's concatenation method
         return 'CONCAT(' . implode('," ",', $columns) . ') LIKE ?';
     }
+
+    public function scopeOrWhereMultipleColumns($query, array $columns, $term)
+    {
+        return $query->orWhereRaw($this->buildMultipleColumnSearch($columns), ["%{$term}%"]);
+    }
 }

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -279,6 +279,7 @@ trait Searchable
             return implode("||' '||", $columns) . ' LIKE ?';
         }
 
+        // Default to MySQL's concatenation method
         return 'CONCAT(' . implode('," ",', $columns) . ') LIKE ?';
     }
 }

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -167,8 +167,8 @@ trait Searchable
                 if($relation == 'user') {
                     $query->orWhereRaw(
                             $this->buildMultipleColumnSearch([
-                                DB::getTablePrefix() . 'users.first_name',
-                                DB::getTablePrefix() . 'users.last_name',
+                                'users.first_name',
+                                'users.last_name',
                             ]),
                             ["%{$term}%"]
                         );
@@ -273,14 +273,16 @@ trait Searchable
      */
     private function buildMultipleColumnSearch(array $columns): string
     {
+        $mappedColumns = collect($columns)->map(fn($column) => DB::getTablePrefix() . $column)->toArray();
+
         $driver = config('database.connections.' . config('database.default') . '.driver');
 
         if ($driver === 'sqlite') {
-            return implode("||' '||", $columns) . ' LIKE ?';
+            return implode("||' '||", $mappedColumns) . ' LIKE ?';
         }
 
         // Default to MySQL's concatenation method
-        return 'CONCAT(' . implode('," ",', $columns) . ') LIKE ?';
+        return 'CONCAT(' . implode('," ",', $mappedColumns) . ') LIKE ?';
     }
 
     /**

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -257,4 +257,15 @@ trait Searchable
 
         return $related->getTable();
     }
+
+    private function buildMultipleColumnSearch(array $columns): string
+    {
+        $driver = config('database.connections.' . config('database.default') . '.driver');
+
+        if ($driver === 'sqlite') {
+            return implode(" || ' ' || ", $columns) . ' LIKE ?';
+        }
+
+        return 'CONCAT(' . implode('," ",', $columns) . ') LIKE ?';
+    }
 }

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -283,6 +283,14 @@ trait Searchable
         return 'CONCAT(' . implode('," ",', $columns) . ') LIKE ?';
     }
 
+    /**
+     * Search a string across multiple columns separated with a space.
+     *
+     * @param Builder $query
+     * @param array $columns - Columns to include in search string.
+     * @param $term
+     * @return Builder
+     */
     public function scopeOrWhereMultipleColumns($query, array $columns, $term)
     {
         return $query->orWhereRaw($this->buildMultipleColumnSearch($columns), ["%{$term}%"]);

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -263,7 +263,7 @@ trait Searchable
         $driver = config('database.connections.' . config('database.default') . '.driver');
 
         if ($driver === 'sqlite') {
-            return implode(" || ' ' || ", $columns) . ' LIKE ?';
+            return implode("||' '||", $columns) . ' LIKE ?';
         }
 
         return 'CONCAT(' . implode('," ",', $columns) . ') LIKE ?';

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -5,6 +5,7 @@ namespace App\Models\Traits;
 use App\Models\Asset;
 use App\Models\CustomField;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 
 /**
  * This trait allows for cleaner searching of models,
@@ -164,7 +165,13 @@ trait Searchable
                 }
                 // I put this here because I only want to add the concat one time in the end of the user relation search
                 if($relation == 'user') {
-                    $query->orWhereRaw('CONCAT (users.first_name, " ", users.last_name) LIKE ?', ["%{$term}%"]);
+                    $query->orWhereRaw(
+                            $this->buildMultipleColumnSearch([
+                                DB::getTablePrefix() . 'users.first_name',
+                                DB::getTablePrefix() . 'users.last_name',
+                            ]),
+                            ["%{$term}%"]
+                        );
                 }
             });
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -646,13 +646,10 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     {
         return $query->where('first_name', 'LIKE', '%' . $search . '%')
             ->orWhere('last_name', 'LIKE', '%' . $search . '%')
-            ->orWhereRaw(
-                $this->buildMultipleColumnSearch([
-                    DB::getTablePrefix() . 'users.first_name',
-                    DB::getTablePrefix() . 'users.last_name',
-                ]),
-                ["%{$search}%"]
-            );
+            ->orWhereMultipleColumns([
+                DB::getTablePrefix() . 'users.first_name',
+                DB::getTablePrefix() . 'users.last_name',
+            ], $search);
     }
 
     /**
@@ -665,13 +662,10 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     public function advancedTextSearch(Builder $query, array $terms) {
 
         foreach($terms as $term) {
-            $query = $query->orWhereRaw(
-                $this->buildMultipleColumnSearch([
-                    DB::getTablePrefix() . 'users.first_name',
-                    DB::getTablePrefix() . 'users.last_name',
-                ]),
-                ["%{$term}%"]
-            );
+            $query->orWhereMultipleColumns([
+                DB::getTablePrefix() . 'users.first_name',
+                DB::getTablePrefix() . 'users.last_name',
+            ], $term);
         }
 
         return $query;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -665,7 +665,13 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     public function advancedTextSearch(Builder $query, array $terms) {
 
         foreach($terms as $term) {
-            $query = $query->orWhereRaw('CONCAT('.DB::getTablePrefix().'users.first_name," ",'.DB::getTablePrefix().'users.last_name) LIKE ?', ["%{$term}%"]);
+            $query = $query->orWhereRaw(
+                $this->buildMultipleColumnSearch([
+                    DB::getTablePrefix() . 'users.first_name',
+                    DB::getTablePrefix() . 'users.last_name',
+                ]),
+                ["%{$term}%"]
+            );
         }
 
         return $query;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -657,17 +657,6 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return $query;
     }
 
-    public function buildMultipleColumnSearch(array $columns): string
-    {
-        $driver = config('database.connections.' . config('database.default') . '.driver');
-
-        if ($driver === 'sqlite') {
-            return implode(" || ' ' || ", $columns) . ' LIKE ?';
-        }
-
-        return 'CONCAT(' . implode('," ",', $columns) . ') LIKE ?';
-    }
-
     /**
      * Run additional, advanced searches.
      *

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -644,17 +644,15 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function scopeSimpleNameSearch($query, $search)
     {
-           $query = $query->where('first_name', 'LIKE', '%'.$search.'%')
-               ->orWhere('last_name', 'LIKE', '%'.$search.'%')
-               ->orWhereRaw(
-                   $this->buildMultipleColumnSearch([
-                       DB::getTablePrefix() . 'users.first_name',
-                       DB::getTablePrefix() . 'users.last_name',
-                   ]),
-                   ["%{$search}%"]
-               );
-
-        return $query;
+        return $query->where('first_name', 'LIKE', '%' . $search . '%')
+            ->orWhere('last_name', 'LIKE', '%' . $search . '%')
+            ->orWhereRaw(
+                $this->buildMultipleColumnSearch([
+                    DB::getTablePrefix() . 'users.first_name',
+                    DB::getTablePrefix() . 'users.last_name',
+                ]),
+                ["%{$search}%"]
+            );
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -647,8 +647,8 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return $query->where('first_name', 'LIKE', '%' . $search . '%')
             ->orWhere('last_name', 'LIKE', '%' . $search . '%')
             ->orWhereMultipleColumns([
-                DB::getTablePrefix() . 'users.first_name',
-                DB::getTablePrefix() . 'users.last_name',
+                'users.first_name',
+                'users.last_name',
             ], $search);
     }
 
@@ -660,11 +660,10 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function advancedTextSearch(Builder $query, array $terms) {
-
         foreach($terms as $term) {
             $query->orWhereMultipleColumns([
-                DB::getTablePrefix() . 'users.first_name',
-                DB::getTablePrefix() . 'users.last_name',
+                'users.first_name',
+                'users.last_name',
             ], $term);
         }
 

--- a/database/seeders/CustomFieldSeeder.php
+++ b/database/seeders/CustomFieldSeeder.php
@@ -38,22 +38,32 @@ class CustomFieldSeeder extends Seeder
             [
                 'custom_field_id' => '1',
                 'custom_fieldset_id' => '1',
+                'order' => 0,
+                'required' => 0,
             ],
             [
                 'custom_field_id' => '2',
                 'custom_fieldset_id' => '1',
+                'order' => 0,
+                'required' => 0,
             ],
             [
               'custom_field_id' => '3',
               'custom_fieldset_id' => '2',
+                'order' => 0,
+                'required' => 0,
             ],
             [
               'custom_field_id' => '4',
               'custom_fieldset_id' => '2',
+                'order' => 0,
+                'required' => 0,
             ],
             [
               'custom_field_id' => '5',
               'custom_fieldset_id' => '2',
+                'order' => 0,
+                'required' => 0,
             ],
 
       ]);

--- a/database/seeders/CustomFieldSeeder.php
+++ b/database/seeders/CustomFieldSeeder.php
@@ -48,24 +48,24 @@ class CustomFieldSeeder extends Seeder
                 'required' => 0,
             ],
             [
-              'custom_field_id' => '3',
-              'custom_fieldset_id' => '2',
+                'custom_field_id' => '3',
+                'custom_fieldset_id' => '2',
                 'order' => 0,
                 'required' => 0,
             ],
             [
-              'custom_field_id' => '4',
-              'custom_fieldset_id' => '2',
+                'custom_field_id' => '4',
+                'custom_fieldset_id' => '2',
                 'order' => 0,
                 'required' => 0,
             ],
             [
-              'custom_field_id' => '5',
-              'custom_fieldset_id' => '2',
+                'custom_field_id' => '5',
+                'custom_fieldset_id' => '2',
                 'order' => 0,
                 'required' => 0,
             ],
 
-      ]);
+        ]);
     }
 }

--- a/tests/Feature/Api/Users/UsersForSelectListTest.php
+++ b/tests/Feature/Api/Users/UsersForSelectListTest.php
@@ -30,6 +30,19 @@ class UsersForSelectListTest extends TestCase
             ->assertJson(fn(AssertableJson $json) => $json->has('results', 3)->etc());
     }
 
+    public function testUsersCanBeSearchedByFirstAndLastName()
+    {
+        User::factory()->create(['first_name' => 'Luke', 'last_name' => 'Skywalker']);
+
+        Passport::actingAs(User::factory()->create());
+        $response = $this->getJson(route('api.users.selectlist', ['search' => 'luke sky']))->assertOk();
+
+        $results = collect($response->json('results'));
+
+        $this->assertEquals(1, $results->count());
+        $this->assertTrue($results->pluck('text')->contains(fn($text) => str_contains($text, 'Luke')));
+    }
+
     public function testUsersScopedToCompanyWhenMultipleFullCompanySupportEnabled()
     {
         $this->settings->enableMultipleFullCompanySupport();

--- a/tests/Feature/Api/Users/UsersSearchTest.php
+++ b/tests/Feature/Api/Users/UsersSearchTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Api\Users;
+
+use App\Models\User;
+use Laravel\Passport\Passport;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class UsersSearchTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testCanSearchByUserFirstAndLastName()
+    {
+        User::factory()->create(['first_name' => 'Luke', 'last_name' => 'Skywalker']);
+        User::factory()->create(['first_name' => 'Darth', 'last_name' => 'Vader']);
+
+        Passport::actingAs(User::factory()->viewUsers()->create());
+        $response = $this->getJson(route('api.users.index', ['search' => 'luke sky']))->assertOk();
+
+        $results = collect($response->json('rows'));
+
+        $this->assertEquals(1, $results->count());
+        $this->assertTrue($results->pluck('name')->contains(fn($text) => str_contains($text, 'Luke')));
+        $this->assertFalse($results->pluck('name')->contains(fn($text) => str_contains($text, 'Darth')));
+    }
+}


### PR DESCRIPTION
# Description

This PR replaces direct calls to MySQL's `CONCAT` function in favor of calling a method, `buildMultipleColumnSearch()`, that checks if the database driver is sqlite and uses it's string concatenation method. This means that the search boxes across the app that were allowing users to be found with a combination of their first and last names will work with sqlite instead of failing due to `CONCAT` not being available.

The `buildMultipleColumnSearch()` method takes an array of columns to join so in the future it can be used in places other than just the first and last name searches we're doing now.

The `CustomFieldSeeder` has also been updated to add default values that are needed to seed sqlite.

I think this change means we can unofficially call sqlite a supported database for use with the app.

## Type of change

- [x] New feature (non-breaking change which adds functionality) ❓