### PR TITLE
Fixed #13372: Put guard around assigning location via LDAP

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -243,7 +243,7 @@ class LdapSync extends Command
                 $user->jobtitle = $item['jobtitle'];
                 $user->country = $item['country'];
                 $user->department_id = $department->id;
-                $user->location_id = $location->id;
+                $user->location_id = $location ? $location->id : null;
 
                 if($item['manager'] != null) {
                     // Check Cache first


### PR DESCRIPTION
A customer [fd-37146] also noticed some errors around LDAP syncs, where if they set no default location at all, the sync returns an error. This puts in a simple tristate to only try to retrieve the ID of the location if the location is not null.

I did a local edit on the customer instance to see if this fix actually does fix the problem and it seems to.

fixes #13372