### PR TITLE
Added back-migration for Big Locale Refactoring

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1342,6 +1342,57 @@ class Helper
      * @param $language_code
      * @return string []
      */
+
+    public static $language_map =  ['af' => 'af-ZA', // Afrikaans
+        'am' => 'am-ET', // Amharic
+        'ar' => 'ar-SA', // Arabic
+        'bg' => 'bg-BG', // Bulgarian
+        'ca' => 'ca-ES', // Catalan
+        'cs' => 'cs-CZ', // Czech
+        'cy' => 'cy-GB', // Welsh
+        'da' => 'da-DK', // Danish
+        'de-i' => 'de-if', // German informal
+        'de' => 'de-DE', // German
+        'el' => 'el-GR', // Greek
+        'en' => 'en-US', // English
+        'et' => 'et-EE', // Estonian
+        'fa' => 'fa-IR', // Persian
+        'fi' => 'fi-FI', // Finnish
+        'fil' => 'fil-PH', // Filipino
+        'fr' => 'fr-FR', // French
+        'he' => 'he-IL', // Hebrew
+        'hr' => 'hr-HR', // Croatian
+        'hu' => 'hu-HU', // Hungarian
+        'id' => 'id-ID', // Indonesian
+        'is' => 'is-IS', // Icelandic
+        'it' => 'it-IT', // Italian
+        'iu' => 'iu-NU', // Inuktitut
+        'ja' => 'ja-JP', // Japanese
+        'ko' => 'ko-KR', // Korean
+        'lt' => 'lt-LT', // Lithuanian
+        'lv' => 'lv-LV', // Latvian
+        'mi' => 'mi-NZ', // Maori
+        'mk' => 'mk-MK', // Macedonian
+        'mn' => 'mn-MN', // Mongolian
+        'ms' => 'ms-MY', // Malay
+        'nl' => 'nl-NL', // Dutch
+        'no' => 'no-NO', // Norwegian
+        'pl' => 'pl-PL', // Polish
+        'ro' => 'ro-RO', // Romanian
+        'ru' => 'ru-RU', // Russian
+        'sk' => 'sk-SK', // Slovak
+        'sl' => 'sl-SI', // Slovenian
+        'so' => 'so-SO', // Somali
+        'ta' => 'ta-IN', // Tamil
+        'th' => 'th-TH', // Thai
+        'tl' => 'tl-PH', // Tagalog
+        'tr' => 'tr-TR', // Turkish
+        'uk' => 'uk-UA', // Ukrainian
+        'vi' => 'vi-VN', // Vietnamese
+        'zu' => 'zu-ZA', // Zulu
+    ];
+
+
     public static function mapLegacyLocale($language_code = null)
     {
 
@@ -1349,62 +1400,25 @@ class Helper
             return $language_code;
         }
 
