### PR TITLE
Fixed accessory checkout via API not sending notification and not adhering to qty limit

### DIFF
--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -278,7 +278,7 @@ class AccessoriesController extends Controller
     public function checkout(Request $request, $accessoryId)
     {
         // Check if the accessory exists
-        if (is_null($accessory = Accessory::find($accessoryId))) {
+        if (is_null($accessory = Accessory::withCount('users as users_count')->find($accessoryId))) {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/accessories/message.does_not_exist')));
         }
 

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Events\CheckoutableCheckedOut;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Transformers\AccessoriesTransformer;
@@ -302,7 +303,7 @@ class AccessoriesController extends Controller
                 'note' => $request->get('note'),
             ]);
 
-            $accessory->logCheckout($request->input('note'), $user);
+            event(new CheckoutableCheckedOut($accessory, $user, Auth::user(), $request->input('note')));
 
             return response()->json(Helper::formatStandardApiResponse('success', null, trans('admin/accessories/message.checkout.success')));
         }

--- a/database/factories/AccessoryFactory.php
+++ b/database/factories/AccessoryFactory.php
@@ -33,7 +33,7 @@ class AccessoryFactory extends Factory
                 $this->faker->randomElement(['Keyboard', 'Wired'])
             ),
             'user_id' => User::factory()->superuser(),
-            'category_id' => Category::factory(),
+            'category_id' => Category::factory()->forAccessories(),
             'model_number' => $this->faker->numberBetween(1000000, 50000000),
             'location_id' => Location::factory(),
             'qty' => 1,
@@ -112,6 +112,25 @@ class AccessoryFactory extends Factory
                 'qty' => 13,
                 'min_amt' => 2,
             ];
+        });
+    }
+
+    public function withoutItemsRemaining()
+    {
+        return $this->state(function () {
+            return [
+                'qty' => 1,
+            ];
+        })->afterCreating(function ($accessory) {
+            $user = User::factory()->create();
+
+            $accessory->users()->attach($accessory->id, [
+                'accessory_id' => $accessory->id,
+                'created_at' => now(),
+                'user_id' => $user->id,
+                'assigned_to' => $user->id,
+                'note' => '',
+            ]);
         });
     }
 }

--- a/database/factories/AccessoryFactory.php
+++ b/database/factories/AccessoryFactory.php
@@ -133,4 +133,11 @@ class AccessoryFactory extends Factory
             ]);
         });
     }
+
+    public function requiringAcceptance()
+    {
+        return $this->afterCreating(function ($accessory) {
+            $accessory->category->update(['require_acceptance' => 1]);
+        });
+    }
 }

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -172,4 +172,10 @@ class CategoryFactory extends Factory
          ]);
      }
 
+    public function forAccessories()
+    {
+        return $this->state([
+            'category_type' => 'accessory',
+        ]);
+    }
 }

--- a/tests/Feature/Api/Accessories/AccessoryCheckoutTest.php
+++ b/tests/Feature/Api/Accessories/AccessoryCheckoutTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Api\Accessories;
+
+use App\Models\Accessory;
+use App\Models\User;
+use App\Notifications\CheckoutAccessoryNotification;
+use Illuminate\Support\Facades\Notification;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class AccessoryCheckoutTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testCheckingOutAccessoryRequiresCorrectPermission()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testValidation()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testAccessoryMustBeAvailableWhenCheckingOut()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testAccessoryCanBeCheckedOut()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testUserSentNotificationUponCheckout()
+    {
+        $this->markTestIncomplete();
+
+        $this->withoutExceptionHandling();
+
+        Notification::fake();
+
+        $accessory = Accessory::factory()->requiringAcceptance()->create();
+        $user = User::factory()->create();
+
+        $this->actingAsForApi(User::factory()->checkoutAccessories()->create())
+            ->postJson(route('api.accessories.checkout', $accessory), [
+                'assigned_to' => $user->id,
+            ]);
+
+        Notification::assertSentTo($user, CheckoutAccessoryNotification::class);
+    }
+
+    public function testActionLogCreatedUponCheckout()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testUserSentEulaUponCheckoutIfAcceptanceRequired()
+    {
+        $this->markTestIncomplete();
+    }
+}

--- a/tests/Feature/Api/Accessories/AccessoryCheckoutTest.php
+++ b/tests/Feature/Api/Accessories/AccessoryCheckoutTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api\Accessories;
 
 use App\Models\Accessory;
+use App\Models\Actionlog;
 use App\Models\User;
 use App\Notifications\CheckoutAccessoryNotification;
 use Illuminate\Support\Facades\Notification;
@@ -78,14 +79,18 @@ class AccessoryCheckoutTest extends TestCase
                 'note' => 'oh hi there',
             ]);
 
-        $this->assertDatabaseHas('action_logs', [
-            'action_type' => 'checkout',
-            'target_id' => $user->id,
-            'target_type' => User::class,
-            'item_id' => $accessory->id,
-            'item_type' => Accessory::class,
-            'user_id' => $actor->id,
-            'note' => 'oh hi there',
-        ]);
+        $this->assertEquals(
+            1,
+            Actionlog::where([
+                'action_type' => 'checkout',
+                'target_id' => $user->id,
+                'target_type' => User::class,
+                'item_id' => $accessory->id,
+                'item_type' => Accessory::class,
+                'user_id' => $actor->id,
+                'note' => 'oh hi there',
+            ])->count(),
+            'Log entry either does not exist or there are more than expected'
+        );
     }
 }

