### PR TITLE
Fixes #13341: Clean up correct seats on license delete

### DIFF
--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -207,7 +207,7 @@ class LicensesController extends Controller
         if ($license->assigned_seats_count == 0) {
             // Delete the license and the associated license seats
             DB::table('license_seats')
-                ->where('id', $license->id)
+                ->where('license_id', $license->id)
                 ->update(['assigned_to' => null, 'asset_id' => null]);
 
             $licenseSeats = $license->licenseseats();


### PR DESCRIPTION
# Description

When you have two licenses:

- License A with X seats checked out
- License B with 0 sets checked out

When you now delete License B, and License A has a seat with the id of License A, then the fields assigned_to and asset_id will be set to NULL.

This happens because in snipe-it/app/Http/Controllers/Licenses/LicensesController.php:210 the query incorrectly checks for id instead of license_id.

Additionally, this does not show up in the activity log.

Before this change, we checked for the `id` collumn in the `license_seats` table, insteasd of using `license_id` for this.

This way, we ensure that we only alter seats belonging to the correct license.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Fixes #13341 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.33
* Webserver version: Apache 2.4.52
* OS version: Ubuntu 22.04


# Checklist:

- [x ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
