### PR TITLE
More graceful failure if ldap_results JSON decode isn’t set

### DIFF
--- a/app/Http/Controllers/Users/LDAPImportController.php
+++ b/app/Http/Controllers/Users/LDAPImportController.php
@@ -56,6 +56,10 @@ class LDAPImportController extends Controller
         $ldap_results_json = Artisan::output();
         $ldap_results = json_decode($ldap_results_json, true);
 
+        if (!$ldap_results) {
+            return redirect()->back()->withInput()->with('error', trans('general.no_results'));
+        }
+
         // Direct user to appropriate status page.
         if ($ldap_results['error']) {
             return redirect()->back()->withInput()->with('error', $ldap_results['error_message']);


### PR DESCRIPTION
This should fix an unusual error that would cause a 500 if the `$ldap_results` variable is empty. 

Screenshot from rollbar: `ErrorException: Trying to access array offset on value of type null...`

<img width="809" alt="Screenshot 2023-10-31 at 5 09 57 PM" src="https://github.com/snipe/snipe-it/assets/197404/0a223677-80df-4f82-ada6-1b3eec18b5cd">
