### PR TITLE
Guard against passing non-integer for company_id when creating asset

### DIFF
--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -20,9 +20,16 @@ class StoreAssetRequest extends ImageUploadRequest
 
     public function prepareForValidation(): void
     {
+        // Guard against users passing in an array for company_id instead of an integer.
+        // If the company_id is not an integer then we simply use what was
+        // provided to be caught by model level validation later.
+        $idForCurrentUser = is_int($this->company_id)
+            ? Company::getIdForCurrentUser($this->company_id)
+            : $this->company_id;
+
         $this->merge([
             'asset_tag' => $this->asset_tag ?? Asset::autoincrement_asset(),
-            'company_id' => Company::getIdForCurrentUser($this->company_id),
+            'company_id' => $idForCurrentUser,
             'assigned_to' => $assigned_to ?? null,
         ]);
     }

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -10,6 +10,7 @@ use App\Models\Statuslabel;
 use App\Models\Supplier;
 use App\Models\User;
 use Carbon\Carbon;
+use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
@@ -424,5 +425,17 @@ class AssetStoreTest extends TestCase
         $this->assertTrue($apiAsset->checkedOutToAsset());
         // I think this makes sense, but open to a sanity check
         $this->assertTrue($asset->assignedAssets()->find($response['payload']['id'])->is($apiAsset));
+    }
+
+    public function testCompanyIdNeedsToBeInteger()
+    {
+        $this->actingAsForApi(User::factory()->createAssets()->create())
+            ->postJson(route('api.assets.store'), [
+                'company_id' => [1],
+            ])
+            ->assertStatusMessageIs('error')
+            ->assertJson(function (AssertableJson $json) {
+                $json->has('messages.company_id')->etc();
+            });
     }
 }


### PR DESCRIPTION
# Description

This PR adds a guard against passing non-integers for `company_id` when creating assets via the API. 

Previously, passing `company_id => [1]` would result in the array, `[1]`, being passed to `Company::getIdForCurrentUser()` which expects an integer or string value at a lower level and throw an exception. (Since this is happening the the `prepareForValidation` method, the rules haven't been checked yet)

Now, we only pass `company_id` to that method if it is an integer or use it as is if it is not. That results in model level validation rules being able to properly pick up it is not an integer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)