### PR TITLE
Updated importer icons

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -156,6 +156,7 @@ return [
     'image_filetypes_help'  => 'Accepted filetypes are jpg, webp, png, gif, and svg. Max upload size allowed is :size.',
     'unaccepted_image_type'  => 'This image file was not readable. Accepted filetypes are jpg, webp, png, gif, and svg. The mimetype of this file is: :mimetype.',
     'import'         	    => 'Import',
+    'import_this_file'      => 'Map fields and process this file',
     'importing'         	=> 'Importing',
     'importing_help'        => 'You can import assets, accessories, licenses, components, consumables, and users via CSV file. <br><br>The CSV should be comma-delimited and formatted with headers that match the ones in the <a href="https://snipe-it.readme.io/docs/importing" target="_new">sample CSVs in the documentation</a>.',
     'import-history'        => 'Import History',

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -624,7 +624,7 @@
                         @can('import')
                             <li{!! (Request::is('import/*') ? ' class="active"' : '') !!}>
                                 <a href="{{ route('imports.index') }}">
-                                    <i class="fas fa-cloud-download-alt fa-fw" aria-hidden="true"></i>
+                                    <i class="fas fa-cloud-upload-alt fa-fw" aria-hidden="true"></i>
                                     <span>{{ trans('general.import') }}</span>
                                 </a>
                             </li>

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -129,8 +129,8 @@
                                     			<td class="col-md-3">{{ Helper::getFormattedDateObject($currentFile->created_at, 'datetime', false) }}</td>
                                     			<td class="col-md-1">{{ Helper::formatFilesizeUnits($currentFile->filesize) }}</td>
                                                 <td class="col-md-1 text-right" style="white-space: nowrap;">
-                                                    <button class="btn btn-sm btn-info" wire:click="selectFile({{ $currentFile->id }})">
-                                                        <i class="fas fa-retweet fa-fw" aria-hidden="true"></i>
+                                                    <button class="btn btn-sm btn-info" wire:click="selectFile({{ $currentFile->id }})" data-tooltip="true" title="{{ trans('general.import_this_file') }}">
+                                                        <i class="fa-solid fa-list-check" aria-hidden="true"></i>
                                                         <span class="sr-only">{{ trans('general.import') }}</span>
                                                     </button>
                                                     <button class="btn btn-sm btn-danger" wire:click="destroy({{ $currentFile->id }})">


### PR DESCRIPTION
It's come up a few times that the importer icon/visual language is a little unclear. This PR attempts to rectify that with hopefully clearer icons and descriptive tooltips.

### Before

<img width="1702" alt="Screenshot 2023-12-12 at 12 12 52 AM" src="https://github.com/snipe/snipe-it/assets/197404/af8949ec-8d86-49f4-909d-29d2f4de6cf5">

### After

<img width="735" alt="Screenshot_2023-12-12_at_12_00_37 AM" src="https://github.com/snipe/snipe-it/assets/197404/5ee62531-b990-4e99-83ee-69eb196944ed">
