### PR TITLE
Fixed GitHub Action tests for v7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Generate key
         run: php artisan key:generate
 
+      - name: Migrate Database
+        run: php artisan migrate
+
       - name: Install Passport
         run: php artisan passport:install
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,7 @@ jobs:
         env:
           DB_CONNECTION: mysql
           DB_DATABASE: snipeit
+          DB_HOST: 127.0.0.1
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root
         run: php artisan test --parallel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Generate key
         run: php artisan key:generate
 
+      - name: Install Passport
+        run: php artisan passport:install --env=testing
+
       - name: Directory Permissions
         run: chmod -R 777 storage bootstrap/cache
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,9 +60,6 @@ jobs:
       - name: Generate key
         run: php artisan key:generate
 
-      - name: Migrate Database
-        run: php artisan migrate
-
       - name: Install Passport
         run: php artisan passport:install
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,14 @@ jobs:
       - name: Generate key
         run: php artisan key:generate
 
+      - name: Migrate Database
+        env:
+          DB_CONNECTION: mysql
+          DB_DATABASE: snipeit
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          DB_USERNAME: root
+        run: php artisan migrate --force
+
       - name: Install Passport
         env:
           DB_CONNECTION: mysql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Generate key
         run: php artisan key:generate
 
+      - name: Install Passport
+        run: php artisan passport:install
+
       - name: Directory Permissions
         run: chmod -R 777 storage bootstrap/cache
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,27 +57,17 @@ jobs:
       - name: Install Dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
 
-      - name: Generate key
-        run: php artisan key:generate
-
-      - name: Migrate Database
+      - name: Setup Laravel
         env:
           DB_CONNECTION: mysql
           DB_DATABASE: snipeit
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root
-        run: php artisan migrate --force
-
-      - name: Install Passport
-        env:
-          DB_CONNECTION: mysql
-          DB_DATABASE: snipeit
-          DB_PORT: ${{ job.services.mysql.ports[3306] }}
-          DB_USERNAME: root
-        run: php artisan passport:install
-
-      - name: Directory Permissions
-        run: chmod -R 777 storage bootstrap/cache
+        run: |
+          php artisan key:generate
+          php artisan migrate --force
+          php artisan passport:install
+          chmod -R 777 storage bootstrap/cache
 
       - name: Execute tests (Unit and Feature tests) via PHPUnit
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,6 @@ jobs:
         env:
           DB_CONNECTION: mysql
           DB_DATABASE: snipeit
-          DB_HOST: 127.0.0.1
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root
         run: php artisan test --parallel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,9 +60,6 @@ jobs:
       - name: Generate key
         run: php artisan key:generate
 
-      - name: Install Passport
-        run: php artisan passport:install
-
       - name: Directory Permissions
         run: chmod -R 777 storage bootstrap/cache
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.4"
-          - "8.0"
-          - "8.1.1"
+          - "8.1"
+          - "8.2"
 
     name: PHP ${{ matrix.php-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,12 @@ jobs:
         run: php artisan key:generate
 
       - name: Install Passport
-        run: php artisan passport:install --env=testing
+        env:
+          DB_CONNECTION: mysql
+          DB_DATABASE: snipeit
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+          DB_USERNAME: root
+        run: php artisan passport:install
 
       - name: Directory Permissions
         run: chmod -R 777 storage bootstrap/cache

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "8.0 - 8.2",
+    "php": "^8.1",
     "ext-curl": "*",
     "ext-fileinfo": "*",
     "ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a7666957fcf514f54340bf80ad18726",
+    "content-hash": "6f3c589a1c2a3a3dc24535abba26e1a6",
     "packages": [
         {
             "name": "alek13/slack",
@@ -15699,7 +15699,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "8.0 - 8.2",
+        "php": "^8.1",
         "ext-curl": "*",
         "ext-fileinfo": "*",
         "ext-json": "*",
@@ -15707,5 +15707,5 @@
         "ext-pdo": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
# Description

This v7 PR fixes the GitHub Action that runs the test suite.

I also bumped the PHP requirement in PHP to `^8.1` which matches what the framework has [set](https://github.com/laravel/framework/blob/2703f3e85511d8a6eb70752fc5d5e2d9287d0712/composer.json#L18).
To generate the new `composer.lock` file without updating all dependencies I ran `composer update --lock`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)