### PR TITLE
Improved test stability and messaging

### DIFF
--- a/tests/Support/CustomTestMacros.php
+++ b/tests/Support/CustomTestMacros.php
@@ -24,7 +24,10 @@ trait CustomTestMacros
             function (Model $model, string $property = 'name') use ($guardAgainstNullProperty) {
                 $guardAgainstNullProperty($model, $property);
 
-                Assert::assertTrue(collect($this['rows'])->pluck($property)->contains(e($model->{$property})));
+                Assert::assertTrue(
+                    collect($this['rows'])->pluck($property)->contains(e($model->{$property})),
+                    "Response did not contain the expected value: {$model->{$property}}"
+                );
 
                 return $this;
             }
@@ -35,7 +38,10 @@ trait CustomTestMacros
             function (Model $model, string $property = 'name') use ($guardAgainstNullProperty) {
                 $guardAgainstNullProperty($model, $property);
 
-                Assert::assertFalse(collect($this['rows'])->pluck($property)->contains(e($model->{$property})));
+                Assert::assertFalse(
+                    collect($this['rows'])->pluck($property)->contains(e($model->{$property})),
+                    "Response contained unexpected value: {$model->{$property}}"
+                );
 
                 return $this;
             }
@@ -46,7 +52,10 @@ trait CustomTestMacros
             function (Model $model, string $property = 'id') use ($guardAgainstNullProperty) {
                 $guardAgainstNullProperty($model, $property);
 
-                Assert::assertTrue(collect($this->json('results'))->pluck('id')->contains(e($model->{$property})));
+                Assert::assertTrue(
+                    collect($this->json('results'))->pluck('id')->contains(e($model->{$property})),
+                    "Response did not contain the expected value: {$model->{$property}}"
+                );
 
                 return $this;
             }
@@ -57,7 +66,10 @@ trait CustomTestMacros
             function (Model $model, string $property = 'id') use ($guardAgainstNullProperty) {
                 $guardAgainstNullProperty($model, $property);
 
-                Assert::assertFalse(collect($this->json('results'))->pluck('id')->contains(e($model->{$property})));
+                Assert::assertFalse(
+                    collect($this->json('results'))->pluck('id')->contains(e($model->{$property})),
+                    "Response contained unexpected value: {$model->{$property}}"
+                );
 
                 return $this;
             }

--- a/tests/Support/CustomTestMacros.php
+++ b/tests/Support/CustomTestMacros.php
@@ -24,7 +24,7 @@ trait CustomTestMacros
             function (Model $model, string $property = 'name') use ($guardAgainstNullProperty) {
                 $guardAgainstNullProperty($model, $property);
 
-                Assert::assertTrue(collect($this['rows'])->pluck($property)->contains($model->{$property}));
+                Assert::assertTrue(collect($this['rows'])->pluck($property)->contains(e($model->{$property})));
 
                 return $this;
             }
@@ -35,7 +35,7 @@ trait CustomTestMacros
             function (Model $model, string $property = 'name') use ($guardAgainstNullProperty) {
                 $guardAgainstNullProperty($model, $property);
 
-                Assert::assertFalse(collect($this['rows'])->pluck($property)->contains($model->{$property}));
+                Assert::assertFalse(collect($this['rows'])->pluck($property)->contains(e($model->{$property})));
 
                 return $this;
             }
@@ -46,7 +46,7 @@ trait CustomTestMacros
             function (Model $model, string $property = 'id') use ($guardAgainstNullProperty) {
                 $guardAgainstNullProperty($model, $property);
 
-                Assert::assertTrue(collect($this->json('results'))->pluck('id')->contains($model->{$property}));
+                Assert::assertTrue(collect($this->json('results'))->pluck('id')->contains(e($model->{$property})));
 
                 return $this;
             }
@@ -57,7 +57,7 @@ trait CustomTestMacros
             function (Model $model, string $property = 'id') use ($guardAgainstNullProperty) {
                 $guardAgainstNullProperty($model, $property);
 
-                Assert::assertFalse(collect($this->json('results'))->pluck('id')->contains($model->{$property}));
+                Assert::assertFalse(collect($this->json('results'))->pluck('id')->contains(e($model->{$property})));
 
                 return $this;
             }


### PR DESCRIPTION
# Description

This tiny PR simply improves some of our custom test response helpers by escaping the model property being checked and adding a help messages that are displayed during failures.

It was rare but I noticed sporadic failures running tests locally when faker generated a name within a factory that had punctuation in it. For example, looking for the generated name `O'Shea` would fail because API responses have the values escaped so we should actually be looking for `O&#039;Shea`.