### PR TITLE
Added unique() to some factory properties

### DIFF
--- a/database/factories/CompanyFactory.php
+++ b/database/factories/CompanyFactory.php
@@ -22,7 +22,7 @@ class CompanyFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->company(),
+            'name' => $this->faker->unique()->company(),
         ];
     }
 }

--- a/database/factories/CustomFieldFactory.php
+++ b/database/factories/CustomFieldFactory.php
@@ -22,7 +22,7 @@ class CustomFieldFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->catchPhrase(),
+            'name' => $this->faker->unique()->catchPhrase(),
             'format' => '',
             'element' => 'text',
             'auto_add_to_fieldsets' => '0',

--- a/database/factories/CustomFieldsetFactory.php
+++ b/database/factories/CustomFieldsetFactory.php
@@ -22,7 +22,7 @@ class CustomFieldsetFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->catchPhrase(),
+            'name' => $this->faker->unique()->catchPhrase(),
         ];
     }
 

--- a/database/factories/DepreciationFactory.php
+++ b/database/factories/DepreciationFactory.php
@@ -23,7 +23,7 @@ class DepreciationFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->catchPhrase(),
+            'name' => $this->faker->unique()->catchPhrase(),
             'user_id' => User::factory()->superuser(),
             'months' => 36,
         ];

--- a/database/factories/ManufacturerFactory.php
+++ b/database/factories/ManufacturerFactory.php
@@ -23,7 +23,7 @@ class ManufacturerFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->company(),
+            'name' => $this->faker->unique()->company(),
             'user_id' => User::factory()->superuser(),
             'support_phone' => $this->faker->phoneNumber(),
             'url' => $this->faker->url(),

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -33,11 +33,11 @@ class UserFactory extends Factory
             'permissions' => '{}',
             'phone' => $this->faker->phoneNumber(),
             'state' => $this->faker->stateAbbr(),
-            'username' => $this->faker->username(),
+            'username' => $this->faker->unique()->username(),
             'zip' => $this->faker->postcode(),
         ];
     }
-    
+
     public function firstAdmin()
     {
         return $this->state(function () {


### PR DESCRIPTION
# Description

This PR adds the `unique()` modifier to a few factory properties that need to be unique. 

This should fix the very rare occurrence of incorrect test failures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) ❓