### PR TITLE
Add remote requirements checking to upgrade.php

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -149,7 +149,7 @@ if ($env_bad !='') {
     echo "!!!!!!!!!!!!!!!!!!!!!!!!! ABORTING THE UPGRADER !!!!!!!!!!!!!!!!!!!!!!\n";
     echo "Please correct the issues above in ".getcwd()."/.env and try again.\n";
     echo "--------------------------------------------------------\n";
-    exit;
+    exit(1);
 }
 
 
@@ -168,7 +168,7 @@ if ((version_compare(phpversion(), $php_min_works, '>=')) && (version_compare(ph
     echo "Snipe-IT requires PHP versions between ".$php_min_works." and ".$php_max_wontwork.".\n";
     echo "Please install a compatible version of PHP and re-run this script again. \n";
     echo "!!!!!!!!!!!!!!!!!!!!!!!!! ABORTING THE UPGRADER !!!!!!!!!!!!!!!!!!!!!!\n";
-    exit;
+    exit(1);
 }
 
 echo "Checking Required PHP extensions... \n\n";
@@ -256,7 +256,7 @@ if ($ext_missing!='') {
     echo "ABORTING THE INSTALLER  \n";
     echo "Please install the extensions above and re-run this script.\n";
     echo "--------------------------------------------------------\n";
-    exit;
+    exit(1);
 } else {
     echo $ext_installed."\n";
 
@@ -311,6 +311,7 @@ if ($dirs_not_writable!='') {
     echo "--------------------- !! ERROR !! ----------------------\n";
     echo "Please check the permissions on the directories above and re-run this script.\n";
     echo "------------------------- :( ---------------------------\n\n";
+    exit(1);
 }
 
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -1,8 +1,24 @@
 <?php
 (PHP_SAPI !== 'cli' || isset($_SERVER['HTTP_USER_AGENT'])) && die('Access denied.');
 
-$php_min_works = '7.4.0';
-$php_max_wontwork = '8.2.0';
+$app_environment = 'develop';
+
+// Check if a branch or tag was passed in the command line,
+// otherwise just use master
+(array_key_exists('1', $argv)) ? $branch = $argv[1] : $branch = 'master';
+
+
+// Fetching most current upgrade requirements from github. Read more here: https://github.com/snipe/snipe-it/pull/14127
+$remote_requirements_file = "https://raw.githubusercontent.com/snipe/snipe-it/$branch/.upgrade_requirements.json";
+$upgrade_requirements = json_decode(file_get_contents($remote_requirements_file), true);
+
+if (! $upgrade_requirements) {
+    die("\nERROR: Failed to retrieve remote requirements from $remote_requirements_file\nExiting.\n\n");
+}
+
+$php_min_works = $upgrade_requirements['php_min_version'];
+$php_max_wontwork = $upgrade_requirements['php_max_wontwork'];
+// done fetching requirements
 
 
 if ((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') || (!function_exists('posix_getpwuid'))) {
@@ -16,12 +32,6 @@ if ((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') || (!function_exists('posix_get
 	}
 }
 
-
-$app_environment = 'develop';
-
-// Check if a branch or tag was passed in the command line,
-// otherwise just use master
-(array_key_exists('1', $argv)) ? $branch = $argv[1] : $branch = 'master';
 
 echo "--------------------------------------------------------\n";
 echo "WELCOME TO THE SNIPE-IT UPGRADER! \n";

--- a/upgrade.php
+++ b/upgrade.php
@@ -55,6 +55,12 @@ echo "--------------------------------------------------------\n\n";
 
 // Check the .env looks ok
 $env = file('.env');
+if (! $env){
+    echo "\n!!!!!!!!!!!!!!!!!!!!!!!!!! .ENV FILE ERROR !!!!!!!!!!!!!!!!!!!!!!!!!!\n";
+    echo "Your .env file doesn't seem to exist in this directory or isn't readable! Please look into that.\n";
+    exit(1);
+}
+
 $env_good = '';
 $env_bad = '';
 


### PR DESCRIPTION
### Mainly

quoted from https://github.com/snipe/snipe-it/pull/14127

    There is a race condition in the upgrade.php file where it can't
    currently know the hard requirements for the version it's upgrading to
    until it does a git pull. By that time, it will have pulled new source
    code that possibly relies on an incompatible version of php, leaving you
    with a broken installation.

    Example: You're running v6.2.x on PHP 7.4, which is fine. v7 requires
    PHP 8.1 or 8.2, but we couldn't know that when we released v6. or v5 for
    that matter. We could change the requirements in the most-recent v6
    version of upgrade.php, but that doesn't help anyone who doesn't upgrade
    first to the most recent v6.

With this change, we implement fetching and incorporating the requirements
data from the remote file.

It's just fetching/decoding a couple of json values that replace the 
hard-coded version requirements.

We move the branch checking higher than the php version checking so that we
can use the defined/overridden $branch to decide what branch to pull the
requirements from.

### But also

Check to make sure there's a .env file

While i was testing this, i noticed that it ran right by the .env check, 
even though i don't have a .env file at all. The script checks for a
_bad_ .env, but not a missing one.

Now it does

### Relatedly

   Quit the script when we hit hard errors

   a found a few other points where we talk about exiting and re-running the
   script once fixed, but never actually exit. So i'm adding-in the missing
   exits, and updating any existing exits to make sure we return a failing
   return code to the shell