### PR TITLE
Add `code_version` for Rollbar

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -112,6 +112,7 @@ $config = [
             'handler' => \Rollbar\Laravel\MonologHandler::class,
             'access_token' => env('ROLLBAR_TOKEN'),
             'level' => env('ROLLBAR_LEVEL', 'error'),
+            'code_version' => config('version.full_app_version'),
         ],
     ],
 


### PR DESCRIPTION
# Description
Pretty straightforward, adds `code_version` for rollbar, enables a few new features in Rollbar (see https://docs.rollbar.com/docs/versions#new-version-notifications) 

# Testing 
As far as I know I don't have a way to test this, but can infer that this should be fine according to the docs. 
https://docs.rollbar.com/docs/versions#new-version-notifications says 

> To the above array you can add any other Rollbar configuration options you would normally use in the [Rollbar PHP SDK](https://docs.rollbar.com/docs/php#section-configuration).

And further down they give the example 
```
Rollbar::init(
    array(
        'access_token' => ROLLBAR_TEST_TOKEN,
        'environment' => 'production',
        'code_version' => '1.0.0'
    )
);
``` 
which seems to take the same options as the config. 