### PR TITLE
Search on supplier name attached to maintenance

### DIFF
--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -73,6 +73,7 @@ class AssetMaintenance extends Model implements ICompanyableChild
         'asset'     => ['name', 'asset_tag'],
         'asset.model'     => ['name', 'model_number'],
         'asset.supplier' => ['name'],
+        'supplier' => ['name'],
     ];
 
     public function getCompanyableParents()


### PR DESCRIPTION
This is a fix/addendum to #14108, which added the functionality to search through the *asset's* supplier, but not to the supplier of the maintenance itself. 

