### PR TITLE
Fixed #13562 - Added inline file link

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesFilesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesFilesController.php
@@ -161,22 +161,19 @@ class AccessoriesFilesController extends Controller
                     ->header('Content-Type', 'text/plain');
             } else {
 
+                // Display the file inline
+                if (request('inline') == 'true') {
+                    $headers = [
+                        'Content-Disposition' => 'inline',
+                    ];
+                    return Storage::download($file, $log->filename, $headers);
+                }
+
+
                 // We have to override the URL stuff here, since local defaults in Laravel's Flysystem
                 // won't work, as they're not accessible via the web
                 if (config('filesystems.default') == 'local') { // TODO - is there any way to fix this at the StorageHelper layer?
                     return StorageHelper::downloader($file);
-                } else {
-                    if ($download != 'true') {
-                        \Log::debug('display the file');
-                        if ($contents = file_get_contents(Storage::url($file))) { // TODO - this will fail on private S3 files or large public ones
-                            return Response::make(Storage::url($file)->header('Content-Type', mime_content_type($file)));
-                        }
-
-                        return JsonResponse::create(['error' => 'Failed validation: '], 500);
-                    }
-
-                    return StorageHelper::downloader($file);
-
                 }
             }
         }

--- a/app/Http/Controllers/AssetModelsFilesController.php
+++ b/app/Http/Controllers/AssetModelsFilesController.php
@@ -78,7 +78,7 @@ class AssetModelsFilesController extends Controller
      * @return View
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function show($modelId = null, $fileId = null, $download = true)
+    public function show($modelId = null, $fileId = null)
     {
         $model = AssetModel::find($modelId);
         // the asset is valid
@@ -99,12 +99,13 @@ class AssetModelsFilesController extends Controller
                     ->header('Content-Type', 'text/plain');
             }
 
-            if ($download != 'true') {
-                if ($contents = file_get_contents(Storage::url($file))) {
-                    return Response::make(Storage::url($file)->header('Content-Type', mime_content_type($file)));
-                }
+            if (request('inline') == 'true') {
 
-                return JsonResponse::create(['error' => 'Failed validation: '], 500);
+                $headers = [
+                    'Content-Disposition' => 'inline',
+                ];
+
+                return Storage::download($file, $log->filename, $headers);
             }
 
             return StorageHelper::downloader($file);

--- a/app/Http/Controllers/Assets/AssetFilesController.php
+++ b/app/Http/Controllers/Assets/AssetFilesController.php
@@ -79,7 +79,7 @@ class AssetFilesController extends Controller
      * @return View
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function show($assetId = null, $fileId = null, $download = true)
+    public function show($assetId = null, $fileId = null)
     {
         $asset = Asset::find($assetId);
         // the asset is valid
@@ -103,12 +103,13 @@ class AssetFilesController extends Controller
                     ->header('Content-Type', 'text/plain');
             }
 
-            if ($download != 'true') {
-                if ($contents = file_get_contents(Storage::url($file))) {
-                    return Response::make(Storage::url($file)->header('Content-Type', mime_content_type($file)));
-                }
+            if (request('inline') == 'true') {
 
-                return JsonResponse::create(['error' => 'Failed validation: '], 500);
+                $headers = [
+                    'Content-Disposition' => 'inline',
+                ];
+
+                return Storage::download($file, $log->filename, $headers);
             }
 
             return StorageHelper::downloader($file);

--- a/app/Http/Controllers/Components/ComponentsFilesController.php
+++ b/app/Http/Controllers/Components/ComponentsFilesController.php
@@ -132,7 +132,7 @@ class ComponentsFilesController extends Controller
      * @return \Symfony\Component\HttpFoundation\Response
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function show($componentId = null, $fileId = null, $download = true)
+    public function show($componentId = null, $fileId = null)
     {
         \Log::debug('Private filesystem is: '.config('filesystems.default'));
         $component = Component::find($componentId);
@@ -157,21 +157,17 @@ class ComponentsFilesController extends Controller
                     ->header('Content-Type', 'text/plain');
             } else {
 
+                // Display the file inline
+                if (request('inline') == 'true') {
+                    $headers = [
+                        'Content-Disposition' => 'inline',
+                    ];
+                    return Storage::download($file, $log->filename, $headers);
+                }
+
                 if (config('filesystems.default') == 'local') { // TODO - is there any way to fix this at the StorageHelper layer?
                     return StorageHelper::downloader($file);
-                } else {
-                    if ($download != 'true') {
-                        \Log::debug('display the file');
-                        if ($contents = file_get_contents(Storage::url($file))) { // TODO - this will fail on private S3 files or large public ones
-                            return Response::make(Storage::url($file)->header('Content-Type', mime_content_type($file)));
-                        }
-
-                        return JsonResponse::create(['error' => 'Failed validation: '], 500);
-                    }
-
-                    return StorageHelper::downloader($file);
-
-                }
+                } 
             }
         }
 

