### PR TITLE
Added warranty confirmation to asset maintenance table

### DIFF
--- a/app/Http/Controllers/Api/AssetMaintenancesController.php
+++ b/app/Http/Controllers/Api/AssetMaintenancesController.php
@@ -71,7 +71,8 @@ class AssetMaintenancesController extends Controller
                                 'asset_tag',
                                 'asset_name',
                                 'user_id',
-                                'supplier'
+                                'supplier',
+                                'is_warranty',
                             ];
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? e($request->input('sort')) : 'created_at';

--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -59,6 +59,7 @@ class AssetMaintenancesTransformer
             'user_id'    => ($assetmaintenance->admin) ? ['id' => $assetmaintenance->admin->id, 'name'=> e($assetmaintenance->admin->getFullNameAttribute())] : null,
             'created_at' => Helper::getFormattedDateObject($assetmaintenance->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($assetmaintenance->updated_at, 'datetime'),
+            'is_warranty'=> ($assetmaintenance->is_warranty) ? trans('general.yes') : trans('general.no'),
 
         ];
 

--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -59,7 +59,7 @@ class AssetMaintenancesTransformer
             'user_id'    => ($assetmaintenance->admin) ? ['id' => $assetmaintenance->admin->id, 'name'=> e($assetmaintenance->admin->getFullNameAttribute())] : null,
             'created_at' => Helper::getFormattedDateObject($assetmaintenance->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($assetmaintenance->updated_at, 'datetime'),
-            'is_warranty'=> ($assetmaintenance->is_warranty) ? trans('general.yes') : trans('general.no'),
+            'is_warranty'=> $assetmaintenance->is_warranty,
 
         ];
 

--- a/app/Presenters/AssetMaintenancesPresenter.php
+++ b/app/Presenters/AssetMaintenancesPresenter.php
@@ -95,6 +95,7 @@ class AssetMaintenancesPresenter extends Presenter
                 'searchable' => true,
                 'sortable' => true,
                 'title' => trans('admin/asset_maintenances/table.is_warranty'),
+                'formatter' => 'trueFalseFormatter'
             ], [
                 'field' => 'cost',
                 'searchable' => true,

--- a/resources/views/reports/asset_maintenances.blade.php
+++ b/resources/views/reports/asset_maintenances.blade.php
@@ -48,6 +48,7 @@
                     <th data-searchable="true" data-sortable="true" data-field="cost" class="text-right" data-footer-formatter="sumFormatter">{{ trans('admin/asset_maintenances/form.cost') }}</th>
                     <th data-sortable="true" data-field="location" data-formatter="deployedLocationFormatter" data-visible="false">{{ trans('general.location') }}</th>
                     <th data-sortable="true" data-field="rtd_location" data-formatter="deployedLocationFormatter" data-visible="false">{{ trans('admin/hardware/form.default_location') }}</th>
+                    <th data-searchable="true" data-sortable="true" data-field="is_warranty">{{ trans('admin/asset_maintenances/table.is_warranty') }}</th>
                     <th data-searchable="true" data-sortable="true" data-field="user_id" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
                     <th data-searchable="true" data-sortable="true" data-field="notes" data-visible="false">{{ trans('admin/asset_maintenances/form.notes') }}</th>
                 </tr>

--- a/resources/views/reports/asset_maintenances.blade.php
+++ b/resources/views/reports/asset_maintenances.blade.php
@@ -48,7 +48,7 @@
                     <th data-searchable="true" data-sortable="true" data-field="cost" class="text-right" data-footer-formatter="sumFormatter">{{ trans('admin/asset_maintenances/form.cost') }}</th>
                     <th data-sortable="true" data-field="location" data-formatter="deployedLocationFormatter" data-visible="false">{{ trans('general.location') }}</th>
                     <th data-sortable="true" data-field="rtd_location" data-formatter="deployedLocationFormatter" data-visible="false">{{ trans('admin/hardware/form.default_location') }}</th>
-                    <th data-searchable="true" data-sortable="true" data-field="is_warranty">{{ trans('admin/asset_maintenances/table.is_warranty') }}</th>
+                    <th data-searchable="true" data-sortable="true" data-field="is_warranty" data-formatter="trueFalseformatter">{{ trans('admin/asset_maintenances/table.is_warranty') }}</th>
                     <th data-searchable="true" data-sortable="true" data-field="user_id" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
                     <th data-searchable="true" data-sortable="true" data-field="notes" data-visible="false">{{ trans('admin/asset_maintenances/form.notes') }}</th>
                 </tr>


### PR DESCRIPTION
# Description
Adds a response if an asset under maintenance is covered/improved by a warranty in the table view of maintenance requests.

<img width="1071" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/aec2807d-8b27-419f-a49a-df66b9f802b9">

Fixes #13152 

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
