### PR TITLE
Fixed [FD-39640]: preserve sort order when generating asset labels

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -55,7 +55,9 @@ class BulkAssetsController extends Controller
 
 
         $asset_ids = $request->input('ids');
-        $assets = Asset::with('assignedTo', 'location', 'model')->find($asset_ids);
+        // Using the 'short-ternary' A/K/A "Elvis operator" '?:' here because ->input() might return an empty string
+        list($sortname,$sortdir) = explode(" ",$request->input('sort') ?: 'id ASC');
+        $assets = Asset::with('assignedTo', 'location', 'model')->whereIn('id', $asset_ids)->orderBy($sortname, $sortdir)->get();
 
         $models = $assets->unique('model_id');
         $modelNames = [];

--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -6,7 +6,8 @@
       'id' => (isset($id_formname)) ? $id_formname : 'assetsBulkForm',
  ]) }}
 
-
+    {{-- The 'id ASC' will only be used if the cookie is actually empty (like on first-use) --}}
+    <input name="sort" type="hidden" value="id ASC">
     <label for="bulk_actions">
         <span class="sr-only">
             {{ trans('button.bulk_actions') }}

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -161,6 +161,38 @@
 
     });
 
+    // Initialize sort-order for bulk actions (label-generation) for snipe-tables
+    $('.snipe-table').each(function (i, table) {
+        table_cookie_segment = $(table).data('cookie-id-table');
+        name = '';
+        direction = '';
+        cookies = document.cookie.split(";");
+        for(i in cookies) {
+            cookiedef = cookies[i].split("=", 2);
+            cookiedef[0] = cookiedef[0].trim();
+            if (cookiedef[0] == table_cookie_segment + ".bs.table.sortOrder") {
+                direction = cookiedef[1];
+            }
+            if (cookiedef[0] == table_cookie_segment + ".bs.table.sortName") {
+                name = cookiedef[1];
+            }
+        }
+        if (name && direction) {
+            domnode = $($(this).data('bulk-form-id')).get(0);
+            if ( domnode && domnode.elements && domnode.elements.sort ) {
+                domnode.elements.sort.value = name + " " + direction;
+            }
+        }
+    });
+
+    // If sort order changes, update the sort-order for bulk-actions (for label-generation)
+    $('.snipe-table').on('sort.bs.table', function (event, name, order) {
+       domnode = $($(this).data('bulk-form-id')).get(0);
+       // make safe in case there isn't a bulk-form-id, or it's not found, or has no 'sort' element
+       if ( domnode && domnode.elements && domnode.elements.sort ) {
+           domnode.elements.sort.value = name + " " + order;
+       }
+    });
 
 
     


### PR DESCRIPTION
Customer noted that when they generate labels for assets, the ordering isn't the same as the ordering that they selected to generate the listing. Especially when ordering by asset tag, this could start to be important. So this change makes it so that whatever sort order you have selected is whatever is used by the asset tag generation piece.

It adds a new hidden field in the bulk-generate partial to contain sort order. There's new code to dynamically populate that field based on the saved value of the cookie for that particular snipe-table. And there's also some code to look for the Sort events, and update that field accordingly. Then, when the field is passed into the bulkedit controller, that sort order is taken into account when looking up the assets in question. All with sensible fallbacks (`id DESC`).

I tested some possibilities here - such as, what if you can't find a particular DOM node? What if there isn't one even defined? What if it's the first use of the software, and there isn't any cookie set? And I think I covered all the bases there.