### PR TITLE
Fixed Ldap sync test table and table data from overflowing

### DIFF
--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -696,16 +696,15 @@
          * Build the results html table
          */
         function buildLdapTestResults(results) {
-            let html = '<table id="ldap_test_table">'
-                html += '<ul style="list-style: none;padding-left: 5px;">'
+            let html = '<ul style="list-style: none;padding-left: 5px;">'
             html += '<li class="text-success"><i class="fas fa-check" aria-hidden="true"></i> ' + results.login.message + ' </li>'
             html += '<li class="text-success"><i class="fas fa-check" aria-hidden="true"></i> ' + results.bind.message + ' </li>'
             html += '</ul>'
             html += '<div>{{ trans('admin/settings/message.ldap.sync_success') }}</div>'
-            html += '<table class="table table-bordered table-condensed" style="background-color: #fff">'
+            html += '<table class="table table-bordered table-condensed" style=" table-layout:fixed; width:100%; background-color: #fff">'
             html += buildLdapResultsTableHeader()
             html += buildLdapResultsTableBody(results.user_sync.users)
-            html += '</table>'
+            html += '<table>'
             return html;
         }
 
@@ -730,7 +729,7 @@
         {
             let body = '<tbody>'
             for (var i in users) {
-                body += '<tr><td>' + users[i].employee_number + '</td><td>' + users[i].username + '</td><td>' + users[i].firstname + '</td><td>' + users[i].lastname + '</td><td>' + users[i].email + '</td></tr>'
+                body += '<tr><td style="overflow:hidden;">' + users[i].employee_number + '</td><td style="overflow:hidden;">' + users[i].username + '</td><td style="overflow:hidden;">' + users[i].firstname + '</td><td style="overflow:hidden;">' + users[i].lastname + '</td><td style="overflow:hidden;">' + users[i].email + '</td></tr>'
             }
             body += "</tbody>"
             return body;

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -696,7 +696,8 @@
          * Build the results html table
          */
         function buildLdapTestResults(results) {
-            let html = '<ul style="list-style: none;padding-left: 5px;">'
+            let html = '<table id="ldap_test_table">'
+                html += '<ul style="list-style: none;padding-left: 5px;">'
             html += '<li class="text-success"><i class="fas fa-check" aria-hidden="true"></i> ' + results.login.message + ' </li>'
             html += '<li class="text-success"><i class="fas fa-check" aria-hidden="true"></i> ' + results.bind.message + ' </li>'
             html += '</ul>'
@@ -704,7 +705,7 @@
             html += '<table class="table table-bordered table-condensed" style="background-color: #fff">'
             html += buildLdapResultsTableHeader()
             html += buildLdapResultsTableBody(results.user_sync.users)
-            html += '<table>'
+            html += '</table>'
             return html;
         }
 


### PR DESCRIPTION
# Description
This makes the ldap test sync table fixed so columns will not extend outside of the table and table data will not overflow as well.
<img width="652" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/852fbc75-a34e-4eba-908a-38d5f6c0cd57">

Fixes #SC-24333

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
