### PR TITLE
Fixed #13296 Generating Custom Report Error

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -390,9 +390,7 @@ class Asset extends Depreciable
      */
     public function depreciation()
     {
-        if ($this->model) {
-            return $this->model->belongsTo(\App\Models\Depreciation::class, 'depreciation_id');
-        }
+        return $this->model->belongsTo(\App\Models\Depreciation::class, 'depreciation_id');
     }
 
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -703,7 +703,7 @@ class Asset extends Depreciable
      */
     public function model()
     {
-        return $this->belongsTo(\App\Models\AssetModel::class, 'model_id')->withTrashed();
+        return $this->belongsTo(\App\Models\AssetModel::class, 'model_id')->withTrashed()->withDefault();
     }
 
     /**

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -390,7 +390,9 @@ class Asset extends Depreciable
      */
     public function depreciation()
     {
-        return $this->model->belongsTo(\App\Models\Depreciation::class, 'depreciation_id');
+        if ($this->model) {
+            return $this->model->belongsTo(\App\Models\Depreciation::class, 'depreciation_id');
+        }
     }
 
 


### PR DESCRIPTION
# Description
In some edge cases the Custom Report fails when trying to retrieve a belongsTo() relationship over asset models. ~~I added a check to evaluate if the model exists before trying to return that relationship, like in other relationships from the Asset model.~~

Take 2: I added a default blank item in the asset->models relationship, so when it's called in asset->models->depreciation relationship it found one and doesn't fails. I can set a default model with, for example, a name attribute with `not found` as value or something like that, but I think a blank value is equally expressive in this case.

Fixes #13296 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
