### PR TITLE
Moved warranty into manufactuer’s section

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -342,8 +342,9 @@
                                                     @if (($asset->model) && ($asset->model->manufacturer->url))
                                                         <li>
                                                             <i class="fas fa-globe-americas" aria-hidden="true"></i>
-                                                            <a href="{{ $asset->model->manufacturer->url }}">
+                                                            <a href="{{ $asset->model->manufacturer->url }}" target="_blank">
                                                                 {{ $asset->model->manufacturer->url }}
+                                                                <i class="fa fa-external-link" aria-hidden="true"></i>
                                                             </a>
                                                         </li>
                                                     @endif
@@ -351,8 +352,19 @@
                                                     @if (($asset->model) && ($asset->model->manufacturer->support_url))
                                                         <li>
                                                             <i class="far fa-life-ring" aria-hidden="true"></i>
-                                                            <a href="{{ $asset->model->manufacturer->support_url }}">
+                                                            <a href="{{ $asset->model->manufacturer->support_url }}" target="_blank">
                                                                 {{ $asset->model->manufacturer->support_url }}
+                                                                <i class="fa fa-external-link" aria-hidden="true"></i>
+                                                            </a>
+                                                        </li>
+                                                    @endif
+
+                                                    @if (($asset->model->manufacturer) && ($asset->model->manufacturer->warranty_lookup_url!=''))
+                                                        <li>
+                                                            <i class="far fa-wrench" aria-hidden="true"></i>
+                                                            <a href="{{ $asset->present()->dynamicWarrantyUrl() }}" target="_blank">
+                                                                {{ $asset->present()->dynamicWarrantyUrl() }}
+                                                                <i class="fa fa-external-link" aria-hidden="true"><span class="sr-only">{{ trans('admin/hardware/general.mfg_warranty_lookup', ['manufacturer' => $asset->model->manufacturer->name]) }}</span></i>
                                                             </a>
                                                         </li>
                                                     @endif


### PR DESCRIPTION
A few folks have asked that we include the warranty URL in the asset even if no warranty duration was provided. This does that.

<img width="804" alt="Screenshot 2023-07-15 at 10 47 00 AM" src="https://github.com/snipe/snipe-it/assets/197404/3f34df8b-55cd-493c-a402-52cd09028546">
