### PR TITLE
Fixed undeclared variable in ActionlogsTransformer

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -50,13 +50,15 @@ class ActionlogsTransformer
         if (($actionlog->log_meta) && ($actionlog->log_meta!='')) {
             $meta_array = json_decode($actionlog->log_meta);
 
+            $clean_meta = [];
+
             if ($meta_array) {
                 foreach ($meta_array as $fieldname => $fieldata) {
                     $clean_meta[$fieldname]['old'] = $this->clean_field($fieldata->old);
                     $clean_meta[$fieldname]['new'] = $this->clean_field($fieldata->new);
                 }
-
             }
+
             $clean_meta= $this->changedInfo($clean_meta);
         }
 

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -122,9 +122,7 @@ class ActionlogsTransformer
             'log_meta'          => ((isset($clean_meta)) && (is_array($clean_meta))) ? $clean_meta: null,
             'action_date'   => ($actionlog->action_date) ? Helper::getFormattedDateObject($actionlog->action_date, 'datetime'): Helper::getFormattedDateObject($actionlog->created_at, 'datetime'),
         ];
-        //\Log::info("Clean Meta is: ".print_r($clean_meta,true));
 
-        //dd($array);
         return $array;
     }
 


### PR DESCRIPTION
# Description

This PR fixes a bug where the `$clean_logs` variable might not be defined in the `ActionlogsTransformer`. 

Even though the `if` statement on line 50 seems to guard against this, if the `log_meta` column contains `{}` then it will evaluate to `true` but not enter the `if` block on line 53 (line 55 in this PR).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)