### PR TITLE
Fixed notes not saving to action log when licenses are checked in/out

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -101,7 +101,7 @@ class LicenseCheckinController extends Controller
 
         // Was the asset updated?
         if ($licenseSeat->save()) {
-            event(new CheckoutableCheckedIn($licenseSeat, $return_to, Auth::user(), $request->input('note')));
+            event(new CheckoutableCheckedIn($licenseSeat, $return_to, Auth::user(), $request->input('notes')));
 
             if ($backTo == 'user') {
                 return redirect()->route('users.show', $return_to->id)->with('success', trans('admin/licenses/message.checkin.success'));

--- a/app/Http/Controllers/Licenses/LicenseCheckoutController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckoutController.php
@@ -105,7 +105,7 @@ class LicenseCheckoutController extends Controller
             $licenseSeat->assigned_to = $target->assigned_to;
         }
         if ($licenseSeat->save()) {
-            event(new CheckoutableCheckedOut($licenseSeat, $target, Auth::user(), request('note')));
+            event(new CheckoutableCheckedOut($licenseSeat, $target, Auth::user(), request('notes')));
 
             return true;
         }
@@ -122,7 +122,7 @@ class LicenseCheckoutController extends Controller
         $licenseSeat->assigned_to = request('assigned_to');
 
         if ($licenseSeat->save()) {
-            event(new CheckoutableCheckedOut($licenseSeat, $target, Auth::user(), request('note')));
+            event(new CheckoutableCheckedOut($licenseSeat, $target, Auth::user(), request('notes')));
 
             return true;
         }

--- a/tests/Feature/Checkouts/LicenseCheckoutTest.php
+++ b/tests/Feature/Checkouts/LicenseCheckoutTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Checkouts;
+
+use App\Models\Actionlog;
+use App\Models\Asset;
+use App\Models\License;
+use App\Models\LicenseSeat;
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class LicenseCheckoutTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testNotesAreStoredInActionLogOnCheckoutToAsset()
+    {
+        $admin = User::factory()->superuser()->create();
+        $asset = Asset::factory()->create();
+        $licenseSeat = LicenseSeat::factory()->create();
+
+        $this->actingAs($admin)
+            ->post("/licenses/{$licenseSeat->license->id}/checkout", [
+                'checkout_to_type' => 'asset',
+                'assigned_to' => null,
+                'asset_id' => $asset->id,
+                'notes' => 'oh hi there',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('action_logs', [
+            'action_type' => 'checkout',
+            'target_id' => $asset->id,
+            'target_type' => Asset::class,
+            'item_id' => $licenseSeat->license->id,
+            'item_type' => License::class,
+            'note' => 'oh hi there',
+        ]);
+    }
+
+    public function testNotesAreStoredInActionLogOnCheckoutToUser()
+    {
+        $admin = User::factory()->superuser()->create();
+        $licenseSeat = LicenseSeat::factory()->create();
+
+        $this->actingAs($admin)
+            ->post("/licenses/{$licenseSeat->license->id}/checkout", [
+                'checkout_to_type' => 'user',
+                'assigned_to' => $admin->id,
+                'asset_id' => null,
+                'notes' => 'oh hi there',
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('action_logs', [
+            'action_type' => 'checkout',
+            'target_id' => $admin->id,
+            'target_type' => User::class,
+            'item_id' => $licenseSeat->license->id,
+            'item_type' => License::class,
+            'note' => 'oh hi there',
+        ]);
+    }
+}

--- a/tests/Feature/Checkouts/LicenseCheckoutTest.php
+++ b/tests/Feature/Checkouts/LicenseCheckoutTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Checkouts;
 
-use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\License;
 use App\Models\LicenseSeat;
@@ -26,8 +25,7 @@ class LicenseCheckoutTest extends TestCase
                 'assigned_to' => null,
                 'asset_id' => $asset->id,
                 'notes' => 'oh hi there',
-            ])
-            ->assertRedirect();
+            ]);
 
         $this->assertDatabaseHas('action_logs', [
             'action_type' => 'checkout',
@@ -50,8 +48,7 @@ class LicenseCheckoutTest extends TestCase
                 'assigned_to' => $admin->id,
                 'asset_id' => null,
                 'notes' => 'oh hi there',
-            ])
-            ->assertRedirect();
+            ]);
 
         $this->assertDatabaseHas('action_logs', [
             'action_type' => 'checkout',


### PR DESCRIPTION
# Description

This PR follows up #13674 and changes a couple `note` to `notes` so that notes are saved to the action log when licenses are checked in and out.

<img width="766" alt="Showing notes appearing in the History tab" src="https://github.com/snipe/snipe-it/assets/1141514/dbaac04d-9902-4a24-9e98-b3f60cfe0963">



Fixes sc-23932

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)