### PR TITLE
Simplify upload messaging, handle -1% error

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -369,9 +369,9 @@ return [
     'notification_error'    => 'Error:',
     'notification_error_hint' => 'Please check the form below for errors',
     'notification_bulk_error_hint' => 'The following fields had validation errors and were not edited:',
-    'notification_success'  => 'Success:',
-    'notification_warning'   => 'Warning:',
-    'notification_info'      => 'Info:',
+    'notification_success'  => 'Success',
+    'notification_warning'   => 'Warning',
+    'notification_info'      => 'Info',
     'asset_information'     => 'Asset Information',
     'model_name'            => 'Model Name',
     'asset_name'            => 'Asset Name',
@@ -481,5 +481,8 @@ return [
         'address2' => 'Address Line 2',
         'import_note' => 'Imported using csv importer',
     ],
+    'percent_complete' => '% complete',
+    'uploading' => 'Uploading... ',
+    'upload_error' => 'Error uploading file. Please check that there are no empty trailing rows.'
 
 ];

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -8,7 +8,7 @@
 
 {{-- alert --}}
 @if($message != '')
-    <div class="col-md-12" class="{{ $message_type }}">dvfds
+    <div class="col-md-12" class="{{ $message_type }}">
         <div class="alert alert-{{ $this->message_type }} ">
             <button type="button" class="close" wire:click="$set('message','')">&times;</button>
             @if($message_type == 'success')

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -26,7 +26,7 @@
                 <div class="box-body">
                     <div class="alert alert-warning">
 
-                        <h4><i class="fa fa-2x fa-warning info" aria-hidden="true"></i> {{ trans('general.warning', ['warning'=> trans('general.errors_importing')]) }}</h4>
+                        <i class="fa fa-warning info" aria-hidden="true"></i> <strong>{{ trans('general.warning', ['warning'=> trans('general.errors_importing')]) }}</strong>
                     </div>
 
                     <div class="errors-table">

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -24,7 +24,7 @@
             <div class="box">
                 <div class="box-body">
                     <div class="alert alert-warning">
-                        <strong><i class="fa fa-warning info" aria-hidden="true"></i> {{ trans('general.warning', ['warning'=> trans('general.errors_importing')]) }}</strong>
+                        <strong><i class="fa fa-2x fa-warning info" aria-hidden="true"></i> {{ trans('general.warning', ['warning'=> trans('general.errors_importing')]) }}</strong>
                     </div>
 
                     <div class="errors-table">
@@ -65,17 +65,18 @@
                         <div class="row">
 
                             <div class="col-md-12">
+
                                 @if($progress != -1)
-                                    <div class="col-md-9" style="padding-bottom:20px" id='progress-container'>
-                                        <div class="progress progress-striped-active" style="margin-top: 8px"> {{-- so someof these values are in importer.vue! --}}
+                                    <div class="col-md-10 col-sm-5 col-xs-12" style="height: 35px;" id='progress-container'>
+                                        <div class="progress progress-striped-active" style="height: 100%;">
                                             <div id='progress-bar' class="progress-bar {{ $progress_bar_class }}" role="progressbar" style="width: {{ $progress }}%">
-                                                <span id='progress-text'>{{ $progress_message }}</span>
+                                                <h4 id="progress-text">{!! $progress_message  !!}</h4>
                                             </div>
                                         </div>
                                     </div>
                                 @endif
 
-                                <div class="col-md-3 text-right pull-right">
+                                <div class="col-md-2 col-sm-5 col-xs-12 text-right pull-right">
 
                                     <!-- The fileinput-button span is used to style the file input field as button -->
                                     @if (!config('app.lock_passwords'))
@@ -289,7 +290,7 @@
             dataType: 'json',
             done: function(e, data) {
                 @this.progress_bar_class = 'progress-bar-success';
-                @this.progress_message = '{{ trans('general.notification_success') }}'; // TODO - we're already round-tripping to the server here - I'd love it if we could get internationalized text here
+                @this.progress_message = '<i class="fas fa-check faa-pulse animated"></i> {{ trans('general.notification_success') }}';
                 @this.progress = 100;
             },
             add: function(e, data) {
@@ -302,17 +303,12 @@
             },
             progress: function(e, data) {
                 @this.progress = parseInt((data.loaded / data.total * 100, 10));
-                @this.progress_message = @this.progress+'% Complete'; // TODO - make this use general.percent_complete as a translation, passing :percent as a variable
+                @this.progress_message = '{{ trans('general.uploading') }}';
             },
