### PR TITLE
Fixed checkbox/radio button display on models edit for default fields

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -88,7 +88,7 @@ class AssetModelsController extends Controller
         $model->requestable = Request::has('requestable');
 
         if ($request->input('fieldset_id') != '') {
-            $model->fieldset_id = e($request->input('fieldset_id'));
+            $model->fieldset_id = $request->input('fieldset_id');
         }
 
         $model = $request->handleImages($model);
@@ -101,7 +101,6 @@ class AssetModelsController extends Controller
                 }
             }
 
-            // Redirect to the new model  page
             return redirect()->route('models.index')->with('success', trans('admin/models/message.create.success'));
         }
 
@@ -166,17 +165,14 @@ class AssetModelsController extends Controller
 
         $this->removeCustomFieldsDefaultValues($model);
 
-        if ($request->input('fieldset_id') == '') {
-            $model->fieldset_id = null;
-        } else {
-            $model->fieldset_id = $request->input('fieldset_id');
+        $model->fieldset_id = $request->input('fieldset_id');
 
-            if ($this->shouldAddDefaultValues($request->input())) {
-                if (!$this->assignCustomFieldsDefaultValues($model, $request->input('default_values'))){
-                    return redirect()->back()->withInput()->with('error', trans('admin/custom_fields/message.fieldset_default_value.error'));
-                }
+        if ($this->shouldAddDefaultValues($request->input())) {
+            if (!$this->assignCustomFieldsDefaultValues($model, $request->input('default_values'))){
+                return redirect()->back()->withInput()->with('error', trans('admin/custom_fields/message.fieldset_default_value.error'));
             }
         }
+
        
       
        

--- a/database/factories/CustomFieldFactory.php
+++ b/database/factories/CustomFieldFactory.php
@@ -99,7 +99,7 @@ class CustomFieldFactory extends Factory
             return [
                 'name' => 'Test Checkbox',
                 'help_text' => 'This is a sample checkbox.',
-                'field_values' => "One\nTwo\nThree",
+                'field_values' => "One\r\nTwo\r\nThree",
                 'element'   => 'checkbox',
             ];
         });

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -59,15 +59,17 @@
 
 
                                 @elseif($field->element == "radio")
+
                                     @foreach(explode("\r\n", $field->field_values) as $field_value)
-                                        <input type='radio' name="default_values[{{ $field->id }}]" value="{{$field_value}}" {{ $field->defaultValue($model_id) == $field_value ? 'checked="checked"': '' }} />{{ $field_value }}<br />
+                                    <label class="col-md-3 form-control" for="{{ str_slug($field_value) }}">
+                                        <input id="{{ str_slug($field_value) }}" aria-label="{{ str_slug($field->name) }}"  type='radio' name="default_values[{{ $field->id }}]" value="{{$field_value}}" {{ $field->defaultValue($model_id) == $field_value ? 'checked="checked"': '' }} />{{ $field_value }}
                                     @endforeach
 
                                 @elseif($field->element == "checkbox")
 
                                      @foreach(explode("\r\n", $field->field_values) as $field_value)
                                         <label class="col-md-3 form-control" for="{{ str_slug($field_value) }}">
