### PR TITLE
Fixed windows backup filename - swapped colon in timestamp to hyphen to handle windows filesystems

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1136,7 +1136,7 @@ class SettingsController extends Controller
     public function postBackups()
     {
         if (! config('app.lock_passwords')) {
-            Artisan::call('snipeit:backup', ['--filename' => 'manual-backup-'.date('Y-m-d-H:i:s')]);
+            Artisan::call('snipeit:backup', ['--filename' => 'manual-backup-'.date('Y-m-d-H-i-s')]);
             $output = Artisan::output();
 
             // Backup completed


### PR DESCRIPTION
On *some* Windows filesystems, adding the customization of the "manual" passing of the timestamp in the filename so we can show manually initiated backups, manually uploaded backups, etc with a `H:i:s` part of the filename seems like it was causing some issues on some windows machines, causing manual backups to fail with errors. This *should* solve those scenarios.