### PR TITLE
Fixed ErrorException: Undefined array key in importer blade [sc-23864]

### DIFF
--- a/resources/lang/en/help.php
+++ b/resources/lang/en/help.php
@@ -30,5 +30,6 @@ return [
     'consumables'   => 'Consumables are anything purchased that will be used up over time. For example, printer ink or copier paper.',
 
     'depreciations' => 'You can set up asset depreciations to depreciate assets based on straight-line depreciation.',
-
+    
+    'empty_file'    => 'The importer detects that this file is empty.'
 ];

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -241,7 +241,7 @@
                                                                             </div>
 									@else
 									    @php
-										$statusText = trans('general.empty_file');
+										$statusText = trans('help.empty_file');
 										$statusType = 'info';
 									    @endphp
 									@endif

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -235,9 +235,11 @@
                                                                                     ])
                                                                                 }}
                                                                             </div>
+									@if ($activeFile->first_row)
                                                                             <div class="col-md-5">
                                                                                 <p class="form-control-static">{{ str_limit($activeFile->first_row[$index], 50, '...') }}</p>
                                                                             </div>
+									@endif
                                                                         </div><!-- /div row -->
                                                                     @endforeach
                                                                 @else

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -239,6 +239,11 @@
                                                                             <div class="col-md-5">
                                                                                 <p class="form-control-static">{{ str_limit($activeFile->first_row[$index], 50, '...') }}</p>
                                                                             </div>
+									@else
+									    @php
+										$statusText = trans('general.empty_file');
+										$statusType = 'info';
+									    @endphp
 									@endif
                                                                         </div><!-- /div row -->
                                                                     @endforeach

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -235,16 +235,16 @@
                                                                                     ])
                                                                                 }}
                                                                             </div>
-									@if ($activeFile->first_row)
+									                                    @if ($activeFile->first_row)
                                                                             <div class="col-md-5">
                                                                                 <p class="form-control-static">{{ str_limit($activeFile->first_row[$index], 50, '...') }}</p>
                                                                             </div>
-									@else
-									    @php
-										$statusText = trans('help.empty_file');
-										$statusType = 'info';
-									    @endphp
-									@endif
+                                                                        @else
+                                                                            @php
+                                                                            $statusText = trans('help.empty_file');
+                                                                            $statusType = 'info';
+                                                                            @endphp
+                                                                        @endif
                                                                         </div><!-- /div row -->
                                                                     @endforeach
                                                                 @else


### PR DESCRIPTION
# Description
If the file that we are trying to import doesn't have any data, when the importer tries to get the first row to get the sample data in here
 
![image](https://github.com/snipe/snipe-it/assets/653557/df9dcdd0-895f-4099-ba35-3de568e3114a)

the system crash. In this PR I put a condition to mitigate this, then create an info message to let the user know that their CSV doesn't have data. I don't love to use the `@php` directive inside the blade, but couldn't get a better idea.

Fixes [sc-23864]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP Dev Server
* OS version: Debian 12
