### PR TITLE
Quick revert for #13830

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -534,8 +534,10 @@ class AssetsController extends Controller
      * @since [v4.0]
      * @return \Illuminate\Http\JsonResponse
      */
-    public function store(StoreAssetRequest $request)
+    public function store(ImageUploadRequest $request)
     {
+        return Gate::allows('create', new Asset);
+        
         $asset = new Asset();
         $asset->model()->associate(AssetModel::find((int) $request->get('model_id')));
 


### PR DESCRIPTION
This PR partially reverts #13830, which created a regression where auto-incrementing broke for API requests where an asset tag was not present. The logic of putting that into a form request is sound, but I think it has too many echo effects right now. This PR removes the reference to the StoreAssetRequest and reverts it to the ImageUploadRequest, but does not actually delete the StoreAssetRequest. We might be better suited to use mutators or at least rethink the form request rules. 