### PR TITLE
Fixed bug where checkout to location would throw an error if FMCS was enabled

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -91,7 +91,8 @@ class AssetCheckoutController extends Controller
 
             $settings = \App\Models\Setting::getSettings();
 
-            if ($settings->full_multiple_companies_support){
+            // We have to check whether $target->company_id is null here since locations don't have a company yet
+            if (($settings->full_multiple_companies_support) && ((!is_null($target->company_id)) &&  (!is_null($asset->company_id)))) {
                 if ($target->company_id != $asset->company_id){
                     return redirect()->to("hardware/$assetId/checkout")->with('error', trans('general.error_user_company'));
                 }

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -459,7 +459,7 @@ return [
     'serial_number'        => 'Serial Number',
     'item_notes' => ':item Notes',
     'item_name_var' => ':item Name',
-    'error_user_company' => 'User and Asset companies missmatch',
+    'error_user_company' => 'Checkout target company and asset company do not match',
     'error_user_company_accept_view' => 'An Asset assigned to you belongs to a different company so you can\'t accept nor deny it, please check with your manager',
     'importer' => [
         'checked_out_to_fullname' => 'Checked Out to: Full Name',


### PR DESCRIPTION
If full multiple company support is enabled AND the asset has a company ID AND the asset is checked out to location (which doesn't have a company ID), the checkout would fail with a mismatch error.