### PR TITLE
Translation of No Group notice on User edit page

### DIFF
--- a/resources/lang/en/admin/settings/general.php
+++ b/resources/lang/en/admin/settings/general.php
@@ -9,6 +9,7 @@ return [
     'ad_append_domain_help'     => 'User isn\'t required to write "username@domain.local", they can just type "username".',
     'admin_cc_email'            => 'CC Email',
     'admin_cc_email_help'       => 'If you would like to send a copy of checkin/checkout emails that are sent to users to an additional email account, enter it here. Otherwise leave this field blank.',
+    'admin_settings'            => 'Admin Settings',
     'is_ad'				        => 'This is an Active Directory server',
     'alerts'                	=> 'Alerts',
     'alert_title'               => 'Update Notification Settings',

--- a/resources/lang/en/admin/users/table.php
+++ b/resources/lang/en/admin/users/table.php
@@ -21,6 +21,7 @@ return array(
     'manager' 				=> 'Manager',
     'managed_locations'     => 'Managed Locations',
     'name' 					=> 'Name',
+    'nogroup'               => 'No groups have been created yet. To add one, visit: ',
     'notes'                 => 'Notes',
     'password_confirm' 		=> 'Confirm Password',
     'password' 				=> 'Password',

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -553,7 +553,7 @@
                             </div>
                                  @endif
                            @else
-                               <p>No groups have been created yet. Visit <code>Admin Settings > Permission Groups</code> to add one.</p>
+                               <p>{{ trans('admin/users/table.nogroup') }} <code>{{ trans('admin/settings/general.admin_settings') }} > {{ trans('general.groups') }}</code> </p>
                            @endif
 
                               </div>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -553,7 +553,7 @@
                             </div>
                                  @endif
                            @else
-                               <p>{{ trans('admin/users/table.nogroup') }} <code>{{ trans('admin/settings/general.admin_settings') }} > {{ trans('general.groups') }}</code> </p>
+                                      <p>{{ trans('admin/users/table.nogroup') }} <code>{{ trans('admin/settings/general.admin_settings') }} <i class="fa fa-cogs"></i> > {{ trans('general.groups') }} <i class="fas fa-user-friends"></i></code> </p>
                            @endif
 
                               </div>


### PR DESCRIPTION
What it says on the tin. The message at the bottom of the `user>edit` page was untranslated.
It has now been added.

EDIT: for icons
<img width="440" alt="Screenshot 2023-11-28 at 5 51 11 PM" src="https://github.com/snipe/snipe-it/assets/116301219/e51478db-262a-4568-9358-d370e26e9435">

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