--- a/app/Http/Controllers/Consumables/ConsumablesFilesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesFilesController.php
@@ -131,7 +131,7 @@ class ConsumablesFilesController extends Controller
      * @return \Symfony\Consumable\HttpFoundation\Response
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function show($consumableId = null, $fileId = null, $download = true)
+    public function show($consumableId = null, $fileId = null)
     {
         $consumable = Consumable::find($consumableId);
 
@@ -155,22 +155,19 @@ class ConsumablesFilesController extends Controller
                     ->header('Content-Type', 'text/plain');
             } else {
 
+                // Display the file inline
+                if (request('inline') == 'true') {
+                    $headers = [
+                        'Content-Disposition' => 'inline',
+                    ];
+                    return Storage::download($file, $log->filename, $headers);
+                }
+
+
                 // We have to override the URL stuff here, since local defaults in Laravel's Flysystem
                 // won't work, as they're not accessible via the web
                 if (config('filesystems.default') == 'local') { // TODO - is there any way to fix this at the StorageHelper layer?
                     return StorageHelper::downloader($file);
-                } else {
-                    if ($download != 'true') {
-                        \Log::debug('display the file');
-                        if ($contents = file_get_contents(Storage::url($file))) { // TODO - this will fail on private S3 files or large public ones
-                            return Response::make(Storage::url($file)->header('Content-Type', mime_content_type($file)));
-                        }
-
-                        return JsonResponse::create(['error' => 'Failed validation: '], 500);
-                    }
-
-                    return StorageHelper::downloader($file);
-
                 }
             }
         }

--- a/app/Http/Controllers/Licenses/LicenseFilesController.php
+++ b/app/Http/Controllers/Licenses/LicenseFilesController.php
@@ -152,20 +152,18 @@ class LicenseFilesController extends Controller
                     ->header('Content-Type', 'text/plain');
             } else {
 
+                if (request('inline') == 'true') {
+
+                    $headers = [
+                        'Content-Disposition' => 'inline',
+                    ];
+
+                    return Storage::download($file, $log->filename, $headers);
+                }
+
                 // We have to override the URL stuff here, since local defaults in Laravel's Flysystem
                 // won't work, as they're not accessible via the web
                 if (config('filesystems.default') == 'local') { // TODO - is there any way to fix this at the StorageHelper layer?
-                    return StorageHelper::downloader($file);
-                } else {
-                    if ($download != 'true') {
-                        \Log::debug('display the file');
-                        if ($contents = file_get_contents(Storage::url($file))) { // TODO - this will fail on private S3 files or large public ones
-                            return Response::make(Storage::url($file)->header('Content-Type', mime_content_type($file)));
-                        }
-
-                        return JsonResponse::create(['error' => 'Failed validation: '], 500);
-                    }
-
                     return StorageHelper::downloader($file);
 
                 }

--- a/app/Http/Controllers/Users/UserFilesController.php
+++ b/app/Http/Controllers/Users/UserFilesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Users;
 
+use App\Helpers\StorageHelper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetFileRequest;
 use App\Models\Actionlog;
@@ -143,17 +144,17 @@ class UserFilesController extends Controller
             $this->authorize('view', $user);
 
             $log = Actionlog::find($fileId);
-            $file = 'private_uploads/users/'.$log->filename;
 
             // Display the file inline
             if (request('inline') == 'true') {
                 $headers = [
                     'Content-Disposition' => 'inline',
                 ];
-                return Storage::download($file, $log->filename, $headers);
+                return Storage::download('private_uploads/users/'.$log->filename, $log->filename, $headers);
             }
 
-            return Response::download($file); //FIXME this doesn't use the new StorageHelper yet, but it's complicated...
+            return Storage::download('private_uploads/users/'.$log->filename);
+
         }
 
         // Redirect to the user management page if the user doesn't exist

--- a/app/Http/Controllers/Users/UserFilesController.php
+++ b/app/Http/Controllers/Users/UserFilesController.php
@@ -139,18 +139,25 @@ class UserFilesController extends Controller
 
         // the license is valid
         if (isset($user->id)) {
+
             $this->authorize('view', $user);
 
             $log = Actionlog::find($fileId);
-            $file = $log->get_src('users');
+            $file = 'private_uploads/users/'.$log->filename;
+
+            // Display the file inline
+            if (request('inline') == 'true') {
+                $headers = [
+                    'Content-Disposition' => 'inline',
+                ];
+                return Storage::download($file, $log->filename, $headers);
+            }
 
             return Response::download($file); //FIXME this doesn't use the new StorageHelper yet, but it's complicated...
         }
