### PR TITLE
Added Status Label names to Asset history/ Action log 

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -295,8 +295,8 @@ class ActionlogsTransformer
             $newStatus = $status->find($clean_meta['status_id']['new']);
             $newStatusName = $newStatus ? e($newStatus->name) : trans('admin/statuslabels/message.deleted_label');
 
-            $clean_meta['status_id']['old'] = $clean_meta['status_id']['old'] ?  $oldStatusName : trans('general.unassigned');
-            $clean_meta['status_id']['new'] = $clean_meta['status_id']['new'] ?  $newStatusName : trans('general.unassigned');
+            $clean_meta['status_id']['old'] = $clean_meta['status_id']['old'] ? "[id: ".$clean_meta['status_id']['old']."] ". $oldStatusName : trans('general.unassigned');
+            $clean_meta['status_id']['new'] = $clean_meta['status_id']['new'] ? "[id: ".$clean_meta['status_id']['new']."] ". $newStatusName : trans('general.unassigned');
             $clean_meta['Status'] = $clean_meta['status_id'];
             unset($clean_meta['status_id']);
         }

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -6,6 +6,7 @@ use App\Models\Actionlog;
 use App\Models\Asset;
 use App\Models\CustomField;
 use App\Models\Setting;
+use App\Models\Statuslabel;
 use App\Models\Company;
 use App\Models\Supplier;
 use App\Models\Location;
@@ -212,6 +213,7 @@ class ActionlogsTransformer
     {   $location = Location::withTrashed()->get();
         $supplier = Supplier::withTrashed()->get();
         $model = AssetModel::withTrashed()->get();
+        $status = Statuslabel::withTrashed()->get();
         $company = Company::get();
 
 
@@ -284,6 +286,19 @@ class ActionlogsTransformer
             $clean_meta['supplier_id']['new'] = $clean_meta['supplier_id']['new'] ? "[id: ".$clean_meta['supplier_id']['new']."] ". $newSupplierName : trans('general.unassigned');
             $clean_meta['Supplier'] = $clean_meta['supplier_id'];
             unset($clean_meta['supplier_id']);
+        }
+        if(array_key_exists('status_id', $clean_meta)) {
+
+            $oldStatus = $status->find($clean_meta['status_id']['old']);
+            $oldStatusName = $oldStatus ? e($oldStatus->name) : trans('admin/statuslabels/message.deleted_label');
+
+            $newStatus = $status->find($clean_meta['status_id']['new']);
+            $newStatusName = $newStatus ? e($newStatus->name) : trans('admin/statuslabels/message.deleted_label');
+
+            $clean_meta['status_id']['old'] = $clean_meta['status_id']['old'] ?  $oldStatusName : trans('general.unassigned');
+            $clean_meta['status_id']['new'] = $clean_meta['status_id']['new'] ?  $newStatusName : trans('general.unassigned');
+            $clean_meta['Status'] = $clean_meta['status_id'];
+            unset($clean_meta['status_id']);
         }
         if(array_key_exists('asset_eol_date', $clean_meta)) {
             $clean_meta['EOL date'] = $clean_meta['asset_eol_date'];

--- a/resources/lang/en/admin/statuslabels/message.php
+++ b/resources/lang/en/admin/statuslabels/message.php
@@ -3,6 +3,7 @@
 return [
 
     'does_not_exist' => 'Status Label does not exist.',
+    'deleted_label' => 'Deleted Status Label',
     'assoc_assets'	 => 'This Status Label is currently associated with at least one Asset and cannot be deleted. Please update your assets to no longer reference this status and try again. ',
 
     'create' => [


### PR DESCRIPTION
# Description
This adds status label changes to the asset history/ action logs. 
Before:
<img width="1069" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/11c06efb-ca66-481c-9d18-b5ca1d54382c">

After:
<img width="1069" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/65793344-0aa6-40f6-b11e-2e474125af4b">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
