### PR TITLE
fixed ldap location sync

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -83,7 +83,12 @@ class LdapSync extends Command
         $summary = [];
 
         try {
-            if ($this->option('base_dn') != '') {
+            if ( $this->option('location_id') != '') {
+                $location_ou= Location::where('id', '=', $this->option('location_id'))->value('ldap_ou');
+                $search_base = $location_ou;
+                Log::debug('Importing users from specified location OU: \"'.$search_base.'\".');
+             }
+            else if ($this->option('base_dn') != '') {
                 $search_base = $this->option('base_dn');
                 Log::debug('Importing users from specified base DN: \"'.$search_base.'\".');
             } else {


### PR DESCRIPTION
# Description

This fixes the LDAP Location sync. the sync command now checks if a location has been selected first and gives a chance to run the provided location ldap_OU before defaulting to the base dn provided in ldap settings.
<img width="988" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/88d00e71-6950-44de-9037-dbe3ef7a8196">
<img width="684" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/9ef42845-4de5-4204-afc0-56f30988b21c">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
