### PR TITLE
Fixed the storing of group permissions when creating via API

### DIFF
--- a/app/Http/Controllers/Api/GroupsController.php
+++ b/app/Http/Controllers/Api/GroupsController.php
@@ -63,7 +63,7 @@ class GroupsController extends Controller
         $group = new Group;
 
         $group->name = $request->input('name');
-        $group->permissions = $request->input('permissions'); // Todo - some JSON validation stuff here
+        $group->permissions = json_encode($request->input('permissions')); // Todo - some JSON validation stuff here
 
         if ($group->save()) {
             return response()->json(Helper::formatStandardApiResponse('success', $group, trans('admin/groups/message.create.success')));

--- a/tests/Feature/Api/Groups/GroupStoreTest.php
+++ b/tests/Feature/Api/Groups/GroupStoreTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Api\Groups;
+
+use App\Models\Group;
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class GroupStoreTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testStoringGroupRequiresSuperAdminPermission()
+    {
+        $this->actingAsForApi(User::factory()->create())
+            ->postJson(route('api.groups.store'))
+            ->assertForbidden();
+    }
+
+    public function testCanStoreGroup()
+    {
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->postJson(route('api.groups.store'), [
+                'name' => 'My Awesome Group',
+                'permissions' => [
+                    'admin' => '1',
+                    'import' => '1',
+                    'reports.view' => '0',
+                ],
+            ])
+            ->assertOk();
+
+        $group = Group::where('name', 'My Awesome Group')->first();
+
+        $this->assertNotNull($group);
+        $this->assertEquals('1', $group->decodePermissions()['admin']);
+        $this->assertEquals('1', $group->decodePermissions()['import']);
+        $this->assertEquals('0', $group->decodePermissions()['reports.view']);
+    }
+}


### PR DESCRIPTION
# Description

This PR fixes creating groups via the API when permissions are included by json encoding the input just like we do in the web `GroupController`.

Before this change passing something like `{"admin": "1", "import": "1"}` would cause an array to string exception to be thrown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)