### PR TITLE
Fixed ErrorException: Attempt to read property "asset_tag" on null (rollbar #3541)

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -58,8 +58,14 @@ class BulkAssetsController extends Controller
             switch ($request->input('bulk_actions')) {
                 case 'labels':
                     $this->authorize('view', Asset::class);
+                    $assets_found = Asset::find($asset_ids);
+                    
+                    if ($assets_found->isEmpty()){
+                        return redirect()->back();
+                    }
+
                     return (new Label)
-                        ->with('assets', Asset::find($asset_ids))
+                        ->with('assets', $assets_found)
                         ->with('settings', Setting::getSettings())
                         ->with('bulkedit', true)
                         ->with('count', 0);

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -39,10 +39,6 @@ class Label implements View
         $assets = $this->data->get('assets');
         $offset = $this->data->get('offset');
         $template = $this->data->get('template');
-        
-        if ($assets->isEmpty()){
-            return redirect()->back();
-        }
 
         // If disabled, pass to legacy view
         if ((!$settings->label2_enable) && (!$template)) {

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -39,6 +39,10 @@ class Label implements View
         $assets = $this->data->get('assets');
         $offset = $this->data->get('offset');
         $template = $this->data->get('template');
+        
+        if ($assets->isEmpty()){
+            return redirect()->back();
+        }
 
         // If disabled, pass to legacy view
         if ((!$settings->label2_enable) && (!$template)) {


### PR DESCRIPTION
# Description
When trying to generate a label on a deleted asset the system returns a 500 error. I'll put an early return if no assets are found, so the user returns to the asset view with the warning that says the asset is currently deleted.

Fixes rollbar RB-3541

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP Dev server
* OS version: Debian 12
