### PR TITLE
Added validation around department_id in API patch request

### DIFF
--- a/app/Http/Requests/SaveUserRequest.php
+++ b/app/Http/Requests/SaveUserRequest.php
@@ -32,7 +32,7 @@ class SaveUserRequest extends FormRequest
     public function rules()
     {
         $rules = [
-            'department_id' => 'nullable|integer|exists:departments,id',
+            'department_id' => 'nullable|exists:departments,id',
             'manager_id' => 'nullable|exists:users,id',
         ];
 

--- a/app/Http/Requests/SaveUserRequest.php
+++ b/app/Http/Requests/SaveUserRequest.php
@@ -32,6 +32,7 @@ class SaveUserRequest extends FormRequest
     public function rules()
     {
         $rules = [
+            'department_id' => 'nullable|integer|exists:departments,id',
             'manager_id' => 'nullable|exists:users,id',
         ];
 

--- a/tests/Feature/Api/Users/UsersUpdateTest.php
+++ b/tests/Feature/Api/Users/UsersUpdateTest.php
@@ -11,15 +11,28 @@ class UsersUpdateTest extends TestCase
 {
     use InteractsWithSettings;
 
-    public function testSomething()
+
+    public function testCanUpdateUserViaPatch()
     {
-        $this->withoutExceptionHandling();
+        $this->markTestIncomplete();
+    }
+
+    public function testCanUpdateUserViaPut()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testDepartmentPatching()
+    {
         $admin = User::factory()->superuser()->create();
         $user = User::factory()->forDepartment(['name' => 'Department A'])->create();
         $department = Department::factory()->create();
 
         $this->actingAsForApi($admin)->patch(route('api.users.update', $user), [
-            'department_id' => ['id' => $department->id]
+            // This isn't valid but doesn't return an error
+            'department_id' => ['id' => $department->id],
+            // This is the correct syntax
+            // 'department_id' => $department->id,
         ])->assertOk();
 
         $this->assertTrue(

--- a/tests/Feature/Api/Users/UsersUpdateTest.php
+++ b/tests/Feature/Api/Users/UsersUpdateTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Feature\Api\Users;
 
+use App\Models\Company;
 use App\Models\Department;
+use App\Models\Group;
+use App\Models\Location;
 use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
@@ -11,8 +15,89 @@ class UsersUpdateTest extends TestCase
 {
     use InteractsWithSettings;
 
+    public function testValidationForUpdatingUserViaPatch()
+    {
+        $this->markTestIncomplete();
+    }
 
     public function testCanUpdateUserViaPatch()
+    {
+        $admin = User::factory()->superuser()->create();
+        $manager = User::factory()->create();
+        $company = Company::factory()->create();
+        $department = Department::factory()->create();
+        $location = Location::factory()->create();
+        [$groupA, $groupB] = Group::factory()->count(2)->create();
+
+        $user = User::factory()->create([
+            'activated' => false,
+            'two_factor_enrolled' => false,
+            'two_factor_optin' => false,
+            'remote' => false,
+            'vip' => false,
+        ]);
+
+        $this->actingAsForApi($admin)
+            ->patch(route('api.users.update', $user), [
+                'first_name' => 'Mabel',
+                'last_name' => 'Mora',
+                'username' => 'mabel',
+                'password' => 'super-secret',
+                'email' => 'mabel@onlymurderspod.com',
+                // @todo:
+                // 'permissions' => '',
+                'activated' => true,
+                'phone' => '619-555-5555',
+                'jobtitle' => 'Host',
+                'manager_id' => $manager->id,
+                'employee_num' => '1111',
+                'notes' => 'Pretty good artist',
+                'company_id' => $company->id,
+                'two_factor_enrolled' => true,
+                'two_factor_optin' => true,
+                'department_id' => $department->id,
+                'location_id' => $location->id,
+                'remote' => true,
+                'groups' => $groupA->id,
+                'vip' => true,
+                'start_date' => '2021-08-01',
+                'end_date' => '2025-12-31',
+            ])
+            ->assertOk();
+
+        $user->refresh();
+        $this->assertEquals('Mabel', $user->first_name);
+        $this->assertEquals('Mora', $user->last_name);
+        $this->assertEquals('mabel', $user->username);
+        $this->assertTrue(Hash::check('super-secret', $user->password));
+        $this->assertEquals('mabel@onlymurderspod.com', $user->email);
+        $this->assertTrue($user->activated);
+        $this->assertEquals('619-555-5555', $user->phone);
+        $this->assertEquals('Host', $user->jobtitle);
+        $this->assertTrue($user->manager->is($manager));
+        $this->assertEquals('1111', $user->employee_num);
+        $this->assertEquals('Pretty good artist', $user->notes);
+        $this->assertTrue($user->company->is($company));
+        // @todo:
+        // $this->assertEquals(1, $user->two_factor_enrolled);
+        // $this->assertEquals(1, $user->two_factor_optin);
+        $this->assertTrue($user->department->is($department));
+        $this->assertTrue($user->location->is($location));
+        $this->assertEquals(1, $user->remote);
+        $this->assertTrue($user->groups->contains($groupA));
+        $this->assertTrue($user->vip);
+        $this->assertEquals('2021-08-01', $user->start_date);
+        $this->assertEquals('2025-12-31', $user->end_date);
+
+        // `groups` can be an id or array or ids
+        $this->patch(route('api.users.update', $user), ['groups' => [$groupA->id, $groupB->id]]);
+
+        $user->refresh();
+        $this->assertTrue($user->groups->contains($groupA));
+        $this->assertTrue($user->groups->contains($groupB));
+    }
+
+    public function testValidationForUpdatingUserViaPut()
     {
         $this->markTestIncomplete();
     }

--- a/tests/Feature/Api/Users/UsersUpdateTest.php
+++ b/tests/Feature/Api/Users/UsersUpdateTest.php
@@ -15,11 +15,6 @@ class UsersUpdateTest extends TestCase
 {
     use InteractsWithSettings;
 
-    public function testValidationForUpdatingUserViaPatch()
-    {
-        $this->markTestIncomplete();
-    }
-
     public function testCanUpdateUserViaPatch()
     {
         $admin = User::factory()->superuser()->create();
@@ -38,7 +33,7 @@ class UsersUpdateTest extends TestCase
         ]);
 
         $this->actingAsForApi($admin)
-            ->patch(route('api.users.update', $user), [
+            ->patchJson(route('api.users.update', $user), [
                 'first_name' => 'Mabel',
                 'last_name' => 'Mora',
                 'username' => 'mabel',
@@ -107,22 +102,12 @@ class UsersUpdateTest extends TestCase
         $this->markTestIncomplete();
     }
 
-    public function testDepartmentPatching()
+    public function testDepartmentValidation()
     {
-        $admin = User::factory()->superuser()->create();
-        $user = User::factory()->forDepartment(['name' => 'Department A'])->create();
-        $department = Department::factory()->create();
-
-        $this->actingAsForApi($admin)->patch(route('api.users.update', $user), [
-            // This isn't valid but doesn't return an error
-            'department_id' => ['id' => $department->id],
-            // This is the correct syntax
-            // 'department_id' => $department->id,
-        ])->assertOk();
-
-        $this->assertTrue(
-            $user->fresh()->department()->is($department),
-            'User is not associated with expected department'
-        );
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson(route('api.users.update', User::factory()->create()), [
+            // This isn't valid but was not returning an error
+            'department_id' => ['id' => 1],
+        ])->assertJsonValidationErrorFor('department_id');
     }
 }

--- a/tests/Feature/Api/Users/UsersUpdateTest.php
+++ b/tests/Feature/Api/Users/UsersUpdateTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature\Api\Users;
+
+use App\Models\Department;
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class UsersUpdateTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testSomething()
+    {
+        $this->withoutExceptionHandling();
+        $admin = User::factory()->superuser()->create();
+        $user = User::factory()->forDepartment(['name' => 'Department A'])->create();
+        $department = Department::factory()->create();
+
+        $this->actingAsForApi($admin)->patch(route('api.users.update', $user), [
+            'department_id' => ['id' => $department->id]
+        ])->assertOk();
+
+        $this->assertTrue(
+            $user->fresh()->department()->is($department),
+            'User is not associated with expected department'
+        );
+    }
+}

--- a/tests/Feature/Api/Users/UsersUpdateTest.php
+++ b/tests/Feature/Api/Users/UsersUpdateTest.php
@@ -91,23 +91,4 @@ class UsersUpdateTest extends TestCase
         $this->assertTrue($user->groups->contains($groupA));
         $this->assertTrue($user->groups->contains($groupB));
     }
-
-    public function testValidationForUpdatingUserViaPut()
-    {
-        $this->markTestIncomplete();
-    }
-
-    public function testCanUpdateUserViaPut()
-    {
-        $this->markTestIncomplete();
-    }
-
-    public function testDepartmentValidation()
-    {
-        $this->actingAsForApi(User::factory()->superuser()->create())
-            ->patchJson(route('api.users.update', User::factory()->create()), [
-                // This isn't valid but was not returning an error
-                'department_id' => ['id' => 1],
-            ])->assertJsonValidationErrorFor('department_id');
-    }
 }

--- a/tests/Feature/Api/Users/UsersUpdateTest.php
+++ b/tests/Feature/Api/Users/UsersUpdateTest.php
@@ -39,8 +39,7 @@ class UsersUpdateTest extends TestCase
                 'username' => 'mabel',
                 'password' => 'super-secret',
                 'email' => 'mabel@onlymurderspod.com',
-                // @todo:
-                // 'permissions' => '',
+                'permissions' => '{"a.new.permission":"1"}',
                 'activated' => true,
                 'phone' => '619-555-5555',
                 'jobtitle' => 'Host',
@@ -66,6 +65,7 @@ class UsersUpdateTest extends TestCase
         $this->assertEquals('mabel', $user->username);
         $this->assertTrue(Hash::check('super-secret', $user->password));
         $this->assertEquals('mabel@onlymurderspod.com', $user->email);
+        $this->assertArrayHasKey('a.new.permission', $user->decodePermissions());
         $this->assertTrue($user->activated);
         $this->assertEquals('619-555-5555', $user->phone);
         $this->assertEquals('Host', $user->jobtitle);

--- a/tests/Feature/Api/Users/UsersUpdateTest.php
+++ b/tests/Feature/Api/Users/UsersUpdateTest.php
@@ -106,8 +106,8 @@ class UsersUpdateTest extends TestCase
     {
         $this->actingAsForApi(User::factory()->superuser()->create())
             ->patchJson(route('api.users.update', User::factory()->create()), [
-            // This isn't valid but was not returning an error
-            'department_id' => ['id' => 1],
-        ])->assertJsonValidationErrorFor('department_id');
+                // This isn't valid but was not returning an error
+                'department_id' => ['id' => 1],
+            ])->assertJsonValidationErrorFor('department_id');
     }
 }

--- a/tests/Feature/Api/Users/UsersUpdateTest.php
+++ b/tests/Feature/Api/Users/UsersUpdateTest.php
@@ -26,8 +26,6 @@ class UsersUpdateTest extends TestCase
 
         $user = User::factory()->create([
             'activated' => false,
-            'two_factor_enrolled' => false,
-            'two_factor_optin' => false,
             'remote' => false,
             'vip' => false,
         ]);
@@ -47,8 +45,6 @@ class UsersUpdateTest extends TestCase
                 'employee_num' => '1111',
                 'notes' => 'Pretty good artist',
                 'company_id' => $company->id,
-                'two_factor_enrolled' => true,
-                'two_factor_optin' => true,
                 'department_id' => $department->id,
                 'location_id' => $location->id,
                 'remote' => true,
@@ -73,9 +69,6 @@ class UsersUpdateTest extends TestCase
         $this->assertEquals('1111', $user->employee_num);
         $this->assertEquals('Pretty good artist', $user->notes);
         $this->assertTrue($user->company->is($company));
-        // @todo:
-        // $this->assertEquals(1, $user->two_factor_enrolled);
-        // $this->assertEquals(1, $user->two_factor_optin);
         $this->assertTrue($user->department->is($department));
         $this->assertTrue($user->location->is($location));
         $this->assertEquals(1, $user->remote);


### PR DESCRIPTION
# Description

This PR simply adds the smallest amount of validation around the `department_id` field when sending an [API PATCH request](https://snipe-it.readme.io/reference/users-3) for a user. It was pointed out that sending
```
'department_id' => ['id' => 1]`
```

resulted in a success message but didn't actually a change. This is because the endpoint actually needs this format 
```
'department_id' => 1
```

I just added a validation rule that says the `department_id`, if provided, needs to exist in the departments table.

---

I started to go down the path of testing validation for all inputs but decided to keep it simple and focused in this PR.

One thing I noticed is that even though our [docs](https://snipe-it.readme.io/reference/users-3) say `two_factor_enrolled`, and `two_factor_optin` can be updated via this endpoint those properties aren't in the User model's `fillable` array so changes are not applied. I think the docs should be updated to remove those fields right?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)