### PR TITLE
Added licensed to name and email in user profile license view

### DIFF
--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -490,11 +490,12 @@
                     }'>
                 <thead>
                 <tr>
-                  <th class="col-md-4">{{ trans('general.name') }}</th>
+                  <th class="col-md-1">{{ trans('general.name') }}</th>
                   <th class="col-md-4">{{ trans('admin/licenses/form.license_key') }}</th>
-                  <th class="col-md-4">{{ trans('admin/licenses/form.to_name') }}</th>
-                  <th class="col-md-4">{{ trans('admin/licenses/form.to_email') }}</th>
-                  <th class="col-md-4">{{ trans('general.category') }}</th>
+                  <th class="col-md-3">{{ trans('admin/licenses/form.to_name') }}</th>
+                  <th class="col-md-3">{{ trans('admin/licenses/form.to_email') }}</th>
+                  <th class="col-md-1">{{ trans('general.category') }}</th>
+
                 </tr>
                 </thead>
                 <tbody>

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -491,7 +491,9 @@
                 <thead>
                 <tr>
                   <th class="col-md-4">{{ trans('general.name') }}</th>
-                  <th class="col-md-4">{{ trans('admin/hardware/form.serial') }}</th>
+                  <th class="col-md-4">{{ trans('admin/licenses/form.license_key') }}</th>
+                  <th class="col-md-4">{{ trans('admin/licenses/form.to_name') }}</th>
+                  <th class="col-md-4">{{ trans('admin/licenses/form.to_email') }}</th>
                   <th class="col-md-4">{{ trans('general.category') }}</th>
                 </tr>
                 </thead>
@@ -506,6 +508,18 @@
                         ------------
                       @endcan
                     </td>
+                    <td>
+                      @can('viewKeys', $license)
+                        {{ $license->license_name }}
+                      @else
+                        ------------
+                      @endcan
+                    </td>
+                    @can('viewKeys', $license)
+                    <td>{{$license->license_email}}</td>
+                    @else
+                      ------------
+                    @endcan
                     <td>{{ $license->category->name }}</td>
                   </tr>
                 @endforeach

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -490,11 +490,11 @@
                     }'>
                 <thead>
                 <tr>
-                  <th class="col-md-1">{{ trans('general.name') }}</th>
-                  <th class="col-md-4">{{ trans('admin/licenses/form.license_key') }}</th>
-                  <th class="col-md-3">{{ trans('admin/licenses/form.to_name') }}</th>
-                  <th class="col-md-3">{{ trans('admin/licenses/form.to_email') }}</th>
-                  <th class="col-md-1">{{ trans('general.category') }}</th>
+                  <th>{{ trans('general.name') }}</th>
+                  <th>{{ trans('admin/licenses/form.license_key') }}</th>
+                  <th>{{ trans('admin/licenses/form.to_name') }}</th>
+                  <th>{{ trans('admin/licenses/form.to_email') }}</th>
+                  <th>{{ trans('general.category') }}</th>
 
                 </tr>
                 </thead>


### PR DESCRIPTION
# Description
This adds info for the user to use so they can activate their license without administrative assistance. 

If a user is granted permission to `viewKeys` then they will be able to see two additional columns now under the User's license tab-- the `email` it is licenses to, and the `name` associated with the license.

<img width="1069" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/67349f2d-2c44-45ab-91e9-0b935d2ef97e">

Fixes #13982

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
