### PR TITLE
Fixed Not reassignable Licenses shouldn't show 'Checkin All Seats' button [sc-23506]

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -128,6 +128,13 @@ class LicenseCheckinController extends Controller
         $license = License::findOrFail($licenseId);
         $this->authorize('checkin', $license);
 
+        if (! $license->reassignable) {
+            // Not allowed to checkin
+            Session::flash('error', 'License not reassignable.');
+
+            return redirect()->back()->withInput();
+        }
+
         $licenseSeatsByUser = LicenseSeat::where('license_id', '=', $licenseId)
             ->whereNotNull('assigned_to')
             ->with('user')

--- a/resources/lang/en/admin/licenses/general.php
+++ b/resources/lang/en/admin/licenses/general.php
@@ -26,6 +26,7 @@ return array(
                 'modal'             => 'This will action checkin one seat. | This action will checkin all :checkedout_seats_count seats for this license.',
                 'enabled_tooltip'   => 'Checkin ALL seats for this license from both users and assets',
                 'disabled_tooltip'  => 'This is disabled because there are no seats currently checked out',
+                'disabled_tooltip_reassignable'  => 'This is disabled because the License is not reassignable',
                 'success'           => 'License successfully checked in! | All licenses were successfully checked in!',
                 'log_msg'           => 'Checked in via bulk license checkout in license GUI',
             ],

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -577,17 +577,23 @@
     @endcan
 
     @can('checkin', $license)
-
-      @if (($license->seats - $license->availCount()->count()) > 0 )
-        <a href="#" class="btn btn-block bg-purple" style="margin-bottom: 25px;" data-toggle="modal" data-tooltip="true"  data-target="#checkinFromAllModal" data-content="{{ trans('general.sure_to_delete') }} data-title="{{  trans('general.delete') }}" onClick="return false;">
-          {{ trans('admin/licenses/general.bulk.checkin_all.button') }}
-        </a>
-      @else
+  
+      @if (($license->seats - $license->availCount()->count()) <= 0 )
         <span data-tooltip="true" title=" {{ trans('admin/licenses/general.bulk.checkin_all.disabled_tooltip') }}">
             <a href="#" class="btn btn-block bg-purple disabled" style="margin-bottom: 25px;">
              {{ trans('admin/licenses/general.bulk.checkin_all.button') }}
             </a>
-          </span>
+        </span>
+      @elseif (! $license->reassignable)
+        <span data-tooltip="true" title=" {{ trans('admin/licenses/general.bulk.checkin_all.disabled_tooltip_reassignable') }}">
+            <a href="#" class="btn btn-block bg-purple disabled" style="margin-bottom: 25px;">
+             {{ trans('admin/licenses/general.bulk.checkin_all.button') }}
+            </a>
+        </span>
+      @else
+        <a href="#" class="btn btn-block bg-purple" style="margin-bottom: 25px;" data-toggle="modal" data-tooltip="true"  data-target="#checkinFromAllModal" data-content="{{ trans('general.sure_to_delete') }} data-title="{{  trans('general.delete') }}" onClick="return false;">
+          {{ trans('admin/licenses/general.bulk.checkin_all.button') }}
+        </a>
       @endif
     @endcan
 


### PR DESCRIPTION
# Description
Following on some freshdesk I think I discovered an issue. 

If the license is reassignable, it should let checkout and checkin as much as the user with proper permissions wants.
I the license is not reassignable, it let the user checkout every seat, but not checkin as the license can't be assigned to anyone else.

So the 'Checkin All Seats' option should be disabled if license is not reassignable, which is not the case right now. I modified the LicenseCheckinController so it now evaluates first if the License is reassignable or not, which shouldn't be necessary since I also disable the button in the view, but just to be sure.

Also, as mentioned, I edit the view to disable the 'Checkin All Seats' button if the License is not reassignable. I don't love that I repeated a lot of code in the new condition of the blade, but I wanted to show in a tooltip why the button is disabled. If is beacuse of the License not being reassignable:

![image](https://github.com/snipe/snipe-it/assets/653557/4c4e3223-a4f4-482a-a039-2893c4bb1659)

And if no License seat is checked out:

![image](https://github.com/snipe/snipe-it/assets/653557/35e98418-a809-4096-84f6-c1bf1e997e05)


Fixes kinda  [sc-23506]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11