### PR TITLE
Run ChipperCI on all PRs (take three)

### DIFF
--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -15,9 +15,7 @@ on:
       - develop
 
   pull_request:
-    branches:
-      - master/.*
-      - develop/.*
+    branches: .*
 
 pipeline:
   - name: Setup


### PR DESCRIPTION
# Description

This is another attempt (#13218 and #13265) to get ChipperCI to run on each PR and not only when branches are merged to develop and master. I thought I got it last time but....no dice.

[Docs on Build Triggers](https://chipperci.com/docs/builds/build-restrictions/)