### PR TITLE
Link back to asset on create

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -204,12 +204,8 @@ class AssetsController extends Controller
         }
 
         if ($success) {
-            // Redirect to the asset listing page
-            $minutes = 518400;
-            // dd( $_POST['options']);
-            // Cookie::queue(Cookie::make('optional_info', json_decode($_POST['options']), $minutes));
             return redirect()->route('hardware.index')
-                ->with('success', trans('admin/hardware/message.create.success'));
+                ->with('success-unescaped', trans('admin/hardware/message.create.success_linked', ['link' => route('hardware.show', $asset->id), 'id', 'tag' => $asset->asset_tag]));
                
       
         }

--- a/app/Http/Controllers/Components/ComponentCheckinController.php
+++ b/app/Http/Controllers/Components/ComponentCheckinController.php
@@ -96,8 +96,8 @@ class ComponentCheckinController extends Controller
             $asset = Asset::find($component_assets->asset_id);
 
             event(new CheckoutableCheckedIn($component, $asset, Auth::user(), $request->input('note'), Carbon::now()));
-            if($backto == 'asset'){
-                return redirect()->route('hardware.view', $asset->id)->with('success',
+            if ($backto == 'asset'){
+                return redirect()->route('hardware.show', $asset->id)->with('success',
                     trans('admin/components/message.checkin.success'));
             }
 

--- a/resources/lang/en/admin/hardware/message.php
+++ b/resources/lang/en/admin/hardware/message.php
@@ -11,6 +11,7 @@ return [
     'create' => [
         'error'   		=> 'Asset was not created, please try again. :(',
         'success' 		=> 'Asset created successfully. :)',
+        'success_linked' => 'Asset with tag :tag was created successfully. <strong><a href=":link" style="color: white;">Click here to view</a></strong>.',
     ],
 
     'update' => [

--- a/resources/views/notifications.blade.php
+++ b/resources/views/notifications.blade.php
@@ -35,6 +35,18 @@
 @endif
 
 
+@if ($message = Session::get('success-unescaped'))
+    <div class="col-md-12">
+        <div class="alert alert-success fade in">
+            <button type="button" class="close" data-dismiss="alert">&times;</button>
+            <i class="fas fa-check faa-pulse animated"></i>
+            <strong>{{ trans('general.notification_success') }}: </strong>
+            {!!  $message !!}
+        </div>
+    </div>
+@endif
+
+
 @if ($assets = Session::get('assets'))
     @foreach ($assets as $asset)
         <div class="col-md-12">

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -122,6 +122,7 @@ Route::group(
             [AssetCheckinController::class, 'store']
         )->name('hardware.checkin.store');
 
+        // Redirect old legacy /asset_id/view urls to the resource route version
         Route::get('{assetId}/view', function ($assetId) {
             return redirect()->route('hardware.show', ['hardware' => $assetId]);
         });

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -186,11 +186,8 @@ Route::resource('hardware',
         AssetsController::class, 
         [
             'middleware' => ['auth'],
-            'parameters' => ['asset' => 'asset_id',
-                'names' => [
-                'show' => 'view',
-            ],
-        ],
+            'parameters' => ['asset' => 'asset_id'],
+            'names' => ['show' => 'view'],
 ]);
 
 Route::get('ht/{any?}',

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -122,9 +122,9 @@ Route::group(
             [AssetCheckinController::class, 'store']
         )->name('hardware.checkin.store');
 
-        Route::get('{assetId}/view',
-            [AssetsController::class, 'show']
-        )->name('hardware.view');
+        Route::get('{assetId}/view', function ($assetId) {
+            return redirect()->route('hardware.show', ['hardware' => $assetId]);
+        });
 
         Route::get('{assetId}/qr_code', 
             [AssetsController::class, 'getQrCode']
@@ -178,13 +178,17 @@ Route::group(
         Route::post('bulkcheckout',
             [BulkAssetsController::class, 'storeCheckout']
         )->name('hardware.bulkcheckout.store');
+
     });
 
 Route::resource('hardware', 
         AssetsController::class, 
         [
             'middleware' => ['auth'],
-            'parameters' => ['asset' => 'asset_id'
+            'parameters' => ['asset' => 'asset_id',
+                'names' => [
+                'show' => 'view',
+            ],
         ],
 ]);
 


### PR DESCRIPTION
This got a little messier than I had hoped. The intent was to provide a link back to the asset when a new asset has been created successfully (which this PR does), but I also realized one of the first routes we used a decade ago is... kinda wrong? We normally use the convention of `https://localhost/hardware/asset_id`, but the `hardware.view` route was producing `https://localhost/hardware/asset_id/view` as the URL. While it wasn't really causing any harm but was inconsistent with the way we access other things (and inconsistent with the resource routes.) I think that was a throwback from long before I knew what resource routes were. 😬

So now the `/view` URL redirects back to the normal resource route style.

We also now have an unescaped success message which should allow us to use this type of methodology moving forward.

<img width="1682" alt="Screenshot 2023-11-08 at 2 39 50 PM" src="https://github.com/snipe/snipe-it/assets/197404/1cb37585-21a8-456c-945f-f112301990c4">
