### PR TITLE
Fixed ErrorException: Array to String Conversion rb17355

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -530,7 +530,6 @@ class AssetsController extends Controller
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @param \App\Http\Requests\ImageUploadRequest $request
      * @since [v4.0]
-     * @return JsonResponse
      */
     public function store(ImageUploadRequest $request)
     {
@@ -579,6 +578,10 @@ class AssetsController extends Controller
 
         if (($model) && ($model->fieldset)) {
             foreach ($model->fieldset->fields as $field) {
+                //reduce "array to string conversion" exceptions - ideally we'd handle this in a form request, but this works for now
+                if(is_array($request->input($field->db_column, null))) {
+                    return response()->json(Helper::formatStandardApiResponse('error', null, 'This custom field can not be an array', 200));
+                }
 
                 // Set the field value based on what was sent in the request
                 $field_val = $request->input($field->db_column, null);

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -578,13 +578,14 @@ class AssetsController extends Controller
 
         if (($model) && ($model->fieldset)) {
             foreach ($model->fieldset->fields as $field) {
-                //reduce "array to string conversion" exceptions - ideally we'd handle this in a form request, but this works for now
-                if(is_array($request->input($field->db_column, null))) {
-                    return response()->json(Helper::formatStandardApiResponse('error', null, 'This custom field can not be an array', 200));
-                }
 
                 // Set the field value based on what was sent in the request
                 $field_val = $request->input($field->db_column, null);
+
+                //reduce "array to string conversion" exceptions - ideally we'd handle this in a form request, but this works for now
+                if(is_array($field_val)) {
+                    return response()->json(Helper::formatStandardApiResponse('error', null, 'This custom field can not be an array', 200));
+                }
 
                 // If input value is null, use custom field's default value
                 if ($field_val == null) {

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -582,11 +582,6 @@ class AssetsController extends Controller
                 // Set the field value based on what was sent in the request
                 $field_val = $request->input($field->db_column, null);
 
-                //reduce "array to string conversion" exceptions - ideally we'd handle this in a form request, but this works for now
-                if(is_array($field_val)) {
-                    return response()->json(Helper::formatStandardApiResponse('error', null, 'This custom field can not be an array', 200));
-                }
-
                 // If input value is null, use custom field's default value
                 if ($field_val == null) {
                     \Log::debug('Field value for '.$field->db_column.' is null');

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -220,10 +220,6 @@ class Asset extends Depreciable
             }
         }
 
-        if (!is_array($params)){
-            return false;
-        }
-
         return parent::save($params);
     }
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -220,7 +220,9 @@ class Asset extends Depreciable
             }
         }
 
-
+        if (!is_array($params)){
+            return false;
+        }
 
         return parent::save($params);
     }

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -92,6 +92,8 @@ class CustomFieldset extends Model
 
             array_push($rule, $field->attributes['format']);
             $rules[$field->db_column_name()] = $rule;
+            //add not_array to rules for all fields
+            $rules[$field->db_column_name()][] = 'not_array';
         }
 
         return $rules;

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -232,6 +232,10 @@ class ValidationServiceProvider extends ServiceProvider
                 return true;
             }
         });
+
+        Validator::extend('not_array', function ($attribute, $value, $parameters, $validator) {
+            return !is_array($value);
+        });
     }
 
     /**

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -95,7 +95,7 @@ return [
     'url'                  => 'The :attribute format is invalid.',
     'unique_undeleted'     => 'The :attribute must be unique.',
     'non_circular'         => 'The :attribute must not create a circular reference.',
-    'not_array'            => 'The :attribute field can not be an array.',
+    'not_array'            => 'The :attribute field cannot be an array.',
     'disallow_same_pwd_as_user_fields' => 'Password cannot be the same as the username.',
     'letters'              => 'Password must contain at least one letter.',
     'numbers'              => 'Password must contain at least one number.',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -95,6 +95,7 @@ return [
     'url'                  => 'The :attribute format is invalid.',
     'unique_undeleted'     => 'The :attribute must be unique.',
     'non_circular'         => 'The :attribute must not create a circular reference.',
+    'not_array'            => 'The :attribute field can not be an array.',
     'disallow_same_pwd_as_user_fields' => 'Password cannot be the same as the username.',
     'letters'              => 'Password must contain at least one letter.',
     'numbers'              => 'Password must contain at least one number.',


### PR DESCRIPTION
# Description
As a normally insecure person, I'm almost never sure about the solutions I found. But this time I feel particularly unsure about this one... 

We received this error in rollbar a fair amount of times, and it appears to come from a custom Python script. And the error is thrown at the `Asset::save()` method override line wich say `return parent::save($params)`, but we received the `$params` variable as an array and if it doesn't exist we initialize it as an empty array.

But I can't test it properly because I don't any idea how they are arriving at that point nor the data they are trying to send to, I just know what the rollbar is telling me that is happening so I kind of only treat the symptom without fix the root cause (sorry, I'm watching a lot of House MD lately).

Fixes rollbar 17355

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: PHP Dev Server
* OS version: Debian 11
