### PR TITLE
Making Cancel Button Red on on Edit/Create windows

### DIFF
--- a/resources/views/partials/forms/edit/submit.blade.php
+++ b/resources/views/partials/forms/edit/submit.blade.php
@@ -1,7 +1,7 @@
 <!-- partials/forms/edit/submit.blade.php -->
 
 <div class="box-footer text-right" style="padding-bottom: 0px;">
-    <a class="btn btn-link pull-left" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>
+    <a class="btn btn-danger pull-left" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>
     <button type="submit" accesskey="s" class="btn btn-primary"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('general.save') }}</button>
 </div>
 <!-- / partials/forms/edit/submit.blade.php -->


### PR DESCRIPTION
# Description

During testing for v7, I found that the cancel button was white. this created a white on white background and the button looked more like a link.

This PR simply changes the button to be more obviously a button.
<img width="261" alt="Screenshot 2023-10-30 at 6 43 33 PM" src="https://github.com/snipe/snipe-it/assets/116301219/c3b7d19e-5cf8-42bd-9eca-de62b7283e30">

Fixes: shortcut story 23885
- [x] Bug fix (non-breaking change which fixes an issue)
