### PR TITLE
Email in License Seat Table

### DIFF
--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -27,7 +27,7 @@ class LicenseSeatsController extends Controller
         if ($license = License::find($licenseId)) {
             $this->authorize('view', $license);
 
-            $seats = LicenseSeat::with('license', 'user', 'asset', 'user.department')
+            $seats = LicenseSeat::with('license', 'user', 'email', 'asset', 'user.department')
                 ->where('license_seats.license_id', $licenseId);
 
             $order = $request->input('order') === 'asc' ? 'asc' : 'desc';

--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -27,7 +27,7 @@ class LicenseSeatsController extends Controller
         if ($license = License::find($licenseId)) {
             $this->authorize('view', $license);
 
-            $seats = LicenseSeat::with('license', 'user', 'email', 'asset', 'user.department')
+            $seats = LicenseSeat::with('license', 'user', 'asset', 'user.department')
                 ->where('license_seats.license_id', $licenseId);
 
             $order = $request->input('order') === 'asc' ? 'asc' : 'desc';

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -29,6 +29,7 @@ class LicenseSeatsTransformer
             'assigned_user' => ($seat->user) ? [
                 'id' => (int) $seat->user->id,
                 'name'=> e($seat->user->present()->fullName),
+                'email' => e($seat->user->email),
                 'department'=> ($seat->user->department) ?
                         [
                             'id' => (int) $seat->user->department->id,

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -229,6 +229,14 @@ class LicensePresenter extends Presenter
                 'visible' => true,
                 'formatter' => 'usersLinkObjFormatter',
             ], [
+                'field' => 'email',
+                'searchable' => false,
+                'sortable' => false,
+                'switchable' => true,
+                'title' => trans('admin/users/table.email'),
+                'visible' => true,
+                'formatter' => 'emailFormatter',
+            ], [
                 'field' => 'department',
                 'searchable' => false,
                 'sortable' => true,
@@ -236,8 +244,7 @@ class LicensePresenter extends Presenter
                 'title' => trans('general.department'),
                 'visible' => false,
                 'formatter' => 'departmentNameLinkFormatter',
-            ],
-            [
+            ], [
                 'field' => 'assigned_asset',
                 'searchable' => false,
                 'sortable' => false,

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -229,7 +229,7 @@ class LicensePresenter extends Presenter
                 'visible' => true,
                 'formatter' => 'usersLinkObjFormatter',
             ], [
-                'field' => 'email',
+                'field' => 'assigned_user.email',
                 'searchable' => false,
                 'sortable' => false,
                 'switchable' => true,


### PR DESCRIPTION
# Description
Email address is added to the license seat view tab.  Upon selecting the tab, a view of the email address for the user assigned to that license seat appears to the right of their name.  This info will also be in the export if the export is made from the license view page.

[SC24316](https://app.shortcut.com/grokability/story/24316/include-email-in-license-seat-table)
[Ticket 39372](https://support.snipeitapp.com/a/tickets/39372)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Test locally. New feature is only a view addition

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
