### PR TITLE
Fixed #13359 Advanced search by Default Location does not work

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1433,6 +1433,12 @@ class Asset extends Depreciable
                     });
                 }
 
+                if ($fieldname == 'rtd_location') {
+                    $query->whereHas('defaultLoc', function ($query) use ($search_val) {
+                        $query->where('locations.name', 'LIKE', '%'.$search_val.'%');
+                    });
+                }
+
                 if ($fieldname =='assigned_to') {
                     $query->whereHasMorph('assignedTo', [User::class], function ($query) use ($search_val) {
                         $query->where(function ($query) use ($search_val) {


### PR DESCRIPTION
# Description
Advanced search when looking for default location (rtd_location) wasn't working. This PR adds the query to Asset model `scopeByFilter()` method.

Fixes #13359 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