-        // Prepare the error message
-        $error = trans('admin/users/message.user_not_found', ['id' => $userId]);
 
-        // Redirect to the licence management page
-        return redirect()->route('users.index')->with('error', $error);
+        // Redirect to the user management page if the user doesn't exist
+        return redirect()->route('users.index')->with('error',  trans('admin/users/message.user_not_found', ['id' => $userId]));
     }
 
 }

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -210,10 +210,15 @@
                                                 </td>
                                                 <td>
                                                     @if ($file->filename)
-                                                        <a href="{{ route('show.accessoryfile', [$accessory->id, $file->id, 'download' => 'true']) }}" class="btn btn-default">
+                                                        <a href="{{ route('show.accessoryfile', [$accessory->id, $file->id]) }}" class="btn btn-sm btn-default">
                                                             <i class="fas fa-download" aria-hidden="true"></i>
                                                             <span class="sr-only">{{ trans('general.download') }}</span>
                                                         </a>
+
+                                                        <a href="{{ route('show.accessoryfile', [$accessory->id, $file->id, 'inline' => 'true']) }}" class="btn btn-sm btn-default" target="_blank">
+                                                            <i class="fa fa-external-link" aria-hidden="true"></i>
+                                                        </a>
+
                                                     @endif
                                                 </td>
                                                 <td>{{ $file->created_at }}</td>

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -203,10 +203,15 @@
                       </td>
                       <td>
                         @if ($file->filename)
-                          <a href="{{ route('show.componentfile', [$component->id, $file->id, 'download' => 'true']) }}" class="btn btn-default">
+                          <a href="{{ route('show.componentfile', [$component->id, $file->id]) }}" class="btn btn-sm btn-default">
                             <i class="fas fa-download" aria-hidden="true"></i>
                             <span class="sr-only">{{ trans('general.download') }}</span>
                           </a>
+
+                          <a href="{{ route('show.componentfile', [$component->id, $file->id, 'inline' => 'true']) }}" class="btn btn-sm btn-default" target="_blank">
+                            <i class="fa fa-external-link" aria-hidden="true"></i>
+                          </a>
+
                         @endif
                       </td>
                       <td>{{ $file->created_at }}</td>

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -160,9 +160,13 @@
                       </td>
                       <td>
                         @if ($file->filename)
-                          <a href="{{ route('show.consumablefile', [$consumable->id, $file->id, 'download' => 'true']) }}" class="btn btn-default">
+                          <a href="{{ route('show.consumablefile', [$consumable->id, $file->id]) }}" class="btn btn-sm btn-default">
                             <i class="fas fa-download" aria-hidden="true"></i>
                             <span class="sr-only">{{ trans('general.download') }}</span>
+                          </a>
+
+                          <a href="{{ route('show.consumablefile', [$consumable->id, $file->id, 'inline' => 'true']) }}" class="btn btn-sm btn-default" target="_blank">
+                            <i class="fa fa-external-link" aria-hidden="true"></i>
                           </a>
                         @endif
                       </td>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1266,8 +1266,12 @@
                                                 </td>
                                                 <td>
                                                     @if (($file->filename) && (Storage::exists('private_uploads/assets/'.$file->filename)))
-                                                        <a href="{{ route('show/assetfile', [$asset->id, $file->id]) }}" class="btn btn-default">
+                                                        <a href="{{ route('show/assetfile', [$asset->id, $file->id, 'download'=>'true']) }}" class="btn btn-sm btn-default">
                                                             <i class="fas fa-download" aria-hidden="true"></i>
+                                                        </a>
+
+                                                        <a href="{{ route('show/assetfile', [$asset->id, $file->id, 'inline'=>'true']) }}" class="btn btn-sm btn-default" target="_blank">
+                                                            <i class="fa fa-external-link" aria-hidden="true"></i>
                                                         </a>
                                                     @endif
                                                 </td>
@@ -1363,9 +1367,14 @@
                                                 </td>
                                                 <td>
                                                     @if (($file->filename) && (Storage::exists('private_uploads/assetmodels/'.$file->filename)))
-                                                        <a href="{{ route('show/modelfile', [$asset->model->id, $file->id]) }}" class="btn btn-default">
+                                                        <a href="{{ route('show/modelfile', [$asset->model->id, $file->id]) }}" class="btn btn-sm btn-default">
                                                             <i class="fas fa-download" aria-hidden="true"></i>
                                                         </a>
