### PR TITLE
Don’t cast as boolean, do validate as boolean for User validation 

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -82,7 +82,6 @@ class Asset extends Depreciable
         'location_id'    => 'integer',
         'rtd_company_id' => 'integer',
         'supplier_id'    => 'integer',
-        'byod'           => 'boolean',
         'created_at'     => 'datetime',
         'updated_at'   => 'datetime',
         'deleted_at'  => 'datetime',
@@ -105,6 +104,7 @@ class Asset extends Depreciable
         'purchase_cost'   => 'numeric|nullable|gte:0',
         'supplier_id'     => 'exists:suppliers,id|nullable',
         'asset_eol_date'  => 'date|max:10|min:10|nullable',
+        'byod'            => 'boolean',
     ];
 
   /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -69,15 +69,12 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     ];
 
     protected $casts = [
-        'activated'    => 'boolean',
         'manager_id'   => 'integer',
         'location_id'  => 'integer',
         'company_id'   => 'integer',
-        'vip'      => 'boolean',
         'created_at'   => 'datetime',
         'updated_at'   => 'datetime',
         'deleted_at'   => 'datetime',
-        'autoassign_licenses'    => 'boolean',
     ];
 
     /**
@@ -103,6 +100,9 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         'state'                   => 'min:2|max:191|nullable',
         'country'                 => 'min:2|max:191|nullable',
         'zip'                     => 'max:10|nullable',
+        'vip'                     => 'boolean',
+        'remote'                  => 'boolean',
+        'activated'               => 'boolean',
     ];
 
     /**

--- a/tests/Feature/Api/Users/UpdateUserApiTest.php
+++ b/tests/Feature/Api/Users/UpdateUserApiTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Api\Users;
+
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+use Tests\Support\InteractsWithAuthentication;
+
+
+class UpdateUserApiTest extends TestCase
+{
+    use InteractsWithSettings;
+    use InteractsWithAuthentication;
+
+    public function testApiUsersCanBeActivatedWithNumber()
+    {
+        $admin = User::factory()->superuser()->create();
+        $user = User::factory()->create(['activated' => 0]);
+
+        $this->actingAsForApi($admin)
+            ->patch(route('api.users.update', $user), [
+                'activated' => 1,
+            ]);
+
+        $this->assertEquals(1, $user->refresh()->activated);
+    }
+
+    public function testApiUsersCanBeActivatedWithBooleanTrue()
+    {
+        $admin = User::factory()->superuser()->create();
+        $user = User::factory()->create(['activated' => false]);
+
+        $this->actingAsForApi($admin)
+            ->patch(route('api.users.update', $user), [
+                'activated' => true,
+            ]);
+
+        $this->assertEquals(1, $user->refresh()->activated);
+    }
+
+    public function testApiUsersCanBeDeactivatedWithNumber()
+    {
+        $admin = User::factory()->superuser()->create();
+        $user = User::factory()->create(['activated' => true]);
+
+        $this->actingAsForApi($admin)
+            ->patch(route('api.users.update', $user), [
+                'activated' => 0,
+            ]);
+
+        $this->assertEquals(0, $user->refresh()->activated);
+    }
+
+    public function testApiUsersCanBeDeactivatedWithBooleanFalse()
+    {
+        $admin = User::factory()->superuser()->create();
+        $user = User::factory()->create(['activated' => true]);
+
+        $this->actingAsForApi($admin)
+            ->patch(route('api.users.update', $user), [
+                'activated' => false,
+            ]);
+
+        $this->assertEquals(0, $user->refresh()->activated);
+    }
+
+}

--- a/tests/Feature/Users/UpdateUserTest.php
+++ b/tests/Feature/Users/UpdateUserTest.php
@@ -10,10 +10,10 @@ class UpdateUserTest extends TestCase
 {
     use InteractsWithSettings;
 
-    public function testUsersCanBeActivated()
+    public function testUsersCanBeActivatedWithNumber()
     {
         $admin = User::factory()->superuser()->create();
-        $user = User::factory()->create(['activated' => false]);
+        $user = User::factory()->create(['activated' => 0]);
 
         $this->actingAs($admin)
             ->put(route('users.update', $user), [
@@ -25,7 +25,22 @@ class UpdateUserTest extends TestCase
         $this->assertEquals(1, $user->refresh()->activated);
     }
 
-    public function testUsersCanBeDeactivated()
+    public function testUsersCanBeActivatedWithBooleanTrue()
+    {
+        $admin = User::factory()->superuser()->create();
+        $user = User::factory()->create(['activated' => false]);
+
+        $this->actingAs($admin)
+            ->put(route('users.update', $user), [
+                'first_name' => $user->first_name,
+                'username' => $user->username,
+                'activated' => true,
+            ]);
+
+        $this->assertEquals(1, $user->refresh()->activated);
+    }
+
+    public function testUsersCanBeDeactivatedWithNumber()
     {
         $admin = User::factory()->superuser()->create();
         $user = User::factory()->create(['activated' => true]);
@@ -34,9 +49,22 @@ class UpdateUserTest extends TestCase
             ->put(route('users.update', $user), [
                 'first_name' => $user->first_name,
                 'username' => $user->username,
-                // checkboxes that are not checked are
-                // not included in the request payload
-                // 'activated' => 0,
+                'activated' => 0,
+            ]);
+
+        $this->assertEquals(0, $user->refresh()->activated);
+    }
+
+    public function testUsersCanBeDeactivatedWithBooleanFalse()
+    {
+        $admin = User::factory()->superuser()->create();
+        $user = User::factory()->create(['activated' => true]);
+
+        $this->actingAs($admin)
+            ->put(route('users.update', $user), [
+                'first_name' => $user->first_name,
+                'username' => $user->username,
+                'activated' => false,
             ]);
 
         $this->assertEquals(0, $user->refresh()->activated);
@@ -50,10 +78,6 @@ class UpdateUserTest extends TestCase
             ->put(route('users.update', $admin), [
                 'first_name' => $admin->first_name,
                 'username' => $admin->username,
-                // checkboxes that are disabled are not
-                // included in the request payload
-                // even if they are checked
-                // 'activated' => 0,
             ]);
 
         $this->assertEquals(1, $admin->refresh()->activated);

--- a/tests/Feature/Users/UpdateUserTest.php
+++ b/tests/Feature/Users/UpdateUserTest.php
@@ -22,7 +22,7 @@ class UpdateUserTest extends TestCase
                 'activated' => 1,
             ]);
 
-        $this->assertTrue($user->refresh()->activated);
+        $this->assertEquals(1, $user->refresh()->activated);
     }
 
     public function testUsersCanBeDeactivated()
@@ -39,7 +39,7 @@ class UpdateUserTest extends TestCase
                 // 'activated' => 0,
             ]);
 
-        $this->assertFalse($user->refresh()->activated);
+        $this->assertEquals(0, $user->refresh()->activated);
     }
 
     public function testUsersUpdatingThemselvesDoNotDeactivateTheirAccount()
@@ -56,6 +56,6 @@ class UpdateUserTest extends TestCase
                 // 'activated' => 0,
             ]);
 
-        $this->assertTrue($admin->refresh()->activated);
+        $this->assertEquals(1, $admin->refresh()->activated);
     }
 }


### PR DESCRIPTION
This should make the behavior of the API for boolean fields a little more consistent. What's goofy though is if you're using postman, this [fails using true/false, but works with 1 or 0](https://stackoverflow.com/questions/61713836/laravels-validation-failed-for-boolean-value-sended-by-postman#comment109161647_61713836).

<img width="771" alt="Screenshot 2023-08-30 at 4 42 42 PM" src="https://github.com/snipe/snipe-it/assets/197404/80b38fbb-e1ef-4484-ab74-3fc90b79a6a0">
<img width="760" alt="Screenshot 2023-08-30 at 4 42 48 PM" src="https://github.com/snipe/snipe-it/assets/197404/9c9df2de-a31f-444e-9c10-aafae0b5e285">

I guess we just have to document that in the API docs. :-/