### PR TITLE
Added default map back to the importer

### DIFF
--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -19,22 +19,76 @@ abstract class Importer
      * Id of User performing import
      * @var
      */
+    
     protected $user_id;
     /**
      * Are we updating items in the import
      * @var bool
      */
+
     protected $updating;
+
     /**
      * Default Map of item fields->csv names
      *
      * This has been moved into app/Http/Livewire/Importer.php to be more granular.
-     * @todo - remove references to this property since we don't use it anymore.
+     * This private variable is ONLY used for the cli-importer.
      *
+     * @todo - find a way to make this less duplicative
      * @var array
      */
     private $defaultFieldMap = [
-
+        'asset_tag' => 'asset tag',
+        'activated' => 'activated',
+        'category' => 'category',
+        'checkout_class' => 'checkout type', // Supports Location or User for assets.  Using checkout_class instead of checkout_type because type exists on asset already.
+        'checkout_location' => 'checkout location',
+        'company' => 'company',
+        'item_name' => 'item name',
+        'item_number' => 'item number',
+        'image' => 'image',
+        'expiration_date' => 'expiration date',
+        'location' => 'location',
+        'notes' => 'notes',
+        'license_email' => 'licensed to email',
+        'license_name' => 'licensed to name',
+        'maintained' => 'maintained',
+        'manufacturer' => 'manufacturer',
+        'asset_model' => 'model name',
+        'model_number' => 'model number',
+        'order_number' => 'order number',
+        'purchase_cost' => 'purchase cost',
+        'purchase_date' => 'purchase date',
+        'purchase_order' => 'purchase order',
+        'qty' => 'quantity',
+        'reassignable' => 'reassignable',
+        'requestable' => 'requestable',
+        'seats' => 'seats',
+        'serial' => 'serial number',
+        'status' => 'status',
+        'supplier' => 'supplier',
+        'termination_date' => 'termination date',
+        'warranty_months' => 'warranty',
+        'full_name' => 'full name',
+        'email' => 'email',
+        'username' => 'username',
+        'address' => 'address',
+        'address2' => 'address2',
+        'city' => 'city',
+        'state' => 'state',
+        'country' => 'country',
+        'zip' => 'zip',
+        'jobtitle' => 'job title',
+        'employee_num' => 'employee number',
+        'phone_number' => 'phone number',
+        'first_name' => 'first name',
+        'last_name' => 'last name',
+        'department' => 'department',
+        'manager_name' => 'manager full name',
+        'manager_username' => 'manager username',
+        'min_amt' => 'minimum quantity',
+        'remote' => 'remote',
+        'vip' => 'vip',
     ];
     /**
      * Map of item fields->csv names


### PR DESCRIPTION
This is basically a reversal of https://github.com/snipe/snipe-it/commit/d228b7f3472e024b9d1a5b68ec3d7253ed67e66f, but with some added comments. When we refactored the importer to make it more Livewire-y, we pulled out a variable that we thought we didn't need anymore. It's only come up recently because some folks use the cli importer a lot more than we realized, and that commit broke the cli for them. 

We do need to find a way to make this less duplicative, either by importing the variables from the Livewire side, or vice versa. This should at least fix the cli importer for now, and won't interfere with the GUI importer.