### PR TITLE
Fix translation string in user importer

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -459,7 +459,7 @@ return [
         'checked_out_to_email' => 'Checked Out to: Email',
         'checked_out_to_tag' => 'Checked Out to: Asset Tag',
         'manager_first_name' => 'Manager First Name',
-        'manager_last_name' => 'Manager First Name',
+        'manager_last_name' => 'Manager Last Name',
         'manager_full_name' => 'Manager Full Name',
         'manager_username' => 'Manager Username',
         'checkout_type' => 'Checkout Type',


### PR DESCRIPTION
# Description

This PR fixes an (english) translation string where the user importer had `Manager First Name` listed for the last name field.

**Before**
![before](https://github.com/snipe/snipe-it/assets/1141514/9abc4aed-5139-4c4c-9443-f4a33b635825)

**After:**
![after](https://github.com/snipe/snipe-it/assets/1141514/2cbe2136-5de4-4503-a580-799a707dbe4e)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)