### PR TITLE
Properly return SCIM Exceptions

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -75,7 +75,8 @@ class Handler extends ExceptionHandler
 
         // Handle SCIM exceptions
         if ($e instanceof SCIMException) {
-            return response()->json(Helper::formatStandardApiResponse('error', null, 'Invalid SCIM Request'), 400);
+            return $e->render($request);
+            //return response()->json(Helper::formatStandardApiResponse('error', null, 'Invalid SCIM Request'), 400);
         }
 
         // Handle standard requests that fail because Carbon cannot parse the date on validation (when a submitted date value is definitely not a date)

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -75,8 +75,12 @@ class Handler extends ExceptionHandler
 
         // Handle SCIM exceptions
         if ($e instanceof SCIMException) {
-            return $e->render($request);
-            //return response()->json(Helper::formatStandardApiResponse('error', null, 'Invalid SCIM Request'), 400);
+            try {
+                $e->report(); // logs as 'debug', so shouldn't get too noisy
+            } catch(\Exception $reportException) {
+                //do nothing
+            }
+            return $e->render($request); // ALL SCIMExceptions have the 'render()' method
         }
 
         // Handle standard requests that fail because Carbon cannot parse the date on validation (when a submitted date value is definitely not a date)


### PR DESCRIPTION
We have a customer who had some initial SCIM setup done on his instance against Azure, but then deleted his users and tried to have SCIM re-create them.

Azure tries, as part of the re-provisioning process, to call a GET for those users it _thought_ it knew about, but when those users turn out to not exist, we return our own style of JSON response, which violates the SCIM spec. Azure seems to have gotten upset at our HTTP status codes as well as our payloads in these circumstances.

It turns out our SCIM library already has some nice facilities for returning SCIMExceptions - the `render()` method. So we return that. Additionally, I thought it might be handy to throw the error in the SCIM log, but our handy-dandy SCIMException already has a method that goes straight to `Log::debug()` so I just went with that.