### PR TITLE
Fixed Call to a member function checkedOutToUser() on null [rollbar-3598]

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1021,7 +1021,12 @@ class ReportsController extends Controller
 
         $assetsForReport = $acceptances
             ->filter(function ($acceptance) {
-                return $acceptance->checkoutable_type == 'App\Models\Asset' && $acceptance->checkoutable->checkedOutToUser();
+                $acceptance_checkoutable_flag = false;
+                if ($acceptance->checkoutable){
+                    $acceptance_checkoutable_flag = $acceptance->checkoutable->checkedOutToUser();
+                }
+                
+                return $acceptance->checkoutable_type == 'App\Models\Asset' && $acceptance_checkoutable_flag;
             })
             ->map(function($acceptance) {
                 return ['assetItem' => $acceptance->checkoutable, 'acceptance' => $acceptance];


### PR DESCRIPTION
# Description
In https://github.com/snipe/snipe-it/pull/13574 I added a call to the `Asset::checkedOutToUser()`  function to decide if show an asset in the Unaccepted Asset report. But I turned out to introduce a bug when the asset is deleted before the user accept it. 

I added a boolean to be set by the function if the asset still exists, and if not I passed it as false, so that register also get filetered in the report.

Fixes rollbar 3598

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP Dev Server
* OS version: Debian 12
