### PR TITLE
Check that there is a company before trying to get name property

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -39,7 +39,7 @@ class Label implements View
         $assets = $this->data->get('assets');
         $offset = $this->data->get('offset');
         $template = $this->data->get('template');
-        
+
         // If disabled, pass to legacy view
         if ((!$settings->label2_enable) && (!$template)) {
             return view('hardware/labels')
@@ -49,8 +49,12 @@ class Label implements View
                 ->with('count', $this->data->get('count'));
         }
 
-        if (empty($template)) $template = LabelModel::find($settings->label2_template);
-        elseif (is_string($template)) $template = LabelModel::find($template);
+        // If a specific template was set, use it, otherwise fall back to default
+        if (empty($template)) {
+            $template = LabelModel::find($settings->label2_template);
+        } elseif (is_string($template)) {
+            $template = LabelModel::find($template);
+        }
 
         $template->validate();
 
@@ -87,25 +91,36 @@ class Label implements View
                 $assetData->put('tag', $asset->asset_tag);
 
                 if ($template->getSupportTitle()) {
-                    $title = !empty($settings->label2_title) ?
-                        str_ireplace('{COMPANY}', $asset->company->name, $settings->label2_title) :
+
+                    if ($asset->company && !empty($settings->label2_title)) {
+                        $title = str_replace('{COMPANY}', $asset->company->name, $settings->label2_title);
                         $settings->qr_text;
-                    if (!empty($title)) $assetData->put('title', $title);
+                        $assetData->put('title', $title);
+                    }
                 }
 
                 if ($template->getSupportLogo()) {
-                    $logo = $settings->label2_asset_logo ?
-                        (
-                            !empty($asset->company->image) ? 
-                                Storage::disk('public')->path('companies/'.e($asset->company->image)) :
-                                null
-                        ) :
-                        (
-                            !empty($settings->label_logo) ?
-                                Storage::disk('public')->path(''.e($settings->label_logo)) :
-                                null
-                        );
-                    if (!empty($logo)) $assetData->put('logo', $logo);
+
+                    $logo = null;
+
+                    // Should we be trying to use a logo at all?
+                    if ($settings->label2_asset_logo='1') {
+
+                        // If we don't have a company image, fall back to the general site label image
+                        if (!empty($settings->label_logo)) {
+                            $logo = Storage::disk('public')->path('/'.e($settings->label_logo));
+                        }
+
+                        // If we have a company logo, use that first
+                        if (($asset->company) && ($asset->company->image!='')) {
+                            $logo = Storage::disk('public')->path('companies/'.e($asset->company->image));
+                        }
+
+                    }
+
+                    if (!empty($logo)) {
+                        $assetData->put('logo', $logo);
+                    }
                 }
 
                 if ($template->getSupport1DBarcode()) {

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -128,7 +128,7 @@
 
                                     <label class="form-control">
                                         <input type="checkbox" value="1" name="label2_asset_logo"{{ ((old('label2_asset_logo') == '1') || ($setting->label2_asset_logo) == '1') ? ' checked="checked"' : '' }} aria-label="label2_asset_logo">
-                                        {{ trans('general.yes') }}
+                                        {{ Form::label('label2_asset_logo', trans('admin/settings/general.label2_asset_logo')) }}
                                     </label>
                                     <p class="help-block">
                                         {!! trans('admin/settings/general.label2_asset_logo_help', ['setting_name' => trans('admin/settings/general.brand').' &gt; '.trans('admin/settings/general.label_logo')]) !!}


### PR DESCRIPTION
This hopefully fixes some of the final issues in #12050. I've added some comments and made sure to check that the asset in question has a company before trying to pull the name property, and fixed it so that if you select to use a logo, it will try to use the company logo first, but if it can't find one and it can't find a label image from the branding settings, it should default to no logo.

In my print preview (we just moved so we don't have a working printer yet), I'm still seeing the black outline for the labels, and I'm not sure we want that if they actually print on the screen. 

(The smiley is the company logo, the very tired me is a second company with an image, the snipe logo head is the overall "company label logo" - none of the other assets have companies and therefore fall back rot the generic logo)

<img width="1624" alt="Screenshot 2023-08-16 at 1 24 29 AM" src="https://github.com/snipe/snipe-it/assets/197404/44876f96-53d0-43e3-a63b-31eaa46f38c9">

<img width="1537" alt="Screenshot 2023-08-16 at 1 16 19 AM" src="https://github.com/snipe/snipe-it/assets/197404/daa832cf-ef2b-4f9f-862b-b7043c27e143">

That serial number gets pretty hard to read, but I'm not sure what - if anything - we can do about that.

I'm probably going to merge this, just because it's acting a little funny for users on master, but I'd probably want @cram42's feedback to make sure all of the changes I made today align with the intent and his testing. 