### PR TITLE
Changed data source input to select in new label engine

### DIFF
--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -7,8 +7,10 @@ use App\Models\AssetModel;
 use App\Models\Category;
 use App\Models\Company;
 use App\Models\Labels\Label;
+use App\Models\Location;
 use App\Models\Manufacturer;
 use App\Models\Setting;
+use App\Models\Supplier;
 use App\Models\User;
 use App\View\Label as LabelView;
 use Illuminate\Support\Facades\Storage;
@@ -33,18 +35,20 @@ class LabelsController extends Controller
         $exampleAsset->name = 'JEN-867-5309';
         $exampleAsset->asset_tag = 'TCA-00001';
         $exampleAsset->serial = 'SN9876543210';
+        $exampleAsset->asset_eol_date = '2025-01-01';
+        $exampleAsset->order_number = '12345';
+        $exampleAsset->purchase_date = '2023-01-01';
+        $exampleAsset->status_id = 1;
 
-        $exampleAsset->company = new Company();
-        $exampleAsset->company->id = 999999;
-        $exampleAsset->company->name = 'Test Company Limited';
-        $exampleAsset->company->image = 'company-image-test.png';
+        $exampleAsset->company = new Company([
+            'name' => 'Test Company Limited',
+            'phone' => '1-555-555-5555',
+            'email' => 'company@example.com',
+        ]);
 
-        $exampleAsset->assignedto = new User();
-        $exampleAsset->assignedto->id = 999999;
-        $exampleAsset->assignedto->first_name = 'Test';
-        $exampleAsset->assignedto->last_name = 'Person';
-        $exampleAsset->assignedto->username = 'Test.Person';
-        $exampleAsset->assignedto->employee_num = '0123456789';
+        $exampleAsset->setRelation('assignedTo', new User(['first_name' => 'Luke', 'last_name' => 'Skywalker']));
+        $exampleAsset->defaultLoc = new Location(['name' => 'Building 1', 'phone' => '1-555-555-5555']);
+        $exampleAsset->location = new Location(['name' => 'Building 2', 'phone' => '1-555-555-5555']);
 
         $exampleAsset->model = new AssetModel();
         $exampleAsset->model->id = 999999;
@@ -53,6 +57,10 @@ class LabelsController extends Controller
         $exampleAsset->model->manufacturer = new Manufacturer();
         $exampleAsset->model->manufacturer->id = 999999;
         $exampleAsset->model->manufacturer->name = 'Test Manufacturing Inc.';
+        $exampleAsset->model->manufacturer->support_email = 'support@test.com';
+        $exampleAsset->model->manufacturer->support_phone = '1-555-555-5555';
+        $exampleAsset->model->manufacturer->support_url = 'https://example.com';
+        $exampleAsset->supplier = new Supplier(['name' => 'Test Company Limited']);
         $exampleAsset->model->category = new Category();
         $exampleAsset->model->category->id = 999999;
         $exampleAsset->model->category->name = 'Test Category';

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -7,6 +7,7 @@ use App\Helpers\StorageHelper;
 use App\Http\Requests\ImageUploadRequest;
 use App\Http\Requests\SettingsSamlRequest;
 use App\Http\Requests\SetupUserRequest;
+use App\Models\CustomField;
 use App\Models\Group;
 use App\Models\Setting;
 use App\Models\Asset;
