### PR TITLE
Added last check in column and filter to custom asset report

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -905,6 +905,7 @@ class AssetsController extends Controller
 
         $asset->expected_checkin = null;
         $asset->last_checkout = null;
+        $asset->last_checkin = now();
         $asset->assigned_to = null;
         $asset->assignedTo()->disassociate($asset);
         $asset->accepted = null;

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -68,6 +68,7 @@ class AssetCheckinController extends Controller
 
         $asset->expected_checkin = null;
         $asset->last_checkout = null;
+        $asset->last_checkin = now();
         $asset->assigned_to = null;
         $asset->assignedTo()->disassociate($asset);
         $asset->assigned_type = null;

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -545,6 +545,10 @@ class ReportsController extends Controller
                 $header[] = trans('admin/hardware/table.checkout_date');
             }
 
+            if ($request->filled('checkin_date')) {
+                $header[] = trans('admin/hardware/table.last_checkin_date');
+            }
+
             if ($request->filled('expected_checkin')) {
                 $header[] = trans('admin/hardware/form.expected_checkin');
             }
@@ -649,6 +653,13 @@ class ReportsController extends Controller
                 $checkout_end = \Carbon::parse($request->input('checkout_date_end'))->endOfDay();
 
                 $assets->whereBetween('assets.last_checkout', [$checkout_start, $checkout_end]);
+            }
+
+            if (($request->filled('checkin_date_start')) && ($request->filled('checkin_date_end'))) {
+                $assets->whereBetween('last_checkin', [
+                    Carbon::parse($request->input('checkin_date_start'))->startOfDay(),
+                    Carbon::parse($request->input('checkin_date_end'))->endOfDay(),
+                ]);
             }
 
             if (($request->filled('expected_checkin_start')) && ($request->filled('expected_checkin_end'))) {
@@ -833,6 +844,12 @@ class ReportsController extends Controller
 
                     if ($request->filled('checkout_date')) {
                         $row[] = ($asset->last_checkout) ? $asset->last_checkout : '';
+                    }
+
+                    if ($request->filled('checkin_date')) {
+                        $row[] = ($asset->last_checkin)
+                            ? Carbon::parse($asset->last_checkin)->format('Y-m-d')
+                            : '';
                     }
 
                     if ($request->filled('expected_checkin')) {

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -655,10 +655,11 @@ class ReportsController extends Controller
                 $assets->whereBetween('assets.last_checkout', [$checkout_start, $checkout_end]);
             }
 
-            if (($request->filled('checkin_date_start')) && ($request->filled('checkin_date_end'))) {
+            if (($request->filled('checkin_date_start'))) {
                 $assets->whereBetween('last_checkin', [
                     Carbon::parse($request->input('checkin_date_start'))->startOfDay(),
-                    Carbon::parse($request->input('checkin_date_end'))->endOfDay(),
+                    // use today's date is `checkin_date_end` is not provided
+                    Carbon::parse($request->input('checkin_date_end', now()))->endOfDay(),
                 ]);
             }
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -73,6 +73,7 @@ class Asset extends Depreciable
     protected $casts = [
         'purchase_date' => 'date',
         'last_checkout' => 'datetime',
+        'last_checkin' => 'datetime',
         'expected_checkin' => 'date',
         'last_audit_date' => 'datetime',
         'next_audit_date' => 'date',

--- a/database/migrations/2023_08_17_202638_add_last_checkin_to_assets.php
+++ b/database/migrations/2023_08_17_202638_add_last_checkin_to_assets.php
@@ -18,7 +18,7 @@ class AddLastCheckinToAssets extends Migration
         });
 
         DB::statement(
-            "UPDATE " . DB::getTablePrefix() . "assets SET last_checkin=(SELECT MAX(" . DB::getTablePrefix() . "action_logs.action_date) FROM " . DB::getTablePrefix() . "action_logs WHERE item_type='App\\\Models\\\Asset' AND " . DB::getTablePrefix() . "action_logs.item_id=" . DB::getTablePrefix() . "assets.id AND " . DB::getTablePrefix() . "action_logs.action_type='checkin from'"
+            "UPDATE " . DB::getTablePrefix() . "assets SET last_checkin=(SELECT MAX(" . DB::getTablePrefix() . "action_logs.action_date) FROM " . DB::getTablePrefix() . "action_logs WHERE item_type='App\\\Models\\\Asset' AND " . DB::getTablePrefix() . "action_logs.item_id=" . DB::getTablePrefix() . "assets.id AND " . DB::getTablePrefix() . "action_logs.action_type='checkin from')"
         );
     }
 

