### PR TITLE
Fieldset Properly Sortable in Asset Models Table

### DIFF
--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -46,6 +46,7 @@ class AssetModelsController extends Controller
                 'requestable',
                 'assets_count',
                 'category',
+                'fieldset',
             ];
 
         $assetmodels = AssetModel::select([

--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -94,6 +94,9 @@ class AssetModelsController extends Controller
             case 'category':
                 $assetmodels->OrderCategory($order);
                 break;
+            case 'fieldset':
+                $assetmodels->OrderFieldset($order);
+                break;
             default:
                 $assetmodels->orderBy($sort, $order);
                 break;

--- a/app/Models/AssetModel.php
+++ b/app/Models/AssetModel.php
@@ -291,4 +291,9 @@ class AssetModel extends SnipeModel
     {
         return $query->leftJoin('categories', 'models.category_id', '=', 'categories.id')->orderBy('categories.name', $order);
     }
+
+    public function scopeOrderFieldset($query, $order)
+    {
+        return $query->leftJoin('custom_fieldsets', 'models.fieldset_id', '=', 'custom_fieldsets.id')->orderBy('custom_fieldsets.name', $order);
+    }
 }


### PR DESCRIPTION
# Description

Pretty straightforward, what it says on the tin - adds a scope to the `AssetModel` model for sorting the Fieldset properly on the Asset Model table. 

Fixes https://app.shortcut.com/grokability/story/23596/ascending-descending-sort-for-fieldsets-in-the-models-table-not-working


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Table Tested

**Test Configuration**:
* PHP version: 8.1
* MySQL version 8.1
