### PR TITLE
Fixed #13298 "No records Found" when Switching between Single and Multi-Page Licenses

### DIFF
--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -42,6 +42,11 @@ class LicenseSeatsController extends Controller
 
             // Make sure the offset and limit are actually integers and do not exceed system limits
             $offset = ($request->input('offset') > $seats->count()) ? $seats->count() : abs($request->input('offset'));
+
+            if ($offset >= $total ){
+                $offset = 0;
+            }
+
             $limit = app('api_limit_value');
 
             $seats = $seats->skip($offset)->take($limit)->get();


### PR DESCRIPTION
# Description
Example of use case: If we have a license that have 20 license seats and we have the BootstrapTable pagination set to show tables with 10 items per page, when we are in the second page (license seats from 11 to 20) and then we try to see another license, but it only has 10 license seats, as the offset is remembered the system still try to retrieve license seats from range 11 to 20, but that license only have from 1 to 10, and shows a message that no records where found.

In this PR I just adjust the offset value if is the same or bigger than the license seats total of the license we are looking at the moment. This also have the benefit of still remember the page we were when coming back to the license with bigger number of license seats.

Fixes #13298 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP Dev Server
* OS version: Debian 11