### PR TITLE
Enforce SAML assertion ID uniqueness and notValidOnOrAfter attribute [FD-37019]

### DIFF
--- a/app/Console/Commands/SamlClearExpiredNonces.php
+++ b/app/Console/Commands/SamlClearExpiredNonces.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\SamlNonce;
+
+class SamlClearExpiredNonces extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'saml:clear_expired_nonces';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        SamlNonce::where('not_valid_after','<=',now())->delete();
+        return 0;
+    }
+}

--- a/app/Console/Commands/SamlClearExpiredNonces.php
+++ b/app/Console/Commands/SamlClearExpiredNonces.php
@@ -19,7 +19,7 @@ class SamlClearExpiredNonces extends Command
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'Clears out expired SAML assertions from the saml_nonces table';
 
     /**
      * Create a new command instance.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -25,6 +25,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('backup:clean')->daily();
         $schedule->command('snipeit:upcoming-audits')->daily();
         $schedule->command('auth:clear-resets')->everyFifteenMinutes();
+        $schedule->command('saml:clear_expired_nonces')->weekly();
     }
 
     /**

--- a/app/Models/SamlNonce.php
+++ b/app/Models/SamlNonce.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SamlNonce extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['nonce','not_on_or_after'];
+
+    public $timestamps = false;
+}

--- a/app/Services/Saml.php
+++ b/app/Services/Saml.php
@@ -394,6 +394,8 @@ class Saml
             'nameIdSPNameQualifier' => $auth->getNameIdSPNameQualifier(),
             'sessionIndex' => $auth->getSessionIndex(),
             'sessionExpiration' => $auth->getSessionExpiration(),
+            'nonce' => $auth->getLastAssertionId(),
+            'assertionNotOnOrAfter' => $auth->getLastAssertionNotOnOrAfter(),
         ];
     }
 

--- a/database/migrations/2024_01_24_145544_create_saml_nonce_table.php
+++ b/database/migrations/2024_01_24_145544_create_saml_nonce_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSamlNonceTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('saml_nonces', function (Blueprint $table) {
+            $table->id();
+            $table->string('nonce')->index();
+            $table->datetime('not_valid_after')->index();
+            //$table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('saml_nonces');
+    }
+}

--- a/database/migrations/2024_01_24_145544_create_saml_nonce_table.php
+++ b/database/migrations/2024_01_24_145544_create_saml_nonce_table.php
@@ -13,12 +13,14 @@ class CreateSamlNonceTable extends Migration
      */
     public function up()
     {
-        Schema::create('saml_nonces', function (Blueprint $table) {
-            $table->id();
-            $table->string('nonce')->index();
-            $table->datetime('not_valid_after')->index();
-            //$table->timestamps();
-        });
+        if (! Schema::hasTable('saml_nonces') ) {
+            Schema::create('saml_nonces', function (Blueprint $table) {
+                $table->id();
+                $table->string('nonce')->index();
+                $table->datetime('not_valid_after')->index();
+                //$table->timestamps();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2024_01_24_145544_create_saml_nonce_table.php
+++ b/database/migrations/2024_01_24_145544_create_saml_nonce_table.php
@@ -18,7 +18,6 @@ class CreateSamlNonceTable extends Migration
                 $table->id();
                 $table->string('nonce')->index();
                 $table->datetime('not_valid_after')->index();
-                //$table->timestamps();
             });
         }
     }


### PR DESCRIPTION
Our SAML system was ignoring the fact that assertionID's in SAML are meant to only be used once. Additionally, there's an attribute in each assertion called notOnOrAfter which needs to be respected, and we weren't.

These weren't really exploitable issues - if an attacker can sniff TLS traffic, you're already gonna have a pretty bad time. And the IdP's themselves won't certify older SAML assertions anyways. But they're issues that will come up on some customer's pen-tests, and it just doesn't look good for us to fail those. Now we shouldn't anymore.

This handles both of those, and includes a new Artisan command to clear old assertions from the table. Additionally, I added it to the kernel so that the regular scheduler will run the cleaning command weekly (which seems like enough; this is a pretty narrow table).

There was also some stuff where we were throwing a brand-new exception in our exception handler - when we already have a perfectly serviceable one that we can re-throw ourselves. So I just used that. I also made it so that these errors - which are client-side errors, not server-side errors, will now use a 400-series HTTP status code rather than 500.