### PR TITLE
Use proper alias for table scope

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1566,7 +1566,7 @@ class Asset extends Depreciable
     */
     public function scopeOrderModelNumber($query, $order)
     {
-        return $query->leftJoin('models as model_number_sort', 'assets.model_id', '=', 'models.id')->orderBy('models.model_number', $order);
+        return $query->leftJoin('models as model_number_sort', 'assets.model_id', '=', 'model_number_sort.id')->orderBy('model_number_sort.model_number', $order);
     }
 
 


### PR DESCRIPTION
Saw this pop up on the demo and it seems pretty straightforward. An error would be triggered if you try to sort on model name or number number, since the scope wasn't using the correct aliases.

We could probably clean up the `requestable()` method in the API controller as well, since we don't actually expose category, etc in that screen.