### PR TITLE
Fixed user search not adhering to company scoping

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -75,7 +75,6 @@ class UsersController extends Controller
 
         ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables', 'createdBy',)
             ->withCount('assets as assets_count', 'licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count');
-        $users = Company::scopeCompanyables($users);
 
 
         if ($request->filled('activated')) {
@@ -271,6 +270,8 @@ class UsersController extends Controller
         } elseif (($request->filled('all')) && ($request->input('all') == 'true')) {
             $users = $users->withTrashed();
         }
+
+        $users = Company::scopeCompanyables($users);
         
         $total = $users->count();
         $users = $users->skip($offset)->take($limit)->get();


### PR DESCRIPTION
# Description

This PR fixes an issue where users from different companies were displayed in the table when text was entered in the search box on the user index page (`/users`).

Fixes #13540

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)