### PR TITLE
Fixed Broken order by manufacturer in Assets table [sc-23313]

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1667,7 +1667,7 @@ class Asset extends Depreciable
     public function scopeOrderManufacturer($query, $order)
     {
         return $query->join('models as order_asset_model', 'assets.model_id', '=', 'order_asset_model.id')
-            ->join('manufacturers as manufacturer_order', 'order_asset_model.manufacturer_id', '=', 'manufacturer_order.id')
+            ->leftjoin('manufacturers as manufacturer_order', 'order_asset_model.manufacturer_id', '=', 'manufacturer_order.id')
             ->orderBy('manufacturer_order.name', $order);
     }
 


### PR DESCRIPTION
# Description
When sorting assets by manufacturers, the assets that do not have a manufacturer will not show up in the All Assets list, instead of just leaving the manufacturer column entry blank, as it does for other columns, e.g. Asset Name.

This PR replaces the join clause in the Asset's `scopeOrderManufacturer` eloquent query for a left join so it keep the already queried tables and results without take away the results that doesn't have a manufacturer.

Fixes # [sc-23313]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11