+
+                                                        <a href="{{ route('show/modelfile', [$asset->model->id, $file->id, 'inline'=>'true']) }}" class="btn btn-sm btn-default" target="_blank">
+                                                            <i class="fa fa-external-link" aria-hidden="true"></i>
+                                                        </a>
+
                                                     @endif
                                                 </td>
                                                 <td>

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -474,10 +474,15 @@
                 </td>
                 <td>
                   @if ($file->filename)
-                    <a href="{{ route('show.licensefile', [$license->id, $file->id, 'download' => 'true']) }}" class="btn btn-default">
+                    <a href="{{ route('show.licensefile', [$license->id, $file->id]) }}" class="btn btn-sm btn-default">
                       <i class="fas fa-download" aria-hidden="true"></i>
                       <span class="sr-only">{{ trans('general.download') }}</span>
                     </a>
+
+                    <a href="{{ route('show.licensefile', [$license->id, $file->id, 'inline' => 'true']) }}" class="btn btn-sm btn-default" target="_blank">
+                      <i class="fa fa-external-link" aria-hidden="true"></i>
+                    </a>
+
                   @endif
                 </td>
                 <td>{{ $file->created_at }}</td>

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -168,9 +168,14 @@
                                             </td>
                                             <td>
                                                 @if (($file->filename) && (Storage::exists('private_uploads/assetmodels/'.$file->filename)))
-                                                    <a href="{{ route('show/modelfile', [$model->id, $file->id]) }}" class="btn btn-default">
+                                                    <a href="{{ route('show/modelfile', [$model->id, $file->id]) }}" class="btn btn-sm btn-default">
                                                         <i class="fas fa-download" aria-hidden="true"></i>
                                                     </a>
+
+                                                    <a href="{{ route('show/modelfile', [$model->id, $file->id, 'inline'=>'true']) }}" class="btn btn-sm btn-default" target="_blank">
+                                                        <i class="fa fa-external-link" aria-hidden="true"></i>
+                                                    </a>
+
                                                 @endif
                                             </td>
                                             <td>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -913,7 +913,7 @@
                             <td>
                                 @if (($file->filename) && (Storage::exists('private_uploads/users/'.$file->filename)))
                                    @if (Helper::checkUploadIsImage($file->get_src('users')))
-                                        <a href="{{ route('show/userfile', ['userId' => $user->id, 'fileId' => $file->id, 'download' => 'false']) }}" data-toggle="lightbox" data-type="image"><img src="{{ route('show/userfile', ['userId' => $user->id, 'fileId' => $file->id]) }}" class="img-thumbnail" style="max-width: 50px;"></a>
+                                        <a href="{{ route('show/userfile', [$user->id, $file->id, 'inline' => 'true']) }}" data-toggle="lightbox" data-type="image"><img src="{{ route('show/userfile', [$user->id, $file->id, 'inline' => 'true']) }}" class="img-thumbnail" style="max-width: 50px;"></a>
                                     @else
                                         {{ trans('general.preview_not_available') }}
                                     @endif

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -937,9 +937,13 @@
                             <td>
                                 @if ($file->filename)
                                     @if (Storage::exists('private_uploads/users/'.$file->filename))
-                                        <a href="{{ route('show/userfile', [$user->id, $file->id]) }}" class="btn btn-default">
+                                        <a href="{{ route('show/userfile', [$user->id, $file->id]) }}" class="btn btn-sm btn-default">
                                             <i class="fas fa-download" aria-hidden="true"></i>
                                             <span class="sr-only">{{ trans('general.download') }}</span>
+                                        </a>
+
+                                        <a href="{{ route('show/userfile', [$user->id, $file->id, 'inline' => 'true']) }}" class="btn btn-sm btn-default" target="_blank">
+                                            <i class="fa fa-external-link" aria-hidden="true"></i>
                                         </a>
                                     @endif
                                 @endif


### PR DESCRIPTION
This adds the functionality back in to be able to preview files in the browser *as well as* the current behavior to download them. PDF file previewing in the browser will depend on browser compatibility, plugins, etc. I also dropped the size of the button down to match the `btn-sm` class for the trash icon.

<img width="1241" alt="Screenshot 2023-09-05 at 6 35 37 PM" src="https://github.com/snipe/snipe-it/assets/197404/489d9a69-220d-4b6b-b5db-ce5a188e6465">

Some of this is a little repetitive, but that's an artifact of Assets being the first and only first-class object in the system that allowed file uploads. We've added onto that over time, but the file handling stuff should probably be refactored at some point for more standardization and less copypasta.

![copypasta](https://github.com/snipe/snipe-it/assets/197404/631d7c30-c2a1-4ebe-a79b-6f66fdb5b7ed)


This fixes #13562.