### PR TITLE
Fixed #13365 - Added LOGIN_AUTOCOMPLETE as env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,7 @@ AWS_DEFAULT_REGION=null
 # --------------------------------------------
 LOGIN_MAX_ATTEMPTS=5
 LOGIN_LOCKOUT_DURATION=60
+LOGIN_AUTOCOMPLETE=false
 
 # --------------------------------------------
 # OPTIONAL: FORGOTTEN PASSWORD SETTINGS

--- a/config/auth.php
+++ b/config/auth.php
@@ -132,4 +132,16 @@ return [
 
     'password_timeout' =>  env('PASSWORD_CONFIRM_TIMEOUT', 10800),
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Login form autocomplete
+    |--------------------------------------------------------------------------
+    |
+    | Determine whether to include autocomplete="off" on the login form. Some users may want to disable
+    | autocomplete for compliance with security requirements.
+    |
+    */
+    'login_autocomplete' => env('LOGIN_AUTOCOMPLETE', false),
+
 ];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -4,8 +4,9 @@
 {{-- Page content --}}
 @section('content')
 
-    <form role="form" action="{{ url('/login') }}" method="POST" autocomplete="false">
+    <form role="form" action="{{ url('/login') }}" method="POST" autocomplete="{{ (config('auth.login_autocomplete') === true) ? 'on' : 'off'  }}">
         <input type="hidden" name="_token" value="{{ csrf_token() }}" />
+
 
         <!-- this is a hack to prevent Chrome from trying to autocomplete fields -->
         <input type="text" name="prevent_autofill" id="prevent_autofill" value="" style="display:none;" aria-hidden="true">
@@ -45,12 +46,12 @@
 
                                         <div class="form-group{{ $errors->has('username') ? ' has-error' : '' }}">
                                             <label for="username"><i class="fas fa-user" aria-hidden="true"></i> {{ trans('admin/users/table.username')  }}</label>
-                                            <input class="form-control" placeholder="{{ trans('admin/users/table.username')  }}" name="username" type="text" id="username" autocomplete="off" autofocus>
+                                            <input class="form-control" placeholder="{{ trans('admin/users/table.username')  }}" name="username" type="text" id="username" autocomplete="{{ (config('auth.login_autocomplete') === true) ? 'on' : 'off'  }}" autofocus>
                                             {!! $errors->first('username', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                         </div>
                                         <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
                                             <label for="password"><i class="fa fa-key" aria-hidden="true"></i> {{ trans('admin/users/table.password')  }}</label>
-                                            <input class="form-control" placeholder="{{ trans('admin/users/table.password')  }}" name="password" type="password" id="password" autocomplete="off">
+                                            <input class="form-control" placeholder="{{ trans('admin/users/table.password')  }}" name="password" type="password" id="password" autocomplete="{{ (config('auth.login_autocomplete') === true) ? 'on' : 'off'  }}">
                                             {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                         </div>
                                         <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">


### PR DESCRIPTION
This is a potential fix for #13365 by adding a new env var (`LOGIN_AUTOCOMPLETE`) to the auth configs to allow the ability to toggle `autocomplete="off"` to the login form and form elements. It will default to false, since some security compliance regulations require it to be turned off since the login form handles sensitive information.

This might be unnecessary since modern Firefox (and many other web browsers) [already ignore this tag](https://caniuse.com/input-autocomplete-onoff), but it's the only thing I can think of that would affect whether or not Firefox will remember logins.

### Related Info:

- https://bugzilla.mozilla.org/show_bug.cgi?id=956906
- https://security.stackexchange.com/questions/49326/should-websites-be-allowed-to-disable-autocomplete-on-forms-or-fields 