### PR TITLE
Fixed checkbox formatting on quickstart

### DIFF
--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -48,23 +48,19 @@
   <div class="row">
 
     <div class="form-group col-lg-6">
-      <label>{{trans('admin/settings/general.auto_increment_assets')}}</label>
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" value="1" name="auto_increment_assets">{{trans('admin/settings/general.auto_increment_assets')}}
-        </label>
-      </div>
+
+      <label class="form-control form-control">
+        <input type="checkbox" value="1" name="auto_increment_assets">{{trans('admin/settings/general.auto_increment_assets')}}
+      </label>
+
     </div>
 
     <!-- Multi Company Support -->
     <div class="form-group col-lg-6">
-            {{ Form::label('full_multiple_companies_support', trans('admin/settings/general.full_multiple_companies_support_text')) }}
-          <div class="checkbox">
-            <label>
-              <input type="checkbox" value="1" name="full_multiple_companies_support">  {{ trans('admin/settings/general.full_multiple_companies_support_text') }}
-            </label>
-          </div>
-        </div>
+      <label class="form-control form-control">
+        <input type="checkbox" value="1" name="full_multiple_companies_support">  {{ trans('admin/settings/general.full_multiple_companies_support_text') }}
+      </label>
+    </div>
 
 
   </div>
@@ -156,12 +152,9 @@
 
     <!-- Email credentials -->
     <div class="form-group col-lg-12">
-      <label>{{ trans('admin/users/general.email_credentials') }}</label>
-      <div class="checkbox">
-        <label>
-          <input type="checkbox" value="1" name="email_creds">{{ trans('admin/users/general.email_credentials_text') }}
-        </label>
-      </div>
+      <label class="form-control form-control">
+        <input type="checkbox" value="1" name="email_creds">{{ trans('admin/users/general.email_credentials_text') }}
+      </label>
     </div>
   </div> <!--/.COL-LG-12-->
 @stop

--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -1,5 +1,5 @@
 @extends('layouts/setup')
-{{ trans('admin/users/table.createuser') }}
+
 @section('title')
 {{ trans('admin/users/general.create_user') }} ::
 @parent


### PR DESCRIPTION
This fixes the layout of the checkboxes on the QuickStart. It had not been updated to use the non-iCheck formatting. 

### Before:

<img width="1217" alt="Screenshot_2023-09-01_at_3 43 10_PM" src="https://github.com/snipe/snipe-it/assets/197404/6d5e7f87-a675-47e8-a78b-5c9c8287d8a1">


### After:

<img width="989" alt="Screenshot 2023-09-14 at 6 47 04 PM" src="https://github.com/snipe/snipe-it/assets/197404/d44df2ad-8c9f-4639-8d66-bb65f6e2fb3b">
