### PR TITLE
Fixes #14154  Sending PATCH request to /hardware with assigned_to set breaks the asset view

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -636,8 +636,11 @@ class AssetsController extends Controller
                 $asset->company_id = Company::getIdForCurrentUser($request->get('company_id')) : '';
 
             ($request->filled('rtd_location_id')) ?
-                $asset->location_id = $request->get('rtd_location_id') : null;
+		$asset->location_id = $request->get('rtd_location_id') : null;
 
+
+            ($request->filled('assigned_to') && $request->filled('assigned_type')) ?
+		    $asset->assigned_type = $request->get('assigned_type') : $asset->assigned_type = 'App\Models\User';
             /**
             * this is here just legacy reasons. Api\AssetController
             * used image_source  once to allow encoded image uploads.

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -636,11 +636,10 @@ class AssetsController extends Controller
                 $asset->company_id = Company::getIdForCurrentUser($request->get('company_id')) : '';
 
             ($request->filled('rtd_location_id')) ?
-		$asset->location_id = $request->get('rtd_location_id') : null;
-
+		        $asset->location_id = $request->get('rtd_location_id') : null;
 
             ($request->filled('assigned_to') && $request->filled('assigned_type')) ?
-		    $asset->assigned_type = $request->get('assigned_type') : $asset->assigned_type = 'App\Models\User';
+		        $asset->assigned_type = $request->get('assigned_type') : $asset->assigned_type = 'App\Models\User';
             /**
             * this is here just legacy reasons. Api\AssetController
             * used image_source  once to allow encoded image uploads.


### PR DESCRIPTION
# Description
When patching an asset, if the field 'assigned_to' is updated and the  'assigned_type' is not set the view of that asset breaks. I edited the update method in the API so if 'assigned_type' is not defined, the system assume that it's trying to assign it to a user.

Fixes #14154 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
