### PR TITLE
Fixed #13376 Component checkout via API returns error

### DIFF
--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -235,7 +235,7 @@ class ComponentsController extends Controller
         $this->authorize('checkout', $component);
 
         $validator = Validator::make($request->all(), [
-            'asset_id'          => 'required|exists:assets,id',
+            'assigned_to'          => 'required|exists:assets,id',
             'assigned_qty'      => "required|numeric|min:1|digits_between:1,".$component->numRemaining(),
         ]);
 


### PR DESCRIPTION
# Description
When checking out a component via API in the backend we where validating the `asset_id` variable instead of `assigned_to`, producing an error because it never validate as true.

Fixes #13376

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP Dev Server
* OS version: Debian 11