### PR TITLE
Added strtolower for category type

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -553,8 +553,8 @@ class Helper
             'license' => trans('general.license'),
         ];
 
-        if($selection != null){
-            return $category_types[$selection];
+        if ($selection != null){
+            return $category_types[strtolower($selection)];
         }
         else
         return $category_types;


### PR DESCRIPTION
This fixes an issue where if data was inserted into the category table for `category_type` but was uppercased, it would fail. This lowercases the comparison. (I'm still trying to figure out how that data would get in there that way - API maybe?)