### PR TITLE
Fix client side validation in the v7 branch

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -420,6 +420,7 @@ class SettingsController extends Controller
         // Only allow the site name and CSS to be changed if lock_passwords is false
         // Because public demos make people act like dicks
         if (! config('app.lock_passwords')) {
+            $request->validate(['site_name' => 'required']);
             $setting->site_name = $request->input('site_name');
             $setting->custom_css = $request->input('custom_css');
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "jquery-slimscroll": "^1.3.8",
                 "jquery-ui": "^1.13.2",
                 "jquery-ui-bundle": "^1.12.1",
+                "jquery-validation": "^1.20.0",
                 "jquery.iframe-transport": "^1.0.0",
                 "jspdf-autotable": "^3.5.30",
                 "less": "^4.2.0",
@@ -7787,6 +7788,14 @@
             "version": "1.12.1",
             "resolved": "https://registry.npmjs.org/jquery-ui-bundle/-/jquery-ui-bundle-1.12.1.tgz",
             "integrity": "sha512-GHaOlAemudaYqrBzaU0XutgC/vBwcvd+SBQ+TtUTA+dLx4PiVQAfTm3ABrh+JzhV6PZBOk8AIhsC9l+XggpldQ=="
+        },
+        "node_modules/jquery-validation": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.20.0.tgz",
+            "integrity": "sha512-c8tg4ltIIP6L7l0bZ79sRzOJYquyjS48kQZ6iv8MJ2r0OYztxtkWYKTReZyU2/zVFYiINB29i0Z/IRNNuJQN1g==",
+            "peerDependencies": {
+                "jquery": "^1.7 || ^2.0 || ^3.1"
+            }
         },
         "node_modules/jquery.iframe-transport": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "jquery-slimscroll": "^1.3.8",
         "jquery-ui": "^1.13.2",
         "jquery-ui-bundle": "^1.12.1",
+        "jquery-validation": "^1.20.0",
         "jquery.iframe-transport": "^1.0.0",
         "jspdf-autotable": "^3.5.30",
         "less": "^4.2.0",

--- a/resources/views/depreciations/edit.blade.php
+++ b/resources/views/depreciations/edit.blade.php
@@ -17,7 +17,7 @@
     </label>
     <div class="col-md-7 col-sm-12 {{  (Helper::checkIfRequired($item, 'months')) ? ' required' : '' }}">
         <div class="col-md-7" style="padding-left:0px">
