### PR TITLE
Fixed #13276 Error Showing Requested Assets

### DIFF
--- a/app/Models/CheckoutRequest.php
+++ b/app/Models/CheckoutRequest.php
@@ -18,7 +18,7 @@ class CheckoutRequest extends Model
 
     public function requestingUser()
     {
-        return $this->user()->first();
+        return $this->user()->withTrashed()->first();
     }
 
     public function requestedItem()

--- a/resources/views/hardware/requested.blade.php
+++ b/resources/views/hardware/requested.blade.php
@@ -89,7 +89,7 @@
                             @endif
                             </td>
                             <td>
-                                @if ($request->requestingUser())
+                                @if ($request->requestingUser() && !$request->requestingUser()->trashed())
                                 <a href="{{ config('app.url') }}/users/{{ $request->requestingUser()->id }}">
                                     {{ $request->requestingUser()->present()->fullName() }}
                                 </a>


### PR DESCRIPTION
# Description
I add a withTrashed() method to the function that looks for the relationship between requested assets and the user that request it, so the view doesn't crash when trying to show those assets.

Fixes #13276

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP Dev server
* OS version: Debian 10
