### PR TITLE
Added `CompanyableTrait` to `Department` model

### DIFF
--- a/app/Http/Controllers/Api/DepartmentsController.php
+++ b/app/Http/Controllers/Api/DepartmentsController.php
@@ -27,7 +27,7 @@ class DepartmentsController extends Controller
         $this->authorize('view', Department::class);
         $allowed_columns = ['id', 'name', 'image', 'users_count'];
 
-        $departments = Company::scopeCompanyables(Department::select(
+        $departments = Department::select(
             'departments.id',
             'departments.name',
             'departments.phone',
@@ -37,8 +37,8 @@ class DepartmentsController extends Controller
             'departments.manager_id',
             'departments.created_at',
             'departments.updated_at',
-            'departments.image'),
-             "company_id", "departments")->with('users')->with('location')->with('manager')->with('company')->withCount('users as users_count');
+            'departments.image'
+        )->with('users')->with('location')->with('manager')->with('company')->withCount('users as users_count');
 
         if ($request->filled('search')) {
             $departments = $departments->TextSearch($request->input('search'));

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -9,6 +9,7 @@ use Watson\Validating\ValidatingTrait;
 
 class Department extends SnipeModel
 {
+    use CompanyableTrait;
     use HasFactory;
 
     /**

--- a/tests/Feature/Api/Departments/DepartmentIndexTest.php
+++ b/tests/Feature/Api/Departments/DepartmentIndexTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Api\Departments;
 use App\Models\Company;
 use App\Models\Department;
 use App\Models\User;
+use Illuminate\Routing\Route;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
@@ -12,6 +13,18 @@ use Tests\TestCase;
 class DepartmentIndexTest extends TestCase
 {
     use InteractsWithSettings;
+
+    public function testViewingDepartmentIndexRequiresAuthentication()
+    {
+        $this->getJson(route('api.departments.index'))->assertRedirect();
+    }
+
+    public function testViewingDepartmentIndexRequiresPermission()
+    {
+        $this->actingAsForApi(User::factory()->create())
+            ->getJson(route('api.departments.index'))
+            ->assertForbidden();
+    }
 
     public function testDepartmentIndexReturnsExpectedDepartments()
     {

--- a/tests/Feature/Api/Departments/DepartmentIndexTest.php
+++ b/tests/Feature/Api/Departments/DepartmentIndexTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature\Api\Departments;
+
+use App\Models\Company;
+use App\Models\Department;
+use App\Models\User;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class DepartmentIndexTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testDepartmentIndexReturnsExpectedDepartments()
+    {
+        Department::factory()->count(3)->create();
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(
+                route('api.departments.index', [
+                    'sort' => 'name',
+                    'order' => 'asc',
+                    'offset' => '0',
+                    'limit' => '20',
+                ]))
+            ->assertOk()
+            ->assertJsonStructure([
+                'total',
+                'rows',
+            ])
+            ->assertJson(fn(AssertableJson $json) => $json->has('rows', 3)->etc());
+    }
+
+    public function testDepartmentIndexAdheresToCompanyScoping()
+    {
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $departmentA = Department::factory()->for($companyA)->create();
+        $departmentB = Department::factory()->for($companyB)->create();
+
+        $superUser = $companyA->users()->save(User::factory()->superuser()->make());
+        $userInCompanyA = $companyA->users()->save(User::factory()->viewDepartments()->make());
+        $userInCompanyB = $companyB->users()->save(User::factory()->viewDepartments()->make());
+
+        $this->settings->disableMultipleFullCompanySupport();
+
+        $this->actingAsForApi($superUser)
+            ->getJson(route('api.departments.index'))
+            ->assertResponseContainsInRows($departmentA)
+            ->assertResponseContainsInRows($departmentB);
+
+        $this->actingAsForApi($userInCompanyA)
+            ->getJson(route('api.departments.index'))
+            ->assertResponseContainsInRows($departmentA)
+            ->assertResponseContainsInRows($departmentB);
+
+        $this->actingAsForApi($userInCompanyB)
+            ->getJson(route('api.departments.index'))
+            ->assertResponseContainsInRows($departmentA)
+            ->assertResponseContainsInRows($departmentB);
+
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $this->actingAsForApi($superUser)
+            ->getJson(route('api.departments.index'))
+            ->assertResponseContainsInRows($departmentA)
+            ->assertResponseContainsInRows($departmentB);
+
+        $this->actingAsForApi($userInCompanyA)
+            ->getJson(route('api.departments.index'))
+            ->assertResponseContainsInRows($departmentA)
+            ->assertResponseDoesNotContainInRows($departmentB);
+
+        $this->actingAsForApi($userInCompanyB)
+            ->getJson(route('api.departments.index'))
+            ->assertResponseDoesNotContainInRows($departmentA)
+            ->assertResponseContainsInRows($departmentB);
+    }
+}


### PR DESCRIPTION
# Description

This PR adds a ~~couple~~ (see edit) simple tests around the `Api/DepartmentsController`'s `index` method to ensure it returns the number of rows expected (specific values aren't tested) and that the results adhere to full company scoping when it is enabled.

Since we have a passing test for adhering to company scoping we can add the `CompanyableTrait` to the `Department` model and remove the `Company::scopeCompanyables()` wrapper in the controller.

This is another small step in the direction of simplifying how models are scoped to companies.

---

Edit: snuck in a couple more simple tests for authentication and authorization.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) (sort of ❓)