### PR TITLE
Fixed #13500 - Try to prevent the browser from pre-filling the LDAP password

### DIFF
--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -18,6 +18,15 @@
         .checkbox label {
             padding-right: 40px;
         }
+
+        /*
+           Don't make the password field *look* readonly - this is for usability, so admins don't think they can't edit this field.
+         */
+        .form-control[readonly] {
+            background-color: white;
+            color: #555555;
+            cursor:text;
+        }
     </style>
 
     @if ((!function_exists('ldap_connect')) || (!function_exists('ldap_set_option')) || (!function_exists('ldap_bind')))
@@ -34,9 +43,11 @@
     @endif
 
 
-    {{ Form::open(['method' => 'POST', 'files' => false, 'autocomplete' => 'false', 'class' => 'form-horizontal', 'role' => 'form']) }}
+    {{ Form::open(['method' => 'POST', 'files' => false, 'autocomplete' => 'off', 'class' => 'form-horizontal', 'role' => 'form']) }}
     <!-- CSRF Token -->
     {{csrf_field()}}
+
+    <input type="hidden" name="username" value="{{ Request::old('username', $user->username) }}">
 
     <!-- this is a hack to prevent Chrome from trying to autocomplete fields -->
     <input type="text" name="prevent_autofill" id="prevent_autofill" value="" style="display:none;" />
@@ -53,7 +64,6 @@
                     </h4>
                 </div>
                 <div class="box-body">
-
 
                     <div class="col-md-11 col-md-offset-1">
 
@@ -230,7 +240,7 @@
                                 {{ Form::label('ldap_uname', trans('admin/settings/general.ldap_uname')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_uname', Request::old('ldap_uname', $setting->ldap_uname), ['class' => 'form-control','placeholder' => trans('general.example') .'binduser@example.com', $setting->demoMode]) }}
+                                {{ Form::text('ldap_uname', Request::old('ldap_uname', $setting->ldap_uname), ['class' => 'form-control','autocomplete' => 'off', 'placeholder' => trans('general.example') .'binduser@example.com', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_uname', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -244,7 +254,7 @@
                                 {{ Form::label('ldap_pword', trans('admin/settings/general.ldap_pword')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::password('ldap_pword', ['class' => 'form-control','placeholder' => trans('general.example') .' binduserpassword', $setting->demoMode]) }}
+                                {{ Form::password('ldap_pword', ['class' => 'form-control', 'autocomplete' => 'off', 'onfocus' => "this.removeAttribute('readonly');", $setting->demoMode, ' readonly']) }}
                                 {!! $errors->first('ldap_pword', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -538,7 +548,7 @@
                                         <input type="text" name="ldaptest_user" id="ldaptest_user"  class="form-control" placeholder="LDAP username">
                                     </div>
                                     <div class="col-md-4">
-                                    <input type="password" name="ldaptest_password" id="ldaptest_password" class="form-control" placeholder="LDAP password">
+                                    <input type="password" name="ldaptest_password" id="ldaptest_password" class="form-control" placeholder="LDAP password" autocomplete="off" readonly onfocus="this.removeAttribute('readonly');">
                                     </div>
                                     <div class="col-md-3">
                                         <a class="btn btn-default btn-sm" id="ldaptestlogin" style="margin-right: 10px;">{{ trans('admin/settings/general.ldap_test') }}</a>


### PR DESCRIPTION
This is an attempt to fix #13500, where the user's browser was pre-filling the `ldap_pword` field to be "helpful", which meant every time they saved the LDAP settings, the `ldap_pword` field would be overwritten in the database to their own user password. Thanks, browser! Super helpful.

@Godmartinz - if this looks okay, can we try to apply this to your new LDAP livewire stuff? (We should also maybe add a new class to the CSS to make this part of our actual CSS, versus inlining it, as those in dark mode will have a white field that will look pretty jarring. A new class like `hide-readonly` or something. 

This PR yoinks a lot of the functionality from the user edit/create page for largely the same reasons - before adding that, admins who were editing a user wouldn't notice that the browser filled in that field with the admin's password:

https://github.com/snipe/snipe-it/blob/b93adf44c87900c179a8e067e38199492ce46741/resources/views/users/edit.blade.php#L27-L31

https://github.com/snipe/snipe-it/blob/b93adf44c87900c179a8e067e38199492ce46741/resources/views/users/edit.blade.php#L153-L163

