### PR TITLE
Fix for LDAP syncing with base_dn and location_id and location [FD-39651]

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -88,18 +88,20 @@ class LdapSync extends Command
             /**
              * if a location ID has been specified, use that OU
              */
-            if ( $this->option('location_id') != '') {
+            if ( $this->option('location_id') ) {
 
                 foreach($this->option('location_id') as $location_id){
                     $location_ou = Location::where('id', '=', $location_id)->value('ldap_ou');
                     $search_base = $location_ou;
                     Log::debug('Importing users from specified location OU: \"'.$search_base.'\".');
                  }
+            }
 
             /**
-             * Otherwise if a manual base DN has been specified, use that
+             *  if a manual base DN has been specified, use that. Allow the Base DN to override
+             *  even if there's a location-based DN - if you picked it, you must have picked it for a reason.
              */
-            } elseif ($this->option('base_dn') != '') {
+            if ($this->option('base_dn') != '') {
                 $search_base = $this->option('base_dn');
                 Log::debug('Importing users from specified base DN: \"'.$search_base.'\".');
             }
@@ -125,14 +127,14 @@ class LdapSync extends Command
 
         /* Determine which location to assign users to by default. */
         $location = null; // TODO - this would be better called "$default_location", which is more explicit about its purpose
-            if ($this->option('location') != '') {
-                if ($location = Location::where('name', '=', $this->option('location'))->first()) {
-                    Log::debug('Location name ' . $this->option('location') . ' passed');
-                    Log::debug('Importing to ' . $location->name . ' (' . $location->id . ')');
-                }
+        if ($this->option('location') != '') {
+            if ($location = Location::where('name', '=', $this->option('location'))->first()) {
+                Log::debug('Location name ' . $this->option('location') . ' passed');
+                Log::debug('Importing to ' . $location->name . ' (' . $location->id . ')');
+            }
 
-            } elseif ($this->option('location_id') != '') {
-                foreach($this->option('location_id') as $location_id) {
+        } elseif ($this->option('location_id')) {
+            foreach($this->option('location_id') as $location_id) {
                 if ($location = Location::where('id', '=', $location_id)->first()) {
                     Log::debug('Location ID ' . $location_id . ' passed');
                     Log::debug('Importing to ' . $location->name . ' (' . $location->id . ')');


### PR DESCRIPTION
We had a few bugs and a few formatting problems with the LDAP sync script, and it was affecting at least one of our users.

Specifically, if you had both `--location_id` and `--base_dn` settings set as parameters, the `--base_dn` setting wouldn't take effect.

Additionally, if you try to work around that by setting `--location`, a weird slightly different bug would get triggered, and the `--base_dn` would still not get respected.

Finally, there were some weird problems with the indenting that I decided to fix while I was in there. I normally don't like to do that because it can make finding out which changes are substantial or not much harder, but in this case the wrong indents were making it hard for me to read the file.