### PR TITLE
Removed the black label from around the default labels in new label engine

### DIFF
--- a/app/Models/Labels/DefaultLabel.php
+++ b/app/Models/Labels/DefaultLabel.php
@@ -86,7 +86,7 @@ class DefaultLabel extends RectangleSheet
 
     public function getColumns() { return $this->columns; }
     public function getRows()    { return $this->rows; }
-    public function getLabelBorder() { return 0.01; }
+    public function getLabelBorder() { return 0; }
 
     public function getLabelWidth()  { return $this->labelWidth; }
     public function getLabelHeight() { return $this->labelHeight; }


### PR DESCRIPTION
This removes the blank line around the labels in the new label engine. This border was retained from the legacy label system, but doesn't make sense here, since the new system generates a PDF (instead of HTML), and we can't make those borders not show up in print in the PDF.