### PR TITLE
fix slack channel notifications

### DIFF
--- a/app/Notifications/AuditNotification.php
+++ b/app/Notifications/AuditNotification.php
@@ -23,6 +23,7 @@ class AuditNotification extends Notification
     public function __construct($params)
     {
         //
+        $this->settings = Setting::getSettings();
         $this->params = $params;
     }
 
@@ -43,9 +44,12 @@ class AuditNotification extends Notification
 
     public function toSlack()
     {
+        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
         return (new SlackMessage)
             ->success()
             ->content(class_basename(get_class($this->params['item'])).' Audited')
+            ->from(($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot')
+            ->to($channel)
             ->attachment(function ($attachment) {
                 $item = $this->params['item'];
                 $admin_user = $this->params['admin'];

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -92,6 +92,7 @@ class CheckinAccessoryNotification extends Notification
         $item = $this->item;
         $note = $this->note;
         $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
+        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
@@ -101,6 +102,7 @@ class CheckinAccessoryNotification extends Notification
         return (new SlackMessage)
             ->content(':arrow_down: :keyboard: '.trans('mail.Accessory_Checkin_Notification'))
             ->from($botname)
+            ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -65,6 +65,7 @@ class CheckinAssetNotification extends Notification
         $item = $this->item;
         $note = $this->note;
         $botname = ($this->settings->webhook_botname != '') ? $this->settings->webhook_botname : 'Snipe-Bot';
+        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
             trans('general.administrator') => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
@@ -75,6 +76,7 @@ class CheckinAssetNotification extends Notification
         return (new SlackMessage)
             ->content(':arrow_down: :computer: '.trans('mail.Asset_Checkin_Notification'))
             ->from($botname)
+            ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckinLicenseSeatNotification.php
+++ b/app/Notifications/CheckinLicenseSeatNotification.php
@@ -63,6 +63,7 @@ class CheckinLicenseSeatNotification extends Notification
         $item = $this->item;
         $note = $this->note;
         $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
+        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         if ($admin) {
             $fields = [
@@ -79,6 +80,7 @@ class CheckinLicenseSeatNotification extends Notification
         return (new SlackMessage)
             ->content(':arrow_down: :floppy_disk: '.trans('mail.License_Checkin_Notification'))
             ->from($botname)
+            ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -79,6 +79,7 @@ class CheckoutAccessoryNotification extends Notification
         $item = $this->item;
         $note = $this->note;
         $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
+        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
@@ -88,6 +89,7 @@ class CheckoutAccessoryNotification extends Notification
         return (new SlackMessage)
             ->content(':arrow_up: :keyboard: Accessory Checked Out')
             ->from($botname)
+            ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -96,6 +96,7 @@ class CheckoutAssetNotification extends Notification
         $item = $this->item;
         $note = $this->note;
         $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
+        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
@@ -109,6 +110,7 @@ class CheckoutAssetNotification extends Notification
         return (new SlackMessage)
             ->content(':arrow_up: :computer: '.trans('mail.Asset_Checkout_Notification'))
             ->from($botname)
+            ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -85,6 +85,7 @@ class CheckoutConsumableNotification extends Notification
         $item = $this->item;
         $note = $this->note;
         $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
+        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
@@ -94,6 +95,7 @@ class CheckoutConsumableNotification extends Notification
         return (new SlackMessage)
             ->content(':arrow_up: :paperclip: Consumable Checked Out')
             ->from($botname)
+            ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/CheckoutLicenseSeatNotification.php
+++ b/app/Notifications/CheckoutLicenseSeatNotification.php
@@ -85,6 +85,7 @@ class CheckoutLicenseSeatNotification extends Notification
         $item = $this->item;
         $note = $this->note;
         $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
+        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
             'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
@@ -94,6 +95,7 @@ class CheckoutLicenseSeatNotification extends Notification
         return (new SlackMessage)
             ->content(':arrow_up: :floppy_disk: License Checked Out')
             ->from($botname)
+            ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/RequestAssetCancelation.php
+++ b/app/Notifications/RequestAssetCancelation.php
@@ -74,6 +74,7 @@ class RequestAssetCancelation extends Notification
         $note = $this->note;
         $qty = $this->item_quantity;
         $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
+        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
             'QTY' => $qty,
@@ -87,6 +88,7 @@ class RequestAssetCancelation extends Notification
         return (new SlackMessage)
             ->content(trans('mail.a_user_canceled'))
             ->from($botname)
+            ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)

--- a/app/Notifications/RequestAssetNotification.php
+++ b/app/Notifications/RequestAssetNotification.php
@@ -74,6 +74,7 @@ class RequestAssetNotification extends Notification
         $item = $this->item;
         $note = $this->note;
         $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
+        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
             'QTY' => $qty,
@@ -83,6 +84,7 @@ class RequestAssetNotification extends Notification
         return (new SlackMessage)
             ->content(trans('mail.Item_Requested'))
             ->from($botname)
+            ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $fields) {
                 $attachment->title(htmlspecialchars_decode($item->present()->name), $item->present()->viewUrl())
                     ->fields($fields)


### PR DESCRIPTION
# Description

As the slack notification doesnt use the channel which can be configured in the admin settings, this PR should fix that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I didnt test it as I dont have an environment at hand.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
