### PR TITLE
Added model name and number to quickscan

### DIFF
--- a/resources/views/hardware/quickscan-checkin.blade.php
+++ b/resources/views/hardware/quickscan-checkin.blade.php
@@ -81,6 +81,8 @@
                         <thead>
                         <tr>
                             <th>{{ trans('general.asset_tag') }}</th>
+                            <th>{{ trans('general.asset_model') }}</th>
+                            <th>{{ trans('general.model_no') }}</th>
                             <th>{{ trans('general.quickscan_checkin_status') }}</th>
                             <th></th>
                         </tr>
@@ -126,7 +128,7 @@
                 data : formData,
                 success : function (data) {
                     if (data.status == 'success') {
-                        $('#checkedin tbody').prepend("<tr class='success'><td>" + data.payload.asset + "</td><td>" + data.messages + "</td><td><i class='fas fa-check text-success'></i></td></tr>");
+                        $('#checkedin tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.payload.model + "</td><td>" + data.payload.model_number + "</td><td>" + data.messages + "</td><td><i class='fas fa-check text-success'></i></td></tr>");
                         incrementOnSuccess();
                     } else {
                         handlecheckinFail(data);
@@ -146,17 +148,21 @@
         });
 
         function handlecheckinFail (data) {
-            if (data.payload.asset) {
-                var asset = data.payload.asset;
+            if (data.payload.asset_tag) {
+                var asset_tag = data.payload.asset_tag;
+                var model = data.payload.model;
+                var model_number = data.payload.model_number;
             } else {
-                var asset = '';
+                var asset_tag = '';
+                var model = '';
+                var model_number = '';
             }
             if (data.messages) {
                 var messages = data.messages;
             } else {
                 var messages = '';
             }
-            $('#checkedin tbody').prepend("<tr class='danger'><td>" + asset + "</td><td>" + messages + "</td><td><i class='fas fa-times text-danger'></i></td></tr>");
+            $('#checkedin tbody').prepend("<tr class='danger'><td>" + asset_tag + "</td><td>" + model + "</td><td>" + model_number + "</td><td>" + messages + "</td><td><i class='fas fa-times text-danger'></i></td></tr>");
         }
 
         function incrementOnSuccess() {


### PR DESCRIPTION
This PR adds model name and model number to the quick scan results table. I do worry that on smaller screens, this might get cramped, but when dealing with a large number of assets, the additional information could be useful.

The original request was also to include asset name, but I just don't see how we'd manage to fit that in there, and given the fact that many users don't even utilize asset names, this seemed like a good compromise. 

### Before

<img width="1700" alt="Screenshot 2023-12-12 at 4 24 26 AM" src="https://github.com/snipe/snipe-it/assets/197404/9e8af131-7c7f-4ae9-b76e-5f0576b863da">


### After

<img width="1700" alt="Screenshot 2023-12-12 at 4 22 07 AM" src="https://github.com/snipe/snipe-it/assets/197404/853ede44-20ea-4e99-bc8f-72e9d04e68f6">

Fixes FD-39270
