### PR TITLE
Map Snipe-IT logs to storage logs folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
     - "8000:80"
     volumes:
-    - ./logs:/var/www/html/storage/logs
+    - ./storage/logs:/var/www/html/storage/logs
     depends_on:
     - mariadb
     - redis


### PR DESCRIPTION
# Description

Docker compose currently maps `./logs` which doesn't exist in the root of this repo and will throw an error for the user. 

Fixes # (issue) [Discord Link](https://discord.com/channels/849770616521359401/953725309864263723/1166382432921071669)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Changes applied and running `docker-compose up`

Relevant logs (database connection in my ENV is not correct so there's errors above this, but no error output about the logs folder:

```
snipe-it-mariadb-1  | 2023-10-24 16:28:10 0 [Warning] You need to use --log-bin to make --expire-logs-days or --binlog-expire-logs-seconds work.
snipeit             |
snipeit             |       +36 vendor frames
snipeit             |   37  artisan:35
snipeit             |       Illuminate\Foundation\Console\Kernel::handle()
snipe-it-mariadb-1  | 2023-10-24 16:28:10 0 [Note] Server socket created on IP: '0.0.0.0'.
snipe-it-mariadb-1  | 2023-10-24 16:28:10 0 [Note] Server socket created on IP: '::'.
snipe-it-mariadb-1  | 2023-10-24 16:28:10 0 [Warning] 'proxies_priv' entry '@% root@10e2ced05b13' ignored in --skip-name-resolve mode.
snipe-it-mariadb-1  | 2023-10-24 16:28:10 0 [Note] mysqld: ready for connections.
snipe-it-mariadb-1  | Version: '10.6.4-MariaDB-1:10.6.4+maria~focal'  socket: '/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
snipe-it-mariadb-1  | 2023-10-24 16:28:10 0 [Note] InnoDB: Buffer pool(s) load completed at 231024 16:28:10
snipeit             | Configuration cache cleared!
snipeit             | Configuration cache cleared!
snipeit             | Configuration cached successfully!
snipeit             | AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.18.0.5. Set the 'ServerName' directive globally to suppress this message
```


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
