### PR TITLE
Added Inline markdown method

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -29,7 +29,7 @@ class Helper
         $Parsedown->setSafeMode(true);
 
         if ($str) {
-            return $Parsedown->text($str);
+            return $Parsedown->line($str);
         }
     }
 

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -29,6 +29,16 @@ class Helper
         $Parsedown->setSafeMode(true);
 
         if ($str) {
+            return $Parsedown->text($str);
+        }
+    }
+
+    public static function parseEscapedMarkedownInline($str = null)
+    {
+        $Parsedown = new \Parsedown();
+        $Parsedown->setSafeMode(true);
+
+        if ($str) {
             return $Parsedown->line($str);
         }
     }

--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -32,7 +32,7 @@ class AccessoriesTransformer
             'model_number' => ($accessory->model_number) ? e($accessory->model_number) : null,
             'category' => ($accessory->category) ? ['id' => $accessory->category->id, 'name'=> e($accessory->category->name)] : null,
             'location' => ($accessory->location) ? ['id' => $accessory->location->id, 'name'=> e($accessory->location->name)] : null,
-            'notes' => ($accessory->notes) ? Helper::parseEscapedMarkedown($accessory->notes) : null,
+            'notes' => ($accessory->notes) ? Helper::parseEscapedMarkedownInline($accessory->notes) : null,
             'qty' => ($accessory->qty) ? (int) $accessory->qty : null,
             'purchase_date' => ($accessory->purchase_date) ? Helper::getFormattedDateObject($accessory->purchase_date, 'date') : null,
             'purchase_cost' => Helper::formatCurrencyOutput($accessory->purchase_cost),

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -110,7 +110,7 @@ class ActionlogsTransformer
                 'type' => e($actionlog->targetType()),
             ] : null,
 
-            'note'          => ($actionlog->note) ? Helper::parseEscapedMarkedown($actionlog->note): null,
+            'note'          => ($actionlog->note) ? Helper::parseEscapedMarkedownInline($actionlog->note): null,
             'signature_file'   => ($actionlog->accept_signature) ? route('log.signature.view', ['filename' => $actionlog->accept_signature ]) : null,
             'log_meta'          => ((isset($clean_meta)) && (is_array($clean_meta))) ? $clean_meta: null,
             'action_date'   => ($actionlog->action_date) ? Helper::getFormattedDateObject($actionlog->action_date, 'datetime'): Helper::getFormattedDateObject($actionlog->created_at, 'datetime'),

--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -49,7 +49,7 @@ class AssetMaintenancesTransformer
                 'id' => (int) $assetmaintenance->asset->defaultLoc->id,
                 'name'=> e($assetmaintenance->asset->defaultLoc->name),
             ] : null,
-            'notes'         => ($assetmaintenance->notes) ? Helper::parseEscapedMarkedown($assetmaintenance->notes) : null,
+            'notes'         => ($assetmaintenance->notes) ? Helper::parseEscapedMarkedownInline($assetmaintenance->notes) : null,
             'supplier'      => ($assetmaintenance->supplier) ? ['id' => $assetmaintenance->supplier->id, 'name'=> e($assetmaintenance->supplier->name)] : null,
             'cost'          => Helper::formatCurrencyOutput($assetmaintenance->cost),
             'asset_maintenance_type'          => e($assetmaintenance->asset_maintenance_type),

--- a/app/Http/Transformers/AssetModelsTransformer.php
+++ b/app/Http/Transformers/AssetModelsTransformer.php
@@ -63,7 +63,7 @@ class AssetModelsTransformer
             'default_fieldset_values' => $default_field_values,
             'eol' => ($assetmodel->eol > 0) ? $assetmodel->eol.' months' : 'None',
             'requestable' => ($assetmodel->requestable == '1') ? true : false,
