### PR TITLE
Fix label wrapping on category edit page

### DIFF
--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -43,7 +43,7 @@
         @if ($snipeSettings->default_eula_text!='')
             <label class="form-control">
                 {{ Form::checkbox('use_default_eula', '1', old('use_default_eula', $item->use_default_eula), ['aria-label'=>'use_default_eula']) }}
-                {!! trans('admin/categories/general.use_default_eula') !!}
+                <span>{!! trans('admin/categories/general.use_default_eula') !!}</span>
             </label>
         @else
             <label class="form-control form-control--disabled">


### PR DESCRIPTION
# Description

This PR simply adds a span tag so a label is displayed properly on the category edit page.

| Before | After |
|-|-|
| <img width="585" alt="Category edit page before changes" src="https://github.com/snipe/snipe-it/assets/1141514/66fa0271-2e24-4eb1-a1ef-7e5437bea846"> | <img width="590" alt="Category edit page after changes" src="https://github.com/snipe/snipe-it/assets/1141514/d030cce1-25a8-430c-946f-b512afe53ef5"> |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)