### PR TITLE
Fixes EOL on Custom Report

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -744,7 +744,7 @@ class ReportsController extends Controller
                     }
 
                     if ($request->filled('eol')) {
-                        $row[] = ($asset->purchase_date != '') ? $asset->present()->eol_date() : '';
+                        $row[] = ($asset->eol_explicit) ? $asset->asset_eol_date : $asset->present()->eol_date();
                     }
 
                     if ($request->filled('order')) {

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -744,7 +744,7 @@ class ReportsController extends Controller
                     }
 
                     if ($request->filled('eol')) {
-                        $row[] = ($asset->eol_explicit) ? $asset->asset_eol_date : $asset->present()->eol_date();
+                            $row[] = ($asset->asset_eol_date) ? $asset->asset_eol_date : '';
                     }
 
                     if ($request->filled('order')) {


### PR DESCRIPTION
# Description
EOL on custom report was pulling only calculated date, now checks if explicit is set and shows the explicit date. 

Fixes #13531 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested export with explicit and non-explicit EOL dates

**Test Configuration**:
* PHP version: 8.1
* MySQL version 8.1
 feature works
