### PR TITLE
Fixed consumable user view route name

### DIFF
--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -74,7 +74,7 @@
                         data-sort-name="name"
                         id="consumablesCheckedoutTable"
                         class="table table-striped snipe-table"
-                        data-url="{{route('api.consumables.showUsers', $consumable->id)}}"
+                        data-url="{{route('api.consumables.show.users', $consumable->id)}}"
                         data-export-options='{
                 "fileName": "export-consumables-{{ str_slug($consumable->name) }}-checkedout-{{ date('Y-m-d') }}",
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]

--- a/routes/api.php
+++ b/routes/api.php
@@ -280,16 +280,8 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
                 Api\ConsumablesController::class, 
                 'getDataView'
             ]
-        )->name('api.consumables.showUsers');
+        )->name('api.consumables.show.users');
 
-
-        // This is LEGACY endpoint URL and should be removed in the next major release
-        Route::get('view/{id}/users',
-              [
-                  Api\ConsumablesController::class,
-                  'getDataView'
-              ]
-        )->name('api.consumables.showUsers');
 
         Route::post('{consumable}/checkout',
             [


### PR DESCRIPTION
This fixes a duplicate route name that was only throwing errors when you try to cache routes (which most people don't do.)