### PR TITLE
Handle case where value is deleted in history

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -10,6 +10,8 @@ use App\Models\Supplier;
 use App\Models\Location;
 use App\Models\AssetModel;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Support\Facades\Crypt;
 
 class ActionlogsTransformer
 {
@@ -69,9 +71,36 @@ class ActionlogsTransformer
 
                             if ($custom_field->db_column == $fieldname) {
 
-                                if ($custom_field->field_encrypted == '1') {
-                                    $clean_meta[$fieldname]['old'] = "************";
-                                    $clean_meta[$fieldname]['new'] = "************";
+                                if ($custom_field->field_encrypted == '1')  {
+
+                                    // Unset these fields. We need to decrypt them, since even if the decrypted value
+                                    // didn't change, their value in the DB will, so we have to compare the unencrypted version
+                                    // to see if the values actually did change
+                                    unset($clean_meta[$fieldname]);
+                                    unset($clean_meta[$fieldname]);
+
+                                    $enc_old = '';
+                                    $enc_new = '';
+
+                                    try  {
+                                        $enc_old = \Crypt::decryptString($this->clean_field($fieldata->old));
+                                    } catch (\Exception $e) {
+                                        \Log::debug('Could not decrypt field - maybe the key changed?');
+                                    }
+
+                                    try {
+                                        $enc_new = \Crypt::decryptString($this->clean_field($fieldata->new));
+                                    } catch (\Exception $e) {
+                                        \Log::debug('Could not decrypt field - maybe the key changed?');
+                                    }
+
+                                    if ($enc_old != $enc_new) {
+                                        \Log::debug('custom fields do not match');
+                                        $clean_meta[$fieldname]['old'] = "************";
+                                        $clean_meta[$fieldname]['new'] = "************";
+                                    }
+
+
                                 }
 
                             }
@@ -178,15 +207,31 @@ class ActionlogsTransformer
 
 
         if(array_key_exists('rtd_location_id',$clean_meta)) {
-            $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."] ". e($location->find($clean_meta['rtd_location_id']['old'])->name) : trans('general.unassigned');
-            $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."] ". e($location->find($clean_meta['rtd_location_id']['new'])->name) : trans('general.unassigned');
+
+            $oldRtd = $location->find($clean_meta['rtd_location_id']['old']);
+            $oldRtdName = $oldRtd ? e($oldRtd->name) : trans('general.deleted');
+
+            $newRtd = $location->find($clean_meta['rtd_location_id']['new']);
+            $newRtdName = $newRtd ? e($newRtd->name) : trans('general.deleted');
+
+            $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."] ". $oldRtdName : 'foo';
+            $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."] ". $newRtdName : trans('general.unassigned');
             $clean_meta['Default Location'] = $clean_meta['rtd_location_id'];
             unset($clean_meta['rtd_location_id']);
         }
 
+
         if (array_key_exists('location_id', $clean_meta)) {
-            $clean_meta['location_id']['old'] = $clean_meta['location_id']['old'] ? "[id: ".$clean_meta['location_id']['old']."] ".e($location->find($clean_meta['location_id']['old'])->name): trans('general.unassigned');
-            $clean_meta['location_id']['new'] = $clean_meta['location_id']['new'] ? "[id: ".$clean_meta['location_id']['new']."] ".e($location->find($clean_meta['location_id']['new'])->name) : trans('general.unassigned');
+
+            $oldLocation = $location->find($clean_meta['location_id']['old']);
+            $oldLocationName = $oldLocation ? e($oldLocation->name) : trans('general.deleted');
+
+            $newLocation = $location->find($clean_meta['location_id']['new']);
+            $newLocationName = $newLocation ? e($newLocation->name) : trans('general.deleted');
+
+
+            $clean_meta['location_id']['old'] = $clean_meta['location_id']['old'] ? "[id: ".$clean_meta['location_id']['old']."] ". $oldLocationName : trans('general.deleted');
+            $clean_meta['location_id']['new'] = $clean_meta['location_id']['new'] ? "[id: ".$clean_meta['location_id']['new']."] ". $newLocationName : trans('general.unassigned');
             $clean_meta['Current Location'] = $clean_meta['location_id'];
             unset($clean_meta['location_id']);
         }

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -214,7 +214,7 @@ class ActionlogsTransformer
             $newRtd = $location->find($clean_meta['rtd_location_id']['new']);
             $newRtdName = $newRtd ? e($newRtd->name) : trans('general.deleted');
 
-            $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."] ". $oldRtdName : 'foo';
+            $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."] ". $oldRtdName : '';
             $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."] ". $newRtdName : trans('general.unassigned');
             $clean_meta['Default Location'] = $clean_meta['rtd_location_id'];
             unset($clean_meta['rtd_location_id']);

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -215,7 +215,7 @@ class ActionlogsTransformer
             $newRtdName = $newRtd ? e($newRtd->name) : trans('general.deleted');
 
             $clean_meta['rtd_location_id']['old'] = $clean_meta['rtd_location_id']['old'] ? "[id: ".$clean_meta['rtd_location_id']['old']."] ". $oldRtdName : '';
-            $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."] ". $newRtdName : trans('general.unassigned');
+            $clean_meta['rtd_location_id']['new'] = $clean_meta['rtd_location_id']['new'] ? "[id: ".$clean_meta['rtd_location_id']['new']."] ". $newRtdName : '';
             $clean_meta['Default Location'] = $clean_meta['rtd_location_id'];
             unset($clean_meta['rtd_location_id']);
         }
@@ -230,8 +230,8 @@ class ActionlogsTransformer
             $newLocationName = $newLocation ? e($newLocation->name) : trans('general.deleted');
 
 
-            $clean_meta['location_id']['old'] = $clean_meta['location_id']['old'] ? "[id: ".$clean_meta['location_id']['old']."] ". $oldLocationName : trans('general.deleted');
-            $clean_meta['location_id']['new'] = $clean_meta['location_id']['new'] ? "[id: ".$clean_meta['location_id']['new']."] ". $newLocationName : trans('general.unassigned');
+            $clean_meta['location_id']['old'] = $clean_meta['location_id']['old'] ? "[id: ".$clean_meta['location_id']['old']."] ". $oldLocationName : '';
+            $clean_meta['location_id']['new'] = $clean_meta['location_id']['new'] ? "[id: ".$clean_meta['location_id']['new']."] ". $newLocationName : '';
             $clean_meta['Current Location'] = $clean_meta['location_id'];
             unset($clean_meta['location_id']);
         }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -72,8 +72,7 @@ class Asset extends Depreciable
 
     protected $casts = [
         'purchase_date' => 'date',
-        'asset_eol_date' => 'date',
-        'eol_explicit' => 'boolean', 
+        'eol_explicit' => 'boolean',
         'last_checkout' => 'datetime',
         'last_checkin' => 'datetime',
         'expected_checkin' => 'date',


### PR DESCRIPTION
This is a sort of stopgap for #13710, which handles a few different cases

__EOL Date will not show as changed if it was not actually changed anymore.__ It was being cast as a date which was really turning it into a date time 

__Encrypted fields will not show as changed if they're not really changed.__ We're still storing the change in history, since the encrypted value *does* change. This really needs to be handled in the controllers where we don't "save" those fields to the asset itself if nothing was changed.

And finally - the real reason I started this - this fixes an error where if a certain set of circumstances have occurred,  an asset's history will look empty with an `ErrorException: Attempt to read property "name" on null` error. This would happen when the following happens:

1. Asset ABC had a location of 123.
2. Asset ABC gets edited to have a location of XYZ
3. Location 123 gets soft-deleted AND purged
4. Asset history is now broken

I'd really like to handle this better by actually capturing the "at that time" value when the asset is saved, to prevent people from sidestepping the history by editing Location 123 to be XYZ, without ever touching the asset. If the asset was changed, the location name/id *at the time* should be what we're logging, so we know that *at that time*, the location was named 123. But alas, that's an issue for a different PR.

<img width="269" alt="Screenshot 2023-10-13 at 7 51 59 PM" src="https://github.com/snipe/snipe-it/assets/197404/aabb4f28-fd7b-44ed-b0e8-bc249a64bfce">
