### PR TITLE
Fixed #11794 Admins Cannot View Encrypted Field

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -101,10 +101,10 @@ class AssetsTransformer
             foreach ($asset->model->fieldset->fields as $field) {
                 if ($field->isFieldDecryptable($asset->{$field->db_column})) {
                     $decrypted = Helper::gracefulDecrypt($field, $asset->{$field->db_column});
-                    $value = (Gate::allows('superadmin')) ? $decrypted : strtoupper(trans('admin/custom_fields/general.encrypted'));
+                    $value = (Gate::allows('superadmin') || Gate::allows('admin')) ? $decrypted : strtoupper(trans('admin/custom_fields/general.encrypted'));
 
                     if ($field->format == 'DATE'){
-                        if (Gate::allows('superadmin')){
+                        if (Gate::allows('superadmin') || Gate::allows('admin')){
                             $value = Helper::getFormattedDateObject($value, 'date', false);
                         } else {
                            $value = strtoupper(trans('admin/custom_fields/general.encrypted'));

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -101,10 +101,10 @@ class AssetsTransformer
             foreach ($asset->model->fieldset->fields as $field) {
                 if ($field->isFieldDecryptable($asset->{$field->db_column})) {
                     $decrypted = Helper::gracefulDecrypt($field, $asset->{$field->db_column});
-                    $value = (Gate::allows('superadmin') || Gate::allows('admin')) ? $decrypted : strtoupper(trans('admin/custom_fields/general.encrypted'));
+                    $value = (Gate::allows('assets.view.encrypted_custom_fields')) ? $decrypted : strtoupper(trans('admin/custom_fields/general.encrypted'));
 
                     if ($field->format == 'DATE'){
-                        if (Gate::allows('superadmin') || Gate::allows('admin')){
+                        if (Gate::allows('assets.view.encrypted_custom_fields')){
                             $value = Helper::getFormattedDateObject($value, 'date', false);
                         } else {
                            $value = strtoupper(trans('admin/custom_fields/general.encrypted'));

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -146,6 +146,11 @@ class AuthServiceProvider extends ServiceProvider
             }
         });
 
+        Gate::define('assets.view.encrypted_custom_fields', function ($user) {
+            if($user->hasAccess('assets.view.encrypted_custom_fields')){
+                return true;
+            }
+        });
 
         // -----------------------------------------
         // Reports

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -106,6 +106,13 @@ return [
             'display'    => true,
         ],
 
+        [
+            'permission' => 'assets.view.encrypted_custom_fields',
+            'label'      => 'View and Modify Encrypted Custom Fields',
+            'note'       => '',
+            'display'    => true,
+        ],
+
     ],
 
     'Accessories' => [

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -460,7 +460,7 @@
                                                     @endif
 
                                                     @if ($field->isFieldDecryptable($asset->{$field->db_column_name()} ))
-                                                        @canany(['superuser', 'admin'])
+                                                        @can('assets.view.encrypted_custom_fields')
                                                             @if (($field->format=='URL') && ($asset->{$field->db_column_name()}!=''))
                                                                 <a href="{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}" target="_new">{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}</a>
                                                             @elseif (($field->format=='DATE') && ($asset->{$field->db_column_name()}!=''))
@@ -470,7 +470,7 @@
                                                             @endif
                                                         @else
                                                             {{ strtoupper(trans('admin/custom_fields/general.encrypted')) }}
-                                                        @endcanany
+                                                        @endcan
 
                                                     @else
                                                         @if (($field->format=='BOOLEAN') && ($asset->{$field->db_column_name()}!=''))

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -460,7 +460,7 @@
                                                     @endif
 
                                                     @if ($field->isFieldDecryptable($asset->{$field->db_column_name()} ))
-                                                        @can('superuser')
+                                                        @canany(['superuser', 'admin'])
                                                             @if (($field->format=='URL') && ($asset->{$field->db_column_name()}!=''))
                                                                 <a href="{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}" target="_new">{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}</a>
                                                             @elseif (($field->format=='DATE') && ($asset->{$field->db_column_name()}!=''))
@@ -470,7 +470,7 @@
                                                             @endif
                                                         @else
                                                             {{ strtoupper(trans('admin/custom_fields/general.encrypted')) }}
-                                                        @endcan
+                                                        @endcanany
 
                                                     @else
                                                         @if (($field->format=='BOOLEAN') && ($asset->{$field->db_column_name()}!=''))

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -53,7 +53,7 @@
 
 
                 @else
-                    @if (($field->field_encrypted=='0') || (Gate::allows('admin')))
+                    @if (($field->field_encrypted=='0') || (Gate::allows('assets.view.encrypted_custom_fields')))
                     <input type="text" value="{{ Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}" id="{{ $field->db_column_name() }}" class="form-control" name="{{ $field->db_column_name() }}" placeholder="Enter {{ strtolower($field->format) }} text">
                         @else
                             <input type="text" value="{{ strtoupper(trans('admin/custom_fields/general.encrypted')) }}" class="form-control disabled" disabled>


### PR DESCRIPTION
# Description
Add permission to 'admin' roles to see encrypted fields values when looking for an asset (`AssetsTransformer`), and when viewing the details of a determined asset (`resources/views/hardware/view.blade.php`).

Fixes #11794 

## Type of change
- [x} Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: PHP dev server
* OS version: Debian 11
