### PR TITLE
Fixed FD-38641 - Bulk asset edit unable to update model_id, misc other bugs

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -290,11 +290,7 @@ class BulkAssetsController extends Controller
 
             } // end asset foreach
 
-            \Log::debug($has_errors.' errors');
             if ($has_errors > 0) {
-                \Log::debug('Error array:');
-                \Log::debug(print_r($error_array, true));
-                //dd($error_array);
                 return redirect($bulk_back_url)->with('bulk_asset_errors', $error_array);
             }
 

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -250,12 +250,16 @@ class BulkAssetsController extends Controller
 
                                 // These fields aren't encrypted, just carry on as usual
                                 } else {
+
+
                                     if ((array_key_exists($field->db_column, $this->update_array)) && ($asset->{$field->db_column} != $this->update_array[$field->db_column])) {
-                                        $asset->{$field->db_column} = $this->update_array[$field->db_column];
+
+                                        // Check if this is an array, and if so, flatten it
                                         if (is_array($this->update_array[$field->db_column])) {
                                             $asset->{$field->db_column} = implode(', ', $this->update_array[$field->db_column]);
+                                        } else {
+                                            $asset->{$field->db_column} = $this->update_array[$field->db_column];
                                         }
-
                                     }
                                 }
 
@@ -264,20 +268,10 @@ class BulkAssetsController extends Controller
                 } // end custom fields handler
 
 
+
                 // Check if it passes validation, and then try to save
-                if ($asset->update($this->update_array)) {
-                    $logAction = new Actionlog();
-                    $logAction->item_type = Asset::class;
-                    $logAction->item_id = $assetId;
-                    $logAction->created_at =  date("Y-m-d H:i:s");
-                    $logAction->user_id = Auth::id();
-                    $logAction->log_meta = json_encode($changed);
-                    $logAction->logaction('update');
+                if (!$asset->update($this->update_array)) {
 
-                }  else {
-
-                    \Log::debug('Error bag:');
-                    \Log::debug(print_r($asset->getErrors(), true));
                     // Build the error array
                     foreach ($asset->getErrors()->toArray() as $key => $message) {
                         for ($x = 0; $x < count($message); $x++) {
@@ -286,7 +280,7 @@ class BulkAssetsController extends Controller
                         }
                     }
 
-                } // end if saved
+                }  // end if saved
 
             } // end asset foreach
 

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -238,17 +238,26 @@ class BulkAssetsController extends Controller
                                 if ((array_key_exists($field->db_column, $this->update_array)) && ($field->field_encrypted=='1')) {
                                     $decrypted_old = Helper::gracefulDecrypt($field, $asset->{$field->db_column});
 
-                                    // Check if the decrypted existing value is different from one we just submitted
-                                    // and if not, pull it out of the object
+                                    /*
+                                     * Check if the decrypted existing value is different from one we just submitted
+                                     * and if not, pull it out of the object since it shouldn't really be updating at all.
+                                     * If we don't do this, it will try to re-encrypt it, and the same value encrypted two
+                                     * different times will have different values, so it will *look* like it was updated
+                                     * but it wasn't.
+                                     */
                                     if ($decrypted_old != $this->update_array[$field->db_column]) {
                                         $asset->{$field->db_column} = \Crypt::encrypt($this->update_array[$field->db_column]);
                                     } else {
-                                        \Log::debug('The decrypted existing value is the same as the one submitted - unset it');
+                                        /*
+                                         * Remove the encrypted custom field from the update_array, since nothing changed
+                                         */
                                         unset($this->update_array[$field->db_column]);
                                         unset($asset->{$field->db_column});
                                     }
 
-                                // These fields aren't encrypted, just carry on as usual
+                                /*
+                                 * These custom fields aren't encrypted, just carry on as usual
+                                 */
                                 } else {
 
 

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -162,7 +162,6 @@ class BulkAssetsController extends Controller
                     ->conditionallyAddItem('expected_checkin')
                     ->conditionallyAddItem('order_number')
                     ->conditionallyAddItem('requestable')
-                    ->conditionallyAddItem('model_id')
                     ->conditionallyAddItem('status_id')
                     ->conditionallyAddItem('supplier_id')
                     ->conditionallyAddItem('warranty_months')

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -103,8 +103,8 @@ class ActionlogsTransformer
 
                                         // Display the changes if the user is an admin or superadmin
                                         if (Gate::allows('admin')) {
-                                            $clean_meta[$fieldname]['old'] = ($enc_old) ? unserialize($enc_old): 'null';
-                                            $clean_meta[$fieldname]['new'] = ($enc_new) ? unserialize($enc_new): 'null';
+                                            $clean_meta[$fieldname]['old'] = ($enc_old) ? unserialize($enc_old): '';
+                                            $clean_meta[$fieldname]['new'] = ($enc_new) ? unserialize($enc_new): '';
                                         }
 
                                     }

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -101,9 +101,10 @@ class ActionlogsTransformer
                                         $clean_meta[$fieldname]['old'] = "************";
                                         $clean_meta[$fieldname]['new'] = "************";
 
