### PR TITLE
Upgrade to new branch for our fork of laravel-scim-server

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -78,25 +78,25 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/grokability/laravel-scim-server.git",
-                "reference": "9e8dd2d3958d3c3c05d0a99fe6475361ad9e9419"
+                "reference": "dda6dfb60d70fb6cca4b8d4ce1c5f4c19deaab2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/9e8dd2d3958d3c3c05d0a99fe6475361ad9e9419",
-                "reference": "9e8dd2d3958d3c3c05d0a99fe6475361ad9e9419",
+                "url": "https://api.github.com/repos/grokability/laravel-scim-server/zipball/dda6dfb60d70fb6cca4b8d4ce1c5f4c19deaab2d",
+                "reference": "dda6dfb60d70fb6cca4b8d4ce1c5f4c19deaab2d",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
-                "illuminate/database": "^6.0|^7.0|^8.0|^9.0",
-                "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
+                "illuminate/console": "^6.0|^7.0|^8.0|^9.0|^10.0",
+                "illuminate/database": "^6.0|^7.0|^8.0|^9.0|^10.0",
+                "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
                 "php": "^7.0|^8.0",
                 "tmilos/scim-filter-parser": "^1.3",
                 "tmilos/scim-schema": "^0.1.0"
             },
             "require-dev": {
                 "laravel/legacy-factories": "*",
-                "orchestra/testbench": "^5.0|^6.0"
+                "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0"
             },
             "default-branch": true,
             "type": "library",
@@ -133,7 +133,7 @@
             "support": {
                 "source": "https://github.com/grokability/laravel-scim-server/tree/master"
             },
-            "time": "2023-01-12T00:32:07+00:00"
+            "time": "2023-09-07T16:45:26+00:00"
         },
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
This changes our `composer.lock` file to take our latest 'zipball' of our fork of the (very fantastic)  arietimmerman/laravel-scim-server, which does our SCIM integration.

The fixes in there improve some of our SCIM-trace logging, give us Laravel v10 support (without deprecating anything backwards), and give us the ability to take some Azure AD SCIM-client updates that we were unable to read before.

I've done extensive testing on this, but I'm going to go through one more cycle before I declare this 'ready to merge' - but I'm pretty confident right now.