### PR TITLE
Fixed: wrong index reference in MoveUploadsToNewDisk.php

### DIFF
--- a/app/Console/Commands/MoveUploadsToNewDisk.php
+++ b/app/Console/Commands/MoveUploadsToNewDisk.php
@@ -112,7 +112,7 @@ class MoveUploadsToNewDisk extends Command
                     $filename = basename($private_upload[$x]);
 
                     try {
-                        Storage::put($private_type . '/' . $filename, file_get_contents($private_upload[$i]));
+                        Storage::put($private_type . '/' . $filename, file_get_contents($private_upload[$x]));
                         $new_url = Storage::url($private_type . '/' . $filename, $filename);
                         $this->info($type_count . '. PRIVATE: ' . $filename . ' was copied to ' . $new_url);
                     } catch (\Exception $e) {


### PR DESCRIPTION
# Description

Usage of undefined reference fixed

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test in dev, UAT and production setup that `php artisan snipeit:move-uploads` runs through without issue

**Test Configuration**:
* PHP version: 7.4.33
* MySQL version: 10.5.19-MariaDB
* Webserver version: Apache/2.4.56
* OS version: Debian 11


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
