### PR TITLE
Fixed sqlite exception in migration

### DIFF
--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -75,7 +75,7 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
     private function eolUpdateExpression(): Expression
     {
         if (DB::getDriverName() === 'sqlite') {
-            return DB::raw("DATE(purchase_date, '+' || (SELECT eol FROM models WHERE models.id = assets.model_id) || ' months')");
+            return DB::raw("DATE(purchase_date, '+' || (SELECT eol FROM " . DB::getTablePrefix() ."models WHERE models.id = assets.model_id) || ' months')");
         }
 
         // Default to MySQL's method

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -3,6 +3,7 @@
 use App\Models\Asset;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -50,7 +51,7 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
             ->whereNotNull('model_id')
             ->join('models', 'assets.model_id', '=', 'models.id')
             ->update([
-                'asset_eol_date' => DB::raw('DATE_ADD(purchase_date, INTERVAL ' . DB::getTablePrefix() . 'models.eol MONTH)')
+                'asset_eol_date' => $this->eolUpdateExpression(),
             ]);
     }
 
@@ -65,5 +66,19 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
         Schema::table('assets', function (Blueprint $table) {
                 $table->dropColumn('eol_explicit');
         });
+    }
+
+    /**
+     * This method returns the correct database express for either
+     * mysql or sqlite depending on the driver being used.
+     */
+    private function eolUpdateExpression(): Expression
+    {
+        if (DB::getDriverName() === 'sqlite') {
+            return DB::raw("DATE(purchase_date, '+' || (SELECT eol FROM models WHERE models.id = assets.model_id) || ' months')");
+        }
+
+        // Default to MySQL's method
+        return DB::raw('DATE_ADD(purchase_date, INTERVAL ' . DB::getTablePrefix() . 'models.eol MONTH)');
     }
 }

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -75,7 +75,11 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
     private function eolUpdateExpression(): Expression
     {
         if (DB::getDriverName() === 'sqlite') {
-            return DB::raw("DATE(purchase_date, '+' || (SELECT eol FROM " . DB::getTablePrefix() ."models WHERE models.id = assets.model_id) || ' months')");
+            return DB::raw("DATE(purchase_date, '+' || (SELECT eol FROM " . DB::getTablePrefix() . "models WHERE models.id = assets.model_id) || ' months')");
+        }
+
+        if (DB::getDriverName() === 'pgsql') {
+            return DB::raw("date(purchase_date + interval '1 month' * (SELECT eol FROM " . DB::getTablePrefix() . "models WHERE models.id = assets.model_id))");
         }
 
         // Default to MySQL's method

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -69,7 +69,7 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
     }
 
     /**
-     * This method returns the correct database express for either
+     * This method returns the correct database expression for either
      * mysql or sqlite depending on the driver being used.
      */
     private function eolUpdateExpression(): Expression

--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -70,7 +70,7 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
 
     /**
      * This method returns the correct database expression for either
-     * mysql or sqlite depending on the driver being used.
+     * mysql, postgres, or sqlite depending on the driver being used.
      */
     private function eolUpdateExpression(): Expression
     {


### PR DESCRIPTION
# Description

We recently introduced a migration that uses the `DATE_ADD` function that is available in mysql but not sqlite. Even though we don't explicitly support sqlite we do use it when running tests locally so allowing that migration to run successfully while using sqlite would be nice. This PR updates the migration to check if sqlite is being used and changes the expression to an equivalent method.

I don't love writing code that checks which database driver is being used but I think it's ok in this case.

---

For reference the exception being thrown when running the tests using sqlite was:
```
Illuminate\Database\QueryException : SQLSTATE[HY000]: General error: 1 near "models": syntax error (SQL: update "assets" set "asset_eol_date" = DATE_ADD(purchase_date, INTERVAL models.eol MONTH) where "rowid" in (select "assets"."rowid" from "assets" inner join "models" on "assets"."model_id" = "models"."id" where "asset_eol_date" is null and "purchase_date" is not null and "model_id" is not null))
```

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)