### PR TITLE
Fixed the inability to load location select when editing profile

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -253,8 +253,12 @@ class LocationsController extends Controller
      */
     public function selectlist(Request $request)
     {
-
-        $this->authorize('view.selectlists');
+        // If a user is in the process of editing their profile, as determined by the referrer,
+        // then we check that they have permission to edit their own location.
+        // Otherwise, we do our normal check that they can view select lists.
+        $request->headers->get('referer') === route('profile')
+            ? $this->authorize('self.edit_location')
+            : $this->authorize('view.selectlists');
 
         $locations = Location::select([
             'locations.id',

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -424,4 +424,12 @@ class UserFactory extends Factory
         });
     }
 
+    public function canEditOwnLocation()
+    {
+        return $this->state(function () {
+            return [
+                'permissions' => '{"self.edit_location":"1"}',
+            ];
+        });
+    }
 }

--- a/tests/Feature/Api/Locations/LocationsForSelectListTest.php
+++ b/tests/Feature/Api/Locations/LocationsForSelectListTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Api\Locations;
+
+use App\Models\Location;
+use App\Models\User;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class LocationsForSelectListTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testGettingLocationListRequiresProperPermission()
+    {
+        $this->actingAsForApi(User::factory()->create())
+            ->getJson(route('api.locations.selectlist'))
+            ->assertForbidden();
+    }
+
+    public function testLocationsReturned()
+    {
+        Location::factory()->create();
+
+        // see the where the "view.selectlists" is defined in the AuthServiceProvider
+        // for info on why "createUsers()" is used here.
+        $this->actingAsForApi(User::factory()->createUsers()->create())
+            ->getJson(route('api.locations.selectlist'))
+            ->assertOk()
+            ->assertJsonStructure([
+                'results',
+                'pagination',
+                'total_count',
+                'page',
+                'page_count',
+            ])
+            ->assertJson(fn(AssertableJson $json) => $json->has('results', 1)->etc());
+    }
+
+    public function testLocationsAreReturnedWhenUserIsUpdatingTheirProfileAndHasPermissionToUpdateLocation()
+    {
+        $this->actingAsForApi(User::factory()->canEditOwnLocation()->create())
+            ->withHeader('referer', route('profile'))
+            ->getJson(route('api.locations.selectlist'))
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
# Description

Currently, when users are granted the ability to edit their own location via the `Profile Edit Location` permission they might not be able to do so if they don't have other, non-obvious, permissions granted as well.

<img width="537" alt="screenshot of the self permission section" src="https://github.com/snipe/snipe-it/assets/1141514/78a336b8-9de9-4404-9f18-6589a42d72cd">

This is because the `view.selectlists` permission we [check against](https://github.com/snipe/snipe-it/blob/23a1b2d60ae6e536924c0773278b5768c4e0a414/app/Providers/AuthServiceProvider.php#L202-L222) doesn't take this scenario into account.

This PR fixes that by checking against the `self.edit_location` permission if the user is in the process of updating their profile. I'm not entirely convinced this is the best approach since the referer header can be spoofed but it provides a solution to the issue.

Fixes #13269

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)