### PR TITLE
Fixed Attempt to read property require_acceptance on null [rollbar-3557]

### DIFF
--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -323,7 +323,10 @@ class License extends Depreciable
      */
     public function checkin_email()
     {
-        return $this->category->checkin_email;
+        if ($this->category) {
+            return $this->category->checkin_email;
+        }
+        return false;
     }
 
     /**
@@ -335,7 +338,11 @@ class License extends Depreciable
      */
     public function requireAcceptance()
     {
-        return $this->category->require_acceptance;
+        if ($this->category) {
+            return $this->category->require_acceptance;
+        }
+
+        return false;
     }
 
     /**
@@ -348,14 +355,16 @@ class License extends Depreciable
      */
     public function getEula()
     {
-
-        if ($this->category->eula_text) {
-            return Helper::parseEscapedMarkedown($this->category->eula_text);
-        } elseif ($this->category->use_default_eula == '1') {
-            return Helper::parseEscapedMarkedown(Setting::getSettings()->default_eula_text);
-        } else {
-            return false;
+        if ($this->category){
+            if ($this->category->eula_text) {
+                return Helper::parseEscapedMarkedown($this->category->eula_text);
+            } elseif ($this->category->use_default_eula == '1') {
+                return Helper::parseEscapedMarkedown(Setting::getSettings()->default_eula_text);
+            } 
         }
+
+        return false;
+        
     }
 
     /**

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -48,7 +48,10 @@ class LicenseSeat extends SnipeModel implements ICompanyableChild
      */
     public function requireAcceptance()
     {
-        return $this->license->category->require_acceptance;
+        if ($this->license && $this->license->category) {
+            return $this->license->category->require_acceptance;
+        }
+        return false;
     }
 
     public function getEula()


### PR DESCRIPTION
# Description
This is another one that should never happen... When a License doesn't have a category assigned or the category assigned no longer exists (which should never happen since assigned categories aren't allowed to be deleted) when you try to checkout that license the system breaks trying to get some properties linked to that category. 

I added a couple of guard clauses around some License and LicenseSeat models functions to prevent this. But I'm not sure if that's the correct approach, I was thinking on return an error if the category assigned is erroneous, but I'm not sure if an incorrect category is a big enough issue to not allow a checkout.

Fixes rollbar 3557

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.21
* Webserver version: PHP Dev server
* OS version: Debian 11


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes