### PR TITLE
Fixes Default Location Being Set During Asset Creation and Checkout

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -146,7 +146,8 @@ class AssetsController extends Controller
                 $asset->next_audit_date = Carbon::now()->addMonths($settings->audit_interval)->toDateString();
             }
 
-            if ($asset->assigned_to == '') {
+            // Set location_id to rtd_location_id ONLY if the asset isn't being checked out
+            if (!request('assigned_user') && !request('assigned_asset') && !request('assigned_location')) {
                 $asset->location_id = $request->input('rtd_location_id', null);
             }
 


### PR DESCRIPTION
# Description

Resolves an issue where the current location would still be set as the default even when the asset was being checked out at creation. `assigned_to` was not being set so the original condition didn't work as intended. 

Fixes #14146 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
