### PR TITLE
Clearer labels barcode text

### DIFF
--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -349,7 +349,7 @@ return [
     'label2_fields_help'      => 'Fields can be added, removed, and reordered in the left column. For each field, multiple options for Label and DataSource can be added, removed, and reordered in the right column.',
     'help_asterisk_bold'    => 'Text entered as <code>**text**</code> will be displayed as bold',
     'help_blank_to_use'     => 'Leave blank to use the value from <code>:setting_name</code>',
-    'help_default_will_use' => '<code>:default</code> will use the value from <code>:setting_name</code>',
+    'help_default_will_use' => '<code>:default</code> will use the value from <code>:setting_name</code>. <br>Note that the value of the barcodes must comply with the respective barcode spec in order to be successfully generated. Please see <a href="https://snipe-it.readme.io/docs/barcodes">the documentation <i class="fa fa-external-link"></i></a> for more details. ',
     'default'               => 'Default',
     'none'                  => 'None',
     'google_callback_help' => 'This should be entered as the callback URL in your Google OAuth app settings in your organization&apos;s <strong><a href="https://console.cloud.google.com/" target="_blank">Google developer console <i class="fa fa-external-link" aria-hidden="true"></i></a></strong>.',

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -106,7 +106,7 @@
                                 <div class="col-md-3 text-right">
                                     {{ Form::label('label2_title', trans('admin/settings/general.label2_title'), ['class'=>'control-label']) }}
                                 </div>
-                                <div class="col-md-9">
+                                <div class="col-md-7">
                                     {{ Form::text('label2_title', old('label2_title', $setting->label2_title), [ 'class'=>'form-control', 'placeholder'=>$setting->qr_text, 'aria-label'=>'label2_title' ]) }}
                                     {!! $errors->first('label2_title', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                     <p class="help-block">{!! trans('admin/settings/general.label2_title_help') !!}</p>
@@ -142,7 +142,7 @@
                                 <div class="col-md-3 text-right">
                                     {{ Form::label('label2_1d_type', trans('admin/settings/general.label2_1d_type'), ['class'=>'control-label']) }}
                                 </div>
-                                <div class="col-md-9">
+                                <div class="col-md-7">
                                     @php
                                         $select1DValues = [
                                             'default' => trans('admin/settings/general.default').' [ '.$setting->alt_barcode.' ]',
@@ -174,7 +174,7 @@
                                 <div class="col-md-3 text-right">
                                     {{ Form::label('label2_2d_type', trans('admin/settings/general.label2_2d_type'), ['class'=>'control-label']) }}
                                 </div>
-                                <div class="col-md-9">
+                                <div class="col-md-7">
                                     @php
                                         $select2DValues = [
                                             'default'    => trans('admin/settings/general.default').' [ '.$setting->barcode_type.' ]',


### PR DESCRIPTION
We run into an issue where people pick 1D barcodes that are not compatible with their asset tags, which causes the barcode generation to break. For example, if you have selected EAN5, your asset tags need to be 5 characters, numbers only. If your asset tags are a combination of numbers and letters, that won't be compatible. This isn't something Snipe-IT is enforcing, it's just how those barcodes work in their spec, but I suppose a lot of people don't know that part, so it looks like it's breaking on our end. 

### Before 

<img width="1440" alt="Screenshot 2023-08-26 at 5 46 11 PM" src="https://github.com/snipe/snipe-it/assets/197404/2e1b3d1d-47bd-4f87-b982-25f1326ab53c">


### After 

<img width="1423" alt="Screenshot 2023-08-26 at 5 46 23 PM" src="https://github.com/snipe/snipe-it/assets/197404/91bde8ba-422c-4db4-a908-4cacc4ed0ae6">

This is a stopgap to at least point people to the right direction to look for help. I'll be fleshing out more of the docs with links to their specific specifications shortly (because apparently Google is difficult.)
