### PR TITLE
Fixed #13905 - Use `unique_undeleted` instead of `unique_serial`

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -99,15 +99,16 @@ class Asset extends Depreciable
         'expected_checkin' => 'date|nullable',
         'location_id'     => 'exists:locations,id|nullable',
         'rtd_location_id' => 'exists:locations,id|nullable',
-        'asset_tag'      => 'required|min:1|max:255|unique_undeleted:assets,asset_tag|not_array',
+        'asset_tag'       => 'required|min:1|max:255|unique_undeleted:assets,asset_tag|not_array',
         'purchase_date'   => 'date|date_format:Y-m-d|nullable',
-        'serial'          => 'unique_serial|nullable',
+        'serial'          => 'unique_undeleted:assets,serial|nullable',
         'purchase_cost'   => 'numeric|nullable|gte:0',
         'supplier_id'     => 'exists:suppliers,id|nullable',
         'asset_eol_date'  => 'date|nullable',
         'eol_explicit'    => 'boolean|nullable',
         'byod'            => 'boolean',
     ];
+
 
   /**
    * The attributes that are mass assignable.

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -63,13 +63,7 @@ class ValidationServiceProvider extends ServiceProvider
          * `unique_undeleted:table,fieldname` in your rules out of the box
          */
         Validator::extend('unique_undeleted', function ($attribute, $value, $parameters, $validator) {
-
-            \Log::debug('Parameters: ');
-            \Log::debug(print_r($parameters, true));
-
-            \Log::debug('Attribute: '. $attribute);
-            \Log::debug('Value: '. $value);
-
+            
             if (count($parameters)) {
 
                 // This is a bit of a shim, but serial doesn't have any other rules around it other than that it's nullable

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -63,12 +63,11 @@ class ValidationServiceProvider extends ServiceProvider
          * `unique_undeleted:table,fieldname` in your rules out of the box
          */
         Validator::extend('unique_undeleted', function ($attribute, $value, $parameters, $validator) {
-            
+
             if (count($parameters)) {
 
                 // This is a bit of a shim, but serial doesn't have any other rules around it other than that it's nullable
                 if (($parameters[0]=='assets') && ($attribute == 'serial') && (Setting::getSettings()->unique_serial != '1')) {
-                    \Log::debug('Checking for serial and it is not unique');
                     return true;
                 }
 

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -46,43 +46,62 @@ class ValidationServiceProvider extends ServiceProvider
             return $validator->passes();
         });
 
-        // Unique only if undeleted
-        // This works around the use case where multiple deleted items have the same unique attribute.
-        // (I think this is a bug in Laravel's validator?)
-        // $parameters is the rule parameters, like `unique_undeleted:users,id` - $parameters[0] is users, $parameters[1] is id
-        // the UniqueUndeletedTrait prefills these so you can just use `unique_undeleted` in your rules (but this would only work directly in the model)
+
+        /**
+         * Unique only if undeleted.
+         *
+         * This works around the use case where multiple deleted items have the same unique attribute.
+         * (I think this is a bug in Laravel's validator?)
+         *
+         * $attribute is the FIELDNAME you're checking against
+         * $value is the VALUE of the item you're checking against the existing values in the fieldname
+         * $parameters[0] is the TABLE NAME you're querying
+         * $parameters[1] is the ID of the item you're querying - this makes it work on saving, checkout, etc,
+         *   since it defaults to 0 if there is no item created yet (new item), but populates the ID if editing
+         *
+         * The UniqueUndeletedTrait prefills these parameters, so you can just use
+         * `unique_undeleted:table,fieldname` in your rules out of the box
+         */
         Validator::extend('unique_undeleted', function ($attribute, $value, $parameters, $validator) {
+
+            \Log::debug('Parameters: ');
+            \Log::debug(print_r($parameters, true));
+
+            \Log::debug('Attribute: '. $attribute);
+            \Log::debug('Value: '. $value);
+
             if (count($parameters)) {
-                $count = DB::table($parameters[0])->select('id')->where($attribute, '=', $value)->whereNull('deleted_at')->where('id', '!=', $parameters[1])->count();
+
+                // This is a bit of a shim, but serial doesn't have any other rules around it other than that it's nullable
+                if (($parameters[0]=='assets') && ($attribute == 'serial') && (Setting::getSettings()->unique_serial != '1')) {
+                    \Log::debug('Checking for serial and it is not unique');
+                    return true;
+                }
+
+                $count = DB::table($parameters[0])
+                    ->select('id')
+                    ->where($attribute, '=', $value)
+                    ->whereNull('deleted_at')
+                    ->where('id', '!=', $parameters[1])->count();
 
                 return $count < 1;
             }
         });
 
         // Unique if undeleted for two columns
-            // Same as unique_undeleted but taking the combination of two columns as unique constrain.
-            Validator::extend('two_column_unique_undeleted', function ($attribute, $value, $parameters, $validator) {
-                if (count($parameters)) {
-                    $count = DB::table($parameters[0])
-                             ->select('id')->where($attribute, '=', $value)
-                             ->whereNull('deleted_at')
-                             ->where('id', '!=', $parameters[1])
-                             ->where($parameters[2], $parameters[3])->count();
-
-                    return $count < 1;
-                }
-            });
-
-
-        Validator::extend('unique_serial', function ($attribute, $value, $parameters, $validator) {
-            if(Setting::getSettings()->unique_serial == '1') {
-                $count = DB::table('assets')->select('id')->where('serial', '=', $value)->whereNull('deleted_at')->count();
+        // Same as unique_undeleted but taking the combination of two columns as unique constrain.
+        Validator::extend('two_column_unique_undeleted', function ($attribute, $value, $parameters, $validator) {
+            if (count($parameters)) {
+                $count = DB::table($parameters[0])
+                         ->select('id')->where($attribute, '=', $value)
+                         ->whereNull('deleted_at')
+                         ->where('id', '!=', $parameters[1])
+                         ->where($parameters[2], $parameters[3])->count();
 
                 return $count < 1;
-            } else {
-                return true;
             }
         });
+
 
         // Prevent circular references
         //


### PR DESCRIPTION
This fixes a regression created in #13887 (which was created because of a bug created in #13830), where because `unique_serial` was turned into a real custom validator but didn't have any traits associated with it, it wouldn't let you edit (or checkout, checkin, etc) assets if unique serial was enabled. 

![BNt_xJnBwyG91kZnfiA0Zo_w8A8fjnXGHw](https://github.com/snipe/snipe-it/assets/197404/86f4f2c0-e607-4b19-ab77-78949bf296a0)

The crappy workaround for this right now (before this PR gets merged) is to disable the uniqueness constraint when checking items in/out, and then turn it back on when you're done, but we can all agree this is a terrible solution. 

Rather than have two custom validators that do the same thing, and add the UniqueSerialTrait back in, this PR adds a check to see if the table is `assets`, the field is `serial`, and whether or not the settings require it to be unique. This allows us to just use the original `unique_undeleted` and the trait that handles those things, which means the original issue that was being fixed (the rollbar on form requests) won't re-occur.

I also clarified some incorrect information around how the `$parameters`, `$attribute` and `$value` parameters in the validator work, which should help clear up future confusion.

## Testing:

### With Unique Serial Enforcement enabled:

- create a new asset
- edit an existing asset
- do a POST and PATCH via the hardware API
- checkout and asset
- checkin an asset
- audit an asset

__Note__: this test will get wonky if you have more than one of the same serial already and THEN turn on unique serial constraints, but that's sort of to be expected - we can work on that later.

### Without Unique Serial Enforcement enabled:

- create a new asset
- edit an existing asset
- do a POST and PATCH via the hardware API
- checkout and asset
- checkin an asset
- audit an asset

### Todo in a future PR:

- Modify the notification blade to check for arrays and handle those a little more elegantly (parse the array)
- Potentially set up guardrails so that if there are any non-unique serial numbers, the checkbox for turning unique serial numbers on is greyed out
- Possibly allow checkout/checkin if serial numbers are not unique if unique serials are enabled, since they would have been created *before* the uniqueness constraint was enabled

Fixes #13905, FD-39082