### PR TITLE
Removed attribute assigning blank EOL as 0

### DIFF
--- a/app/Models/AssetModel.php
+++ b/app/Models/AssetModel.php
@@ -46,15 +46,6 @@ class AssetModel extends SnipeModel
     protected $injectUniqueIdentifier = true;
     use ValidatingTrait;
 
-    public function setEolAttribute($value)
-    {
-        if ($value == '') {
-            $value = 0;
-        }
-
-        $this->attributes['eol'] = $value;
-    }
-
     /**
      * The attributes that are mass assignable.
      *

--- a/tests/Unit/AssetModelTest.php
+++ b/tests/Unit/AssetModelTest.php
@@ -10,16 +10,7 @@ use Tests\TestCase;
 class AssetModelTest extends TestCase
 {
     use InteractsWithSettings;
-
-    public function testAnAssetModelZerosOutBlankEols()
-    {
-        $am = new AssetModel;
-        $am->eol = '';
-        $this->assertTrue($am->eol === 0);
-        $am->eol = '4';
-        $this->assertTrue($am->eol == 4);
-    }
-
+    
     public function testAnAssetModelContainsAssets()
     {
         $category = Category::factory()->create([


### PR DESCRIPTION
There was a magical attribute that was assigning the model's EOL rate to 0 if it was blank. This corrects that behavior, and removes the test that is no longer needed. We're not sure if this is directly related to FD-39934, but in trying to reproduce their issue, we discovered this one.