-            fail: function(e, data) {
+            fail: function() {
                 @this.progress_bar_class = "progress-bar-danger";
                 @this.progress = 100;
-
-                var error_message = ''
-                for(var i in data.jqXHR.responseJSON.messages) {
-                    error_message += i+": "+data.jqXHR.responseJSON.messages[i].join(", ")
-                }
-                @this.progress_message = error_message;
+                @this.progress_message = '<i class="fas fa-exclamation-triangle faa-pulse animated"></i> {{ trans('general.upload_error') }}';
             }
         })
 

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -9,7 +9,7 @@
 {{-- alert --}}
 @if($message != '')
     <div class="col-md-12" class="{{ $message_type }}">
-        <div class="alert alert-{{ $this->message_type }} ">
+        <div class="alert alert-{{ $this->message_type }}">
             <button type="button" class="close" wire:click="$set('message','')">&times;</button>
             @if($message_type == 'success')
                 <i class="fas fa-check faa-pulse animated" aria-hidden="true"></i>

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -8,7 +8,7 @@
 
 {{-- alert --}}
 @if($message != '')
-    <div class="col-md-12" class="{{ $message_type }}">
+    <div class="col-md-12" class="{{ $message_type }}">dvfds
         <div class="alert alert-{{ $this->message_type }} ">
             <button type="button" class="close" wire:click="$set('message','')">&times;</button>
             @if($message_type == 'success')
@@ -20,11 +20,13 @@
     </div>
 @endif
 
-@if($import_errors)
+        @if($import_errors)
+          <div class="col-md-12">
             <div class="box">
                 <div class="box-body">
                     <div class="alert alert-warning">
-                        <strong><i class="fa fa-2x fa-warning info" aria-hidden="true"></i> {{ trans('general.warning', ['warning'=> trans('general.errors_importing')]) }}</strong>
+
+                        <h4><i class="fa fa-2x fa-warning info" aria-hidden="true"></i> {{ trans('general.warning', ['warning'=> trans('general.errors_importing')]) }}</h4>
                     </div>
 
                     <div class="errors-table">
@@ -57,6 +59,7 @@
                     </div>
                 </div>
             </div>
+       </div>
 @endif
 
             <div class="col-md-9">

--- a/resources/views/notifications.blade.php
+++ b/resources/views/notifications.blade.php
@@ -3,7 +3,7 @@
     <div class="alert alert-danger fade in">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
-        <strong>{{ trans('general.notification_error') }}</strong>
+        <strong>{{ trans('general.notification_error') }}:</strong>
          {{ trans('general.notification_error_hint') }}
     </div>
 </div>
@@ -16,7 +16,7 @@
         <div class="alert alert-success fade in">
             <button type="button" class="close" data-dismiss="alert">&times;</button>
             <i class="fas fa-check faa-pulse animated"></i>
-            <strong>{{ trans('general.notification_success') }} </strong>
+            <strong>{{ trans('general.notification_success') }}: </strong>
             {{ $message }}
         </div>
     </div>
@@ -28,7 +28,7 @@
     <div class="alert alert-success fade in">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         <i class="fas fa-check faa-pulse animated"></i>
-        <strong>{{ trans('general.notification_success') }} </strong>
+        <strong>{{ trans('general.notification_success') }}: </strong>
         {{ $message }}
     </div>
 </div>
@@ -67,7 +67,7 @@
             <div class="alert alert-info fade in">
                 <button type="button" class="close" data-dismiss="alert">&times;</button>
                 <i class="fas fa-info-circle faa-pulse animated"></i>
-                <strong>{{ trans('general.consumable_information') }} </strong>
+                <strong>{{ trans('general.consumable_information') }}</strong>
                 <ul><li><b>{{ trans('general.consumable_name') }}</b> {{ $consumable->name }}</li></ul>
             </div>
         </div>
@@ -120,7 +120,7 @@
     <div class="alert alert alert-danger fade in">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
-        <strong>{{ trans('general.notification_error') }} </strong>
+        <strong>{{ trans('general.notification_error') }}: </strong>
        {{ trans('general.notification_bulk_error_hint') }}
             @foreach($messages as $message) 
                 <ul>
@@ -137,7 +137,7 @@
     <div class="alert alert-warning fade in">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
-        <strong>{{ trans('general.notification_warning') }} </strong>
+        <strong>{{ trans('general.notification_warning') }}: </strong>
         {{ $message }}
     </div>
 </div>
@@ -149,7 +149,7 @@
     <div class="alert alert-info fade in">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         <i class="fas fa-info-circle faa-pulse animated"></i>
-        <strong>{{ trans('general.notification_info') }} </strong>
+        <strong>{{ trans('general.notification_info') }}: </strong>
         {{ $message }}
     </div>
 </div>


### PR DESCRIPTION
This doesn't really *fix* the issue as such, but it makes it look less terrible and confusing. I don't think the % uploaded ever actually worked properly (or files uploaded fast enough that we never saw the % increase). We can always revisit this and try to get the % actually working correctly if we want to.


https://github.com/snipe/snipe-it/assets/197404/6f4b3d7c-cbed-446f-a593-63bc18c69f40

