### PR TITLE
Re-add the option for asset_eol_date as an import field

### DIFF
--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -215,6 +215,7 @@ class Importer extends Component
             'manufacturer' => trans('general.manufacturer'),
             'order_number' => trans('general.order_number'),
             'image' => trans('general.importer.image_filename'),
+            'asset_eol_date' => trans('admin/hardware/form.eol_date'),
             /**
              * Checkout fields:
              * Assets can be checked out to other assets, people, or locations, but we currently


### PR DESCRIPTION
[fd-36545] We _had_ this before, but due to a refactor it somehow got merged out :/

I tested this by uploading a CSV with a specific EOL date set in a column, and mapping that (well, it auto-mapped), and then importing, and then making sure that the assets showed up with that EOL date. That worked.