### PR TITLE
Fixed #12434: Include Docker Specific Paths for dompdf chroot

### DIFF
--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -74,8 +74,11 @@ return array(
          * This is only checked on command line call by dompdf.php, but not by
          * direct class use like:
          * $dompdf = new DOMPDF();	$dompdf->load_html($htmldata); $dompdf->render(); $pdfdata = $dompdf->output();
+         * 
+         * 
+         * Hardcoding 2 Paths needed for Docker Containers
          */
-        "chroot" => realpath(base_path()),
+        "chroot" => realpath(base_path()) . ",/var/lib/snipeit/data/uploads,/var/lib/snipeit/data/private_uploads",
 
         /**
          * Whether to enable font subsetting or not.


### PR DESCRIPTION
# Description
Dompdf uses a chroot functionality to limit the folders its allowed to work in, this mr addes twot folders that are symlinked when building the container


Fixes #12434

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on latest docker image tag
- [x] tested on v6.1.0 image tag
- [x] tested on a vm deployment

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
