### PR TITLE
Fixes #13609 - disallow sorting on age

### DIFF
--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -142,8 +142,8 @@ class AssetPresenter extends Presenter
                 'formatter' => 'dateDisplayFormatter',
             ], [
                 'field' => 'age',
-                'searchable' => true,
-                'sortable' => true,
+                'searchable' => false,
+                'sortable' => false,
                 'visible' => false,
                 'title' => trans('general.age'),
             ], [


### PR DESCRIPTION
This disallows the sort arrows on the `age` column, since it's a displayed calculated value, not one that lives in the database.