### PR TITLE
Added better handling of information of asset history 

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -147,32 +147,32 @@ class ActionlogsTransformer
     {
 
         if(array_key_exists('rtd_location_id',$clean_meta)) {
-            $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."]". Location::find($clean_meta['rtd_location_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."]". Location::find($clean_meta['rtd_location_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."] ". Location::find($clean_meta['rtd_location_id']['old'])->name : trans('general.unassigned');
+            $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."] ". Location::find($clean_meta['rtd_location_id']['new'])->name : trans('general.unassigned');
             $clean_meta['Default Location'] = $clean_meta['rtd_location_id'];
             unset($clean_meta['rtd_location_id']);
         }
         if(array_key_exists('location_id', $clean_meta)) {
-            $clean_meta['location_id']['old'] = $clean_meta['location_id']['old'] ? "[id: ".$clean_meta['location_id']['old']."]".Location::find($clean_meta['location_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['location_id']['new'] = $clean_meta['location_id']['new'] ? "[id: ".$clean_meta['location_id']['new']."]".Location::find($clean_meta['location_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['location_id']['old'] = $clean_meta['location_id']['old'] ? "[id: ".$clean_meta['location_id']['old']."] ".Location::find($clean_meta['location_id']['old'])->name : trans('general.unassigned');
+            $clean_meta['location_id']['new'] = $clean_meta['location_id']['new'] ? "[id: ".$clean_meta['location_id']['new']."] ".Location::find($clean_meta['location_id']['new'])->name : trans('general.unassigned');
             $clean_meta['Current Location'] = $clean_meta['location_id'];
             unset($clean_meta['location_id']);
         }
         if(array_key_exists('model_id', $clean_meta)) {
-            $clean_meta['model_id']['old'] = "[id: ".$clean_meta['model_id']['old']."]".AssetModel::find($clean_meta['model_id']['old'])->name;
-            $clean_meta['model_id']['new'] = "[id: ".$clean_meta['model_id']['new']."]".AssetModel::find($clean_meta['model_id']['new'])->name; /* model is required at asset creation */
+            $clean_meta['model_id']['old'] = "[id: ".$clean_meta['model_id']['old']."] ".AssetModel::find($clean_meta['model_id']['old'])->name;
+            $clean_meta['model_id']['new'] = "[id: ".$clean_meta['model_id']['new']."] ".AssetModel::find($clean_meta['model_id']['new'])->name; /* model is required at asset creation */
             $clean_meta['Model'] = $clean_meta['model_id'];
             unset($clean_meta['model_id']);
         }
         if(array_key_exists('company_id', $clean_meta)) {
             $clean_meta['company_id']['old'] = $clean_meta['company_id']['old'] ? "[id: ".$clean_meta['company_id']['old']."]".Company::find($clean_meta['company_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['company_id']['new'] = $clean_meta['company_id']['new'] ? "[id: ".$clean_meta['company_id']['new']."]".Company::find($clean_meta['company_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['company_id']['new'] = $clean_meta['company_id']['new'] ? "[id: ".$clean_meta['company_id']['new']."] ".Company::find($clean_meta['company_id']['new'])->name : trans('general.unassigned');
             $clean_meta['Company'] = $clean_meta['company_id'];
             unset($clean_meta['company_id']);
         }
         if(array_key_exists('supplier_id', $clean_meta)) {
-            $clean_meta['supplier_id']['old'] = $clean_meta['supplier_id']['old'] ? "[id: ".$clean_meta['supplier_id']['old']."]".Supplier::find($clean_meta['supplier_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['supplier_id']['new'] = $clean_meta['supplier_id']['new'] ? "[id: ".$clean_meta['supplier_id']['new']."]".Supplier::find($clean_meta['supplier_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['supplier_id']['old'] = $clean_meta['supplier_id']['old'] ? "[id: ".$clean_meta['supplier_id']['old']."] ".Supplier::find($clean_meta['supplier_id']['old'])->name : trans('general.unassigned');
+            $clean_meta['supplier_id']['new'] = $clean_meta['supplier_id']['new'] ? "[id: ".$clean_meta['supplier_id']['new']."] ".Supplier::find($clean_meta['supplier_id']['new'])->name : trans('general.unassigned');
             $clean_meta['Supplier'] = $clean_meta['supplier_id'];
             unset($clean_meta['supplier_id']);
         }

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -147,32 +147,32 @@ class ActionlogsTransformer
     {
 
         if(array_key_exists('rtd_location_id',$clean_meta)) {
-            $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? Location::find($clean_meta['rtd_location_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? Location::find($clean_meta['rtd_location_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."]". Location::find($clean_meta['rtd_location_id']['old'])->name : trans('general.unassigned');
+            $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."]". Location::find($clean_meta['rtd_location_id']['new'])->name : trans('general.unassigned');
             $clean_meta['Default Location'] = $clean_meta['rtd_location_id'];
             unset($clean_meta['rtd_location_id']);
         }
         if(array_key_exists('location_id', $clean_meta)) {
-            $clean_meta['location_id']['old'] = $clean_meta['location_id']['old'] ? Location::find($clean_meta['location_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['location_id']['new'] = $clean_meta['location_id']['new'] ? Location::find($clean_meta['location_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['location_id']['old'] = $clean_meta['location_id']['old'] ? "[id: ".$clean_meta['location_id']['old']."]".Location::find($clean_meta['location_id']['old'])->name : trans('general.unassigned');
+            $clean_meta['location_id']['new'] = $clean_meta['location_id']['new'] ? "[id: ".$clean_meta['location_id']['new']."]".Location::find($clean_meta['location_id']['new'])->name : trans('general.unassigned');
             $clean_meta['Current Location'] = $clean_meta['location_id'];
             unset($clean_meta['location_id']);
         }
         if(array_key_exists('model_id', $clean_meta)) {
-            $clean_meta['model_id']['old'] = AssetModel::find($clean_meta['model_id']['old'])->name;
-            $clean_meta['model_id']['new'] = AssetModel::find($clean_meta['model_id']['new'])->name; /* model is required at asset creation */
+            $clean_meta['model_id']['old'] = "[id: ".$clean_meta['model_id']['old']."]".AssetModel::find($clean_meta['model_id']['old'])->name;
+            $clean_meta['model_id']['new'] = "[id: ".$clean_meta['model_id']['new']."]".AssetModel::find($clean_meta['model_id']['new'])->name; /* model is required at asset creation */
             $clean_meta['Model'] = $clean_meta['model_id'];
             unset($clean_meta['model_id']);
         }
         if(array_key_exists('company_id', $clean_meta)) {
-            $clean_meta['company_id']['old'] = $clean_meta['company_id']['old'] ? Company::find($clean_meta['company_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['company_id']['new'] = $clean_meta['company_id']['new'] ? Company::find($clean_meta['company_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['company_id']['old'] = $clean_meta['company_id']['old'] ? "[id: ".$clean_meta['company_id']['old']."]".Company::find($clean_meta['company_id']['old'])->name : trans('general.unassigned');
+            $clean_meta['company_id']['new'] = $clean_meta['company_id']['new'] ? "[id: ".$clean_meta['company_id']['new']."]".Company::find($clean_meta['company_id']['new'])->name : trans('general.unassigned');
             $clean_meta['Company'] = $clean_meta['company_id'];
             unset($clean_meta['company_id']);
         }
         if(array_key_exists('supplier_id', $clean_meta)) {
-            $clean_meta['supplier_id']['old'] = $clean_meta['supplier_id']['old'] ? Supplier::find($clean_meta['supplier_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['supplier_id']['new'] = $clean_meta['supplier_id']['new'] ? Supplier::find($clean_meta['supplier_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['supplier_id']['old'] = $clean_meta['supplier_id']['old'] ? "[id: ".$clean_meta['supplier_id']['old']."]".Supplier::find($clean_meta['supplier_id']['old'])->name : trans('general.unassigned');
+            $clean_meta['supplier_id']['new'] = $clean_meta['supplier_id']['new'] ? "[id: ".$clean_meta['supplier_id']['new']."]".Supplier::find($clean_meta['supplier_id']['new'])->name : trans('general.unassigned');
             $clean_meta['Supplier'] = $clean_meta['supplier_id'];
             unset($clean_meta['supplier_id']);
         }

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -4,6 +4,10 @@ namespace App\Http\Transformers;
 use App\Helpers\Helper;
 use App\Models\Actionlog;
 use App\Models\Setting;
+use App\Models\Company;
+use App\Models\Supplier;
+use App\Models\Location;
+use App\Models\AssetModel;
 use Illuminate\Database\Eloquent\Collection;
 
 class ActionlogsTransformer
@@ -53,6 +57,7 @@ class ActionlogsTransformer
                 }
 
             }
+            $clean_meta= $this->changedInfo($clean_meta);
         }
 
         $file_url = '';
@@ -131,6 +136,49 @@ class ActionlogsTransformer
             $array[] = (new UsersTransformer)->transformUser($user);
         }
         return (new DatatablesTransformer)->transformDatatables($array, $total);
+    }
+    /**
+     * This takes the ids of the changed attributes and returns the names instead for the history view of an Asset
+     *
+     * @param  array $clean_meta
+     * @return array
+     */
+    public function changedInfo(array $clean_meta)
+    {
+
+        if(array_key_exists('rtd_location_id',$clean_meta)) {
+            $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? Location::find($clean_meta['rtd_location_id']['old'])->name : trans('general.unassigned');
+            $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? Location::find($clean_meta['rtd_location_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['Default Location'] = $clean_meta['rtd_location_id'];
+            unset($clean_meta['rtd_location_id']);
+        }
+        if(array_key_exists('location_id', $clean_meta)) {
+            $clean_meta['location_id']['old'] = $clean_meta['location_id']['old'] ? Location::find($clean_meta['location_id']['old'])->name : trans('general.unassigned');
+            $clean_meta['location_id']['new'] = $clean_meta['location_id']['new'] ? Location::find($clean_meta['location_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['Current Location'] = $clean_meta['location_id'];
+            unset($clean_meta['location_id']);
+        }
+        if(array_key_exists('model_id', $clean_meta)) {
+            $clean_meta['model_id']['old'] = AssetModel::find($clean_meta['model_id']['old'])->name;
+            $clean_meta['model_id']['new'] = AssetModel::find($clean_meta['model_id']['new'])->name; /* model is required at asset creation */
+            $clean_meta['Model'] = $clean_meta['model_id'];
+            unset($clean_meta['model_id']);
+        }
+        if(array_key_exists('company_id', $clean_meta)) {
+            $clean_meta['company_id']['old'] = $clean_meta['company_id']['old'] ? Company::find($clean_meta['company_id']['old'])->name : trans('general.unassigned');
+            $clean_meta['company_id']['new'] = $clean_meta['company_id']['new'] ? Company::find($clean_meta['company_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['Company'] = $clean_meta['company_id'];
+            unset($clean_meta['company_id']);
+        }
+        if(array_key_exists('supplier_id', $clean_meta)) {
+            $clean_meta['supplier_id']['old'] = $clean_meta['supplier_id']['old'] ? Supplier::find($clean_meta['supplier_id']['old'])->name : trans('general.unassigned');
+            $clean_meta['supplier_id']['new'] = $clean_meta['supplier_id']['new'] ? Supplier::find($clean_meta['supplier_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['Supplier'] = $clean_meta['supplier_id'];
+            unset($clean_meta['supplier_id']);
+        }
+
+        return $clean_meta;
+
     }
 
 

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -283,6 +283,7 @@ return [
     'user'					=> 'User',
     'accepted'			    => 'accepted',
     'declined'			    => 'declined',
+    'unassigned'            => 'Unassigned',
     'unaccepted_asset_report' => 'Unaccepted Assets',
     'users'                 => 'Users',
     'viewall'				=> 'View All',


### PR DESCRIPTION
# Description
This adds `changedInfo()` to the action log transformer, which will interpret changes in a more readable way.


array keys have been renamed to be more readable (e.g `rtd_location_id` is now `Default Location`) in the History tab of an asset. This information will be displayed if you edit/update a single asset or multiple assets at once.

If an asset never had a supplier, default location, company, or location already assigned to it, it will be noted as 'unassigned' (example below). If supplier, default location, company, or location are removed it will go back to unassigned as well.

Before:
<img width="1780" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/6f347d6b-83f5-4262-9c73-d3d4acea56c8">

After:
<img width="1780" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/120dfa18-22a4-4571-9b74-141b1c53fdb6">

Removed the Supplier:
<img width="1064" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/cc6b3324-55d6-424f-944f-f267eccb071d">


Fixes #sc-14441

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
