### PR TITLE
Fixed #14114 - correctly sort related fields for labels

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -49,15 +49,87 @@ class BulkAssetsController extends Controller
             return redirect()->back()->with('error', trans('admin/hardware/message.update.no_assets_selected'));
         }
 
+        $asset_ids = $request->input('ids');
+
         // Figure out where we need to send the user after the update is complete, and store that in the session
         $bulk_back_url = request()->headers->get('referer');
         session(['bulk_back_url' => $bulk_back_url]);
 
+        $allowed_columns = [
+            'id',
+            'name',
+            'asset_tag',
+            'serial',
+            'model_number',
+            'last_checkout',
+            'notes',
+            'expected_checkin',
+            'order_number',
+            'image',
+            'assigned_to',
+            'created_at',
+            'updated_at',
+            'purchase_date',
+            'purchase_cost',
+            'last_audit_date',
+            'next_audit_date',
+            'warranty_months',
+            'checkout_counter',
+            'checkin_counter',
+            'requests_counter',
+            'byod',
+            'asset_eol_date',
+        ];
 
-        $asset_ids = $request->input('ids');
-        // Using the 'short-ternary' A/K/A "Elvis operator" '?:' here because ->input() might return an empty string
-        list($sortname,$sortdir) = explode(" ",$request->input('sort') ?: 'id ASC');
-        $assets = Asset::with('assignedTo', 'location', 'model')->whereIn('id', $asset_ids)->orderBy($sortname, $sortdir)->get();
+
+        /**
+         * Make sure the column is allowed, and if it's a custom field, make sure we strip the custom_fields. prefix
+         */
+        $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
+        $sort_override = str_replace('custom_fields.', '', $request->input('sort'));
+
+        // This handles all of the pivot sorting below (versus the assets.* fields in the allowed_columns array)
+        $column_sort = in_array($sort_override, $allowed_columns) ? $sort_override : 'assets.id';
+
+        $assets = Asset::with('assignedTo', 'location', 'model')->whereIn('assets.id', $asset_ids);
+
+        switch ($sort_override) {
+            case 'model':
+                $assets->OrderModels($order);
+                break;
+            case 'model_number':
+                $assets->OrderModelNumber($order);
+                break;
+            case 'category':
+                $assets->OrderCategory($order);
+                break;
+            case 'manufacturer':
+                $assets->OrderManufacturer($order);
+                break;
+            case 'company':
+                $assets->OrderCompany($order);
+                break;
+            case 'location':
+                $assets->OrderLocation($order);
+            case 'rtd_location':
+                $assets->OrderRtdLocation($order);
+                break;
+            case 'status_label':
+                $assets->OrderStatus($order);
+                break;
+            case 'supplier':
+                $assets->OrderSupplier($order);
+                break;
+            case 'assigned_to':
+                $assets->OrderAssigned($order);
+                break;
+            default:
+                $assets->orderBy($column_sort, $order);
+                break;
+        }
+
+        \Log::debug($assets->toSql());
+        $assets = $assets->get();
 
         $models = $assets->unique('model_id');
         $modelNames = [];

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -128,7 +128,6 @@ class BulkAssetsController extends Controller
                 break;
         }
 
-        \Log::debug($assets->toSql());
         $assets = $assets->get();
 
         $models = $assets->unique('model_id');

--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -6,8 +6,9 @@
       'id' => (isset($id_formname)) ? $id_formname : 'assetsBulkForm',
  ]) }}
 
-    {{-- The 'id ASC' will only be used if the cookie is actually empty (like on first-use) --}}
-    <input name="sort" type="hidden" value="id ASC">
+    {{-- The sort and order will only be used if the cookie is actually empty (like on first-use) --}}
+    <input name="sort" type="hidden" value="assets.id">
+    <input name="order" type="hidden" value="asc">
     <label for="bulk_actions">
         <span class="sr-only">
             {{ trans('button.bulk_actions') }}

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -164,23 +164,24 @@
     // Initialize sort-order for bulk actions (label-generation) for snipe-tables
     $('.snipe-table').each(function (i, table) {
         table_cookie_segment = $(table).data('cookie-id-table');
-        name = '';
-        direction = '';
+        sort = '';
+        order = '';
         cookies = document.cookie.split(";");
         for(i in cookies) {
             cookiedef = cookies[i].split("=", 2);
             cookiedef[0] = cookiedef[0].trim();
             if (cookiedef[0] == table_cookie_segment + ".bs.table.sortOrder") {
-                direction = cookiedef[1];
+                order = cookiedef[1];
             }
             if (cookiedef[0] == table_cookie_segment + ".bs.table.sortName") {
-                name = cookiedef[1];
+                sort = cookiedef[1];
             }
         }
-        if (name && direction) {
+        if (sort && order) {
             domnode = $($(this).data('bulk-form-id')).get(0);
             if ( domnode && domnode.elements && domnode.elements.sort ) {
-                domnode.elements.sort.value = name + " " + direction;
+                domnode.elements.sort.value = sort;
+                domnode.elements.order.value = order;
             }
         }
     });
@@ -190,7 +191,8 @@
        domnode = $($(this).data('bulk-form-id')).get(0);
        // make safe in case there isn't a bulk-form-id, or it's not found, or has no 'sort' element
        if ( domnode && domnode.elements && domnode.elements.sort ) {
-           domnode.elements.sort.value = name + " " + order;
+           domnode.elements.sort.value = name;
+           domnode.elements.order.value = order;
        }
     });
 


### PR DESCRIPTION
Previously, if you selected multiple assets that were sorted in your list view, the labels would crash if you were sorting on something that wasn't directly on the assets table (category, model, location, status label, etc) with the error of

```
Illuminate\Database\QueryException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'status_label' in 'order clause' (SQL: select * from `assets` where `id` in (68, 66) and `assets`.`deleted_at` is null order by `status_label` desc)
```

since `assets.status_label` isn't a field, and we have to reach through `assets.status_id` -> `status_labels.id` to find out the name of the status label an asset has (and the same goes for company, category, etc). We already have those query scopes set up, since they're the same ones the API and listings pages use, so this implements them here as well. 

This fixes RB-17764 and sc-24511, and is related to  #14114.