### PR TITLE
Fixed #13317 Accessories declined by user remain assigned

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -245,6 +245,36 @@ class AcceptanceController extends Controller
             $return_msg = trans('admin/users/message.accepted');
 
         } else {
+
+            /**
+             * Check for the eula-pdfs directory
+             */
+            if (! Storage::exists('private_uploads/eula-pdfs')) {
+                Storage::makeDirectory('private_uploads/eula-pdfs', 775);
+            }
+
+            if (Setting::getSettings()->require_accept_signature == '1') {
+                
+                // Check if the signature directory exists, if not create it
+                if (!Storage::exists('private_uploads/signatures')) {
+                    Storage::makeDirectory('private_uploads/signatures', 775);
+                }
+
+                // The item was accepted, check for a signature
+                if ($request->filled('signature_output')) {
+                    $sig_filename = 'siglog-' . Str::uuid() . '-' . date('Y-m-d-his') . '.png';
+                    $data_uri = $request->input('signature_output');
+                    $encoded_image = explode(',', $data_uri);
+                    $decoded_image = base64_decode($encoded_image[1]);
+                    Storage::put('private_uploads/signatures/' . $sig_filename, (string)$decoded_image);
+
+                    // No image data is present, kick them back.
+                    // This mostly only applies to users on super-duper crapola browsers *cough* IE *cough*
+                } else {
+                    return redirect()->back()->with('error', trans('general.shitty_browser'));
+                }
+            }
+            
             // Format the data to send the declined notification
             $branding_settings = SettingsController::getPDFBranding();
 
@@ -281,10 +311,17 @@ class AcceptanceController extends Controller
                 'item_model' => $display_model,
                 'item_serial' => $item->serial,
                 'declined_date' => Carbon::parse($acceptance->declined_at)->format('Y-m-d'),
+                'signature' => ($sig_filename) ? storage_path() . '/private_uploads/signatures/' . $sig_filename : null,
                 'assigned_to' => $assigned_to,
                 'company_name' => $branding_settings->site_name,
                 'date_settings' => $branding_settings->date_display_format,
             ];
+
+            if ($pdf_view_route!='') {
+                \Log::debug($pdf_filename.' is the filename, and the route was specified.');
+                $pdf = Pdf::loadView($pdf_view_route, $data);
+                Storage::put('private_uploads/eula-pdfs/' .$pdf_filename, $pdf->output());
+            }
 
             $acceptance->decline($sig_filename);
             $acceptance->notify(new AcceptanceAssetDeclinedNotification($data));

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -32,6 +32,16 @@ class Accessory extends SnipeModel
 
     use Searchable;
     use Acceptable;
+
+    public function declinedCheckout(User $declinedBy, $signature)
+    {
+        if (is_null($accessory_user = \DB::table('accessories_users')->where('assigned_to', $declinedBy->id)->where('accessory_id', $this->id)->latest('created_at'))) {
+            // Redirect to the accessory management page with error
+            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.does_not_exist'));
+        }
+
+        $accessory_user->limit(1)->delete();
+    }
     
     /**
      * The attributes that should be included when searching the model.

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -32,16 +32,6 @@ class Accessory extends SnipeModel
 
     use Searchable;
     use Acceptable;
-
-    public function declinedCheckout(User $declinedBy, $signature)
-    {
-        if (is_null($accessory_user = \DB::table('accessories_users')->where('assigned_to', $declinedBy->id)->where('accessory_id', $this->id)->latest('created_at'))) {
-            // Redirect to the accessory management page with error
-            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.does_not_exist'));
-        }
-
-        $accessory_user->limit(1)->delete();
-    }
     
     /**
      * The attributes that should be included when searching the model.
@@ -357,6 +347,22 @@ class Accessory extends SnipeModel
         $remaining = $total - $checkedout;
 
         return (int) $remaining;
+    }
+
+    /**
+     * Run after the checkout acceptance was declined by the user
+     * 
+     * @param  User   $acceptedBy
+     * @param  string $signature
+     */
+    public function declinedCheckout(User $declinedBy, $signature)
+    {
+        if (is_null($accessory_user = \DB::table('accessories_users')->where('assigned_to', $declinedBy->id)->where('accessory_id', $this->id)->latest('created_at'))) {
+            // Redirect to the accessory management page with error
+            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.does_not_exist'));
+        }
+
+        $accessory_user->limit(1)->delete();
     }
 
     /**


### PR DESCRIPTION
# Description
When an accessory is checked out and acceptance is required, if the user rejects the asset it remains assigned to them. This is contrary to the behavior on assets which are unassigned if declined, so I added the `declinedCheckout` method to the Accessory model.

Then, as the linked issue remarks, the signature when the asset is rejected is not showed in history. I also add this to the declined item functionality. Maybe is a little out of scope, but I think it's a small change and can be made here.

Fixes #13317 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
