### PR TITLE
Fixed Employee Number no longer importing [sc-23497]

### DIFF
--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -315,7 +315,7 @@ class Importer extends Component
             'gravatar' => trans('general.importer.gravatar'),
             'start_date'    => trans('general.start_date'),
             'end_date'   => trans('general.end_date'),
-            'employee_number'   => trans('general.employee_number'),
+            'employee_num'   => trans('general.employee_number'),
         ];
 
         $this->locations_fields  = [


### PR DESCRIPTION
# Description
The field mapping in the User Importer was using an incorrect field name for Employee Number ´employee_number´ instead of ´employee_num´. I was thinking if we made this change to make the field name clearer or more easily readable? But I change it to ´employee_num´ anyways because I don't think it was hard to understand that way either.

Fixes [sc-23497]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP Dev server
* OS version: Debian 11
