### PR TITLE
Fixed HTML double-encoded on checkout emails.

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -98,7 +98,7 @@ class AssetCheckoutController extends Controller
                 }
             }
             
-            if ($asset->checkOut($target, $admin, $checkout_at, $expected_checkin, e($request->get('note')), $request->get('name'))) {
+            if ($asset->checkOut($target, $admin, $checkout_at, $expected_checkin, $request->get('note'), $request->get('name'))) {
                 return redirect()->route('hardware.index')->with('success', trans('admin/hardware/message.checkout.success'));
             }
 


### PR DESCRIPTION
We were using the `e()` escaping on the asset checkout for the notes field, which is not necessary since we escape that on the way out. in the API and in notification emails.

<img width="486" alt="e72-r0xuRC-Pfr2l7ymeg0J3-XrdHki6Yw" src="https://github.com/snipe/snipe-it/assets/197404/221468e2-0ae7-4b6a-ad74-7c99e7ef020d">

<img width="1643" alt="Screenshot 2023-12-12 at 1 29 35 PM" src="https://github.com/snipe/snipe-it/assets/197404/fbfe346f-c512-4994-8dad-6c856ccb6e41">

