### PR TITLE
Fixed #13167 Default location not being set/updated upon check-in

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -102,6 +102,10 @@ class AssetCheckinController extends Controller
         if ($request->filled('location_id')) {
             \Log::debug('NEW Location ID: '.$request->get('location_id'));
             $asset->location_id = $request->get('location_id');
+
+            if ($request->get('update_default_location') == 0){
+                $asset->rtd_location_id = $request->get('location_id');
+            }
         }
 
         $checkin_at = date('Y-m-d H:i:s');

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -94,14 +94,15 @@ class AssetCheckinController extends Controller
             \Log::debug('Manually override the location IDs');
             \Log::debug('Original Location ID: '.$asset->location_id);
             $asset->location_id = '';
-            \Log::debug('New RTD Location ID: '.$asset->location_id);
+            \Log::debug('New Location ID: '.$asset->location_id);
         }
 
         $asset->location_id = $asset->rtd_location_id;
 
         if ($request->filled('location_id')) {
             \Log::debug('NEW Location ID: '.$request->get('location_id'));
-            $asset->location_id = e($request->get('location_id'));
+            $asset->location_id = $request->get('location_id');
+            $asset->rtd_location_id = $request->get('location_id');
         }
 
         $checkin_at = date('Y-m-d H:i:s');

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -102,7 +102,6 @@ class AssetCheckinController extends Controller
         if ($request->filled('location_id')) {
             \Log::debug('NEW Location ID: '.$request->get('location_id'));
             $asset->location_id = $request->get('location_id');
-            $asset->rtd_location_id = $request->get('location_id');
         }
 
         $checkin_at = date('Y-m-d H:i:s');

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -73,7 +73,7 @@
                       </div>
                     </div>
 
-                  @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'location_id', 'help_text' => ($asset->defaultLoc) ? 'You can choose to check this asset in to a location other than the default location of '.$asset->defaultLoc->name.' if one is set.' : null])
+                  @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'location_id', 'help_text' => ($asset->defaultLoc) ? 'You can choose to check this asset in to a location other than the default location of '.$asset->defaultLoc->name.' if one is set.' : null, 'hide_location_radio' => true])
 
                   <!-- Checkout/Checkin Date -->
                     <div class="form-group{{ $errors->has('checkin_at') ? ' has-error' : '' }}">

--- a/resources/views/partials/forms/edit/location-select.blade.php
+++ b/resources/views/partials/forms/edit/location-select.blade.php
@@ -30,6 +30,21 @@
     </div>
     @endif
 
+<!-- Update actual location  -->
+<div class="form-group">
+    <div class="col-md-9 col-md-offset-3">
+        <label class="form-control">
+            {{ Form::radio('update_default_location', '1', old('update_default_location'), ['checked'=> 'checked', 'aria-label'=>'update_default_location']) }}
+            {{ trans('admin/hardware/form.asset_location') }}
+        </label>
+        <label class="form-control">
+            {{ Form::radio('update_default_location', '0', old('update_default_location'), ['aria-label'=>'update_default_location']) }}
+            {{ trans('admin/hardware/form.asset_location_update_default_current') }}
+        </label>
+
+    </div>
+</div> <!--/form-group-->
+
 
 </div>
 

--- a/resources/views/partials/forms/edit/location-select.blade.php
+++ b/resources/views/partials/forms/edit/location-select.blade.php
@@ -30,21 +30,21 @@
     </div>
     @endif
 
-<!-- Update actual location  -->
-<div class="form-group">
-    <div class="col-md-9 col-md-offset-3">
-        <label class="form-control">
-            {{ Form::radio('update_default_location', '1', old('update_default_location'), ['checked'=> 'checked', 'aria-label'=>'update_default_location']) }}
-            {{ trans('admin/hardware/form.asset_location') }}
-        </label>
-        <label class="form-control">
-            {{ Form::radio('update_default_location', '0', old('update_default_location'), ['aria-label'=>'update_default_location']) }}
-            {{ trans('admin/hardware/form.asset_location_update_default_current') }}
-        </label>
-
-    </div>
-</div> <!--/form-group-->
-
+    @if (isset($hide_location_radio))
+    <!-- Update actual location  -->
+    <div class="form-group">
+        <div class="col-md-9 col-md-offset-3">
+            <label class="form-control">
+                {{ Form::radio('update_default_location', '1', old('update_default_location'), ['checked'=> 'checked', 'aria-label'=>'update_default_location']) }}
+                {{ trans('admin/hardware/form.asset_location') }}
+            </label>
+            <label class="form-control">
+                {{ Form::radio('update_default_location', '0', old('update_default_location'), ['aria-label'=>'update_default_location']) }}
+                {{ trans('admin/hardware/form.asset_location_update_default_current') }}
+            </label>
+        </div>
+    </div> <!--/form-group-->
+    @endif
 
 </div>
 


### PR DESCRIPTION
# Description
If a location is provided at asset checkin, we use to only set the `location_id`, but with this PR now we also set the `rtd_location_id` which is the Default Location, looks like a small change but I kinda struggle to fully understand the logic behind the referenced issue, so I hope it makes sense? I think it does but, not the first time I'm wrong! 

I also got rid of an escaping `e()` method, because the system "control" the locations dropdown so I don't think it's necessary here.

Fixes #13167

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11