### PR TITLE
Fixed #13129: Add missing LDAP lib required for LDAPS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ gcc \
 make \
 autoconf \
 libc-dev \
+libldap-common \
 pkg-config \
 libmcrypt-dev \
 php8.1-dev \


### PR DESCRIPTION
This should provide LDAPS support out of the box, and fix #13129

# Description

Add libldap-common in installed dependencies, so that phpldap is able to validate LDAPS certificates.

Fixes #13129

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This is a suggested bugfix, and hasn't been tested yet.

# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
