### PR TITLE
Added Attribute names instead of ids for Asset history

### DIFF
--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -4,8 +4,12 @@ namespace App\Observers;
 
 use App\Models\Actionlog;
 use App\Models\Asset;
+use App\Models\AssetModel;
+use App\Models\Location;
+use App\Models\Company;
 use App\Models\Setting;
-use Illuminate\Support\Facades\Cache;
+use App\Models\Supplier;
+use Illuminate\Database\Eloquent\Model;
 use Auth;
 
 class AssetObserver
@@ -47,6 +51,7 @@ class AssetObserver
                     $changed[$key]['new'] = $asset->getAttributes()[$key];
                 }
 	    }
+
                $changed= $this->changedInfo($changed, $asset);
 
 	    if (empty($changed)){
@@ -62,24 +67,32 @@ class AssetObserver
             $logAction->logaction('update');
         }
     }
+    /**
+     * This takes the ids of the changed attributes and returns the names instead for the history view of an Asset
+     *
+     * @param  $asset
+     * @return void
+     */
     public function changedInfo($changed, $asset){
-        $relationships_to_check = ['company_id', 'rtd_location_id', 'model_id','supplier_id', 'location_id' ];
-        $list_of_change = [] ;
 
                 if(array_key_exists('rtd_location_id',$changed)) {
+                    $changed['rtd_location_id']['old'] = Location::find($changed['rtd_location_id']['old'])->name;
                     $changed['rtd_location_id']['new'] = $asset->defaultloc->name;
                 }
                if(array_key_exists('model_id', $changed)) {
+                   $changed['model_id']['old'] = AssetModel::find($changed['model_id']['old'])->name;
                    $changed['model_id']['new'] = $asset->model->name;
                }
                 if(array_key_exists('company_id', $changed)) {
+                    $changed['company_id']['old'] = Company::find($changed['company_id']['old'])->name;
                     $changed['company_id']['new'] = $asset->company->name;
                 }
                 if(array_key_exists('supplier_id', $changed)) {
+                    $changed['supplier_id']['old'] = Supplier::find($changed['supplier_id']['old'])->name;
                     $changed['supplier_id']['new'] = $asset->supplier->name;
                 }
+
             return $changed;
-//            dd($changed);
 
         }
 

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -9,7 +9,6 @@ use App\Models\Location;
 use App\Models\Company;
 use App\Models\Setting;
 use App\Models\Supplier;
-use Illuminate\Database\Eloquent\Model;
 use Auth;
 
 class AssetObserver

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -5,6 +5,7 @@ namespace App\Observers;
 use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\Setting;
+use Illuminate\Support\Facades\Cache;
 use Auth;
 
 class AssetObserver
@@ -39,14 +40,14 @@ class AssetObserver
         {
             $changed = [];
 
+
             foreach ($asset->getRawOriginal() as $key => $value) {
                 if ($asset->getRawOriginal()[$key] != $asset->getAttributes()[$key]) {
                     $changed[$key]['old'] = $asset->getRawOriginal()[$key];
                     $changed[$key]['new'] = $asset->getAttributes()[$key];
-                    dd($this->changedInfo($changed,$asset));
                 }
-
 	    }
+               $changed= $this->changedInfo($changed, $asset);
 
 	    if (empty($changed)){
 	        return;
@@ -62,17 +63,23 @@ class AssetObserver
         }
     }
     public function changedInfo($changed, $asset){
-        $relationships_to_check = ['company_id', 'rtd_location_id', 'model_id','supplier_id' ];
+        $relationships_to_check = ['company_id', 'rtd_location_id', 'model_id','supplier_id', 'location_id' ];
         $list_of_change = [] ;
 
                 if(array_key_exists('rtd_location_id',$changed)) {
-                    $list_of_change[] = $asset->defaultloc->name;
+                    $changed['rtd_location_id']['new'] = $asset->defaultloc->name;
                 }
                if(array_key_exists('model_id', $changed)) {
-                   $list_of_change[] = $asset->model->name;
+                   $changed['model_id']['new'] = $asset->model->name;
                }
-
-            return $list_of_change;
+                if(array_key_exists('company_id', $changed)) {
+                    $changed['company_id']['new'] = $asset->company->name;
+                }
+                if(array_key_exists('supplier_id', $changed)) {
+                    $changed['supplier_id']['new'] = $asset->supplier->name;
+                }
+            return $changed;
+//            dd($changed);
 
         }
 

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -43,7 +43,9 @@ class AssetObserver
                 if ($asset->getRawOriginal()[$key] != $asset->getAttributes()[$key]) {
                     $changed[$key]['old'] = $asset->getRawOriginal()[$key];
                     $changed[$key]['new'] = $asset->getAttributes()[$key];
+                    dd($this->changedInfo($changed,$asset));
                 }
+
 	    }
 
 	    if (empty($changed)){
@@ -59,6 +61,21 @@ class AssetObserver
             $logAction->logaction('update');
         }
     }
+    public function changedInfo($changed, $asset){
+        $relationships_to_check = ['company_id', 'rtd_location_id', 'model_id','supplier_id' ];
+        $list_of_change = [] ;
+
+                if(array_key_exists('rtd_location_id',$changed)) {
+                    $list_of_change[] = $asset->defaultloc->name;
+                }
+               if(array_key_exists('model_id', $changed)) {
+                   $list_of_change[] = $asset->model->name;
+               }
+
+            return $list_of_change;
+
+        }
+
 
     /**
      * Listen to the Asset created event, and increment


### PR DESCRIPTION
# Description
When the  `location` `company` `model` or `supplier` attributes are changed on an asset it now shows the names associated with these respective ids.

Before:
<img width="1664" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/5debb559-7218-4506-8ca4-76bda9c84a76">

After:
<img width="1664" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/813aad31-9530-4d3f-82de-ec02cd1ffd14">



Fixes #SC-14441

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
