### PR TITLE
added an option to bulk edit location & fixed location bug

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -189,8 +189,14 @@ class BulkAssetsController extends Controller
                 }
 
                 if ($request->filled('rtd_location_id')) {
-                    $this->update_array['rtd_location_id'] = $request->input('rtd_location_id');
+                    if (($request->filled('update_real_loc')) && (($request->input('update_real_loc')) == '0')) {
+                        $this->update_array['rtd_location_id'] = $request->input('rtd_location_id');
+                    }
                     if (($request->filled('update_real_loc')) && (($request->input('update_real_loc')) == '1')) {
+                        $this->update_array['location_id'] = $request->input('rtd_location_id');
+                        $this->update_array['rtd_location_id'] = $request->input('rtd_location_id');
+                    }
+                    if (($request->filled('update_real_loc')) && (($request->input('update_real_loc')) == '2')) {
                         $this->update_array['location_id'] = $request->input('rtd_location_id');
                     }
                 }

--- a/resources/lang/en/admin/hardware/form.php
+++ b/resources/lang/en/admin/hardware/form.php
@@ -49,6 +49,7 @@ return [
     'asset_location' => 'Update Asset Location',
     'asset_location_update_default_current' => 'Update default location AND actual location',
     'asset_location_update_default' => 'Update only default location',
+    'asset_location_update_actual' => 'Update only actual location',
     'asset_not_deployable' => 'That asset status is not deployable. This asset cannot be checked out.',
     'asset_deployable' => 'That status is deployable. This asset can be checked out.',
     'processing_spinner' => 'Processing... (This might take a bit of time on large files)',

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -92,9 +92,13 @@
                   {{ Form::radio('update_real_loc', '1', old('update_real_loc'), ['checked'=> 'checked', 'aria-label'=>'update_real_loc']) }}
                   {{ trans('admin/hardware/form.asset_location_update_default_current') }}
                 </label>
+              <label class="form-control">
+                {{ Form::radio('update_real_loc', '0', old('update_real_loc'), ['aria-label'=>'update_default_loc']) }}
+                {{ trans('admin/hardware/form.asset_location_update_default') }}
+              </label>
                 <label class="form-control">
-                  {{ Form::radio('update_real_loc', '0', old('update_real_loc'), ['aria-label'=>'update_default_loc']) }}
-                  {{ trans('admin/hardware/form.asset_location_update_default') }}
+                  {{ Form::radio('update_real_loc', '2', old('update_real_loc'), ['aria-label'=>'update_default_loc']) }}
+                  {{ trans('admin/hardware/form.asset_location_update_actual') }}
                 </label>
 
             </div>


### PR DESCRIPTION
# Description
Fixes an issue when bulk editing locations of assets. Also adds a third radio button to change the current/actual location of an asset.
<img width="636" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/221cd5ea-d5ea-4ea8-8a82-01fb6400c0f4">

Fixes #13572 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
