### PR TITLE
Fixed bug where license checkout/checkin notes were not being saved

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -76,7 +76,7 @@ class LicenseCheckinController extends Controller
 
         // Declare the rules for the form validation
         $rules = [
-            'note'   => 'string|nullable',
+            'notes'   => 'string|nullable',
         ];
 
         // Create a new validator instance from our validation rules
@@ -97,6 +97,7 @@ class LicenseCheckinController extends Controller
         // Update the asset data
         $licenseSeat->assigned_to = null;
         $licenseSeat->asset_id = null;
+        $licenseSeat->notes = $request->input('notes');
 
         // Was the asset updated?
         if ($licenseSeat->save()) {

--- a/app/Http/Controllers/Licenses/LicenseCheckoutController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckoutController.php
@@ -63,6 +63,7 @@ class LicenseCheckoutController extends Controller
 
         $licenseSeat = $this->findLicenseSeatToCheckout($license, $seatId);
         $licenseSeat->user_id = Auth::id();
+        $licenseSeat->notes = $request->input('notes');
         
 
         $checkoutMethod = 'checkoutTo'.ucwords(request('checkout_to_type'));

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -45,6 +45,7 @@ class LicenseSeatsTransformer
                 'name'=> e($seat->location()->name),
             ] : null,
             'reassignable' => (bool) $seat->license->reassignable,
+            'notes' => e($seat->notes),
             'user_can_checkout' => (($seat->assigned_to == '') && ($seat->asset_id == '')),
         ];
 

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -255,6 +255,14 @@ class LicensePresenter extends Presenter
                 'formatter' => 'locationsLinkObjFormatter',
             ],
             [
+                'field' => 'notes',
+                'searchable' => false,
+                'sortable' => false,
+                'visible' => false,
+                'title' => trans('general.notes'),
+                'formatter' => 'notesFormatter'
+            ],
+            [
                 'field' => 'checkincheckout',
                 'searchable' => false,
                 'sortable' => false,

--- a/resources/views/licenses/checkin.blade.php
+++ b/resources/views/licenses/checkin.blade.php
@@ -49,11 +49,11 @@
             </div>
 
             <!-- Note -->
-            <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
+            <div class="form-group {{ $errors->has('notes') ? 'error' : '' }}">
                 <label for="note" class="col-md-2 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                 <div class="col-md-7">
-                    <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note', $licenseSeat->note) }}</textarea>
-                    {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    <textarea class="col-md-6 form-control" id="notes" name="notes"></textarea>
+                    {!! $errors->first('notes', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
             </div>
                         <div class="box-footer">

--- a/resources/views/licenses/checkout.blade.php
+++ b/resources/views/licenses/checkout.blade.php
@@ -55,10 +55,10 @@
 
 
                     <!-- Note -->
-                    <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
+                    <div class="form-group {{ $errors->has('notes') ? 'error' : '' }}">
                         <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                         <div class="col-md-7">
-                            <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
+                            <textarea class="col-md-6 form-control" id="notes" name="notes">{{ old('note') }}</textarea>
                             {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                         </div>
                     </div>


### PR DESCRIPTION
Looks like this has been broken for a while but nobody noticed.

<img width="1259" alt="Screenshot 2023-09-28 at 3 40 52 PM" src="https://github.com/snipe/snipe-it/assets/197404/212b60c1-369e-4825-af1e-2769dcd6a6c1">
