### PR TITLE
Redirect if the license can’t be found

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckoutController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckoutController.php
@@ -30,15 +30,17 @@ class LicenseCheckoutController extends Controller
         // Check that the license is valid
         if ($license = License::find($licenseId)) {
 
+            $this->authorize('checkout', $license);
             // If the license is valid, check that there is an available seat
             if ($license->avail_seats_count < 1) {
                 return redirect()->route('licenses.index')->with('error', 'There are no available seats for this license');
             }
+            return view('licenses/checkout', compact('license'));
         }
 
-        $this->authorize('checkout', $license);
+        return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.not_found'));
 
-        return view('licenses/checkout', compact('license'));
+
     }
 
     /**


### PR DESCRIPTION
This is a small fix that prevents a rollbar/500 error from triggering if someone hits the demo while the seeders are running or have just run. Basically, someone trying to check out a license that no longer exists since the DB reset itself (as it does on the demo, on a cron.)

Should not affect any normal circumstances. We're already doing this check on the checkout save method.