### PR TITLE
Added correct counting of licenses seats through pagination

### DIFF
--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -52,7 +52,7 @@ class LicenseSeatsController extends Controller
             $seats = $seats->skip($offset)->take($limit)->get();
 
             if ($seats) {
-                return (new LicenseSeatsTransformer)->transformLicenseSeats($seats, $total, $page);
+                return (new LicenseSeatsTransformer)->transformLicenseSeats($seats, $total,$offset,$page);
             }
         }
 

--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -48,11 +48,11 @@ class LicenseSeatsController extends Controller
             }
 
             $limit = app('api_limit_value');
-
+            $page = $request->get('page');
             $seats = $seats->skip($offset)->take($limit)->get();
 
             if ($seats) {
-                return (new LicenseSeatsTransformer)->transformLicenseSeats($seats, $total);
+                return (new LicenseSeatsTransformer)->transformLicenseSeats($seats, $total, $page);
             }
         }
 

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -12,8 +12,9 @@ class LicenseSeatsTransformer
     public function transformLicenseSeats(Collection $seats, $total, $offset, $page)
     {
         $array = [];
-        $offset = isset($offset) ? $offset : 0;
+        $offset = $offset ?? 0;
         $seat_count = 0 +($offset *($page + 1));
+
         foreach ($seats as $seat) {
             $seat_count++;
             $array[] = self::transformLicenseSeat($seat, $seat_count);

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -12,6 +12,7 @@ class LicenseSeatsTransformer
     public function transformLicenseSeats(Collection $seats, $total, $offset, $page)
     {
         $array = [];
+        $offset = isset($offset) ? $offset : 0;
         $seat_count = 0 +($offset *($page + 1));
         foreach ($seats as $seat) {
             $seat_count++;

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 class LicenseSeatsTransformer
 {
-    public function transformLicenseSeats(Collection $seats, $total)
+    public function transformLicenseSeats(Collection $seats, $total, $page)
     {
         $array = [];
         $seat_count = 0;

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -9,10 +9,10 @@ use Illuminate\Database\Eloquent\Collection;
 
 class LicenseSeatsTransformer
 {
-    public function transformLicenseSeats(Collection $seats, $total, $page)
+    public function transformLicenseSeats(Collection $seats, $total, $offset, $page)
     {
         $array = [];
-        $seat_count = 0;
+        $seat_count = 0 +($offset *($page + 1));
         foreach ($seats as $seat) {
             $seat_count++;
             $array[] = self::transformLicenseSeat($seat, $seat_count);


### PR DESCRIPTION
# Description

The lIcenses seat number would restart if the page was changed. Now licenses seats count continues through pagination

<img width="1853" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/afffba79-698e-49ed-9b97-5d37cdb1c997">

Fixes #14067

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
