### PR TITLE
Fixed ErrorExemption: Attempt to read property "id" on bool [sc-23945]

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -144,7 +144,7 @@ class AssetImporter extends ItemImporter
             // If we have a target to checkout to, lets do so.
             //-- user_id is a property of the abstract class Importer, which this class inherits from and it's setted by
             //-- the class that needs to use it (command importer or GUI importer inside the project).
-            if (isset($target)) {
+            if (isset($target) && ($target !== false)) {
                 if (!is_null($asset->assigned_to)){
                     if ($asset->assigned_to != $target->id){
                         event(new CheckoutableCheckedIn($asset, User::find($asset->assigned_to), Auth::user(), $asset->notes, date('Y-m-d H:i:s')));


### PR DESCRIPTION
# Description
In https://github.com/snipe/snipe-it/pull/13799 was added to the action log the "checkedin" action if we change the user associated with that asset. 

But an error was introduced, because the `createOrFetchUser()` function used to find the user we want to use for the checkout action returns `false` if some conditions are met (username is blank for example), so when we try to compare id's to see if its the same user that have originally assigned the asset the system crash. In this PR I ignore the new checkout if the `$target` variable is false (no user is passed to checkout). 

Fixes [sc-23945]

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.23
* Webserver version: PHP Dev Server
* OS version: Debian 12
