### PR TITLE
Added eula-pdfs to allow-list on restore

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -91,6 +91,7 @@ class RestoreFromBackup extends Command
             'storage/private_uploads/users',
             'storage/private_uploads/licenses',
             'storage/private_uploads/signatures',
+            'storage/private_uploads/eula-pdfs',
         ];
         $private_files = [
             'storage/oauth-private.key',


### PR DESCRIPTION
The restore tool previously left out the eula-pdfs directory so those files had to be manually copied over. This adds the directory to the allow-list.