### PR TITLE
Fixed #13670 - order number missing from license import

### DIFF
--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -275,6 +275,7 @@ class Importer extends Component
             'license_email' => trans('admin/licenses/form.to_email'),
             'license_name' => trans('admin/licenses/form.to_name'),
             'purchase_order' => trans('admin/licenses/form.purchase_order'),
+            'order_number' => trans('general.order_number'),
             'reassignable' => trans('admin/licenses/form.reassignable'),
             'seats' => trans('admin/licenses/form.seats'),
             'notes' => trans('general.notes'),

--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -28,7 +28,7 @@ abstract class Importer
     /**
      * Default Map of item fields->csv names
      *
-     * This has been moved into Livewire/Importer.php to be more granular.
+     * This has been moved into app/Http/Livewire/Importer.php to be more granular.
      * @todo - remove references to this property since we don't use it anymore.
      *
      * @var array

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -65,6 +65,7 @@ class LicenseImporter extends ItemImporter
         $this->item['license_name'] = $this->findCsvMatch($row, 'license_name');
         $this->item['maintained'] = $this->findCsvMatch($row, 'maintained');
         $this->item['purchase_order'] = $this->findCsvMatch($row, 'purchase_order');
+        $this->item['order_number'] = $this->findCsvMatch($row, 'order_number');
         $this->item['reassignable'] = $this->findCsvMatch($row, 'reassignable');
         $this->item['manufacturer'] = $this->createOrFetchManufacturer($this->findCsvMatch($row, 'manufacturer'));
 


### PR DESCRIPTION
Looks like we were missing order number from the license importer. This adds it back in.