### PR TITLE
Added `$user->created_by` to API user create method

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -353,6 +353,7 @@ class UsersController extends Controller
 
         $user = new User;
         $user->fill($request->all());
+        $user->created_by = Auth::user()->id;
 
         if ($request->has('permissions')) {
             $permissions_array = $request->input('permissions');


### PR DESCRIPTION
We weren't storing the admin ID of the creating admin the bearer token belongs to when a user was being created via API. Now we are.