### PR TITLE
Clarified upload error text

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -485,7 +485,7 @@ return [
     ],
     'percent_complete' => '% complete',
     'uploading' => 'Uploading... ',
-    'upload_error' => 'Error uploading file. Please check that there are no empty trailing rows.',
+    'upload_error' => 'Error uploading file. Please check that there are no empty rows and that no column names are duplicated.',
     'copy_to_clipboard' => 'Copy to Clipboard',
     'copied' => 'Copied!',
 


### PR DESCRIPTION
I ran into an issue today where the user had duplicate column names (address, city, state, etc) in their CSV import and the file upload was failing. While we definitely need to give better specific feedback on WHY an upload is failing, this language change can at least point people in the right direction.