### PR TITLE
Have ChipperCI run on each PR

### DIFF
--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -14,6 +14,11 @@ on:
       - master
       - develop
 
+  pull_request:
+    branches:
+      - master
+      - develop
+
 pipeline:
   - name: Setup
     cmd: |


### PR DESCRIPTION
# Description

This PR simply updates the configuration so that ChipperCI runs on every PR opened against `master` and `develop`.