### PR TITLE
Resolve Duplicate Activity Logs for Imports

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -599,12 +599,7 @@ class AssetsController extends Controller
                 $target = Location::find(request('assigned_location'));
             }
             if (isset($target)) {
-                $asset->checkOut($target,
-                                Auth::user(),
-                                date('Y-m-d H:i:s'),
-                                '',
-                                'Checked out on asset creation',
-                                e($request->get('name')));
+                $asset->checkOut($target, Auth::user(), date('Y-m-d H:i:s'), '', 'Checked out on asset creation', e($request->get('name')));
             }
 
             if ($asset->image) {

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -599,7 +599,12 @@ class AssetsController extends Controller
                 $target = Location::find(request('assigned_location'));
             }
             if (isset($target)) {
-                $asset->checkOut($target, Auth::user(), date('Y-m-d H:i:s'), '', 'Checked out on asset creation', e($request->get('name')));
+                $asset->checkOut($target,
+                                Auth::user(),
+                                date('Y-m-d H:i:s'),
+                                '',
+                                'Checked out on asset creation',
+                                e($request->get('name')));
             }
 
             if ($asset->image) {

--- a/app/Importer/AccessoryImporter.php
+++ b/app/Importer/AccessoryImporter.php
@@ -46,10 +46,9 @@ class AccessoryImporter extends ItemImporter
         $this->item['min_amt'] = $this->findCsvMatch($row, "min_amt");
         $accessory->fill($this->sanitizeItemForStoring($accessory));
 
-        //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.
-        // $accessory->unsetEventDispatcher();
+        // This sets an attribute on the Loggable trait for the action log
+        $accessory->setImported(true);
         if ($accessory->save()) {
-            $accessory->logCreate('Imported using CSV Importer');
             $this->log('Accessory '.$this->item['name'].' was created');
 
             return;

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -138,7 +138,8 @@ class AssetImporter extends ItemImporter
        
         if ($asset->save()) {
 
-            $asset->logCreate(trans('general.importer.import_note'));
+            //$asset->logCreate(trans('general.importer.import_note'));
+            $asset->setImported(true);
             $this->log('Asset '.$this->item['name'].' with serial number '.$this->item['serial'].' was created');
 
             // If we have a target to checkout to, lets do so.

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -135,7 +135,7 @@ class AssetImporter extends ItemImporter
                 $asset->{$custom_field} = $val;
             }
         }
-        //this sets an attribute on the Loggable trait for the action log
+        // This sets an attribute on the Loggable trait for the action log
         $asset->setImported(true);
         if ($asset->save()) {
 

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -135,11 +135,10 @@ class AssetImporter extends ItemImporter
                 $asset->{$custom_field} = $val;
             }
         }
