### PR TITLE
Fixed asset model query in action log transformer

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -159,8 +159,8 @@ class ActionlogsTransformer
             unset($clean_meta['location_id']);
         }
         if(array_key_exists('model_id', $clean_meta)) {
-            $clean_meta['model_id']['old'] = "[id: ".$clean_meta['model_id']['old']."] ".AssetModel::find($clean_meta['model_id']['old'])->name;
-            $clean_meta['model_id']['new'] = "[id: ".$clean_meta['model_id']['new']."] ".AssetModel::find($clean_meta['model_id']['new'])->name; /* model is required at asset creation */
+            $clean_meta['model_id']['old'] = "[id: ".$clean_meta['model_id']['old']."] ".AssetModel::withTrashed()->find($clean_meta['model_id']['old'])->name;
+            $clean_meta['model_id']['new'] = "[id: ".$clean_meta['model_id']['new']."] ".AssetModel::withTrashed()->find($clean_meta['model_id']['new'])->name; /* model is required at asset creation */
             $clean_meta['Model'] = $clean_meta['model_id'];
             unset($clean_meta['model_id']);
         }


### PR DESCRIPTION
# Description

This PR updates the asset model query to include trashed models to ensure the action log can be rendered properly.

This is a quick fix and there might be additional follow up fixes in the near future but this works for me.

Fixes #13508 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)