### PR TITLE
Fixed nullability on asset model `min qty` column

### DIFF
--- a/database/migrations/2023_09_13_200913_fix_asset_model_min_qty_nullability.php
+++ b/database/migrations/2023_09_13_200913_fix_asset_model_min_qty_nullability.php
@@ -26,7 +26,7 @@ class FixAssetModelMinQtyNullability extends Migration
     public function down()
     {
         Schema::table('models', function (Blueprint $table) {
-            $table->integer('min_amt')->default(null)->change();
+            $table->integer('min_amt')->nullable(false)->change();
         });
     }
 }

--- a/database/migrations/2023_09_13_200913_fix_asset_model_min_qty_nullability.php
+++ b/database/migrations/2023_09_13_200913_fix_asset_model_min_qty_nullability.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class FixAssetModelMinQtyNullability extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('models', function (Blueprint $table) {
+            $table->integer('min_amt')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('models', function (Blueprint $table) {
+            $table->integer('min_amt')->default(null)->change();
+        });
+    }
+}


### PR DESCRIPTION
# Description
Fixes the `min_amt` column from defaulting to 0, to being nullable. 

<img width="827" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/ba9cdfb8-8b17-4dbd-88ef-f6ca4839783f">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
