### PR TITLE
Speed up EOL Migration

### DIFF
--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -42,21 +42,6 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
                 }
             });
 
-        // Update the asset_eol_date column with the calculated value if it doesn't exist
-        //    Asset::whereNull('asset_eol_date')->with('model')->chunkById(500, function ($assets) {
-        //        foreach ($assets as $asset) {
-        //            if ($asset->model->eol && $asset->purchase_date) {
-        //                try {
-        //                    $asset_eol_date = CarbonImmutable::parse($asset->purchase_date)->addMonths($asset->model->eol)->format('Y-m-d');
-        //                    $asset->update(['asset_eol_date' => $asset_eol_date]);
-        //                } catch (\Exception $e) {
-        //                    Log::info('purchase date invalid for asset ' . $asset->id);
-        //                }
-        //            }
-        //        }
-        //    });
-        //    Asset::whereNull('asset_eol_date')->whereNotNull('purchase_date')->has('model')
-        //        ->update(['asset_eol_date' => DB::raw('LEFT JOIN models ON assets.model_id = models.id) DATE_ADD(purchase_date, INTERVAL models.eol MONTH)')]);
         DB::table('assets')
             ->whereNull('asset_eol_date')
             ->whereNotNull('purchase_date')

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -36,7 +36,7 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
                         if ($asset->model->eol) {
                             if ($months != $asset->model->eol) {
                                  $assetToUpdateEolExplicit = $asset->id;
-                                //$asset->update(['eol_explicit' => true]);
+                                $asset->update(['eol_explicit' => true]);
                             }
                         } else {
                             $asset->update(['eol_explicit' => true]);

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -35,11 +35,11 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
                         if ($asset->model->eol) {
                             if ($months != $asset->model->eol) {
                                  $assetsToUpdateEolExplicit = $asset->id;
-                                $asset->update(['eol_explicit' => true]);
+                                //$asset->update(['eol_explicit' => true]);
                             }
                         } else {
                             $assetsToUpdateEolExplicit = $asset->id;
-                            $asset->update(['eol_explicit' => true]);
+                            //$asset->update(['eol_explicit' => true]);
                         }
                     }
                 }

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -4,6 +4,7 @@ use App\Models\Asset;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Log;
 
@@ -22,37 +23,44 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
 
 
         // Update the eol_explicit column with the value from asset_eol_date if it exists and is different from the calculated value
