### PR TITLE
Add missing relationship check in Asset Transformer

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -38,7 +38,7 @@ class AssetsTransformer
             'byod' => ($asset->byod ? true : false),
 
             'model_number' => (($asset->model) && ($asset->model->model_number)) ? e($asset->model->model_number) : null,
-            'eol' => ($asset->model->eol != '') ? $asset->model->eol : null,
+            'eol' => (($asset->model) && ($asset->model->eol != '')) ? $asset->model->eol : null,
             'asset_eol_date' => ($asset->asset_eol_date != '') ? Helper::getFormattedDateObject($asset->asset_eol_date, 'date') : null,
             'status_label' => ($asset->assetstatus) ? [
                 'id' => (int) $asset->assetstatus->id,


### PR DESCRIPTION
# Description

This PR simply checks to see if the `model` relationship exists on the asset being transformed before attempting to use one of it's properties like we do elsewhere in the transformer.

Fixes #13198 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)