-                                        <input id="{{ str_slug($field_value) }}" type="checkbox" aria-label="{{ str_slug($field->name) }}" name="default_values[{{ $field->id }}][]" value="{{ $field_value }}"{{ in_array($field_value, explode(', ',$field->defaultValue($model_id))) ? ' checked="checked"': '' }}> {{ $field_value }}
+                                            <input id="{{ str_slug($field_value) }}" type="checkbox" aria-label="{{ str_slug($field->name) }}" name="default_values[{{ $field->id }}][]" value="{{ $field_value }}"{{ in_array($field_value, explode(', ',$field->defaultValue($model_id))) ? ' checked="checked"': '' }}> {{ $field_value }}
                                         </label>
                                     @endforeach
 

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -1,54 +1,77 @@
-<span> {{-- This <span> doesn't seem to fix it, neither does a div? --}}
+<span>
+
     <div class="form-group{{ $errors->has('custom_fieldset') ? ' has-error' : '' }}">
-        <label for="custom_fieldset" class="col-md-3 control-label">{{ trans('admin/models/general.fieldset') }}</label>
-            <div class="col-md-5">
-                {{ Form::select('fieldset_id', Helper::customFieldsetList(), old('fieldset_id', $fieldset_id), array('class'=>'select2 js-fieldset-field livewire-select2', 'style'=>'width:100%; min-width:350px', 'aria-label'=>'custom_fieldset', 'data-livewire-component' => $_instance->id)) }}
-                {!! $errors->first('custom_fieldset', '<span class="alert-msg" aria-hidden="true"><br><i class="fas fa-times"></i> :message</span>') !!}
-            </div>
-            <div class="col-md-3">
-                    <label class="form-control">
-                    {{ Form::checkbox('add_default_values', 1, old('add_default_values', $add_default_values), ['data-livewire-component' => $_instance->id, 'id' => 'add_default_values', 'wire:model' => 'add_default_values']) }}
-                    {{ trans('admin/models/general.add_default_values') }}
-                </label>
-            </div>
+        <label for="custom_fieldset" class="col-md-3 control-label">
+            {{ trans('admin/models/general.fieldset') }}
+        </label>
+        <div class="col-md-5">
+            {{ Form::select('fieldset_id', Helper::customFieldsetList(), old('fieldset_id', $fieldset_id), array('class'=>'select2 js-fieldset-field livewire-select2', 'style'=>'width:100%; min-width:350px', 'aria-label'=>'custom_fieldset', 'data-livewire-component' => $_instance->id)) }}
+            {!! $errors->first('custom_fieldset', '<span class="alert-msg" aria-hidden="true"><br><i class="fas fa-times"></i> :message</span>') !!}
+        </div>
+        <div class="col-md-3">
+                <label class="form-control">
+                {{ Form::checkbox('add_default_values', 1, old('add_default_values', $add_default_values), ['data-livewire-component' => $_instance->id, 'id' => 'add_default_values', 'wire:model' => 'add_default_values']) }}
+                {{ trans('admin/models/general.add_default_values') }}
+            </label>
+        </div>
     </div>
+
     @if ($this->add_default_values ) {{-- 'if the checkbox is enabled *AND* there are more than 0 fields in the fieldsset' --}}
-    <div style="padding-left: 10px; padding-bottom: 0px; margin-bottom: -15px;">
-        <div class="form-group">
             @if ($fields)
+
                 @foreach ($fields as $field)
                     <div class="form-group">
-                    
-                            <label class="col-md-3 control-label{{ $errors->has($field->name) ? ' has-error' : '' }}" for="default-value{{ $field->id }}">{{ $field->name }}</label>
 
-                            <div class="col-md-7">
+                        <label class="col-md-3 control-label{{ $errors->has($field->name) ? ' has-error' : '' }}">{{ $field->name }}</label>
+
+                        <div class="col-md-7">
+
                                 @if ($field->format == "DATE")
+
                                     <div class="input-group col-md-4" style="padding-left: 0px;">
                                         <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd"  data-autoclose="true">
                                             <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="default_values[{{ $field->id }}]" id="default-value{{ $field->id }}" value="{{ $field->defaultValue($model_id) }}">
                                             <span class="input-group-addon"><i class="fas fa-calendar" aria-hidden="true"></i></span>
                                         </div>
                                     </div>
+
                                 @elseif ($field->element == "text")
-                                    <input class="form-control m-b-xs" type="text" value="{{ $field->defaultValue($model_id) }}" id="default-value{{ $field->id }}" name="default_values[{{ $field->id }}]">
+
+
+                                        <input class="form-control" type="text" value="{{ $field->defaultValue($model_id) }}" id="default-value{{ $field->id }}" name="default_values[{{ $field->id }}]">
+
+
                                 @elseif($field->element == "textarea")
-                                    <textarea class="form-control" style="width: 100%;" id="default-value{{ $field->id }}" name="default_values[{{ $field->id }}]">{{ $field->defaultValue($model_id) }}</textarea><br>
+
+
+                                        <textarea class="form-control" style="width: 100%;" id="default-value{{ $field->id }}" name="default_values[{{ $field->id }}]">{{ $field->defaultValue($model_id) }}</textarea>
+
+
                                 @elseif($field->element == "listbox")
 
-                                    <select class="form-control m-b-xs" name="default_values[{{ $field->id }}]">
-                                        <option value=""></option>
-                                        @foreach(explode("\r\n", $field->field_values) as $field_value)
-                                            <option value="{{$field_value}}" {{ $field->defaultValue($model_id) == $field_value ? 'selected="selected"': '' }}>{{ $field_value }}</option>
-                                        @endforeach
-                                    </select>
+
+                                        <select class="form-control" name="default_values[{{ $field->id }}]">
+                                            <option value=""></option>
+                                            @foreach(explode("\r\n", $field->field_values) as $field_value)
+                                                <option value="{{$field_value}}" {{ $field->defaultValue($model_id) == $field_value ? 'selected="selected"': '' }}>{{ $field_value }}</option>
+                                            @endforeach
+                                        </select>
+
+
                                 @elseif($field->element == "radio")
                                     @foreach(explode("\r\n", $field->field_values) as $field_value)
                                         <input type='radio' name="default_values[{{ $field->id }}]" value="{{$field_value}}" {{ $field->defaultValue($model_id) == $field_value ? 'checked="checked"': '' }} />{{ $field_value }}<br />
                                     @endforeach
+
                                 @elseif($field->element == "checkbox")
-                                    @foreach(explode("\r\n", $field->field_values) as $field_value)
-                                        <input type='checkbox' name="default_values[{{ $field->id }}][]" value="{{$field_value}}" {{ in_array($field_value, explode(', ',$field->defaultValue($model_id))) ? 'checked="checked"': '' }} /> {{ $field_value }}<br />
+
+                                     @foreach(explode("\r\n", $field->field_values) as $field_value)
+                                        <label class="col-md-3 form-control" for="{{ str_slug($field_value) }}">
+                                        <input id="{{ str_slug($field_value) }}" type="checkbox" aria-label="{{ str_slug($field->name) }}" name="default_values[{{ $field->id }}][]" value="{{ $field_value }}"{{ in_array($field_value, explode(', ',$field->defaultValue($model_id))) ? ' checked="checked"': '' }}> {{ $field_value }}
+                                        </label>
                                     @endforeach
+
+
                                 @else
                                     <span class="help-block form-error">
                                         Unknown field element: {{ $field->element }}
@@ -58,9 +81,8 @@
                         </div>
 
                 @endforeach
+                </div>
                 @endif
 
-        </div>
-    </div>
     @endif
 </span>

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -63,6 +63,7 @@
                                     @foreach(explode("\r\n", $field->field_values) as $field_value)
                                     <label class="col-md-3 form-control" for="{{ str_slug($field_value) }}">
                                         <input id="{{ str_slug($field_value) }}" aria-label="{{ str_slug($field->name) }}"  type='radio' name="default_values[{{ $field->id }}]" value="{{$field_value}}" {{ $field->defaultValue($model_id) == $field_value ? 'checked="checked"': '' }} />{{ $field_value }}
+                                    </label>
                                     @endforeach
 
                                 @elseif($field->element == "checkbox")


### PR DESCRIPTION
The default custom field values at the model level were displaying weird when they were a checkbox or radio button set. This PR should fix that, and also makes the UI more accessible via screen reader and touch screen by correctly using labels.

### Before
<img width="796" alt="Screenshot 2023-12-13 at 6 31 31 AM" src="https://github.com/snipe/snipe-it/assets/197404/a4d6e0d6-54e8-4f33-8889-2195f75f0282">

### After
<img width="810" alt="Screenshot 2023-12-13 at 6 32 47 AM" src="https://github.com/snipe/snipe-it/assets/197404/4e92fac4-cf29-41f6-ba23-be3bcde8e849">

One thing I did notice, @uberbrady - and this was broken before, so this PR doesn't fix that - when setting default values via checkbox in that model edit page, if any of the checkboxes are checked, the model will not validate on save:


https://github.com/snipe/snipe-it/assets/197404/27684b20-e861-40b9-b5bf-317cb7490c0b

I'll create a shortcut for you. The UX on that is also a little weird, but we can work through that as well.

Fixes FD-37233