### PR TITLE
Fixed datetime displayed on license edit for fields that should be date

### DIFF
--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -34,9 +34,9 @@ class License extends Depreciable
 
 
     protected $casts = [
-        'purchase_date' => 'date:Y-m-d',
-        'expiration_date' => 'date:Y-m-d',
-        'termination_date' => 'date:Y-m-d',
+        'purchase_date' => 'date',
+        'expiration_date' => 'date',
+        'termination_date' => 'date',
         'category_id'  => 'integer',
         'company_id'   => 'integer',
     ];

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -32,10 +32,11 @@ class License extends Depreciable
     protected $guarded = 'id';
     protected $table = 'licenses';
 
+
     protected $casts = [
-        'purchase_date' => 'date',
-        'expiration_date' => 'date',
-        'termination_date' => 'date',
+        'purchase_date' => 'date:Y-m-d',
+        'expiration_date' => 'date:Y-m-d',
+        'termination_date' => 'date:Y-m-d',
         'category_id'  => 'integer',
         'company_id'   => 'integer',
     ];

--- a/resources/views/licenses/edit.blade.php
+++ b/resources/views/licenses/edit.blade.php
@@ -79,7 +79,7 @@
 
     <div class="input-group col-md-4">
         <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true" data-date-clear-btn="true">
-            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expiration_date" id="expiration_date" value="{{ old('expiration_date', $item->expiration_date) }}" maxlength="10">
+            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expiration_date" id="expiration_date" value="{{ old('expiration_date', ($item->expiration_date) ? $item->expiration_date->format('Y-m-d') : '') }}" maxlength="10">
             <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
         </div>
         {!! $errors->first('expiration_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
@@ -93,7 +93,7 @@
 
     <div class="input-group col-md-4">
         <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-autoclose="true" data-date-clear-btn="true">
-            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="termination_date" id="termination_date" value="{{ old('termination_date', $item->termination_date) }}" maxlength="10">
+            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="termination_date" id="termination_date" value="{{ old('termination_date', ($item->termination_date) ? $item->termination_date->format('Y-m-d') : '') }}" maxlength="10">
             <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
         </div>
         {!! $errors->first('termination_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}


### PR DESCRIPTION
<img width="539" alt="Screenshot 2023-10-31 at 12 04 38 PM" src="https://github.com/snipe/snipe-it/assets/197404/7ec86ae7-5990-4f14-b32a-e797919d4d7a">

I'm not sure why the [cast formatting](https://laravel.com/docs/8.x/eloquent-mutators#date-casting) doesn't work here. If I include the format, it throws validation errors, even though the format is correct:

<img width="425" alt="Screenshot 2023-10-31 at 12 30 22 PM" src="https://github.com/snipe/snipe-it/assets/197404/3fbea19a-f3e9-4cde-8d71-8bc36092da6a">

Results in: 

<img width="523" alt="Screenshot 2023-10-31 at 12 30 10 PM" src="https://github.com/snipe/snipe-it/assets/197404/09b91aff-a57f-4956-a03a-9905fa7318a6">

(Don't get fooled by the error message - that's custom, and we use YYYY-MM-DD there because not everyone knows PHP vernacular for date time formatting.)

In testing this, I *may* have stumbled across something weird with date validation on the API, but I'll test that more for another PR.
