### PR TITLE
Check for valid date in custom report

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -23,6 +23,7 @@ use Input;
 use League\Csv\Reader;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use League\Csv\EscapeFormula;
+use App\Http\Requests\CustomAssetReportRequest;
 
 
 /**
@@ -403,10 +404,11 @@ class ReportsController extends Controller
      * @since [v1.0]
      * @return \Illuminate\Http\Response
      */
-    public function postCustom(Request $request)
+    public function postCustom(CustomAssetReportRequest $request)
     {
         ini_set('max_execution_time', env('REPORT_TIME_LIMIT', 12000)); //12000 seconds = 200 minutes
         $this->authorize('reports.view');
+
 
         \Debugbar::disable();
         $customfields = CustomField::get();
@@ -645,7 +647,7 @@ class ReportsController extends Controller
             if (($request->filled('created_start')) && ($request->filled('created_end'))) {
                 $created_start = \Carbon::parse($request->input('created_start'))->startOfDay();
                 $created_end = \Carbon::parse($request->input('created_end'))->endOfDay();
-                
+
                 $assets->whereBetween('assets.created_at', [$created_start, $created_end]);
             }
             if (($request->filled('checkout_date_start')) && ($request->filled('checkout_date_end'))) {
@@ -656,22 +658,22 @@ class ReportsController extends Controller
             }
 
             if (($request->filled('checkin_date_start'))) {
-                $assets->whereBetween('last_checkin', [
-                    Carbon::parse($request->input('checkin_date_start'))->startOfDay(),
-                    // use today's date is `checkin_date_end` is not provided
-                    Carbon::parse($request->input('checkin_date_end', now()))->endOfDay(),
-                ]);
+                    $assets->whereBetween('last_checkin', [
+                        Carbon::parse($request->input('checkin_date_start'))->startOfDay(),
+                        // use today's date is `checkin_date_end` is not provided
+                        Carbon::parse($request->input('checkin_date_end', now()))->endOfDay(),
+                    ]);
             }
 
             if (($request->filled('expected_checkin_start')) && ($request->filled('expected_checkin_end'))) {
-                $assets->whereBetween('assets.expected_checkin', [$request->input('expected_checkin_start'), $request->input('expected_checkin_end')]);
+                    $assets->whereBetween('assets.expected_checkin', [$request->input('expected_checkin_start'), $request->input('expected_checkin_end')]);
             }
 
             if (($request->filled('last_audit_start')) && ($request->filled('last_audit_end'))) {
-                $last_audit_start = \Carbon::parse($request->input('last_audit_start'))->startOfDay();
-                $last_audit_end = \Carbon::parse($request->input('last_audit_end'))->endOfDay();
+                    $last_audit_start = \Carbon::parse($request->input('last_audit_start'))->startOfDay();
+                    $last_audit_end = \Carbon::parse($request->input('last_audit_end'))->endOfDay();
 
-                $assets->whereBetween('assets.last_audit_date', [$last_audit_start, $last_audit_end]);
+                    $assets->whereBetween('assets.last_audit_date', [$last_audit_start, $last_audit_end]);
             }
 
             if (($request->filled('next_audit_start')) && ($request->filled('next_audit_end'))) {

--- a/app/Http/Requests/CustomAssetReportRequest.php
+++ b/app/Http/Requests/CustomAssetReportRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests;
+
+class CustomAssetReportRequest extends Request
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'purchase_date'         => 'date|date_format:Y-m-d|nullable',
+            'checkout_date'         => 'date|date_format:Y-m-d|nullable',
+            'checkin_date'          => 'date|date_format:Y-m-d|nullable',
+            'purchase_start'        => 'date|date_format:Y-m-d|nullable',
+            'purchase_end'          => 'date|date_format:Y-m-d|nullable',
+            'created_start'         => 'date|date_format:Y-m-d|nullable',
+            'created_end'           => 'date|date_format:Y-m-d|nullable',
+            'checkout_date_start'   => 'date|date_format:Y-m-d|nullable',
+            'checkout_date_end'     => 'date|date_format:Y-m-d|nullable',
+            'expected_checkin_start'      => 'date|date_format:Y-m-d|nullable',
+            'expected_checkin_end'        => 'date|date_format:Y-m-d|nullable',
+            'checkin_date_start'      => 'date|date_format:Y-m-d|nullable',
+            'checkin_date_end'        => 'date|date_format:Y-m-d|nullable',
+            'last_audit_start'      => 'date|date_format:Y-m-d|nullable',
+            'last_audit_end'        => 'date|date_format:Y-m-d|nullable',
+            'next_audit_start'      => 'date|date_format:Y-m-d|nullable',
+            'next_audit_end'        => 'date|date_format:Y-m-d|nullable',
+        ];
+    }
+
+    public function response(array $errors)
+    {
+        return $this->redirector->back()->withInput()->withErrors($errors, $this->errorBag);
+    }
+}

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -259,79 +259,131 @@
             <!-- Order Number -->
             <div class="form-group">
               <label for="by_order_number" class="col-md-3 control-label">{{ trans('general.order_number') }}</label>
