### PR TITLE
Delete notes column map from assets importer

### DIFF
--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -214,7 +214,6 @@ class Importer extends Component
             'model_notes' => trans('general.item_notes', ['item' => trans('admin/hardware/form.model')]),
             'manufacturer' => trans('general.manufacturer'),
             'order_number' => trans('general.order_number'),
-            'notes' => trans('general.notes'),
             'image' => trans('general.importer.image_filename'),
             /**
              * Checkout fields:


### PR DESCRIPTION
# Description
Related to https://github.com/snipe/snipe-it/pull/12975, when I add the Asset Notes and Model Notes mapping to the asset importer I forgot to delete the simple Notes column mapping which now ends doing nothing there.

Fixes

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11