--- a/tests/Feature/Checkouts/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/AccessoryCheckoutTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Checkouts;
 
 use App\Models\Accessory;
+use App\Models\Actionlog;
 use App\Models\User;
 use App\Notifications\CheckoutAccessoryNotification;
 use Illuminate\Support\Facades\Notification;
@@ -78,14 +79,18 @@ class AccessoryCheckoutTest extends TestCase
                 'note' => 'oh hi there',
             ]);
 
-        $this->assertDatabaseHas('action_logs', [
-            'action_type' => 'checkout',
-            'target_id' => $user->id,
-            'target_type' => User::class,
-            'item_id' => $accessory->id,
-            'item_type' => Accessory::class,
-            'user_id' => $actor->id,
-            'note' => 'oh hi there',
-        ]);
+        $this->assertEquals(
+            1,
+            Actionlog::where([
+                'action_type' => 'checkout',
+                'target_id' => $user->id,
+                'target_type' => User::class,
+                'item_id' => $accessory->id,
+                'item_type' => Accessory::class,
+                'user_id' => $actor->id,
+                'note' => 'oh hi there',
+            ])->count(),
+            'Log entry either does not exist or there are more than expected'
+        );
     }
 }

--- a/tests/Feature/Checkouts/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/AccessoryCheckoutTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature\Checkouts;
 
 use App\Models\Accessory;
-use App\Models\Actionlog;
 use App\Models\User;
 use App\Notifications\CheckoutAccessoryNotification;
 use Illuminate\Support\Facades\Notification;

--- a/tests/Feature/Checkouts/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/AccessoryCheckoutTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Checkouts;
+
+use App\Models\Accessory;
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class AccessoryCheckoutTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testCheckingOutAccessoryRequiresCorrectPermission()
+    {
+        $this->actingAs(User::factory()->create())
+            ->post(route('accessories.checkout.store', Accessory::factory()->create()))
+            ->assertForbidden();
+    }
+
+    public function testValidation()
+    {
+        $accessory = Accessory::factory()->create();
+
+        $this->actingAs(User::factory()->checkoutAccessories()->create())
+            ->post(route('accessories.checkout.store', $accessory), [
+                // missing assigned_to
+            ])
+            ->assertSessionHas('error');
+    }
+
+    public function testAccessoryMustBeAvailableWhenCheckingOut()
+    {
+        $this->actingAs(User::factory()->checkoutAccessories()->create())
+            ->post(route('accessories.checkout.store', Accessory::factory()->withoutItemsRemaining()->create()), [
+                'assigned_to' => User::factory()->create()->id,
+            ])
+            ->assertSessionHas('error');
+    }
+
+    public function testAccessoryCanBeCheckedOut()
+    {
+        $accessory = Accessory::factory()->create();
+
+        $user = User::factory()->create();
+
+        $this->actingAs(User::factory()->checkoutAccessories()->create())
+            ->post(route('accessories.checkout.store', $accessory), [
+                'assigned_to' => $user->id,
+            ]);
+
+        $this->assertTrue($accessory->users->contains($user));
+    }
+
+    public function testUserSentEulaUponCheckoutIfAcceptanceRequired()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testActionLogCreatedUponCheckout()
+    {
+        $this->markTestIncomplete();
+
+        // check 'note' is saved in action_logs
+        // check 'action_source' is saved in action_logs as gui
+    }
+}

--- a/tests/Feature/Checkouts/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/AccessoryCheckoutTest.php
@@ -22,10 +22,8 @@ class AccessoryCheckoutTest extends TestCase
 
     public function testValidation()
     {
-        $accessory = Accessory::factory()->create();
-
         $this->actingAs(User::factory()->checkoutAccessories()->create())
-            ->post(route('accessories.checkout.store', $accessory), [
+            ->post(route('accessories.checkout.store', Accessory::factory()->create()), [
                 // missing assigned_to
             ])
             ->assertSessionHas('error');
@@ -43,7 +41,6 @@ class AccessoryCheckoutTest extends TestCase
     public function testAccessoryCanBeCheckedOut()
     {
         $accessory = Accessory::factory()->create();
-
         $user = User::factory()->create();
 
         $this->actingAs(User::factory()->checkoutAccessories()->create())


### PR DESCRIPTION
# Description

There are two bugs around checking out accessories via API:
1. Users are not sent checkout notifications like they receive when an accessory is checked out via the web.
2. We're not actually preventing accessories from being checked out when there aren't any more available (ie: accessory has a `qty` of 5 and 5 are currently checked out, sending another checkout request via the api will not be blocked due to not having an item available).

This PR solves those issues by bringing the api controller method more inline with the web controller that already handles the cases above.

I added tests for the web and API controller methods but really, only the API test cases `testAccessoryMustBeAvailableWhenCheckingOut()` and `testUserSentNotificationUponCheckout` would fail without the changes inside of `Api/AccessoriesController`.

---

Partially fixes #13782 (another PR for consumables will follow this one)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)