### PR TITLE
Fixed english and attribute placeholder

### DIFF
--- a/resources/lang/en-US/validation.php
+++ b/resources/lang/en-US/validation.php
@@ -96,7 +96,7 @@ return [
     'url'                  => 'The :attribute format is invalid.',
     'unique_undeleted'     => 'The :attribute must be unique.',
     'non_circular'         => 'The :attribute must not create a circular reference.',
-    'not_array'            => ':atribute harus array.',
+    'not_array'            => ':attribute cannot be an array.',
     'disallow_same_pwd_as_user_fields' => 'Password cannot be the same as the username.',
     'letters'              => 'Password must contain at least one letter.',
     'numbers'              => 'Password must contain at least one number.',


### PR DESCRIPTION
Looks like we were using `:atribute` instead of `:attribute` in the translation string.