### PR TITLE
Current value added to asset index page

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -501,7 +501,6 @@ class ReportsController extends Controller
                 $header[] = trans('general.zip');
             }
 
-
             if ($request->filled('assigned_to')) {
                 $header[] = trans('admin/hardware/table.checkoutto');
                 $header[] = trans('general.type');
@@ -531,22 +530,23 @@ class ReportsController extends Controller
                 $header[] = trans('general.status');
             }
 
-            if ($request->filled('warranty')) {
-                $header[] = 'Warranty';
-                $header[] = 'Warranty Expires';
-            }
-            if ($request->filled('depreciation')) {
-                $header[] = 'Value';
-                $header[] = 'Diff';
-                $header[] = 'Fully Depreciated';
-            }
-
             if ($request->filled('checkout_date')) {
                 $header[] = trans('admin/hardware/table.checkout_date');
             }
 
             if ($request->filled('expected_checkin')) {
                 $header[] = trans('admin/hardware/form.expected_checkin');
+            }
+
+            if ($request->filled('depreciation')) {
+                $header[] = trans('admin/hardware/table.book_value');
+                $header[] = trans('admin/hardware/table.diff');
+                $header[] = trans('admin/hardware/form.fully_depreciated');
+            }
+
+            if ($request->filled('warranty')) {
+                $header[] = trans('admin/hardware/form.warranty');
+                $header[] = trans('admin/hardware/form.warranty_expires');
             }
 
             if ($request->filled('created_at')) {

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -530,12 +530,9 @@ class ReportsController extends Controller
                 $header[] = trans('general.status');
             }
 
-            if ($request->filled('checkout_date')) {
-                $header[] = trans('admin/hardware/table.checkout_date');
-            }
-
-            if ($request->filled('expected_checkin')) {
-                $header[] = trans('admin/hardware/form.expected_checkin');
+            if ($request->filled('warranty')) {
+                $header[] = trans('admin/hardware/form.warranty');
+                $header[] = trans('admin/hardware/form.warranty_expires');
             }
 
             if ($request->filled('depreciation')) {
@@ -544,9 +541,12 @@ class ReportsController extends Controller
                 $header[] = trans('admin/hardware/form.fully_depreciated');
             }
 
-            if ($request->filled('warranty')) {
-                $header[] = trans('admin/hardware/form.warranty');
-                $header[] = trans('admin/hardware/form.warranty_expires');
+            if ($request->filled('checkout_date')) {
+                $header[] = trans('admin/hardware/table.checkout_date');
+            }
+
+            if ($request->filled('expected_checkin')) {
+                $header[] = trans('admin/hardware/form.expected_checkin');
             }
 
             if ($request->filled('created_at')) {

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -92,6 +92,7 @@ class AssetsTransformer
             'checkout_counter' => (int) $asset->checkout_counter,
             'requests_counter' => (int) $asset->requests_counter,
             'user_can_checkout' => (bool) $asset->availableForCheckout(),
+            'book_value' => Helper::formatCurrencyOutput($asset->getLinearDepreciatedValue()),
         ];
 
 

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -154,6 +154,13 @@ class AssetPresenter extends Presenter
                 'footerFormatter' => 'sumFormatter',
                 'class' => 'text-right',
             ], [
+                "field" => "book_value",
+                "searchable" => true,
+                "sortable" => true,
+                "title" => trans('admin/hardware/table.book_value'),
+                "footerFormatter" => 'sumFormatter',
+                "class" => "text-right",
+            ],[
                 'field' => 'order_number',
                 'searchable' => true,
                 'sortable' => true,

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -155,8 +155,8 @@ class AssetPresenter extends Presenter
                 'class' => 'text-right',
             ], [
                 "field" => "book_value",
-                "searchable" => true,
-                "sortable" => true,
+                "searchable" => false,
+                "sortable" => false,
                 "title" => trans('admin/hardware/table.book_value'),
                 "footerFormatter" => 'sumFormatter',
                 "class" => "text-right",


### PR DESCRIPTION
Current value has been added as a column in the assets index page.

<img width="1353" alt="Screenshot 2023-06-22 at 5 02 34 PM" src="https://github.com/snipe/snipe-it/assets/116301219/4280f538-2f03-46f3-8cde-28cd07ed5bd9">

FIxes: FD-36095

Additionally, translations have been added in the Warranty and Depreciation column headers when exporting reports.

Cocurrently, I discovered that Current Value is not sorting correctly, tho looking like it should. This is occuring in multiple places, and is a fix that is out of scope for this PR.  Therefore, CV will NOT correctly sort high to low or low to high at this time.


- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
tested locally

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
