### PR TITLE
Small fixes to checkbox layout in general settings blade

### DIFF
--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -14,11 +14,7 @@
 {{-- Page content --}}
 @section('content')
 
-    <style>
-        .checkbox label {
-            padding-right: 40px;
-        }
-    </style>
+
 
 
 
@@ -260,11 +256,13 @@
                                               trans('admin/settings/general.show_archived_in_list')) }}
                            </div>
                            <div class="col-md-9">
-                               {{ Form::checkbox('show_archived_in_list', '1', Request::old('show_archived_in_list', $setting->show_archived_in_list),array('class' => 'minimal')) }}
-                               {{ trans('admin/settings/general.show_archived_in_list_text') }}
-                               {!! $errors->first('show_archived_in_list', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
 
-                           </div>
+                                   <label class="form-control">
+                                       {{ Form::checkbox('show_archived_in_list', '1', old('show_archived_in_list', $setting->show_archived_in_list),array('aria-label'=>'show_archived_in_list')) }}
+                                       {{ trans('admin/settings/general.show_archived_in_list_text') }}
+                                   </label>
+                                   {!! $errors->first('show_archived_in_list', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                          </div>
                        </div>
 
                        <!-- Show assets assigned to user's assets -->
@@ -274,8 +272,10 @@
                                               trans('admin/settings/general.show_assigned_assets')) }}
                            </div>
                            <div class="col-md-9">
+                               <label class="form-control">
                                {{ Form::checkbox('show_assigned_assets', '1', Request::old('show_assigned_assets', $setting->show_assigned_assets),array('class' => 'minimal')) }}
                                {{ trans('general.yes') }}
+                               </label>
                                <p class="help-block">{{ trans('admin/settings/general.show_assigned_assets_help') }}</p>
                                {!! $errors->first('show_assigned_assets', '<span class="alert-msg">:message</span>') !!}
                            </div>


### PR DESCRIPTION
On a customer call today I noticed that a few of the checkboxes in the General Settings page were not re-fitted to the new (non-iCheck) layout. This fixes that.

### Before
<img width="945" alt="Screenshot 2023-08-22 at 2 10 09 PM" src="https://github.com/snipe/snipe-it/assets/197404/1b00d9ca-3429-4ce2-a7cc-cad6d8ffb958">


### After

<img width="958" alt="Screenshot 2023-08-22 at 2 10 19 PM" src="https://github.com/snipe/snipe-it/assets/197404/f11cd275-3df8-4f75-95bf-aa2b36a807d9">
