### PR TITLE
Added min_amt value to model detail page

### DIFF
--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -236,6 +236,12 @@
                         </li>
                     @endif
 
+                    @if ($model->min_amt)
+                        <li>{{ trans('general.min_amt') }}:
+                           {{$model->min_amt }}
+                        </li>
+                    @endif
+
                     @if ($model->manufacturer)
                         <li>
                             {{ trans('general.manufacturer') }}:


### PR DESCRIPTION
This value was missing on the detail page and was only visible on the edit screen.