### PR TITLE
Reset checkout to value when navigating away from type 

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -142,9 +142,11 @@ class CheckoutableListener
         $notifiables = collect();
 
         /**
-         * Notify the user who checked out the item
+         * Notify who checked out the item as long as the model can route notifications
          */
-        $notifiables->push($event->checkedOutTo);
+        if (method_exists($event->checkedOutTo, 'routeNotificationFor')) {
+            $notifiables->push($event->checkedOutTo);
+        }
 
         /**
          * Notify Admin users if the settings is activated

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -454,12 +454,18 @@ $(document).ready(function () {
                 $('#assigned_location').hide();
                 $('.notification-callout').fadeOut();
 
+                $('[name="assigned_location"]').val('').trigger('change.select2');
+                $('[name="assigned_user"]').val('').trigger('change.select2');
+
             } else if (assignto_type == 'location') {
                 $('#current_assets_box').fadeOut();
                 $('#assigned_asset').hide();
                 $('#assigned_user').hide();
                 $('#assigned_location').show();
                 $('.notification-callout').fadeOut();
+
+                $('[name="assigned_asset"]').val('').trigger('change.select2');
+                $('[name="assigned_user"]').val('').trigger('change.select2');
             } else  {
 
                 $('#assigned_asset').hide();
@@ -470,6 +476,8 @@ $(document).ready(function () {
                 }
                 $('.notification-callout').fadeIn();
 
+                $('[name="assigned_asset"]').val('').trigger('change.select2');
+                $('[name="assigned_location"]').val('').trigger('change.select2');
             }
         });
     });


### PR DESCRIPTION
(what a terrible PR name)

# Description

Currently when creating or cloning an asset it is possible to submit bad data about the check out via these inputs:

<img width="438" alt="Checkout to inputs" src="https://github.com/snipe/snipe-it/assets/1141514/ee2698d5-10cd-4b8c-81c5-6175dd1dad68">

As an example, clicking Location, picking a location, going back to User, then submitting, sends the following to the server (notice that `assigned_location` is still populated):

```
"checkout_to_type" => "user"
"assigned_user" => null
"assigned_asset" => null
"assigned_location" => "9"
```

Example showing the steps to recreate:

https://github.com/snipe/snipe-it/assets/1141514/7db8079b-ee45-4526-9efa-af9fff22a9ce

---

With this PR the `assigned_x` fields are nulled out:
```
"checkout_to_type" => "user"
"assigned_user" => null
"assigned_asset" => null
"assigned_location" => null
```

Be aware that this now means that users clicking "Location", selecting a location, clicking away and then back, will have the selected Location removed:

https://github.com/snipe/snipe-it/assets/1141514/dd4fda9c-aa7f-4b97-b5fa-5e4284fcdb05

---

I also updated the `CheckoutableListener` to make sure the model that was checked out *to* has the `routeNotificationFor()` method on it (provided by the `Notifiable` trait). This should ensure we don't have anymore `Exception caught during checkout notification: Call to undefined method App\Models\Location::routeNotificationFor()` showing up in logs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)