### PR TITLE
Fixed uncaught type error when attempting to render barcodes with invalid characters

### DIFF
--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -31,7 +31,7 @@ class LabelsController extends Controller
 
         $exampleAsset->id = 999999;
         $exampleAsset->name = 'JEN-867-5309';
-        $exampleAsset->asset_tag = 'TCA-00001';
+        $exampleAsset->asset_tag = '100001';
         $exampleAsset->serial = 'SN9876543210';
 
         $exampleAsset->company = new Company();

--- a/app/Models/Labels/Label.php
+++ b/app/Models/Labels/Label.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use TCPDF;
 use TCPDF_STATIC;
+use TypeError;
 
 /**
  * Model for Labels.
@@ -372,7 +373,7 @@ abstract class Label
         if (empty($value)) return;
         try {
             $pdf->write1DBarcode($value, $type, $x, $y, $width, $height, null, ['stretch'=>true]);
-        } catch (\Exception $e) {
+        } catch (\Exception|TypeError $e) {
             \Log::error('The 1D barcode ' . $value . ' is not compliant with the barcode type '. $type);
         }
     }


### PR DESCRIPTION
# Description

This PR catches the `TypeError` that is thrown when attempting to generate a barcode for an asset whose tag doesn't comply with the type configured in settings. 

As an example, the 1d barcode type `EAN13` can only contain digits so choosing that type and attempting to generate a label for an asset that has another other than digits as it's tag will trigger the error.

I also adjusted the "dummy" asset that is used to preview labels so that its asset tag is renderable by more barcode types.

After this change, instead of returning an exception page when this error occurs, the labels are generated without the barcode included.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)