### PR TITLE
Fixed #14173: Use new SnipeTranslator to handle pluralized localizations

### DIFF
--- a/app/Providers/SnipeTranslationServiceProvider.php
+++ b/app/Providers/SnipeTranslationServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Providers;
+
+use App\Services\SnipeTranslator;
+use Illuminate\Translation\TranslationServiceProvider;
+
+class SnipeTranslationServiceProvider extends TranslationServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //This is almost an *EXACT* carbon-copy of the TranslationServiceProvider, except with a modified Translator
+        $this->registerLoader();
+
+        $this->app->singleton('translator', function ($app) {
+            $loader = $app['translation.loader'];
+
+            // When registering the translator component, we'll need to set the default
+            // locale as well as the fallback locale. So, we'll grab the application
+            // configuration so we can easily get both of these values from there.
+            $locale = $app['config']['app.locale'];
+
+            $trans = new SnipeTranslator($loader, $locale); //the ONLY changed line
+
+            $trans->setFallback($app['config']['app.fallback_locale']);
+
+            return $trans;
+        });
+    }
+}

--- a/app/Services/SnipeTranslator.php
+++ b/app/Services/SnipeTranslator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Translation\Translator;
+
+/***************************************************************
+ * This is just a very, very light modification to the default Laravel Translator.
+ * The only difference it has is that it modifies the $locale
+ * value when the pluralizations are done so we can switch over from en-US to en_US (for example).
+ *
+ * This means our translation directories can stay where they are (en-US), but the
+ * pluralization code can get executed against a locale of en_US
+ * (Which is required by Symfony, for some inexplicable reason)
+ *
+ * This method is called by the trans_choice() helper, which we *do* use a lot.
+ ***************************************************************/
+class SnipeTranslator extends Translator {
+
+    //This is copied-and-pasted (almost) verbatim from Illuminate\Translation\Translator
+    public function choice($key, $number, array $replace = [], $locale = null)
+    {
+        $line = $this->get(
+            $key, $replace, $locale = $this->localeForChoice($locale)
+        );
+
+        // If the given "number" is actually an array or countable we will simply count the
+        // number of elements in an instance. This allows developers to pass an array of
+        // items without having to count it on their end first which gives bad syntax.
+        if (is_array($number) || $number instanceof Countable) {
+            $number = count($number);
+        }
+
+        $replace['count'] = $number;
+
+        $underscored_locale = str_replace("-","_",$locale); // OUR CHANGE.
+        return $this->makeReplacements( // BELOW - that $underscored_locale is the *ONLY* modified part
+            $this->getSelector()->choose($line, $number, $underscored_locale), $replace
+        );
+    }
+
+}

--- a/config/app.php
+++ b/config/app.php
@@ -277,7 +277,8 @@ return [
         Illuminate\Redis\RedisServiceProvider::class,
         Illuminate\Auth\Passwords\PasswordResetServiceProvider::class,
         Illuminate\Session\SessionServiceProvider::class,
-        Illuminate\Translation\TranslationServiceProvider::class,
+//        Illuminate\Translation\TranslationServiceProvider::class, //replaced on next line
+        App\Providers\SnipeTranslationServiceProvider::class, //we REPLACE the default Laravel translator with our own
         Illuminate\Validation\ValidationServiceProvider::class,
         Illuminate\View\ViewServiceProvider::class,
         Barryvdh\DomPDF\ServiceProvider::class,


### PR DESCRIPTION
Our locale directories are named things like 'en-US'. But the pluralization code used by Laravel (through Symfony) requires locale names to be in the format en_US. This change introduces a new Translator, SnipeTranslator, which is a tiny set of changes against the built-in one. It additionally adds a SnipeTranslationServiceProvider, which loads up the new Translator.

Fixes #14173