### PR TITLE
Fixes creating invalid query with null values

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -136,7 +136,7 @@ class AssetsController extends Controller
 
         // Search custom fields by column name
         foreach ($all_custom_fields as $field) {
-            if ($request->filled($field->db_column_name())) {
+            if ($request->filled($field->db_column_name()) && $field->db_column_name()) {
                 $assets->where($field->db_column_name(), '=', $request->input($field->db_column_name()));
             }
         }


### PR DESCRIPTION
# Description

This PR adds a guard against adding a null value to the query and subsequently throwing an exception upon the execution of that query.  

Having a custom field with a null `db_column` can cause this error since `$request->filled(null)` is truthy.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)