### PR TITLE
Fixed potential call to a member function toArray() on null

### DIFF
--- a/app/Models/Labels/Field.php
+++ b/app/Models/Labels/Field.php
@@ -21,7 +21,7 @@ class Field {
 
     public static function makeArray(Field $field, Asset $asset) {
         return $field->getOptions()
-            // filter out any null accidental FieldOptions
+            // filter out any FieldOptions that are accidentally null
             ->filter()
             ->map(fn($option) => $option->toArray($asset))
             ->filter(fn($result) => $result['value'] != null);

--- a/app/Models/Labels/Field.php
+++ b/app/Models/Labels/Field.php
@@ -21,6 +21,8 @@ class Field {
 
     public static function makeArray(Field $field, Asset $asset) {
         return $field->getOptions()
+            // filter out any null accidental FieldOptions
+            ->filter()
             ->map(fn($option) => $option->toArray($asset))
             ->filter(fn($result) => $result['value'] != null);
     }


### PR DESCRIPTION
# Description

This PR addresses an exception that can be thrown when attempting to call `->toArray()` on an expected `FieldOption` that is null. Ideally this wouldn't happen but it is possible to get into this state when using the new label engine (I'm still not sure how exactly though).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)