### PR TITLE
Fixed #13417 - Added mailgun endpoint option, defaulting to the US

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -25,6 +25,7 @@ return [
     'mailgun' => [
         'domain' => env('MAILGUN_DOMAIN'),
         'secret' => env('MAILGUN_SECRET'),
+        'endpoint' => env('MAILGUN_ENDPOINT', 'api.mailgun.net'),
     ],
 
     'mandrill' => [


### PR DESCRIPTION
This just adds the mailgun endpoint to the services config file (defaulting to the US region so we don't break existing integrations), allowing UK mailgun users to add `MAILGUN_ENDPOINT=api.eu.mailgun.net` to their env per the [mailgun](https://documentation.mailgun.com/en/latest/api-intro.html#base-url-1) and [laravel](https://laravel.com/docs/8.x/mail#mailgun-driver) documentation. 
