### PR TITLE
Allowed permissions in the user factory to be chained

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -81,11 +81,7 @@ class UserFactory extends Factory
 
     public function superuser()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"superuser":"1"}',
-            ];
-        });
+        return $this->appendPermission(['superuser' => '1']);
     }
 
     public function admin()
@@ -102,342 +98,204 @@ class UserFactory extends Factory
 
     public function viewAssets()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"assets.view":"1"}',
-            ];
-        });
+        return $this->appendPermission(['assets.view' => '1']);
     }
 
     public function createAssets()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"assets.create":"1"}',
-            ];
-        });
+        return $this->appendPermission(['assets.create' => '1']);
     }
 
     public function editAssets()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"assets.edit":"1"}',
-            ];
-        });
+        return $this->appendPermission(['assets.edit' => '1']);
     }
 
     public function deleteAssets()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"assets.delete":"1"}',
-            ];
-        });
+        return $this->appendPermission(['assets.delete' => '1']);
     }
 
     public function checkinAssets()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"assets.checkin":"1"}',
-            ];
-        });
+        return $this->appendPermission(['assets.checkin' => '1']);
     }
 
     public function checkoutAssets()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"assets.checkout":"1"}',
-            ];
-        });
+        return $this->appendPermission(['assets.checkout' => '1']);
     }
 
     public function viewRequestableAssets()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"assets.view.requestable":"1"}',
-            ];
-        });
+        return $this->appendPermission(['assets.view.requestable' => '1']);
     }
 
     public function viewAccessories()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"accessories.view":"1"}',
-            ];
-        });
+        return $this->appendPermission(['accessories.view' => '1']);
     }
 
     public function createAccessories()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"accessories.create":"1"}',
-            ];
-        });
+        return $this->appendPermission(['accessories.create' => '1']);
     }
 
     public function editAccessories()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"accessories.edit":"1"}',
-            ];
-        });
+        return $this->appendPermission(['accessories.edit' => '1']);
     }
 
     public function deleteAccessories()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"accessories.delete":"1"}',
-            ];
-        });
+        return $this->appendPermission(['accessories.delete' => '1']);
     }
 
     public function checkinAccessories()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"accessories.checkin":"1"}',
-            ];
-        });
+        return $this->appendPermission(['accessories.checkin' => '1']);
     }
 
     public function checkoutAccessories()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"accessories.checkout":"1"}',
-            ];
-        });
+        return $this->appendPermission(['accessories.checkout' => '1']);
     }
 
     public function viewConsumables()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"consumables.view":"1"}',
-            ];
-        });
+        return $this->appendPermission(['consumables.view' => '1']);
     }
 
     public function createConsumables()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"consumables.create":"1"}',
-            ];
-        });
+        return $this->appendPermission(['consumables.create' => '1']);
     }
 
     public function editConsumables()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"consumables.edit":"1"}',
-            ];
-        });
+        return $this->appendPermission(['consumables.edit' => '1']);
     }
 
     public function deleteConsumables()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"consumables.delete":"1"}',
-            ];
-        });
+        return $this->appendPermission(['consumables.delete' => '1']);
     }
 
     public function checkinConsumables()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"consumables.checkin":"1"}',
-            ];
-        });
+        return $this->appendPermission(['consumables.checkin' => '1']);
     }
 
     public function checkoutConsumables()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"consumables.checkout":"1"}',
-            ];
-        });
+        return $this->appendPermission(['consumables.checkout' => '1']);
     }
 
     public function viewDepartments()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"departments.view":"1"}',
-            ];
-        });
+        return $this->appendPermission(['departments.view' => '1']);
     }
 
     public function viewLicenses()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"licenses.view":"1"}',
-            ];
-        });
+        return $this->appendPermission(['licenses.view' => '1']);
     }
 
     public function createLicenses()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"licenses.create":"1"}',
-            ];
-        });
+        return $this->appendPermission(['licenses.create' => '1']);
     }
 
     public function editLicenses()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"licenses.edit":"1"}',
-            ];
-        });
+        return $this->appendPermission(['licenses.edit' => '1']);
     }
 
     public function deleteLicenses()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"licenses.delete":"1"}',
-            ];
-        });
+        return $this->appendPermission(['licenses.delete' => '1']);
     }
 
     public function checkoutLicenses()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"licenses.checkout":"1"}',
-            ];
-        });
+        return $this->appendPermission(['licenses.checkout' => '1']);
     }
 
     public function viewKeysLicenses()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"licenses.keys":"1"}',
-            ];
-        });
+        return $this->appendPermission(['licenses.keys' => '1']);
     }
 
     public function viewComponents()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"components.view":"1"}',
-            ];
-        });
+        return $this->appendPermission(['components.view' => '1']);
     }
 
     public function createComponents()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"components.create":"1"}',
-            ];
-        });
+        return $this->appendPermission(['components.create' => '1']);
     }
 
     public function editComponents()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"components.edit":"1"}',
-            ];
-        });
+        return $this->appendPermission(['components.edit' => '1']);
     }
 
     public function deleteComponents()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"components.delete":"1"}',
-            ];
-        });
+        return $this->appendPermission(['components.delete' => '1']);
     }
 
     public function checkinComponents()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"components.checkin":"1"}',
-            ];
-        });
+        return $this->appendPermission(['components.checkin' => '1']);
     }
 
     public function checkoutComponents()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"components.checkout":"1"}',
-            ];
-        });
+        return $this->appendPermission(['components.checkout' => '1']);
     }
 
     public function viewUsers()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"users.view":"1"}',
-            ];
-        });
+        return $this->appendPermission(['users.view' => '1']);
     }
 
     public function createUsers()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"users.create":"1"}',
-            ];
-        });
+        return $this->appendPermission(['users.create' => '1']);
     }
 
     public function editUsers()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"users.edit":"1"}',
-            ];
-        });
+        return $this->appendPermission(['users.edit' => '1']);
     }
 
     public function deleteUsers()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"users.delete":"1"}',
-            ];
-        });
+        return $this->appendPermission(['users.delete' => '1']);
     }
 
     public function canEditOwnLocation()
     {
-        return $this->state(function () {
-            return [
-                'permissions' => '{"self.edit_location":"1"}',
-            ];
-        });
+        return $this->appendPermission(['self.edit_location' => '1']);
     }
 
     public function canViewReports()
     {
-        return $this->state(function () {
+        return $this->appendPermission(['reports.view' => '1']);
+    }
+
+    private function appendPermission(array $permission)
+    {
+        return $this->state(function ($currentState) use ($permission) {
             return [
-                'permissions' => '{"reports.view":"1"}',
+                'permissions' => json_encode(
+                    array_merge(
+                        json_decode($currentState['permissions'], true),
+                        $permission
+                    )
+                ),
             ];
         });
     }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -30,7 +30,7 @@ class UserFactory extends Factory
             'locale' => 'en',
             'notes' => 'Created by DB seeder',
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-            'permissions' => '{"user":"0"}',
+            'permissions' => '{}',
             'phone' => $this->faker->phoneNumber(),
             'state' => $this->faker->stateAbbr(),
             'username' => $this->faker->username(),


### PR DESCRIPTION
# Description

This PR allows multiple permissions to be added when chaining off of the user factory.

Previously, trying to apply two permissions in this way:
```php
User::factory()->viewComponents()->viewUsers()->create();
```
would result in only the second permission, being able to view users, to be applied.

This PR fixes that by calling a new method within all of the permission related factory states of the user model that appends the permission instead of overwrites it.

## Type of change

- [x] New feature (non-breaking change which adds functionality)