### PR TITLE
Fixed #13516 - Use int not string if no DB_PORT specified

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -69,7 +69,7 @@ return [
         'mysql' => [
             'driver'    => 'mysql',
             'host'      => env('DB_HOST', 'localhost'),
-            'port'      => env('DB_PORT', '3306'),
+            'port'      => env('DB_PORT', 3306),
             'database'  => env('DB_DATABASE', 'forge'),
             'username'  => env('DB_USERNAME', 'forge'),
             'password'  => env('DB_PASSWORD', ''),


### PR DESCRIPTION
This should fix #13516. If you didn't specify a `DB_PORT` in your `.env`, we would default to `'3306'` (a string) when it should have been an int. This meant that if you didn't specify a `DB_PORT`, some users would get:

```
[2023-08-23 15:14:13] production.ERROR: Spatie\DbDumper\DbDumper::setPort(): Argument #1 ($port) must be of type int, string given, called in /var/www/html/vendor/spatie/laravel-backup/src/Tasks/Backup/DbDumperFactory.php on line 56 {"userId":1,"exception":"[object] (TypeError(code: 0): Spatie\\DbDumper\\DbDumper::setPort(): Argument #1 ($port) must be of type int, string given, called in /var/www/html/vendor/spatie/laravel-backup/src/Tasks/Backup/DbDumperFactory.php on line 56 at /var/www/html/vendor/spatie/db-dumper/src/DbDumper.php:120)
[stacktrace]
```