### PR TITLE
Fixed #13628 - removed duplicate favicon tag

### DIFF
--- a/resources/views/layouts/basic.blade.php
+++ b/resources/views/layouts/basic.blade.php
@@ -11,7 +11,6 @@
     <link rel="shortcut icon" type="image/ico" href="{{ ($snipeSettings) && ($snipeSettings->favicon!='') ?  Storage::disk('public')->url('').e($snipeSettings->favicon) : 'favicon.ico' }} ">
     {{-- stylesheets --}}
     <link rel="stylesheet" href="{{ url(mix('css/dist/all.css')) }}">
-    <link rel="shortcut icon" type="image/ico" href="{{ url(asset('favicon.ico')) }}">
 
     <script nonce="{{ csrf_token() }}">
         window.snipeit = {


### PR DESCRIPTION
Removed the duplicate favicon tag that was overriding the one above it. Fixes #13628