### PR TITLE
Make sure we're getting an object instead of a collection on Asset API for model_id

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -574,8 +574,8 @@ class AssetsController extends Controller
         $asset = $request->handleImages($asset);
 
         // Update custom fields in the database.
-        // Validation for these fields is handled through the AssetRequest form request
-        $model = AssetModel::find($request->get('model_id'));
+        // Sometimes people send arrays to this. They shouldn't, but they do, so we use "first()" to get the first match
+        $model = AssetModel::where('id', '=', $request->get('model_id'))->first();
 
         if (($model) && ($model->fieldset)) {
             foreach ($model->fieldset->fields as $field) {

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -574,10 +574,11 @@ class AssetsController extends Controller
         $asset = $request->handleImages($asset);
 
         // Update custom fields in the database.
-        // Sometimes people send arrays to this. They shouldn't, but they do, so we use "first()" to get the first match
-        $model = AssetModel::where('id', '=', $request->get('model_id'))->first();
+        $model = AssetModel::find($request->input('model_id'));
 
-        if (($model) && ($model->fieldset)) {
+        // Check that it's an object and not a collection
+        // (Sometimes people send arrays here and they shouldn't
+        if (($model) && ($model instanceof AssetModel) && ($model->fieldset)) {
             foreach ($model->fieldset->fields as $field) {
 
                 // Set the field value based on what was sent in the request


### PR DESCRIPTION
We were being haunted by a bug that was returning ` Property [fieldset] does not exist on this collection instance` via API for some users. In introspecting their payloads, they were sending an array instead of an int as the model ID. While we validate this at the asset level, when we're searching for the model ID., laravel can sometimes "helpfully" return a collection instead of a specific object. This is all well and good, but in this case we want only one `model_id`'s results.