### PR TITLE
Fixed #13300 Custom Asset Report, Checkout date range never includes current day

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -639,10 +639,16 @@ class ReportsController extends Controller
             }
 
             if (($request->filled('created_start')) && ($request->filled('created_end'))) {
-                $assets->whereBetween(\DB::raw('DATE(assets.created_at)'), [$request->input('created_start'), $request->input('created_end')]);
+                $created_start = \Carbon::parse($request->input('created_start'))->startOfDay();
+                $created_end = \Carbon::parse($request->input('created_end'))->endOfDay();
+                
+                $assets->whereBetween('assets.created_at', [$created_start, $created_end]);
             }
             if (($request->filled('checkout_date_start')) && ($request->filled('checkout_date_end'))) {
-                $assets->whereBetween(\DB::raw('DATE(assets.last_checkout)'), [$request->input('checkout_date_start'), $request->input('checkout_date_end') ]);
+                $checkout_start = \Carbon::parse($request->input('checkout_date_start'))->startOfDay();
+                $checkout_end = \Carbon::parse($request->input('checkout_date_end'))->endOfDay();
+
+                $assets->whereBetween('assets.last_checkout', [$checkout_start, $checkout_end]);
             }
 
             if (($request->filled('expected_checkin_start')) && ($request->filled('expected_checkin_end'))) {
@@ -650,7 +656,10 @@ class ReportsController extends Controller
             }
 
             if (($request->filled('last_audit_start')) && ($request->filled('last_audit_end'))) {
-                $assets->whereBetween(\DB::raw('DATE(assets.last_audit_date)'), [$request->input('last_audit_start'), $request->input('last_audit_end')]);
+                $last_audit_start = \Carbon::parse($request->input('last_audit_start'))->startOfDay();
+                $last_audit_end = \Carbon::parse($request->input('last_audit_end'))->endOfDay();
+
+                $assets->whereBetween('assets.last_audit_date', [$last_audit_start, $last_audit_end]);
             }
 
             if (($request->filled('next_audit_start')) && ($request->filled('next_audit_end'))) {

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -639,10 +639,10 @@ class ReportsController extends Controller
             }
 
             if (($request->filled('created_start')) && ($request->filled('created_end'))) {
-                $assets->whereBetween('assets.created_at', [$request->input('created_start'), $request->input('created_end')]);
+                $assets->whereBetween(\DB::raw('DATE(assets.created_at)'), [$request->input('created_start'), $request->input('created_end')]);
             }
             if (($request->filled('checkout_date_start')) && ($request->filled('checkout_date_end'))) {
-                $assets->whereBetween('assets.last_checkout', [$request->input('checkout_date_start'), $request->input('checkout_date_end')]);
+                $assets->whereBetween(\DB::raw('DATE(assets.last_checkout)'), [$request->input('checkout_date_start'), $request->input('checkout_date_end') ]);
             }
 
             if (($request->filled('expected_checkin_start')) && ($request->filled('expected_checkin_end'))) {
@@ -650,7 +650,7 @@ class ReportsController extends Controller
             }
 
             if (($request->filled('last_audit_start')) && ($request->filled('last_audit_end'))) {
-                $assets->whereBetween('assets.last_audit_date', [$request->input('last_audit_start'), $request->input('last_audit_end')]);
+                $assets->whereBetween(\DB::raw('DATE(assets.last_audit_date)'), [$request->input('last_audit_start'), $request->input('last_audit_end')]);
             }
 
             if (($request->filled('next_audit_start')) && ($request->filled('next_audit_end'))) {


### PR DESCRIPTION
# Description
We had a problem with the Custom Asset report in the `Checkout Range`, as we stored the `last_checkout` field as a DATETIME, when we made a Checkout Range for example from '2023/07/01' to '2023/07/13', if the checkout was today at this moment we got into the database field for example '2023/07/13 16:06:23', which is out of the dates range because of the 'extra' time we are storing.

So I add a cast of the type date to the `last_checkout` column in the query, so the report can ignore that time part of the DATETIME type and the results are retrieved correctly. I also include in the fix `created_at` and `last_audit_date` which probably have the same problem.

Fixes #13300

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 8.1
* MySQL version:  8.0.23
* Webserver version: PHP Dev Server
* OS version: Debian 11