### PR TITLE
added proper margin-top to sidebar menu on bigger resolutions

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -680,15 +680,15 @@ th.css-accessory > .th-inner::before
     margin-top:160px;
   }
 }
-@media screen and (max-width: 771px) and (min-width: 512px){
+@media screen and (max-width: 912px) and (min-width: 512px){
   .sidebar-menu {
-    margin-top:160px
+    margin-top:100px
   }
 }
 
-@media screen and (max-width: 1098px) and (min-width: 772px){
+@media screen and (max-width: 1268px) and (min-width: 912px){
   .sidebar-menu {
-    margin-top:98px
+    margin-top:50px
   }
 }
 


### PR DESCRIPTION
# Description

Keeps the the sidebar menu in line with the header across all screen sizes above 771px

Fixes #13641 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
