### PR TITLE
Set fallback locale to new locale code

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -112,7 +112,7 @@ return [
     |
     */
 
-    'fallback_locale' => env('FALLBACK_LOCALE', 'en-US'),
+    'fallback_locale' => 'en-US',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -112,7 +112,7 @@ return [
     |
     */
 
-    'fallback_locale' => 'en',
+    'fallback_locale' => env('FALLBACK_LOCALE', 'en-US'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
In testing, we found a few places where the mapping didn't work for the new language locales. Updating the `fallback_locale` in the config sorts this out though. 