### PR TITLE
Added trim to import values

### DIFF
--- a/app/Importer/AccessoryImporter.php
+++ b/app/Importer/AccessoryImporter.php
@@ -34,7 +34,7 @@ class AccessoryImporter extends ItemImporter
             }
 
             $this->log('Updating Accessory');
-            $this->item['model_number'] = $this->findCsvMatch($row, "model_number");
+            $this->item['model_number'] = trim($this->findCsvMatch($row, "model_number"));
             $accessory->update($this->sanitizeItemForUpdating($accessory));
             $accessory->save();
 

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -80,13 +80,13 @@ class AssetImporter extends ItemImporter
             $this->log('No Matching Asset, Creating a new one');
             $asset = new Asset;
         }
-        $this->item['notes'] = $this->findCsvMatch($row, 'asset_notes');
-        $this->item['image'] = $this->findCsvMatch($row, 'image');
-        $this->item['requestable'] = ($this->fetchHumanBoolean($this->findCsvMatch($row, 'requestable')) == 1) ? '1' : 0;
+        $this->item['notes'] = trim($this->findCsvMatch($row, 'asset_notes'));
+        $this->item['image'] = trim($this->findCsvMatch($row, 'image'));
+        $this->item['requestable'] = trim(($this->fetchHumanBoolean($this->findCsvMatch($row, 'requestable'))) == 1) ? '1' : 0;
         $asset->requestable = $this->item['requestable'];
-        $this->item['warranty_months'] = intval($this->findCsvMatch($row, 'warranty_months'));
+        $this->item['warranty_months'] = intval(trim($this->findCsvMatch($row, 'warranty_months')));
         $this->item['model_id'] = $this->createOrFetchAssetModel($row);
-        $this->item['byod'] = ($this->fetchHumanBoolean($this->findCsvMatch($row, 'byod')) == 1) ? '1' : 0;
+        $this->item['byod'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'byod'))) == 1) ? '1' : 0;
 
 
         // If no status ID is found

