### PR TITLE
Check for max PHP version in upgrader

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -1,7 +1,9 @@
 <?php
 (PHP_SAPI !== 'cli' || isset($_SERVER['HTTP_USER_AGENT'])) && die('Access denied.');
 
-$required_php_min = '7.4.0';
+$php_min_works = '7.4.0';
+$php_max_wontwork = '8.2.0';
+
 
 if ((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') || (!function_exists('posix_getpwuid'))) {
 	echo "Skipping user check as it is not supported on Windows or Posix is not installed on this server. \n";
@@ -123,12 +125,12 @@ echo $env_good;
 
 if ($env_bad !='') {
 
-    echo "\n--------------------- !! ERROR !! ----------------------\n";
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!!! .ENV FILE ERROR !!!!!!!!!!!!!!!!!!!!!!!!!!\n";
     echo "Your .env file is misconfigured. Upgrade cannot continue.\n";
     echo "--------------------------------------------------------\n\n";
     echo $env_bad;
     echo "\n\n--------------------------------------------------------\n";
-    echo "ABORTING THE INSTALLER  \n";
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!! ABORTING THE UPGRADER !!!!!!!!!!!!!!!!!!!!!!\n";
     echo "Please correct the issues above in ".getcwd()."/.env and try again.\n";
     echo "--------------------------------------------------------\n";
     exit;
@@ -136,21 +138,22 @@ if ($env_bad !='') {
 
 
 echo "\n--------------------------------------------------------\n";
-echo "STEP 2: Checking PHP requirements: \n";
+echo "STEP 2: Checking PHP requirements: (Required PHP >=". $php_min_works. " - <".$php_max_wontwork.") \n";
 echo "--------------------------------------------------------\n\n";
 
-if (version_compare(PHP_VERSION, $required_php_min, '<')) {
-    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ERROR !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
-    echo "This version of PHP (".PHP_VERSION.") is not compatible with Snipe-IT.\n";
-    echo "Snipe-IT requires PHP version ".$required_php_min." or greater. Please upgrade \n";
-    echo "your version of PHP (web/php-fcgi and cli) and try running this script again.\n\n\n";
-    exit;
+if ((version_compare(phpversion(), $php_min_works, '>=')) && (version_compare(phpversion(), $php_max_wontwork, '<'))) {
+
+    echo "√ Current PHP version: (" . phpversion() . ") is at least " . $php_min_works . " and less than ".$php_max_wontwork."! Continuing... \n";
+    echo sprintf("FYI: The php.ini used by this PHP is: %s\n\n", get_cfg_var('cfg_file_path'));
 
 } else {
-    echo "Current PHP version: (" . PHP_VERSION . ") is at least ".$required_php_min." - continuing... \n";
-    echo sprintf("FYI: The php.ini used by this PHP is: %s\n\n", get_cfg_var('cfg_file_path'));
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!! PHP VERSION ERROR !!!!!!!!!!!!!!!!!!!!!!!!!\n";
+    echo "This version of PHP (".phpversion().") is NOT compatible with Snipe-IT.\n";
+    echo "Snipe-IT requires PHP versions between ".$php_min_works." and ".$php_max_wontwork.".\n";
+    echo "Please install a compatible version of PHP and re-run this script again. \n";
+    echo "!!!!!!!!!!!!!!!!!!!!!!!!! ABORTING THE UPGRADER !!!!!!!!!!!!!!!!!!!!!!\n";
+    exit;
 }
-
 
 echo "Checking Required PHP extensions... \n\n";
 


### PR DESCRIPTION
This just tweaks the upgrade script to check for a version of PHP that's too high. While this is documented in the Requirements section of the docs, this should hopefully provide a safeguard or at least more visual feedback to the upgrading.

If it passes (I had an early exit after the version check just to be able to test - it would normally just continue through the upgrader):

<img width="934" alt="Screenshot 2023-07-05 at 6 46 15 PM" src="https://github.com/snipe/snipe-it/assets/197404/621f41f9-59d6-4d2c-b0c4-81ef51d56878">

If it fails (I had to use a fake max version number here to trigger the fail):

<img width="934" alt="Screenshot 2023-07-05 at 6 45 59 PM" src="https://github.com/snipe/snipe-it/assets/197404/4614335c-83f3-4a77-ab2c-1487785d73c5">

