### PR TITLE
Refactored checkout for items with bad or missing category

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -18,31 +18,36 @@ class AccessoryCheckoutController extends Controller
      * Return the form to checkout an Accessory to a user.
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @param  int $accessoryId
+     * @param  int $id
      * @return View
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function create($accessoryId)
+    public function create($id)
     {
-        // Check if the accessory exists
-        if (is_null($accessory = Accessory::withCount('users as users_count')->find($accessoryId))) {
-            // Redirect to the accessory management page with error
-            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.not_found'));
-        }
 
-        // Make sure there is at least one available to checkout
-        if ($accessory->numRemaining() <= 0){
-            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.unavailable'));
-        }
-        
-        if ($accessory->category) {
+        if ($accessory = Accessory::withCount('users as users_count')->find($id)) {
+
             $this->authorize('checkout', $accessory);
 
-            // Get the dropdown of users and then pass it to the checkout view
-            return view('accessories/checkout', compact('accessory'));
+            if ($accessory->category) {
+                // Make sure there is at least one available to checkout
+                if ($accessory->numRemaining() <= 0){
+                    return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.checkout.unavailable'));
+                }
+
+                // Return the checkout view
+                return view('accessories/checkout', compact('accessory'));
+            }
+
+            // Invalid category
+            return redirect()->route('accessories.edit', ['accessory' => $accessory->id])
+                ->with('error', trans('general.invalid_item_category_single', ['type' => trans('general.accessory')]));
+
         }
 
-        return redirect()->back()->with('error', 'The category type for this accessory is not valid. Edit the accessory and select a valid accessory category.');
+        // Not found
+        return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.not_found'));
+
     }
 
     /**

--- a/app/Http/Controllers/Components/ComponentCheckoutController.php
+++ b/app/Http/Controllers/Components/ComponentCheckoutController.php
@@ -20,25 +20,38 @@ class ComponentCheckoutController extends Controller
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @see ComponentCheckoutController::store() method that stores the data.
      * @since [v3.0]
-     * @param int $componentId
+     * @param int $id
      * @return \Illuminate\Contracts\View\View
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function create($componentId)
+    public function create($id)
     {
-        // Check if the component exists
-        if (is_null($component = Component::find($componentId))) {
-            // Redirect to the component management page with error
-            return redirect()->route('components.index')->with('error', trans('admin/components/message.not_found'));
-        }
-        $this->authorize('checkout', $component);
 
-        // Make sure there is at least one available to checkout
-        if ($component->numRemaining() <= 0){
-            return redirect()->route('components.index')->with('error', trans('admin/components/message.checkout.unavailable'));
+        if ($component = Component::find($id)) {
+
+            $this->authorize('checkout', $component);
+
+            // Make sure the category is valid
+            if ($component->category) {
+
+                // Make sure there is at least one available to checkout
+                if ($component->numRemaining() <= 0){
+                    return redirect()->route('components.index')
+                        ->with('error', trans('admin/components/message.checkout.unavailable'));
+                }
+
+                // Return the checkout view
+                return view('components/checkout', compact('component'));
+            }
+
+            // Invalid category
+            return redirect()->route('components.edit', ['component' => $component->id])
+                ->with('error', trans('general.invalid_item_category_single', ['type' => trans('general.component')]));
         }
 
-        return view('components/checkout', compact('component'));
+        // Not found
+        return redirect()->route('components.index')->with('error', trans('admin/components/message.not_found'));
+
     }
 
     /**

--- a/app/Http/Controllers/Licenses/LicenseCheckoutController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckoutController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Licenses;
 use App\Events\CheckoutableCheckedOut;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\LicenseCheckoutRequest;
+use App\Models\Accessory;
 use App\Models\Asset;
 use App\Models\License;
 use App\Models\LicenseSeat;
@@ -21,23 +22,35 @@ class LicenseCheckoutController extends Controller
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v1.0]
-     * @param $licenseId
+     * @param $id
      * @return \Illuminate\Contracts\View\View
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function create($licenseId)
+    public function create($id)
     {
-        // Check that the license is valid
-        if ($license = License::find($licenseId)) {
+
+        if ($license = License::find($id)) {
 
             $this->authorize('checkout', $license);
-            // If the license is valid, check that there is an available seat
-            if ($license->avail_seats_count < 1) {
-                return redirect()->route('licenses.index')->with('error', 'There are no available seats for this license');
+
+            if ($license->category) {
+
+                // Make sure there is at least one available to checkout
+                if ($license->availCount()->count() < 1){
+                    return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.checkout.not_enough_seats'));
+                }
+
+                // Return the checkout view
+                return view('licenses/checkout', compact('license'));
             }
-            return view('licenses/checkout', compact('license'));
+
+            // Invalid category
+            return redirect()->route('licenses.edit', ['license' => $license->id])
+                ->with('error', trans('general.invalid_item_category_single', ['type' => trans('general.license')]));
+
         }
 
+        // Not found
         return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.not_found'));
 
 

--- a/resources/lang/en/admin/licenses/message.php
+++ b/resources/lang/en/admin/licenses/message.php
@@ -9,6 +9,7 @@ return array(
     'assoc_users'	 => 'This license is currently checked out to a user and cannot be deleted. Please check the license in first, and then try deleting again. ',
     'select_asset_or_person' => 'You must select an asset or a user, but not both.',
     'not_found' => 'License not found',
+    'seats_available' => ':seat_count seats available',
 
 
     'create' => array(
@@ -41,7 +42,8 @@ return array(
 
     'checkout' => array(
         'error'   => 'There was an issue checking out the license. Please try again.',
-        'success' => 'The license was checked out successfully'
+        'success' => 'The license was checked out successfully',
+        'not_enough_seats' => 'Not enough license seats available for checkout',
     ),
 
     'checkin' => array(

--- a/resources/views/licenses/checkout.blade.php
+++ b/resources/views/licenses/checkout.blade.php
@@ -21,15 +21,23 @@
 
             <div class="box box-default">
                 <div class="box-header with-border">
-                    <h2 class="box-title"> {{ $license->name }}</h2>
+                    <h2 class="box-title"> {{ $license->name }} ({{ trans('admin/licenses/message.seats_available', ['seat_count' => $license->availCount()->count()]) }})</h2>
                 </div>
                 <div class="box-body">
+
 
                     <!-- Asset name -->
                     <div class="form-group">
                         <label class="col-sm-3 control-label">{{ trans('admin/hardware/form.name') }}</label>
-                        <div class="col-md-6">
+                        <div class="col-md-9">
                             <p class="form-control-static">{{ $license->name }}</p>
+                        </div>
+                    </div>
+                    <!-- Category -->
+                    <div class="form-group">
+                        <label class="col-sm-3 control-label">{{ trans('general.category') }}</label>
+                        <div class="col-md-9">
+                            <p class="form-control-static">{{ $license->category->name }}</p>
                         </div>
                     </div>
 
@@ -57,8 +65,8 @@
                     <!-- Note -->
                     <div class="form-group {{ $errors->has('notes') ? 'error' : '' }}">
                         <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
-                        <div class="col-md-7">
-                            <textarea class="col-md-6 form-control" id="notes" name="notes">{{ old('note') }}</textarea>
+                        <div class="col-md-8">
+                            <textarea class="col-md-6 form-control" id="notes" name="notes" style="width: 100%">{{ old('note') }}</textarea>
                             {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                         </div>
                     </div>


### PR DESCRIPTION
This is building on what I started in #13904, where somehow some items can exist in the database with missing or invalid categories. When that happens, the `require_acceptance` method fails, since it's trying to check on the category to see whether or not the checkout should trigger an acceptance email to the end user. 

@spencerrlongg - I know we discussed having you handle this, but the rollbars were making me crazy, and it's Thanksgiving :)

Fixes RB-17485 and probably several others.