### PR TITLE
Fixed the checkout button for Accessory checkout

### DIFF
--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -17,7 +17,7 @@
 
 <div class="row">
   <div class="col-md-9">
-    <form class="form-horizontal" method="post" action="" autocomplete="off">
+    <form class="form-horizontal" id="checkout_form" method="post" action="" autocomplete="off">
     <!-- CSRF Token -->
     <input type="hidden" name="_token" value="{{ csrf_token() }}" />
 
@@ -90,7 +90,7 @@
        </div>
        <div class="box-footer">
           <a class="btn btn-link" href="{{ URL::previous() }}">{{ trans('button.cancel') }}</a>
-          <button type="submit" class="btn btn-primary pull-right"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('general.checkout') }}</button>
+          <button type="submit" id="submit_button" class="btn btn-primary pull-right"><i class="fas fa-check icon-white" aria-hidden="true"></i> {{ trans('general.checkout') }}</button>
        </div>
     </div> <!-- .box.box-default -->
   </form>
@@ -99,3 +99,15 @@
 
 
 @stop
+@section('moar_scripts')
+    <script>
+        $(document).ready(function () {
+            $('#checkout_form').submit(function (event) {
+                event.preventDefault();
+
+            $('#submit_button').prop('disabled', true);
+            this.submit();
+            });
+        });
+    </script>
+@endsection


### PR DESCRIPTION
# Description

If you repeatedly clicked on the 'checkout' button you could register multiple checkouts. This fix disables the checkout button after it has been submitted once.

Before:

https://github.com/snipe/snipe-it/assets/47435081/059f624b-ba86-4bb7-8749-224af1825d97



After:

https://github.com/snipe/snipe-it/assets/47435081/1f27dde5-7d95-4e8d-bb51-ed976ebc8f28




Fixes #14077
## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
