### PR TITLE
Fixed #12548 Cloning a model blanks fieldset of new one

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -286,6 +286,7 @@ class AssetModelsController extends Controller
         return view('models/edit')
             ->with('depreciation_list', Helper::depreciationList())
             ->with('item', $model)
+            ->with('model_id', $model_to_clone->id)
             ->with('clone_model', $model_to_clone);
     }
 

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -34,12 +34,13 @@
 </div>
 
 @php
-    if (is_null($item->id)){
-        $item->id = $item->getOriginal('id');
+    $model_id = $item->id;
+    if (is_null($model_id)){
+        $model_id = $item->getOriginal('id');
     }
 @endphp
 <!-- Custom Fieldset -->
-@livewire('custom-field-set-default-values-for-model',["model_id" => $item->id])
+@livewire('custom-field-set-default-values-for-model',["model_id" => $model_id])
 
 @include ('partials.forms.edit.notes')
 @include ('partials.forms.edit.requestable', ['requestable_text' => trans('admin/models/general.requestable')])

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -33,14 +33,9 @@
     </div>
 </div>
 
-@php
-    $model_id = $item->id;
-    if (is_null($model_id)){
-        $model_id = $item->getOriginal('id');
-    }
-@endphp
 <!-- Custom Fieldset -->
-@livewire('custom-field-set-default-values-for-model',["model_id" => $model_id])
+<!-- If $item->id is null we are cloning the model and we need the $model_id variable -->
+@livewire('custom-field-set-default-values-for-model',["model_id" => ($item->id) ? $item->id : $model_id])
 
 @include ('partials.forms.edit.notes')
 @include ('partials.forms.edit.requestable', ['requestable_text' => trans('admin/models/general.requestable')])

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -33,6 +33,11 @@
     </div>
 </div>
 
+@php
+    if (is_null($item->id)){
+        $item->id = $item->getOriginal('id');
+    }
+@endphp
 <!-- Custom Fieldset -->
 @livewire('custom-field-set-default-values-for-model',["model_id" => $item->id])
 


### PR DESCRIPTION
# Description
When a model is cloned, as the clone doesn't have an `id` the `custom_field` is not populated.

I don't love this solution as I had to add PHP code to the blade view to handle when the `id` field is null to detect when we are cloning the model. But I can't come up with a better solution. Let me know if you think there's  a more elegant way to fix it.

Fixes #12548 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 12
