### PR TITLE
Fixed #13464 typo in accessories clone

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -126,7 +126,7 @@ class AccessoriesController extends Controller
     public function getClone($accessoryId = null)
     {
 
-        $this->authorize('create', Accesory::class);
+        $this->authorize('create', Accessory::class);
 
         // Check if the asset exists
         if (is_null($accessory_to_clone = Accessory::find($accessoryId))) {

--- a/resources/lang/es-MX/admin/kits/general.php
+++ b/resources/lang/es-MX/admin/kits/general.php
@@ -12,7 +12,7 @@ return [
     'none_models'                       => 'No hay suficientes activos disponibles para :model para asignar. :qty son requeridos. ',
     'none_licenses'                     => 'No hay suficientes licencias disponibles para :license para asignar. :qty son requeridos. ',
     'none_consumables'                  => 'No hay suficientes unidades disponibles de :consumable para asignar. :qty son requeridas. ',
-    'none_accessory'                    => 'No hay suficientes unidades disponibles de :accesory para asignar. :qty son requeridas. ',
+    'none_accessory'                    => 'No hay suficientes unidades disponibles de :accessory para asignar. :qty son requeridas. ',
     'append_accessory'                  => 'Añadir accesorio',
     'update_appended_accessory'         => 'Actualizar accesorio adjunto',
     'append_consumable'                 => 'Añadir consumible',


### PR DESCRIPTION
This fixes #13464 (which was introduced in #12680), where a limited user would not be able to clone an accessory because there was a typo in the gate name. 