+                                        // Display the changes if the user is an admin or superadmin
                                         if (Gate::allows('admin')) {
-                                            $clean_meta[$fieldname]['old'] = unserialize($enc_old);
-                                            $clean_meta[$fieldname]['new'] = unserialize($enc_new);
+                                            $clean_meta[$fieldname]['old'] = ($enc_old) ? unserialize($enc_old): '(blank)';
+                                            $clean_meta[$fieldname]['new'] = ($enc_new) ? unserialize($enc_new): '(blank)';
                                         }
 
                                     }

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -3,6 +3,7 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Actionlog;
+use App\Models\Asset;
 use App\Models\CustomField;
 use App\Models\Setting;
 use App\Models\Company;
@@ -12,6 +13,7 @@ use App\Models\AssetModel;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Gate;
 
 class ActionlogsTransformer
 {
@@ -98,6 +100,12 @@ class ActionlogsTransformer
                                         \Log::debug('custom fields do not match');
                                         $clean_meta[$fieldname]['old'] = "************";
                                         $clean_meta[$fieldname]['new'] = "************";
+
+                                        if (Gate::allows('admin')) {
+                                            $clean_meta[$fieldname]['old'] = unserialize($enc_old);
+                                            $clean_meta[$fieldname]['new'] = unserialize($enc_new);
+                                        }
+
                                     }
 
 

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -103,8 +103,8 @@ class ActionlogsTransformer
 
                                         // Display the changes if the user is an admin or superadmin
                                         if (Gate::allows('admin')) {
-                                            $clean_meta[$fieldname]['old'] = ($enc_old) ? unserialize($enc_old): '(blank)';
-                                            $clean_meta[$fieldname]['new'] = ($enc_new) ? unserialize($enc_new): '(blank)';
+                                            $clean_meta[$fieldname]['old'] = ($enc_old) ? unserialize($enc_old): 'null';
+                                            $clean_meta[$fieldname]['new'] = ($enc_new) ? unserialize($enc_new): 'null';
                                         }
 
                                     }

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -11,7 +11,7 @@ use Carbon\Carbon;
 class AssetObserver
 {
     /**
-     * Listen to the User updating event. This fires automatically every time an asset is saved.
+     * Listen to the Asset updating event. This fires automatically every time an existing asset is saved.
      *
      * @param  Asset  $asset
      * @return void

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -11,7 +11,7 @@ use Carbon\Carbon;
 class AssetObserver
 {
     /**
-     * Listen to the User created event.
+     * Listen to the User updating event. This fires automatically every time an asset is saved.
      *
      * @param  Asset  $asset
      * @return void

--- a/database/factories/ActionlogFactory.php
+++ b/database/factories/ActionlogFactory.php
@@ -38,7 +38,7 @@ class ActionlogFactory extends Factory
     {
         return $this->state(function () {
             $target = User::inRandomOrder()->first();
-            $asset = Asset::RTD()->inRandomOrder()->first();
+            $asset = Asset::inRandomOrder()->RTD()->first();
 
             $asset->update(
                     [

--- a/database/factories/CustomFieldFactory.php
+++ b/database/factories/CustomFieldFactory.php
@@ -81,4 +81,26 @@ class CustomFieldFactory extends Factory
             ];
         });
     }
+
+    public function testEncrypted()
+    {
+        return $this->state(function () {
+            return [
+                'name' => 'Test Encrypted',
+                'help_text' => 'This is a test encrypted field.',
+            ];
+        });
+    }
+
+    public function testCheckbox()
+    {
+        return $this->state(function () {
+            return [
+                'name' => 'Test Checkbox',
+                'help_text' => 'This is a test checkbox.',
+                'field_values' => "One\nTwo\nThree",
+                'element'   => 'checkbox',
+            ];
+        });
+    }
 }

--- a/database/factories/CustomFieldFactory.php
+++ b/database/factories/CustomFieldFactory.php
@@ -26,6 +26,7 @@ class CustomFieldFactory extends Factory
             'format' => '',
             'element' => 'text',
             'auto_add_to_fieldsets' => '0',
+            'show_in_requestable_list' => '0',
         ];
     }
 
@@ -66,6 +67,7 @@ class CustomFieldFactory extends Factory
             return [
                 'name' => 'CPU',
                 'help_text' => 'The speed of the processor on this device.',
+                'show_in_requestable_list' => '1',
             ];
         });
     }

--- a/database/factories/CustomFieldFactory.php
+++ b/database/factories/CustomFieldFactory.php
@@ -87,6 +87,7 @@ class CustomFieldFactory extends Factory
         return $this->state(function () {
             return [
                 'name' => 'Test Encrypted',
+                'field_encrypted' => '1',
                 'help_text' => 'This is a test encrypted field.',
             ];
         });

--- a/database/factories/CustomFieldFactory.php
+++ b/database/factories/CustomFieldFactory.php
@@ -88,7 +88,7 @@ class CustomFieldFactory extends Factory
             return [
                 'name' => 'Test Encrypted',
                 'field_encrypted' => '1',
-                'help_text' => 'This is a test encrypted field.',
+                'help_text' => 'This is a sample encrypted field.',
             ];
         });
     }
@@ -98,9 +98,19 @@ class CustomFieldFactory extends Factory
         return $this->state(function () {
             return [
                 'name' => 'Test Checkbox',
-                'help_text' => 'This is a test checkbox.',
+                'help_text' => 'This is a sample checkbox.',
                 'field_values' => "One\nTwo\nThree",
                 'element'   => 'checkbox',
+            ];
+        });
+    }
+
+    public function testRequired()
+    {
+        return $this->state(function () {
+            return [
+                'name' => 'Test Required',
+                'help_text' => 'This is a sample required field.',
             ];
         });
     }

--- a/database/seeders/CustomFieldSeeder.php
+++ b/database/seeders/CustomFieldSeeder.php
@@ -33,6 +33,9 @@ class CustomFieldSeeder extends Seeder
         CustomField::factory()->count(1)->ram()->create();
         CustomField::factory()->count(1)->cpu()->create();
         CustomField::factory()->count(1)->macAddress()->create();
+        CustomField::factory()->count(1)->testEncrypted()->create();
+        CustomField::factory()->count(1)->testCheckbox()->create();
+
 
         DB::table('custom_field_custom_fieldset')->insert([
             [
@@ -62,6 +65,33 @@ class CustomFieldSeeder extends Seeder
             [
                 'custom_field_id' => '5',
                 'custom_fieldset_id' => '2',
+                'order' => 0,
+                'required' => 0,
+            ],
+
+            [
+                'custom_field_id' => '6',
+                'custom_fieldset_id' => '2',
+                'order' => 0,
+                'required' => 0,
+            ],
+
+            [
+                'custom_field_id' => '6',
+                'custom_fieldset_id' => '1',
+                'order' => 0,
+                'required' => 0,
+            ],
+
+            [
+                'custom_field_id' => '7',
+                'custom_fieldset_id' => '2',
+                'order' => 0,
+                'required' => 0,
+            ],
+            [
+                'custom_field_id' => '7',
+                'custom_fieldset_id' => '1',
                 'order' => 0,
                 'required' => 0,
             ],

--- a/database/seeders/CustomFieldSeeder.php
+++ b/database/seeders/CustomFieldSeeder.php
@@ -35,6 +35,7 @@ class CustomFieldSeeder extends Seeder
         CustomField::factory()->count(1)->macAddress()->create();
         CustomField::factory()->count(1)->testEncrypted()->create();
         CustomField::factory()->count(1)->testCheckbox()->create();
+        CustomField::factory()->count(1)->testRequired()->create();
 
 
         DB::table('custom_field_custom_fieldset')->insert([
@@ -94,6 +95,13 @@ class CustomFieldSeeder extends Seeder
                 'custom_fieldset_id' => '1',
                 'order' => 0,
                 'required' => 0,
+            ],
+
+            [
+                'custom_field_id' => '8',
+                'custom_fieldset_id' => '1',
+                'order' => 0,
+                'required' => 1,
             ],
 
         ]);

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -38,12 +38,13 @@ class DatabaseSeeder extends Seeder
         $this->call(DepreciationSeeder::class);
         $this->call(StatuslabelSeeder::class);
         $this->call(AccessorySeeder::class);
+        $this->call(CustomFieldSeeder::class);
         $this->call(AssetSeeder::class);
         $this->call(LicenseSeeder::class);
         $this->call(ComponentSeeder::class);
         $this->call(ConsumableSeeder::class);
         $this->call(ActionlogSeeder::class);
-        $this->call(CustomFieldSeeder::class);
+
 
         Artisan::call('snipeit:sync-asset-locations', ['--output' => 'all']);
         $output = Artisan::output();

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -368,7 +368,7 @@ return [
     'consumables_count'     => 'Consumables Count',
     'components_count'      => 'Components Count',
     'licenses_count'        => 'Licenses Count',
-    'notification_error'    => 'Error:',
+    'notification_error'    => 'Error',
     'notification_error_hint' => 'Please check the form below for errors',
     'notification_bulk_error_hint' => 'The following fields had validation errors and were not edited:',
     'notification_success'  => 'Success',

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -151,6 +151,7 @@
               <th data-visible="false" data-sortable="true" class="text-center"><i class="fa fa-eye" aria-hidden="true"><span class="sr-only">Visible to User</span></i></th>
               <th data-sortable="true" data-searchable="true" class="text-center"><i class="fa fa-envelope" aria-hidden="true"><span class="sr-only">{{ trans('admin/custom_fields/general.show_in_email_short') }}</span></i></th>
               <th data-sortable="true" data-searchable="true" class="text-center"><i class="fa fa-laptop fa-fw" aria-hidden="true"><span class="sr-only">{{ trans('admin/custom_fields/general.show_in_requestable_list_short') }}</span></i></th>
+              <th data-sortable="true" data-searchable="true" class="text-center"><i class="fa-solid fa-fingerprint"><span class="sr-only">{{ trans('admin/custom_fields/general.unique') }}</span></i></th>
               <th data-sortable="true" data-searchable="true" class="text-center">{{ trans('admin/custom_fields/general.field_element_short') }}</th>
               <th data-searchable="true">{{ trans('admin/custom_fields/general.fieldsets') }}</th>
               <th>{{ trans('button.actions') }}</th>
@@ -176,6 +177,7 @@
               <td class="text-center">{!!  ($field->display_in_user_view=='1' ? '<i class="fa fa-check text-success"></i>' : '<i class="fa fa-times text-danger"></i>') !!}</td>
               <td class="text-center">{!! ($field->show_in_email=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"><span class="sr-only">'.trans('general.yes').'</span></i>' : '<i class="fas fa-times text-danger" aria-hidden="true"><span class="sr-only">'.trans('general.no').'</span></i>'  !!}</td>
               <td class="text-center">{!! ($field->show_in_requestable_list=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"><span class="sr-only">'.trans('general.yes').'</span></i>' : '<i class="fas fa-times text-danger" aria-hidden="true"><span class="sr-only">'.trans('general.no').'</span></i>'  !!}</td>
+              <td class="text-center">{!! ($field->is_unique=='1') ? '<i class="fas fa-check text-success" aria-hidden="true"><span class="sr-only">'.trans('general.yes').'</span></i>' : '<i class="fas fa-times text-danger" aria-hidden="true"><span class="sr-only">'.trans('general.no').'</span></i>'  !!}</td>
               <td>{{ $field->element }}</td>
               <td>
                 @foreach($field->fieldset as $fieldset)

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -62,7 +62,7 @@
              </div>
               <div class="col-md-5">
                 <label class="form-control">
-                  {{ Form::checkbox('null_expected_checkin_date', '1', false, ['checked' => 'false']) }}
+                  {{ Form::checkbox('null_expected_checkin_date', '1', false) }}
                   {{ trans_choice('general.set_to_null', count($assets), ['asset_count' => count($assets)]) }}
                 </label>
               </div>

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -37,21 +37,20 @@
               @elseif ($field->element=='checkbox')
                     <!-- Checkboxes -->
                   @foreach ($field->formatFieldValuesAsArray() as $key => $value)
-                      <div>
-                          <label>
-                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" class="minimal" {{  isset($item) ? (in_array($value, array_map('trim', explode(',', $item->{$field->db_column_name()}))) ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, array_map('trim', explode(',', $field->defaultValue($model->id)))) ? ' checked="checked"' : '')) }}>
-                              {{ $value }}
-                          </label>
-                      </div>
+                      <label class="form-control">
+                          <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" {{  isset($item) ? (in_array($value, array_map('trim', explode(',', $item->{$field->db_column_name()}))) ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, array_map('trim', explode(',', $field->defaultValue($model->id)))) ? ' checked="checked"' : '')) }}>
+                          {{ $value }}
+                      </label>
+
                   @endforeach
             @elseif ($field->element=='radio')
             @foreach ($field->formatFieldValuesAsArray() as $value)
-              <div>
-                  <label>
-                      <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" class="minimal" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($value, explode(', ', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
+
+                  <label class="form-control">
+                      <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($value, explode(', ', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
                       {{ $value }}
                   </label>
-              </div>
+
             @endforeach
 
             @endif

--- a/resources/views/notifications.blade.php
+++ b/resources/views/notifications.blade.php
@@ -115,17 +115,19 @@
 @endif
 
 
-@if ($messages = Session::get('bulk_errors'))
+@if ($messages = Session::get('bulk_asset_errors'))
 <div class="col-md-12">
     <div class="alert alert alert-danger fade in">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
         <strong>{{ trans('general.notification_error') }}: </strong>
        {{ trans('general.notification_bulk_error_hint') }}
-            @foreach($messages as $message) 
+            @foreach($messages as $key => $message)
+                @for ($x = 0; $x < count($message); $x++)
                 <ul>
-                    <li>{{ $message }}</li>
-                </ul> 
+                    <li>{{ $message[$x] }}</li>
+                </ul>
+            @endfor
             @endforeach
     </div>
 </div>

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -531,21 +531,16 @@
 
     function changeLogFormatter(value) {
 
-        console.dir(value);
         var result = '';
         var pretty_index = '';
-
-        console.error('first the formatter');
 
             for (var index in value) {
 
 
                 // Check if it's a custom field
                 if (index.startsWith('_snipeit_')) {
-                    console.error('It is a custom field');
                     pretty_index = index.replace("_snipeit_", "Custom:_");
                 } else {
-                    console.error('Not a custom field');
                     pretty_index = index;
                 }
 

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -530,13 +530,40 @@
 
 
     function changeLogFormatter(value) {
+
+        console.dir(value);
         var result = '';
+        var pretty_index = '';
+
+        console.error('first the formatter');
+
             for (var index in value) {
-                result += index + ': <del>' + value[index].old + '</del>  <i class="fas fa-long-arrow-alt-right" aria-hidden="true"></i> ' + value[index].new + '<br>'
+
+
+                // Check if it's a custom field
+                if (index.startsWith('_snipeit_')) {
+                    console.error('It is a custom field');
+                    pretty_index = index.replace("_snipeit_", "Custom:_");
+                } else {
+                    console.error('Not a custom field');
+                    pretty_index = index;
+                }
+
+                extra_pretty_index = prettyLog(pretty_index);
+
+                result += extra_pretty_index + ': <del>' + value[index].old + '</del>  <i class="fas fa-long-arrow-alt-right" aria-hidden="true"></i> ' + value[index].new + '<br>'
             }
 
         return result;
 
+    }
+
+    function prettyLog(str) {
+        let frags = str.split('_');
+        for (let i = 0; i < frags.length; i++) {
+            frags[i] = frags[i].charAt(0).toUpperCase() + frags[i].slice(1);
+        }
+        return frags.join(' ');
     }
 
 


### PR DESCRIPTION
A customer in our [Discord channel](https://discord.gg/yZFtShAcKk) discovered a bug where he was having problems updating the model of assets that had custom fields. Once I went down that rabbit hole, I found a few more potential optimizations with some refactoring.

Since I was in there, I did a little extra work, namely:

- making the meta log output nicer (God I hate JavaScript)
- adding a "unique" icon to the custom fields page so you can easily see which fields require unique constraints
- fixed the checkbox/radio button display - I had missed them when we moved away from iCheck so I hadn't realized they looked so weird
- Added some new custom fields seeders so we have a few more examples to make testing this easier
- Fixed #13774 (I think)

### Bulk Update
https://github.com/snipe/snipe-it/assets/197404/2a236731-52e9-4eea-8e6f-6a66c65f1369

### Unique indicator
https://github.com/snipe/snipe-it/assets/197404/260d022a-54d1-4366-9209-6568637085bf

### Nicer changelog
<img width="1502" alt="Screenshot 2023-10-26 at 9 31 03 AM" src="https://github.com/snipe/snipe-it/assets/197404/e2f4c12a-8d91-4bd2-90aa-bf8267adc568">

### Next Up
I'd still like to continue down the refactor path and see if we can't make that a less chonk set of queries. It's kinda slow right now, and a lot of them are repeats. Some of this will be from the validation where we're checking to make sure that the location, etc actually exists in the database (which I know we have all pontificated on solutions for) but there are also just kind of a bunch we could probably tighten up.

I'd also like to better handle #13798 - we do this already for some fields but not all. It's going to be annoying, but it will be less confusing. (Basically, right now, you can't blank out a lot of the fields - they just default to whatever they were before unless you submit *something*.)
