### PR TITLE
Fixes double logging on asset restore

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -763,14 +763,6 @@ class AssetsController extends Controller
             }
 
             if ($asset->restore()) {
-
-                $logaction = new Actionlog();
-                $logaction->item_type = Asset::class;
-                $logaction->item_id = $asset->id;
-                $logaction->created_at = date('Y-m-d H:i:s');
-                $logaction->user_id = Auth::user()->id;
-                $logaction->logaction('restored');
-
                 return response()->json(Helper::formatStandardApiResponse('success', trans('admin/hardware/message.restore.success')), 200);
             }
 

--- a/app/Http/Controllers/Api/ManufacturersController.php
+++ b/app/Http/Controllers/Api/ManufacturersController.php
@@ -187,7 +187,7 @@ class ManufacturersController extends Controller
                 $logaction->item_id = $manufacturer->id;
                 $logaction->created_at = date('Y-m-d H:i:s');
                 $logaction->user_id = Auth::user()->id;
-                $logaction->logaction('restored');
+                $logaction->logaction('restore');
 
                 return response()->json(Helper::formatStandardApiResponse('success', trans('admin/manufacturers/message.restore.success')), 200);
             }

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -704,7 +704,7 @@ class UsersController extends Controller
                 $logaction->item_id = $user->id;
                 $logaction->created_at = date('Y-m-d H:i:s');
                 $logaction->user_id = Auth::user()->id;
-                $logaction->logaction('restored');
+                $logaction->logaction('restore');
 
                 return response()->json(Helper::formatStandardApiResponse('success', trans('admin/users/message.restore.success')), 200);
             }

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -260,7 +260,7 @@ class AssetModelsController extends Controller
                 $logaction->item_id = $model->id;
                 $logaction->created_at = date('Y-m-d H:i:s');
                 $logaction->user_id = Auth::user()->id;
-                $logaction->logaction('restored');
+                $logaction->logaction('restore');
 
 
                 // Redirect them to the deleted page if there are more, otherwise the section index

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -803,13 +803,6 @@ class AssetsController extends Controller
             }
 
             if ($asset->restore()) {
-                $logaction = new Actionlog();
-                $logaction->item_type = Asset::class;
-                $logaction->item_id = $asset->id;
-                $logaction->created_at = date('Y-m-d H:i:s');
-                $logaction->user_id = Auth::user()->id;
-                $logaction->logaction('restored');
-
                 // Redirect them to the deleted page if there are more, otherwise the section index
                 $deleted_assets = Asset::onlyTrashed()->count();
                 if ($deleted_assets > 0) {

--- a/app/Http/Controllers/ManufacturersController.php
+++ b/app/Http/Controllers/ManufacturersController.php
@@ -238,7 +238,7 @@ class ManufacturersController extends Controller
                 $logaction->item_id = $manufacturer->id;
                 $logaction->created_at = date('Y-m-d H:i:s');
                 $logaction->user_id = Auth::user()->id;
-                $logaction->logaction('restored');
+                $logaction->logaction('restore');
 
                 // Redirect them to the deleted page if there are more, otherwise the section index
                 $deleted_manufacturers = Manufacturer::onlyTrashed()->count();

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -398,7 +398,7 @@ class UsersController extends Controller
                 $logaction->item_id = $user->id;
                 $logaction->created_at = date('Y-m-d H:i:s');
                 $logaction->user_id = Auth::user()->id;
-                $logaction->logaction('restored');
+                $logaction->logaction('restore');
 
                 // Redirect them to the deleted page if there are more, otherwise the section index
                 $deleted_users = User::onlyTrashed()->count();

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -22,6 +22,13 @@ class AssetObserver
         $attributesOriginal = $asset->getRawOriginal();
         $same_checkout_counter = false;
         $same_checkin_counter = false;
+        $restoring_or_deleting = false;
+
+
+        // This is a gross hack to prevent the double logging when restoring an asset
+        if (array_key_exists('deleted_at', $attributes)  && array_key_exists('deleted_at', $attributesOriginal)){
+            $restoring_or_deleting = (($attributes['deleted_at'] != $attributesOriginal['deleted_at']));
+        }
 
         if (array_key_exists('checkout_counter', $attributes) && array_key_exists('checkout_counter', $attributesOriginal)){
             $same_checkout_counter = (($attributes['checkout_counter'] == $attributesOriginal['checkout_counter']));
@@ -33,11 +40,12 @@ class AssetObserver
 
         // If the asset isn't being checked out or audited, log the update.
         // (Those other actions already create log entries.)
-	if (($attributes['assigned_to'] == $attributesOriginal['assigned_to']) 
+	    if (($attributes['assigned_to'] == $attributesOriginal['assigned_to'])
 	    && ($same_checkout_counter) && ($same_checkin_counter)
             && ((isset( $attributes['next_audit_date']) ? $attributes['next_audit_date'] : null) == (isset($attributesOriginal['next_audit_date']) ? $attributesOriginal['next_audit_date']: null))
-            && ($attributes['last_checkout'] == $attributesOriginal['last_checkout']))
+            && ($attributes['last_checkout'] == $attributesOriginal['last_checkout']) && ($restoring_or_deleting!=true))
         {
+            \Log::debug('Log the update');
             $changed = [];
 
             foreach ($asset->getRawOriginal() as $key => $value) {
@@ -119,6 +127,22 @@ class AssetObserver
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
         $logAction->logaction('delete');
+    }
+
+    /**
+     * Listen to the Asset deleting event.
+     *
+     * @param  Asset  $asset
+     * @return void
+     */
+    public function restoring(Asset $asset)
+    {
+        $logAction = new Actionlog();
+        $logAction->item_type = Asset::class;
+        $logAction->item_id = $asset->id;
+        $logAction->created_at = date('Y-m-d H:i:s');
+        $logAction->user_id = Auth::id();
+        $logAction->logaction('restore');
     }
 
     /**


### PR DESCRIPTION
The asset observer was logging the update in addition to our manual logging of the restore action. This fixes that, and uses the new verb "restore" (was "restored")