### PR TITLE
Avoid accidentally wiping local database when running tests

### DIFF
--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -23,7 +23,9 @@ pipeline:
   - name: Setup
     cmd: |
       cp -v .env.example .env
-      
+#     This is simply to allow passing the guard in TestCase@setUp()
+#     https://chipperci.com/docs/builds/env
+      touch .env.testing
       composer install --no-interaction --prefer-dist --optimize-autoloader
 
   - name: Generate Key

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -7,6 +7,7 @@ use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Laravel\Dusk\TestCase as BaseTestCase;
+use RuntimeException;
 
 abstract class DuskTestCase extends BaseTestCase
 {
@@ -21,6 +22,12 @@ abstract class DuskTestCase extends BaseTestCase
      */
     public static function prepare()
     {
+        if (!file_exists(realpath(__DIR__ . '/../') . '/.env.dusk.local')) {
+            throw new RuntimeException(
+                '.env.dusk.local file does not exist. Aborting to avoid wiping your local database'
+            );
+        }
+
         if (! static::runningInSail()) {
             static::startChromeDriver();
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Tests;
 use App\Http\Middleware\SecurityHeaders;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use RuntimeException;
 use Tests\Support\CustomTestMacros;
 use Tests\Support\InteractsWithAuthentication;
 use Tests\Support\InteractsWithSettings;
@@ -22,6 +23,12 @@ abstract class TestCase extends BaseTestCase
 
     protected function setUp(): void
     {
+        if (!file_exists(realpath(__DIR__ . '/../') . '/.env.testing')) {
+            throw new RuntimeException(
+                '.env.testing file does not exist. Aborting to avoid wiping your local database'
+            );
+        }
+
         parent::setUp();
 
         $this->withoutMiddleware($this->globallyDisabledMiddleware);


### PR DESCRIPTION
# Description

This PR adds guards before the running of PHPUnit and Dusk tests that check to see if env files have been created to avoid falling back to the `.env` file and ending up with the local database being wiped.

For PHPUnit tests, if the user hasn't created a `.env.testing` file then the tests will not run.
For Dusk tests, a `.env.dusk.local` is required.

## Type of change

- [x] New feature (non-breaking change which adds functionality)