-              <div class="col-md-5 col-sm-8">
+              <div class="col-md-7">
                 <input class="form-control" type="text" name="by_order_number" value="" aria-label="by_order_number">
               </div>
             </div>
 
           <!-- Purchase Date -->
-            <div class="form-group purchase-range">
+            <div class="form-group purchase-range{{ ($errors->has('purchase_start') || $errors->has('purchase_end')) ? ' has-error' : '' }}">
               <label for="purchase_start" class="col-md-3 control-label">{{ trans('general.purchase_date') }} {{  trans('general.range') }}</label>
-              <div class="input-daterange input-group col-md-6" id="datepicker">
-                <input type="text" class="form-control" name="purchase_start" aria-label="purchase_start">
+              <div class="input-daterange input-group col-md-7" id="datepicker">
+                <input type="text" class="form-control" name="purchase_start" aria-label="purchase_start" value="{{ old('purchase_start') }}">
                 <span class="input-group-addon">to</span>
-                <input type="text" class="form-control" name="purchase_end" aria-label="purchase_end">
+                <input type="text" class="form-control" name="purchase_end" aria-label="purchase_end" value="{{ old('purchase_end') }}">
               </div>
+
+                @if ($errors->has('purchase_start') || $errors->has('purchase_end'))
+                    <div class="col-md-9 col-lg-offset-3">
+                        {!! $errors->first('purchase_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('purchase_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    </div>
+                @endif
+
             </div>
 
             <!-- Created Date -->
-            <div class="form-group purchase-range">
+            <div class="form-group purchase-range{{ ($errors->has('created_start') || $errors->has('created_end')) ? ' has-error' : '' }}">
               <label for="created_start" class="col-md-3 control-label">{{ trans('general.created_at') }} {{  trans('general.range') }}</label>
-              <div class="input-daterange input-group col-md-6" id="datepicker">
-                <input type="text" class="form-control" name="created_start" aria-label="created_start">
+              <div class="input-daterange input-group col-md-7" id="datepicker">
+                <input type="text" class="form-control" name="created_start" aria-label="created_start" value="{{ old('created_start') }}">
                 <span class="input-group-addon">to</span>
-                <input type="text" class="form-control" name="created_end" aria-label="created_end">
+                <input type="text" class="form-control" name="created_end" aria-label="created_end" value="{{ old('created_end') }}">
               </div>
+
+                @if ($errors->has('created_start') || $errors->has('created_end'))
+                    <div class="col-md-9 col-lg-offset-3">
+                        {!! $errors->first('created_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('created_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    </div>
+                @endif
             </div>
 
           <!-- Checkout Date -->
-          <div class="form-group checkout-range">
+          <div class="form-group checkout-range{{ ($errors->has('checkout_date_start') || $errors->has('checkout_date_end')) ? ' has-error' : '' }}">
               <label for="checkout_date" class="col-md-3 control-label">{{ trans('general.checkout') }} {{  trans('general.range') }}</label>
-              <div class="input-daterange input-group col-md-6" id="datepicker">
-                  <input type="text" class="form-control" name="checkout_date_start" aria-label="checkout_date_start">
+              <div class="input-daterange input-group col-md-7" id="datepicker">
+                  <input type="text" class="form-control" name="checkout_date_start" aria-label="checkout_date_start" value="{{ old('checkout_date_start') }}">
                   <span class="input-group-addon">to</span>
-                  <input type="text" class="form-control" name="checkout_date_end" aria-label="checkout_date_end">
+                  <input type="text" class="form-control" name="checkout_date_end" aria-label="checkout_date_end" value="{{ old('checkout_date_end') }}">
               </div>
+
+              @if ($errors->has('checkout_date_start') || $errors->has('checkout_date_end'))
+                  <div class="col-md-9 col-lg-offset-3">
+                      {!! $errors->first('checkout_date_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      {!! $errors->first('checkout_date_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                  </div>
+              @endif
+
           </div>
 
           <!-- Last Checkin Date -->
-          <div class="form-group checkin-range">
+          <div class="form-group checkin-range{{ ($errors->has('checkin_date_start') || $errors->has('checkin_date_end')) ? ' has-error' : '' }}">
               <label for="checkin_date" class="col-md-3 control-label">{{ trans('admin/hardware/table.last_checkin_date') }}</label>
-              <div class="input-daterange input-group col-md-6" id="datepicker">
-                  <input type="text" class="form-control" name="checkin_date_start" aria-label="checkin_date_start">
+              <div class="input-daterange input-group col-md-7" id="datepicker">
+                  <input type="text" class="form-control" name="checkin_date_start" aria-label="checkin_date_start" value="{{ old('checkin_date_start') }}">
                   <span class="input-group-addon">{{ strtolower(trans('general.to')) }}</span>
-                  <input type="text" class="form-control" name="checkin_date_end" aria-label="checkin_date_end">
+                  <input type="text" class="form-control" name="checkin_date_end" aria-label="checkin_date_end" value="{{ old('checkin_date_end') }}">
               </div>
+
+              @if ($errors->has('checkin_date_start') || $errors->has('checkin_date_end'))
+                  <div class="col-md-9 col-lg-offset-3">
+                      {!! $errors->first('checkin_date_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      {!! $errors->first('checkin_date_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                  </div>
+              @endif
           </div>
 
             <!-- Expected Checkin Date -->
-            <div class="form-group expected_checkin-range">
+            <div class="form-group expected_checkin-range{{ ($errors->has('expected_checkin_start') || $errors->has('expected_checkin_end')) ? ' has-error' : '' }}">
               <label for="expected_checkin_start" class="col-md-3 control-label">{{ trans('admin/hardware/form.expected_checkin') }}</label>
-              <div class="input-daterange input-group col-md-6" id="datepicker">
-                <input type="text" class="form-control" name="expected_checkin_start" aria-label="expected_checkin_start">
+              <div class="input-daterange input-group col-md-7" id="datepicker">
+                <input type="text" class="form-control" name="expected_checkin_start" aria-label="expected_checkin_start" value="{{ old('expected_checkin_start') }}">
                 <span class="input-group-addon">to</span>
-                <input type="text" class="form-control" name="expected_checkin_end" aria-label="expected_checkin_end">
+                <input type="text" class="form-control" name="expected_checkin_end" aria-label="expected_checkin_end" value="{{ old('expected_checkin_end') }}">
               </div>
+
+                @if ($errors->has('expected_checkin_start') || $errors->has('expected_checkin_end'))
+                    <div class="col-md-9 col-lg-offset-3">
+                        {!! $errors->first('expected_checkin_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        {!! $errors->first('expected_checkin_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                    </div>
+                @endif
+
             </div>
 
               <!-- Last Audit Date -->
-              <div class="form-group last_audit-range">
+              <div class="form-group last_audit-range{{ ($errors->has('last_audit_start') || $errors->has('last_audit_end')) ? ' has-error' : '' }}">
                   <label for="last_audit_start" class="col-md-3 control-label">{{ trans('general.last_audit') }}</label>
-                  <div class="input-daterange input-group col-md-6" id="datepicker">
-                      <input type="text" class="form-control" name="last_audit_start" aria-label="last_audit_start">
+                  <div class="input-daterange input-group col-md-7" id="datepicker">
+                      <input type="text" class="form-control" name="last_audit_start" aria-label="last_audit_start" value="{{ old('last_audit_start') }}">
                       <span class="input-group-addon">to</span>
-                      <input type="text" class="form-control" name="last_audit_end" aria-label="last_audit_end">
+                      <input type="text" class="form-control" name="last_audit_end" aria-label="last_audit_end" value="{{ old('last_audit_end') }}">
                   </div>
+
+                  @if ($errors->has('last_audit_start') || $errors->has('last_audit_end'))
+                      <div class="col-md-9 col-lg-offset-3">
+                          {!! $errors->first('last_audit_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('last_audit_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      </div>
+                  @endif
               </div>
 
               <!-- Next Audit Date -->
-              <div class="form-group next_audit-range">
+              <div class="form-group next_audit-range{{ ($errors->has('next_audit_start') || $errors->has('next_audit_end')) ? ' has-error' : '' }}">
                   <label for="next_audit_start" class="col-md-3 control-label">{{ trans('general.next_audit_date') }}</label>
-                  <div class="input-daterange input-group col-md-6" id="datepicker">
-                      <input type="text" class="form-control" name="next_audit_start" aria-label="nex_audit_start">
+                  <div class="input-daterange input-group col-md-7" id="datepicker">
+                      <input type="text" class="form-control" name="next_audit_start" aria-label="next_audit_start" value="{{ old('next_audit_start') }}">
                       <span class="input-group-addon">to</span>
-                      <input type="text" class="form-control" name="next_audit_end" aria-label="next_audit_end">
+                      <input type="text" class="form-control" name="next_audit_end" aria-label="next_audit_end" value="{{ old('next_audit_end') }}">
                   </div>
+
+                  @if ($errors->has('next_audit_start') || $errors->has('next_audit_end'))
+                      <div class="col-md-9 col-lg-offset-3">
+                          {!! $errors->first('next_audit_start', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          {!! $errors->first('next_audit_end', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                      </div>
+                  @endif
               </div>
 
             <div class="col-md-9 col-md-offset-3">


### PR DESCRIPTION
This adds a Custom Report request which simply validates the date format that gets passed, in the event someone has javascript turned off and tries to enter invalid dates.

<img width="558" alt="Screenshot 2023-10-18 at 2 11 19 PM" src="https://github.com/snipe/snipe-it/assets/197404/f7a2065d-51fd-4430-8024-aa6a4f7d330f">
<img width="561" alt="Screenshot 2023-10-18 at 2 11 56 PM" src="https://github.com/snipe/snipe-it/assets/197404/dd6ffef8-1d7f-4a69-91a5-d6652cbf1098">
<img width="590" alt="Screenshot 2023-10-18 at 2 16 39 PM" src="https://github.com/snipe/snipe-it/assets/197404/57290ebf-131d-4318-ad04-15a05f16a8fa">
