### PR TITLE
Made develop the target branch for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
I *think* this is the correct level for where they want this in [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch), but if not, please let me know :)

This should just make it easier for me to accept dependabot PRs (which currently target to `master`) by making them target `develop` instead. 