### PR TITLE
Fixed some bugs around tooltips, the sidebar, and lightbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "css-loader": "^5.0.0",
                 "ekko-lightbox": "^5.1.1",
                 "imagemin": "^8.0.1",
+                "jquery-form-validator": "^2.3.79",
                 "jquery-slimscroll": "^1.3.8",
                 "jquery-ui": "^1.13.2",
                 "jquery-ui-bundle": "^1.12.1",
@@ -7756,6 +7757,19 @@
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
             "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
+        },
+        "node_modules/jquery-form-validator": {
+            "version": "2.3.79",
+            "resolved": "https://registry.npmjs.org/jquery-form-validator/-/jquery-form-validator-2.3.79.tgz",
+            "integrity": "sha512-/jG1qy7FEcGFCGlnEst5pOn1SZi3awDxRrlGDHdBEnY8Ga5zXA00OnAKIZV8fUCpUTT003BPbFBDR7hlgOsN8w==",
+            "dependencies": {
+                "jquery": "2.2.4"
+            }
+        },
+        "node_modules/jquery-form-validator/node_modules/jquery": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
+            "integrity": "sha512-lBHj60ezci2u1v2FqnZIraShGgEXq35qCzMv4lITyHGppTnA13rwR0MgwyNJh9TnDs3aXUvd1xjAotfraMHX/Q=="
         },
         "node_modules/jquery-knob": {
             "version": "1.2.11",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "css-loader": "^5.0.0",
         "ekko-lightbox": "^5.1.1",
         "imagemin": "^8.0.1",
+        "jquery-form-validator": "^2.3.79",
         "jquery-slimscroll": "^1.3.8",
         "jquery-ui": "^1.13.2",
         "jquery-ui-bundle": "^1.12.1",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -154,7 +154,7 @@ mix.combine(
     "./resources/assets/js/extensions/pGenerator.jquery.js",
     "./node_modules/chart.js/dist/Chart.js",
     "./resources/assets/js/signature_pad.js",
-    //"./node_modules/jquery-form-validator/form-validator/jquery.form-validator.js", //problem?
+    "./node_modules/jquery-form-validator/form-validator/jquery.form-validator.js",
     "./node_modules/list.js/dist/list.js",
     "./node_modules/clipboard/dist/clipboard.js",
   ],


### PR DESCRIPTION
# Description

This PR, targeting the v7 branch, re-adds the `jquery-form-validator` library that exists in v6 but was removed in the process of prepping v7.

Note: The test failures are fixed in #13864

---

The removal caused a few interesting bugs.

I first noticed that this tooltip was missing
![missing tooltip](https://github.com/snipe/snipe-it/assets/1141514/fc61e3cf-5c0d-4460-bc1e-d6d1e3be6569)

and realized there was an error in the console:
```
Uncaught TypeError: $.validate is not a function
```
The issue was on [this line](https://github.com/snipe/snipe-it/blob/da30292d84b40071b7a50e0759ce1cda3cf7c10d/resources/views/layouts/default.blade.php#L969) and meant that the javascript that followed was never actually run.

Re-adding the library fixes the following bugs:
- Tooltip on create pages (mentioned above)
- The sidebar not remembering if it should be expanded or not
- Lightbox not being registered correctly and opening images directly instead of in the expected "popover" view:
<img width="852" alt="lightbox" src="https://github.com/snipe/snipe-it/assets/1141514/5eb02450-3546-45fa-8571-998e9d047760">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)