### PR TITLE
Fixed route for accessory index

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -131,7 +131,8 @@ class AccessoriesController extends Controller
         // Check if the asset exists
         if (is_null($accessory_to_clone = Accessory::find($accessoryId))) {
             // Redirect to the asset management page
-            return redirect()->route('accessory.index')->with('error', trans('admin/accessories/message.does_not_exist'));
+            return redirect()->route('accessories.index')
+                ->with('error', trans('admin/accessories/message.does_not_exist', ['id' => $accessoryId]));
         }
 
         $accessory = clone $accessory_to_clone;


### PR DESCRIPTION
Looks like we were pulling the wrong route on accessory cloning if the accessory ID isn't valid.