### PR TITLE
Added ability to show/hide custom fields in list views by default

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -109,6 +109,7 @@ class CustomFieldsController extends Controller
             "is_unique" => $request->get("is_unique", 0),
             "display_in_user_view" => $display_in_user_view,
             "auto_add_to_fieldsets" => $request->get("auto_add_to_fieldsets", 0),
+            "show_in_listview" => $request->get("show_in_listview", 0),
             "user_id" => Auth::id()
         ]);
 
@@ -265,6 +266,7 @@ class CustomFieldsController extends Controller
         $field->is_unique     = $request->get("is_unique", 0);
         $field->display_in_user_view = $display_in_user_view;
         $field->auto_add_to_fieldsets = $request->get("auto_add_to_fieldsets", 0);
+        $field->show_in_listview = $request->get("show_in_listview", 0);
 
         if ($request->get('format') == 'CUSTOM REGEX') {
             $field->format = e($request->get('custom_format'));

--- a/app/Http/Transformers/CustomFieldsTransformer.php
+++ b/app/Http/Transformers/CustomFieldsTransformer.php
@@ -49,6 +49,7 @@ class CustomFieldsTransformer
             'required'   =>  (($field->pivot) && ($field->pivot->required=='1')) ? true : false,
             'display_in_user_view' =>  ($field->display_in_user_view =='1') ? true : false,
             'auto_add_to_fieldsets' =>  ($field->auto_add_to_fieldsets == '1') ? true : false,
+            'show_in_listview'  => ($field->show_in_listview == '1') ? true : false,
             'created_at' => Helper::getFormattedDateObject($field->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($field->updated_at, 'datetime'),
         ];

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -53,6 +53,7 @@ class CustomField extends Model
         'element' => 'required|in:text,listbox,textarea,checkbox,radio',
         'field_encrypted' => 'nullable|boolean',
         'auto_add_to_fieldsets' => 'boolean',
+        'show_in_listview' => 'boolean',
     ];
 
     /**
@@ -71,6 +72,7 @@ class CustomField extends Model
         'is_unique',
         'display_in_user_view',
         'auto_add_to_fieldsets',
+        'show_in_listview',
 
     ];
 

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -292,7 +292,7 @@ class AssetPresenter extends Presenter
                 'formatter'=> 'customFieldsFormatter',
                 'escape' => true,
                 'class' => ($field->field_encrypted == '1') ? 'css-padlock' : '',
-                'visible' => true,
+                'visible' => ($field->show_in_listview == '1') ? true : false,
             ];
         }
 

--- a/database/migrations/2023_07_14_004221_add_show_in_list_view_to_custom_fields.php
+++ b/database/migrations/2023_07_14_004221_add_show_in_list_view_to_custom_fields.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddShowInListViewToCustomFields extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('custom_fields', function (Blueprint $table) {
+            $table->boolean('show_in_listview')->nullable()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('custom_fields', function (Blueprint $table) {
+            if (Schema::hasColumn('custom_fields', 'show_in_listview')) {
+                $table->dropColumn('show_in_listview');
+            }
+        });
+    }
+}

--- a/resources/lang/en/admin/custom_fields/general.php
+++ b/resources/lang/en/admin/custom_fields/general.php
@@ -51,4 +51,7 @@ return [
     'display_in_user_view_table' => 'Visible to User',
     'auto_add_to_fieldsets' => 'Automatically add this to every new fieldset',
     'add_to_preexisting_fieldsets' => 'Add to any existing fieldsets',
+    'show_in_listview' => 'Show in list views by default. Authorized users will still be able to show/hide via the column selector.',
+    'show_in_listview_short' => 'Show in lists',
+
 ];

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -118,12 +118,21 @@
               </div>
           </div>
 
-          <!-- Auto-Add to Future Fieldsets  -->
+
+
+              <!-- Auto-Add to Future Fieldsets  -->
           <div class="form-group {{ $errors->has('auto_add_to_fieldsets') ? ' has-error' : '' }}"  id="auto_add_to_fieldsets">
               <div class="col-md-9 col-md-offset-3">
                   <label class="form-control">
                       <input type="checkbox" name="auto_add_to_fieldsets" aria-label="auto_add_to_fieldsets" value="1"{{ (old('auto_add_to_fieldsets') || $field->auto_add_to_fieldsets) ? ' checked="checked"' : '' }}>
                       {{ trans('admin/custom_fields/general.auto_add_to_fieldsets') }}
+                  </label>
+              </div>
+
+              <div class="col-md-9 col-md-offset-3">
+                  <label class="form-control">
+                      <input type="checkbox" name="show_in_listview" aria-label="show_in_listview" value="1"{{ (old('show_in_listview') || $field->show_in_listview) ? ' checked="checked"' : '' }}>
+                      {{ trans('admin/custom_fields/general.show_in_listview') }}
                   </label>
               </div>
 

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -145,6 +145,9 @@
               <th data-sortable="true"><i class="fa fa-lock" aria-hidden="true"></i>
                 <span class="hidden-xs hidden-sm hidden-md hidden-lg">{{ trans('admin/custom_fields/general.encrypted') }}</span>
               </th>
+              <th data-sortable="true"><i class="fa fa-list" aria-hidden="true"></i>
+                <span class="hidden-xs hidden-sm hidden-md hidden-lg">{{ trans('admin/custom_fields/general.show_in_listview_short') }}</span>
+              </th>
               <th data-visible="false" data-sortable="true"><i class="fa fa-eye" aria-hidden="true"><span class="sr-only">Visible to User</span></i></th>
               <th data-sortable="true" data-searchable="true"><i class="fa fa-envelope" aria-hidden="true"><span class="sr-only">Show in Email</span></i></th>
               <th data-sortable="true" data-searchable="true">{{ trans('admin/custom_fields/general.field_element_short') }}</th>
@@ -168,6 +171,7 @@
               </td>
               <td>{{ $field->format }}</td>
               <td>{!!  ($field->field_encrypted=='1' ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times text-danger"></i>') !!}</td>
+              <td>{!!  ($field->show_in_listview=='1' ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times text-danger"></i>') !!}</td>
               <td>{!!  ($field->display_in_user_view=='1' ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times text-danger"></i>') !!}</td>
               <td class='text-center'>{!! ($field->show_in_email=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"><span class="sr-only">'.trans('general.yes').'</span></i>' : '<i class="fas fa-times text-danger" aria-hidden="true"><span class="sr-only">'.trans('general.no').'</span></i>'  !!}</td>
               <td>{{ $field->element }}</td>


### PR DESCRIPTION
This adds the option on custom fields to determine whether they should be shown/hidden by default versus just showing them all by default before a user has made their choices to show/hide them.

<img width="1396" alt="Screenshot 2023-07-14 at 9 09 07 AM" src="https://github.com/snipe/snipe-it/assets/197404/5a0a56ba-d18d-4657-b6c6-d9f7f5b5979f">

<img width="1390" alt="Screenshot 2023-07-14 at 9 09 20 AM" src="https://github.com/snipe/snipe-it/assets/197404/1a20bf73-6ae6-4b0e-8eb1-855b330aa964">
