### PR TITLE
feature: Added asset_tag column in requestable assets page

### DIFF
--- a/resources/views/account/requestable-assets.blade.php
+++ b/resources/views/account/requestable-assets.blade.php
@@ -57,6 +57,7 @@
                                         <thead>
                                             <tr>
                                                 <th class="col-md-1" data-field="image" data-formatter="imageFormatter" data-sortable="true">{{ trans('general.image') }}</th>
+                                                <th class="col-md-2" data-field="asset_tag" data-sortable="true" >{{ trans('general.asset_tag') }}</th>                                                
                                                 <th class="col-md-2" data-field="model" data-sortable="true">{{ trans('admin/hardware/table.asset_model') }}</th>
                                                 <th class="col-md-2" data-field="model_number" data-sortable="true">{{ trans('admin/models/table.modelnumber') }}</th>
                                                 <th class="col-md-2" data-field="name" data-sortable="true">{{ trans('admin/hardware/form.name') }}</th>


### PR DESCRIPTION
# Description

Added asset_tag column in requestable assets page.
Now User should be able to select asset tag column to show in requestable assets page.
As shown in screenshot below:
![image](https://github.com/snipe/snipe-it/assets/111287779/5202a228-5bad-480a-a415-499bab61b044)


Fixes #12886

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Test A: Go to Requestable Assets, second column will be the Added "Asset Tag" Column.
- [x] Test B: By clicking check box, Asset Tag colummn will toggle On and Off.
![image](https://github.com/snipe/snipe-it/assets/111287779/ef8ae738-46d7-4027-8f2d-8e0dcd328054)


**Test Configuration**:
* PHP version:  PHP 8.0.28
* MySQL version: 10.4.28-MariaDB
* Webserver version: Apache/2.4.56
* OS version: Windows 11

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
