### PR TITLE
User department now visible in side pane of asset view page

### DIFF
--- a/resources/lang/en/admin/hardware/general.php
+++ b/resources/lang/en/admin/hardware/general.php
@@ -45,5 +45,5 @@ return [
     'alert_details' => 'Please see below for details.',
     'custom_export' => 'Custom Export',
     'mfg_warranty_lookup' => ':manufacturer Warranty Status Lookup',
-    'user_department' => 'User Department: ',
+    'user_department' => 'User Department',
 ];

--- a/resources/lang/en/admin/hardware/general.php
+++ b/resources/lang/en/admin/hardware/general.php
@@ -45,4 +45,5 @@ return [
     'alert_details' => 'Please see below for details.',
     'custom_export' => 'Custom Export',
     'mfg_warranty_lookup' => ':manufacturer Warranty Status Lookup',
+    'user_department' => 'User Department: ',
 ];

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -553,7 +553,7 @@
                                         <div class="row">
                                             <div class="col-md-2">
                                                 <strong>
-                                                    {{ trans('admin/hardware/table.git_value') }}
+                                                    {{ trans('admin/hardware/table.current_value') }}
                                                 </strong>
                                             </div>
                                             <div class="col-md-6">

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -920,7 +920,7 @@
                                             @endif
 
                                             @if((isset($asset->assignedTo)) && ($asset->assignedTo->department!=''))
-                                                <li>{{ trans('admin/hardware/general.user_department') }}{{ $asset->assignedTo->department->name}}</li>
+                                                <li>{{ trans('admin/hardware/general.user_department') }}: {{ $asset->assignedTo->department->name}}</li>
                                             @endif
 
                                             @if (isset($asset->location))

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -920,7 +920,7 @@
                                             @endif
 
                                             @if((isset($asset->assignedTo)) && ($asset->assignedTo->department!=''))
-                                                <li>{{ $asset->assignedTo->department->name}}</li>
+                                                <li>{{ trans('admin/hardware/general.user_department') }}{{ $asset->assignedTo->department->name}}</li>
                                             @endif
 
                                             @if (isset($asset->location))

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -919,7 +919,7 @@
                                                 </li>
                                             @endif
 
-                                            @if((isset($asset->assignedTo)) && ($asset->assignedTo->department!=''))
+                                            @if((isset($asset->assignedTo)) && ($asset->assignedTo->department))
                                                 <li>{{ trans('admin/hardware/general.user_department') }}: {{ $asset->assignedTo->department->name}}</li>
                                             @endif
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -553,7 +553,7 @@
                                         <div class="row">
                                             <div class="col-md-2">
                                                 <strong>
-                                                    {{ trans('admin/hardware/table.current_value') }}
+                                                    {{ trans('admin/hardware/table.git_value') }}
                                                 </strong>
                                             </div>
                                             <div class="col-md-6">
@@ -917,6 +917,10 @@
                                                     <i class="fas fa-phone" aria-hidden="true"></i>
                                                     <a href="tel:{{ $asset->assignedTo->phone }}">{{ $asset->assignedTo->phone }}</a>
                                                 </li>
+                                            @endif
+
+                                            @if((isset($asset->assignedTo)) && ($asset->assignedTo->department!=''))
+                                                <li>{{ $asset->assignedTo->department->name}}</li>
                                             @endif
 
                                             @if (isset($asset->location))


### PR DESCRIPTION
Department for a user is now visible in side pane when looking at an asset view.

<img width="502" alt="Screenshot 2023-06-22 at 7 08 25 PM" src="https://github.com/snipe/snipe-it/assets/116301219/42bc45fb-ce0d-4c35-b315-bea5138b6642">


Department is NOT visible on the index page as to reduce confusion, as we do not allow assets to be checked out to departments.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
tested locally

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