-            <input class="form-control" type="text" name="months" id="months" value="{{ Request::old('months', $item->months) }}" style="width: 80px;"{!!  (\App\Helpers\Helper::checkIfRequired($item, 'months')) ? ' data-validation="required" required' : '' !!} />
+            <input class="form-control" type="text" name="months" id="months" value="{{ Request::old('months', $item->months) }}" style="width: 80px;"{!!  (\App\Helpers\Helper::checkIfRequired($item, 'months')) ? ' required' : '' !!} />
             {!! $errors->first('months', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -26,14 +26,14 @@
           <div class="col-md-7 col-sm-12{{  (Helper::checkIfRequired($item, 'asset_tag')) ? ' required' : '' }}">
 
 
-          <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ old('asset_tag', $item->asset_tag) }}" data-validation="required">
+          <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ old('asset_tag', $item->asset_tag) }}" required>
               {!! $errors->first('asset_tags', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
               {!! $errors->first('asset_tag', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
           </div>
       @else
           <!-- we are creating a new asset - let people use more than one asset tag -->
           <div class="col-md-7 col-sm-12{{  (Helper::checkIfRequired($item, 'asset_tag')) ? ' required' : '' }}">
-              <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ old('asset_tags.1', \App\Models\Asset::autoincrement_asset()) }}" data-validation="required">
+              <input class="form-control" type="text" name="asset_tags[1]" id="asset_tag" value="{{ old('asset_tags.1', \App\Models\Asset::autoincrement_asset()) }}" required>
               {!! $errors->first('asset_tags', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
               {!! $errors->first('asset_tag', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
           </div>
@@ -295,7 +295,7 @@
                 box_html += '<span class="fields_wrapper">';
                 box_html += '<div class="form-group"><label for="asset_tag" class="col-md-3 control-label">{{ trans('admin/hardware/form.tag') }} ' + x + '</label>';
                 box_html += '<div class="col-md-7 col-sm-12 required">';
-                box_html += '<input type="text"  class="form-control" name="asset_tags[' + x + ']" value="{{ (($snipeSettings->auto_increment_prefix!='') && ($snipeSettings->auto_increment_assets=='1')) ? $snipeSettings->auto_increment_prefix : '' }}'+ auto_tag +'" data-validation="required">';
+                box_html += '<input type="text"  class="form-control" name="asset_tags[' + x + ']" value="{{ (($snipeSettings->auto_increment_prefix!='') && ($snipeSettings->auto_increment_assets=='1')) ? $snipeSettings->auto_increment_prefix : '' }}'+ auto_tag +'" required>';
                 box_html += '</div>';
                 box_html += '<div class="col-md-2 col-sm-12">';
                 box_html += '<a href="#" class="remove_field btn btn-default btn-sm"><i class="fas fa-minus"></i></a>';

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -965,6 +965,7 @@
                 $('.js-copy-link').tooltip('hide').attr('data-original-title', '{{ trans('general.copied') }}').tooltip('show');
             });
 
+            // Reference: https://jqueryvalidation.org/validate/
             $('#create-form').validate({
                 ignore: 'input[type=hidden]',
                 errorClass: 'help-block form-error',
@@ -979,6 +980,10 @@
                 highlight: function(inputElement) {
                     $(inputElement).parent().addClass('has-error');
                     $(inputElement).closest('.help-block').remove();
+                },
+                onfocusout: function(element) {
+                    // console.log($(element).valid());
+                    return $(element).valid();
                 },
             });
 

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -970,7 +970,7 @@
                 errorClass: 'help-block form-error',
                 errorElement: 'span',
                 errorPlacement: function(error, element) {
-                    $(element).hasClass('select2')
+                    $(element).hasClass('select2') || $(element).hasClass('js-data-ajax')
                         // If the element is a select2 then place the error above the input
                         ? element.parents('.required').append(error)
                         // Otherwise place it after

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -966,7 +966,16 @@
             });
 
             $('#create-form').validate({
-                ignore: 'input[type=hidden]'
+                ignore: 'input[type=hidden]',
+                errorClass: 'help-block form-error',
+                errorElement: 'span',
+                errorPlacement: function(error, element) {
+                    element.parents('.required').append(error);
+                },
+                highlight: function(inputElement) {
+                    $(inputElement).parent().addClass('has-error');
+                    $(inputElement).closest('.help-block').remove();
+                },
             });
 
 

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -965,12 +965,7 @@
                 $('.js-copy-link').tooltip('hide').attr('data-original-title', '{{ trans('general.copied') }}').tooltip('show');
             });
 
-            // ignore: 'input[type=hidden]' is required here to validate the select2 lists
-            $.validate({
-                form: '#create-form',
-                modules: 'date, toggleDisabled',
-                disabledFormFilter: '#create-form',
-                showErrorDialogs: true,
+            $('#create-form').validate({
                 ignore: 'input[type=hidden]'
             });
 

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -982,7 +982,6 @@
                     $(inputElement).closest('.help-block').remove();
                 },
                 onfocusout: function(element) {
-                    // console.log($(element).valid());
                     return $(element).valid();
                 },
             });

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -970,7 +970,11 @@
                 errorClass: 'help-block form-error',
                 errorElement: 'span',
                 errorPlacement: function(error, element) {
-                    element.parents('.required').append(error);
+                    $(element).hasClass('select2')
+                        // If the element is a select2 then place the error above the input
+                        ? element.parents('.required').append(error)
+                        // Otherwise place it after
+                        : error.insertAfter(element);
                 },
                 highlight: function(inputElement) {
                     $(inputElement).parent().addClass('has-error');

--- a/resources/views/partials/forms/edit/category-select.blade.php
+++ b/resources/views/partials/forms/edit/category-select.blade.php
@@ -4,7 +4,7 @@
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
 
     <div class="col-md-7{{  (isset($item) && (Helper::checkIfRequired($item, $fieldname))) ? ' required' : '' }}">
-        <select class="js-data-ajax" data-endpoint="categories/{{ (isset($category_type)) ? $category_type : 'assets' }}" data-placeholder="{{ trans('general.select_category') }}" name="{{ $fieldname }}" style="width: 100%" id="category_select_id" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' data-validation="required" required' : '' !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+        <select class="js-data-ajax" data-endpoint="categories/{{ (isset($category_type)) ? $category_type : 'assets' }}" data-placeholder="{{ trans('general.select_category') }}" name="{{ $fieldname }}" style="width: 100%" id="category_select_id" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' required ' : '' !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
             @if ($category_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $category_id }}" selected="selected" role="option" aria-selected="true"  role="option">
                     {{ (\App\Models\Category::find($category_id)) ? \App\Models\Category::find($category_id)->name : '' }}

