### PR TITLE
Fixed validation handling on backup uploads

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -26,7 +26,7 @@ use Response;
 use App\Http\Requests\SlackSettingsRequest;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Artisan;
-use Validator;
+use Illuminate\Support\Facades\Validator;
 
 /**
  * This controller handles all actions related to Settings for
@@ -1248,13 +1248,11 @@ class SettingsController extends Controller
             if (!$request->hasFile('file')) {
                 return redirect()->route('settings.backups.index')->with('error', 'No file uploaded');
             } else {
+
                 $max_file_size = Helper::file_upload_max_size();
-
-                $rules = [
+                $validator = Validator::make($request->all(), [
                     'file' => 'required|mimes:zip|max:'.$max_file_size,
-                ];
-
-                $validator = \Validator::make($request->all(), $rules);
+                ]);
 
                 if ($validator->passes()) {
 
@@ -1265,7 +1263,7 @@ class SettingsController extends Controller
                         return redirect()->route('settings.backups.index')->with('success', 'File uploaded');
                 }
 
-                return redirect()->route('settings.backups.index')->withErrors($request->getErrors());
+                return redirect()->route('settings.backups.index')->withErrors($validator);
 
             }
 

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -137,7 +137,7 @@
         @csrf
 
         
-      <div class="form-group {{ $errors->has((isset($fieldname) ? $fieldname : 'image')) ? 'has-error' : '' }}" style="margin-bottom: 0px;">
+      <div class="form-group {{ $errors->has((isset($fieldname) ? $fieldname : 'file')) ? 'has-error' : '' }}" style="margin-bottom: 0px;">
         <div class="col-md-8 col-xs-8">
           
           
@@ -145,26 +145,18 @@
             <label class="btn btn-default col-md-12 col-xs-12" aria-hidden="true">
               <i class="fas fa-paperclip" aria-hidden="true"></i>
                 {{ trans('button.select_file')  }}
-
                 <input type="file" name="file" class="js-uploadFile" id="uploadFile" data-maxsize="{{ Helper::file_upload_max_size() }}" accept="application/zip" style="display:none;" aria-label="file" aria-hidden="true">
-                
-                
-            </label>   
-
+            </label>
         </div>
         <div class="col-md-4 col-xs-4">
             <button class="btn btn-primary col-md-12 col-xs-12" id="uploadButton" disabled>{{ trans('button.upload') }} <span id="uploadIcon"></span></button>
         </div>
-
-
         <div class="col-md-12">
           
           <p class="label label-default col-md-12" style="font-size: 120%!important; margin-top: 10px; margin-bottom: 10px;" id="uploadFile-info"></p>
-          
           <p class="help-block" style="margin-top: 10px;" id="uploadFile-status">{{ trans_choice('general.filetypes_accepted_help', 1, ['size' => Helper::file_upload_max_size_readable(), 'types' => '.zip']) }}</p>     
-          {!! $errors->first('image', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-         
-
+          {!! $errors->first('file', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+            
         </div>  
             
     </div>


### PR DESCRIPTION
This solves two different issues - one being that we were not correctly calling the validator with the validation failure response, and the second that we weren't displaying the form errors correctly. 

The only way you could reach this error reasonably is if you fiddled with the DOM to remove the `accept-type` in the form field and tried to upload something that wasn't a zip file.

This fixes  RB-17140 and RB-17141