### PR TITLE
Fixed #13510 - do not use translations in migrations

### DIFF
--- a/database/migrations/2022_10_25_215520_add_label2_settings.php
+++ b/database/migrations/2022_10_25_215520_add_label2_settings.php
@@ -21,11 +21,7 @@ class AddLabel2Settings extends Migration
             $table->string('label2_1d_type')->default('default');
             $table->string('label2_2d_type')->default('default');
             $table->string('label2_2d_target')->default('hardware_id');
-            $table->string('label2_fields')->default(
-                trans('admin/hardware/form.name').'=name;'.
-                trans('admin/hardware/form.serial').'=serial;'.
-                trans('admin/hardware/form.model').'=model.name;'
-            );
+            $table->string('label2_fields')->default('name=name;serial=serial;model=model.name;');
         });
     }
 


### PR DESCRIPTION
This should hopefully fix #13510. The original PR was trying to be very clever and use the translated strings for the default values, but unfortunately values with apostrophes (French, etc) would break the migration. 