### PR TITLE
Added eager loading for `changedinfo` and removed encrypted values from Asset history

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -153,7 +153,6 @@ class ActionlogsTransformer
      */
     public function changedInfo(array $clean_meta)
     {   $location = Location::withTrashed()->get();
-        $company = Company::withTrashed()->get();
         $supplier = Supplier::withTrashed()->get();
         $model = AssetModel::withTrashed()->get();
 
@@ -179,8 +178,14 @@ class ActionlogsTransformer
             unset($clean_meta['model_id']);
         }
         if(array_key_exists('company_id', $clean_meta)) {
-            $clean_meta['company_id']['old'] = $clean_meta['company_id']['old'] ? "[id: ".$clean_meta['company_id']['old']."]".$company->find($clean_meta['company_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['company_id']['new'] = $clean_meta['company_id']['new'] ? "[id: ".$clean_meta['company_id']['new']."] ".$company->find($clean_meta['company_id']['new'])->name : trans('general.unassigned');
+            $oldCompany = Company::find($clean_meta['company_id']['old']);
+            $oldCompanyName = $oldCompany->name ?? trans('admin/companies/message.deleted');
+
+            $newCompany = Company::find($clean_meta['company_id']['new']);
+            $newCompanyName = $newCompany->name ?? trans('admin/companies/message.deleted');
+
+            $clean_meta['company_id']['old'] = $clean_meta['company_id']['old'] ? "[id: ".$clean_meta['company_id']['old']."] ". $oldCompanyName : trans('general.unassigned');
+            $clean_meta['company_id']['new'] = $clean_meta['company_id']['new'] ? "[id: ".$clean_meta['company_id']['new']."] ". $newCompanyName : trans('general.unassigned');
             $clean_meta['Company'] = $clean_meta['company_id'];
             unset($clean_meta['company_id']);
         }

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -52,12 +52,18 @@ class ActionlogsTransformer
 
             if ($meta_array) {
                 foreach ($meta_array as $fieldname => $fieldata) {
-                    $clean_meta[$fieldname]['old'] = $this->clean_field($fieldata->old);
-                    $clean_meta[$fieldname]['new'] = $this->clean_field($fieldata->new);
-                }
+                    if ((strlen($this->clean_field($fieldata->old)) == 200) || (strlen($this->clean_field($fieldata->new))== 200)) {
+                        $clean_meta[$fieldname]['old'] = "encrypted";
+                        $clean_meta[$fieldname]['new'] = "encrypted";
+                    } else {
+                        $clean_meta[$fieldname]['old'] = $this->clean_field($fieldata->old);
+                        $clean_meta[$fieldname]['new'] = $this->clean_field($fieldata->new);
+                    }
 
+                }
+                \Log::info("Clean Meta is: " . print_r($clean_meta, true));
+                $clean_meta = $this->changedInfo($clean_meta);
             }
-            $clean_meta= $this->changedInfo($clean_meta);
         }
 
         $file_url = '';
@@ -120,7 +126,7 @@ class ActionlogsTransformer
             'log_meta'          => ((isset($clean_meta)) && (is_array($clean_meta))) ? $clean_meta: null,
             'action_date'   => ($actionlog->action_date) ? Helper::getFormattedDateObject($actionlog->action_date, 'datetime'): Helper::getFormattedDateObject($actionlog->created_at, 'datetime'),
         ];
-        //\Log::info("Clean Meta is: ".print_r($clean_meta,true));
+//        \Log::info("Clean Meta is: ".print_r($clean_meta,true));
 
         //dd($array);
         return $array;
@@ -175,6 +181,11 @@ class ActionlogsTransformer
             $clean_meta['supplier_id']['new'] = $clean_meta['supplier_id']['new'] ? "[id: ".$clean_meta['supplier_id']['new']."] ".Supplier::find($clean_meta['supplier_id']['new'])->name : trans('general.unassigned');
             $clean_meta['Supplier'] = $clean_meta['supplier_id'];
             unset($clean_meta['supplier_id']);
