### PR TITLE
Set default sorting on backups to latest first

### DIFF
--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -40,7 +40,8 @@
                     data-id-table="system-backups"
                     data-search="true"
                     data-side-pagination="client"
-                    data-sort-order="asc"
+                    data-sort-order="desc"
+                    data-sort-name="modified_display"
                     id="system-backups"
                     class="table table-striped snipe-table">
             <thead>


### PR DESCRIPTION
This should eventually be turned into an API endpoint instead of using client-side sorting, but this should at least give you the backup list sorted by latest.