### PR TITLE
Cancel requested assets without checkin/out [ch-17606]

### DIFF
--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -121,7 +121,7 @@ class ViewAssetsController extends Controller
 
         if (($item_request = $item->isRequestedBy($user)) || $cancel_by_admin) {
             $item->cancelRequest($requestingUser);
-            $data['item_quantity'] = $item_request->qty;
+            $data['item_quantity'] = ($item_request) ? $item_request->qty : 1;
             $logaction->logaction('request_canceled');
 
             if (($settings->alert_email != '') && ($settings->alerts_enabled == '1') && (! config('app.lock_passwords'))) {

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -82,7 +82,7 @@ class ViewAssetsController extends Controller
         return view('account/requestable-assets', compact('assets', 'models'));
     }
 
-    public function getRequestItem(Request $request, $itemType, $itemId = null)
+    public function getRequestItem(Request $request, $itemType, $itemId = null, $cancel_by_admin = false, $requestingUser = null)
     {
         $item = null;
         $fullItemType = 'App\\Models\\'.studly_case($itemType);
@@ -119,8 +119,8 @@ class ViewAssetsController extends Controller
 
         $settings = Setting::getSettings();
 
-        if ($item_request = $item->isRequestedBy($user)) {
-            $item->cancelRequest();
+        if (($item_request = $item->isRequestedBy($user)) || $cancel_by_admin) {
+            $item->cancelRequest($requestingUser);
             $data['item_quantity'] = $item_request->qty;
             $logaction->logaction('request_canceled');
 

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -128,7 +128,7 @@ class ViewAssetsController extends Controller
                 $settings->notify(new RequestAssetCancelation($data));
             }
 
-            return redirect()->route('requestable-assets')->with('success')->with('success', trans('admin/hardware/message.requests.canceled'));
+            return redirect()->back()->with('success')->with('success', trans('admin/hardware/message.requests.canceled'));
         } else {
             $item->request();
             if (($settings->alert_email != '') && ($settings->alerts_enabled == '1') && (! config('app.lock_passwords'))) {

--- a/app/Models/Requestable.php
+++ b/app/Models/Requestable.php
@@ -38,8 +38,12 @@ trait Requestable
         $this->requests()->where('user_id', Auth::id())->delete();
     }
 
-    public function cancelRequest()
+    public function cancelRequest($user_id = null)
     {
-        $this->requests()->where('user_id', Auth::id())->update(['canceled_at' => \Carbon\Carbon::now()]);
+        if (!$user_id){
+            $user_id = Auth::id();
+        }
+
+        $this->requests()->where('user_id', $user_id)->update(['canceled_at' => \Carbon\Carbon::now()]);
     }
 }

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -436,6 +436,7 @@ return [
     'errors_importing'          => 'Some Errors occurred while importing: ',
     'warning'                   => 'WARNING: :warning',
     'success_redirecting'       => '"Success... Redirecting.',
+    'cancel_request'            => 'Cancel this item request',
     'setup_successful_migrations' => 'Your database tables have been created',
     'setup_migration_output' => 'Migration output:',
     'setup_migration_create_user' => 'Next: Create User',

--- a/resources/views/hardware/requested.blade.php
+++ b/resources/views/hardware/requested.blade.php
@@ -24,7 +24,7 @@
                        'id' => 'bulkForm']) }}
                     <div class="row">
                         <div class="col-md-12">
-
+                    {{ Form::close() }}
         @if ($requestedItems->count() > 0)
         <div class="table-responsive">
             <table
@@ -51,7 +51,7 @@
                         <th class="col-md-2" data-sortable="true">{{ trans('admin/hardware/form.expected_checkin') }}</th>
                         <th class="col-md-3" data-sortable="true">{{ trans('admin/hardware/table.requesting_user') }}</th>
                         <th class="col-md-2">{{ trans('admin/hardware/table.requested_date') }}</th>
-                        <th class="col-md-1">{{ trans('general.checkin').'/'.trans('general.checkout') }}</th>
+                        <th class="col-md-1" colspan="2">{{ trans('button.actions') }}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -103,6 +103,9 @@
                                 @endif
                             </td>
                             <td>{{ App\Helpers\Helper::getFormattedDateObject($request->created_at, 'datetime', false) }}</td>
+                            <td>
+                                    <form action="{{ config('app.url') }}/account/request-asset/{{ $request->requestable->id }}'" method="POST">@csrf<button class="btn btn-danger btn-sm" data-tooltip="true" title="Cancel this item request">{{ trans('button.cancel') }}</button></form>
+                            </td>
                             <td>
                                 @if ($request->itemType() == "asset")
                                     @if ($request->requestable->assigned_to=='')

--- a/resources/views/hardware/requested.blade.php
+++ b/resources/views/hardware/requested.blade.php
@@ -17,11 +17,6 @@
         <div class="col-md-12">
             <div class="box">
                 <div class="box-body">
