### PR TITLE
Handle redirect from after POST request from backup restore

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -224,6 +224,11 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth', 'authorize:superuser
             [SettingsController::class, 'postUploadBackup']
         )->name('settings.backups.upload');
 
+        // Handle redirect from after POST request from backup restore
+        Route::get('/restore/{filename?}', function () {
+            return redirect(route('settings.backups.index'));
+        });
+
         Route::get('/', [SettingsController::class, 'getBackups'])->name('settings.backups.index');
     });
 


### PR DESCRIPTION
Previously, we used (wrongly) to try to redirect to the POST request from the backup restore on login afterwards (since we try to "remember" where a user was trying to go if they're not logged in). This would throw a method not allowed error, since POST is the only option accepted with that route signature. This now just gracefully redirects back to the backups page. 