### PR TITLE
Added User Phone & Address Fields to Custom Asset Report

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -528,6 +528,30 @@ class ReportsController extends Controller
                 $header[] = trans('admin/users/table.title');
             }
 
+            if ($request->filled('phone')) {
+                $header[] = trans('admin/users/table.phone');
+            }
+
+            if ($request->filled('user_address')) {
+                $header[] = trans('general.user') .' '. trans('general.address');
+            }
+
+            if ($request->filled('user_city')) {
+                $header[] = trans('general.user') .' '. trans('general.city');
+            }
+
+            if ($request->filled('user_state')) {
+                $header[] = trans('general.user') .' '. trans('general.state');
+            }
+
+            if ($request->filled('user_country')) {
+                $header[] = trans('general.user') .' '. trans('general.country');
+            }
+
+            if ($request->filled('user_zip')) {
+                $header[] = trans('general.user') .' '. trans('general.zip');
+            }
+
             if ($request->filled('status')) {
                 $header[] = trans('general.status');
             }
@@ -823,6 +847,54 @@ class ReportsController extends Controller
                     if ($request->filled('title')) {
                         if ($asset->checkedOutToUser()) {
                             $row[] = ($asset->assignedto) ? $asset->assignedto->jobtitle : '';
+                        } else {
+                            $row[] = ''; // Empty string if unassigned
+                        }
+                    }
+
+                    if ($request->filled('phone')) {
+                        if ($asset->checkedOutToUser()) {
+                            $row[] = ($asset->assignedto) ? $asset->assignedto->phone : '';
+                        } else {
+                            $row[] = ''; // Empty string if unassigned
+                        }
+                    }
+
+                    if ($request->filled('user_address')) {
+                        if ($asset->checkedOutToUser()) {
+                            $row[] = ($asset->assignedto) ? $asset->assignedto->address : '';
+                        } else {
+                            $row[] = ''; // Empty string if unassigned
+                        }
+                    }
+
+                    if ($request->filled('user_city')) {
+                        if ($asset->checkedOutToUser()) {
+                            $row[] = ($asset->assignedto) ? $asset->assignedto->city : '';
+                        } else {
+                            $row[] = ''; // Empty string if unassigned
+                        }
+                    }
+
+                    if ($request->filled('user_state')) {
+                        if ($asset->checkedOutToUser()) {
+                            $row[] = ($asset->assignedto) ? $asset->assignedto->state : '';
+                        } else {
+                            $row[] = ''; // Empty string if unassigned
+                        }
+                    }
+
+                    if ($request->filled('user_country')) {
+                        if ($asset->checkedOutToUser()) {
+                            $row[] = ($asset->assignedto) ? $asset->assignedto->country : '';
+                        } else {
+                            $row[] = ''; // Empty string if unassigned
+                        }
+                    }
+
+                    if ($request->filled('user_zip')) {
+                        if ($asset->checkedOutToUser()) {
+                            $row[] = ($asset->assignedto) ? $asset->assignedto->zip : '';
                         } else {
                             $row[] = ''; // Empty string if unassigned
                         }

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -221,6 +221,38 @@
                 {{ trans('admin/users/table.title') }}
               </label>
 
+                <!-- new -->
+
+              <label class="form-control">
+                  {{ Form::checkbox('phone', '1', '1') }}
+                  {{ trans('admin/users/table.phone') }}
+              </label>
+
+              <label class="form-control">
+                  {{ Form::checkbox('user_address', '1', '1') }}
+                  {{ trans('general.address') }}
+              </label>
+
+              <label class="form-control">
+                  {{Form::checkbox('user_city', '1', '1')}}
+                  {{ trans('general.city') }}
+              </label>
+
+              <label class="form-control">
+                  {{Form::checkbox('user_state', '1', '1')}}
+                  {{ trans('general.state') }}
+              </label>
+
+              <label class="form-control">
+                  {{Form::checkbox('user_country', '1', '1')}}
+                  {{ trans('general.country') }}
+              </label>
+
+              <label class="form-control">
+                  {{Form::checkbox('user_zip', '1', '1')}}
+                  {{ trans('general.zip') }}
+              </label>
+
 
 
             @if ($customfields->count() > 0)


### PR DESCRIPTION
# Description
Quick addition of user phone and address fields to custom asset report, as requested in #13789 

Not sure if I did the translation strings in a way that makes sense, but needed a way to differentiate "User Address" and the general location "Address" - so just concatenated the translation strings together. 

<img width="685" alt="image" src="https://github.com/snipe/snipe-it/assets/7305753/f9c16503-24c3-48e4-99c5-193b57296f2e">

<img width="653" alt="image" src="https://github.com/snipe/snipe-it/assets/7305753/579c9272-adc0-4e35-8aff-9cb4d764d49a">


Fixes #13789 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested with assigned and unassigned assets in an export with blank and filled values in the fields. 

**Test Configuration**:
* PHP version: 8.1
* MySQL version 8.1