--- a/database/migrations/2023_08_17_202638_add_last_checkin_to_assets.php
+++ b/database/migrations/2023_08_17_202638_add_last_checkin_to_assets.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddLastCheckinToAssets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->dateTime('last_checkin')->after('last_checkout')->nullable();
+        });
+
+        DB::statement(
+            "UPDATE " . DB::getTablePrefix() . "assets SET last_checkin=(SELECT MAX(" . DB::getTablePrefix() . "action_logs.action_date) FROM " . DB::getTablePrefix() . "action_logs WHERE item_type='App\\\Models\\\Asset' AND " . DB::getTablePrefix() . "action_logs.item_id=" . DB::getTablePrefix() . "assets.id AND " . DB::getTablePrefix() . "action_logs.action_type='checkin from'"
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('assets', function (Blueprint $table) {
+            $table->dropColumn('last_checkin');
+        });
+    }
+}

--- a/resources/lang/en/admin/hardware/table.php
+++ b/resources/lang/en/admin/hardware/table.php
@@ -14,6 +14,7 @@ return [
     'dl_csv' 		=> 'Download CSV',
     'eol' 			=> 'EOL',
     'id'      		=> 'ID',
+    'last_checkin_date' => 'Last Checkin Date',
     'location' 		=> 'Location',
     'purchase_cost'	=> 'Cost',
     'purchase_date'	=> 'Purchased',

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -142,6 +142,11 @@
               </label>
 
               <label class="form-control">
+                {{ Form::checkbox('checkin_date', '1', '1') }}
+                {{ trans('admin/hardware/table.last_checkin_date') }}
+              </label>
+
+              <label class="form-control">
                 {{ Form::checkbox('expected_checkin', '1', '1') }}
                 {{ trans('admin/hardware/form.expected_checkin') }}
               </label>
@@ -289,6 +294,16 @@
               </div>
           </div>
 
+          <!-- Last Checkin Date -->
+          <div class="form-group checkin-range">
+              <label for="checkin_date" class="col-md-3 control-label">{{ trans('admin/hardware/table.last_checkin_date') }}</label>
+              <div class="input-daterange input-group col-md-6" id="datepicker">
+                  <input type="text" class="form-control" name="checkin_date_start" aria-label="checkin_date_start">
+                  <span class="input-group-addon">{{ strtolower(trans('general.to')) }}</span>
+                  <input type="text" class="form-control" name="checkin_date_end" aria-label="checkin_date_end">
+              </div>
+          </div>
+
             <!-- Expected Checkin Date -->
             <div class="form-group expected_checkin-range">
               <label for="expected_checkin_start" class="col-md-3 control-label">{{ trans('admin/hardware/form.expected_checkin') }}</label>
@@ -375,6 +390,13 @@
           format: 'yyyy-mm-dd'
       });
       $('.checkout-range .input-daterange').datepicker({
+          clearBtn: true,
+          todayHighlight: true,
+          endDate: '0d',
+          format: 'yyyy-mm-dd'
+      });
+
+      $('.checkin-range .input-daterange').datepicker({
           clearBtn: true,
           todayHighlight: true,
           endDate: '0d',

--- a/tests/Feature/Api/Assets/AssetCheckinTest.php
+++ b/tests/Feature/Api/Assets/AssetCheckinTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature\Api\Assets;
+
+use App\Models\Asset;
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class AssetCheckinTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testLastCheckInFieldIsSetOnCheckin()
+    {
+        $admin = User::factory()->superuser()->create();
+        $asset = Asset::factory()->create(['last_checkin' => null]);
+
+        $asset->checkOut(User::factory()->create(), $admin, now());
+
+        $this->actingAsForApi($admin)
+            ->postJson(route('api.asset.checkin', $asset))
+            ->assertOk();
+
+        $this->assertNotNull(
+            $asset->fresh()->last_checkin,
+            'last_checkin field should be set on checkin'
+        );
+    }
+}

--- a/tests/Feature/Assets/AssetCheckinTest.php
+++ b/tests/Feature/Assets/AssetCheckinTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature\Assets;
+
+use App\Models\Asset;
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class AssetCheckinTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testLastCheckInFieldIsSetOnCheckin()
+    {
+        $admin = User::factory()->superuser()->create();
+        $asset = Asset::factory()->create(['last_checkin' => null]);
+
+        $asset->checkOut(User::factory()->create(), $admin, now());
+
+        $this->actingAs($admin)
+            ->post(route('hardware.checkin.store', [
+                'assetId' => $asset->id,
+            ]))
+            ->assertRedirect();
+
+        $this->assertNotNull(
+            $asset->fresh()->last_checkin,
+            'last_checkin field should be set on checkin'
+        );
+    }
+}

