### PR TITLE
Fixed License importer missing Checkout to: Username and Checkout to: Email in dropdown [sc-23456]

### DIFF
--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -284,6 +284,8 @@ class Importer extends Component
             'maintained' => trans('admin/licenses/form.maintained'),
             'checkout_class' => trans('general.importer.checkout_type'),
             'serial' => trans('general.license_serial'),
+            'email' => trans('general.importer.checked_out_to_email'),
+            'username' => trans('general.importer.checked_out_to_username'),
         ];
 
         $this->users_fields  = [


### PR DESCRIPTION
# Description
Title is sufficiently descriptive. :P

Fixes [sc-23456]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: PHP dev server
* OS version: Debian 11
