### PR TITLE
Set qty mutators

### DIFF
--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -366,6 +366,35 @@ class Accessory extends SnipeModel
     }
 
     /**
+     * -----------------------------------------------
+     * BEGIN MUTATORS
+     * -----------------------------------------------
+     **/
+
+    /**
+     * This sets a value for qty if no value is given. The database does not allow this
+     * field to be null, and in the other areas of the code, we set a default, but the importer
+     * does not.
+     *
+     * This simply checks that there is a value for quantity, and if there isn't, set it to 0.
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since v6.3.4
+     * @param $value
+     * @return void
+     */
+    public function setQtyAttribute($value)
+    {
+        $this->attributes['qty'] = (!$value) ? 0 : intval($value);
+    }
+
+    /**
+     * -----------------------------------------------
+     * BEGIN QUERY SCOPES
+     * -----------------------------------------------
+     **/
+
+    /**
     * Query builder scope to order on company
     *
     * @param  \Illuminate\Database\Query\Builder  $query  Query builder instance

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -224,6 +224,37 @@ class Component extends SnipeModel
         return $this->qty - $this->numCheckedOut();
     }
 
+
+    /**
+     * -----------------------------------------------
+     * BEGIN MUTATORS
+     * -----------------------------------------------
+     **/
+
+    /**
+     * This sets a value for qty if no value is given. The database does not allow this
+     * field to be null, and in the other areas of the code, we set a default, but the importer
+     * does not.
+     *
+     * This simply checks that there is a value for quantity, and if there isn't, set it to 0.
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since v6.3.4
+     * @param $value
+     * @return void
+     */
+    public function setQtyAttribute($value)
+    {
+        $this->attributes['qty'] = (!$value) ? 0 : intval($value);
+    }
+
+    /**
+     * -----------------------------------------------
+     * BEGIN QUERY SCOPES
+     * -----------------------------------------------
+     **/
+
+
     /**
      * Query builder scope to order on company
      *

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -340,6 +340,35 @@ class Consumable extends SnipeModel
     }
 
     /**
+     * -----------------------------------------------
+     * BEGIN MUTATORS
+     * -----------------------------------------------
+     **/
+
+    /**
+     * This sets a value for qty if no value is given. The database does not allow this
+     * field to be null, and in the other areas of the code, we set a default, but the importer
+     * does not.
+     *
+     * This simply checks that there is a value for quantity, and if there isn't, set it to 0.
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since v6.3.4
+     * @param $value
+     * @return void
+     */
+    public function setQtyAttribute($value)
+    {
+        $this->attributes['qty'] = (!$value) ? 0 : intval($value);
+    }
+
+    /**
+     * -----------------------------------------------
+     * BEGIN QUERY SCOPES
+     * -----------------------------------------------
+     **/
+
+    /**
      * Query builder scope to order on company
      *
      * @param  \Illuminate\Database\Query\Builder  $query  Query builder instance


### PR DESCRIPTION
This should hopefully solve a user error issue where the qty column is not set or is null in the importer. It just checks that `$value` (in this case `qty`) is not null, and if it is, it sets it to 0.

This should fix RB-16959/SC-20167.
