### PR TITLE
Fixed status and model in bulk edit

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -86,6 +86,7 @@ class BulkAssetsController extends Controller
                    
                 case 'restore':
                     $this->authorize('update', Asset::class);
+                    $assets = Asset::withTrashed()->find($asset_ids);
                     $assets->each(function ($asset) {
                         $this->authorize('delete', $asset);
                     });

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -41,9 +41,7 @@ class BulkAssetsController extends Controller
     public function edit(Request $request)
     {
         $this->authorize('view', Asset::class);
-
-        \Log::debug('Bulk action was triggered: '.$request->input('bulk_actions'));
-
+        
         if (! $request->filled('ids')) {
             return redirect()->back()->with('error', trans('admin/hardware/message.update.no_assets_selected'));
         }
@@ -77,7 +75,6 @@ class BulkAssetsController extends Controller
                     return view('hardware/bulk-delete')->with('assets', $assets);
                    
                 case 'restore':
-                    \Log::debug('We seem to be bulk restoring');
                     $this->authorize('update', Asset::class);
                     $assets->each(function ($asset) {
                         $this->authorize('delete', $asset);
@@ -86,7 +83,6 @@ class BulkAssetsController extends Controller
 
                 case 'edit':
                     $this->authorize('update', Asset::class);
-                    \Log::debug('We seem to be bulk editing');
 
                     return view('hardware/bulk')
                         ->with('assets', $asset_ids)
@@ -120,23 +116,14 @@ class BulkAssetsController extends Controller
 
        $custom_field_columns = CustomField::all()->pluck('db_column')->toArray();
 
-        \Log::debug('ALL Custom fields columns - these may or may not apply: ');
-        \Log::debug(print_r($custom_field_columns, true));
      
         if (! $request->filled('ids') || count($request->input('ids')) == 0) {
             return redirect($bulk_back_url)->with('error', trans('admin/hardware/message.update.no_assets_selected'));
         }
 
-        // $assetsIds = array_keys($request->input('ids'));
-        \Log::debug('Request IDs:');
-        \Log::debug(print_r(array_keys($request->input('ids')), true));
 
         $assets = Asset::whereIn('id', array_keys($request->input('ids')))->get();
 
-        \Log::debug('Affected asset list: ');
-        foreach ($assets as $log_asset) {
-            \Log::debug(' - Asset affected: '.$log_asset->asset_tag);
-        }
 
 
         /**
@@ -221,9 +208,7 @@ class BulkAssetsController extends Controller
                  * fieldset-specific attributes.
                  */
                 if ($request->filled('model_id')) {
-                    \Log::debug('Change the model ID!');
-                    $asset->model_id = Model::find($request->input('model_id'))->id;
-                    \Log::debug('New model ID is:'.$asset->model_id);
+                    $asset->model_id = AssetModel::find($request->input('model_id'))->id;
                 }
 
                 /**
@@ -233,10 +218,7 @@ class BulkAssetsController extends Controller
                  * to someone/something.
                  */
                 if ($request->filled('status_id')) {
-                    \Log::debug('Change the status ID!');
                     $updated_status = Statuslabel::find($request->input('status_id'));
-                    \Log::debug('New status ID is:'.$updated_status->id);
-                    \Log::debug('Status label type is: '.$updated_status->getStatuslabelType());
 
                     // We cannot assign a non-deployable status type if the asset is already assigned.
                     // This could probably be added to a form request.
@@ -296,10 +278,6 @@ class BulkAssetsController extends Controller
 
                 }
 
-                \Log::debug('What changed?');
-                \Log::debug(print_r($changed, true));
-                
-
                 /**
                  * Start all the custom fields shenanigans
                  */
@@ -348,9 +326,6 @@ class BulkAssetsController extends Controller
                 }
 
 
-
-
-                \Log::debug(print_r($this->update_array, true));
                 // Check if it passes validation, and then try to save
                 if (!$asset->update($this->update_array)) {
 

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -42,6 +42,9 @@ class BulkAssetsController extends Controller
     {
         $this->authorize('view', Asset::class);
 
+        /**
+         * No asset IDs were passed
+         */
         if (! $request->filled('ids')) {
             return redirect()->back()->with('error', trans('admin/hardware/message.update.no_assets_selected'));
         }
@@ -49,6 +52,7 @@ class BulkAssetsController extends Controller
         // Figure out where we need to send the user after the update is complete, and store that in the session
         $bulk_back_url = request()->headers->get('referer');
         session(['bulk_back_url' => $bulk_back_url]);
+
 
         $asset_ids = $request->input('ids');
         $assets = Asset::with('assignedTo', 'location', 'model')->find($asset_ids);
@@ -92,9 +96,9 @@ class BulkAssetsController extends Controller
 
                     return view('hardware/bulk')
                         ->with('assets', $asset_ids)
+                        ->with('statuslabel_list', Helper::statusLabelList())
                         ->with('models', $models->pluck(['model']))
-                        ->with('modelNames', $modelNames)
-                        ->with('statuslabel_list', Helper::statusLabelList());
+                        ->with('modelNames', $modelNames);
             }
         }
 

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -221,7 +221,7 @@ class BulkAssetsController extends Controller
                  * fieldset-specific attributes.
                  */
                 if ($request->filled('model_id')) {
-                    $asset->model_id = AssetModel::find($request->input('model_id'))->id;
+                    $this->update_array['model_id'] = AssetModel::find($request->input('model_id'))->id;
                 }
 
                 /**
@@ -241,7 +241,7 @@ class BulkAssetsController extends Controller
                         ($asset->assigned_to == '')
                         || ($updated_status->deployable == '1') && ($asset->assetstatus->deployable == '1')
                     ) {
-                        $asset->status_id = $updated_status->id;
+                        $this->update_array['status_id'] = $updated_status->id;
                     }
 
                 }

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -53,12 +53,7 @@ class BulkAssetsController extends Controller
         $asset_ids = $request->input('ids');
         $assets = Asset::with('assignedTo', 'location', 'model')->find($asset_ids);
 
-        //custom fields logic
-        $asset_custom_field = Asset::with(['model.fieldset.fields', 'model'])->whereIn('id', $asset_ids)->whereHas('model', function ($query) {
-            return $query->where('fieldset_id', '!=', null);
-        })->get();
-
-        $models = $asset_custom_field->unique('model_id');
+        $models = $assets->unique('model_id');
         $modelNames = [];
         foreach($models as $model) {
             $modelNames[] = $model->model->name;

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -7,6 +7,8 @@ use App\Helpers\Helper;
 use App\Http\Controllers\CheckInOutRequest;
 use App\Http\Controllers\Controller;
 use App\Models\Asset;
+use App\Models\AssetModel;
+use App\Models\Statuslabel;
 use App\Models\Setting;
 use App\View\Label;
 use Illuminate\Http\Request;
@@ -174,6 +176,8 @@ class BulkAssetsController extends Controller
                     ->conditionallyAddItem('expected_checkin')
                     ->conditionallyAddItem('order_number')
                     ->conditionallyAddItem('requestable')
+                    ->conditionallyAddItem('model_id')
+                    ->conditionallyAddItem('status_id')
                     ->conditionallyAddItem('supplier_id')
                     ->conditionallyAddItem('warranty_months')
                     ->conditionallyAddItem('next_audit_date');
@@ -224,25 +228,6 @@ class BulkAssetsController extends Controller
 
                 }
 
-                $existing_assetmodel = $asset->model;
-
-
-                // Use the new model_id and add it to the existing $this
-                if (($request->filled('model_id')) && ($request->input('model_id')!= $existing_assetmodel->id)) {
-                    \Log::debug('Old and new models are different - change from '.$asset->model->id.' to model '.$request->input('model_id'));
-                    $this->update_array['model_id'] =  $request->input('model_id');
-                    $updated_model = \App\Models\AssetModel::find($request->input('model_id'));
-                }
-
-                $existing_status = $asset->statuslabel;
-
-                // Use the new status_id and add it to the existing $this
-                if (($request->filled('status_id')) && ($request->input('status_id')!= $existing_status->id)) {
-                    \Log::debug('Old and new models are different - change from '.$asset->statuslabel->id.' to model '.$request->input('status_id'));
-                    $this->update_array['status_id'] =  $request->input('status_id');
-                    $updated_status = \App\Models\Statuslabel::find($request->input('status_id'));
-                }
-
 
                 // Anything that happens past this WILL NOT BE logged in the edit log
                 $changed = [];
@@ -256,15 +241,14 @@ class BulkAssetsController extends Controller
 
                 \Log::debug('What changed?');
                 \Log::debug(print_r($changed, true));
-
-
-
+                
 
                 /** Start all the custom fields shenanigans */
                 if ($custom_fields_present) {
 
                     // Make sure this model is valid
-                    $assetCustomFields = ($updated_model) ? $updated_model->fieldset : null;
+                    // ALISON - FIX THIS BEFORE PUSHING
+                    $assetCustomFields = ($request->input('model_id')) ? $request->input('model_id')->fieldset : null;
 
                     if ($assetCustomFields && $assetCustomFields->fields) {
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -266,7 +266,7 @@ class Asset extends Depreciable
 
     /**
      * Determines if an asset is available for checkout.
-     * This checks to see if the it's checked out to an invalid (deleted) user
+     * This checks to see if it's checked out to an invalid (deleted) user
      * OR if the assigned_to and deleted_at fields on the asset are empty AND
      * that the status is deployable
      *
@@ -288,6 +288,31 @@ class Asset extends Depreciable
 
             }
         }
+        return false;
+    }
+
+
+    /**
+     * Determines if an asset is available for checkout.
+     * This checks to see if it's checked out to an invalid (deleted) user
+     * OR if the assigned_to and deleted_at fields on the asset are empty AND
+     * that the status is deployable
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v3.0]
+     * @return bool
+     */
+    public function isDeployableMeta()
+    {
+
+        // The asset status is not archived and is deployable
+        if (($this->assetstatus) && ($this->assetstatus->archived == '0') && (! $this->deleted_at)
+            && ($this->assetstatus->deployable == '1'))
+        {
+            return true;
+
+        }
+
         return false;
     }
 
@@ -753,7 +778,7 @@ class Asset extends Depreciable
     }
 
     /**
-     * Establishes the asset -> status relationship
+     * Establishes the asset -> license seats relationship
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v4.0]

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -293,31 +293,6 @@ class Asset extends Depreciable
 
 
     /**
-     * Determines if an asset is available for checkout.
-     * This checks to see if it's checked out to an invalid (deleted) user
-     * OR if the assigned_to and deleted_at fields on the asset are empty AND
-     * that the status is deployable
-     *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v3.0]
-     * @return bool
-     */
-    public function isDeployableMeta()
-    {
-
-        // The asset status is not archived and is deployable
-        if (($this->assetstatus) && ($this->assetstatus->archived == '0') && (! $this->deleted_at)
-            && ($this->assetstatus->deployable == '1'))
-        {
-            return true;
-
-        }
-
-        return false;
-    }
-
-
-    /**
      * Checks the asset out to the target
      *
      * @todo The admin parameter is never used. Can probably be removed.

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -491,5 +491,6 @@ return [
     'upload_error' => 'Error uploading file. Please check that there are no empty rows and that no column names are duplicated.',
     'copy_to_clipboard' => 'Copy to Clipboard',
     'copied' => 'Copied!',
+    'status_compatibility' => 'If assets are already assigned, they cannot be changed to a non-deployable status type and this value change will be skipped.',
 
 ];

--- a/resources/views/hardware/bulk-restore.blade.php
+++ b/resources/views/hardware/bulk-restore.blade.php
@@ -30,7 +30,7 @@
               <tr>
                 <td></td>
                 <td>{{ trans('admin/hardware/table.id') }}</td>
-                <td>{{ trans('admin/hardware/table.name') }}</td>
+                <td>{{ trans('admin/hardware/form.name') }}</td>
                 <td>{{ trans('admin/hardware/table.location')}}</td>
               </tr>
             </thead>

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -21,15 +21,16 @@
 
 
 
-    <div class="callout callout-warning">
-      <i class="fas fa-exclamation-triangle"></i> {{ trans_choice('admin/hardware/form.bulk_update_warn', count($assets), ['asset_count' => count($assets)]) }}
-    </div>
-
     <form class="form-horizontal" method="post" action="{{ route('hardware/bulksave') }}" autocomplete="off" role="form">
       {{ csrf_field() }}
 
       <div class="box box-default">
         <div class="box-body">
+
+          <div class="callout callout-warning">
+            <i class="fas fa-exclamation-triangle"></i> {{ trans_choice('admin/hardware/form.bulk_update_warn', count($assets), ['asset_count' => count($assets)]) }}
+          </div>
+
           <!-- Purchase Date -->
           <div class="form-group {{ $errors->has('purchase_date') ? ' has-error' : '' }}">
             <label for="purchase_date" class="col-md-3 control-label">{{ trans('admin/hardware/form.date') }}</label>
@@ -75,6 +76,7 @@
             </label>
             <div class="col-md-7">
               {{ Form::select('status_id', $statuslabel_list , old('status_id'), array('class'=>'select2', 'style'=>'width:100%', 'aria-label'=>'status_id')) }}
+              <p class="help-block">If assets are already assigned, they cannot be changed to a non-deployable status type and this value change will be skipped.</p>
               {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             </div>
           </div>

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -29,6 +29,10 @@
 
           <div class="callout callout-warning">
             <i class="fas fa-exclamation-triangle"></i> {{ trans_choice('admin/hardware/form.bulk_update_warn', count($assets), ['asset_count' => count($assets)]) }}
+
+            @if (count($models) > 0)
+              {{ trans_choice('admin/hardware/form.bulk_update_with_custom_field', count($models), ['asset_model_count' => count($models)]) }}
+            @endif
           </div>
 
           <!-- Purchase Date -->
@@ -76,7 +80,7 @@
             </label>
             <div class="col-md-7">
               {{ Form::select('status_id', $statuslabel_list , old('status_id'), array('class'=>'select2', 'style'=>'width:100%', 'aria-label'=>'status_id')) }}
-              <p class="help-block">If assets are already assigned, they cannot be changed to a non-deployable status type and this value change will be skipped.</p>
+              <p class="help-block">{{ trans('general.status_compatibility') }}</p>
               {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
             </div>
           </div>
@@ -190,8 +194,8 @@
             </div>
           </div>
 
+          @include("models/custom_fields_form_bulk_edit",["models" => $models])
 
-      
           @foreach ($assets as $key => $value)
             <input type="hidden" name="ids[{{ $value }}]" value="1">
           @endforeach

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -19,11 +19,10 @@
 
     <p>{{ trans('admin/hardware/form.bulk_update_help') }}</p>
 
+
+
     <div class="callout callout-warning">
       <i class="fas fa-exclamation-triangle"></i> {{ trans_choice('admin/hardware/form.bulk_update_warn', count($assets), ['asset_count' => count($assets)]) }}
-        @if (count($models) > 0)
-            {{ trans_choice('admin/hardware/form.bulk_update_with_custom_field', count($models), ['asset_model_count' => count($models)]) }} 
-        @endif 
     </div>
 
     <form class="form-horizontal" method="post" action="{{ route('hardware/bulksave') }}" autocomplete="off" role="form">
@@ -189,7 +188,7 @@
             </div>
           </div>
 
-            @include("models/custom_fields_form_bulk_edit",["models" => $models])
+
       
           @foreach ($assets as $key => $value)
             <input type="hidden" name="ids[{{ $value }}]" value="1">

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1206,15 +1206,15 @@
                 <thead>
                 <tr>
                   <th data-visible="true" data-field="icon" style="width: 40px;" class="hidden-xs" data-formatter="iconFormatter">{{ trans('admin/hardware/table.icon') }}</th>
-                  <th class="col-sm-2" data-visible="true" data-field="action_date" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
-                  <th class="col-sm-1" data-visible="true" data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
-                  <th class="col-sm-1" data-visible="true" data-field="action_type">{{ trans('general.action') }}</th>
-                  <th class="col-sm-2" data-visible="true" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>
-                  <th class="col-sm-2" data-visible="true" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.target') }}</th>
-                  <th class="col-sm-2" data-field="note">{{ trans('general.notes') }}</th>
-                  <th class="col-md-3" data-field="signature_file" data-visible="false"  data-formatter="imageFormatter">{{ trans('general.signature') }}</th>
-                  <th class="col-md-3" data-visible="false" data-field="file" data-visible="false"  data-formatter="fileUploadFormatter">{{ trans('general.download') }}</th>
-                  <th class="col-sm-2" data-field="log_meta" data-visible="true" data-formatter="changeLogFormatter">{{ trans('admin/hardware/table.changed')}}</th>
+                  <th data-visible="true" data-field="action_date" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
+                  <th data-visible="true" data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
+                  <th data-visible="true" data-field="action_type">{{ trans('general.action') }}</th>
+                  <th data-visible="true" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>
+                  <th data-visible="true" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.target') }}</th>
+                  <th data-field="note">{{ trans('general.notes') }}</th>
+                  <th data-field="signature_file" data-visible="false"  data-formatter="imageFormatter">{{ trans('general.signature') }}</th>
+                  <th data-visible="false" data-field="file" data-visible="false"  data-formatter="fileUploadFormatter">{{ trans('general.download') }}</th>
+                  <th data-field="log_meta" data-visible="true" data-formatter="changeLogFormatter">{{ trans('admin/hardware/table.changed')}}</th>
                 </tr>
                 </thead>
               </table>


### PR DESCRIPTION
This should fix a few issues we were having with bulk editing as it relates to model IDs and status IDs, where models with particular custom field settings wouldn't update (uniqueness, requiredness) and status labels wouldn't update at all if there were any that couldn't work (setting something that's checked out to be archived without checking the item in first.)

I still think there are some additional optimizations we can make here, but this should fix the issues. (This one is a good candidate for Livewire IMHO)

To test this, make sure you have some models with custom fields, some without, and make sure at least one of the custom fields is required and another one is unique. 

We want to make sure of the following:

- history is correctly recorded for all changes
- custom fields actually do update
- model ID and status ID update *where appropriate* but do not if they shouldn't (for example, if the assets are already checked out and the new status is not deployable)
- If there are uniqueness constraints and/or required constraints, those will provide useful feedback and not save

I had to rebase this and already found something weird missing, so please test this carefully. 

Touches on FD-38693, FD-38724, and FD-38903