--- a/app/Importer/ComponentImporter.php
+++ b/app/Importer/ComponentImporter.php
@@ -28,8 +28,8 @@ class ComponentImporter extends ItemImporter
     {
         $component = null;
         $this->log('Creating Component');
-        $component = Component::where('name', $this->item['name'])
-                        ->where('serial', $this->item['serial'])
+        $component = Component::where('name', trim($this->item['name']))
+                        ->where('serial', trim($this->item['serial']))
                         ->first();
 
         if ($component) {

--- a/app/Importer/ConsumableImporter.php
+++ b/app/Importer/ConsumableImporter.php
@@ -26,7 +26,7 @@ class ConsumableImporter extends ItemImporter
      */
     public function createConsumableIfNotExists($row)
     {
-        $consumable = Consumable::where('name', $this->item['name'])->first();
+        $consumable = Consumable::where('name', trim($this->item['name']))->first();
         if ($consumable) {
             if (! $this->updating) {
                 $this->log('A matching Consumable '.$this->item['name'].' already exists.  ');
@@ -41,9 +41,9 @@ class ConsumableImporter extends ItemImporter
         }
         $this->log('No matching consumable, creating one');
         $consumable = new Consumable();
-        $this->item['model_number'] = $this->findCsvMatch($row, 'model_number');
-        $this->item['item_no'] = $this->findCsvMatch($row, 'item_number');
-        $this->item['min_amt'] = $this->findCsvMatch($row, "min_amt");
+        $this->item['model_number'] = trim($this->findCsvMatch($row, 'model_number'));
+        $this->item['item_no'] = trim($this->findCsvMatch($row, 'item_number'));
+        $this->item['min_amt'] = trim($this->findCsvMatch($row, "min_amt"));
         $consumable->fill($this->sanitizeItemForStoring($consumable));
         //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.
         $consumable->unsetEventDispatcher();

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -372,7 +372,7 @@ class ItemImporter extends Importer
         if (empty($asset_statuslabel_name)) {
             return null;
         }
-        $status = Statuslabel::where(['name' => trim($asset_statuslabel_name]))->first();
+       $status = Statuslabel::where(['name' => trim($asset_statuslabel_name)])->first();
 
         if ($status) {
             $this->log('A matching Status '.$asset_statuslabel_name.' already exists');

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -372,7 +372,7 @@ class ItemImporter extends Importer
         if (empty($asset_statuslabel_name)) {
             return null;
         }
-        $status = Statuslabel::where(['name' => $asset_statuslabel_name])->first();
+        $status = Statuslabel::where(['name' => trim($asset_statuslabel_name]))->first();
 
         if ($status) {
             $this->log('A matching Status '.$asset_statuslabel_name.' already exists');
@@ -381,7 +381,7 @@ class ItemImporter extends Importer
         }
         $this->log('Creating a new status');
         $status = new Statuslabel();
-        $status->name = $asset_statuslabel_name;
+        $status->name = trim($asset_statuslabel_name);
 
         $status->deployable = 1;
         $status->pending = 0;
@@ -420,7 +420,7 @@ class ItemImporter extends Importer
 
         //Otherwise create a manufacturer.
         $manufacturer = new Manufacturer();
-        $manufacturer->name = $item_manufacturer;
+        $manufacturer->name = trim($item_manufacturer);
         $manufacturer->user_id = $this->user_id;
 
         if ($manufacturer->save()) {

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -55,19 +55,19 @@ class LicenseImporter extends ItemImporter
             $this->log('No Matching License, Creating a new one');
             $license = new License;
         }
-        $asset_tag = $this->item['asset_tag'] = $this->findCsvMatch($row, 'asset_tag'); // used for checkout out to an asset.
+        $asset_tag = $this->item['asset_tag'] = trim($this->findCsvMatch($row, 'asset_tag')); // used for checkout out to an asset.
 
         $this->item["expiration_date"] = null;
         if ($this->findCsvMatch($row, "expiration_date")!='') {
-            $this->item["expiration_date"] = date("Y-m-d 00:00:01", strtotime($this->findCsvMatch($row, "expiration_date")));
+            $this->item["expiration_date"] = date("Y-m-d 00:00:01", strtotime(trim($this->findCsvMatch($row, "expiration_date"))));
         }
-        $this->item['license_email'] = $this->findCsvMatch($row, 'license_email');
-        $this->item['license_name'] = $this->findCsvMatch($row, 'license_name');
-        $this->item['maintained'] = $this->findCsvMatch($row, 'maintained');
-        $this->item['purchase_order'] = $this->findCsvMatch($row, 'purchase_order');
-        $this->item['order_number'] = $this->findCsvMatch($row, 'order_number');
-        $this->item['reassignable'] = $this->findCsvMatch($row, 'reassignable');
-        $this->item['manufacturer'] = $this->createOrFetchManufacturer($this->findCsvMatch($row, 'manufacturer'));
+        $this->item['license_email'] = trim($this->findCsvMatch($row, 'license_email'));
+        $this->item['license_name'] = trim($this->findCsvMatch($row, 'license_name'));
+        $this->item['maintained'] = trim($this->findCsvMatch($row, 'maintained'));
+        $this->item['purchase_order'] = trim($this->findCsvMatch($row, 'purchase_order'));
+        $this->item['order_number'] = trim($this->findCsvMatch($row, 'order_number'));
+        $this->item['reassignable'] = trim($this->findCsvMatch($row, 'reassignable'));
+        $this->item['manufacturer'] = $this->createOrFetchManufacturer(trim($this->findCsvMatch($row, 'manufacturer')));
 
         if($this->item['reassignable'] == "")
         {

--- a/app/Importer/LocationImporter.php
+++ b/app/Importer/LocationImporter.php
@@ -53,21 +53,21 @@ class LocationImporter extends ItemImporter
         }
 
         // Pull the records from the CSV to determine their values
-        $this->item['name'] = $this->findCsvMatch($row, 'name');
-        $this->item['address'] = $this->findCsvMatch($row, 'address');
-        $this->item['address2'] = $this->findCsvMatch($row, 'address2');
-        $this->item['city'] = $this->findCsvMatch($row, 'city');
-        $this->item['state'] = $this->findCsvMatch($row, 'state');
-        $this->item['country'] = $this->findCsvMatch($row, 'country');
-        $this->item['zip'] = $this->findCsvMatch($row, 'zip');
-        $this->item['currency'] = $this->findCsvMatch($row, 'currency');
-        $this->item['ldap_ou'] = $this->findCsvMatch($row, 'ldap_ou');
-        $this->item['manager'] = $this->findCsvMatch($row, 'manager');
-        $this->item['manager_username'] = $this->findCsvMatch($row, 'manager_username');
+        $this->item['name'] = trim($this->findCsvMatch($row, 'name'));
+        $this->item['address'] = trim($this->findCsvMatch($row, 'address'));
+        $this->item['address2'] = trim($this->findCsvMatch($row, 'address2'));
+        $this->item['city'] = trim($this->findCsvMatch($row, 'city'));
+        $this->item['state'] = trim($this->findCsvMatch($row, 'state'));
+        $this->item['country'] = trim($this->findCsvMatch($row, 'country'));
+        $this->item['zip'] = trim($this->findCsvMatch($row, 'zip'));
+        $this->item['currency'] = trim($this->findCsvMatch($row, 'currency'));
+        $this->item['ldap_ou'] = trim($this->findCsvMatch($row, 'ldap_ou'));
+        $this->item['manager'] = trim($this->findCsvMatch($row, 'manager'));
+        $this->item['manager_username'] = trim($this->findCsvMatch($row, 'manager_username'));
         $this->item['user_id'] = \Auth::user()->id;
 
         if ($this->findCsvMatch($row, 'parent_location')) {
-            $this->item['parent_id'] = $this->createOrFetchLocation($this->findCsvMatch($row, 'parent_location'));
+            $this->item['parent_id'] = $this->createOrFetchLocation(trim($this->findCsvMatch($row, 'parent_location')));
         }
 
         if (!empty($this->item['manager'])) {

--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -42,32 +42,32 @@ class UserImporter extends ItemImporter
     public function createUserIfNotExists(array $row)
     {
         // Pull the records from the CSV to determine their values
-        $this->item['id'] = $this->findCsvMatch($row, 'id');
-        $this->item['username'] = $this->findCsvMatch($row, 'username');
-        $this->item['first_name'] = $this->findCsvMatch($row, 'first_name');
-        $this->item['last_name'] = $this->findCsvMatch($row, 'last_name');
-        $this->item['email'] = $this->findCsvMatch($row, 'email');
-        $this->item['gravatar'] = $this->findCsvMatch($row, 'gravatar');
-        $this->item['phone'] = $this->findCsvMatch($row, 'phone_number');
-        $this->item['website'] = $this->findCsvMatch($row, 'website');
-        $this->item['jobtitle'] = $this->findCsvMatch($row, 'jobtitle');
-        $this->item['address'] = $this->findCsvMatch($row, 'address');
-        $this->item['city'] = $this->findCsvMatch($row, 'city');
-        $this->item['state'] = $this->findCsvMatch($row, 'state');
-        $this->item['country'] = $this->findCsvMatch($row, 'country');
-        $this->item['start_date'] = $this->findCsvMatch($row, 'start_date');
-        $this->item['end_date'] = $this->findCsvMatch($row, 'end_date');
-        $this->item['zip'] = $this->findCsvMatch($row, 'zip');
-        $this->item['activated'] = ($this->fetchHumanBoolean($this->findCsvMatch($row, 'activated')) == 1) ? '1' : 0;
-        $this->item['employee_num'] = $this->findCsvMatch($row, 'employee_num');
-        $this->item['department_id'] = $this->createOrFetchDepartment($this->findCsvMatch($row, 'department'));
-        $this->item['manager_id'] = $this->fetchManager($this->findCsvMatch($row, 'manager_first_name'), $this->findCsvMatch($row, 'manager_last_name'));
-        $this->item['remote'] =($this->fetchHumanBoolean($this->findCsvMatch($row, 'remote')) ==1 ) ? '1' : 0;
-        $this->item['vip'] = ($this->fetchHumanBoolean($this->findCsvMatch($row, 'vip')) ==1 ) ? '1' : 0;
-        $this->item['autoassign_licenses'] = ($this->fetchHumanBoolean($this->findCsvMatch($row, 'autoassign_licenses')) ==1 ) ? '1' : 0;
+        $this->item['id'] = trim($this->findCsvMatch($row, 'id'));
+        $this->item['username'] = trim($this->findCsvMatch($row, 'username'));
+        $this->item['first_name'] = trim($this->findCsvMatch($row, 'first_name'));
+        $this->item['last_name'] = trim($this->findCsvMatch($row, 'last_name'));
+        $this->item['email'] = trim($this->findCsvMatch($row, 'email'));
+        $this->item['gravatar'] = trim($this->findCsvMatch($row, 'gravatar'));
+        $this->item['phone'] = trim($this->findCsvMatch($row, 'phone_number'));
+        $this->item['website'] = trim($this->findCsvMatch($row, 'website'));
+        $this->item['jobtitle'] = trim($this->findCsvMatch($row, 'jobtitle'));
+        $this->item['address'] = trim($this->findCsvMatch($row, 'address'));
+        $this->item['city'] = trim($this->findCsvMatch($row, 'city'));
+        $this->item['state'] = trim($this->findCsvMatch($row, 'state'));
+        $this->item['country'] = trim($this->findCsvMatch($row, 'country'));
+        $this->item['start_date'] = trim($this->findCsvMatch($row, 'start_date'));
+        $this->item['end_date'] = trim($this->findCsvMatch($row, 'end_date'));
+        $this->item['zip'] = trim($this->findCsvMatch($row, 'zip'));
+        $this->item['activated'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'activated'))) == 1) ? '1' : 0;
+        $this->item['employee_num'] = trim($this->findCsvMatch($row, 'employee_num'));
+        $this->item['department_id'] = trim($this->createOrFetchDepartment(trim($this->findCsvMatch($row, 'department'))));
+        $this->item['manager_id'] = $this->fetchManager(trim($this->findCsvMatch($row, 'manager_first_name'), $this->findCsvMatch($row, 'manager_last_name')));
+        $this->item['remote'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'remote'))) == 1 ) ? '1' : 0;
+        $this->item['vip'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'vip'))) ==1 ) ? '1' : 0;
+        $this->item['autoassign_licenses'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'autoassign_licenses'))) ==1 ) ? '1' : 0;
 
 
-        $user_department = $this->findCsvMatch($row, 'department');
+        $user_department = trim($this->findCsvMatch($row, 'department'));
         if ($this->shouldUpdateField($user_department)) {
             $this->item['department_id'] = $this->createOrFetchDepartment($user_department);
         }


### PR DESCRIPTION
This just adds some `trim()` methods around the imported field values. We recently had a customer who ended up with duplicate statuses, since `Ready to Deploy` and `Ready to Deploy ` are not the same string. 

I'm not 100% sure I've gotten everything in this PR, but I'll keep testing. 