### PR TITLE
Created mutator on category checkin_email

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -249,6 +249,26 @@ class Category extends SnipeModel
 
     /**
      * -----------------------------------------------
+     * BEGIN MUTATORS
+     * -----------------------------------------------
+     **/
+
+    /**
+     * This sets the checkin_value to a boolean 0 or 1. This accounts for forms or API calls that
+     * explicitly pass the checkin_email field but it has a null or empty value.
+     *
+     * This will also correctly parse "true"/"false" passed.
+     *
+     * @param $value
+     * @return void
+     */
+    public function setCheckinEmailAttribute($value)
+    {
+        $this->attributes['checkin_email'] = (int) filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * -----------------------------------------------
      * BEGIN QUERY SCOPES
      * -----------------------------------------------
      **/

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -257,7 +257,7 @@ class Category extends SnipeModel
      * This sets the checkin_value to a boolean 0 or 1. This accounts for forms or API calls that
      * explicitly pass the checkin_email field but it has a null or empty value.
      *
-     * This will also correctly parse "true"/"false" passed.
+     * This will also correctly parse a 1/0 if "true"/"false" is passed.
      *
      * @param $value
      * @return void


### PR DESCRIPTION
This wouldn't happen in normal use, but we see it with the API explorer, since that posts the form as it is on the page, which means `checkin_email` will be posted but could possibly be null. The database field itself isn't nullable, and if you *don't* send the field, it will gracefully default to 0 (since the DB field is default 0), but if you *do* pass the field in the payload and it's null, the DB get's angry.

This mutator is a quick fix that will make sure that it's ALWAYS set to a boolean value, even if the value passed is null. 

This has the added benefit of correctly handle `true` and `false` as payload values and converting them into the 1 or 0 that the database is expecting. It's not truthy in the way that if you pass it `4` or `butts` as the `checkin_email` value, it will return a 0, but I think that's fine.

This fixes Demo RB-3659