### PR TITLE
Moved limit and offset in user API to after additional qualifiers

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -192,11 +192,6 @@ class UsersController extends Controller
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
 
-        // Make sure the offset and limit are actually integers and do not exceed system limits
-        $offset = ($request->input('offset') > $users->count()) ? $users->count() : app('api_offset_value');
-        $limit = app('api_limit_value');
-
-
         switch ($request->input('sort')) {
             case 'manager':
                 $users = $users->OrderManager($order);
@@ -273,7 +268,17 @@ class UsersController extends Controller
         }
 
         $users = Company::scopeCompanyables($users);
-        
+
+
+        // Make sure the offset and limit are actually integers and do not exceed system limits
+        $offset = ($request->input('offset') > $users->count()) ? $users->count() : app('api_offset_value');
+        $limit = app('api_limit_value');
+
+        \Log::debug('Requested offset: '. $request->input('offset'));
+        \Log::debug('App offset: '. app('api_offset_value'));
+        \Log::debug('Actual offset: '. $offset);
+        \Log::debug('Limit: '. $limit);
+
         $total = $users->count();
         $users = $users->skip($offset)->take($limit)->get();
 


### PR DESCRIPTION
This should be a fix for something that's been a bug for a while, but is rarely implemented in the use case we were presented with. Basically, we were calling the count before the additional qualifiers, so the total we were providing wasn't exactly correct. 