### PR TITLE
Added factories to autolabeler action

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -18,5 +18,5 @@ importer: ["/app/Importer/*","/app/Http/Livewire/Importer.php", "resources/views
 cli / artisan: ["/app/Console/*"]
 LDAP: ["*Ldap*", "/app/Console/Commands/Ldap*","/app/Models/Ldap.php"]
 docker: ["*docker/*", "Dockerfile", "Dockerfile.alpine", "Dockerfile.fpm-alpine", ".dockerignore", ".env.docker"]
-tests: ["/tests/*", "/stubs"]
+tests: ["/tests/*", "/database/factories/*", "/stubs"]
 config: .github


### PR DESCRIPTION
# Description

This PR simply adds the `database/factories/` directory to the autolabeler action config so changes to factories are labeled since changes to factories can change test behavior.