### PR TITLE
Fixed: tighter check for valid model

### DIFF
--- a/resources/lang/en/admin/models/message.php
+++ b/resources/lang/en/admin/models/message.php
@@ -3,7 +3,7 @@
 return array(
 
     'does_not_exist' => 'Model does not exist.',
-    'no_association' => 'NO MODEL ASSOCIATED.',
+    'no_association' => 'WARNING! The asset model for this item is invalid or missing!',
     'no_association_fix' => 'This will break things in weird and horrible ways. Edit this asset now to assign it a model.',
     'assoc_users'	 => 'This model is currently associated with one or more assets and cannot be deleted. Please delete the assets, and then try deleting again. ',
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -75,8 +75,7 @@
         @if (!$asset->model)
             <div class="col-md-12">
                 <div class="callout callout-danger">
-                    <h2>{{ trans('admin/models/message.no_association') }}</h2>
-                        <p>{{ trans('admin/models/message.no_association_fix') }}</p>
+                      <p><strong>{{ trans('admin/models/message.no_association') }}</strong> {{ trans('admin/models/message.no_association_fix') }}</p>
                 </div>
             </div>
         @endif
@@ -183,7 +182,7 @@
                           </span>
                         <span class="hidden-xs hidden-sm">
                             {{ trans('general.additional_files') }}
-                            {!! ($asset->model->uploads->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($asset->model->uploads->count()).'</badge>' : '' !!}
+                            {!! ($asset->model) && ($asset->model->uploads->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($asset->model->uploads->count()).'</badge>' : '' !!}
                           </span>
                     </a>
                     </li>
@@ -626,7 +625,7 @@
                                                 {{ $asset->warranty_months }}
                                                 {{ trans('admin/hardware/form.months') }}
 
-                                                @if (($asset->model->manufacturer) && ($asset->model->manufacturer->warranty_lookup_url!=''))
+                                                @if (($asset->model) && ($asset->model->manufacturer) && ($asset->model->manufacturer->warranty_lookup_url!=''))
                                                     <a href="{{ $asset->present()->dynamicWarrantyUrl() }}" target="_blank">
                                                         <i class="fa fa-external-link" aria-hidden="true"><span class="sr-only">{{ trans('admin/hardware/general.mfg_warranty_lookup', ['manufacturer' => $asset->model->manufacturer->name]) }}</span></i>
                                                     </a>
@@ -1305,7 +1304,7 @@
                         <div class="row">
                             <div class="col-md-12">
 
-                                @if ($asset->model->uploads->count() > 0)
+                                @if (($asset->model) && ($asset->model->uploads->count() > 0))
                                     <table
                                             class="table table-striped snipe-table"
                                             id="assetModelFileHistory"


### PR DESCRIPTION
This should honestly never ever happen, since at a the model level we check for a valid model, BUT when it does happen (assuming the user manually edited something in the database, or restored from the before times when we didn't validate as strictly) that an asset has an invalid or null `model_id`, this should return a friendlier error message (versus a 500 error.)

This used to work this way, but when I added the model file tab and some of the manufacturer info, it *assumed* that relationship was a valid one, which broke the warning and would just then return a 500 error with a ` Trying to get property 'uploads' of non-object at /Users/snipe/Sites/snipe-it/snipe-it/storage/framework/views` error.