### PR TITLE
Fixed #13592 Unable to delete Asset Models from the asset model view [sc-23705]

### DIFF
--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -344,7 +344,10 @@
                 @else
 
                     <div class="col-md-12" style="padding-bottom: 10px;">
-                        <a href="{{ route('models.destroy', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-danger hidden-print">{{ trans('general.delete') }}</a>
+                        <form action="{{ route('models.destroy', $model->id)  }}" method='POST'>
+                            @csrf @method('DELETE')
+                            <button style="width: 100%;" class="btn btn-sm btn-danger hidden-print">{{ trans('general.delete') }}</button>
+                        </form>
                     </div>
                 @endif
            @endcan


### PR DESCRIPTION
# Description
The delete button in the asset model view doesn't work because it lacks the `DELETE` method that needs to be passed to the route to translate it to the correct URI.

So I changed the `href` HTML input type to a `button` inside a form with the correct route and method needed so the feature works as expected.

Fixes #13592

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 12
