### PR TITLE
Making Serial Number the logic checked against for new imports

### DIFF
--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -34,7 +34,7 @@ class LicenseImporter extends ItemImporter
     public function createLicenseIfNotExists(array $row)
     {
         $editingLicense = false;
-        $license = License::where('serial', $this->item['serial'])
+        $license = License::where('serial', $this->item['serial'])->where('name', $this->item['name'])
                     ->first();
         if ($license) {
             if (! $this->updating) {

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -38,7 +38,13 @@ class LicenseImporter extends ItemImporter
                     ->first();
         if ($license) {
             if (! $this->updating) {
-                $this->log('A matching License '.$this->item['name'].' with serial '.$this->item['serial'].' already exists');
+
+                if($this->item['serial'] != "") {
+                    $this->log('A matching License ' . $this->item['name'] . ' with serial ' . $this->item['serial'] . ' already exists');
+                }
+                else {
+                    $this->log('A matching License ' . $this->item['name'] . ' with no serial number already exists');
+                }
 
                 return;
             }

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -31,7 +31,7 @@ class LicenseImporter extends ItemImporter
     public function createLicenseIfNotExists(array $row)
     {
         $editingLicense = false;
-        $license = License::where('name', $this->item['name'])
+        $license = License::where('serial', $this->item['serial'])
                     ->first();
         if ($license) {
             if (! $this->updating) {
@@ -57,6 +57,10 @@ class LicenseImporter extends ItemImporter
         $this->item['maintained'] = $this->findCsvMatch($row, 'maintained');
         $this->item['purchase_order'] = $this->findCsvMatch($row, 'purchase_order');
         $this->item['reassignable'] = $this->findCsvMatch($row, 'reassignable');
+        if($this->item['reassignable'] == "")
+        {
+            $this->item['reassignable'] = 1;
+        }
         $this->item['seats'] = $this->findCsvMatch($row, 'seats');
         
         $this->item["termination_date"] = null;

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -27,6 +27,9 @@ class LicenseImporter extends ItemImporter
      * @since 4.0
      * @param array $row
      * @return License|mixed|null
+     * updated @author Jes Vinsmoke
+     * @since 6.1
+     *
      */
     public function createLicenseIfNotExists(array $row)
     {


### PR DESCRIPTION
Change to importing licenses.

When importing new licenses and the "update existing" is unchecked, the serial number will now be the unique identifier used for imports.

For licenses that have multiple seats on one serial number, users should enter the amount of seats in a column titled `seats` to match the importer syntax.  Users can then assign seats out view the view page, or by clicking into the specific license and clicking on the seats tab.

**NOTE**: clicking the update existing will overwrite data if multiple matching serial numbers are in the import file. Thus, users are advised to be sure of their data before importing with update existing checked.


Fixes #
Freshdesk: 35948, 35412, et al
Github: https://github.com/snipe/snipe-it/issues/8947

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-Tested locally with sample imports of all combos of names/serial numbers

**Test Configuration**:
* PHP version: 8.0
* MySQL version
* Webserver version
* OS version


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
