### PR TITLE
Added model name and number to dynamic url

### DIFF
--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -548,8 +548,10 @@ class AssetPresenter extends Presenter
     public function dynamicWarrantyUrl()
     {
         $warranty_lookup_url = $this->model->model->manufacturer->warranty_lookup_url;
-        $url = (str_replace('{LOCALE}',\App\Models\Setting::getSettings()->locale,$warranty_lookup_url));
-        $url = (str_replace('{SERIAL}',$this->model->serial,$url));
+        $url = (str_replace('{LOCALE}',\App\Models\Setting::getSettings()->locale, $warranty_lookup_url));
+        $url = (str_replace('{SERIAL}', urlencode($this->model->serial), $url));
+        $url = (str_replace('{MODEL_NAME}', urlencode($this->model->model->name), $url));
+        $url = (str_replace('{MODEL_NUMBER}', urlencode($this->model->model->model_number), $url));
         return $url;
     }
 

--- a/resources/lang/en/admin/manufacturers/message.php
+++ b/resources/lang/en/admin/manufacturers/message.php
@@ -2,7 +2,7 @@
 
 return array(
 
-    'support_url_help' => 'Use <code>{LOCALE}</code> and <code>{SERIAL}</code> in your URL as variables to have those values auto-populate when viewing assets.',
+    'support_url_help' => 'Variables <code>{LOCALE}</code>, <code>{SERIAL}</code>, <code>{MODEL_NUMBER}</code>, and <code>{MODEL_NAME}</code> may be used in your URL to have those values auto-populate when viewing assets - for example https://support.apple.com/{LOCALE}/{SERIAL}.',
     'does_not_exist' => 'Manufacturer does not exist.',
     'assoc_users'	 => 'This manufacturer is currently associated with at least one model and cannot be deleted. Please update your models to no longer reference this manufacturer and try again. ',
 


### PR DESCRIPTION
Some manufacturers require additional information in their service lookup urls, so we've added `{MODEL_NAME}` and `{MODEL_NUMBER}` to the dynamic url.

### Manufacturer Edit
<img width="1063" alt="Screenshot 2023-08-31 at 6 07 53 PM" src="https://github.com/snipe/snipe-it/assets/197404/6cb4dbd0-2c5e-4444-be0d-d988566eb90e">

### Asset View
<img width="798" alt="Screenshot 2023-08-31 at 6 08 12 PM" src="https://github.com/snipe/snipe-it/assets/197404/3d75945c-46fc-4ead-bf8a-79752db8a3f5">
