### PR TITLE
Fixed #13382 - confusion around localization date

### DIFF
--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -63,7 +63,7 @@ Form::macro('date_display_format', function ($name = 'date_display_format', $sel
     }
     $select = '<select name="'.$name.'" class="'.$class.'" style="min-width:250px" aria-label="'.$name.'">';
     foreach ($date_display_formats as $format => $date_display_format) {
-        $select .= '<option value="'.$format.'"'.($selected == $format ? ' selected="selected" role="option" aria-selected="true"' : ' aria-selected="false"').'">'.$date_display_format.'</option> ';
+        $select .= '<option value="'.$format.'"'.($selected == $format ? ' selected="selected" role="option" aria-selected="true"' : ' aria-selected="false"').'">'.$format.' (Example: '.$date_display_format.')</option> ';
     }
 
     $select .= '</select>';

--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -59,11 +59,11 @@ Form::macro('date_display_format', function ($name = 'date_display_format', $sel
     ];
 
     foreach ($formats as $format) {
-        $date_display_formats[$format] = Carbon::parse(date('Y').'-'.date('m').'-25')->format($format);
+        $date_display_formats[$format] = Carbon::parse(date('Y-m-d'))->format($format);
     }
-    $select = '<select name="'.$name.'" class="'.$class.'" style="min-width:250px" aria-label="'.$name.'">';
+    $select = '<select name="'.$name.'" class="'.$class.'" style="min-width:100%" aria-label="'.$name.'">';
     foreach ($date_display_formats as $format => $date_display_format) {
-        $select .= '<option value="'.$format.'"'.($selected == $format ? ' selected="selected" role="option" aria-selected="true"' : ' aria-selected="false"').'">'.$format.' (Example: '.$date_display_format.')</option> ';
+        $select .= '<option value="'.$format.'"'.($selected == $format ? ' selected="selected" role="option" aria-selected="true"' : ' aria-selected="false"').'">'.$date_display_format.'</option> ';
     }
 
     $select .= '</select>';

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -38,7 +38,7 @@
                 <div class="box-body">
 
 
-                    <div class="col-md-11 col-md-offset-1">
+                    <div class="col-md-12">
 
                         <!-- Language -->
                         <div class="form-group {{ $errors->has('site_name') ? 'error' : '' }}">
@@ -52,17 +52,22 @@
                             </div>
                         </div>
 
+
                         <!-- Date format -->
                         <div class="form-group {{ $errors->has('time_display_format') ? 'error' : '' }}">
                             <div class="col-md-3">
                                 {{ Form::label('time_display_format', trans('general.time_and_date_display')) }}
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-md-10">
                                 {!! Form::date_display_format('date_display_format', Request::old('date_display_format', $setting->date_display_format), 'select2') !!}
-
+                            </div>
+                            <div class="col-md-3">
                                 {!! Form::time_display_format('time_display_format', Request::old('time_display_format', $setting->time_display_format), 'select2') !!}
 
-                                {!! $errors->first('time_display_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                            </div>
+                            {!! $errors->first('time_display_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                            <div class="col-md-11 col-offset-3">
+                                <p class="help-block">The date shown in the drop-down is just an example to display the different date formats. It is not meant to reflect today's date.</p>
                             </div>
                         </div>
 

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -58,17 +58,15 @@
                             <div class="col-md-3">
                                 {{ Form::label('time_display_format', trans('general.time_and_date_display')) }}
                             </div>
-                            <div class="col-md-10">
+                            <div class="col-md-5">
                                 {!! Form::date_display_format('date_display_format', Request::old('date_display_format', $setting->date_display_format), 'select2') !!}
                             </div>
                             <div class="col-md-3">
                                 {!! Form::time_display_format('time_display_format', Request::old('time_display_format', $setting->time_display_format), 'select2') !!}
+                            </div>
+                            
+                            {!! $errors->first('time_display_format', '<div class="col-md-9 col-md-offset-3"><span class="alert-msg" aria-hidden="true">:message</span> </div>') !!}
 
-                            </div>
-                            {!! $errors->first('time_display_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                            <div class="col-md-11 col-offset-3">
-                                <p class="help-block">The date shown in the drop-down is just an example to display the different date formats. It is not meant to reflect today's date.</p>
-                            </div>
                         </div>
 
                         <!-- Currency -->


### PR DESCRIPTION
Fixes #13382 - This is a small change that will hopefully clear up confusing around the date format select list. I had previously used this month, then the day of 25, and the current year (so that date formats like Feb 3, 2023 - which could be month-day-year OR day-month-year would be clearer, since there is no 25th month), but it seems it was causing confusion. This uses today's date, and hopefully the format is guessable via the other options in the menu.

This could still be confusing if the user is changing this on a day where the month and the day are the same (Feb 2, 2023) which was also what I was trying to avoid, but hopefully this will help. (I had considered including the `$format` in the dropdown, but not everyone will know what `n/d/y` means. ¯\_(ツ)_/¯ 