### PR TITLE
Fixed notification logic to ensure check in and out emails are delivered

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -61,12 +61,10 @@ class CheckoutableListener
                 Notification::route('slack', Setting::getSettings()->webhook_endpoint)
                     ->notify($this->getCheckoutNotification($event));
             }
-        }
-        catch (ClientException $e){
-            Log::debug("Exception caught during checkout notification: ".$e->getMessage());
-        }
-        catch (Exception $e) {
-            Log::error("Exception caught during checkout notification: ".$e->getMessage());
+        } catch (ClientException $e) {
+            Log::debug("Exception caught during checkout notification: " . $e->getMessage());
+        } catch (Exception $e) {
+            Log::error("Exception caught during checkout notification: " . $e->getMessage());
         }
     }
 
@@ -114,12 +112,10 @@ class CheckoutableListener
                 Notification::route('slack', Setting::getSettings()->webhook_endpoint)
                     ->notify($this->getCheckinNotification($event));
             }
-        }
-        catch (ClientException $e){
-            Log::debug("Exception caught during checkout notification: ".$e->getMessage());
-        }
-        catch (Exception $e) {
-            Log::error("Exception caught during checkin notification: ".$e->getMessage());
+        } catch (ClientException $e) {
+            Log::debug("Exception caught during checkout notification: " . $e->getMessage());
+        } catch (Exception $e) {
+            Log::error("Exception caught during checkin notification: " . $e->getMessage());
         }
     }      
 

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -18,6 +18,7 @@ use App\Notifications\CheckoutAccessoryNotification;
 use App\Notifications\CheckoutAssetNotification;
 use App\Notifications\CheckoutConsumableNotification;
 use App\Notifications\CheckoutLicenseSeatNotification;
+use GuzzleHttp\Exception\ClientException;
 use Illuminate\Support\Facades\Notification;
 use Exception;
 use Log;
@@ -61,6 +62,16 @@ class CheckoutableListener
                 );
             }
         } catch (Exception $e) {
+            if ($e instanceof ClientException){
+                $statusCode = $e->getResponse()->getStatusCode();
+                // If status code is in 400 range, we don't want to log it as an error
+                // @todo: 300 and 500 as well?
+                if ($statusCode >= 400 && $statusCode < 500) {
+                    Log::debug("Exception caught during checkout notification: ".$e->getMessage());
+                    return;
+                }
+            }
+
             Log::error("Exception caught during checkout notification: ".$e->getMessage());
         }
     }

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -42,7 +42,7 @@ class CheckoutableListener
         /**
          * Make a checkout acceptance and attach it in the notification
          */
-        $acceptance = $this->getCheckoutAcceptance($event);       
+        $acceptance = $this->getCheckoutAcceptance($event);
 
         try {
             if (! $event->checkedOutTo->locale) {
@@ -61,12 +61,11 @@ class CheckoutableListener
                 Notification::route('slack', Setting::getSettings()->webhook_endpoint)
                     ->notify($this->getCheckoutNotification($event));
             }
-        } catch (Exception $e) {
-            if ($e instanceof ClientException){
-                Log::debug("Exception caught during checkout notification: ".$e->getMessage());
-                return;
-            }
-
+        }
+        catch (ClientException $e){
+            Log::debug("Exception caught during checkout notification: ".$e->getMessage());
+        }
+        catch (Exception $e) {
             Log::error("Exception caught during checkout notification: ".$e->getMessage());
         }
     }
@@ -115,12 +114,11 @@ class CheckoutableListener
                 Notification::route('slack', Setting::getSettings()->webhook_endpoint)
                     ->notify($this->getCheckinNotification($event));
             }
-        } catch (Exception $e) {
-            if ($e instanceof ClientException){
-                Log::debug("Exception caught during checkout notification: ".$e->getMessage());
-                return;
-            }
-
+        }
+        catch (ClientException $e){
+            Log::debug("Exception caught during checkout notification: ".$e->getMessage());
+        }
+        catch (Exception $e) {
             Log::error("Exception caught during checkin notification: ".$e->getMessage());
         }
     }      

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -98,11 +98,6 @@ class CheckoutableListener
         }
 
         try {
-            if ($this->shouldSendWebhookNotification()) {
-                Notification::route('slack', Setting::getSettings()->webhook_endpoint)
-                    ->notify($this->getCheckinNotification($event));
-            }
-
             // Use default locale
             if (! $event->checkedOutTo->locale) {
                 Notification::locale(Setting::getSettings()->locale)->send(
@@ -115,7 +110,17 @@ class CheckoutableListener
                     $this->getCheckinNotification($event)
                 );
             }
+
+            if ($this->shouldSendWebhookNotification()) {
+                Notification::route('slack', Setting::getSettings()->webhook_endpoint)
+                    ->notify($this->getCheckinNotification($event));
+            }
         } catch (Exception $e) {
+            if ($e instanceof ClientException){
+                Log::debug("Exception caught during checkout notification: ".$e->getMessage());
+                return;
+            }
+
             Log::error("Exception caught during checkin notification: ".$e->getMessage());
         }
     }      

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -45,11 +45,6 @@ class CheckoutableListener
         $acceptance = $this->getCheckoutAcceptance($event);       
 
         try {
-            if ($this->shouldSendWebhookNotification()) {
-                Notification::route('slack', Setting::getSettings()->webhook_endpoint)
-                    ->notify($this->getCheckoutNotification($event));
-            }
-
             if (! $event->checkedOutTo->locale) {
                 Notification::locale(Setting::getSettings()->locale)->send(
                     $this->getNotifiables($event),
@@ -60,6 +55,11 @@ class CheckoutableListener
                     $this->getNotifiables($event),
                     $this->getCheckoutNotification($event, $acceptance)
                 );
+            }
+
+            if ($this->shouldSendWebhookNotification()) {
+                Notification::route('slack', Setting::getSettings()->webhook_endpoint)
+                    ->notify($this->getCheckoutNotification($event));
             }
         } catch (Exception $e) {
             if ($e instanceof ClientException){

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -63,13 +63,8 @@ class CheckoutableListener
             }
         } catch (Exception $e) {
             if ($e instanceof ClientException){
-                $statusCode = $e->getResponse()->getStatusCode();
-                // If status code is in 400 range, we don't want to log it as an error
-                // @todo: 300 and 500 as well?
-                if ($statusCode >= 400 && $statusCode < 500) {
-                    Log::debug("Exception caught during checkout notification: ".$e->getMessage());
-                    return;
-                }
+                Log::debug("Exception caught during checkout notification: ".$e->getMessage());
+                return;
             }
 
             Log::error("Exception caught during checkout notification: ".$e->getMessage());


### PR DESCRIPTION
# Description

In this PR, email notifications are now sent before webhook notifications to ensure their deliverability in the cases where the webhook notification fails.

In addition, webhook that do fail are logged at the `debug` level as opposed to the `error` level that was used before.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)