--- a/tests/Feature/Reports/CustomReportTest.php
+++ b/tests/Feature/Reports/CustomReportTest.php
@@ -107,4 +107,29 @@ class CustomReportTest extends TestCase
             ->assertDontSeeTextInStreamedResponse('Asset A')
             ->assertSeeTextInStreamedResponse('Asset B');
     }
+
+    public function testCanLimitAssetsByLastCheckIn()
+    {
+        Asset::factory()->create(['name' => 'Asset A', 'last_checkin' => '2023-08-01']);
+        Asset::factory()->create(['name' => 'Asset B', 'last_checkin' => '2023-08-02']);
+        Asset::factory()->create(['name' => 'Asset C', 'last_checkin' => '2023-08-03']);
+        Asset::factory()->create(['name' => 'Asset D', 'last_checkin' => '2023-08-04']);
+        Asset::factory()->create(['name' => 'Asset E', 'last_checkin' => '2023-08-05']);
+
+        $this->actingAs(User::factory()->canViewReports()->create())
+            ->post('reports/custom', [
+                'asset_name' => '1',
+                'asset_tag' => '1',
+                'serial' => '1',
+                'checkin_date' => '1',
+                'checkin_date_start' => '2023-08-02',
+                'checkin_date_end' => '2023-08-04',
+            ])->assertOk()
+            ->assertHeader('content-type', 'text/csv; charset=UTF-8')
+            ->assertDontSeeTextInStreamedResponse('Asset A')
+            ->assertSeeTextInStreamedResponse('Asset B')
+            ->assertSeeTextInStreamedResponse('Asset C')
+            ->assertSeeTextInStreamedResponse('Asset D')
+            ->assertDontSeeTextInStreamedResponse('Asset E');
+    }
 }


### PR DESCRIPTION
# Description

This PR adds the `Last Checkin Date` column and `Last Checkin Date` range filter to the Custom Asset Report:

![Some fields on the custom report page](https://github.com/snipe/snipe-it/assets/1141514/2fadeabd-800c-4303-8634-3882c4153ef7)

The column displays the date and time the asset was last checked in and the filter allows for only returning items that were last checked in during range. Since we are only searching the last check in, an asset that was checked in during the range but then checked out and checked in outside of the range, it will not be included.



One question: Should the label be `Last Checkin Date` (which matches the labels below it), `Last Checkin Date Range` (which matches the labels above, or should I update the labels to all have Range?

---

Closes: [Shortcut Story #23356: Add check in date range filter on the custom asset report](https://app.shortcut.com/grokability/story/23356/add-check-in-date-range-filter-on-the-custom-asset-report)
Follows up on #13323

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)