@@ -809,9 +810,10 @@ class SettingsController extends Controller
      */
     public function getLabels()
     {
-        $setting = Setting::getSettings();
-
-        return view('settings.labels', compact('setting'));
+        return view('settings.labels', [
+            'setting' => Setting::getSettings(),
+            'customFields' => CustomField::all(),
+        ]);
     }
 
     /**

--- a/app/Models/Labels/FieldOption.php
+++ b/app/Models/Labels/FieldOption.php
@@ -14,6 +14,14 @@ class FieldOption {
 
     public function getValue(Asset $asset) {
         $dataPath = collect(explode('.', $this->dataSource));
+
+        // assignedTo directly on the asset is a special case where
+        // we want to avoid returning the property directly
+        // and instead return the entity's presented name.
+        if ($dataPath[0] === 'assignedTo'){
+           return $asset->assignedTo->present()->fullName();
+        }
+        
         return $dataPath->reduce(function ($myValue, $path) {
             try { return $myValue ? $myValue->{$path} : ${$myValue}; }
             catch (\Exception $e) { return $myValue; }

--- a/app/Models/Labels/FieldOption.php
+++ b/app/Models/Labels/FieldOption.php
@@ -19,7 +19,7 @@ class FieldOption {
         // we want to avoid returning the property directly
         // and instead return the entity's presented name.
         if ($dataPath[0] === 'assignedTo'){
-           return $asset->assignedTo->present()->fullName();
+            return $asset->assignedTo ?  $asset->assignedTo->present()->fullName() : null;
         }
         
         return $dataPath->reduce(function ($myValue, $path) {

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -304,13 +304,10 @@
                         <label style="grid-area: label-title">Label</label>
                         <input style="grid-area: label-field" x-model="option.label" />
                         <label style="grid-area: source-title">DataSource</label>
-                        {{--<input style="grid-area: source-field" x-model="option.datasource" />--}}
                         <select style="grid-area: source-field" x-model="option.datasource">
                             <optgroup label="Asset">
                                 <option value="asset_tag">Asset Tag</option>
-                                <option value="byod">Asset BYOD</option>
                                 <option value="asset_eol_date">Asset EOL Date</option>
-                                <option value="expected_checkin">Asset Expected Checkin</option>
                                 <option value="name">Asset Name</option>
                                 <option value="order_number">Asset Order Number</option>
                                 <option value="purchase_cost">Asset Purchase Cost</option>

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -307,17 +307,16 @@
                         <select style="grid-area: source-field" x-model="option.datasource">
                             <optgroup label="Asset">
                                 <option value="asset_tag">Asset Tag</option>
-                                <option value="asset_eol_date">Asset EOL Date</option>
                                 <option value="name">Asset Name</option>
-                                <option value="order_number">Asset Order Number</option>
-                                <option value="purchase_cost">Asset Purchase Cost</option>
-                                <option value="purchase_date">Asset Purchase Date</option>
                                 <option value="serial">Asset Serial</option>
+                                <option value="asset_eol_date">Asset EOL Date</option>
+                                <option value="order_number">Asset Order Number</option>
+                                <option value="purchase_date">Asset Purchase Date</option>
                                 <option value="assignedTo">Assigned To</option>
                             </optgroup>
                             <optgroup label="Asset Model">
-                                <option value="model.model_number">Asset Model Number</option>
                                 <option value="model.name">Asset Model Name</option>
+                                <option value="model.model_number">Asset Model Number</option>
                             </optgroup>
                             <optgroup label="Manufacturer">
                                 <option value="model.manufacturer.name">Manufacturer Name</option>
@@ -338,14 +337,14 @@
                                 <option value="defaultLoc.name">Default Location Name</option>
                                 <option value="defaultLoc.phone">Default Location Phone</option>
                             </optgroup>
+                            <optgroup label="Location">
+                                <option value="location.name">Location Name</option>
+                                <option value="location.phone">Location Phone</option>
+                            </optgroup>
                             <optgroup label="Company">
                                 <option value="company.email">Company Email</option>
                                 <option value="company.name">Company Name</option>
                                 <option value="company.phone">Company Phone</option>
-                            </optgroup>
-                            <optgroup label="Location">
-                                <option value="location.name">Location Name</option>
-                                <option value="location.phone">Location Phone</option>
                             </optgroup>
                             <optgroup label="Custom Fields">
                                 @foreach($customFields as $customField)

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -305,49 +305,49 @@
                         <input style="grid-area: label-field" x-model="option.label" />
                         <label style="grid-area: source-title">DataSource</label>
                         {{--<input style="grid-area: source-field" x-model="option.datasource" />--}}
-                        <select style="grid-area: source-field">
+                        <select style="grid-area: source-field" x-model="option.datasource">
                             <optgroup label="Asset">
-                                <option value="asset_eol_date">EOL Date</option>
                                 <option value="asset_tag">Asset Tag</option>
-                                <option value="byod">BYOD</option>
-                                <option value="expected_checkin">Expected Checkin</option>
-                                <option value="name">Name</option>
-                                <option value="order_number">Order Number</option>
-                                <option value="purchase_cost">Purchase Cost</option>
-                                <option value="purchase_date">Purchase Date</option>
-                                <option value="serial">Serial</option>
+                                <option value="byod">Asset BYOD</option>
+                                <option value="asset_eol_date">Asset EOL Date</option>
+                                <option value="expected_checkin">Asset Expected Checkin</option>
+                                <option value="name">Asset Name</option>
+                                <option value="order_number">Asset Order Number</option>
+                                <option value="purchase_cost">Asset Purchase Cost</option>
+                                <option value="purchase_date">Asset Purchase Date</option>
+                                <option value="serial">Asset Serial</option>
                             </optgroup>
                             <optgroup label="Asset Model">
                                 <option value="model.model_number">Asset Model Number</option>
                                 <option value="model.name">Asset Model Name</option>
                             </optgroup>
                             <optgroup label="Manufacturer">
-                                <option value="model.manufacturer.name">name</option>
-                                <option value="model.manufacturer.support_email">support_email</option>
-                                <option value="model.manufacturer.support_phone">support_phone</option>
-                                <option value="model.manufacturer.support_url">support_url</option>
+                                <option value="model.manufacturer.name">Manufacturer Name</option>
+                                <option value="model.manufacturer.support_email">Manufacturer Support Email</option>
+                                <option value="model.manufacturer.support_phone">Manufacturer Support Phone</option>
+                                <option value="model.manufacturer.support_url">Manufacturer Support URL</option>
                             </optgroup>
                             <optgroup label="Category">
-                                <option value="model.category.name">name</option>
+                                <option value="model.category.name">Category Name</option>
                             </optgroup>
                             <optgroup label="Status">
-                                <option value="assetstatus.name">name</option>
+                                <option value="assetstatus.name">Status</option>
                             </optgroup>
                             <optgroup label="Supplier">
-                                <option value="supplier.name">name</option>
+                                <option value="supplier.name">Supplier Name</option>
                             </optgroup>
                             <optgroup label="Default Location">
-                                <option value="defaultLoc.name">name</option>
-                                <option value="defaultLoc.phone">phone</option>
+                                <option value="defaultLoc.name">Default Location Name</option>
+                                <option value="defaultLoc.phone">Default Location Phone</option>
                             </optgroup>
                             <optgroup label="Company">
-                                <option value="company.email">email</option>
-                                <option value="company.name">name</option>
-                                <option value="company.phone">phone</option>
+                                <option value="company.email">Company Email</option>
+                                <option value="company.name">Company Name</option>
+                                <option value="company.phone">Company Phone</option>
                             </optgroup>
                             <optgroup label="Location">
-                                <option value="location.name">name</option>
-                                <option value="location.phone">phone</option>
+                                <option value="location.name">Location Name</option>
+                                <option value="location.phone">Location Phone</option>
                             </optgroup>
                         </select>
                     </div>

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -346,6 +346,11 @@
                                 <option value="location.name">Location Name</option>
                                 <option value="location.phone">Location Phone</option>
                             </optgroup>
+                            <optgroup label="Custom Fields">
+                                @foreach($customFields as $customField)
+                                    <option value="{{ $customField->db_column }}">{{ $customField->name }}</option>
+                                @endforeach
+                            </optgroup>
                         </select>
                     </div>
                 </template>

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -304,7 +304,52 @@
                         <label style="grid-area: label-title">Label</label>
                         <input style="grid-area: label-field" x-model="option.label" />
                         <label style="grid-area: source-title">DataSource</label>
-                        <input style="grid-area: source-field" x-model="option.datasource" />
+                        {{--<input style="grid-area: source-field" x-model="option.datasource" />--}}
+                        <select style="grid-area: source-field">
+                            <optgroup label="Asset">
+                                <option value="asset_eol_date">EOL Date</option>
+                                <option value="asset_tag">Asset Tag</option>
+                                <option value="byod">BYOD</option>
+                                <option value="expected_checkin">Expected Checkin</option>
+                                <option value="name">Name</option>
+                                <option value="order_number">Order Number</option>
+                                <option value="purchase_cost">Purchase Cost</option>
+                                <option value="purchase_date">Purchase Date</option>
+                                <option value="serial">Serial</option>
+                            </optgroup>
+                            <optgroup label="Asset Model">
+                                <option value="model.model_number">Asset Model Number</option>
+                                <option value="model.name">Asset Model Name</option>
+                            </optgroup>
+                            <optgroup label="Manufacturer">
+                                <option value="model.manufacturer.name">name</option>
+                                <option value="model.manufacturer.support_email">support_email</option>
+                                <option value="model.manufacturer.support_phone">support_phone</option>
+                                <option value="model.manufacturer.support_url">support_url</option>
+                            </optgroup>
+                            <optgroup label="Category">
+                                <option value="model.category.name">name</option>
+                            </optgroup>
+                            <optgroup label="Status">
+                                <option value="assetstatus.name">name</option>
+                            </optgroup>
+                            <optgroup label="Supplier">
+                                <option value="supplier.name">name</option>
+                            </optgroup>
+                            <optgroup label="Default Location">
+                                <option value="defaultLoc.name">name</option>
+                                <option value="defaultLoc.phone">phone</option>
+                            </optgroup>
+                            <optgroup label="Company">
+                                <option value="company.email">email</option>
+                                <option value="company.name">name</option>
+                                <option value="company.phone">phone</option>
+                            </optgroup>
+                            <optgroup label="Location">
+                                <option value="location.name">name</option>
+                                <option value="location.phone">phone</option>
+                            </optgroup>
+                        </select>
                     </div>
                 </template>
             </template>

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -313,6 +313,7 @@
                                 <option value="purchase_cost">Asset Purchase Cost</option>
                                 <option value="purchase_date">Asset Purchase Date</option>
                                 <option value="serial">Asset Serial</option>
+                                <option value="assignedTo">Assigned To</option>
                             </optgroup>
                             <optgroup label="Asset Model">
                                 <option value="model.model_number">Asset Model Number</option>

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -216,7 +216,7 @@
                                     {{ Form::label('label2_fields', trans('admin/settings/general.label2_fields')) }}
                                 </div>
                                 <div class="col-md-9">
-                                    @include('partials.label2-field-definitions', [ 'name' => 'label2_fields', 'value' => old('label2_fields', $setting->label2_fields) ])
+                                    @include('partials.label2-field-definitions', [ 'name' => 'label2_fields', 'value' => old('label2_fields', $setting->label2_fields), 'customFields' => $customFields ])
                                     {!! $errors->first('label2_fields', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                     <p class="help-block">{{ trans('admin/settings/general.label2_fields_help') }}</p>
                                 </div>


### PR DESCRIPTION
# Description

This PR improves the experience selecting data sources in the new label engine by replacing the need to manually type out property strings with selecting from a list. This change also allows displaying who/what assets are checked out to on the label via the "Assigned To" option.

Before
![image](https://github.com/snipe/snipe-it/assets/1141514/12fb9924-84f9-4506-bdf3-900ffec3a3ec)

After
![image](https://github.com/snipe/snipe-it/assets/1141514/b46c48b0-ca00-4551-beeb-973ed16bd15b)

I made some sensible choices on which properties to include as options but can add more if needed.
![image](https://github.com/snipe/snipe-it/assets/1141514/4de1f624-4c6d-49a4-948c-88daa5a71a2f)


---

## Notes:

- currently custom fields are selectable but will not show up in the preview section at the top of the settings page. Before I tackle implementing that I wanted to make sure the direction of this PR is acceptable.
- For the same reason I haven't moved the strings I added through the translate function.

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)