### PR TITLE
Fixed the Column header Serial to Product Key for Licenses

### DIFF
--- a/resources/views/licenses/checkin.blade.php
+++ b/resources/views/licenses/checkin.blade.php
@@ -36,7 +36,7 @@
 
             <!-- Serial -->
             <div class="form-group">
-                <label class="col-sm-2 control-label">{{ trans('admin/hardware/form.serial') }}</label>
+                <label class="col-sm-2 control-label">{{ trans('admin/licenses/form.license_key') }}</label>
                 <div class="col-md-6">
                     <p class="form-control-static">
                         @can('viewKeys', $licenseSeat->license)

--- a/resources/views/licenses/checkout.blade.php
+++ b/resources/views/licenses/checkout.blade.php
@@ -43,7 +43,7 @@
 
                     <!-- Serial -->
                     <div class="form-group">
-                        <label class="col-sm-3 control-label">{{ trans('admin/hardware/form.serial') }}</label>
+                        <label class="col-sm-3 control-label">{{ trans('admin/licenses/form.license_key') }}</label>
                         <div class="col-md-9">
                             <p class="form-control-static" style="word-wrap: break-word;">
                                 @can('viewKeys', $license)

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -727,7 +727,7 @@
               <thead>
                 <tr>
                   <th class="col-md-5">{{ trans('general.name') }}</th>
-                  <th>{{ trans('admin/hardware/form.serial') }}</th>
+                  <th>{{ trans('admin/licenses/form.license_key') }}</th>
                   <th data-footer-formatter="sumFormatter" data-fieldname="purchase_cost">{{ trans('general.purchase_cost') }}</th>
                   <th>{{ trans('admin/licenses/form.purchase_order') }}</th>
                   <th>{{ trans('general.order_number') }}</th>


### PR DESCRIPTION
# Description

Updates the Column name of Serial to Product Key in  license chech-out and check-in blades, and User's License Tab.

Fixes #13977 

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