-            'notes' => Helper::parseEscapedMarkedown($assetmodel->notes),
+            'notes' => Helper::parseEscapedMarkedownInline($assetmodel->notes),
             'created_at' => Helper::getFormattedDateObject($assetmodel->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($assetmodel->updated_at, 'datetime'),
             'deleted_at' => Helper::getFormattedDateObject($assetmodel->deleted_at, 'datetime'),

--- a/app/Http/Transformers/AssetModelsTransformer.php
+++ b/app/Http/Transformers/AssetModelsTransformer.php
@@ -63,7 +63,7 @@ class AssetModelsTransformer
             'default_fieldset_values' => $default_field_values,
             'eol' => ($assetmodel->eol > 0) ? $assetmodel->eol.' months' : 'None',
             'requestable' => ($assetmodel->requestable == '1') ? true : false,
-            'notes' => Helper::parseEscapedMarkedownInline($assetmodel->notes),
+            'notes' => nl2br(Helper::parseEscapedMarkedownInline($assetmodel->notes)),
             'created_at' => Helper::getFormattedDateObject($assetmodel->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($assetmodel->updated_at, 'datetime'),
             'deleted_at' => Helper::getFormattedDateObject($assetmodel->deleted_at, 'datetime'),

--- a/app/Http/Transformers/AssetModelsTransformer.php
+++ b/app/Http/Transformers/AssetModelsTransformer.php
@@ -63,7 +63,7 @@ class AssetModelsTransformer
             'default_fieldset_values' => $default_field_values,
             'eol' => ($assetmodel->eol > 0) ? $assetmodel->eol.' months' : 'None',
             'requestable' => ($assetmodel->requestable == '1') ? true : false,
-            'notes' => nl2br(Helper::parseEscapedMarkedownInline($assetmodel->notes)),
+            'notes' => Helper::parseEscapedMarkedownInline($assetmodel->notes),
             'created_at' => Helper::getFormattedDateObject($assetmodel->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($assetmodel->updated_at, 'datetime'),
             'deleted_at' => Helper::getFormattedDateObject($assetmodel->deleted_at, 'datetime'),

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -58,7 +58,7 @@ class AssetsTransformer
                 'id' => (int) $asset->supplier->id,
                 'name'=> e($asset->supplier->name),
             ] : null,
-            'notes' => ($asset->notes) ? Helper::parseEscapedMarkedown($asset->notes) : null,
+            'notes' => ($asset->notes) ? Helper::parseEscapedMarkedownInline($asset->notes) : null,
             'order_number' => ($asset->order_number) ? e($asset->order_number) : null,
             'company' => ($asset->company) ? [
                 'id' => (int) $asset->company->id,

--- a/app/Http/Transformers/ComponentsTransformer.php
+++ b/app/Http/Transformers/ComponentsTransformer.php
@@ -46,7 +46,7 @@ class ComponentsTransformer
                 'id' => (int) $component->company->id,
                 'name' => e($component->company->name),
             ] : null,
-            'notes' => ($component->notes) ? Helper::parseEscapedMarkedown($component->notes) : null,
+            'notes' => ($component->notes) ? Helper::parseEscapedMarkedownInline($component->notes) : null,
             'created_at' => Helper::getFormattedDateObject($component->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($component->updated_at, 'datetime'),
             'user_can_checkout' =>  ($component->numRemaining() > 0) ? 1 : 0,

--- a/app/Http/Transformers/ConsumablesTransformer.php
+++ b/app/Http/Transformers/ConsumablesTransformer.php
@@ -39,7 +39,7 @@ class ConsumablesTransformer
             'purchase_cost'  => Helper::formatCurrencyOutput($consumable->purchase_cost),
             'purchase_date'  => Helper::getFormattedDateObject($consumable->purchase_date, 'date'),
             'qty'           => (int) $consumable->qty,
-            'notes'         => ($consumable->notes) ? Helper::parseEscapedMarkedown($consumable->notes) : null,
+            'notes'         => ($consumable->notes) ? Helper::parseEscapedMarkedownInline($consumable->notes) : null,
             'created_at' => Helper::getFormattedDateObject($consumable->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($consumable->updated_at, 'datetime'),
         ];

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -34,7 +34,7 @@ class LicensesTransformer
             'depreciation' => ($license->depreciation) ? ['id' => (int) $license->depreciation->id,'name'=> e($license->depreciation->name)] : null,
             'purchase_cost' => Helper::formatCurrencyOutput($license->purchase_cost),
             'purchase_cost_numeric' => $license->purchase_cost,
-            'notes' => Helper::parseEscapedMarkedown($license->notes),
+            'notes' => Helper::parseEscapedMarkedownInline($license->notes),
             'expiration_date' => Helper::getFormattedDateObject($license->expiration_date, 'date'),
             'seats' => (int) $license->seats,
             'free_seats_count' => (int) $license->free_seats_count,

--- a/app/Http/Transformers/SuppliersTransformer.php
+++ b/app/Http/Transformers/SuppliersTransformer.php
@@ -43,7 +43,7 @@ class SuppliersTransformer
                 'licenses_count' => (int) $supplier->licenses_count,
                 'consumables_count' => (int) $supplier->consumables_count,
                 'components_count' => (int) $supplier->components_count,
-                'notes' => ($supplier->notes) ? Helper::parseEscapedMarkedown($supplier->notes) : null,
+                'notes' => ($supplier->notes) ? Helper::parseEscapedMarkedownInline($supplier->notes) : null,
                 'created_at' => Helper::getFormattedDateObject($supplier->created_at, 'datetime'),
                 'updated_at' => Helper::getFormattedDateObject($supplier->updated_at, 'datetime'),
 

--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -53,7 +53,7 @@ class UsersTransformer
                     'id' => (int) $user->userloc->id,
                     'name'=> e($user->userloc->name),
                 ] : null,
-                'notes'=> Helper::parseEscapedMarkedown($user->notes),
+                'notes'=> Helper::parseEscapedMarkedownInline($user->notes),
                 'permissions' => $user->decodePermissions(),
                 'activated' => ($user->activated == '1') ? true : false,
                 'autoassign_licenses' => ($user->autoassign_licenses == '1') ? true : false,

--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -123,6 +123,7 @@ class AssetModelPresenter extends Presenter
                 'switchable' => true,
                 'title' => trans('general.notes'),
                 'visible' => false,
+                'formatter' => 'notesFormatter',
             ],
             [
                 'field' => 'created_at',

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -287,7 +287,7 @@
               </strong>
           </div>
           <div class="col-md-9">
-              {!! nl2br(e($accessory->notes)) !!}
+              {!! nl2br(Helper::parseEscapedMarkedownInline($accessory->notes)) !!}
           </div>
        </div>
 

--- a/resources/views/asset_maintenances/view.blade.php
+++ b/resources/views/asset_maintenances/view.blade.php
@@ -93,7 +93,7 @@ use Carbon\Carbon;
       <div class="row">
         <div class="col-md-12 col-sm-12" style="padding-bottom: 10px; margin-left: 15px; word-wrap: break-word;">
           <strong>{{ trans('admin/asset_maintenances/form.notes') }}: </strong>
-          {{ $assetMaintenance->notes }}
+          {!! nl2br(Helper::parseEscapedMarkedownInline($assetMaintenance->notes)) !!}
         </div>
       </div>
       <!-- 5th Row End -->

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -155,7 +155,7 @@
 
                       <td>
                         @if ($file->note)
-                          {{ $file->note }}
+                          {!! nl2br(Helper::parseEscapedMarkedownInline($file->note)) !!}
                         @endif
                       </td>
                       <td>
@@ -275,7 +275,7 @@
       </strong>
               </div>
     <div class="col-md-12">
-      {!! nl2br(e($consumable->notes)) !!}
+      {!! nl2br(Helper::parseEscapedMarkedownInline($consumable->notes)) !!}
             </div>
           </div>
   @endif

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -730,7 +730,7 @@
                                             </strong>
                                         </div>
                                         <div class="col-md-6">
-                                               {!! nl2br(e($asset->notes)) !!}
+                                            {!! nl2br(Helper::parseEscapedMarkedownInline($asset->notes)) !!}
                                         </div>
                                     </div>
 

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -357,7 +357,7 @@
                       </strong>
                     </div>
                     <div class="col-md-9">
-                      {!! nl2br(e($license->notes)) !!}
+                      {!! nl2br(Helper::parseEscapedMarkedownInline($license->notes)) !!}
                     </div>
                   </div>
                   @endif

--- a/resources/views/suppliers/view.blade.php
+++ b/resources/views/suppliers/view.blade.php
@@ -338,7 +338,7 @@
               @endif
 
               @if ($supplier->notes!='')
-                  <li><i class="fa fa-comment"></i> {{ $supplier->notes }}</li>
+                  <li><i class="fa fa-comment"></i> {!! nl2br(Helper::parseEscapedMarkedownInline($supplier->notes)) !!}</li>
               @endif
 
           </ul>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -633,7 +633,7 @@
                         {{ trans('admin/users/table.notes') }}
                       </div>
                       <div class="col-md-9">
-                        {{ $user->notes }}
+                          {!! nl2br(Helper::parseEscapedMarkedownInline($user->notes)) !!}
                       </div>
 
                     </div>


### PR DESCRIPTION
This fixes a sort-of bug introduced in #13222 which added markdown to notes - very helpful if you often include links in your notes - much less helpful if you use hashes like for order numbers (`#12345`), since the markdown parses the entire block of text and would turn that hashed line into a giant `<h1></h1>` headline. 

I realize this is a bit duplicative, but I'm actually okay with it, since it forces you to explicitly decide which of these you want. It could have been passed as a parameter to the same method, but I think this is clearer in intent. 

This way, notes still parse links and other light formatting, but there dashboard message, footer, EULAs, etc still work as expected.

<img width="1505" alt="Screenshot 2023-07-11 at 11 41 16 AM" src="https://github.com/snipe/snipe-it/assets/197404/1cd63200-7872-4ea1-b68f-0f17ff68d207">
<img width="1502" alt="Screenshot 2023-07-11 at 11 41 36 AM" src="https://github.com/snipe/snipe-it/assets/197404/436b6fc4-fb22-462e-86fc-3253507127a3">


I'm noticing that our CSP isn't preventing outside images from being parsed in markdown, and that's something I'm trying to sort out, either by blocking images altogether in markdown, or fixing the CSP. (CSP can be set by the web server as well, so it's not entirely our responsibility, but you can currently embed images via markdown even on the demo, so this PR doesn't break anything.)

This would fix FD-36680

This *feels* weird, since we're no longer using the `{{ $foo }}` built-in escaping, but the markdown stuff handles that.

The test text I used to check for XSS in JS/Markdown is:

```
Created by DB *seeder*

#123456

https://snipe.net is __awesome__

<b>Hello!</b>

[Basic](javascript:alert('Basic'))
[Local Storage](javascript:alert(JSON.stringify(localStorage)))
[CaseInsensitive](JaVaScRiPt:alert('CaseInsensitive'))
[URL](javascript://www.google.com%0Aalert('URL'))
[In Quotes]('javascript:alert("InQuotes")')

[xss](javascript:alert%281%29)
```
