### PR TITLE
Added user agent, remote_ip, action_source to action_logs

### DIFF
--- a/app/Http/Controllers/Api/ReportsController.php
+++ b/app/Http/Controllers/Api/ReportsController.php
@@ -40,6 +40,14 @@ class ReportsController extends Controller
             $actionlogs = $actionlogs->where('action_type', '=', $request->input('action_type'))->orderBy('created_at', 'desc');
         }
 
+        if ($request->filled('action_source')) {
+            $actionlogs = $actionlogs->where('action_source', '=', $request->input('action_source'))->orderBy('created_at', 'desc');
+        }
+
+        if ($request->filled('remote_ip')) {
+            $actionlogs = $actionlogs->where('remote_ip', '=', $request->input('remote_ip'))->orderBy('created_at', 'desc');
+        }
+
         if ($request->filled('uploads')) {
             $actionlogs = $actionlogs->whereNotNull('filename')->orderBy('created_at', 'desc');
         }
@@ -52,6 +60,9 @@ class ReportsController extends Controller
             'accept_signature',
             'action_type',
             'note',
+            'remote_ip',
+            'user_agent',
+            'action_source',
         ];
 
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -252,6 +252,9 @@ class ReportsController extends Controller
                 trans('general.model_no'),
                 'To',
                 trans('general.notes'),
+                trans('admin/settings/general.login_ip'),
+                trans('admin/settings/general.login_user_agent'),
+                trans('general.action_source'),
                 'Changed',
 
             ];
@@ -298,6 +301,9 @@ class ReportsController extends Controller
                         $target_name,
                         ($actionlog->note) ? e($actionlog->note) : '',
                         $actionlog->log_meta,
+                        $actionlog->remote_ip,
+                        $actionlog->user_agent,
+                        $actionlog->action_source,
                     ];
                     fputcsv($handle, $row);
                 }

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -181,6 +181,9 @@ class ActionlogsTransformer
             'note'          => ($actionlog->note) ? Helper::parseEscapedMarkedownInline($actionlog->note): null,
             'signature_file'   => ($actionlog->accept_signature) ? route('log.signature.view', ['filename' => $actionlog->accept_signature ]) : null,
             'log_meta'          => ((isset($clean_meta)) && (is_array($clean_meta))) ? $clean_meta: null,
+            'remote_ip'          => ($actionlog->remote_ip) ??  null,
+            'user_agent'          => ($actionlog->user_agent) ??  null,
+            'action_source'          => ($actionlog->action_source) ??  null,
             'action_date'   => ($actionlog->action_date) ? Helper::getFormattedDateObject($actionlog->action_date, 'datetime'): Helper::getFormattedDateObject($actionlog->created_at, 'datetime'),
         ];
 

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -25,7 +25,17 @@ class Actionlog extends SnipeModel
 
     protected $table = 'action_logs';
     public $timestamps = true;
-    protected $fillable = ['created_at', 'item_type', 'user_id', 'item_id', 'action_type', 'note', 'target_id', 'target_type', 'stored_eula'];
+    protected $fillable = [
+        'created_at',
+        'item_type',
+        'user_id',
+        'item_id',
+        'action_type',
+        'note',
+        'target_id',
+        'target_type',
+        'stored_eula'
+    ];
 
     use Searchable;
 
@@ -34,7 +44,15 @@ class Actionlog extends SnipeModel
      *
      * @var array
      */
-    protected $searchableAttributes = ['action_type', 'note', 'log_meta','user_id'];
+    protected $searchableAttributes = [
+        'action_type',
+        'note',
+        'log_meta',
+        'user_id',
+        'remote_ip',
+        'user_agent',
+        'action_source'
+    ];
 
     /**
      * The relations and their attributes that should be included when searching the model.

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -266,6 +266,9 @@ class Actionlog extends SnipeModel
     public function logaction($actiontype)
     {
         $this->action_type = $actiontype;
+        $this->remote_ip =  request()->ip();
+        $this->user_agent = request()->header('User-Agent');
+        $this->action_source = $this->determineActionSource();
 
         if ($this->save()) {
             return true;
@@ -329,5 +332,23 @@ class Actionlog extends SnipeModel
                  ->orderBy('item_id', 'asc')
                  ->orderBy('created_at', 'asc')
                  ->get();
+    }
+
+    public function determineActionSource() {
+
+        // This is an API call
+        if (((request()->header('content-type') && (request()->header('accept'))=='application/json'))
+            && (starts_with(request()->header('authorization'), 'Bearer '))) {
+            return 'api';
+        }
+
+       // This is probably NOT an API call
+        if (request()->filled('_token')) {
+            return 'gui';
+        }
+
+        // We're not sure, probably cli
+        return 'cli/unknown';
+
     }
 }

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -334,6 +334,13 @@ class Actionlog extends SnipeModel
                  ->get();
     }
 
+    /**
+     * Determines what the type of request is so we can log it to the action_log
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since v6.3.0
+     * @return string
+     */
     public function determineActionSource() {
 
         // This is an API call

--- a/database/migrations/2023_12_14_032522_add_remote_ip_and_action_source_to_action_logs.php
+++ b/database/migrations/2023_12_14_032522_add_remote_ip_and_action_source_to_action_logs.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddRemoteIpAndActionSourceToActionLogs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            $table->string('action_source')->nullable()->default(null);
+            $table->ipAddress('remote_ip')->nullable()->default(null);
+            $table->string('user_agent')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('action_logs', function (Blueprint $table) {
+            if (Schema::hasColumn('action_logs', 'action_source')) {
+                $table->dropColumn('action_source');
+            }
+            if (Schema::hasColumn('action_logs', 'remote_ip')) {
+                $table->dropColumn('remote_ip');
+            }
+            if (Schema::hasColumn('action_logs', 'user_agent')) {
+                $table->dropColumn('user_agent');
+            }
+        });
+    }
+}

