### PR TITLE
Syncs readme to DockerHub description

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,22 @@
+name: Update Docker Hub Description
+on:
+  push:
+    branches:
+      - master
+      - develop
+    paths:
+      - README.md
+      - .github/workflows/dockerhub-description.yml
+jobs:
+  dockerHubDescription:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker Hub Description
+        uses: grokability/dockerhub-description@7ea9d275c7cdbe2b676a093a0308c50665e3b8b4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          repository: snipe/snipe-it
+          readme-filepath: ./README.md


### PR DESCRIPTION
# Description

This PR syncs the readme to [DockerHub](https://hub.docker.com/r/snipe/snipe-it) when the readme is updated during a push to the master or develop branches.

We're using a forked version of the [action](https://github.com/peter-evans/dockerhub-description) in Docker's [docs](https://docs.docker.com/build/ci/github-actions/update-dockerhub-desc/). The only reason we're using the forked version is because the action has access to the docker username and access token.

Since there isn't an easy way to test this without creating a new repo on GitHub and DockerHub, I'll keep an eye on [our page](https://hub.docker.com/r/snipe/snipe-it) in DockerHub after this PR is merged to make sure it worked as expected.

## Type of change

- [x] Bug fix(ish) (non-breaking change which fixes an issue)