### PR TITLE
Fixed user total asset cost to appear conditionally

### DIFF
--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -638,14 +638,14 @@
 
                     </div>
                     @endif
+                   @if($user->getUserTotalCost()->total_user_cost > 0)
                    <div class="row">
-
                        <div class="col-md-3">
                            {{ trans('admin/users/table.total_assets_cost') }}
                        </div>
                        <div class="col-md-9">
                            {{Helper::formatCurrencyOutput($user->getUserTotalCost()->total_user_cost)}}
-                           @if($user->getUserTotalCost()->total_user_cost > 0)
+
                            <a id="optional_info" class="text-primary">
                                <i class="fa fa-caret-right fa-2x" id="optional_info_icon"></i>
                                <strong>{{ trans('admin/hardware/form.optional_infos') }}</strong>
@@ -658,15 +658,11 @@
                                {{trans('general.licenses').': '. Helper::formatCurrencyOutput($user->getUserTotalCost()->license_cost)}}<br>
                                {{trans('general.accessories').': '.Helper::formatCurrencyOutput($user->getUserTotalCost()->accessory_cost)}}<br>
                                </div>
-                           @endif
                            </div>
-                   </div>
-
+                   </div><!--/.row-->
+                   @endif
                   </div> <!--/end striped container-->
                 </div> <!-- end col-md-9 -->
-   
-            
-            
           </div> <!--/.row-->
         </div><!-- /.tab-pane -->
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -645,6 +645,7 @@
                        </div>
                        <div class="col-md-9">
                            {{Helper::formatCurrencyOutput($user->getUserTotalCost()->total_user_cost)}}
+                           @if($user->getUserTotalCost()->total_user_cost > 0)
                            <a id="optional_info" class="text-primary">
                                <i class="fa fa-caret-right fa-2x" id="optional_info_icon"></i>
                                <strong>{{ trans('admin/hardware/form.optional_infos') }}</strong>
@@ -657,6 +658,7 @@
                                {{trans('general.licenses').': '. Helper::formatCurrencyOutput($user->getUserTotalCost()->license_cost)}}<br>
                                {{trans('general.accessories').': '.Helper::formatCurrencyOutput($user->getUserTotalCost()->accessory_cost)}}<br>
                                </div>
+                           @endif
                            </div>
                    </div>
 


### PR DESCRIPTION
# Description

This enhancement will only show an asset breakdown for a user if they have an asset assigned to them that have a cost associated with it:
<img width="488" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/c0c899d2-2100-4ba9-acba-6120c160c9c0">
No cost, No breakdown:
<img width="488" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/03622660-0693-467c-815c-bba9d2b58264">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
