### PR TITLE
Resolves Exceptions When An Array is Submitted and Exception Occurs Before Validation

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,7 +4,6 @@ namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use App\Helpers\Helper;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Auth\AuthenticationException;
 use ArieTimmerman\Laravel\SCIMServer\Exceptions\SCIMException;

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,6 +4,7 @@ namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use App\Helpers\Helper;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Auth\AuthenticationException;
 use ArieTimmerman\Laravel\SCIMServer\Exceptions\SCIMException;
@@ -148,6 +149,11 @@ class Handler extends ExceptionHandler
         }
 
         return redirect()->guest('login');
+    }
+
+    protected function invalidJson($request, ValidationException $exception)
+    {
+        return response()->json(Helper::formatStandardApiResponse('error', null, $exception->errors()), 200);
     }
 
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -536,8 +536,6 @@ class AssetsController extends Controller
      */
     public function store(StoreAssetRequest $request)
     {
-        $this->authorize('create', Asset::class);
-
         $asset = new Asset();
         $asset->model()->associate(AssetModel::find((int) $request->get('model_id')));
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Events\CheckoutableCheckedIn;
+use App\Http\Requests\StoreAssetRequest;
 use Illuminate\Support\Facades\Gate;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
@@ -32,6 +33,7 @@ use Str;
 use TCPDF;
 use Validator;
 use Route;
+
 
 /**
  * This class controls all actions related to assets for
@@ -532,7 +534,7 @@ class AssetsController extends Controller
      * @since [v4.0]
      * @return \Illuminate\Http\JsonResponse
      */
-    public function store(ImageUploadRequest $request)
+    public function store(StoreAssetRequest $request)
     {
         $this->authorize('create', Asset::class);
 

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -35,11 +35,11 @@ class StoreAssetRequest extends ImageUploadRequest
             parent::rules(),
         );
 
-            // unsets unique check here, that check cannot run twice.
-            $rules['asset_tags.*'] = $rules['asset_tag'];
-            unset($rules['asset_tag']);
-            $rules['serials.*'] = $rules['serial'];
-            unset($rules['serial']);
+        // unsets unique check here, that check cannot run twice.
+        $rules['asset_tags.*'] = $rules['asset_tag'];
+        unset($rules['asset_tag']);
+        $rules['serials.*'] = $rules['serial'];
+        unset($rules['serial']);
 
         return $rules;
     }

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Asset;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class StoreAssetRequest extends ImageUploadRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        //TODO: make sure this works
+        //return Gate::allows('create', new Asset);
+    }
+
+    public function prepareForValidation(): void
+    {
+        //
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        $rules = array_merge(
+            (new Asset)->getRules(),
+            parent::rules(),
+        );
+
+        if(!$this->expectsJson()) {
+            //accepts an array for the gui form
+            $rules['asset_tags.*'] = $rules['asset_tag'];
+            unset($rules['asset_tag']);
+            $rules['serials.*'] = $rules['serial'];
+            unset($rules['serial']);
+        }
+
+        return $rules;
+    }
+}

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -35,12 +35,6 @@ class StoreAssetRequest extends ImageUploadRequest
             parent::rules(),
         );
 
-        // unsets unique check here, that check cannot run twice.
-        $rules['asset_tags.*'] = $rules['asset_tag'];
-        unset($rules['asset_tag']);
-        $rules['serials.*'] = $rules['serial'];
-        unset($rules['serial']);
-
         return $rules;
     }
 }

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -15,7 +15,6 @@ class StoreAssetRequest extends ImageUploadRequest
      */
     public function authorize(): bool
     {
-        // TODO: make sure this works
         return Gate::allows('create', new Asset);
     }
 

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -15,8 +15,8 @@ class StoreAssetRequest extends ImageUploadRequest
      */
     public function authorize(): bool
     {
-        //TODO: make sure this works
-        //return Gate::allows('create', new Asset);
+        // TODO: make sure this works
+        return Gate::allows('create', new Asset);
     }
 
     public function prepareForValidation(): void
@@ -36,13 +36,11 @@ class StoreAssetRequest extends ImageUploadRequest
             parent::rules(),
         );
 
-        if(!$this->expectsJson()) {
-            //accepts an array for the gui form
+            // unsets unique check here, that check cannot run twice.
             $rules['asset_tags.*'] = $rules['asset_tag'];
             unset($rules['asset_tag']);
             $rules['serials.*'] = $rules['serial'];
             unset($rules['serial']);
-        }
 
         return $rules;
     }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -100,10 +100,7 @@ class Asset extends Depreciable
         'expected_checkin' => 'date|nullable',
         'location_id'     => 'exists:locations,id|nullable',
         'rtd_location_id' => 'exists:locations,id|nullable',
