### PR TITLE
Added/Fixed: track changes on asset checkin/out

### DIFF
--- a/app/Events/CheckoutableCheckedIn.php
+++ b/app/Events/CheckoutableCheckedIn.php
@@ -15,18 +15,20 @@ class CheckoutableCheckedIn
     public $checkedInBy;
     public $note;
     public $action_date; // Date setted in the hardware.checkin view at the checkin_at input, for the action log
+    public $originalValues;
 
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct($checkoutable, $checkedOutTo, User $checkedInBy, $note, $action_date = null)
+    public function __construct($checkoutable, $checkedOutTo, User $checkedInBy, $note, $action_date = null, $originalValues = [])
     {
         $this->checkoutable = $checkoutable;
         $this->checkedOutTo = $checkedOutTo;
         $this->checkedInBy = $checkedInBy;
         $this->note = $note;
         $this->action_date = $action_date ?? date('Y-m-d');
+        $this->originalValues = $originalValues;
     }
 }

--- a/app/Events/CheckoutableCheckedOut.php
+++ b/app/Events/CheckoutableCheckedOut.php
@@ -14,17 +14,19 @@ class CheckoutableCheckedOut
     public $checkedOutTo;
     public $checkedOutBy;
     public $note;
+    public $originalValues;
 
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct($checkoutable, $checkedOutTo, User $checkedOutBy, $note)
+    public function __construct($checkoutable, $checkedOutTo, User $checkedOutBy, $note, $originalValues = [])
     {
         $this->checkoutable = $checkoutable;
         $this->checkedOutTo = $checkedOutTo;
         $this->checkedOutBy = $checkedOutBy;
         $this->note = $note;
+        $this->originalValues = $originalValues;
     }
 }

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -924,10 +924,14 @@ class AssetsController extends Controller
         }
         
         $checkin_at = $request->filled('checkin_at') ? $request->input('checkin_at').' '. date('H:i:s') : date('Y-m-d H:i:s');
+        $originalValues = $asset->getRawOriginal();
 
+        if (($request->filled('checkin_at')) && ($request->get('checkin_at') != date('Y-m-d'))) {
+            $originalValues['action_date'] = $checkin_at;
+        }
 
         if ($asset->save()) {
-            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $checkin_at));
+            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $checkin_at, $originalValues));
 
             return response()->json(Helper::formatStandardApiResponse('success', ['asset'=> e($asset->asset_tag)], trans('admin/hardware/message.checkin.success')));
         }

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -108,8 +108,11 @@ class AssetCheckinController extends Controller
             }
         }
 
+        $originalValues = $asset->getRawOriginal();
+
         $checkin_at = date('Y-m-d H:i:s');
         if (($request->filled('checkin_at')) && ($request->get('checkin_at') != date('Y-m-d'))) {
+            $originalValues['action_date'] = $checkin_at;
             $checkin_at = $request->get('checkin_at');
         }
 