+        }
+        if(array_key_exists('asset_eol_date', $clean_meta)) {
+
+            $clean_meta['EOL date'] = $clean_meta['asset_eol_date'];
+            unset($clean_meta['asset_eol_date']);
         }
 
         return $clean_meta;

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -56,7 +56,7 @@ class ActionlogsTransformer
                 foreach ($meta_array as $fieldname => $fieldata) {
                     if( str_starts_with($fieldname, '_snipeit_')){
 
-                        if( $custom_field->where('name', '=', $fieldname)->where('field_encrypted', true)){
+                        if( $custom_field->where('db_column', '=', $fieldname)->where('field_encrypted', true)){
                             $clean_meta[$fieldname]['old'] = "encrypted";
                             $clean_meta[$fieldname]['new'] = "encrypted";
                         }

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -152,10 +152,10 @@ class ActionlogsTransformer
      * @return array
      */
     public function changedInfo(array $clean_meta)
-    {   $location = Location::all();
-        $company = Company::all();
-        $supplier = Supplier::all();
-        $model = AssetModel::all();
+    {   $location = Location::withTrashed()->all();
+        $company = Company::withTrashed()->all();
+        $supplier = Supplier::withTrashed()->all();
+        $model = AssetModel::withTrashed()->get();
 
 
         if(array_key_exists('rtd_location_id',$clean_meta)) {

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -55,7 +55,6 @@ class ActionlogsTransformer
             if ($meta_array) {
                 foreach ($meta_array as $fieldname => $fieldata) {
                     if( str_starts_with($fieldname, '_snipeit_')){
-
                         if( $custom_field->where('db_column', '=', $fieldname)->where('field_encrypted', true)){
                             $clean_meta[$fieldname]['old'] = "encrypted";
                             $clean_meta[$fieldname]['new'] = "encrypted";
@@ -65,7 +64,6 @@ class ActionlogsTransformer
                         $clean_meta[$fieldname]['old'] = $this->clean_field($fieldata->old);
                         $clean_meta[$fieldname]['new'] = $this->clean_field($fieldata->new);
                     }
-
                 }
                 $clean_meta = $this->changedInfo($clean_meta);
             }
@@ -132,7 +130,6 @@ class ActionlogsTransformer
             'action_date'   => ($actionlog->action_date) ? Helper::getFormattedDateObject($actionlog->action_date, 'datetime'): Helper::getFormattedDateObject($actionlog->created_at, 'datetime'),
         ];
 //        \Log::info("Clean Meta is: ".print_r($clean_meta,true));
-
         //dd($array);
         return $array;
     }

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -151,10 +151,11 @@ class ActionlogsTransformer
      * @param  array $clean_meta
      * @return array
      */
-    public function changedInfo(array $clean_meta)
-    {   $location = Location::withTrashed()->all();
-        $company = Company::withTrashed()->all();
-        $supplier = Supplier::withTrashed()->all();
+    public function changedInfo(array $clean_meta) {
+
+        $location = Location::withTrashed()->get();
+        $company = Company::withTrashed()->get();
+        $supplier = Supplier::withTrashed()->get();
         $model = AssetModel::withTrashed()->get();
 
 

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -152,10 +152,10 @@ class ActionlogsTransformer
      * @return array
      */
     public function changedInfo(array $clean_meta)
-    {   $location = Location::all();
-        $company = Company::all();
-        $supplier = Supplier::all();
-        $model = AssetModel::all();
+    {   $location = Location::withTrashed()->get();
+        $company = Company::withTrashed()->get();
+        $supplier = Supplier::withTrashed()->get();
+        $model = AssetModel::withTrashed()->get();
 
 
         if(array_key_exists('rtd_location_id',$clean_meta)) {

--- a/resources/lang/en/admin/companies/message.php
+++ b/resources/lang/en/admin/companies/message.php
@@ -2,6 +2,7 @@
 
 return [
     'does_not_exist' => 'Company does not exist.',
+    'deleted'        => 'Deleted company',
     'assoc_users'    => 'This company is currently associated with at least one model and cannot be deleted. Please update your models to no longer reference this company and try again. ',
     'create' => [
         'error'   => 'Company was not created, please try again.',


### PR DESCRIPTION
# Description

Checks if a field is encrypted and returns `encrypted` instead of the hashed string. asset_eol_date now reads `EOL date` in the Asset History Log

<img width="231" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/085f731d-b310-4313-acc6-fb17a9dc6a59">

Also eager loads the queries with soft deletes which was needed for the `changedInfo` method

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