-        // okay, i know this looks scary - but it's not. it checks to see if the asset tag is unique, but only if the asset is not deleted - `NULL,NULL` says to ignore the unique rule if following conditions are met
-        // https://laracasts.com/discuss/channels/laravel/unique-validation-with-soft-delete
-        // this is tested and verified
-        'asset_tag'       => 'required|min:1|max:255|unique:assets,asset_tag,NULL,NULL,deleted_at,NULL',
+        'asset_tag'      => 'required|min:1|max:255|unique_undeleted:assets,asset_tag',
         'purchase_date'   => 'date|date_format:Y-m-d|nullable',
         'serial'          => 'unique_serial|nullable',
         'purchase_cost'   => 'numeric|nullable|gte:0',

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -100,7 +100,10 @@ class Asset extends Depreciable
         'expected_checkin' => 'date|nullable',
         'location_id'     => 'exists:locations,id|nullable',
         'rtd_location_id' => 'exists:locations,id|nullable',
-        'asset_tag'       => 'required|min:1|max:255|unique_undeleted',
+        // okay, i know this looks scary - but it's not. it checks to see if the asset tag is unique, but only if the asset is not deleted - `NULL,NULL` says to ignore the unique rule if following conditions are met
+        // https://laracasts.com/discuss/channels/laravel/unique-validation-with-soft-delete
+        // this is tested and verified
+        'asset_tag'       => 'required|min:1|max:255|unique:assets,asset_tag,NULL,NULL,deleted_at,NULL',
         'purchase_date'   => 'date|date_format:Y-m-d|nullable',
         'serial'          => 'unique_serial|nullable',
         'purchase_cost'   => 'numeric|nullable|gte:0',

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -91,7 +91,7 @@ class Asset extends Depreciable
 
     protected $rules = [
         'name'            => 'max:255|nullable',
-        'model_id'        => 'required|integer|exists:models,id,deleted_at,NULL',
+        'model_id'        => 'required|integer|exists:models,id,deleted_at,NULL|not_array',
         'status_id'       => 'required|integer|exists:status_labels,id',
         'company_id'      => 'integer|nullable',
         'warranty_months' => 'numeric|nullable|digits_between:0,240',

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -48,6 +48,8 @@ class ValidationServiceProvider extends ServiceProvider
         // Unique only if undeleted
         // This works around the use case where multiple deleted items have the same unique attribute.
         // (I think this is a bug in Laravel's validator?)
+        // $parameters is the rule parameters, like `unique_undeleted:users,id` - $parameters[0] is users, $parameters[1] is id
+        // the UniqueUndeletedTrait prefills these so you can just use `unique_undeleted` in your rules (but this would only work directly in the model)
         Validator::extend('unique_undeleted', function ($attribute, $value, $parameters, $validator) {
             if (count($parameters)) {
                 $count = DB::table($parameters[0])->select('id')->where($attribute, '=', $value)->whereNull('deleted_at')->where('id', '!=', $parameters[1])->count();

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Feature\Api\Assets;
+
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class AssetStoreTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testRequiresPermissionToCreateAsset()
+    {
+        $this->actingAsForApi(User::factory()->create())
+            ->postJson(route('api.assets.store'))
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
# Description
There are certain cases when an array (and feasibly other values) are submitted and an exception is raised because validation hasn't been run yet. This introduces the idea of taking our model-level validation rules, and using them in the form request so that when bad data is submitted it's rejected before any other code runs. The model level validation still runs and is useful in the case that values are changed in the code. 

This only applies to the API asset store right now, but I'd like to expand it to much of the API for similar reasons. 

I added  the new `not_array` rule to `model_id` to resolve the initial issue. (This didn't resolve the initial issue, because the exception was being raised before validation had started on the model, but does resolve the issue now) 

I have also moved the Gate up a level to the form request, this has the similar benefit of rejecting any requests before it gets past the request layer. I tested this manually, and @marcusmoore wrote a test that passes and I trust him. 😄 

I've customized the global `invalidJson()` to be identical to Snipe-IT's standard response as Laravel prefers to throw a 422 on validation. 

The form request extends ImageUploadRequest. 

The `unique_undeleted` rule didn't work in the form request without specifying table and column, from what I can gather that's because without the parameters specified, the Trait is what supplies them to the rule, which obviously isn't present at the request. 

I'm putting this against develop as it resolves current exceptions, but would be happy to put against v7 if that's preferred. 

Fixes SC-23921 (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

`unique_undeleted:assets,asset_tag` is tested, API requests and responses are tested, gate is tested. 

**Test Configuration**:
* PHP version: 8.1
* MySQL version 8.1