### PR TITLE
Fixed Attempt to read property fields on null [sc-23903]

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -212,9 +212,11 @@ class Asset extends Depreciable
 
                 $this->rules += $model->fieldset->validation_rules();
 
-                foreach ($this->model->fieldset->fields as $field){
-                    if($field->format == 'BOOLEAN'){
-                        $this->{$field->db_column} = filter_var($this->{$field->db_column}, FILTER_VALIDATE_BOOLEAN);
+                if ($this->model->fieldset){
+                    foreach ($this->model->fieldset->fields as $field){
+                        if($field->format == 'BOOLEAN'){
+                            $this->{$field->db_column} = filter_var($this->{$field->db_column}, FILTER_VALIDATE_BOOLEAN);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Description
I added a condition to only go trough customfields if the relationship `$this->model->fieldset` exist. I hate this because I can't remember why I need to add that other foreach, I feel that I need to revisit this to refactor or at least understand why I write such a weird thing. But yeah, we are here and the error doesn't happen anymore.

Fixes shortcut 23903

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP Dev Server
* OS version: Debian 12
