### PR TITLE
Fixed #13521 - make modal “select files” button wider

### DIFF
--- a/resources/views/modals/upload-file.blade.php
+++ b/resources/views/modals/upload-file.blade.php
@@ -15,15 +15,15 @@
             <div class="modal-body">
 
                 <div class="row">
-                    <div class="col-md-3">
+                    <div class="col-md-12">
 
-                        <label class="btn btn-default">
-                            {{ trans('button.select_file')  }}
+                        <label class="btn btn-default btn-block">
+                            {{ trans('button.select_files')  }}
                             <input type="file" name="file[]" multiple="true" class="js-uploadFile" id="uploadFile" data-maxsize="{{ Helper::file_upload_max_size() }}" accept="image/*,.csv,.zip,.rar,.doc,.docx,.xls,.xlsx,.xml,.lic,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/plain,.pdf,application/rtf,application/json" style="display:none" required>
                         </label>
 
                     </div>
-                    <div class="col-md-9">
+                    <div class="col-md-12">
                         <span id="uploadFile-info"></span>
                     </div>
                     <div class="col-md-12">


### PR DESCRIPTION
While I don't think this visually looks as nice as the previous incarnation, a user brought up that for languages that have very long strings as the phrase for "select file" or "select files", the button text runs off the side of the button. This change makes the button the full width of the modal, and puts the selected files underneath.

### Before

![262925549-03b12e7e-8433-4ba4-9999-b83e9d8e230e](https://github.com/snipe/snipe-it/assets/197404/59eb5bbb-5fc8-4961-9e43-820275a79925)


### After

<img width="634" alt="Screenshot 2023-08-28 at 12 36 41 PM" src="https://github.com/snipe/snipe-it/assets/197404/30c9cc1e-a5c9-47a3-925f-d0e5419a2c8b">

Fixes #13521
