### PR TITLE
Modified re-crypter to also work when given a CLI old-key

### DIFF
--- a/app/Console/Commands/RotateAppKey.php
+++ b/app/Console/Commands/RotateAppKey.php
@@ -7,6 +7,7 @@ use App\Models\CustomField;
 use App\Models\Setting;
 use Artisan;
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Encryption\Encrypter;
 
 class RotateAppKey extends Command
@@ -16,14 +17,17 @@ class RotateAppKey extends Command
      *
      * @var string
      */
-    protected $signature = 'snipeit:rotate-key';
+    protected $signature = 'snipeit:rotate-key
+                            {previous_key? : The previous key to rotate from} 
+                            {--emergency : Emergency mode - rotate from .env APP_KEY to newly-generated one, modifying .env} 
+                            {--force : Skip interactive confirmation}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'Rotates APP_KEY to a new value, optionally taking the previous key as an argument';
 
     /**
      * Create a new command instance.
@@ -42,26 +46,42 @@ class RotateAppKey extends Command
      */
     public function handle()
     {
-        if ($this->confirm("\n****************************************************\nTHIS WILL MODIFY YOUR APP_KEY AND DE-CRYPT YOUR ENCRYPTED CUSTOM FIELDS AND \nRE-ENCRYPT THEM WITH A NEWLY GENERATED KEY. \n\nThere is NO undo. \n\nMake SURE you have a database backup and a backup of your .env generated BEFORE running this command. \n\nIf you do not save the newly generated APP_KEY to your .env in this process, \nyour encrypted data will no longer be decryptable. \n\nAre you SURE you wish to continue, and have confirmed you have a database backup and an .env backup? ")) {
+        //make sure they specify only exactly one of --emergency, or a filename. Not neither, and not both.
+        if ( (!$this->option('emergency') && !$this->argument('previous_key')) || ( $this->option('emergency') && $this->argument('previous_key'))) {
+            $this->error("Specify only one of --emergency, or an app key value, in order to rotate keys");
+            return 1;
+        }
+        if ( $this->option('emergency') ) {
+            $msg = "\n****************************************************\nTHIS WILL MODIFY YOUR APP_KEY AND DE-CRYPT YOUR ENCRYPTED CUSTOM FIELDS AND \nRE-ENCRYPT THEM WITH A NEWLY GENERATED KEY. \n\nThere is NO undo. \n\nMake SURE you have a database backup and a backup of your .env generated BEFORE running this command. \n\nIf you do not save the newly generated APP_KEY to your .env in this process, \nyour encrypted data will no longer be decryptable. \n\nAre you SURE you wish to continue, and have confirmed you have a database backup and an .env backup? ";
+        } else {
+            $msg = "\n****************************************************\nTHIS WILL DE-CRYPT YOUR ENCRYPTED CUSTOM FIELDS AND RE-ENCRYPT THEM WITH YOUR\nAPP_KEY.\n\nThere is NO undo. \n\nMake SURE you have a database backup BEFORE running this command. \n\nAre you SURE you wish to continue, and have confirmed you have a database backup? ";
+        }
+        if ($this->option('force') || $this->confirm($msg)) {
 
             // Get the existing app_key and ciphers
             // We put them in a variable since we clear the cache partway through here.
-            $old_app_key = config('app.key');
-            $cipher = config('app.cipher');
+            if ($this->option('emergency')) {
+                $old_app_key = config('app.key');
+                $cipher = config('app.cipher');
 
-            // Generate a new one
-            Artisan::call('key:generate', ['--show' => true]);
-            $new_app_key = Artisan::output();
+                // Generate a new one
+                Artisan::call('key:generate', ['--show' => true]);
+                $new_app_key = trim(Artisan::output());
 
-            // Clear the config cache
-            Artisan::call('config:clear');
+                // Clear the config cache
+                Artisan::call('config:clear');
 
-            $this->warn('Your app cipher is: '.$cipher);
-            $this->warn('Your old APP_KEY is: '.$old_app_key);
-            $this->warn('Your new APP_KEY is: '.$new_app_key);
+                // Write the new app key to the .env file
+                $this->writeNewEnvironmentFileWith($new_app_key);
+            } elseif ($this->argument('previous_key')) {
+                $old_app_key = $this->argument('previous_key');
+                $cipher = config('app.cipher'); // just a guess?
+                $new_app_key = config('app.key');
+            }
 
-            // Write the new app key to the .env file
-            $this->writeNewEnvironmentFileWith($new_app_key);
+            $this->warn('Your app cipher is: ' . $cipher);
+            $this->warn('Your old APP_KEY is: ' . $old_app_key);
+            $this->warn('Your new APP_KEY is: ' . $new_app_key);
 
             // Manually create an old encrypter instance using the old app key
             // and also create a new encrypter instance so we can re-crypt the field
@@ -75,8 +95,16 @@ class RotateAppKey extends Command
                 $assets = Asset::whereNotNull($field->db_column)->get();
 
                 foreach ($assets as $asset) {
-                    $asset->{$field->db_column} = $oldEncrypter->decrypt($asset->{$field->db_column});
-                    $this->line('DECRYPTED: '.$field->db_column);
+                    try {
+                        $asset->{$field->db_column} = $oldEncrypter->decrypt($asset->{$field->db_column});
+                        $this->line('DECRYPTED: ' . $field->db_column);
+                    } catch (DecryptException $e) {
+                        $this->line('Could not decrypt '. $field->db_column.' using "old key" - skipping...');
+                        continue;
+                    } catch (\Exception $e) {
+                        $this->error("Error decrypting ".$field->db_column.", reason: ".$e->getMessage().". Aborting key rotation");
+                        throw $e;
+                    }
                     $asset->{$field->db_column} = $newEncrypter->encrypt($asset->{$field->db_column});
                     $this->line('ENCRYPTED: '.$field->db_column);
                     $asset->save();
@@ -86,10 +114,14 @@ class RotateAppKey extends Command
             // Handle the LDAP password if one is provided
             $setting = Setting::first();
             if ($setting->ldap_pword != '') {
-                $setting->ldap_pword = $oldEncrypter->decrypt($setting->ldap_pword);
-                $setting->ldap_pword = $newEncrypter->encrypt($setting->ldap_pword);
-                $setting->save();
-                $this->warn('LDAP password has been re-encrypted.');
+                try {
+                    $setting->ldap_pword = $oldEncrypter->decrypt($setting->ldap_pword);
+                    $setting->ldap_pword = $newEncrypter->encrypt($setting->ldap_pword);
+                    $setting->save();
+                    $this->warn('LDAP password has been re-encrypted.');
+                } catch(DecryptException $e) {
+                    $this->warn("Unable to decrypt old LDAP password; skipping");
+                }
             }
         } else {
             $this->info('This operation has been canceled. No changes have been made.');
@@ -104,9 +136,16 @@ class RotateAppKey extends Command
      */
     protected function writeNewEnvironmentFileWith($key)
     {
+        \Log::debug("here is the key replacement pattern which seems to not be firing: ".$this->keyReplacementPattern());
+        \Log::debug("Here's your current env vile: ".file_get_contents($this->laravel->environmentFilePath()));
+        \Log::debug("And here it is being replaced: ".preg_replace(
+                $this->keyReplacementPattern(),
+                'APP_KEY="'.$key.'"',
+                file_get_contents($this->laravel->environmentFilePath())
+            ));
         file_put_contents($this->laravel->environmentFilePath(), preg_replace(
             $this->keyReplacementPattern(),
-            'APP_KEY='.$key,
+            'APP_KEY="'.$key.'"',
             file_get_contents($this->laravel->environmentFilePath())
         ));
     }
@@ -118,7 +157,7 @@ class RotateAppKey extends Command
      */
     protected function keyReplacementPattern()
     {
-        $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
+        $escaped = '="?'.preg_quote($this->laravel['config']['app.key'], '/').'"?';
 
         return "/^APP_KEY{$escaped}/m";
     }

--- a/app/Console/Commands/RotateAppKey.php
+++ b/app/Console/Commands/RotateAppKey.php
@@ -136,13 +136,6 @@ class RotateAppKey extends Command
      */
     protected function writeNewEnvironmentFileWith($key)
     {
-        \Log::debug("here is the key replacement pattern which seems to not be firing: ".$this->keyReplacementPattern());
-        \Log::debug("Here's your current env vile: ".file_get_contents($this->laravel->environmentFilePath()));
-        \Log::debug("And here it is being replaced: ".preg_replace(
-                $this->keyReplacementPattern(),
-                'APP_KEY="'.$key.'"',
-                file_get_contents($this->laravel->environmentFilePath())
-            ));
         file_put_contents($this->laravel->environmentFilePath(), preg_replace(
             $this->keyReplacementPattern(),
             'APP_KEY="'.$key.'"',


### PR DESCRIPTION
We already had this re-crypter function, but I have a slightly different use-case that I need to address, so I made a few small additions.

First off, I added an optional parameter that lets you specify what the *old* key was, using the current `APP_KEY` as the "new key."

Next, I made it so that you have to specify `--emergency` if you want to do the in-place key-change. This better reflects the gravity of what we're doing.

I also added a `--force` option to skip the confirmation prompt, which might be useful in automated scenarios.

I made it more tolerant of decrypting old values - if they don't decrypt correctly, we `catch()` that and move on.

I made sure that the new `APP_KEY` was enclosed in quotes - this isn't strictly speaking necessary but I think it's cleaner.

I improved the key-replacement code so that it would be able to replace an `APP_KEY` that _may_ be enclosed in quotes.

## Tests

I ran several key rotations and ensured that my custom fields were still readable, and the `.env` file correctly reflected the new keys each time.
I did several runs with an old key that was never actually used in reality and ensured that the data didn't get mangled. The 'skip' functionality worked correctly.
I did several runs where I manually cycled the key, and specified the old key on the command line, and it correctly re-crypted the values.