### PR TITLE
Added #13754 - asset history tab to locations view

### DIFF
--- a/resources/views/locations/view.blade.php
+++ b/resources/views/locations/view.blade.php
@@ -104,6 +104,17 @@
                     </span>
                   </a>
               </li>
+              
+              <li>
+                  <a href="#history" data-toggle="tab">
+                    <span class="hidden-lg hidden-md">
+                        <i class="fas fa-hdd fa-2x" aria-hidden="true"></i>
+                    </span>
+                      <span class="hidden-xs hidden-sm">
+                          {{ trans('general.history') }}
+                    </span>
+                  </a>
+              </li>
           </ul>
 
 
@@ -318,6 +329,51 @@
                           </table>
                       </div><!-- /.table-responsive -->
               </div><!-- /.tab-pane -->
+
+                <div class="tab-pane" id="history">
+                    <h2 class="box-title">{{ trans('general.history') }}</h2>
+                    <!-- checked out assets table -->
+                    <div class="row">
+                        <div class="col-md-12">
+                            <table
+                                    class="table table-striped snipe-table"
+                                    id="assetHistory"
+                                    data-pagination="true"
+                                    data-id-table="assetHistory"
+                                    data-search="true"
+                                    data-side-pagination="server"
+                                    data-show-columns="true"
+                                    data-show-fullscreen="true"
+                                    data-show-refresh="true"
+                                    data-sort-order="desc"
+                                    data-sort-name="created_at"
+                                    data-show-export="true"
+                                    data-export-options='{
+                        "fileName": "export-location-asset-{{  $location->id }}-history",
+                        "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                    }'
+
+                    data-url="{{ route('api.activity.index', ['target_id' => $location->id, 'target_type' => 'location']) }}"
+                    data-cookie-id-table="assetHistory"
+                    data-cookie="true">
+                                <thead>
+                                    <tr>
+                                        <th data-visible="true" data-field="icon" style="width: 40px;" class="hidden-xs" data-formatter="iconFormatter">{{ trans('admin/hardware/table.icon') }}</th>
+                                        <th class="col-sm-2" data-visible="true" data-field="action_date" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
+                                        <th class="col-sm-1" data-visible="true" data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
+                                        <th class="col-sm-1" data-visible="true" data-field="action_type">{{ trans('general.action') }}</th>
+                                        <th class="col-sm-2" data-visible="true" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>
+                                        <th class="col-sm-2" data-visible="true" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.target') }}</th>
+                                        <th class="col-sm-2" data-field="note">{{ trans('general.notes') }}</th>
+                                        <th class="col-md-3" data-field="signature_file" data-visible="false"  data-formatter="imageFormatter">{{ trans('general.signature') }}</th>
+                                        <th class="col-md-3" data-visible="false" data-field="file" data-visible="false"  data-formatter="fileUploadFormatter">{{ trans('general.download') }}</th>
+                                        <th class="col-sm-2" data-field="log_meta" data-visible="true" data-formatter="changeLogFormatter">{{ trans('admin/hardware/table.changed')}}</th>
+                                    </tr>
+                                </thead>
+                            </table>
+                        </div>
+                    </div> <!-- /.row -->
+                </div> <!-- /.tab-pane history -->
 
           </div><!--/.col-md-9-->
       </div><!--/.col-md-9-->


### PR DESCRIPTION
# Description

Locations view template now includes the asset history for assets assigned to the location being viewed. It's now possible to see assets that have previously been checked out to the location, and not just the assets that are currently checked out.

Fixes #13754 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Test Configuration**:
* PHP version: 8.1.17
* MySQL version: 10.6.12 MariaDB
* Webserver version: Apache 2.4.52
* OS version: Ubuntu


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
