### PR TITLE
Fixed Unaccepted Assets report has incorrect people [freshdesk-37808]

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1021,7 +1021,7 @@ class ReportsController extends Controller
 
         $assetsForReport = $acceptances
             ->filter(function ($acceptance) {
-                return $acceptance->checkoutable_type == 'App\Models\Asset';
+                return $acceptance->checkoutable_type == 'App\Models\Asset' && $acceptance->checkoutable->checkedOutToUser();
             })
             ->map(function($acceptance) {
                 return ['assetItem' => $acceptance->checkoutable, 'acceptance' => $acceptance];


### PR DESCRIPTION
# Description
When an asset is checked out to a location or another asset and requires users to accept them, they appear in the Unaccepted Assets report and tries to show the user they have assigned, which is incorrect because those entities can't accept an asset.

Notifications aren't sent, so I just filter those acceptances to not appear in the report if they aren't assigned to users.

Fixes freshdesk #37808

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version:  8.0.31
* Webserver version: PHP Dev Server
* OS version: Debian 12
