### PR TITLE
Fixes potentially invalid name in consumable factory

### DIFF
--- a/database/factories/ConsumableFactory.php
+++ b/database/factories/ConsumableFactory.php
@@ -27,7 +27,7 @@ class ConsumableFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->words(),
+            'name' => $this->faker->words(3, true),
             'category_id' => Category::factory(),
             'user_id' => User::factory()->superuser(),
             'item_no' => $this->faker->numberBetween(1000000, 50000000),

--- a/database/factories/ConsumableFactory.php
+++ b/database/factories/ConsumableFactory.php
@@ -27,7 +27,7 @@ class ConsumableFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->word(),
+            'name' => $this->faker->words(),
             'category_id' => Category::factory(),
             'user_id' => User::factory()->superuser(),
             'item_no' => $this->faker->numberBetween(1000000, 50000000),


### PR DESCRIPTION
# Description

This tiny PR ensures a Consumable model created via its factory has a valid name. Previously, it was possible to generate a name with only two characters while the Consumable's rules say it needs to be at least three characters.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) (sorta)