### PR TITLE
Escape the asset tag before passing it to the view

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -205,8 +205,9 @@ class AssetsController extends Controller
         }
 
         if ($success) {
+            \Log::debug(e($asset->asset_tag));
             return redirect()->route('hardware.index')
-                ->with('success-unescaped', trans('admin/hardware/message.create.success_linked', ['link' => route('hardware.show', $asset->id), 'id', 'tag' => $asset->asset_tag]));
+                ->with('success-unescaped', trans('admin/hardware/message.create.success_linked', ['link' => route('hardware.show', $asset->id), 'id', 'tag' => e($asset->asset_tag)]));
                
       
         }


### PR DESCRIPTION
Just realized we weren't escaping the asset tag when we were passing it to the un-escaped view. This fixes that.