### PR TITLE
Check for the array key in `$activeFile->first_row` in importer

### DIFF
--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -235,7 +235,7 @@
                                                                                     ])
                                                                                 }}
                                                                             </div>
-									                                    @if ($activeFile->first_row)
+									                                    @if (($activeFile->first_row) && (array_key_exists($index, $activeFile->first_row)))
                                                                             <div class="col-md-5">
                                                                                 <p class="form-control-static">{{ str_limit($activeFile->first_row[$index], 50, '...') }}</p>
                                                                             </div>


### PR DESCRIPTION
This should handle the occasional (if weird) error when the `$index` value isn't set in the importer. Fixes RB-17272