### PR TITLE
Fixed #13098: Status Label Chart Color, resets to default when editing a Status Label

### DIFF
--- a/resources/views/statuslabels/edit.blade.php
+++ b/resources/views/statuslabels/edit.blade.php
@@ -71,14 +71,11 @@
 
 @section('moar_scripts')
     <!-- bootstrap color picker -->
-    <?php 
-    $color = request()->old('color', $item->color) ? request()->old('color', $item->color) : '#AA3399';
-    ?>
     <script nonce="{{ csrf_token() }}">
 
         $(function() {
             $('.color').colorpicker({
-                color: '{{ $color }}',
+                color: `{{ old('color', $item->color) ?: '#AA3399' }}`,
                 format: 'hex'
             });
         });

--- a/resources/views/statuslabels/edit.blade.php
+++ b/resources/views/statuslabels/edit.blade.php
@@ -71,11 +71,14 @@
 
 @section('moar_scripts')
     <!-- bootstrap color picker -->
+    <?php 
+    $color = request()->old('color', $item->color) ? request()->old('color', $item->color) : '#AA3399';
+    ?>
     <script nonce="{{ csrf_token() }}">
 
         $(function() {
             $('.color').colorpicker({
-                color: '#AA3399',
+                color: '{{ $color }}',
                 format: 'hex'
             });
         });


### PR DESCRIPTION
# Description

This PR includes a fix for the issue tracked under issue number #13049. The issue involved the Status Label Chart Color resetting to its default state when a Status Label was being edited. This was problematic as it didn't allow users to maintain their chosen colour when making modifications to their Status Labels.

Fixes #13049

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: Create a new Status Label, set a custom colour, save and edit the same Status Label. Verified that the custom colour remained.
- [x] Test B: Edit an existing Status Label with a custom colour. Verified that the custom colour remained during the editing process.


**Test Configuration**:
* PHP version: 8.0
* MySQL version: 8.1.17
* Webserver version: Apache/2.4.56 (Debian)
* OS version: Mac OS


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
