### PR TITLE
clarifies an address column under locations

### DIFF
--- a/app/Presenters/LocationPresenter.php
+++ b/app/Presenters/LocationPresenter.php
@@ -106,7 +106,7 @@ class LocationPresenter extends Presenter
                 'searchable' => true,
                 'sortable' => true,
                 'switchable' => true,
-                'title' =>  trans('admin/locations/table.address'),
+                'title' =>  trans('admin/locations/table.address2'),
                 'visible' => false,
             ],
             [

--- a/resources/lang/en/admin/locations/table.php
+++ b/resources/lang/en/admin/locations/table.php
@@ -15,6 +15,7 @@ return [
     'print_all_assigned'        => 'Print All Assigned',
     'name'                      => 'Location Name',
     'address'                   => 'Address',
+    'address2'                   => 'Address Line 2',
     'zip'                       => 'Postal Code',
     'locations'                 => 'Locations',
     'parent'                    => 'Parent',


### PR DESCRIPTION
# Description

Renames the second Address Column to "Address Line 2" for clarification.
<img width="439" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/cc72903c-a3b7-4fcb-8f73-f66894f6a876">


Fixes #SC-23814

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
