### PR TITLE
New Translation Strings for Custom Asset Export

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -539,23 +539,23 @@ class ReportsController extends Controller
             }
 
             if ($request->filled('user_address')) {
-                $header[] = trans('general.user') .' '. trans('general.address');
+                $header[] = trans('admin/reports/general.custom_export.user_address');
             }
 
             if ($request->filled('user_city')) {
-                $header[] = trans('general.user') .' '. trans('general.city');
+                $header[] = trans('admin/reports/general.custom_export.user_city');
             }
 
             if ($request->filled('user_state')) {
-                $header[] = trans('general.user') .' '. trans('general.state');
+                $header[] = trans('admin/reports/general.custom_export.user_state');
             }
 
             if ($request->filled('user_country')) {
-                $header[] = trans('general.user') .' '. trans('general.country');
+                $header[] = trans('admin/reports/general.custom_export.user_country');
             }
 
             if ($request->filled('user_zip')) {
-                $header[] = trans('general.user') .' '. trans('general.zip');
+                $header[] = trans('admin/reports/general.custom_export.user_zip');
             }
 
             if ($request->filled('status')) {

--- a/resources/lang/en/admin/reports/general.php
+++ b/resources/lang/en/admin/reports/general.php
@@ -6,5 +6,12 @@ return [
     'send_reminder' => 'Send reminder',
     'reminder_sent' => 'Reminder sent',
     'acceptance_deleted' => 'Acceptance request deleted',
-    'acceptance_request' => 'Acceptance request'
+    'acceptance_request' => 'Acceptance request',
+    'custom_export' => [
+        'user_address' => 'User Address',
+        'user_city' => 'User City',
+        'user_state' => 'User State',
+        'user_country' => 'User Country',
+        'user_zip' => 'User Zip'
+    ]
 ];


### PR DESCRIPTION
# Description
On the tin, see: https://github.com/snipe/snipe-it/pull/13803#issuecomment-1785349771

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Observed an export successfully. 😄 

**Test Configuration**:
* PHP version: 8.1
* MySQL version 8.1