@@ -132,7 +135,7 @@ class AssetCheckinController extends Controller
 
         // Was the asset updated?
         if ($asset->save()) {
-            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $checkin_at));
+            event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $checkin_at, $originalValues));
 
             if ((isset($user)) && ($backto == 'user')) {
                 return redirect()->route('users.show', $user->id)->with('success', trans('admin/hardware/message.checkin.success'));

--- a/app/Listeners/LogListener.php
+++ b/app/Listeners/LogListener.php
@@ -33,7 +33,7 @@ class LogListener
      */
     public function onCheckoutableCheckedIn(CheckoutableCheckedIn $event)
     {
-        $event->checkoutable->logCheckin($event->checkedOutTo, $event->note, $event->action_date);
+        $event->checkoutable->logCheckin($event->checkedOutTo, $event->note, $event->action_date, $event->originalValues);
     }
 
     /**
@@ -46,7 +46,7 @@ class LogListener
      */
     public function onCheckoutableCheckedOut(CheckoutableCheckedOut $event)
     {
-        $event->checkoutable->logCheckout($event->note, $event->checkedOutTo, $event->checkoutable->last_checkout);
+        $event->checkoutable->logCheckout($event->note, $event->checkedOutTo, $event->checkoutable->last_checkout, $event->originalValues);
     }
 
     /**

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -332,6 +332,13 @@ class Asset extends Depreciable
             }
         }
 
+        $originalValues = $this->getRawOriginal();
+
+        // attempt to detect change in value if different from today's date
+        if ($checkout_at && strpos($checkout_at, date('Y-m-d')) === false) {
+            $originalValues['action_date'] = date('Y-m-d H:i:s');
+        }
+
         if ($this->save()) {
             if (is_int($admin)) {
                 $checkedOutBy = User::findOrFail($admin);
@@ -340,7 +347,7 @@ class Asset extends Depreciable
             } else {
                 $checkedOutBy = Auth::user();
             }
-            event(new CheckoutableCheckedOut($this, $target, $checkedOutBy, $note));
+            event(new CheckoutableCheckedOut($this, $target, $checkedOutBy, $note, $originalValues));
 
             $this->increment('checkout_counter', 1);
 

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -23,7 +23,7 @@ trait Loggable
      * @since [v3.4]
      * @return \App\Models\Actionlog
      */
-    public function logCheckout($note, $target, $action_date = null)
+    public function logCheckout($note, $target, $action_date = null, $originalValues = [])
     {
         $log = new Actionlog;
         $log = $this->determineLogItemType($log);
@@ -62,6 +62,23 @@ trait Loggable
             $log->action_date = date('Y-m-d H:i:s');
         }
 
+        $changed = [];
+        $originalValues = array_intersect_key($originalValues, array_flip(['action_date','name','status_id','location_id','expected_checkin']));
+
+        foreach ($originalValues as $key => $value) {
+            if ($key == 'action_date' && $value != $action_date) {
+                $changed[$key]['old'] = $value;
+                $changed[$key]['new'] = is_string($action_date) ? $action_date : $action_date->format('Y-m-d H:i:s');
+            } elseif ($value != $this->getAttributes()[$key]) {
+                $changed[$key]['old'] = $value;
+                $changed[$key]['new'] = $this->getAttributes()[$key];
+            }
+        }
+
+        if (!empty($changed)){
+            $log->log_meta = json_encode($changed);
+        }
+
         $log->logaction('checkout');
 
         return $log;
@@ -89,7 +106,7 @@ trait Loggable
      * @since [v3.4]
      * @return \App\Models\Actionlog
      */
-    public function logCheckin($target, $note, $action_date = null)
+    public function logCheckin($target, $note, $action_date = null, $originalValues = [])
     {
         $settings = Setting::getSettings();
         $log = new Actionlog;
@@ -114,13 +131,9 @@ trait Loggable
             }
         }
 
-
         $log->location_id = null;
         $log->note = $note;
         $log->action_date = $action_date;
-        if (! $log->action_date) {
-            $log->action_date = date('Y-m-d H:i:s');
-        }
 
         if (! $log->action_date) {
             $log->action_date = date('Y-m-d H:i:s');
@@ -128,6 +141,23 @@ trait Loggable
 
         if (Auth::user()) {
             $log->user_id = Auth::user()->id;
+        }
+
+        $changed = [];
+        $originalValues = array_intersect_key($originalValues, array_flip(['action_date','name','status_id','location_id','expected_checkin']));
+
+        foreach ($originalValues as $key => $value) {
+            if ($key == 'action_date' && $value != $action_date) {
+                $changed[$key]['old'] = $value;
+                $changed[$key]['new'] = is_string($action_date) ? $action_date : $action_date->format('Y-m-d H:i:s');
+            } elseif ($value != $this->getAttributes()[$key]) {
+                $changed[$key]['old'] = $value;
+                $changed[$key]['new'] = $this->getAttributes()[$key];
+            }
+        }
+
+        if (!empty($changed)){
+            $log->log_meta = json_encode($changed);
         }
 
         $log->logaction('checkin from');


### PR DESCRIPTION
# Description

At the moment changes to action_date, name, status_id, location_id and expected_checkin during Asset checkin/out are not tracked in the actionlog
![image](https://github.com/snipe/snipe-it/assets/63399474/bbcad882-5103-4bda-a585-09f1691b51b6)
Currently missing changes
![image](https://github.com/snipe/snipe-it/assets/63399474/662d03ca-d429-41c5-94bf-efdb608c60d2)

This PR fixes the actionlog to contain these changes
![image](https://github.com/snipe/snipe-it/assets/63399474/81e97b2b-56db-4522-ba78-f63db101dae2)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested via UI and API
- Checked out asset with no changes
- Checked in asset with no changes
- Checked out asset with changes
- Checked in asset with changes

**Test Configuration**:
* PHP version: 8.1.22
* MySQL version
* Webserver version: Apache/2.4.57
* OS version: Ubuntu


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
