### PR TITLE
Fixed #13213 - Use the Helper::parseEscapedMarkedown in notes

### DIFF
--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -32,7 +32,7 @@ class AccessoriesTransformer
             'model_number' => ($accessory->model_number) ? e($accessory->model_number) : null,
             'category' => ($accessory->category) ? ['id' => $accessory->category->id, 'name'=> e($accessory->category->name)] : null,
             'location' => ($accessory->location) ? ['id' => $accessory->location->id, 'name'=> e($accessory->location->name)] : null,
-            'notes' => ($accessory->notes) ? e($accessory->notes) : null,
+            'notes' => ($accessory->notes) ? Helper::parseEscapedMarkedown($accessory->notes) : null,
             'qty' => ($accessory->qty) ? (int) $accessory->qty : null,
             'purchase_date' => ($accessory->purchase_date) ? Helper::getFormattedDateObject($accessory->purchase_date, 'date') : null,
             'purchase_cost' => Helper::formatCurrencyOutput($accessory->purchase_cost),

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -110,7 +110,7 @@ class ActionlogsTransformer
                 'type' => e($actionlog->targetType()),
             ] : null,
 
-            'note'          => ($actionlog->note) ? e($actionlog->note): null,
+            'note'          => ($actionlog->note) ? Helper::parseEscapedMarkedown($actionlog->note): null,
             'signature_file'   => ($actionlog->accept_signature) ? route('log.signature.view', ['filename' => $actionlog->accept_signature ]) : null,
             'log_meta'          => ((isset($clean_meta)) && (is_array($clean_meta))) ? $clean_meta: null,
             'action_date'   => ($actionlog->action_date) ? Helper::getFormattedDateObject($actionlog->action_date, 'datetime'): Helper::getFormattedDateObject($actionlog->created_at, 'datetime'),

--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -49,7 +49,7 @@ class AssetMaintenancesTransformer
                 'id' => (int) $assetmaintenance->asset->defaultLoc->id,
                 'name'=> e($assetmaintenance->asset->defaultLoc->name),
             ] : null,
-            'notes'         => ($assetmaintenance->notes) ? e($assetmaintenance->notes) : null,
+            'notes'         => ($assetmaintenance->notes) ? Helper::parseEscapedMarkedown($assetmaintenance->notes) : null,
             'supplier'      => ($assetmaintenance->supplier) ? ['id' => $assetmaintenance->supplier->id, 'name'=> e($assetmaintenance->supplier->name)] : null,
             'cost'          => Helper::formatCurrencyOutput($assetmaintenance->cost),
             'asset_maintenance_type'          => e($assetmaintenance->asset_maintenance_type),

--- a/app/Http/Transformers/AssetModelsTransformer.php
+++ b/app/Http/Transformers/AssetModelsTransformer.php
@@ -63,7 +63,7 @@ class AssetModelsTransformer
             'default_fieldset_values' => $default_field_values,
             'eol' => ($assetmodel->eol > 0) ? $assetmodel->eol.' months' : 'None',
             'requestable' => ($assetmodel->requestable == '1') ? true : false,
-            'notes' => e($assetmodel->notes),
+            'notes' => Helper::parseEscapedMarkedown($assetmodel->notes),
             'created_at' => Helper::getFormattedDateObject($assetmodel->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($assetmodel->updated_at, 'datetime'),
             'deleted_at' => Helper::getFormattedDateObject($assetmodel->deleted_at, 'datetime'),

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -58,7 +58,7 @@ class AssetsTransformer
                 'id' => (int) $asset->supplier->id,
                 'name'=> e($asset->supplier->name),
             ] : null,
