### PR TITLE
Use Query Builder instead of Model for Update to Skip Observer

### DIFF
--- a/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
+++ b/database/migrations/2023_07_13_052204_denormalized_eol_and_add_column_for_explicit_date_to_assets.php
@@ -36,10 +36,12 @@ class DenormalizedEolAndAddColumnForExplicitDateToAssets extends Migration
                     }
                     if ($asset->model->eol) {
                         if ($months != $asset->model->eol) {
-                            $asset->update(['eol_explicit' => true]);
+                            DB::table('assets')->where('id', $asset->id)->update(['eol_explicit' => true]);
                         }
-                    } else {
-                        $asset->update(['eol_explicit' => true]);
+                    }
+                    // if there is NO model eol, but there is a purchase date and an asset_eol_date (which is what is left over) the asset_eol_date has still been explicitly set
+                    else {
+                        DB::table('assets')->where('id', $asset->id)->update(['eol_explicit' => true]);
                     }
                 }
             }


### PR DESCRIPTION
# Description
On the tin, fixes problem with later migration and the observer because of using eloquent to do an update in the migration. 

Partial credit to @marcusmoore 

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ran through migration testing different eol scenarios.


**Test Configuration**:
* PHP version: 8.1
* MySQL version 8.2
