### PR TITLE
Add php version requirements file for future-proofing upgrades

### DIFF
--- a/.upgrade_requirements.json
+++ b/.upgrade_requirements.json
@@ -2,7 +2,7 @@
     "DOC1": "This file is meant to be pulled from the current HEAD of the desired branch, NOT referenced locally",
     "DOC2": "In other words, what you see locally are the requirements for your _current_ install",
     "DOC3": "Please don't rely on these versions for planning upgrades unless you've fetched the most recent version",
-    "DOC4": "You should really just ignore it and tun upgrade.php. Really",
+    "DOC4": "You should really just ignore it and run upgrade.php. Really",
     "php_min_version": "8.1.0",
     "php_max_major_minor": "8.2",
     "php_max_wontwork": "8.3.0",

--- a/.upgrade_requirements.json
+++ b/.upgrade_requirements.json
@@ -5,5 +5,6 @@
     "DOC4": "You should really just ignore it and tun upgrade.php. Really",
     "php_min_version": "8.1.0",
     "php_max_major_minor": "8.2",
-    "php_max_wontwork": "8.3.0"
+    "php_max_wontwork": "8.3.0",
+    "current_snipeit_version": "6.3"
 }

--- a/upgrade_requirements.json
+++ b/upgrade_requirements.json
@@ -1,10 +1,4 @@
 {
-    "v6": {
-        "php_min_version": "7.4.0",
-        "php_max_major": "8.1"
-    },
-    "v7": {
-        "php_min_version": "8.1.0",
-        "php_max_major": "8.2"
-    }
+    "php_min_version": "8.1.0",
+    "php_max_major": "8.2"
 }

--- a/upgrade_requirements.json
+++ b/upgrade_requirements.json
@@ -1,0 +1,10 @@
+{
+    "v6": {
+        "php_min_version": "7.4.0",
+        "php_max_major": "8.1"
+    },
+    "v7": {
+        "php_min_version": "8.1.0",
+        "php_max_major": "8.2"
+    }
+}

--- a/upgrade_requirements.json
+++ b/upgrade_requirements.json
@@ -4,6 +4,6 @@
     "DOC3": "Please don't rely on these versions for planning upgrades unless you've fetched the most recent version",
     "DOC4": "You should really just ignore it and tun upgrade.php. Really",
     "php_min_version": "8.1.0",
-    "php_max_major": "8.2",
+    "php_max_major_minor": "8.2",
     "php_max_wontwork": "8.3.0"
 }

--- a/upgrade_requirements.json
+++ b/upgrade_requirements.json
@@ -1,4 +1,9 @@
 {
+    "DOC1": "This file is meant to be pulled from the current HEAD of the desired branch, NOT referenced locally",
+    "DOC2": "In other words, what you see locally are the requirements for your _current_ install",
+    "DOC3": "Please don't rely on these versions for planning upgrades unless you've fetched the most recent version",
+    "DOC4": "You should really just ignore it and tun upgrade.php. Really",
     "php_min_version": "8.1.0",
-    "php_max_major": "8.2"
+    "php_max_major": "8.2",
+    "php_max_wontwork": "8.3.0"
 }


### PR DESCRIPTION
There is a race condition in the upgrade.php file where it can't
currently know the hard requirements for the version it's upgrading to
until it does a git pull. By that time, it will have pulled new source
code that possibly relies on an incompatible version of php, leaving you
with a broken installation.

Example: You're running v6.2.x on PHP 7.4, which is fine. v7 requires
PHP 8.1 or 8.2, but we couldn't know that when we released v6. or v5 for
that matter. We could change the requirements in the most-recent v6
version of upgrade.php, but that doesn't help anyone who doesn't upgrade
first to the most recent v6. 

With this change we'll keep a requirements file,
.upgrade_requirements.json, up to date in the root of the default
branch as the requirements to upgrade to HEAD change.

The upgrade.php file will query this file _from Github_ at runtime, to
see if it's safe to pull down the rest of the repo, and warn you if not.

tl;dr, instead of hard-coding the php version requirements into
upgrade.php, we'll fetch the current ones from the live repo at runtime

This file is being added in a separate PR from the upgrade.php changes
so that testing of the script can be done against the live repo. Cart
and horse, and all that.