-       
+        //this sets an attribute on the Loggable trait for the action log
+        $asset->setImported(true);
         if ($asset->save()) {
 
-            //$asset->logCreate(trans('general.importer.import_note'));
-            $asset->setImported(true);
             $this->log('Asset '.$this->item['name'].' with serial number '.$this->item['serial'].' was created');
 
             // If we have a target to checkout to, lets do so.

--- a/app/Importer/ComponentImporter.php
+++ b/app/Importer/ComponentImporter.php
@@ -48,10 +48,10 @@ class ComponentImporter extends ItemImporter
         $this->log('No matching component, creating one');
         $component = new Component;
         $component->fill($this->sanitizeItemForStoring($component));
-        //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.
-        $component->unsetEventDispatcher();
+
+        // This sets an attribute on the Loggable trait for the action log
+        $component->setImported(true);
         if ($component->save()) {
-            $component->logCreate('Imported using CSV Importer');
             $this->log('Component '.$this->item['name'].' was created');
 
             // If we have an asset tag, checkout to that asset.

--- a/app/Importer/ConsumableImporter.php
+++ b/app/Importer/ConsumableImporter.php
@@ -45,10 +45,10 @@ class ConsumableImporter extends ItemImporter
         $this->item['item_no'] = trim($this->findCsvMatch($row, 'item_number'));
         $this->item['min_amt'] = trim($this->findCsvMatch($row, "min_amt"));
         $consumable->fill($this->sanitizeItemForStoring($consumable));
-        //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.
-        $consumable->unsetEventDispatcher();
+
+        // This sets an attribute on the Loggable trait for the action log
+        $consumable->setImported(true);
         if ($consumable->save()) {
-            $consumable->logCreate('Imported using CSV Importer');
             $this->log('Consumable '.$this->item['name'].' was created');
 
             return;

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -85,10 +85,10 @@ class LicenseImporter extends ItemImporter
         } else {
             $license->fill($this->sanitizeItemForStoring($license));
         }
-        //FIXME: this disables model validation.  Need to find a way to avoid double-logs without breaking everything.
-        // $license->unsetEventDispatcher();
+
+        // This sets an attribute on the Loggable trait for the action log
+        $license->setImported(true);
         if ($license->save()) {
-            $license->logCreate('Imported using csv importer');
             $this->log('License '.$this->item['name'].' with serial number '.$this->item['serial'].' was created');
 
             // Lets try to checkout seats if the fields exist and we have seats.

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -19,6 +19,9 @@ class Actionlog extends SnipeModel
 {
     use HasFactory;
 
+    // This is to manually set the source (via setActionSource()) for determineActionSource()
+    protected ?string $source = null;
+
     protected $presenter = \App\Presenters\ActionlogPresenter::class;
     use SoftDeletes;
     use Presentable;
@@ -341,7 +344,12 @@ class Actionlog extends SnipeModel
      * @since v6.3.0
      * @return string
      */
-    public function determineActionSource() {
+    public function determineActionSource(): string
+    {
+        // This is a manually set source
+        if($this->source) {
+            return $this->source;
+        }
 
         // This is an API call
         if (((request()->header('content-type') && (request()->header('accept'))=='application/json'))
@@ -357,5 +365,11 @@ class Actionlog extends SnipeModel
         // We're not sure, probably cli
         return 'cli/unknown';
 
+    }
+
+    // Manually sets $this->source for determineActionSource()
+    public function setActionSource($source = null): void
+    {
+        $this->source = $source;
     }
 }

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Auth;
 
 trait Loggable
 {
+    public ?bool $imported = false; // Import note attribute
+
     /**
      * @author  Daniel Meltzer <dmeltzer.devel@gmail.com>
      * @since [v3.4]
@@ -16,6 +18,16 @@ trait Loggable
     public function log()
     {
         return $this->morphMany(Actionlog::class, 'item');
+    }
+
+    public function setImported(bool $bool): void
+    {
+        $this->imported = $bool;
+    }
+
+    public function getImported(): bool
+    {
+        return $this->imported;
     }
 
     /**

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -8,7 +8,8 @@ use Illuminate\Support\Facades\Auth;
 
 trait Loggable
 {
-    public ?bool $imported = false; // Import note attribute
+    // an attribute for setting whether or not the item was imported
+    public ?bool $imported = false;
 
     /**
      * @author  Daniel Meltzer <dmeltzer.devel@gmail.com>
@@ -23,11 +24,6 @@ trait Loggable
     public function setImported(bool $bool): void
     {
         $this->imported = $bool;
-    }
-
-    public function getImported(): bool
-    {
-        return $this->imported;
     }
 
     /**

--- a/app/Observers/AccessoryObserver.php
+++ b/app/Observers/AccessoryObserver.php
@@ -39,7 +39,7 @@ class AccessoryObserver
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
         if($accessory->imported) {
-            $logAction->note = trans('general.importer.import_note');
+            $logAction->setActionSource('importer');
         }
         $logAction->logaction('create');
     }

--- a/app/Observers/AccessoryObserver.php
+++ b/app/Observers/AccessoryObserver.php
@@ -38,6 +38,9 @@ class AccessoryObserver
         $logAction->item_id = $accessory->id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
+        if($accessory->imported) {
+            $logAction->note = trans('general.importer.import_note');
+        }
         $logAction->logaction('create');
     }
 

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -110,7 +110,7 @@ class AssetObserver
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
         if($asset->imported) {
-            $logAction->note = trans('general.importer.import_note');
+            $logAction->setActionSource('importer');
         }
         $logAction->logaction('create');
     }

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -109,6 +109,10 @@ class AssetObserver
         $logAction->item_id = $asset->id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
+        $logAction->note = 'poop';
+        if($asset->getImported()) {
+            $logAction->note = "this asset was imported";
+        }
         $logAction->logaction('create');
     }
 

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -109,9 +109,8 @@ class AssetObserver
         $logAction->item_id = $asset->id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
-        $logAction->note = 'poop';
-        if($asset->getImported()) {
-            $logAction->note = "this asset was imported";
+        if($asset->imported) {
+            $logAction->note = trans('general.importer.import_note');
         }
         $logAction->logaction('create');
     }

--- a/app/Observers/ComponentObserver.php
+++ b/app/Observers/ComponentObserver.php
@@ -39,7 +39,7 @@ class ComponentObserver
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
         if($component->imported) {
-            $logAction->note = trans('general.importer.import_note');
+            $logAction->setActionSource('importer');
         }
         $logAction->logaction('create');
     }

--- a/app/Observers/ComponentObserver.php
+++ b/app/Observers/ComponentObserver.php
@@ -38,6 +38,9 @@ class ComponentObserver
         $logAction->item_id = $component->id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
+        if($component->imported) {
+            $logAction->note = trans('general.importer.import_note');
+        }
         $logAction->logaction('create');
     }
 

--- a/app/Observers/ConsumableObserver.php
+++ b/app/Observers/ConsumableObserver.php
@@ -38,6 +38,9 @@ class ConsumableObserver
         $logAction->item_id = $consumable->id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
+        if($consumable->imported) {
+            $logAction->note = trans('general.importer.import_note');
+        }
         $logAction->logaction('create');
     }
 

--- a/app/Observers/ConsumableObserver.php
+++ b/app/Observers/ConsumableObserver.php
@@ -39,7 +39,7 @@ class ConsumableObserver
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
         if($consumable->imported) {
-            $logAction->note = trans('general.importer.import_note');
+            $logAction->setActionSource('importer');
         }
         $logAction->logaction('create');
     }

--- a/app/Observers/LicenseObserver.php
+++ b/app/Observers/LicenseObserver.php
@@ -38,6 +38,9 @@ class LicenseObserver
         $logAction->item_id = $license->id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
+        if($license->imported) {
+            $logAction->note = trans('general.importer.import_note');
+        }
         $logAction->logaction('create');
     }
 

--- a/app/Observers/LicenseObserver.php
+++ b/app/Observers/LicenseObserver.php
@@ -39,7 +39,7 @@ class LicenseObserver
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->user_id = Auth::id();
         if($license->imported) {
-            $logAction->note = trans('general.importer.import_note');
+            $logAction->setActionSource('importer');
         }
         $logAction->logaction('create');
     }

--- a/sample_csvs/components-sample.csv
+++ b/sample_csvs/components-sample.csv
@@ -1,0 +1,2 @@
+Item Name,Purchase Date,Purchase Cost,Location,Company,Order Number,Serial number,Category,Quantity
+RTX 4080,2024-01-01,5000.00,Austin,Grokability,2790,123456789,GPU,10


### PR DESCRIPTION
# Description
Resolves the issue with duplicate activity logs for items that were created using the importer by setting an attribute on the Loggable trait and removing the specific log point on the importer classes, setting the attribute at import time, and then checking for it on the observer to set the note correctly. 

Also added a sample CSV for Components. 

Fixes SC:23514

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested each of the import types to make sure no more duplicates and that they were logged correctly. 

**Test Configuration**:
* PHP version: 8.1
* MySQL version 8.1


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
