### PR TITLE
Fixes ChipperCi Pipeline

### DIFF
--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -37,11 +37,11 @@ pipeline:
 
   - name: PHPUnit Unit Tests
     cmd: |
-      # php artisan test --testsuite Unit
+      # phpunit --testsuite Unit
 
   - name: PHPUnit Feature Tests
     cmd: |
-      # php artisan test --testsuite Feature
+      # phpunit --testsuite Feature
 
 #  - name: Browser Tests
 #    cmd: |

--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -21,6 +21,7 @@ pipeline:
   - name: Setup
     cmd: |
       cp -v .env.testing.example .env
+      touch .env.testing
       composer install --no-interaction --prefer-dist --optimize-autoloader
 
   - name: Generate Key

--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -20,8 +20,7 @@ on:
 pipeline:
   - name: Setup
     cmd: |
-      cp -v .env.testing.example .env
-      touch .env.testing
+      cp -v .env.testing.example .env.testing
       composer install --no-interaction --prefer-dist --optimize-autoloader
 
   - name: Generate Key

--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -20,8 +20,7 @@ on:
 pipeline:
   - name: Setup
     cmd: |
-      cp -v .env.example .env
-      touch .env.testing
+      cp -v .env.testing .env
       composer install --no-interaction --prefer-dist --optimize-autoloader
 
   - name: Generate Key

--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -20,7 +20,7 @@ on:
 pipeline:
   - name: Setup
     cmd: |
-      cp -v .env.testing .env
+      cp -v .env.testing.example .env
       composer install --no-interaction --prefer-dist --optimize-autoloader
 
   - name: Generate Key

--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -33,15 +33,15 @@ pipeline:
 
   - name: Run Migrations
     cmd: |
-      # php artisan migrate --force
+      php artisan migrate --force
 
   - name: PHPUnit Unit Tests
     cmd: |
-      # php artisan test --testsuite Unit
+      php artisan test --testsuite Unit
 
   - name: PHPUnit Feature Tests
     cmd: |
-      # php artisan test --testsuite Feature
+      php artisan test --testsuite Feature
 
 #  - name: Browser Tests
 #    cmd: |

--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -20,6 +20,7 @@ on:
 pipeline:
   - name: Setup
     cmd: |
+      cp -v .env.testing.example .env
       cp -v .env.testing.example .env.testing
       composer install --no-interaction --prefer-dist --optimize-autoloader
 

--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -37,11 +37,11 @@ pipeline:
 
   - name: PHPUnit Unit Tests
     cmd: |
-      # phpunit --testsuite Unit
+      # php artisan test --testsuite Unit
 
   - name: PHPUnit Feature Tests
     cmd: |
-      # phpunit --testsuite Feature
+      # php artisan test --testsuite Feature
 
 #  - name: Browser Tests
 #    cmd: |

--- a/.chipperci.yml
+++ b/.chipperci.yml
@@ -21,8 +21,6 @@ pipeline:
   - name: Setup
     cmd: |
       cp -v .env.example .env
-#     This is simply to allow passing the guard in TestCase@setUp()
-#     https://chipperci.com/docs/builds/env
       touch .env.testing
       composer install --no-interaction --prefer-dist --optimize-autoloader
 


### PR DESCRIPTION
# Description

This PR fixes our ChipperCI Pipeline in a few ways:
1. Fixes a syntax error (using `#` for a comment in an invalid place)
2. Creates `.env` and `.env.testing` which seems strange but gets around the guard we have in our root `TestCase`
3. Actually runs the tests by uncommenting the previously commented commands (🤦🏾 sorry about that)