### PR TITLE
Fixed #13336 - Save unhashed password if no password provided

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -180,10 +180,6 @@ class LdapSync extends Command
             }
         }
 
-        /* Create user account entries in Snipe-IT */
-        $tmp_pass = substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, 20);
-        $pass = bcrypt($tmp_pass);
-
         $manager_cache = [];
 
         if($ldap_default_group != null) {
@@ -229,7 +225,7 @@ class LdapSync extends Command
                 } else {
                     // Creating a new user.
                     $user = new User;
-                    $user->password = $pass;
+                    $user->password = $user->noPassword();
                     $user->activated = 1; // newly created users can log in by default, unless AD's UAC is in use, or an active flag is set (below)
                     $item['createorupdate'] = 'created';
                 }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -368,9 +368,7 @@ class UsersController extends Controller
         } else {
             $user->password = $user->noPassword();
         }
-
-        $user->password = bcrypt($request->get('password', $tmp_pass));
-
+        
         app('App\Http\Requests\ImageUploadRequest')->handleImages($user, 600, 'image', 'avatars', 'avatar');
         
         if ($user->save()) {

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -362,7 +362,13 @@ class UsersController extends Controller
             $user->permissions = $permissions_array;
         }
 
-        $tmp_pass = substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, 40);
+        // 
+        if ($request->filled('password')) {
+            $user->password = bcrypt($request->get('password'));
+        } else {
+            $user->password = $user->noPassword();
+        }
+
         $user->password = bcrypt($request->get('password', $tmp_pass));
 
         app('App\Http\Requests\ImageUploadRequest')->handleImages($user, 600, 'image', 'avatars', 'avatar');

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -368,7 +368,7 @@ class UsersController extends Controller
         } else {
             $user->password = $user->noPassword();
         }
-        
+
         app('App\Http\Requests\ImageUploadRequest')->handleImages($user, 600, 'image', 'avatars', 'avatar');
         
         if ($user->save()) {

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -191,9 +191,11 @@ class LoginController extends Controller
 
              $ldap_attr = Ldap::parseAndMapLdapAttributes($ldap_user);
 
+            $user->password = $user->noPassword();
             if (Setting::getSettings()->ldap_pw_sync=='1') {
                 $user->password = bcrypt($request->input('password'));
             }
+
             $user->email = $ldap_attr['email'];
             $user->first_name = $ldap_attr['firstname'];
             $user->last_name = $ldap_attr['lastname']; //FIXME (or TODO?) - do we need to map additional fields that we now support? E.g. country, phone, etc.

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -252,7 +252,7 @@ class Ldap extends Model
             $user->last_name = $item['lastname'];
             $user->username = $item['username'];
             $user->email = $item['email'];
-            $user->noPassword();
+            $user->password = $user->noPassword();
 
             if (Setting::getSettings()->ldap_pw_sync == '1') {
                 $user->password = bcrypt($password);

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -252,13 +252,10 @@ class Ldap extends Model
             $user->last_name = $item['lastname'];
             $user->username = $item['username'];
             $user->email = $item['email'];
+            $user->noPassword();
 
             if (Setting::getSettings()->ldap_pw_sync == '1') {
-
                 $user->password = bcrypt($password);
-            } else {
-                $pass = substr(str_shuffle('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'), 0, 25);
-                $user->password = bcrypt($pass);
             }
 
             $user->activated = 1;
@@ -268,7 +265,7 @@ class Ldap extends Model
             if ($user->save()) {
                 return $user;
             } else {
-                LOG::debug('Could not create user.'.$user->getErrors());
+                \Log::debug('Could not create user.'.$user->getErrors());
                 throw new Exception('Could not create user: '.$user->getErrors());
             }
         }

--- a/app/Models/SCIMUser.php
+++ b/app/Models/SCIMUser.php
@@ -9,8 +9,7 @@ class SCIMUser extends User
     protected $throwValidationExceptions = true; // we want model-level validation to fully THROW, not just return false
 
     public function __construct(array $attributes = []) {
-        $attributes['password'] = "*NO PASSWORD*";
-        // $attributes['activated'] = 1;
         parent::__construct($attributes);
+        $this->noPassword();
     }
 }

--- a/app/Models/SCIMUser.php
+++ b/app/Models/SCIMUser.php
@@ -9,8 +9,7 @@ class SCIMUser extends User
     protected $throwValidationExceptions = true; // we want model-level validation to fully THROW, not just return false
 
     public function __construct(array $attributes = []) {
-        $this->noPassword();
+        $attributes['password'] = $this->noPassword();
         parent::__construct($attributes);
-
     }
 }

--- a/app/Models/SCIMUser.php
+++ b/app/Models/SCIMUser.php
@@ -9,7 +9,8 @@ class SCIMUser extends User
     protected $throwValidationExceptions = true; // we want model-level validation to fully THROW, not just return false
 
     public function __construct(array $attributes = []) {
-        parent::__construct($attributes);
         $this->noPassword();
+        parent::__construct($attributes);
+
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -465,6 +465,22 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return $this->belongsToMany(Asset::class, 'checkout_requests', 'user_id', 'requestable_id')->whereNull('canceled_at');
     }
 
+    /**
+     * Set a common string when the user has been imported/synced from:
+     *
+     * - LDAP without password syncing
+     * - SCIM
+     * - CSV import where no password was provided
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since [v6.2.0]
+     * @return string
+     */
+    public function noPassword()
+    {
+        return "*** NO PASSWORD ***";
+    }
+
 
     /**
      * Query builder scope to return NOT-deleted users


### PR DESCRIPTION
This addresses issue #13336, where if LDAP sync is enabled, and then disabled, the LDAP password remains for users that logged in while LDAP sync was enabled. 

By setting passwords to a static string that *isn't* hashed, the user will never be able to login, since we the process of logging in compares only hashes, and the string `*** NO PASSWORD ***` will never ever match a submitted hashed password. 

We have to be careful here to make sure we do not ever hash that NO PASSWORD string, of course. 

This has the added benefit of making importing a large number of LDAP users go faster, since bcrypt does slow things down a bit.