### PR TITLE
Fixed #13723 - race condition on asset observer for older migration

### DIFF
--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -129,7 +129,8 @@ class AssetObserver
      *
      * For example, if there is a database migration that's a bit older and modifies an asset, if the save
      * fires before a field gets created in a later migration and that field in the later migration
-     * is used in this observer, it doesn't actually exist yet and the migration will break.
+     * is used in this observer, it doesn't actually exist yet and the migration will break unless we
+     * use saveQuietly() in the migration which skips this observer.
      *
      * @see https://github.com/snipe/snipe-it/issues/13723#issuecomment-1761315938
      */

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -120,17 +120,29 @@ class AssetObserver
         $logAction->user_id = Auth::id();
         $logAction->logaction('delete');
     }
-   
+
+    /**
+     * Executes every time an asset is saved.
+     *
+     * This matters specifically because any database fields affected here MUST already exist on
+     * the assets table (and/or any related models), or related migrations WILL fail.
+     *
+     * For example, if there is a database migration that's a bit older and modifies an asset, if the save
+     * fires before a field gets created in a later migration and that field in the later migration
+     * is used in this observer, it doesn't actually exist yet and the migration will break.
+     *
+     * @see https://github.com/snipe/snipe-it/issues/13723#issuecomment-1761315938
+     */
     public function saving(Asset $asset)
     {
-        //determine if calculated eol and then calculate it - this should only happen on a new asset
-        if(is_null($asset->asset_eol_date) && !is_null($asset->purchase_date) && !is_null($asset->model->eol)){
+        // determine if calculated eol and then calculate it - this should only happen on a new asset
+        if (is_null($asset->asset_eol_date) && !is_null($asset->purchase_date) && !is_null($asset->model->eol)){
             $asset->asset_eol_date = $asset->purchase_date->addMonths($asset->model->eol)->format('Y-m-d');
             $asset->eol_explicit = false; 
         } 
 
-       //determine if explicit and set eol_explit to true 
-       if(!is_null($asset->asset_eol_date) && !is_null($asset->purchase_date)) {
+       // determine if explicit and set eol_explicit to true
+       if (!is_null($asset->asset_eol_date) && !is_null($asset->purchase_date)) {
             if($asset->model->eol) {
                 $months = Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date); 
                 if($months != $asset->model->eol) {

--- a/database/migrations/2023_01_21_225350_add_eol_date_on_assets_table.php
+++ b/database/migrations/2023_01_21_225350_add_eol_date_on_assets_table.php
@@ -20,14 +20,6 @@ class AddEolDateOnAssetsTable extends Migration
             if (!Schema::hasColumn('assets', 'asset_eol_date')) {
                 $table->date('asset_eol_date')->after('purchase_date')->nullable()->default(null);
             }
-
-            // This is a temporary shim so we don't have to modify the asset observer for migrations where
-            // there is a large version difference. (See the AssetObserver notes). This column gets created
-            // later in 2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
-            // but we have to temporarily create it now so the save method below doesn't break
-            if (!Schema::hasColumn('assets', 'eol_explicit')) {
-                $table->boolean('eol_explicit')->default(false)->after('asset_eol_date');
-            }
         });
 
         // Chunk the model query to get the models that do have an EOL date
@@ -37,7 +29,7 @@ class AddEolDateOnAssetsTable extends Migration
 
                     if ($asset->purchase_date!='') {
                         $asset->asset_eol_date = $asset->present()->eol_date();
-                        $asset->save();
+                        $asset->saveQuietly();
                     }
 
                 }

--- a/database/migrations/2023_01_21_225350_add_eol_date_on_assets_table.php
+++ b/database/migrations/2023_01_21_225350_add_eol_date_on_assets_table.php
@@ -23,6 +23,8 @@ class AddEolDateOnAssetsTable extends Migration
         });
 
         // Chunk the model query to get the models that do have an EOL date
+        // We use saveQuietly() here to skip the AssetObserver, since it modifies fields
+        // that do not yet exist on the assets table.
         AssetModel::whereNotNull('eol')->chunk(10, function ($models) {
             foreach ($models as $model) {
                 foreach ($model->assets as $asset) {

--- a/database/migrations/2023_01_21_225350_add_eol_date_on_assets_table.php
+++ b/database/migrations/2023_01_21_225350_add_eol_date_on_assets_table.php
@@ -17,8 +17,17 @@ class AddEolDateOnAssetsTable extends Migration
     {
 
         Schema::table('assets', function (Blueprint $table) {
+            
             if (!Schema::hasColumn('assets', 'asset_eol_date')) {
                 $table->date('asset_eol_date')->after('purchase_date')->nullable()->default(null);
+            }
+
+            // This is a temporary shim so we don't have to modify the asset observer for migrations where
+            // there is a large version difference. (See the AssetObserver notes). This column gets created
+            // later in 2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+            // but we have to temporarily create it now so the save method below doesn't break
+            if (!Schema::hasColumn('assets', 'eol_explicit')) {
+                $table->boolean('eol_explicit')->default(false)->after('asset_eol_date');
             }
         });
 

--- a/database/migrations/2023_01_21_225350_add_eol_date_on_assets_table.php
+++ b/database/migrations/2023_01_21_225350_add_eol_date_on_assets_table.php
@@ -20,6 +20,14 @@ class AddEolDateOnAssetsTable extends Migration
             if (!Schema::hasColumn('assets', 'asset_eol_date')) {
                 $table->date('asset_eol_date')->after('purchase_date')->nullable()->default(null);
             }
+
+            // This is a temporary shim so we don't have to modify the asset observer for migrations where
+            // there is a large version difference. (See the AssetObserver notes). This column gets created
+            // later in 2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+            // but we have to temporarily create it now so the save method below doesn't break
+            if (!Schema::hasColumn('assets', 'eol_explicit')) {
+                $table->boolean('eol_explicit')->default(false)->after('asset_eol_date');
+            }
         });
 
         // Chunk the model query to get the models that do have an EOL date

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -18,7 +18,9 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
     public function up()
     {
         Schema::table('assets', function (Blueprint $table) {
-            $table->boolean('eol_explicit')->default(false)->after('asset_eol_date');
+            if (!Schema::hasColumn('assets', 'eol_explicit')) {
+                $table->boolean('eol_explicit')->default(false)->after('asset_eol_date');
+            }
         });
 
 


### PR DESCRIPTION
This should fix #13723, where there was a race condition firing a migration from earlier in 2023 which modifies the asset, but the observer touches fields that have not yet been created.

I mostly hate this (especially because we're going back in time to fix migrations) but this seems like the most sane way to clear the upgrade path.