### PR TITLE
Fixed missing translation string for `validation.two_column_unique_undeleted`

### DIFF
--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -80,9 +80,14 @@ class ValidationServiceProvider extends ServiceProvider
                 return $count < 1;
             }
         });
+        
+        /**
+         * Unique if undeleted for two columns
+         *
+         * Same as unique_undeleted but taking the combination of two columns as unique constrain.
+         * This uses the Validator::replacer('two_column_unique_undeleted') below for nicer translations.
+         */
 
-        // Unique if undeleted for two columns
-        // Same as unique_undeleted but taking the combination of two columns as unique constrain.
         Validator::extend('two_column_unique_undeleted', function ($attribute, $value, $parameters, $validator) {
             if (count($parameters)) {
                 $count = DB::table($parameters[0])
@@ -93,6 +98,24 @@ class ValidationServiceProvider extends ServiceProvider
 
                 return $count < 1;
             }
+        });
+
+
+        /**
+         * This is the validator replace static method that allows us to pass the $parameters of the table names
+         * into the translation string in validation.two_column_unique_undeleted for two_column_unique_undeleted
+         * validation messages.
+         *
+         * This is invoked automatically by Validator::extend('two_column_unique_undeleted') above and
+         * produces a translation like: "The name value must be unique across categories and category type."
+         */
+        Validator::replacer('two_column_unique_undeleted', function($message, $attribute, $rule, $parameters) {
+            $message = str_replace(':table1', $parameters[0], $message);
+            $message = str_replace(':table2', $parameters[2], $message);
+
+            // Change underscores to spaces for a friendlier display
+            $message = str_replace('_', ' ', $message);
+            return $message;
         });
 
 

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -87,7 +87,6 @@ class ValidationServiceProvider extends ServiceProvider
          * Same as unique_undeleted but taking the combination of two columns as unique constrain.
          * This uses the Validator::replacer('two_column_unique_undeleted') below for nicer translations.
          */
-
         Validator::extend('two_column_unique_undeleted', function ($attribute, $value, $parameters, $validator) {
             if (count($parameters)) {
                 $count = DB::table($parameters[0])

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -86,6 +86,13 @@ class ValidationServiceProvider extends ServiceProvider
          *
          * Same as unique_undeleted but taking the combination of two columns as unique constrain.
          * This uses the Validator::replacer('two_column_unique_undeleted') below for nicer translations.
+         *
+         * $parameters[0] - the name of the first table we're looking at
+         * $parameters[1] - the ID (this will be 0 on new creations)
+         * $parameters[2] - the name of the second table we're looking at
+         * $parameters[3] - the value that the request is passing for the second table we're
+         *                  checking for uniqueness across
+         *
          */
         Validator::extend('two_column_unique_undeleted', function ($attribute, $value, $parameters, $validator) {
             if (count($parameters)) {
@@ -107,6 +114,9 @@ class ValidationServiceProvider extends ServiceProvider
          *
          * This is invoked automatically by Validator::extend('two_column_unique_undeleted') above and
          * produces a translation like: "The name value must be unique across categories and category type."
+         *
+         * The $parameters passed coincide with the ones the two_column_unique_undeleted custom validator above
+         * uses, so $parameter[0] is the first table and so $parameter[2] is the second table.
          */
         Validator::replacer('two_column_unique_undeleted', function($message, $attribute, $rule, $parameters) {
             $message = str_replace(':table1', $parameters[0], $message);

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -90,6 +90,7 @@ return [
     ],
     'string'               => 'The :attribute must be a string.',
     'timezone'             => 'The :attribute must be a valid zone.',
+    'two_column_unique_undeleted' => 'The :attribute value must be unique across :table1 and :table2. ',
     'unique'               => 'The :attribute has already been taken.',
     'uploaded'             => 'The :attribute failed to upload.',
     'url'                  => 'The :attribute format is invalid.',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -90,7 +90,7 @@ return [
     ],
     'string'               => 'The :attribute must be a string.',
     'timezone'             => 'The :attribute must be a valid zone.',
-    'two_column_unique_undeleted' => 'The :attribute value must be unique across :table1 and :table2. ',
+    'two_column_unique_undeleted' => 'The :attribute must be unique across :table1 and :table2. ',
     'unique'               => 'The :attribute has already been taken.',
     'uploaded'             => 'The :attribute failed to upload.',
     'url'                  => 'The :attribute format is invalid.',


### PR DESCRIPTION
This PR adds a missing translation string for the  `two_column_unique_undeleted` custom validation.

Additionally, plain default validation strings can only accept `:attribute` as a default value in there, so it would end up being confusing as to what two things are being compared. "The name must be unique when something else that we won't tell you is the same" isn't really useful feedback, so I've also added a `Validator::replace()` method in there so we can customize that error feedback a little more. 

### Before

<img width="781" alt="Screenshot 2023-11-21 at 1 50 27 PM" src="https://github.com/snipe/snipe-it/assets/197404/50b169d1-4574-4df6-90ad-8a601fba6e4d">

### After

<img width="777" alt="Screenshot 2023-11-21 at 3 08 27 PM" src="https://github.com/snipe/snipe-it/assets/197404/47f27425-7b9f-4c6c-a6c4-a49b4fff35b7">
