### PR TITLE
Resolves issue with migrations with table prefixes

### DIFF
--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -42,7 +42,7 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
                 }
             });
 
-        DB::table(  'assets')
+        DB::table('assets')
             ->whereNull('asset_eol_date')
             ->whereNotNull('purchase_date')
             ->whereNotNull('model_id')

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -42,13 +42,13 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
                 }
             });
 
-        DB::table('assets')
+        DB::table(  'assets')
             ->whereNull('asset_eol_date')
             ->whereNotNull('purchase_date')
             ->whereNotNull('model_id')
             ->join('models', 'assets.model_id', '=', 'models.id')
             ->update([
-                'asset_eol_date' => DB::raw('DATE_ADD(purchase_date, INTERVAL models.eol MONTH)')
+                'asset_eol_date' => DB::raw('DATE_ADD(purchase_date, INTERVAL ' . DB::getTablePrefix() . 'models.eol MONTH)')
             ]);
     }
 


### PR DESCRIPTION
# Description

The raw statement needs the table prefix added in, this adds that. 

Fixes #13724 (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested migration with and without prefix with and without this change. This resolves issue. 

**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.1
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