-        $languages = [
-            'af' => 'af-ZA', // Afrikaans
-            'am' => 'am-ET', // Amharic
-            'ar' => 'ar-SA', // Arabic
-            'bg' => 'bg-BG', // Bulgarian
-            'ca' => 'ca-ES', // Catalan
-            'cs' => 'cs-CZ', // Czech
-            'cy' => 'cy-GB', // Welsh
-            'da' => 'da-DK', // Danish
-            'de-i' => 'de-if', // German informal
-            'de' => 'de-DE', // German
-            'el' => 'el-GR', // Greek
-            'en' => 'en-US', // English
-            'et' => 'et-EE', // Estonian
-            'fa' => 'fa-IR', // Persian
-            'fi' => 'fi-FI', // Finnish
-            'fil' => 'fil-PH', // Filipino
-            'fr' => 'fr-FR', // French
-            'he' => 'he-IL', // Hebrew
-            'hr' => 'hr-HR', // Croatian
-            'hu' => 'hu-HU', // Hungarian
-            'id' => 'id-ID', // Indonesian
-            'is' => 'is-IS', // Icelandic
-            'it' => 'it-IT', // Italian
-            'iu' => 'iu-NU', // Inuktitut
-            'ja' => 'ja-JP', // Japanese
-            'ko' => 'ko-KR', // Korean
-            'lt' => 'lt-LT', // Lithuanian
-            'lv' => 'lv-LV', // Latvian
-            'mi' => 'mi-NZ', // Maori
-            'mk' => 'mk-MK', // Macedonian
-            'mn' => 'mn-MN', // Mongolian
-            'ms' => 'ms-MY', // Malay
-            'nl' => 'nl-NL', // Dutch
-            'no' => 'no-NO', // Norwegian
-            'pl' => 'pl-PL', // Polish
-            'ro' => 'ro-RO', // Romanian
-            'ru' => 'ru-RU', // Russian
-            'sk' => 'sk-SK', // Slovak
-            'sl' => 'sl-SI', // Slovenian
-            'so' => 'so-SO', // Somali
-            'ta' => 'ta-IN', // Tamil
-            'th' => 'th-TH', // Thai
-            'tl' => 'tl-PH', // Tagalog
-            'tr' => 'tr-TR', // Turkish
-            'uk' => 'uk-UA', // Ukrainian
-            'vi' => 'vi-VN', // Vietnamese
-            'zu' => 'zu-ZA', // Zulu
-        ];
-
-        foreach ($languages as $legacy => $new) {
+        foreach (self::$language_map as $legacy => $new) {
             if ($language_code == $legacy) {
                 \Log::debug('Current language is '.$legacy.', using '.$new.' instead');
                 return $new;
             }
         }
+    }
+
+    public static function mapBackToLegacyLocale($new_locale = null)
+    {
+        if (strlen($new_locale) <= 4) {
+            return $new_locale; //"new locale" apparently wasn't quite so new
+        }
+        $legacy_locale = array_search($new_locale,self::$language_map);
+
+        if($legacy_locale !== false) {
+            return $legacy_locale;
+        }
+        return $new_locale; // better that you have some weird locale that doesn't fit into our mappings anywhere than 'void'
     }
 
 }

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1343,7 +1343,8 @@ class Helper
      * @return string []
      */
 
-    public static $language_map =  ['af' => 'af-ZA', // Afrikaans
+    public static $language_map =  [
+        'af' => 'af-ZA', // Afrikaans
         'am' => 'am-ET', // Amharic
         'ar' => 'ar-SA', // Arabic
         'bg' => 'bg-BG', // Bulgarian
@@ -1413,7 +1414,9 @@ class Helper
         if (strlen($new_locale) <= 4) {
             return $new_locale; //"new locale" apparently wasn't quite so new
         }
-        $legacy_locale = array_search($new_locale,self::$language_map);
+
+        // This does a *reverse* search against our new language map array - given the value, find the *key* for it
+        $legacy_locale = array_search($new_locale, self::$language_map);
 
         if($legacy_locale !== false) {
             return $legacy_locale;

--- a/database/migrations/2023_12_19_081112_fix_language_dirs.php
+++ b/database/migrations/2023_12_19_081112_fix_language_dirs.php
@@ -42,6 +42,19 @@ class FixLanguageDirs extends Migration
      */
     public function down()
     {
-        //
+        $settings = Setting::getSettings();
+        if (($settings) && ($settings->locale != '')) {
+            DB::table('settings')->update(['locale' => Helper::mapBackToLegacyLocale($settings->locale)]);
+        }
+
+        /**
+         * Update the users table
+         */
+        $users = User::whereNotNull('locale')->whereNull('deleted_at')->get();
+        // Skip the model in case the validation rules have changed
+        foreach ($users as $user) {
+            DB::table('users')->where('id', $user->id)->update(['locale' => Helper::mapBackToLegacyLocale($user->locale)]);
+        }
+
     }
 }


### PR DESCRIPTION
Just in case something goes horribly wrong with an upgrade to v6.3.0 (or wherever we land this Giant Locale Change), I thought it best for us to have a back migration.

This change pulls the giant Language Array out into a `$language_map` static variable, so it can continue to be used by the existing `mapLegacyLocale ` static Helper method, as well as the new `mapBackToLegacyLocale` static Helper method. I *could* have done some kind of clever loading up another array with smart keys-and-values, but this is probably *only* going to ever be used in the back-migration, and nowhere else. So hopefully not used much at all. Because of that, I left it unoptimized.

I tested by looking at my users and my settings record, then running the migration, checking those tables again, then migrating back, and checking those tables again. And they seem like they look kinda how you'd expect.