### PR TITLE
Show location in account assigned assets

### DIFF
--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -405,6 +405,7 @@
                       <th class="col-md-2" data-switchable="true" data-visible="true">{{ trans('general.name') }}</th>
                       <th class="col-md-2" data-switchable="true" data-visible="true">{{ trans('admin/hardware/table.asset_model') }}</th>
                       <th class="col-md-3" data-switchable="true" data-visible="true">{{ trans('admin/hardware/table.serial') }}</th>
+                      <th class="col-md-3" data-switchable="true" data-visible="true">{{ trans('general.location') }}</th>
                       @can('self.view_purchase_cost')
                         <th class="col-md-6" data-footer-formatter="sumFormatter" data-fieldname="purchase_cost">{{ trans('general.purchase_cost') }}</th>
                       @endcan
@@ -442,6 +443,7 @@
                           @endif
                         </td>
                         <td>{{ $asset->serial }}</td>
+                        <td>{{ $asset->defaultLoc->name }}</td>
 
                         @can('self.view_purchase_cost')
                         <td>


### PR DESCRIPTION
# Description

This adds a new field to show in /account/view-assets for assigned assets.
It adds default location.

Asset (laptop) is assigned to user (supervisor-teacher)
Teacher gives the asset to a student (location)

I can't find any way to have this relationship so I use the location as a user field. (#13221)

Would be nice if teacher (user) was also able to change the location of an asset assigned to him.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Page works fine. Minimal change.

**Test Configuration**:
* PHP version: 8.0
* MySQL version: MariaDB 10.5.16
* Webserver version: Apache 2.4.53
* OS version: Rocky 9.2


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
