### PR TITLE
Added help text to RTD location field

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -492,5 +492,6 @@ return [
     'copy_to_clipboard' => 'Copy to Clipboard',
     'copied' => 'Copied!',
     'status_compatibility' => 'If assets are already assigned, they cannot be changed to a non-deployable status type and this value change will be skipped.',
+    'rtd_location_help' => 'This is the location of the asset when it is not checked out',
 
 ];

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -65,7 +65,7 @@
     @endif
 
     @include ('partials.forms.edit.notes')
-    @include ('partials.forms.edit.location-select', ['translated_name' => trans('admin/hardware/form.default_location'), 'fieldname' => 'rtd_location_id'])
+    @include ('partials.forms.edit.location-select', ['translated_name' => trans('admin/hardware/form.default_location'), 'fieldname' => 'rtd_location_id', 'help_text' => trans('general.rtd_location_help')])
     @include ('partials.forms.edit.requestable', ['requestable_text' => trans('admin/hardware/general.requestable')])
 
 


### PR DESCRIPTION
This just adds some help text to describe the Default Location to prevent confusion. 

<img width="831" alt="Screenshot 2023-12-05 at 2 41 15 PM" src="https://github.com/snipe/snipe-it/assets/197404/cc140136-d5de-49bb-9cd8-8059de5f97c4">
