### PR TITLE
Check that $this->get_depreciation() returns

### DIFF
--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -68,7 +68,7 @@ class Depreciable extends SnipeModel
      */
     public function getLinearDepreciatedValue() // TODO - for testing it might be nice to have an optional $relative_to param here, defaulted to 'now'
     {
-        if ($this->purchase_date) {
+        if (($this->get_depreciation()) && ($this->purchase_date)) {
             $months_passed = ($this->purchase_date->diff(now())->m)+($this->purchase_date->diff(now())->y*12);
         } else {
             return null;


### PR DESCRIPTION
This fixes an error in the Depreciable.php file that doesn't check to see if `$this->get_depreciation()` exists and is not null before trying to get the `months` property. 

This *might* be related to #13297 but I'm not sure. This is a hotfix, so we'll dig in deeper a little later.