### PR TITLE
Feature #13687 Custom Field Recent Activity to match Custom Field Name

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -175,8 +175,7 @@ class ActionlogsTransformer
     {   $location = Location::withTrashed()->get();
         $supplier = Supplier::withTrashed()->get();
         $model = AssetModel::withTrashed()->get();
-        $company = Company::get();
-        $custom_fields = CustomField::all();
+        $company = Company::get();();
 
 
         if(array_key_exists('rtd_location_id',$clean_meta)) {
@@ -239,7 +238,3 @@ class ActionlogsTransformer
         return $clean_meta;
 
     }
-
-
-
-}

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -175,6 +175,7 @@ class ActionlogsTransformer
         $supplier = Supplier::withTrashed()->get();
         $model = AssetModel::withTrashed()->get();
         $company = Company::get();
+        $custom_fields = CustomField::all();
 
 
         if(array_key_exists('rtd_location_id',$clean_meta)) {
@@ -233,6 +234,18 @@ class ActionlogsTransformer
             $clean_meta['EOL date'] = $clean_meta['asset_eol_date'];
             unset($clean_meta['asset_eol_date']);
         }
+
+        foreach ($clean_meta as $fieldname => $value){
+            if (str_starts_with($fieldname, '_snipeit_')) { 
+                foreach ($custom_fields as $custom_field) {
+                    if ($custom_field->db_column == $fieldname) {
+                        $clean_meta[$custom_field->name] = $clean_meta[$fieldname];
+                        unset($clean_meta[$fieldname]);
+                    }
+                }
+            }    
+        }        
+        
 
         return $clean_meta;
 

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -175,10 +175,10 @@ class ActionlogsTransformer
     {   $location = Location::withTrashed()->get();
         $supplier = Supplier::withTrashed()->get();
         $model = AssetModel::withTrashed()->get();
-        $company = Company::get();();
+        $company = Company::get();
 
 
-        if(array_key_exists('rtd_location_id',$clean_meta)) {
+            if(array_key_exists('rtd_location_id',$clean_meta)) {
             $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."] ". $location->find($clean_meta['rtd_location_id']['old'])->name : trans('general.unassigned');
             $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."] ". $location->find($clean_meta['rtd_location_id']['new'])->name : trans('general.unassigned');
             $clean_meta['Default Location'] = $clean_meta['rtd_location_id'];
@@ -233,8 +233,10 @@ class ActionlogsTransformer
         if(array_key_exists('asset_eol_date', $clean_meta)) {
             $clean_meta['EOL date'] = $clean_meta['asset_eol_date'];
             unset($clean_meta['asset_eol_date']);
-        }
+     
+  }
 
         return $clean_meta;
-
+     
     }
+}

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -73,7 +73,8 @@ class ActionlogsTransformer
                                     $clean_meta[$fieldname]['old'] = "************";
                                     $clean_meta[$fieldname]['new'] = "************";
                                 }
-
+                            $clean_meta[$custom_field->name] = $clean_meta[$fieldname];
+                            unset($clean_meta[$fieldname]);
                             }
 
                         }
@@ -234,18 +235,6 @@ class ActionlogsTransformer
             $clean_meta['EOL date'] = $clean_meta['asset_eol_date'];
             unset($clean_meta['asset_eol_date']);
         }
-
-        foreach ($clean_meta as $fieldname => $value){
-            if (str_starts_with($fieldname, '_snipeit_')) { 
-                foreach ($custom_fields as $custom_field) {
-                    if ($custom_field->db_column == $fieldname) {
-                        $clean_meta[$custom_field->name] = $clean_meta[$fieldname];
-                        unset($clean_meta[$fieldname]);
-                    }
-                }
-            }    
-        }        
-        
 
         return $clean_meta;
 

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -178,7 +178,7 @@ class ActionlogsTransformer
         $company = Company::get();
 
 
-            if(array_key_exists('rtd_location_id',$clean_meta)) {
+        if(array_key_exists('rtd_location_id',$clean_meta)) {
             $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."] ". $location->find($clean_meta['rtd_location_id']['old'])->name : trans('general.unassigned');
             $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."] ". $location->find($clean_meta['rtd_location_id']['new'])->name : trans('general.unassigned');
             $clean_meta['Default Location'] = $clean_meta['rtd_location_id'];
@@ -234,7 +234,7 @@ class ActionlogsTransformer
             $clean_meta['EOL date'] = $clean_meta['asset_eol_date'];
             unset($clean_meta['asset_eol_date']);
      
-  }
+        }
 
         return $clean_meta;
      


### PR DESCRIPTION
# Description
Some work have been made on the ActionLogsTransformer to make the activity report more legible, so I added the Custom Field name to appear in the report instead of the current `_snipeit_custom_field` column name that was appearing until now.

Now instead of this way:
![image](https://github.com/snipe/snipe-it/assets/653557/7ddcb8ab-e5c4-4fe4-8880-b19eb8bf4d0c)

Looks like this:
![image](https://github.com/snipe/snipe-it/assets/653557/aeb9f7dc-98d9-4420-b097-5f76aaee88ae)


Fixes feature request #13687

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 12