-        Asset::whereNotNull('asset_eol_date')->with('model')->chunkById(500, function ($assetsWithEolDates) {
-            foreach ($assetsWithEolDates as $asset) {
-                if ($asset->asset_eol_date && $asset->purchase_date) {
-                    try {
-                        $months = CarbonImmutable::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date);
-                    } catch (\Exception $e) {
-                        Log::info('asset_eol_date invalid for asset '.$asset->id);
-                    }
-                    if ($asset->model->eol) {
-                        if ($months != $asset->model->eol) {
+        $assetsToUpdateEolExplicit = [];
+        DB::transaction(function() {
+            Asset::whereNotNull('asset_eol_date')->with('model')->chunkById(500, function ($assetsWithEolDates) {
+                foreach ($assetsWithEolDates as $asset) {
+                    if ($asset->asset_eol_date && $asset->purchase_date) {
+                        try {
+                            $months = CarbonImmutable::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date);
+                        } catch (\Exception $e) {
+                            Log::info('asset_eol_date invalid for asset ' . $asset->id);
+                        }
+                        if ($asset->model->eol) {
+                            if ($months != $asset->model->eol) {
+                                 $assetToUpdateEolExplicit = $asset->id;
+                                //$asset->update(['eol_explicit' => true]);
+                            }
+                        } else {
                             $asset->update(['eol_explicit' => true]);
                         }
-                    } else {
-                        $asset->update(['eol_explicit' => true]);
                     }
                 }
-            }
+            });
         });
+        //Asset::whereIn('id', $assetToUpdateEolExplicit)->update(['eol_explicit' => true]);
 
-        // Update the asset_eol_date column with the calculated value if it doesn't exist 
-        Asset::whereNull('asset_eol_date')->with('model')->chunkById(500, function ($assets) {
-            foreach ($assets as $asset) {
-                if ($asset->model->eol && $asset->purchase_date) {
-                    try {
-                        $asset_eol_date = CarbonImmutable::parse($asset->purchase_date)->addMonths($asset->model->eol)->format('Y-m-d');
-                        $asset->update(['asset_eol_date' => $asset_eol_date]);
-                    } catch (\Exception $e) {
-                        Log::info('purchase date invalid for asset '.$asset->id);
+        // Update the asset_eol_date column with the calculated value if it doesn't exist
+        DB::transaction(function () {
+            Asset::whereNull('asset_eol_date')->with('model')->chunkById(500, function ($assets) {
+                foreach ($assets as $asset) {
+                    if ($asset->model->eol && $asset->purchase_date) {
+                        try {
+                            $asset_eol_date = CarbonImmutable::parse($asset->purchase_date)->addMonths($asset->model->eol)->format('Y-m-d');
+                            $asset->update(['asset_eol_date' => $asset_eol_date]);
+                        } catch (\Exception $e) {
+                            Log::info('purchase date invalid for asset ' . $asset->id);
+                        }
                     }
                 }
-            }
+            });
         });
     }
 

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -60,6 +60,7 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
         DB::table('assets')
             ->whereNull('asset_eol_date')
             ->whereNotNull('purchase_date')
+            ->whereNotNull('model_id')
             ->join('models', 'assets.model_id', '=', 'models.id')
             ->update([
                 'asset_eol_date' => DB::raw('DATE_ADD(purchase_date, INTERVAL models.eol MONTH)')

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -23,7 +23,7 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
 
 
         // Update the eol_explicit column with the value from asset_eol_date if it exists and is different from the calculated value
-        $assetsToUpdateEolExplicit = [];
+        //$assetsToUpdateEolExplicit = [];
         DB::transaction(function() {
             Asset::whereNotNull('asset_eol_date')->with('model')->chunkById(500, function ($assetsWithEolDates) {
                 foreach ($assetsWithEolDates as $asset) {
@@ -35,7 +35,7 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
                         }
                         if ($asset->model->eol) {
                             if ($months != $asset->model->eol) {
-                                 $assetToUpdateEolExplicit = $asset->id;
+                                 //$assetToUpdateEolExplicit = $asset->id;
                                 $asset->update(['eol_explicit' => true]);
                             }
                         } else {

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -55,8 +55,15 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
         //            }
         //        }
         //    });
-            Asset::whereNull('asset_eol_date')->whereNotNull('purchase_date')->has('model')
-                ->update(['asset_eol_date' => DB::raw('LEFT JOIN models ON assets.model_id = models.id) DATE_ADD(purchase_date, INTERVAL models.eol MONTH)')]);
+        //    Asset::whereNull('asset_eol_date')->whereNotNull('purchase_date')->has('model')
+        //        ->update(['asset_eol_date' => DB::raw('LEFT JOIN models ON assets.model_id = models.id) DATE_ADD(purchase_date, INTERVAL models.eol MONTH)')]);
+        DB::table('assets')
+            ->whereNull('asset_eol_date')
+            ->whereNotNull('purchase_date')
+            ->join('models', 'assets.model_id', '=', 'models.id')
+            ->update([
+                'asset_eol_date' => DB::raw('DATE_ADD(purchase_date, INTERVAL models.eol MONTH)')
+            ]);
     }
 
 


### PR DESCRIPTION
# Description
Refactors the date addition part of the EOL migration to use query builder and a raw statement to do a single bulk update using SQL's DATE_ADD. 

Lowered migration time on ~50k assets from ~6minutes to ~1.5seconds. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested migrations of different sizes, tested with assets that already had dates, and assets that had models with no eol set. 

**Test Configuration**:
* PHP version: 8.1
* MySQL version 8.1

