### PR TITLE
Improved radio button values in custom report form

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -718,10 +718,10 @@ class ReportsController extends Controller
             if ($request->filled('exclude_archived')) {
                 $assets->notArchived();
             }
-            if ($request->input('deleted_assets') == '1') {
+            if ($request->input('deleted_assets') == 'include_deleted') {
                 $assets->withTrashed();
             }
-            if ($request->input('deleted_assets') == '0') {
+            if ($request->input('deleted_assets') == 'only_deleted') {
                 $assets->onlyTrashed();
             }
 

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -434,15 +434,15 @@
               <div class="col-md-9 col-md-offset-3">
 
                   <label class="form-control">
-                    {{ Form::radio('deleted_assets', '', true, ['aria-label'=>'deleted_assets', 'id'=>'deleted_assets_exclude_deleted'])}}
+                    {{ Form::radio('deleted_assets', 'exclude_deleted', true, ['aria-label'=>'deleted_assets', 'id'=>'deleted_assets_exclude_deleted'])}}
                     {{ trans('general.exclude_deleted') }}
                   </label>
                   <label class="form-control">
-                    {{ Form::radio('deleted_assets', '1', old('deleted_assets'), ['aria-label'=>'deleted_assets', 'id'=>'deleted_assets_include_deleted']) }}
+                    {{ Form::radio('deleted_assets', 'include_deleted', old('deleted_assets'), ['aria-label'=>'deleted_assets', 'id'=>'deleted_assets_include_deleted']) }}
                     {{ trans('general.include_deleted') }}
                   </label>
                   <label class="form-control">
-                  {{ Form::radio('deleted_assets', '0', old('deleted_assets'), ['aria-label'=>'deleted_assets','id'=>'deleted_assets_only_deleted']) }}
+                  {{ Form::radio('deleted_assets', 'only_deleted', old('deleted_assets'), ['aria-label'=>'deleted_assets','id'=>'deleted_assets_only_deleted']) }}
                     {{ trans('general.only_deleted') }}
                   </label>
               </div>


### PR DESCRIPTION
# Description

This is a tiny PR that supports an upcoming feature. The change adds more explicit values to the following radio buttons on the custom report page:

![radio buttons on custom report page](https://github.com/snipe/snipe-it/assets/1141514/426e3573-2c9b-45a4-9402-5d9bd425f1c6)

Specifically it sets an actual value, `exclude_deleted`, for the default radio button. Again, this is to support a future feature.


## Type of change

- [x] Bug fix (ish) (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this by deleting an asset and running the report with the three options to make sure behavior didn't break.