### PR TITLE
Hiding Order Column in Custom Fieldsets

### DIFF
--- a/resources/views/custom_fields/fieldsets/view.blade.php
+++ b/resources/views/custom_fields/fieldsets/view.blade.php
@@ -29,7 +29,7 @@
               @can('update', $custom_fieldset)
               <th class="col-md-1"><span class="sr-only">{{ trans('admin/custom_fields/general.reorder') }}</span></th>
               @endcan
-              <th class="col-md-1">{{ trans('admin/custom_fields/general.order') }}</th>
+              <th class="col-md-1" style="display: none;">{{ trans('admin/custom_fields/general.order') }}</th>
               <th class="col-md-3">{{ trans('admin/custom_fields/general.field_name') }}</th>
               <th class="col-md-2">{{ trans('admin/custom_fields/general.field_format') }}</th>
               <th class="col-md-2">{{ trans('admin/custom_fields/general.field_element') }}</th>
@@ -51,7 +51,7 @@
                 </span>
               </td>
               @endcan
-              <td class="index">{{$field->pivot->order + 1}}</td>
+              <td class="index" style="display: none;">{{$field->pivot->order + 1}}</td> {{--this +1 needs to exist to keep the first row from reverting to 0 if you edit/delete fields in/from a fielset--}}
               <td>{{$field->name}}</td>
               <td>{{$field->format}}</td>
               <td>{{$field->element}}</td>
@@ -110,7 +110,7 @@
                   </label>
 
                 </div>
-                <div class="form-group col-md-2">
+                <div class="form-group col-md-2" style="display: none;">
 
                   {{ Form::text('order', $maxid, array('class' => 'form-control col-sm-1 col-md-1', 'style'=> 'width: 80px; padding-;right: 10px;', 'aria-label'=>'order', 'maxlength'=>'3', 'size'=>'3')) }}
                   <label for="order">{{ trans('admin/custom_fields/general.order') }}</label>


### PR DESCRIPTION
There was a bug in the Custom Fieldsets page when associating a custom field to a fieldset. This bug was purely graphical, and would add 1 to the order number you chose when saving a custom field to a fieldset.  EX: you entered 2 for the Order and it saved as a 3.

The mechanics on the backend for ordering custom fields would work correctly, and your order would remain as originally inputted. However, merely touching/clicking/dragging the elipses on the rows used to reorder the custom fields, would re-number that order starting at 0.
<img width="295" alt="Screenshot 2023-11-20 at 8 45 14 PM" src="https://github.com/snipe/snipe-it/assets/116301219/a6071bb1-04bb-4761-bce8-4a316d7b21fc">



EX: you enter Order: 1 2 3 4 5, and then delete the row with Order 4, leaving 1 2 3 5
Once touching an ellipsis, it would reorder on the back end to 0 1 2 3, but would be in the same order.
Only the number changed.
<img width="477" alt="Screenshot 2023-11-20 at 8 43 18 PM" src="https://github.com/snipe/snipe-it/assets/116301219/01f6b18b-6751-4567-8acf-e7be30da7f2f">
<img width="442" alt="Screenshot 2023-11-20 at 8 43 33 PM" src="https://github.com/snipe/snipe-it/assets/116301219/4aa4dc7a-5fb4-4e7c-8a7e-83976c63e370">
<img width="431" alt="Screenshot 2023-11-20 at 8 43 44 PM" src="https://github.com/snipe/snipe-it/assets/116301219/b40ccb95-aa0c-4337-b8f5-7a943639517d">

This PR removes the order column and order input boxes **ONLY VISUALLY**. Thus, removing any confusion or wonkiness in how the app is handling the ordering for you.  The ellipses are still available to drag and reorder the custom fields as you would like.

**OLD**
<img width="962" alt="Screenshot 2023-11-20 at 8 49 32 PM" src="https://github.com/snipe/snipe-it/assets/116301219/8d4bf950-39f5-410c-8572-38f1bcf3c3cc">

**NEW**
<img width="799" alt="Screenshot 2023-11-20 at 8 50 09 PM" src="https://github.com/snipe/snipe-it/assets/116301219/c2d33158-42f8-4904-bc25-c91ce96d9c40">


Fixes #SC-23999

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested via local test instance with TablePlus.
No backend functionality has changed. Order is still a column on the pivot table for custom fields/custom fieldsets and can still be used and set via API.  However, upon touching the ellipses, the rows WILL reorder in the database, starting with 0 for the first row.


**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
