### PR TITLE
Fixed #13256 - Added option to switch to localStorage instead of cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,7 @@ COOKIE_NAME=snipeit_session
 COOKIE_DOMAIN=null
 SECURE_COOKIES=false
 API_TOKEN_EXPIRATION_YEARS=15
+BS_TABLE_STORAGE=cookieStorage
 
 # --------------------------------------------
 # OPTIONAL: SECURITY HEADER SETTINGS

--- a/config/session.php
+++ b/config/session.php
@@ -169,6 +169,7 @@ return [
     | - localStorage: use this if you have a LOT of custom fields and are getting a REQUEST TOO LARGE error
     | - sessionStorage
     |
+    | More info: https://bootstrap-table.com/docs/extensions/cookie/#cookiestorage
     */
 
     'bs_table_storage' => env('BS_TABLE_STORAGE', 'cookieStorage'),

--- a/config/session.php
+++ b/config/session.php
@@ -158,4 +158,19 @@ return [
 
     'secure' => env('SECURE_COOKIES', false),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Bootstrap Table Storage Type
+    |--------------------------------------------------------------------------
+    |
+    | Set the storage that this Bootstrap Table will use.
+    | Valid options are:
+    | - cookieStorage
+    | - localStorage: use this if you have a LOT of custom fields and are getting a REQUEST TOO LARGE error
+    | - sessionStorage
+    |
+    */
+
+    'bs_table_storage' => env('BS_TABLE_STORAGE', 'cookieStorage'),
+
 ];

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -55,6 +55,7 @@
             stickyHeaderOffsetY: stickyHeaderOffsetY + 'px',
             undefinedText: '',
             iconsPrefix: 'fa',
+            cookieStorage: '{{ config('session.bs_table_storage') }}',
             cookie: true,
             cookieExpire: '2y',
             mobileResponsive: true,


### PR DESCRIPTION
This adds the ability to switch from `cookieStorage` to `localStorage` or `sessionStorage` in bootstrap table, which should be useful for folks with a LOT of custom fields hidden.

I set it to default to `cookieStorage` so for most people it won't break their existing remembered items. 