### PR TITLE
Accessory checkin via API reported wrong target user

### DIFF
--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -331,7 +331,7 @@ class AccessoriesController extends Controller
         $accessory = Accessory::find($accessory_user->accessory_id);
         $this->authorize('checkin', $accessory);
 
-        $logaction = $accessory->logCheckin(User::find($accessory_user->user_id), $request->input('note'));
+        $logaction = $accessory->logCheckin(User::find($accessory_user->assigned_to), $request->input('note'));
 
         // Was the accessory updated?
         if (DB::table('accessories_users')->where('id', '=', $accessory_user->id)->delete()) {


### PR DESCRIPTION
Fixes [fd-34518]

We were reporting the `user_id` of the `accessories_users` table, when we wanted to report the `assigned_to` instead. `user_id` is the identity of the Admin doing the thing.

I need to test this before I can sign off on it, so I'm leaving it at draft - but I'll run a couple of API tests against my instance and see if this fix does fix the bug. Then I'll take it off of Draft.