-                    {{ Form::open([
-                      'method' => 'POST',
-                      'route' => ['hardware/bulkedit'],
-                      'class' => 'form-inline',
-                       'id' => 'bulkForm']) }}
                     <div class="row">
                         <div class="col-md-12">
 
@@ -51,7 +46,7 @@
                         <th class="col-md-2" data-sortable="true">{{ trans('admin/hardware/form.expected_checkin') }}</th>
                         <th class="col-md-3" data-sortable="true">{{ trans('admin/hardware/table.requesting_user') }}</th>
                         <th class="col-md-2">{{ trans('admin/hardware/table.requested_date') }}</th>
-                        <th class="col-md-1" colspan="2">{{ trans('button.actions') }}</th>
+                        <th class="col-md-1">{{ trans('button.actions') }}</th> <th></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -143,7 +138,6 @@
                 </div>
             </div>
         </div>
-        {{ Form::close() }}
     </div> <!-- .col-md-12> -->
 </div> <!-- .row -->
 @stop

--- a/resources/views/hardware/requested.blade.php
+++ b/resources/views/hardware/requested.blade.php
@@ -106,7 +106,7 @@
                             <td>
                                 {{ Form::open([
                                     'method' => 'POST',
-                                    'route' => ['account/request-asset', $request->requestable->id],
+                                    'route' => ['account/request-item', $request->itemType(), $request->requestable->id, true, $request->requestingUser()->id],
                                     ]) }}
                                     <button class="btn btn-danger btn-sm" data-tooltip="true" title="Cancel this item request">{{ trans('button.cancel') }}</button>
                                 {{ Form::close() }}

--- a/resources/views/hardware/requested.blade.php
+++ b/resources/views/hardware/requested.blade.php
@@ -104,7 +104,12 @@
                             </td>
                             <td>{{ App\Helpers\Helper::getFormattedDateObject($request->created_at, 'datetime', false) }}</td>
                             <td>
-                                    <form action="{{ config('app.url') }}/account/request-asset/{{ $request->requestable->id }}'" method="POST">@csrf<button class="btn btn-danger btn-sm" data-tooltip="true" title="Cancel this item request">{{ trans('button.cancel') }}</button></form>
+                                {{ Form::open([
+                                    'method' => 'POST',
+                                    'route' => ['account/request-asset', $request->requestable->id],
+                                    ]) }}
+                                    <button class="btn btn-danger btn-sm" data-tooltip="true" title="Cancel this item request">{{ trans('button.cancel') }}</button>
+                                {{ Form::close() }}
                             </td>
                             <td>
                                 @if ($request->itemType() == "asset")

--- a/resources/views/hardware/requested.blade.php
+++ b/resources/views/hardware/requested.blade.php
@@ -24,7 +24,7 @@
                        'id' => 'bulkForm']) }}
                     <div class="row">
                         <div class="col-md-12">
-                    {{ Form::close() }}
+
         @if ($requestedItems->count() > 0)
         <div class="table-responsive">
             <table
@@ -108,7 +108,7 @@
                                     'method' => 'POST',
                                     'route' => ['account/request-item', $request->itemType(), $request->requestable->id, true, $request->requestingUser()->id],
                                     ]) }}
-                                    <button class="btn btn-danger btn-sm" data-tooltip="true" title="Cancel this item request">{{ trans('button.cancel') }}</button>
+                                    <button class="btn btn-warning btn-sm" data-tooltip="true" title="{{ trans('general.cancel_request') }}">{{ trans('button.cancel') }}</button>
                                 {{ Form::close() }}
                             </td>
                             <td>
@@ -143,6 +143,7 @@
                 </div>
             </div>
         </div>
+        {{ Form::close() }}
     </div> <!-- .col-md-12> -->
 </div> <!-- .row -->
 @stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -281,7 +281,7 @@ Route::group(['prefix' => 'account', 'middleware' => ['auth']], function () {
     )->name('account/request-asset');
 
     Route::post(
-        'request/{itemType}/{itemId}',
+        'request/{itemType}/{itemId}/{cancel_by_admin?}/{requestingUser?}',
         [ViewAssetsController::class, 'getRequestItem']
     )->name('account/request-item');
 


### PR DESCRIPTION
# Description
I started working on this looking for a quick and easy win, oh boy! If I was mistaken...

Before we have the Requested Assets view like this:
![image](https://github.com/snipe/snipe-it/assets/653557/c5e77887-a13e-4740-bc7b-f1c7975d4b85)

And now I just added this little button here:
![image](https://github.com/snipe/snipe-it/assets/653557/57361c66-b22e-41a0-8fe2-86ecd0d0da75)

That's basically it, but I have to pass new variables to a route, and change a couple function firms to accept parameters that aren't needed before, I tested it extensively but I would love a couple of extra eyes before merging.

Fixes [ch-17606]

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
