### PR TITLE
Fixed ErrorException: Attempt to read property "id" on null (rollbar #3541)

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -79,13 +79,15 @@ class CheckoutableListener
         /**
          * Send the appropriate notification
          */
-        $acceptances = CheckoutAcceptance::where('checkoutable_id', $event->checkoutable->id ?? null)
-                                        ->where('assigned_to_id', $event->checkedOutTo->id ?? null)
-                                        ->get();
+        if ($event->checkedOutTo && $event->checkoutable){
+            $acceptances = CheckoutAcceptance::where('checkoutable_id', $event->checkoutable->id)
+                                            ->where('assigned_to_id', $event->checkedOutTo->id)
+                                            ->get();
 
-        foreach($acceptances as $acceptance){
-            if($acceptance->isPending()){
-                $acceptance->delete();
+            foreach($acceptances as $acceptance){
+                if($acceptance->isPending()){
+                    $acceptance->delete();
+                }
             }
         }
 

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -79,8 +79,8 @@ class CheckoutableListener
         /**
          * Send the appropriate notification
          */
-        $acceptances = CheckoutAcceptance::where('checkoutable_id', $event->checkoutable->id)
-                                        ->where('assigned_to_id', $event->checkedOutTo->id)
+        $acceptances = CheckoutAcceptance::where('checkoutable_id', $event->checkoutable->id ?? null)
+                                        ->where('assigned_to_id', $event->checkedOutTo->id ?? null)
                                         ->get();
 
         foreach($acceptances as $acceptance){


### PR DESCRIPTION
# Description
For some reason, the notification for license seats checkins breaks, the rollbar only shows occurrences over the demo so I think it's related to that factor. But I added the null coalescing operator anyway, doesn't hurt to be cautious.

Fixes rollbar #3541

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 12