-            'notes' => ($asset->notes) ? e($asset->notes) : null,
+            'notes' => ($asset->notes) ? Helper::parseEscapedMarkedown($asset->notes) : null,
             'order_number' => ($asset->order_number) ? e($asset->order_number) : null,
             'company' => ($asset->company) ? [
                 'id' => (int) $asset->company->id,

--- a/app/Http/Transformers/ComponentsTransformer.php
+++ b/app/Http/Transformers/ComponentsTransformer.php
@@ -46,7 +46,7 @@ class ComponentsTransformer
                 'id' => (int) $component->company->id,
                 'name' => e($component->company->name),
             ] : null,
-            'notes' => ($component->notes) ? e($component->notes) : null,
+            'notes' => ($component->notes) ? Helper::parseEscapedMarkedown($component->notes) : null,
             'created_at' => Helper::getFormattedDateObject($component->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($component->updated_at, 'datetime'),
             'user_can_checkout' =>  ($component->numRemaining() > 0) ? 1 : 0,

--- a/app/Http/Transformers/ConsumablesTransformer.php
+++ b/app/Http/Transformers/ConsumablesTransformer.php
@@ -39,7 +39,7 @@ class ConsumablesTransformer
             'purchase_cost'  => Helper::formatCurrencyOutput($consumable->purchase_cost),
             'purchase_date'  => Helper::getFormattedDateObject($consumable->purchase_date, 'date'),
             'qty'           => (int) $consumable->qty,
-            'notes'         => ($consumable->notes) ? e($consumable->notes) : null,
+            'notes'         => ($consumable->notes) ? Helper::parseEscapedMarkedown($consumable->notes) : null,
             'created_at' => Helper::getFormattedDateObject($consumable->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($consumable->updated_at, 'datetime'),
         ];

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -34,7 +34,7 @@ class LicensesTransformer
             'depreciation' => ($license->depreciation) ? ['id' => (int) $license->depreciation->id,'name'=> e($license->depreciation->name)] : null,
             'purchase_cost' => Helper::formatCurrencyOutput($license->purchase_cost),
             'purchase_cost_numeric' => $license->purchase_cost,
-            'notes' => e($license->notes),
+            'notes' => Helper::parseEscapedMarkedown($license->notes),
             'expiration_date' => Helper::getFormattedDateObject($license->expiration_date, 'date'),
             'seats' => (int) $license->seats,
             'free_seats_count' => (int) $license->free_seats_count,

--- a/app/Http/Transformers/SuppliersTransformer.php
+++ b/app/Http/Transformers/SuppliersTransformer.php
@@ -43,7 +43,7 @@ class SuppliersTransformer
                 'licenses_count' => (int) $supplier->licenses_count,
                 'consumables_count' => (int) $supplier->consumables_count,
                 'components_count' => (int) $supplier->components_count,
-                'notes' => ($supplier->notes) ? e($supplier->notes) : null,
+                'notes' => ($supplier->notes) ? Helper::parseEscapedMarkedown($supplier->notes) : null,
                 'created_at' => Helper::getFormattedDateObject($supplier->created_at, 'datetime'),
                 'updated_at' => Helper::getFormattedDateObject($supplier->updated_at, 'datetime'),
 

--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -53,7 +53,7 @@ class UsersTransformer
                     'id' => (int) $user->userloc->id,
                     'name'=> e($user->userloc->name),
                 ] : null,
-                'notes'=> e($user->notes),
+                'notes'=> Helper::parseEscapedMarkedown($user->notes),
                 'permissions' => $user->decodePermissions(),
                 'activated' => ($user->activated == '1') ? true : false,
                 'autoassign_licenses' => ($user->autoassign_licenses == '1') ? true : false,


### PR DESCRIPTION
This goes through all of the models that have notes and parses them as markdown. I can't imagine there being any unintended consequences here, but that's why they're called *unintended*, right? If anyone can think of a way this could mess people up, please chime in here.

<img width="1606" alt="Screenshot 2023-06-28 at 3 05 49 PM" src="https://github.com/snipe/snipe-it/assets/197404/183dceff-c5d6-41a1-b225-a84d33975610">


Fixes #13213