### PR TITLE
Fixed exception being thrown when selected import was deleted

### DIFF
--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -3,7 +3,6 @@
 namespace App\Http\Livewire;
 
 use App\Models\CustomField;
-use Illuminate\Support\Facades\Session;
 use Livewire\Component;
 
 use App\Models\Import;
@@ -162,11 +161,6 @@ class Importer extends Component
 
     public function mount()
     {
-        if (Session::has('error_message')) {
-            $this->message = Session::get('error_message');
-            $this->message_type = 'danger';
-        }
-
         $this->authorize('import');
         $this->progress = -1; // '-1' means 'don't show the progressbar'
         $this->progress_bar_class = 'progress-bar-warning';
@@ -495,9 +489,10 @@ class Importer extends Component
         $this->activeFile = Import::find($id);
 
         if (!$this->activeFile) {
-            Session::flash('error_message', trans('admin/hardware/message.import.file_missing'));
+            $this->message = trans('admin/hardware/message.import.file_missing');
+            $this->message_type = 'danger';
 
-            return redirect()->route('imports.index');
+            return;
         }
 
         $this->field_map = null;

--- a/resources/lang/en/admin/hardware/message.php
+++ b/resources/lang/en/admin/hardware/message.php
@@ -51,6 +51,7 @@ return [
         'success'               => 'Your file has been imported',
         'file_delete_success'   => 'Your file has been been successfully deleted',
         'file_delete_error'      => 'The file was unable to be deleted',
+        'file_missing' => 'The file selected is missing',
         'header_row_has_malformed_characters' => 'One or more attributes in the header row contain malformed UTF-8 characters',
         'content_row_has_malformed_characters' => 'One or more attributes in the first row of content contain malformed UTF-8 characters',
     ],

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -303,6 +303,7 @@
                 };
                 data.process().done( function () {data.submit();});
                 @this.progress = 0;
+                @this.clearMessage();
             },
             progress: function(e, data) {
                 @this.progress = parseInt((data.loaded / data.total * 100, 10));


### PR DESCRIPTION
# Description

This PR adds nice messaging for the rare case an import file that is deleted is selected from the imports list.

For example:
- Have two tabs open
- Delete an import in one tab
- Switch to the other tab and select the import
- Exception!

https://github.com/snipe/snipe-it/assets/1141514/4f1461f8-26be-4195-8cd4-d38ec1afecb7

With this PR, a message is shown to the user to explain that the file they selected is no more.

https://github.com/snipe/snipe-it/assets/1141514/9d4ff08c-6ed8-48eb-ba84-673760843edf

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)