### PR TITLE
Fixed #13382 The time zone is configured correctly and the date does not change anyway

### DIFF
--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -59,7 +59,7 @@ Form::macro('date_display_format', function ($name = 'date_display_format', $sel
     ];
 
     foreach ($formats as $format) {
-        $date_display_formats[$format] = Carbon::parse(date('Y').'-'.date('m').'-25')->format($format);
+        $date_display_formats[$format] = Carbon::parse(date('Y').'-'.date('m').'-'.date('d'))->format($format);
     }
     $select = '<select name="'.$name.'" class="'.$class.'" style="min-width:250px" aria-label="'.$name.'">';
     foreach ($date_display_formats as $format => $date_display_format) {


### PR DESCRIPTION
# Description
The Localization Settings view uses current year and month to show different date formats, but the day is fixed to '-25'. Some user was claiming that this should change with the timezone config, so I changed it to use current day. This screen:
![image](https://github.com/snipe/snipe-it/assets/653557/342c2ac5-e198-43b1-974b-cbf3779ff0e7)

I'm not sure if it's a legitimate problem, and I ask, but is reasonably small and easy change to be made. If this change is not desired we can just close this PR and inform user. No big deal :)

Fixes #13382 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 12
