### PR TITLE
Use updated icons for activity report

### DIFF
--- a/app/Presenters/ActionlogPresenter.php
+++ b/app/Presenters/ActionlogPresenter.php
@@ -38,21 +38,62 @@ class ActionlogPresenter extends Presenter
 
     public function icon()
     {
-        $itemicon = 'fas fa-paperclip';
+        
+        // User related icons
+        if ($this->itemType() == 'user') {
 
-        if ($this->itemType() == 'asset') {
-            return 'fas fa-barcode';
-        } elseif ($this->itemType() == 'accessory') {
-            return 'far fa-keyboard';
-        } elseif ($this->itemType() == 'consumable') {
-            return 'fas fa-tint';
-        } elseif ($this->itemType() == 'license') {
-            return 'far fa-save';
-        } elseif ($this->itemType() == 'component') {
-            return 'far fa-hdd';
-        } elseif ($this->itemType() == 'user') {
-            return 'fa-solid fa-people-arrows';
+            if ($this->actionType()=='create new') {
+                return 'fa-solid fa-user-plus';
+            }
+
+            if ($this->actionType()=='merged') {
+                return 'fa-solid fa-people-arrows';
+            }
+
+            if ($this->actionType()=='delete') {
+                return 'fa-solid fa-user-minus';
+            }
+
+            if ($this->actionType()=='delete') {
+                return 'fa-solid fa-user-minus';
+            }
+
+            if ($this->actionType()=='update') {
+                return 'fa-solid fa-user-pen';
+            }
+             return 'fa-solid fa-user';
         }
+
+        // Everything else
+        if ($this->actionType()=='create new') {
+            return 'fa-solid fa-plus';
+        }
+
+        if ($this->actionType()=='delete') {
+            return 'fa-solid fa-user-xmark';
+        }
+
+        if ($this->actionType()=='update') {
+            return 'fa-solid fa-pen';
+        }
+
+        if ($this->actionType()=='restore') {
+            return 'fa-solid fa-trash-arrow-up';
+        }
+
+        if ($this->actionType()=='upload') {
+            return 'fas fa-paperclip';
+        }
+
+        if ($this->actionType()=='checkout') {
+            return 'fa-solid fa-rotate-left';
+        }
+
+        if ($this->actionType()=='checkin from') {
+            return 'fa-solid fa-rotate-right';
+        }
+
+        return 'fa-solid fa-rotate-right';
 
     }
 


### PR DESCRIPTION
This updates the activity report icons to be more descriptive of the action versus the thing that was acted upon, since we already have those icons in the item/target section of the report.

<img width="1095" alt="Screenshot 2023-11-22 at 9 00 14 PM" src="https://github.com/snipe/snipe-it/assets/197404/39125c87-4e30-48c5-968d-8c72756c5102">
