### PR TITLE
Fixed #13450 - remove escaping on saveing new custom fields

### DIFF
--- a/app/Http/Controllers/CustomFieldsetsController.php
+++ b/app/Http/Controllers/CustomFieldsetsController.php
@@ -94,7 +94,7 @@ class CustomFieldsetsController extends Controller
         $this->authorize('create', CustomField::class);
 
         $fieldset = new CustomFieldset([
-                'name' => e($request->get('name')),
+                'name' => $request->get('name'),
                 'user_id' => Auth::user()->id,
         ]);
 


### PR DESCRIPTION
This fixes #13450 - we were escaping the fieldset name on storing a new fieldname.