### PR TITLE
First pass at 'deployed' status-label-type

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -462,10 +462,17 @@ class Helper
      * @since [v2.5]
      * @return array
      */
-    public static function statusLabelList()
+    public static function statusLabelList($for_checkin = false)
     {
-        $statuslabel_list = ['' => trans('general.select_statuslabel')] + Statuslabel::orderBy('default_label', 'desc')->orderBy('name', 'asc')->orderBy('deployable', 'desc')
-                ->pluck('name', 'id')->toArray();
+
+        $statusquery = Statuslabel::orderBy('default_label', 'desc')->orderBy('name', 'asc')->orderBy('deployable', 'desc');
+
+        if (Statuslabel::has_deployed_statuses() && $for_checkin) {
+            $statusquery->where("deployed","!=","1");
+        }
+
+        $statuslabel_list = ['' => trans('general.select_statuslabel')] +
+            $statusquery->pluck('name', 'id')->toArray();
 
         return $statuslabel_list;
     }
@@ -491,6 +498,14 @@ class Helper
         return $statuslabel_list;
     }
 
+    public static function deployedStatusLabelList()
+    {
+        return Statuslabel::where('deployed', '=', '1')->orderBy('default_label', 'desc')
+            ->orderBy('name', 'asc')
+            ->orderBy('deployed', 'desc')
+            ->pluck('name', 'id')->toArray();
+    }
+
     /**
      * Get the list of status label types in an array to make a dropdown menu
      *
@@ -503,6 +518,7 @@ class Helper
         $statuslabel_types =
               ['' => trans('admin/hardware/form.select_statustype')]
             + ['deployable' => trans('admin/hardware/general.deployable')]
+            + ['deployed' => trans('general.deployed')]
             + ['pending' => trans('admin/hardware/general.pending')]
             + ['undeployable' => trans('admin/hardware/general.undeployable')]
             + ['archived' => trans('admin/hardware/general.archived')];

--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -46,6 +46,8 @@ class StatuslabelsController extends Controller
                 $statuslabels = $statuslabels->Archived();
             } elseif (strtolower($request->input('status_type')) == 'deployable') {
                 $statuslabels = $statuslabels->Deployable();
+            } elseif (strtolower($request->input('status_type')) == 'deployed') {
+                $statuslabels = $statuslabels->Deployed();
             } elseif (strtolower($request->input('status_type')) == 'undeployable') {
                 $statuslabels = $statuslabels->Undeployable();
             }

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -35,7 +35,7 @@ class AssetCheckinController extends Controller
 
         $this->authorize('checkin', $asset);
 
-        return view('hardware/checkin', compact('asset'))->with('statusLabel_list', Helper::statusLabelList())->with('backto', $backto);
+        return view('hardware/checkin', compact('asset'))->with('statusLabel_list', Helper::statusLabelList(true))->with('backto', $backto);
     }
 
     /**
@@ -75,7 +75,7 @@ class AssetCheckinController extends Controller
         $asset->name = $request->get('name');
 
         if ($request->filled('status_id')) {
-            $asset->status_id = e($request->get('status_id'));
+            $asset->status_id = e($request->get('status_id')); //need to do a check here?
         }
 
         // This is just meant to correct legacy issues where some user data would have 0

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\AssetCheckoutRequest;
 use App\Models\Asset;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Auth;
+use App\Models\Statuslabel;
 
 class AssetCheckoutController extends Controller
 {
@@ -35,7 +36,7 @@ class AssetCheckoutController extends Controller
 
         if ($asset->availableForCheckout()) {
             return view('hardware/checkout', compact('asset'))
-                ->with('statusLabel_list', Helper::deployableStatusLabelList());
+                ->with('statusLabel_list', Statuslabel::has_deployed_statuses() ? Helper::deployedStatusLabelList() :  Helper::deployableStatusLabelList()); // <- definitely need that helper to be adjusted?
         }
 
         return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.checkout.not_available'));

--- a/app/Http/Controllers/StatuslabelsController.php
+++ b/app/Http/Controllers/StatuslabelsController.php
@@ -78,6 +78,7 @@ class StatuslabelsController extends Controller
         $statusLabel->user_id = Auth::id();
         $statusLabel->notes = $request->input('notes');
         $statusLabel->deployable = $statusType['deployable'];
+        $statusLabel->deployed = $statusType['deployed'];
         $statusLabel->pending = $statusType['pending'];
         $statusLabel->archived = $statusType['archived'];
         $statusLabel->color = $request->input('color');
@@ -110,7 +111,7 @@ class StatuslabelsController extends Controller
 
         $use_statuslabel_type = $item->getStatuslabelType();
 
-        $statuslabel_types = ['' => trans('admin/hardware/form.select_statustype')] + ['undeployable' => trans('admin/hardware/general.undeployable')] + ['pending' => trans('admin/hardware/general.pending')] + ['archived' => trans('admin/hardware/general.archived')] + ['deployable' => trans('admin/hardware/general.deployable')];
+        $statuslabel_types = ['' => trans('admin/hardware/form.select_statustype')] + ['undeployable' => trans('admin/hardware/general.undeployable')] + ['pending' => trans('admin/hardware/general.pending')] + ['archived' => trans('admin/hardware/general.archived')] + ['deployable' => trans('admin/hardware/general.deployable')] + ['deployed' => trans('general.deployed')];
 
         return view('statuslabels/edit', compact('item', 'statuslabel_types'))->with('use_statuslabel_type', $use_statuslabel_type);
     }

--- a/app/Http/Requests/AssetCheckoutRequest.php
+++ b/app/Http/Requests/AssetCheckoutRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests;
 
+use App\Models\Statuslabel;
+
 class AssetCheckoutRequest extends Request
 {
     /**
@@ -28,6 +30,11 @@ class AssetCheckoutRequest extends Request
             'status_id'             => 'exists:status_labels,id,deployable,1',
             'checkout_to_type'      => 'required|in:asset,location,user',
         ];
+
+        // if using the 'deployed' status-type, change the status_id rule
+        if (Statuslabel::has_deployed_statuses()) {
+            $rules['status_id'] = 'exists:status_labels,id,deployed,1';
+        }
 
         return $rules;
     }

--- a/database/migrations/2023_05_24_231417_add_deployed_boolean_to_status_labels.php
+++ b/database/migrations/2023_05_24_231417_add_deployed_boolean_to_status_labels.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('status_labels', function (Blueprint $table) {
+            //
+            $table->boolean('deployed')->after('archived');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('status_labels', function (Blueprint $table) {
+            //
+            $table->dropColumn('deployed');
+        });
+    }
+};

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -233,7 +233,9 @@
                                                 @if (($asset->assignedTo) && ($asset->deleted_at==''))
                                                     <i class="fas fa-circle text-blue"></i>
                                                     {{ $asset->assetstatus->name }}
-                                                    <label class="label label-default">{{ trans('general.deployed') }}</label>
+                                                    @if (!App\Models\Statuslabel::has_deployed_statuses())
+                                                        <label class="label label-default">{{ trans('general.deployed') }}</label>
+                                                    @endif
 
                                                     <i class="fas fa-long-arrow-alt-right" aria-hidden="true"></i>
                                                     {!!  $asset->assignedTo->present()->glyph()  !!}

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -2,7 +2,9 @@
 <link rel="stylesheet" href="{{ url(mix('css/dist/bootstrap-table.css')) }}">
 
 @endpush
-
+@php
+$has_deployed_statuses = \App\Models\Statuslabel::has_deployed_statuses();
+@endphp
 @push('js')
 
 <script src="{{ url(mix('js/dist/bootstrap-table.js')) }}"></script>
@@ -197,7 +199,11 @@
                     case 'deployed':
                         text_color = 'blue';
                         icon_style = 'fa-circle';
-                        text_help = '<label class="label label-default">{{ trans('general.deployed') }}</label>';
+                        if (!{{ $has_deployed_statuses }}) {
+                            text_help = '<label class="label label-default">{{ trans('general.deployed') }}</label>';
+                        } else {
+                            text_help = '';
+                        }
                     break;
                     case 'deployable':
                         text_color = 'green';


### PR DESCRIPTION
I know you *hate* having too many WIP PR's up, @snipe , but I wanted to get your eyes on this before I went too far with it.

I think I have the basic logic for check-in and check-out working, and it basically does pretty much what you expect. Here's where I have a few concerns though:

1. I don't know if I like my overly-clever way of engaging the new functionality - if you *have* a 'deployed' statuslabel-type (can be called whatever you want), then the new-way works. Otherwise the old-way works. I thought this might be a nice way to avoid breaking people's workflows too much, but allowing them to switch over whenever they're ready. But maybe we shouldn't do that; maybe we *should* just say 'the new way is the only way on v7!' And just throw a lot of caveats towards people during the upgrade?
2. In a lot of the Edit asset screens, we're going to have to have some clever interplay between which statuslabels we present, based on whether or not an asset is going to be checked out to a person, or not. For example - when creating a new asset, if you pick a 'deployed' status-label-type, but don't actually pick a person to have it be checked-out-to, it will need to fail. If you bulk-edit an asset, and change status in the process, _some_ of those bulk edits will fail *if* the asset is being set to a depoyed-status-label-type, but you have no recipient. And vice-versa for ready-to-deploy. Fixing this isn't *impossible*, it's just something we'll have to be careful about.
3. I took the liberty of removing the extra 'Deployed' label on the status-label - since we now will have dedicated deployed labels (if you are in 'deployed-mode' for status-labels). Easy enough to put back though, if you don't like that.