### PR TITLE
Account for hard-deleted models, suppliers in asset history

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -161,6 +161,7 @@ class ActionlogsTransformer
     {   $location = Location::withTrashed()->get();
         $supplier = Supplier::withTrashed()->get();
         $model = AssetModel::withTrashed()->get();
+        $company = Company::withTrashed()->get();
 
 
         if(array_key_exists('rtd_location_id',$clean_meta)) {
@@ -191,10 +192,10 @@ class ActionlogsTransformer
         }
         if(array_key_exists('company_id', $clean_meta)) {
 
-            $oldCompany = Company::find($clean_meta['company_id']['old']);
+            $oldCompany = $company->find($clean_meta['company_id']['old']);
             $oldCompanyName = $oldCompany->name ?? trans('admin/companies/message.deleted');
 
-            $newCompany = Company::find($clean_meta['company_id']['new']);
+            $newCompany = $company->find($clean_meta['company_id']['new']);
             $newCompanyName = $newCompany->name ?? trans('admin/companies/message.deleted');
 
             $clean_meta['company_id']['old'] = $clean_meta['company_id']['old'] ? "[id: ".$clean_meta['company_id']['old']."] ". $oldCompanyName : trans('general.unassigned');
@@ -204,10 +205,10 @@ class ActionlogsTransformer
         }
         if(array_key_exists('supplier_id', $clean_meta)) {
 
-            $oldSupplier = Supplier::find($clean_meta['supplier_id']['old']);
+            $oldSupplier = $supplier->find($clean_meta['supplier_id']['old']);
             $oldSupplierName = $oldSupplier->name ?? trans('admin/suppliers/message.deleted');
 
-            $newSupplier = Supplier::find($clean_meta['supplier_id']['new']);
+            $newSupplier = $supplier->find($clean_meta['supplier_id']['new']);
             $newSupplierName = $newSupplier->name ?? trans('admin/suppliers/message.deleted');
 
             $clean_meta['supplier_id']['old'] = $clean_meta['supplier_id']['old'] ? "[id: ".$clean_meta['supplier_id']['old']."] ". $oldSupplierName : trans('general.unassigned');

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -177,13 +177,20 @@ class ActionlogsTransformer
         }
         if(array_key_exists('model_id', $clean_meta)) {
 
-            $clean_meta['model_id']['old'] = "[id: ".$clean_meta['model_id']['old']."] ".$model->find($clean_meta['model_id']['old'])->name;
-            $clean_meta['model_id']['new'] = "[id: ".$clean_meta['model_id']['new']."] ".$model->find($clean_meta['model_id']['new'])->name; /* model is required at asset creation */
+            $oldModel = $model->find($clean_meta['model_id']['old']);
+            $oldModelName = $oldModel->name ?? trans('admin/models/message.deleted');
+
+            $newModel = $model->find($clean_meta['model_id']['new']);
+            $newModelName = $newModel->name ?? trans('admin/models/message.deleted');
+
+            $clean_meta['model_id']['old'] = "[id: ".$clean_meta['model_id']['old']."] ".$oldModelName;
+            $clean_meta['model_id']['new'] = "[id: ".$clean_meta['model_id']['new']."] ".$newModelName; /** model is required at asset creation */
 
             $clean_meta['Model'] = $clean_meta['model_id'];
             unset($clean_meta['model_id']);
         }
         if(array_key_exists('company_id', $clean_meta)) {
+
             $oldCompany = Company::find($clean_meta['company_id']['old']);
             $oldCompanyName = $oldCompany->name ?? trans('admin/companies/message.deleted');
 
@@ -196,8 +203,15 @@ class ActionlogsTransformer
             unset($clean_meta['company_id']);
         }
         if(array_key_exists('supplier_id', $clean_meta)) {
-            $clean_meta['supplier_id']['old'] = $clean_meta['supplier_id']['old'] ? "[id: ".$clean_meta['supplier_id']['old']."] ".$supplier->find($clean_meta['supplier_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['supplier_id']['new'] = $clean_meta['supplier_id']['new'] ? "[id: ".$clean_meta['supplier_id']['new']."] ".$supplier->find($clean_meta['supplier_id']['new'])->name : trans('general.unassigned');
+
+            $oldSupplier = Supplier::find($clean_meta['supplier_id']['old']);
+            $oldSupplierName = $oldSupplier->name ?? trans('admin/suppliers/message.deleted');
+
+            $newSupplier = Supplier::find($clean_meta['supplier_id']['new']);
+            $newSupplierName = $newSupplier->name ?? trans('admin/suppliers/message.deleted');
+
+            $clean_meta['supplier_id']['old'] = $clean_meta['supplier_id']['old'] ? "[id: ".$clean_meta['supplier_id']['old']."] ". $oldSupplierName : trans('general.unassigned');
+            $clean_meta['supplier_id']['new'] = $clean_meta['supplier_id']['new'] ? "[id: ".$clean_meta['supplier_id']['new']."] ". $newSupplierName : trans('general.unassigned');
             $clean_meta['Supplier'] = $clean_meta['supplier_id'];
             unset($clean_meta['supplier_id']);
         }

--- a/resources/lang/en/admin/models/message.php
+++ b/resources/lang/en/admin/models/message.php
@@ -2,6 +2,7 @@
 
 return array(
 
+    'deleted' => 'Deleted asset model',
     'does_not_exist' => 'Model does not exist.',
     'no_association' => 'WARNING! The asset model for this item is invalid or missing!',
     'no_association_fix' => 'This will break things in weird and horrible ways. Edit this asset now to assign it a model.',

--- a/resources/lang/en/admin/suppliers/message.php
+++ b/resources/lang/en/admin/suppliers/message.php
@@ -2,6 +2,7 @@
 
 return array(
 
+    'deleted' => 'Deleted supplier',
     'does_not_exist' => 'Supplier does not exist.',
 
 


### PR DESCRIPTION
This catches the scenario where an asset had been previously classified with a model ID or supplier ID that was subsequently hard-deleted.

I think this transformer still needs to be refactored though. I'm seeing the n+1 query problem I mentioned a few weeks ago.

<img width="1649" alt="Screenshot 2023-09-05 at 4 02 03 PM" src="https://github.com/snipe/snipe-it/assets/197404/da160ca6-cf60-44fc-af41-386ff64f6538">


