### PR TITLE
Create user permission to allow... managing user permissions

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -358,7 +358,6 @@ class UsersController extends Controller
 
         if (Gate::allows('users.permissions', $user)) {
 
-            \Log::debug('This user can edit permissions');
             if ($request->has('permissions')) {
                 $permissions_array = $request->input('permissions');
 

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -20,6 +20,7 @@ use App\Notifications\CurrentInventory;
 use Auth;
 use Illuminate\Http\Request;
 use App\Http\Requests\ImageUploadRequest;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 
@@ -355,14 +356,18 @@ class UsersController extends Controller
         $user->fill($request->all());
         $user->created_by = Auth::user()->id;
 
-        if ($request->has('permissions')) {
-            $permissions_array = $request->input('permissions');
+        if (Gate::allows('users.permissions', $user)) {
 
-            // Strip out the superuser permission if the API user isn't a superadmin
-            if (! Auth::user()->isSuperUser()) {
-                unset($permissions_array['superuser']);
+            \Log::debug('This user can edit permissions');
+            if ($request->has('permissions')) {
+                $permissions_array = $request->input('permissions');
+
+                // Strip out the superuser permission if the API user isn't a superadmin
+                if (!Auth::user()->isSuperUser()) {
+                    unset($permissions_array['superuser']);
+                }
+                $user->permissions = $permissions_array;
             }
-            $user->permissions = $permissions_array;
         }
 
         // 
@@ -446,16 +451,17 @@ class UsersController extends Controller
         // We need to use has()  instead of filled()
         // here because we need to overwrite permissions
         // if someone needs to null them out
-        if ($request->has('permissions')) {
-            $permissions_array = $request->input('permissions');
+        if (Gate::allows('users.permissions', Asset::class)) {
+            if ($request->has('permissions')) {
+                $permissions_array = $request->input('permissions');
 
-            // Strip out the superuser permission if the API user isn't a superadmin
-            if (! Auth::user()->isSuperUser()) {
-                unset($permissions_array['superuser']);
+                // Strip out the superuser permission if the API user isn't a superadmin
+                if (!Auth::user()->isSuperUser()) {
+                    unset($permissions_array['superuser']);
+                }
+                $user->permissions = $permissions_array;
             }
-            $user->permissions = $permissions_array;
         }
-
 
 
         // Update the location of any assets checked out to this user

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -125,7 +125,6 @@ class UsersController extends Controller
 
 
         if (Gate::allows('users.permissions', $user)) {
-            \Log::debug('This user can edit permissions');
 
             $permissions_array = $request->input('permission');
             // Strip out the superuser permission if the user isn't a superadmin
@@ -133,8 +132,6 @@ class UsersController extends Controller
                 unset($permissions_array['superuser']);
             }
             $user->permissions = json_encode($permissions_array);
-        } else {
-            \Log::debug('This user can not edit permissions');
         }
 
 
@@ -222,12 +219,7 @@ class UsersController extends Controller
         // permissions here before we update the user.
         $permissions = $request->input('permissions', []);
 
-        \Log::debug('Page loaded permissions:');
-        \Log::debug(print_r($permissions, true));
         app('request')->request->set('permission', $permissions);
-
-        \Log::debug('After App:');
-        \Log::debug(print_r($request->input('permission'), true));
 
         // This is a janky hack to prevent people from changing admin demo user data on the public demo.
         // The $ids 1 and 2 are special since they are seeded as superadmins in the demo seeder.
@@ -248,9 +240,6 @@ class UsersController extends Controller
 
         // Figure out of this user was an admin before this edit
         $orig_permissions_array = $user->decodePermissions();
-
-        \Log::debug('Original User Permissions from the user object:');
-        \Log::debug(print_r($orig_permissions_array, true));
 
         $orig_superuser = '0';
         if (is_array($orig_permissions_array)) {
@@ -308,31 +297,18 @@ class UsersController extends Controller
             $user->password = bcrypt($request->input('password'));
         }
 
-
-            \Log::debug('This user can edit permissions');
-
             if ($request->has('permission')) {
 
-                \Log::debug('The permissions array is present');
-                \Log::debug('New Permissions via Request:');
-                \Log::debug(print_r($request->input('permission'), true));
-
                 $permissions_array = $request->input('permission');
-                \Log::debug('Processed Permissions');
-                \Log::debug(print_r($permissions_array, true));
 
                 // Strip out the superuser permission if the API user isn't a superadmin
                 if (!Auth::user()->isSuperUser()) {
-                    \Log::debug('The user is a superuser');
                     unset($permissions_array['superuser']);
                 }
+
                 $user->permissions = $permissions_array;
             }
-
-
-        \Log::debug('New Permissions we think we are sending: ');
-        \Log::debug(print_r($user->permissions, true));
-
+            
         // Handle uploaded avatar
         app(ImageUploadRequest::class)->handleImages($user, 600, 'avatar', 'avatars', 'avatar');
 

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -298,16 +298,26 @@ class UsersController extends Controller
 
 
         if (Gate::allows('users.permissions', $user)) {
+            \Log::debug('This user can edit permissions');
+
             if ($request->has('permissions')) {
+
+                \Log::debug('The permissions array is present');
                 $permissions_array = $request->input('permissions');
 
                 // Strip out the superuser permission if the API user isn't a superadmin
                 if (!Auth::user()->isSuperUser()) {
+                    \Log::debug('The user is a superuser');
                     unset($permissions_array['superuser']);
                 }
                 $user->permissions = $permissions_array;
+                \Log::debug(print_r($permissions_array, true));
             }
+        } else {
+            \Log::debug('nope');
         }
+
+        \Log::debug(print_r($user->permissions, true));
 
         // Handle uploaded avatar
         app(ImageUploadRequest::class)->handleImages($user, 600, 'avatar', 'avatars', 'avatar');

--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -89,8 +89,6 @@ class ImageUploadRequest extends Request
         } elseif ($this->hasFile($form_fieldname)) {
             $image = $this->file($form_fieldname);
             \Log::debug('Just use regular upload for '.$form_fieldname);
-        } else {
-            \Log::debug('No image found for form fieldname: '.$form_fieldname);
         }
 
         if (isset($image)) {

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -61,6 +61,11 @@ abstract class SnipePermissionsPolicy
         return $user->hasAccess($this->columnName().'.view');
     }
 
+    public function permissions(User $user, $item = null)
+    {
+        return $user->hasAccess($this->columnName().'.permissions');
+    }
+
     public function files(User $user, $item = null)
     {
         return $user->hasAccess($this->columnName().'.files');

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -63,7 +63,7 @@ abstract class SnipePermissionsPolicy
 
     public function permissions(User $user, $item = null)
     {
-        return $user->hasAccess($this->columnName().'.permissions');
+        return $user->hasAccess($this->columnName().'.manage_permissions');
     }
 
     public function files(User $user, $item = null)

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -152,8 +152,8 @@ class AuthServiceProvider extends ServiceProvider
             }
         });
 
-        Gate::define('users.permissions', function ($user) {
-            if ($user->hasAccess('users.permissions')) {
+        Gate::define('users.manage_permissions', function ($user) {
+            if ($user->hasAccess('users.manage_permissions')) {
                 return true;
             }
         });

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -152,6 +152,12 @@ class AuthServiceProvider extends ServiceProvider
             }
         });
 
+        Gate::define('users.permissions', function ($user) {
+            if ($user->hasAccess('users.permissions')) {
+                return true;
+            }
+        });
+
         // -----------------------------------------
         // Reports
         // -----------------------------------------

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -340,6 +340,12 @@ return [
             'display'    => true,
         ],
         [
+            'permission' => 'users.permissions',
+            'label'      => 'User Permissions',
+            'note'       => 'Manage individual User permissions. (Only superusers can edit group memberships)',
+            'display'    => true,
+        ],
+        [
             'permission' => 'users.delete',
             'label'      => 'Delete Users',
             'note'       => '',

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -293,33 +293,6 @@ return [
 
     ],
 
-    'Kits' => [
-        [
-            'permission' => 'kits.view',
-            'label'      => 'View ',
-            'note'       => 'These are predefined kits that can be used to quickly checkout assets, licenses, etc.',
-            'display'    => true,
-        ],
-        [
-            'permission' => 'kits.create',
-            'label'      => 'Create ',
-            'note'       => '',
-            'display'    => true,
-        ],
-        [
-            'permission' => 'kits.edit',
-            'label'      => 'Edit  ',
-            'note'       => '',
-            'display'    => true,
-        ],
-        [
-            'permission' => 'kits.delete',
-            'label'      => 'Delete ',
-            'note'       => '',
-            'display'    => true,
-        ],
-    ],
-
     'Users' => [
         [
             'permission' => 'users.view',
@@ -340,8 +313,8 @@ return [
             'display'    => true,
         ],
         [
-            'permission' => 'users.permissions',
-            'label'      => 'User Permissions',
+            'permission' => 'users.manage_permissions',
+            'label'      => 'Manager user Permissions',
             'note'       => 'Manage individual User permissions. (Only superusers can edit group memberships)',
             'display'    => true,
         ],
@@ -627,7 +600,32 @@ return [
     ],
 
 
-
+    'Kits' => [
+        [
+            'permission' => 'kits.view',
+            'label'      => 'View ',
+            'note'       => 'These are predefined kits that can be used to quickly checkout assets, licenses, etc.',
+            'display'    => true,
+        ],
+        [
+            'permission' => 'kits.create',
+            'label'      => 'Create ',
+            'note'       => '',
+            'display'    => true,
+        ],
+        [
+            'permission' => 'kits.edit',
+            'label'      => 'Edit  ',
+            'note'       => '',
+            'display'    => true,
+        ],
+        [
+            'permission' => 'kits.delete',
+            'label'      => 'Delete ',
+            'note'       => '',
+            'display'    => true,
+        ],
+    ],
 
     'Self' => [
         [

--- a/resources/views/partials/forms/edit/permissions-base.blade.php
+++ b/resources/views/partials/forms/edit/permissions-base.blade.php
@@ -82,6 +82,7 @@
           >
             {{ $permission['label'] }}
           </td>
+        <!-- grant -->
           <td class="col-md-1 permissions-item">
             <label class="sr-only" for="{{ 'permission['.$permission['permission'].']' }}">{{ 'permission['.$permission['permission'].']' }}</label>
 
@@ -91,6 +92,8 @@
               {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[ $permission['permission'] ] == '1', ["value"=>"grant",'class'=>'radiochecker-'.str_slug($area), 'aria-label' =>'permission['.$permission['permission'].']']) }}
             @endif
           </td>
+
+        <!-- deny -->
           <td class="col-md-1 permissions-item">
             @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
               {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ["value"=>"deny", 'disabled'=>'disabled', 'class'=>'radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
@@ -98,6 +101,8 @@
               {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ["value"=>"deny",'class'=>'radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
             @endif
           </td>
+
+        <!-- inherit -->
           <td class="col-md-1 permissions-item">
             @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
               {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ["value"=>"inherit", 'disabled'=>'disabled', 'class'=>'radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -76,7 +76,9 @@
       <div class="nav-tabs-custom">
         <ul class="nav nav-tabs">
           <li class="active"><a href="#info" data-toggle="tab">{{ trans('general.information') }} </a></li>
-          <li><a href="#permissions" data-toggle="tab">{{ trans('general.permissions') }} </a></li>
+            @can('users.permissions')
+            <li><a href="#permissions" data-toggle="tab">{{ trans('general.permissions') }} </a></li>
+            @endcan
         </ul>
 
         <div class="tab-content">
@@ -568,7 +570,7 @@
               </div> <!--/col-md-12-->
             </div>
           </div><!-- /.tab-pane -->
-
+          @can('users.permissions')
           <div class="tab-pane" id="permissions">
             <div class="col-md-12">
               @if (!Auth::user()->isSuperUser())
@@ -592,6 +594,7 @@
                 @include('partials.forms.edit.permissions-base')
             </table>
           </div><!-- /.tab-pane -->
+          @endcan
         </div><!-- /.tab-content -->
         <div class="box-footer text-right">
           <button type="submit" accesskey="s" class="btn btn-primary"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('general.save') }}</button>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -76,7 +76,7 @@
       <div class="nav-tabs-custom">
         <ul class="nav nav-tabs">
           <li class="active"><a href="#info" data-toggle="tab">{{ trans('general.information') }} </a></li>
-            @can('users.permissions')
+            @can('users.manage_permissions')
             <li><a href="#permissions" data-toggle="tab">{{ trans('general.permissions') }} </a></li>
             @endcan
         </ul>
@@ -570,7 +570,7 @@
               </div> <!--/col-md-12-->
             </div>
           </div><!-- /.tab-pane -->
-          @can('users.permissions')
+          @can('users.manage_permissions')
           <div class="tab-pane" id="permissions">
             <div class="col-md-12">
               @if (!Auth::user()->isSuperUser())


### PR DESCRIPTION
Inception!

This is a stab at a PR that would limit users who can create/edit users from being able to assign individual permissions to those users. (As it stands, only superadmins can manage group memberships). More testing needed, but I think this is the right track.