### PR TITLE
Fixed license seats id turning to zero when sorting by department

### DIFF
--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -126,6 +126,7 @@ class LicenseSeat extends SnipeModel implements ICompanyableChild
     {
         return $query->leftJoin('users as license_seat_users', 'license_seats.assigned_to', '=', 'license_seat_users.id')
             ->leftJoin('departments as license_user_dept', 'license_user_dept.id', '=', 'license_seat_users.department_id')
+            ->whereNotNull('license_seats.assigned_to')
             ->orderBy('license_user_dept.name', $order);
     }
 }

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -127,7 +127,6 @@ class LicenseSeat extends SnipeModel implements ICompanyableChild
         return $query->leftJoin('users as license_seat_users', 'license_seats.assigned_to', '=', 'license_seat_users.id')
             ->leftJoin('departments as license_user_dept', 'license_user_dept.id', '=', 'license_seat_users.department_id')
             ->whereNotNull('license_seats.assigned_to')
-            ->whereNotNull('license_user_dept.id')
             ->orderBy('license_user_dept.name', $order);
     }
 }

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -127,6 +127,7 @@ class LicenseSeat extends SnipeModel implements ICompanyableChild
         return $query->leftJoin('users as license_seat_users', 'license_seats.assigned_to', '=', 'license_seat_users.id')
             ->leftJoin('departments as license_user_dept', 'license_user_dept.id', '=', 'license_seat_users.department_id')
             ->whereNotNull('license_seats.assigned_to')
+            ->whereNotNull('license_user_dept.id')
             ->orderBy('license_user_dept.name', $order);
     }
 }


### PR DESCRIPTION
# Description

When you sort by department on a license that has open seats available the id of each seat is turned to 0, because there is no department associated with the empty seat, therefore department id = 0. This updates the query so if a seat is unassigned it will not show when sorting by department. It will reappear when sorting by ID.

https://github.com/snipe/snipe-it/assets/47435081/cd35e657-9e26-4198-bcfd-f99749597f79

Fixes #14081

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