--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -498,5 +498,6 @@ return [
     'action_permission_denied' => 'You do not have permission to :action :item_type ID :id',
     'action_permission_generic' => 'You do not have permission to :action this :item_type',
     'edit' => 'edit',
+    'action_source' => 'Action Source',
 
 ];

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1206,7 +1206,7 @@
                 <thead>
                 <tr>
                   <th data-visible="true" data-field="icon" style="width: 40px;" class="hidden-xs" data-formatter="iconFormatter">{{ trans('admin/hardware/table.icon') }}</th>
-                  <th data-visible="true" data-field="action_date" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
+                  <th data-visible="true" data-field="action_date" data-sortable="true" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
                   <th data-visible="true" data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
                   <th data-visible="true" data-field="action_type">{{ trans('general.action') }}</th>
                   <th data-visible="true" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1214,7 +1214,10 @@
                   <th data-field="note">{{ trans('general.notes') }}</th>
                   <th data-field="signature_file" data-visible="false"  data-formatter="imageFormatter">{{ trans('general.signature') }}</th>
                   <th data-visible="false" data-field="file" data-visible="false"  data-formatter="fileUploadFormatter">{{ trans('general.download') }}</th>
-                  <th data-field="log_meta" data-visible="true" data-formatter="changeLogFormatter">{{ trans('admin/hardware/table.changed')}}</th>
+                   <th data-field="log_meta" data-visible="true" data-formatter="changeLogFormatter">{{ trans('admin/hardware/table.changed')}}</th>
+                   <th data-field="remote_ip" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_ip') }}</th>
+                   <th data-field="user_agent" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_user_agent') }}</th>
+                   <th data-field="action_source" data-visible="false" data-sortable="true">{{ trans('general.action_source') }}</th>
                 </tr>
                 </thead>
               </table>

--- a/resources/views/reports/activity.blade.php
+++ b/resources/views/reports/activity.blade.php
@@ -54,8 +54,8 @@
                             <th class="col-sm-2" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.to') }}</th>
                             <th class="col-sm-1" data-field="note">{{ trans('general.notes') }}</th>
                             <th class="col-sm-2" data-field="log_meta" data-visible="false" data-formatter="changeLogFormatter">{{ trans('general.changed') }}</th>
-                            <th class="col-sm-2" data-field="remote_ip" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_ip') }}</th>
-                            <th class="col-sm-2" data-field="user_agent" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_user_agent') }}</th>
+                            <th data-field="remote_ip" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_ip') }}</th>
+                            <th data-field="user_agent" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_user_agent') }}</th>
                             <th data-field="action_source" data-visible="false" data-sortable="true">{{ trans('general.action_source') }}</th>
                         </tr>
                     </thead>

--- a/resources/views/reports/activity.blade.php
+++ b/resources/views/reports/activity.blade.php
@@ -54,6 +54,9 @@
                             <th class="col-sm-2" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.to') }}</th>
                             <th class="col-sm-1" data-field="note">{{ trans('general.notes') }}</th>
                             <th class="col-sm-2" data-field="log_meta" data-visible="false" data-formatter="changeLogFormatter">{{ trans('general.changed') }}</th>
+                            <th class="col-sm-2" data-field="remote_ip" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_ip') }}</th>
+                            <th class="col-sm-2" data-field="user_agent" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_user_agent') }}</th>
+                            <th data-field="action_source" data-visible="false" data-sortable="true">{{ trans('general.action_source') }}</th>
                         </tr>
                     </thead>
                 </table>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -1003,8 +1003,8 @@
                   @endif
                   <th data-field="item.serial" data-visible="false">{{ trans('admin/hardware/table.serial') }}</th>
                   <th data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
-                  <th class="col-sm-2" data-field="remote_ip" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_ip') }}</th>
-                  <th class="col-sm-2" data-field="user_agent" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_user_agent') }}</th>
+                  <th data-field="remote_ip" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_ip') }}</th>
+                  <th data-field="user_agent" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_user_agent') }}</th>
                   <th data-field="action_source" data-visible="false" data-sortable="true">{{ trans('general.action_source') }}</th>
 
               </tr>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -1003,7 +1003,9 @@
                   @endif
                   <th data-field="item.serial" data-visible="false">{{ trans('admin/hardware/table.serial') }}</th>
                   <th data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
-
+                  <th class="col-sm-2" data-field="remote_ip" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_ip') }}</th>
+                  <th class="col-sm-2" data-field="user_agent" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_user_agent') }}</th>
+                  <th data-field="action_source" data-visible="false" data-sortable="true">{{ trans('general.action_source') }}</th>
 
               </tr>
               </thead>


### PR DESCRIPTION
This PR logs the user agent, remote IP, and the action source of logged actions. This should help us better track down what's happening if data isn't being handled the way we expect, and can be useful for tracking down problematic updates.

<img width="1727" alt="Screenshot 2023-12-14 at 2 46 31 PM" src="https://github.com/snipe/snipe-it/assets/197404/cbb216ec-cd8e-483e-9c5b-6bf2fa48c7ce">


<img width="1725" alt="Screenshot 2023-12-14 at 2 54 51 PM" src="https://github.com/snipe/snipe-it/assets/197404/dc3e44b4-dc00-4ab0-a336-119d547bbaca">
