### PR TITLE
Added broken checkbox to accessory checkin

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoryCheckinController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckinController.php
@@ -57,7 +57,7 @@ class AccessoryCheckinController extends Controller
         }
 
         $accessory = Accessory::find($accessory_user->accessory_id);
-
+        $notes = $request->input('note');
         $this->authorize('checkin', $accessory);
 
         $checkin_at = date('Y-m-d');
@@ -68,8 +68,12 @@ class AccessoryCheckinController extends Controller
         // Was the accessory updated?
         if (DB::table('accessories_users')->where('id', '=', $accessory_user->id)->delete()) {
             $return_to = e($accessory_user->assigned_to);
+            if($request->input('is_broken') == 1){
+                (DB::table('accessories')->decrement('qty'));
+              $notes .= " ".trans('admin/accessories/general.is_broken');
+            }
 
-            event(new CheckoutableCheckedIn($accessory, User::find($return_to), Auth::user(), $request->input('note'), $checkin_at));
+            event(new CheckoutableCheckedIn($accessory, User::find($return_to), Auth::user(), $notes, $checkin_at));
 
             return redirect()->route('accessories.show', $accessory->id)->with('success', trans('admin/accessories/message.checkin.success'));
         }

--- a/resources/lang/en/admin/accessories/general.php
+++ b/resources/lang/en/admin/accessories/general.php
@@ -9,6 +9,7 @@ return array(
     'edit'  							=> 'Edit Accessory',
     'eula_text'							=> 'Category EULA',
     'eula_text_help'					=> 'This field allows you to customize your EULAs for specific types of assets. If you only have one EULA for all of your assets, you can check the box below to use the primary default.',
+    'is_broken'                         => 'Broken or needs replacement',
     'require_acceptance'				=> 'Require users to confirm acceptance of assets in this category.',
     'no_default_eula'					=> 'No primary default EULA found. Add one in Settings.',
     'total'  							=> 'Total',

--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -43,6 +43,15 @@
                                         </div>
                                     </div>
                                     @endif
+                                <!-- Broken/Needs Replacement Checkbox -->
+                                <div class="form-group">
+                                    <div class="col-sm-offset-3 col-sm-9">
+                                        <label class="form-control">
+                                            <input type="checkbox" value="1" name="is_broken" id="is_broken">
+                                            {{ trans('admin/accessories/general.is_broken') }}
+                                        </label>
+                                    </div>
+                                </div>
 
                                     <!-- Note -->
                                     <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">


### PR DESCRIPTION
# Description

This adds a checkbox that allows users to distinguish if an accessory is being checked in for reuse or replacement. This will decrement the total quantity from the accessory table if its checked as broken. It will also auto populate the notes with "Broken or Needs Replacement.
<img width="627" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/38ea2fbf-18c8-4a0c-934b-27a16e96e81a">
<img width="798" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/77950299-74ea-471f-8965-9676f027e44c">

 
Fixes #12997

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
