### PR TITLE
Added user observer

### DIFF
--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Actionlog;
+use App\Models\User;
+use Auth;
+
+class UserObserver
+{
+    /**
+     * Listen to the Asset updating event. This fires automatically every time an existing asset is saved.
+     *
+     * @param  User  $user
+     * @return void
+     */
+    public function updating(User $user)
+    {
+
+        $changed = [];
+        foreach ($user->getRawOriginal() as $key => $value) {
+            if ($user->getRawOriginal()[$key] != $user->getAttributes()[$key]) {
+
+                // Do not store the hashed password in changes
+                if ($key!='password') {
+                    $changed[$key]['old'] = $user->getRawOriginal()[$key];
+                    $changed[$key]['new'] = $user->getAttributes()[$key];
+                } else {
+                    $changed[$key]['old'] = '*************';
+                    $changed[$key]['new'] = '*************';
+                }
+            }
+        }
+
+        $logAction = new Actionlog();
+        $logAction->item_type = User::class;
+        $logAction->item_id = $user->id;
+        $logAction->created_at = date('Y-m-d H:i:s');
+        $logAction->user_id = Auth::id();
+        $logAction->log_meta = json_encode($changed);
+        $logAction->logaction('update');
+    }
+
+    /**
+     * Listen to the Asset created event, and increment
+     * the next_auto_tag_base value in the settings table when i
+     * a new asset is created.
+     *
+     * @param  User $user
+     * @return void
+     */
+    public function created(User $user)
+    {
+        $logAction = new Actionlog();
+        $logAction->item_type = User::class; // can we instead say $logAction->item = $asset ?
+        $logAction->item_id = $user->id;
+        $logAction->created_at = date('Y-m-d H:i:s');
+        $logAction->user_id = Auth::id();
+        $logAction->logaction('create');
+    }
+
+    /**
+     * Listen to the User deleting event.
+     *
+     * @param  User $user
+     * @return void
+     */
+    public function deleting(User $user)
+    {
+        $logAction = new Actionlog();
+        $logAction->item_type = User::class;
+        $logAction->item_id = $user->id;
+        $logAction->created_at = date('Y-m-d H:i:s');
+        $logAction->user_id = Auth::id();
+        $logAction->logaction('delete');
+    }
+
+    /**
+     * Listen to the User deleting event.
+     *
+     * @param  User $user
+     * @return void
+     */
+    public function restoring(User $user)
+    {
+        $logAction = new Actionlog();
+        $logAction->item_type = User::class;
+        $logAction->item_id = $user->id;
+        $logAction->created_at = date('Y-m-d H:i:s');
+        $logAction->user_id = Auth::id();
+        $logAction->logaction('restore');
+    }
+
+
+}

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -19,6 +19,7 @@ class UserObserver
 
         $changed = [];
         foreach ($user->getRawOriginal() as $key => $value) {
+
             if ($user->getRawOriginal()[$key] != $user->getAttributes()[$key]) {
 
                 // Do not store the hashed password in changes
@@ -28,6 +29,16 @@ class UserObserver
                 } else {
                     $changed[$key]['old'] = '*************';
                     $changed[$key]['new'] = '*************';
+                }
+
+                if ($key!='last_login') {
+                    unset($changed['last_login']['old']);
+                    unset($changed['last_login']['new']);
+                }
+
+                if ($key!='permissions') {
+                    unset($changed['permissions']['old']);
+                    unset($changed['permissions']['new']);
                 }
             }
         }

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -22,23 +22,24 @@ class UserObserver
 
             if ($user->getRawOriginal()[$key] != $user->getAttributes()[$key]) {
 
+                $changed[$key]['old'] = $user->getRawOriginal()[$key];
+                $changed[$key]['new'] = $user->getAttributes()[$key];
+
                 // Do not store the hashed password in changes
-                if ($key!='password') {
-                    $changed[$key]['old'] = $user->getRawOriginal()[$key];
-                    $changed[$key]['new'] = $user->getAttributes()[$key];
-                } else {
-                    $changed[$key]['old'] = '*************';
-                    $changed[$key]['new'] = '*************';
+                if ($key == 'password') {
+                    $changed['password']['old'] = '*************';
+                    $changed['password']['new'] = '*************';
                 }
 
-                if ($key!='last_login') {
-                    unset($changed['last_login']['old']);
-                    unset($changed['last_login']['new']);
+                // Do not store last login in changes
+                if ($key == 'last_login') {
+                    unset($changed['last_login']);
+                    unset($changed['last_login']);
                 }
 
-                if ($key!='permissions') {
-                    unset($changed['permissions']['old']);
-                    unset($changed['permissions']['new']);
+                if ($key == 'permissions') {
+                    unset($changed['permissions']);
+                    unset($changed['permissions']);
                 }
             }
         }
@@ -46,6 +47,8 @@ class UserObserver
         $logAction = new Actionlog();
         $logAction->item_type = User::class;
         $logAction->item_id = $user->id;
+        $logAction->target_type = User::class; // can we instead say $logAction->item = $asset ?
+        $logAction->target_id = $user->id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
         $logAction->log_meta = json_encode($changed);
@@ -81,6 +84,8 @@ class UserObserver
         $logAction = new Actionlog();
         $logAction->item_type = User::class;
         $logAction->item_id = $user->id;
+        $logAction->target_type = User::class; // can we instead say $logAction->item = $asset ?
+        $logAction->target_id = $user->id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
         $logAction->logaction('delete');
@@ -97,6 +102,8 @@ class UserObserver
         $logAction = new Actionlog();
         $logAction->item_type = User::class;
         $logAction->item_id = $user->id;
+        $logAction->target_type = User::class; // can we instead say $logAction->item = $asset ?
+        $logAction->target_id = $user->id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
         $logAction->logaction('restore');

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,10 +7,12 @@ use App\Models\Asset;
 use App\Models\Component;
 use App\Models\Consumable;
 use App\Models\License;
+use App\Models\User;
 use App\Models\Setting;
 use App\Models\SnipeSCIMConfig;
 use App\Observers\AccessoryObserver;
 use App\Observers\AssetObserver;
+use App\Observers\UserObserver;
 use App\Observers\ComponentObserver;
 use App\Observers\ConsumableObserver;
 use App\Observers\LicenseObserver;
@@ -58,6 +60,7 @@ class AppServiceProvider extends ServiceProvider
 
         Schema::defaultStringLength(191);
         Asset::observe(AssetObserver::class);
+        User::observe(UserObserver::class);
         Accessory::observe(AccessoryObserver::class);
         Component::observe(ComponentObserver::class);
         Consumable::observe(ConsumableObserver::class);


### PR DESCRIPTION
I know we've long talked about revamping the logging system, but this at least gets us to a point where we are at least tracking some of the changes to the user. There's likely a more elegant way to handle NOT logging things like password hashes, permission changes, etc, but this should do the trick for now.

<img width="1581" alt="Screenshot 2023-11-22 at 8 32 09 PM" src="https://github.com/snipe/snipe-it/assets/197404/adc55cf5-ad55-4afd-bc5b-f0aee8e4b637">
