### PR TITLE
Fixed #14037 - record current time on accessory checkin

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoryCheckinController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckinController.php
@@ -60,9 +60,10 @@ class AccessoryCheckinController extends Controller
 
         $this->authorize('checkin', $accessory);
 
-        $checkin_at = date('Y-m-d');
+        $checkin_hours = date('H:i:s');
+        $checkin_at = date('Y-m-d H:i:s');
         if ($request->filled('checkin_at')) {
-            $checkin_at = $request->input('checkin_at');
+            $checkin_at = $request->input('checkin_at').' '.$checkin_hours;
         }
 
         // Was the accessory updated?


### PR DESCRIPTION
Since accessory checkin (or chicken, as autocorrect would have it) allows you to specify a date, we were treating that datetime as a date field, without providing any hour information. This now takes the current time and appends it correctly. 

<img width="1673" alt="Screenshot 2023-12-15 at 4 41 01 PM" src="https://github.com/snipe/snipe-it/assets/197404/9cd373e0-900e-46cd-a24e-78bf1a3ebef8">
