### PR TITLE
Use `htmlentities()` instead of `htmlspecialcharacters()` on Custom Field Listbox Values

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -103,7 +103,7 @@ class CustomFieldsController extends Controller
             "name" => trim($request->get("name")),
             "element" => $request->get("element"),
             "help_text" => $request->get("help_text"),
-            "field_values" => $request->get("field_values"),
+            "field_values" => e($request->get("field_values")),
             "field_encrypted" => $request->get("field_encrypted", 0),
             "show_in_email" => $show_in_email,
             "is_unique" => $request->get("is_unique", 0),

--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -103,7 +103,7 @@ class CustomFieldsController extends Controller
             "name" => trim($request->get("name")),
             "element" => $request->get("element"),
             "help_text" => $request->get("help_text"),
-            "field_values" => e($request->get("field_values")),
+            "field_values" => $request->get("field_values"),
             "field_encrypted" => $request->get("field_encrypted", 0),
             "show_in_email" => $show_in_email,
             "is_unique" => $request->get("is_unique", 0),
@@ -260,7 +260,7 @@ class CustomFieldsController extends Controller
         
         $field->name          = trim(e($request->get("name")));
         $field->element       = e($request->get("element"));
-        $field->field_values  = e($request->get("field_values"));
+        $field->field_values  = $request->get("field_values");
         $field->user_id       = Auth::id();
         $field->help_text     = $request->get("help_text");
         $field->show_in_email = $show_in_email;

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -9,7 +9,7 @@
               <!-- Listbox -->
               @if ($field->element=='listbox')
                    {{ Form::select($field->db_column_name(), $field->formatFieldValuesAsArray(),
-                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, htmlspecialchars($item->{$field->db_column_name()}, ENT_QUOTES)) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
+                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
 
               @elseif ($field->element=='textarea')
                   <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -9,7 +9,7 @@
               <!-- Listbox -->
               @if ($field->element=='listbox')
                    {{ Form::select($field->db_column_name(), $field->formatFieldValuesAsArray(),
-                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, htmlentities($item->{$field->db_column_name()})) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
+                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, htmlspecialchars($item->{$field->db_column_name()}, ENT_QUOTES)) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
 
               @elseif ($field->element=='textarea')
                   <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -9,7 +9,7 @@
               <!-- Listbox -->
               @if ($field->element=='listbox')
                    {{ Form::select($field->db_column_name(), $field->formatFieldValuesAsArray(),
-                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, htmlspecialchars($item->{$field->db_column_name()}, ENT_QUOTES)) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
+                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, htmlentities($item->{$field->db_column_name()})) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
 
               @elseif ($field->element=='textarea')
                   <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -25,7 +25,7 @@
               <!-- Listbox -->
               @if ($field->element=='listbox')
                   {{ Form::select($field->db_column_name(), $field->formatFieldValuesAsArray(),
-                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, htmlspecialchars($item->{$field->db_column_name()}, ENT_QUOTES)) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
+                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
 
               @elseif ($field->element=='textarea')
                 @if($field->is_unique)

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -25,7 +25,7 @@
               <!-- Listbox -->
               @if ($field->element=='listbox')
                   {{ Form::select($field->db_column_name(), $field->formatFieldValuesAsArray(),
-                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, htmlentities($item->{$field->db_column_name()})) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
+                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, htmlspecialchars($item->{$field->db_column_name()}, ENT_QUOTES)) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
 
               @elseif ($field->element=='textarea')
                 @if($field->is_unique)

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -25,7 +25,7 @@
               <!-- Listbox -->
               @if ($field->element=='listbox')
                   {{ Form::select($field->db_column_name(), $field->formatFieldValuesAsArray(),
-                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, htmlspecialchars($item->{$field->db_column_name()}, ENT_QUOTES)) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
+                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, htmlentities($item->{$field->db_column_name()})) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
 
               @elseif ($field->element=='textarea')
                 @if($field->is_unique)


### PR DESCRIPTION
# Description
On the tin, this seems to allow the list box to function as expected, fixing an issue reported by a user. If there's anything you'd like me to test specifically I'm more than happy to do so, but from what I can tell this should resolve the issue. 

https://www.php.net/manual/en/function.htmlentities.php

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Checked to make sure values in listboxes are still coming through and matching correctly to their DB values. 

**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.2