### PR TITLE
Add default location to tracked changes on checkin actionlog

### DIFF
--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -144,7 +144,7 @@ trait Loggable
         }
 
         $changed = [];
-        $originalValues = array_intersect_key($originalValues, array_flip(['action_date','name','status_id','location_id','expected_checkin']));
+        $originalValues = array_intersect_key($originalValues, array_flip(['action_date','name','status_id','location_id','rtd_location_id','expected_checkin']));
 
         foreach ($originalValues as $key => $value) {
             if ($key == 'action_date' && $value != $action_date) {


### PR DESCRIPTION
# Description

This was missed in PR #13557 for tracking changes on asset checkin/out.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested via UI and API
- Checked in asset with no changes
- Checked in asset with Update Asset Location
- Checked in asset with Update default location AND actual location (only UI)

**Test Configuration**:
* PHP version: 8.1.22
* MySQL version
* Webserver version: Apache/2.4.57
* OS version: Ubuntu


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
