### PR TITLE
Fixed #12978 Custom Field Checkboxes not holding assigned values

### DIFF
--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -306,9 +306,9 @@ class CustomField extends Model
             $arr_parts = explode('|', $arr[$x]);
             if ($arr_parts[0] != '') {
                 if (array_key_exists('1', $arr_parts)) {
-                    $result[$arr_parts[0]] = $arr_parts[1];
+                    $result[$arr_parts[0]] = trim($arr_parts[1]);
                 } else {
-                    $result[$arr_parts[0]] = $arr_parts[0];
+                    $result[$arr_parts[0]] = trim($arr_parts[0]);
                 }
             }
         }


### PR DESCRIPTION
# Description
When a custom field is created with the input type checkbox, if the values for some reason starts or ends with a space character (' ') some problems may occur when editing the assets that use those custom fields. We received the advice of create a migration to fix some already stored values, but I think with these changes that is not necessary, because I'm retrieving the possible values as an array without any space, correcting the underlying problem.

Fixes #12978

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: PHP Dev Server
* OS version: Debian 11
