### PR TITLE
Avoid unnecessarily hydrating models on asset model show page

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -288,7 +288,7 @@ class AssetModelsController extends Controller
     public function show($modelId = null)
     {
         $this->authorize('view', AssetModel::class);
-        $model = AssetModel::withTrashed()->find($modelId);
+        $model = AssetModel::withTrashed()->withCount('assets')->find($modelId);
 
         if (isset($model->id)) {
             return view('models/view', compact('model'));

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -43,7 +43,7 @@
                         </span>
                                     <span class="hidden-xs hidden-sm">
                             {{ trans('general.assets') }}
-                                        {!! (($model->assets) && ($model->assets->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($model->assets->count()).'</badge>' : '' !!}
+                                        {!! (($model->assets_count) && ($model->assets_count > 0 )) ? '<badge class="badge badge-secondary">'.number_format($model->assets_count).'</badge>' : '' !!}
                         </span>
                     </a>
                 </li>
@@ -342,7 +342,7 @@
             @endcan
 
             @can('delete', \App\Models\AssetModel::class)
-                @if ($model->assets->count() > 0)
+                @if ($model->assets_count > 0)
 
                     <div class="col-md-12" style="padding-bottom: 5px;">
                         <button class="btn btn-block btn-sm btn-danger hidden-print disabled" data-tooltip="true"  data-placement="top" data-title="{{ trans('general.cannot_be_deleted') }}">{{ trans('general.delete') }}</button>


### PR DESCRIPTION
# Description

This PR avoids hydrating models that are only used for displaying the related count on the asset model show page.

![CleanShot 2024-01-24 at 16 17 06@2x](https://github.com/snipe/snipe-it/assets/1141514/bf0c2a52-defb-4312-8fa9-d7385ab317de)

Before:
![CleanShot 2024-01-24 at 16 17 20@2x](https://github.com/snipe/snipe-it/assets/1141514/bc3df88f-94fc-4668-9ab5-57c401ba4f93)

After:
![CleanShot 2024-01-24 at 16 17 47@2x](https://github.com/snipe/snipe-it/assets/1141514/edb2bcf2-0a85-44b3-9d33-3a738299a7db)

(hydrated model count is being displayed in debugbar)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)