### PR TITLE
Use relative path in backups for cleaner directory structure

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -36,6 +36,13 @@ return [
             'files' => [
 
                 /*
+                * This path is used to make directories in resulting zip-file relative
+                * Set to false to include complete absolute path
+                * Example: base_path()
+                */
+                'relative_path' => base_path(),
+
+                /*
                  * The list of directories and files that will be included in the backup.
                  */
                 'include' => $included_dirs,


### PR DESCRIPTION
This adds the newer `relative_path` option to the backup config to use a cleaner directory structure for backups.