--- a/resources/views/partials/forms/edit/location-select.blade.php
+++ b/resources/views/partials/forms/edit/location-select.blade.php
@@ -3,7 +3,7 @@
 
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
-        <select class="js-data-ajax" data-endpoint="locations" data-placeholder="{{ trans('general.select_location') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ $fieldname }}_location_select" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' data-validation="required" required' : '' !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+        <select class="js-data-ajax" data-endpoint="locations" data-placeholder="{{ trans('general.select_location') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ $fieldname }}_location_select" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' required ' : '' !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
             @if ($location_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $location_id }}" selected="selected" role="option" aria-selected="true"  role="option">
                     {{ (\App\Models\Location::find($location_id)) ? \App\Models\Location::find($location_id)->name : '' }}

--- a/resources/views/partials/forms/edit/manufacturer-select.blade.php
+++ b/resources/views/partials/forms/edit/manufacturer-select.blade.php
@@ -4,7 +4,7 @@
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
 
     <div class="col-md-7{{  ((isset($required)) && ($required=='true')) ? ' required' : '' }}">
-        <select class="js-data-ajax" data-endpoint="manufacturers" data-placeholder="{{ trans('general.select_manufacturer') }}" name="{{ $fieldname }}" style="width: 100%" id="manufacturer_select_id" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' data-validation="required" required' : '' !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+        <select class="js-data-ajax" data-endpoint="manufacturers" data-placeholder="{{ trans('general.select_manufacturer') }}" name="{{ $fieldname }}" style="width: 100%" id="manufacturer_select_id" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' required ' : '' !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
             @if ($manufacturer_id = old($fieldname,  (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $manufacturer_id }}" selected="selected" role="option" aria-selected="true"  role="option">
                     {{ (\App\Models\Manufacturer::find($manufacturer_id)) ? \App\Models\Manufacturer::find($manufacturer_id)->name : '' }}

--- a/resources/views/partials/forms/edit/model-select.blade.php
+++ b/resources/views/partials/forms/edit/model-select.blade.php
@@ -4,7 +4,7 @@
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
 
     <div class="col-md-7{{  ((isset($field_req)) || ((isset($required) && ($required =='true')))) ?  ' required' : '' }}">
-        <select class="js-data-ajax" data-endpoint="models" data-placeholder="{{ trans('general.select_model') }}" name="{{ $fieldname }}" style="width: 100%" id="model_select_id" aria-label="{{ $fieldname }}"{!!  (isset($field_req) ? ' data-validation="required" required' : '') !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+        <select class="js-data-ajax" data-endpoint="models" data-placeholder="{{ trans('general.select_model') }}" name="{{ $fieldname }}" style="width: 100%" id="model_select_id" aria-label="{{ $fieldname }}"{!!  (isset($field_req) ? ' required ' : '') !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
             @if ($model_id = old($fieldname, ($item->{$fieldname} ?? request($fieldname) ?? '')))
                 <option value="{{ $model_id }}" selected="selected">
                     {{ (\App\Models\AssetModel::find($model_id)) ? \App\Models\AssetModel::find($model_id)->name : '' }}

--- a/resources/views/partials/forms/edit/model-select.blade.php
+++ b/resources/views/partials/forms/edit/model-select.blade.php
@@ -4,7 +4,7 @@
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
 
     <div class="col-md-7{{  ((isset($field_req)) || ((isset($required) && ($required =='true')))) ?  ' required' : '' }}">
-        <select class="js-data-ajax" data-endpoint="models" data-placeholder="{{ trans('general.select_model') }}" name="{{ $fieldname }}" style="width: 100%" id="model_select_id" aria-label="{{ $fieldname }}"{!!  (isset($field_req) ? ' required ' : '') !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+        <select class="select2 js-data-ajax" data-endpoint="models" data-placeholder="{{ trans('general.select_model') }}" name="{{ $fieldname }}" style="width: 100%" id="model_select_id" aria-label="{{ $fieldname }}"{!!  (isset($field_req) ? ' required ' : '') !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
             @if ($model_id = old($fieldname, ($item->{$fieldname} ?? request($fieldname) ?? '')))
                 <option value="{{ $model_id }}" selected="selected">
                     {{ (\App\Models\AssetModel::find($model_id)) ? \App\Models\AssetModel::find($model_id)->name : '' }}

--- a/resources/views/partials/forms/edit/model-select.blade.php
+++ b/resources/views/partials/forms/edit/model-select.blade.php
@@ -4,7 +4,7 @@
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
 
     <div class="col-md-7{{  ((isset($field_req)) || ((isset($required) && ($required =='true')))) ?  ' required' : '' }}">
-        <select class="select2 js-data-ajax" data-endpoint="models" data-placeholder="{{ trans('general.select_model') }}" name="{{ $fieldname }}" style="width: 100%" id="model_select_id" aria-label="{{ $fieldname }}"{!!  (isset($field_req) ? ' required ' : '') !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+        <select class="js-data-ajax" data-endpoint="models" data-placeholder="{{ trans('general.select_model') }}" name="{{ $fieldname }}" style="width: 100%" id="model_select_id" aria-label="{{ $fieldname }}"{!!  (isset($field_req) ? ' required ' : '') !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
             @if ($model_id = old($fieldname, ($item->{$fieldname} ?? request($fieldname) ?? '')))
                 <option value="{{ $model_id }}" selected="selected">
                     {{ (\App\Models\AssetModel::find($model_id)) ? \App\Models\AssetModel::find($model_id)->name : '' }}

--- a/resources/views/partials/forms/edit/name.blade.php
+++ b/resources/views/partials/forms/edit/name.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('name') ? ' has-error' : '' }}">
     <label for="name" class="col-md-3 control-label">{{ $translated_name }}</label>
     <div class="col-md-7 col-sm-12{{  (Helper::checkIfRequired($item, 'name')) ? ' required' : '' }}">
-        <input class="form-control" type="text" name="name" aria-label="name" id="name" value="{{ old('name', $item->name) }}"{!!  (Helper::checkIfRequired($item, 'name')) ? ' data-validation="required" required' : '' !!} />
+        <input class="form-control" type="text" name="name" aria-label="name" id="name" value="{{ old('name', $item->name) }}"{!!  (Helper::checkIfRequired($item, 'name')) ? ' required' : '' !!} />
         {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/quantity.blade.php
+++ b/resources/views/partials/forms/edit/quantity.blade.php
@@ -4,7 +4,7 @@
     <label for="qty" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
     <div class="col-md-7{{  (Helper::checkIfRequired($item, 'qty')) ? ' required' : '' }}">
        <div class="col-md-3" style="padding-left:0px">
-           <input class="form-control" type="text" name="qty" aria-label="qty" id="qty" value="{{ old('qty', $item->qty) }}" {!!  (Helper::checkIfRequired($item, 'qty')) ? ' data-validation="required" required' : '' !!}/>
+           <input class="form-control" type="text" name="qty" aria-label="qty" id="qty" value="{{ old('qty', $item->qty) }}" {!!  (Helper::checkIfRequired($item, 'qty')) ? ' required ' : '' !!}/>
        </div>
        {!! $errors->first('qty', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
    </div>

--- a/resources/views/partials/forms/edit/status-select.blade.php
+++ b/resources/views/partials/forms/edit/status-select.blade.php
@@ -4,7 +4,7 @@
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
 
     <div class="col-md-7{{  ((isset($required)) && ($required=='true')) ? ' required' : '' }}">
-        <select class="js-data-ajax" data-endpoint="statuslabels" data-placeholder="{{ trans('general.select_statuslabel') }}" name="{{ $fieldname }}" style="width: 100%" id="status_select_id" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' data-validation="required" required' : '' !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
+        <select class="js-data-ajax" data-endpoint="statuslabels" data-placeholder="{{ trans('general.select_statuslabel') }}" name="{{ $fieldname }}" style="width: 100%" id="status_select_id" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' required ' : '' !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
             @if ($status_id = old($fieldname,  (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $status_id }}" selected="selected" role="option" aria-selected="true"  role="option">
                     {{ (\App\Models\Statuslabel::find($status_id)) ? \App\Models\Statuslabel::find($status_id)->name : '' }}

--- a/resources/views/partials/forms/edit/status.blade.php
+++ b/resources/views/partials/forms/edit/status.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('status_id') ? ' has-error' : '' }}">
     <label for="status_id" class="col-md-3 control-label">{{ trans('admin/hardware/form.status') }}</label>
     <div class="col-md-7 col-sm-11{{  (Helper::checkIfRequired($item, 'status_id')) ? ' required' : '' }}">
-        {{ Form::select('status_id', $statuslabel_list , old('status_id', $item->status_id), array('class'=>'select2 status_id', 'style'=>'width:100%','id'=>'status_select_id', 'aria-label'=>'status_id', 'data-validation' => "required", 'required' => 'required')) }}
+        {{ Form::select('status_id', $statuslabel_list , old('status_id', $item->status_id), array('class'=>'select2 status_id', 'style'=>'width:100%','id'=>'status_select_id', 'aria-label'=>'status_id', 'required' => 'required')) }}
         {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
     <div class="col-md-2 col-sm-2 text-left">

--- a/resources/views/partials/forms/edit/status.blade.php
+++ b/resources/views/partials/forms/edit/status.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('status_id') ? ' has-error' : '' }}">
     <label for="status_id" class="col-md-3 control-label">{{ trans('admin/hardware/form.status') }}</label>
     <div class="col-md-7 col-sm-11{{  (Helper::checkIfRequired($item, 'status_id')) ? ' required' : '' }}">
-        {{ Form::select('status_id', $statuslabel_list , old('status_id', $item->status_id), array('class'=>'select2 status_id', 'style'=>'width:100%','id'=>'status_select_id', 'aria-label'=>'status_id', 'data-validation' => "required")) }}
+        {{ Form::select('status_id', $statuslabel_list , old('status_id', $item->status_id), array('class'=>'select2 status_id', 'style'=>'width:100%','id'=>'status_select_id', 'aria-label'=>'status_id', 'data-validation' => "required", 'required' => 'required')) }}
         {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
     <div class="col-md-2 col-sm-2 text-left">

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -52,7 +52,7 @@
                                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                 @else
                                     {{ Form::text('site_name',
-                                        Request::old('site_name', $setting->site_name), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management', 'data-validation' => 'required')) }}
+                                        Request::old('site_name', $setting->site_name), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management', 'required' => 'required')) }}
                                 @endif
                                 {!! $errors->first('site_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>

--- a/tests/Feature/Settings/BrandingSettingsTest.php
+++ b/tests/Feature/Settings/BrandingSettingsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Feature\Settings;
+
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class BrandingSettingsTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testSiteNameIsRequired()
+    {
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('settings.branding.save', ['site_name' => '']))
+            ->assertInvalid('site_name');
+    }
+}

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -154,7 +154,7 @@ mix.combine(
     "./resources/assets/js/extensions/pGenerator.jquery.js",
     "./node_modules/chart.js/dist/Chart.js",
     "./resources/assets/js/signature_pad.js",
-    //"./node_modules/jquery-form-validator/form-validator/jquery.form-validator.js", //problem?
+    "./node_modules/jquery-validation/dist/jquery.validate.js",
     "./node_modules/list.js/dist/list.js",
     "./node_modules/clipboard/dist/clipboard.js",
   ],


### PR DESCRIPTION
# Description

Replaces #13863

---

This PR replaces the removed `jquery-form-validator` package with [`jquery-validation`](https://jqueryvalidation.org/), a package that is [actively maintained](https://github.com/jquery-validation/jquery-validation), on the v7 branch.

In doing so it fixes two bugs mentioned in #13863: 

The missing tool tip on create pages is back:
![image](https://github.com/snipe/snipe-it/assets/1141514/c29f8a67-3810-4894-9bf4-34c01bbbd83b)

Lightbox images are displayed over the page without opening in a new tab:
![image](https://github.com/snipe/snipe-it/assets/1141514/7c97431a-b27f-4135-9803-9cf9a1d71650)

---

Here is what "required" validation messages look like with the new package:
![example](https://github.com/snipe/snipe-it/assets/1141514/b21feb38-1c8f-4375-ac4b-7955c9a0e116)


---

There are a few things to note that are different.

First, it doesn't seem like the browser's tooltips don't pop up with the new package. Here is an example of what popped up before but is not happening now:
![browser tooltip](https://github.com/snipe/snipe-it/assets/1141514/ae8c71ee-c317-4b8c-a7bd-1050571e12ae)

In both cases the error message below the input is displayed so the end result is the same but still...it might be worth investigating further in the future.


In addition, previously error messages would appear one at a time but now they appear all at once. (A quick scan of the docs didn't reveal a way to change that)

| Before | After |
|--------|-------|
| ![before](https://github.com/snipe/snipe-it/assets/1141514/5f4fa670-805d-4bf0-9a77-994a3229d566)   | ![after](https://github.com/snipe/snipe-it/assets/1141514/2eb3a43d-fd75-4b24-9a3d-c19306d725ed)  |

---

For reference: [here are the docs](https://jqueryvalidation.org/validate/) on what can be passed to the `validate()` method.

---

I threw in a small test case around ensuring the site name is required on the branding page. Users would have to disable javascript to submit a blank site name on the branding page but having some server side validation doesn't hurt.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) ❓