### PR TITLE
Set table alias for model number sort scope

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1566,7 +1566,7 @@ class Asset extends Depreciable
     */
     public function scopeOrderModelNumber($query, $order)
     {
-        return $query->join('models', 'assets.model_id', '=', 'models.id')->orderBy('models.model_number', $order);
+        return $query->leftJoin('models as model_number_sort', 'assets.model_id', '=', 'models.id')->orderBy('models.model_number', $order);
     }
 
 


### PR DESCRIPTION
This addresses RB-3551, where when sorting on model number, mySQL would complain `Syntax error or access violation: 1066 Not unique table/alias: 'models'`. This error would only occur when sorting on model number.