### PR TITLE
Fixed Asset acceptance error when user company and asset company don't match

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -69,7 +69,7 @@ class AcceptanceController extends Controller
         }
 
         if (! Company::isCurrentUserHasAccess($acceptance->checkoutable)) {
-            return redirect()->route('account.accept')->with('error', trans('general.insufficient_permissions'));
+            return redirect()->route('account.accept')->with('error', trans('general.error_user_company'));
         }
 
         return view('account/accept.create', compact('acceptance'));

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -89,6 +89,14 @@ class AssetCheckoutController extends Controller
                 }
             }
 
+            $settings = \App\Models\Setting::getSettings();
+
+            if ($settings->full_multiple_companies_support){
+                if ($target->company_id != $asset->company_id){
+                    return redirect()->to("hardware/$assetId/checkout")->with('error', trans('general.error_user_company'));
+                }
+            }
+            
             if ($asset->checkOut($target, $admin, $checkout_at, $expected_checkin, e($request->get('note')), $request->get('name'))) {
                 return redirect()->route('hardware.index')->with('success', trans('admin/hardware/message.checkout.success'));
             }

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -453,6 +453,7 @@ return [
     'item_notes' => ':item Notes',
     'item_name_var' => ':item Name',
     'error_user_company' => 'User and Asset companies missmatch',
+    'error_user_company_accpept_view' => 'User and Asset companies doesn\'t match so you can\'t accept nor deny it, please check with your manager',
     'importer' => [
         'checked_out_to_fullname' => 'Checked Out to: Full Name',
         'checked_out_to_first_name' => 'Checked Out to: First Name',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -453,7 +453,7 @@ return [
     'item_notes' => ':item Notes',
     'item_name_var' => ':item Name',
     'error_user_company' => 'User and Asset companies missmatch',
-    'error_user_company_accpept_view' => 'An Asset assigned to you belongs to a different company so you can\'t accept nor deny it, please check with your manager',
+    'error_user_company_accept_view' => 'An Asset assigned to you belongs to a different company so you can\'t accept nor deny it, please check with your manager',
     'importer' => [
         'checked_out_to_fullname' => 'Checked Out to: Full Name',
         'checked_out_to_first_name' => 'Checked Out to: First Name',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -453,7 +453,7 @@ return [
     'item_notes' => ':item Notes',
     'item_name_var' => ':item Name',
     'error_user_company' => 'User and Asset companies missmatch',
-    'error_user_company_accpept_view' => 'User and Asset companies doesn\'t match so you can\'t accept nor deny it, please check with your manager',
+    'error_user_company_accpept_view' => 'An Asset assigned to you belongs to a different company so you can\'t accept nor deny it, please check with your manager',
     'importer' => [
         'checked_out_to_fullname' => 'Checked Out to: Full Name',
         'checked_out_to_first_name' => 'Checked Out to: First Name',

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -452,6 +452,7 @@ return [
     'serial_number'        => 'Serial Number',
     'item_notes' => ':item Notes',
     'item_name_var' => ':item Name',
+    'error_user_company' => 'User and Asset companies missmatch',
     'importer' => [
         'checked_out_to_fullname' => 'Checked Out to: Full Name',
         'checked_out_to_first_name' => 'Checked Out to: First Name',

--- a/resources/views/account/accept/index.blade.php
+++ b/resources/views/account/accept/index.blade.php
@@ -44,8 +44,11 @@
                 @if ($acceptance->checkoutable)
                 <td>{{ ($acceptance->checkoutable) ? $acceptance->checkoutable->present()->name : '' }}</td>
                 <td><a href="{{ route('account.accept.item', $acceptance) }}" class="btn btn-default btn-sm">{{ trans('general.accept_decline') }}</a></td>
+                @else
+                <td> ----- </td>
+                <td> {{ trans('general.error_user_company_accpept_view') }} </td>
+                @endif
               </tr>
-              @endif
               @endforeach
             </tbody>
           </table>

--- a/resources/views/account/accept/index.blade.php
+++ b/resources/views/account/accept/index.blade.php
@@ -46,7 +46,7 @@
                 <td><a href="{{ route('account.accept.item', $acceptance) }}" class="btn btn-default btn-sm">{{ trans('general.accept_decline') }}</a></td>
                 @else
                 <td> ----- </td>
-                <td> {{ trans('general.error_user_company_accpept_view') }} </td>
+                <td> {{ trans('general.error_user_company_accept_view') }} </td>
                 @endif
               </tr>
               @endforeach

--- a/resources/views/account/accept/index.blade.php
+++ b/resources/views/account/accept/index.blade.php
@@ -41,9 +41,11 @@
             <tbody>
               @foreach ($acceptances as $acceptance)
               <tr>
+                @if ($acceptance->checkoutable)
                 <td>{{ ($acceptance->checkoutable) ? $acceptance->checkoutable->present()->name : '' }}</td>
                 <td><a href="{{ route('account.accept.item', $acceptance) }}" class="btn btn-default btn-sm">{{ trans('general.accept_decline') }}</a></td>
               </tr>
+              @endif
               @endforeach
             </tbody>
           </table>


### PR DESCRIPTION
# Description
With full company support activated if an asset is checked out from company A to an user from company B, then when the user from B tries to accept the asset, it appears the 'Error: insufficient permission' sign. 

In this PR I tried to mitigate the issue by not showing any asset to accept/deny if this case already happened, so the users doesn't have to deal with that. And in the asset checkout method I check if full company support is enabled, and if it is now it doesn't allow the checkout to happen. Also it shows a more explicit error message "User and asset companies missmatch".

Fixes internal freshdesk 37131

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 12
