### PR TITLE
Fixed passing invalid argument to `strpos()`

### DIFF
--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -74,9 +74,9 @@ class AssetObserver
             $tag = $asset->asset_tag;
             $prefix = $settings->auto_increment_prefix;
             $number = substr($tag, strlen($prefix));
-            // IF - auto_increment_assets is on, AND (the prefix matches the start of the tag OR there is no prefix)
+            // IF - auto_increment_assets is on, AND (there is no prefix OR the prefix matches the start of the tag)
             //      AND the rest of the string after the prefix is all digits, THEN...
-            if ($settings->auto_increment_assets && (strpos($tag, $prefix) === 0 || $prefix=='') && preg_match('/\d+/',$number) === 1) {
+            if ($settings->auto_increment_assets && ($prefix=='' || strpos($tag, $prefix) === 0) && preg_match('/\d+/',$number) === 1) {
                 // new way of auto-trueing-up auto_increment ID's
                 $next_asset_tag = intval($number, 10) + 1;
                 // we had to use 'intval' because the $number could be '01234' and


### PR DESCRIPTION
# Description

I noticed a couple tests failing when run on PHP 7.4 due to an empty string being passed as the second parameter to [strpos()](https://www.php.net/manual/en/function.strpos.php) which isn't valid pre-8.0.

This small PR moves the existing `$prefix == ''` up so calling `strpos` is skipped if the prefix is an empty string.

@uberbrady can you double-check this makes sense please?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)