### PR TITLE
Accept user ID as authoritative field for updates

### DIFF
--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -288,6 +288,7 @@ class Importer extends Component
         ];
 
         $this->users_fields  = [
+            'id' => trans('general.id'),
             'company' => trans('general.company'),
             'location' => trans('general.location'),
             'department' => trans('general.department'),


### PR DESCRIPTION
This is a small PR that I'd like to use as a sort of test case for updating items directly through their Snipe-IT id number. It doesn't happen that often, but the use case here is that a large organization (with smaller organizations within) does a rebrand, but the rebrand isn't complete yet, so we can't just do some bulk rules on all users universally. 

Since username is the unique identifier for users normally, this can make it tricky to update a user list with new usernames, since we have nothing that already exists to key off of.

This should allow you to export your users list from Snipe-IT, make your changes to your CSV, upload it those changes to the importer and - using the ID number - update the details of the users.