### PR TITLE
Fixed tooltip not loading on encrypted field lock icon on asset detail view

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -973,7 +973,12 @@
 
             $(function () {
 
-                $('[data-tooltip="true"]').tooltip();
+                // Invoke Bootstrap 3's tooltip
+                $('[data-tooltip="true"]').tooltip({
+                    container: 'body',
+                    animation: true,
+                });
+                
                 $('[data-toggle="popover"]').popover();
                 $('.select2 span').addClass('needsclick');
                 $('.select2 span').removeAttr('title');

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -85,3 +85,12 @@
     </div>
   @endforeach
 @endif
+
+
+<script nonce="{{ csrf_token() }}">
+    // We have to re-call the tooltip since this is pulled in after the DOM has loaded
+    $('[data-tooltip="true"]').tooltip({
+        container: 'body',
+        animation: true,
+    });
+</script>


### PR DESCRIPTION
This fixes an issue reported in SC-23552 where the "encrypted field" tooltip was showing as blank - and also fixes one we didn't notice, which is that the tooltip doesn't load at all if you switch models on edit or create, since the DOM is already loaded when we ajax in those form fields. 

### Before

![Clipboard 2023-25-07 at 5 02 37 PM](https://github.com/snipe/snipe-it/assets/197404/3053615e-e4c6-4f33-84cc-d3405a6b27b6)

### After 
<img width="406" alt="Screenshot 2023-08-08 at 6 56 11 PM" src="https://github.com/snipe/snipe-it/assets/197404/b80bfe80-963e-4aed-b954-094f5a888fd7">

### On switching models in create/edit

<img width="903" alt="Screenshot 2023-08-08 at 6 56 25 PM" src="https://github.com/snipe/snipe-it/assets/197404/04ce3ae5-ba73-44ad-8924-cc8fad24e640">

