### PR TITLE
Fixes #13251 - ldap_location attribute

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -212,9 +212,12 @@ class LdapSync extends Command
                 $item['manager'] = $results[$i][$ldap_result_manager][0] ?? '';
                 $item['location'] = $results[$i][$ldap_result_location][0] ?? '';
 
-                $location = Location::firstOrCreate([
-                    'name' => $item['location'],
-                ]);
+                // ONLY if you are using the "ldap_location" option *AND* you have an actual result
+                if ($ldap_result_location && $item['location']) {
+                        $location = Location::firstOrCreate([
+                                'name' => $item['location'],
+                        ]);
+                }
                 $department = Department::firstOrCreate([
                     'name' => $item['department'],
                 ]);


### PR DESCRIPTION
A customer [FD-36851] reports that his locations were being unset in his per-location-specific various LDAP syncs.

It seems like we'll override the Location that a user would be assigned if they were using the `--location` command-line option, even if the user had not configured the LDAP Location field.

This adds a guard clause that will only try to override the location if the field is being used.