### PR TITLE
Fixed missing escaping asset history old/new values

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -178,24 +178,26 @@ class ActionlogsTransformer
 
 
         if(array_key_exists('rtd_location_id',$clean_meta)) {
-            $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."] ". $location->find($clean_meta['rtd_location_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."] ". $location->find($clean_meta['rtd_location_id']['new'])->name : trans('general.unassigned');
+            $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."] ". e($location->find($clean_meta['rtd_location_id']['old'])->name) : trans('general.unassigned');
+            $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."] ". e($location->find($clean_meta['rtd_location_id']['new'])->name) : trans('general.unassigned');
             $clean_meta['Default Location'] = $clean_meta['rtd_location_id'];
             unset($clean_meta['rtd_location_id']);
         }
-        if(array_key_exists('location_id', $clean_meta)) {
-            $clean_meta['location_id']['old'] = $clean_meta['location_id']['old'] ? "[id: ".$clean_meta['location_id']['old']."] ".$location->find($clean_meta['location_id']['old'])->name : trans('general.unassigned');
-            $clean_meta['location_id']['new'] = $clean_meta['location_id']['new'] ? "[id: ".$clean_meta['location_id']['new']."] ".$location->find($clean_meta['location_id']['new'])->name : trans('general.unassigned');
+
+        if (array_key_exists('location_id', $clean_meta)) {
+            $clean_meta['location_id']['old'] = $clean_meta['location_id']['old'] ? "[id: ".$clean_meta['location_id']['old']."] ".e($location->find($clean_meta['location_id']['old'])->name): trans('general.unassigned');
+            $clean_meta['location_id']['new'] = $clean_meta['location_id']['new'] ? "[id: ".$clean_meta['location_id']['new']."] ".e($location->find($clean_meta['location_id']['new'])->name) : trans('general.unassigned');
             $clean_meta['Current Location'] = $clean_meta['location_id'];
             unset($clean_meta['location_id']);
         }
+
         if(array_key_exists('model_id', $clean_meta)) {
 
             $oldModel = $model->find($clean_meta['model_id']['old']);
-            $oldModelName = $oldModel->name ?? trans('admin/models/message.deleted');
+            $oldModelName = $oldModel ? e($oldModel->name) : trans('admin/models/message.deleted');
 
             $newModel = $model->find($clean_meta['model_id']['new']);
-            $newModelName = $newModel->name ?? trans('admin/models/message.deleted');
+            $newModelName = $newModel ? e($newModel->name) : trans('admin/models/message.deleted');
 
             $clean_meta['model_id']['old'] = "[id: ".$clean_meta['model_id']['old']."] ".$oldModelName;
             $clean_meta['model_id']['new'] = "[id: ".$clean_meta['model_id']['new']."] ".$newModelName; /** model is required at asset creation */
@@ -206,10 +208,10 @@ class ActionlogsTransformer
         if(array_key_exists('company_id', $clean_meta)) {
 
             $oldCompany = $company->find($clean_meta['company_id']['old']);
-            $oldCompanyName = $oldCompany->name ?? trans('admin/companies/message.deleted');
+            $oldCompanyName = $oldCompany ? e($oldCompany->name) : trans('admin/company/message.deleted');
 
             $newCompany = $company->find($clean_meta['company_id']['new']);
-            $newCompanyName = $newCompany->name ?? trans('admin/companies/message.deleted');
+            $newCompanyName = $newCompany ? e($newCompany->name) : trans('admin/company/message.deleted');
 
             $clean_meta['company_id']['old'] = $clean_meta['company_id']['old'] ? "[id: ".$clean_meta['company_id']['old']."] ". $oldCompanyName : trans('general.unassigned');
             $clean_meta['company_id']['new'] = $clean_meta['company_id']['new'] ? "[id: ".$clean_meta['company_id']['new']."] ". $newCompanyName : trans('general.unassigned');
@@ -219,10 +221,10 @@ class ActionlogsTransformer
         if(array_key_exists('supplier_id', $clean_meta)) {
 
             $oldSupplier = $supplier->find($clean_meta['supplier_id']['old']);
-            $oldSupplierName = $oldSupplier->name ?? trans('admin/suppliers/message.deleted');
+            $oldSupplierName = $oldSupplier ? e($oldSupplier->name) : trans('admin/suppliers/message.deleted');
 
             $newSupplier = $supplier->find($clean_meta['supplier_id']['new']);
-            $newSupplierName = $newSupplier->name ?? trans('admin/suppliers/message.deleted');
+            $newSupplierName = $newSupplier ? e($newSupplier->name) : trans('admin/suppliers/message.deleted');
 
             $clean_meta['supplier_id']['old'] = $clean_meta['supplier_id']['old'] ? "[id: ".$clean_meta['supplier_id']['old']."] ". $oldSupplierName : trans('general.unassigned');
             $clean_meta['supplier_id']['new'] = $clean_meta['supplier_id']['new'] ? "[id: ".$clean_meta['supplier_id']['new']."] ". $newSupplierName : trans('general.unassigned');


### PR DESCRIPTION
In a recent regression, we were not escaping out the names of old/new values in the asset history, which opened a vulnerability for XSS attacks. Fixes https://huntr.dev/bounties/d6ed5ac1-2ad6-45fd-9492-979820bf60c8/