### PR TITLE
Fixed issue when importing Assets and no status labels exists [sc-23359]

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -12,7 +12,10 @@ class AssetImporter extends ItemImporter
     public function __construct($filename)
     {
         parent::__construct($filename);
-        $this->defaultStatusLabelId = Statuslabel::first()->id;
+
+        if (!is_null(Statuslabel::first())) {
+            $this->defaultStatusLabelId = Statuslabel::first()->id;
+        }
     }
 
     protected function handle($row)


### PR DESCRIPTION
# Description

If we try to import Assets and  no Status Label exists in the system, the importer crash.

In [sc-23359] we get to the consensus that if no Status Label exists and none is setted in the CSV file to import, we automatically create one. But in my tests I found that if no Status Label is assigned in the CSV the Importer returns an error, so I just created a guard clause at the moment we assigned the 'Stastuslabel::first()->id' in the Asset Importer and it takes care of showing the error and let the user know they have to assigned a status in the file.

Let me know if this is incorrect, or I need to consider more things to handle this better.

Fixes  [sc-23359]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: PHP Dev server
* OS version: Debian 11