### PR TITLE
Fixed #13795 Unlogged checkin action post updating the username of an asset through the CSV import

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -5,6 +5,9 @@ namespace App\Importer;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Statuslabel;
+use App\Models\User;
+use App\Events\CheckoutableCheckedIn;
+use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
 
 class AssetImporter extends ItemImporter
@@ -142,6 +145,10 @@ class AssetImporter extends ItemImporter
             //-- user_id is a property of the abstract class Importer, which this class inherits from and it's setted by
             //-- the class that needs to use it (command importer or GUI importer inside the project).
             if (isset($target)) {
+                if ($asset->assigned_to != $target->id){
+                    event(new CheckoutableCheckedIn($asset, User::find($asset->assigned_to), Auth::user(), $asset->notes, date('Y-m-d H:i:s')));
+                }
+
                 $asset->fresh()->checkOut($target, $this->user_id, date('Y-m-d H:i:s'), null, $asset->notes, $asset->name);
             }
 

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -145,8 +145,10 @@ class AssetImporter extends ItemImporter
             //-- user_id is a property of the abstract class Importer, which this class inherits from and it's setted by
             //-- the class that needs to use it (command importer or GUI importer inside the project).
             if (isset($target)) {
-                if ($asset->assigned_to != $target->id){
-                    event(new CheckoutableCheckedIn($asset, User::find($asset->assigned_to), Auth::user(), $asset->notes, date('Y-m-d H:i:s')));
+                if (!is_null($asset->assigned_to)){
+                    if ($asset->assigned_to != $target->id){
+                        event(new CheckoutableCheckedIn($asset, User::find($asset->assigned_to), Auth::user(), $asset->notes, date('Y-m-d H:i:s')));
+                    }
                 }
 
                 $asset->fresh()->checkOut($target, $this->user_id, date('Y-m-d H:i:s'), null, $asset->notes, $asset->name);


### PR DESCRIPTION
# Description
When an asset user is updated via the Importer, the history of said asset doesn't register the checkin/checkout pair of actions, only the checkout.

I add a couple of conditions to check if the current asset the user has assigned is different to the new user targetted for the checkout, to register the checkin event in the action log.

Fixes #13795

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP Dev Server
* OS version: Debian 12