### PR TITLE
Logs non-compliant barcode error as debug message

### DIFF
--- a/app/Models/Labels/Label.php
+++ b/app/Models/Labels/Label.php
@@ -374,7 +374,7 @@ abstract class Label
         try {
             $pdf->write1DBarcode($value, $type, $x, $y, $width, $height, null, ['stretch'=>true]);
         } catch (\Exception|TypeError $e) {
-            \Log::error('The 1D barcode ' . $value . ' is not compliant with the barcode type '. $type);
+            \Log::debug('The 1D barcode ' . $value . ' is not compliant with the barcode type '. $type);
         }
     }
 


### PR DESCRIPTION
# Description

This _tiny_ PR changes the level of the message that is logged for an non-compliant barcode from `error` to `debug` to avoid excess messages in error monitoring tools.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) ❓