### PR TITLE
Fixed consumable checkout via API not sending notification

### DIFF
--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Events\CheckoutableCheckedOut;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Transformers\ConsumablesTransformer;
@@ -11,6 +12,7 @@ use App\Models\Consumable;
 use App\Models\User;
 use Illuminate\Http\Request;
 use App\Http\Requests\ImageUploadRequest;
+use Illuminate\Support\Facades\Auth;
 
 class ConsumablesController extends Controller
 {
@@ -290,17 +292,9 @@ class ConsumablesController extends Controller
                 ]
             );
 
-            // Log checkout event
-            $logaction = $consumable->logCheckout($request->input('note'), $user);
-            $data['log_id'] = $logaction->id;
-            $data['eula'] = $consumable->getEula();
-            $data['first_name'] = $user->first_name;
-            $data['item_name'] = $consumable->name;
-            $data['checkout_date'] = $logaction->created_at;
-            $data['note'] = $logaction->note;
-            $data['require_acceptance'] = $consumable->requireAcceptance();
+        event(new CheckoutableCheckedOut($consumable, $user, Auth::user(), $request->input('note')));
 
-            return response()->json(Helper::formatStandardApiResponse('success', null, trans('admin/consumables/message.checkout.success')));
+        return response()->json(Helper::formatStandardApiResponse('success', null, trans('admin/consumables/message.checkout.success')));
 
     }
 

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -76,7 +76,6 @@ class ConsumableCheckoutController extends Controller
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.checkout.unavailable'));
         }
 
-
         $admin_user = Auth::user();
         $assigned_to = e($request->input('assigned_to'));
 

--- a/database/factories/ConsumableFactory.php
+++ b/database/factories/ConsumableFactory.php
@@ -109,4 +109,11 @@ class ConsumableFactory extends Factory
             ]);
         });
     }
+
+    public function requiringAcceptance()
+    {
+        return $this->afterCreating(function (Consumable $consumable) {
+            $consumable->category->update(['require_acceptance' => 1]);
+        });
+    }
 }

--- a/database/factories/ConsumableFactory.php
+++ b/database/factories/ConsumableFactory.php
@@ -91,4 +91,22 @@ class ConsumableFactory extends Factory
             ];
         });
     }
+
+    public function withoutItemsRemaining()
+    {
+        return $this->state(function () {
+            return [
+                'qty' => 1,
+            ];
+        })->afterCreating(function (Consumable $consumable) {
+            $user = User::factory()->create();
+
+            $consumable->users()->attach($consumable->id, [
+                'consumable_id' => $consumable->id,
+                'user_id' => $user->id,
+                'assigned_to' => $user->id,
+                'note' => '',
+            ]);
+        });
+    }
 }

--- a/tests/Feature/Api/Accessories/AccessoryCheckoutTest.php
+++ b/tests/Feature/Api/Accessories/AccessoryCheckoutTest.php
@@ -21,7 +21,7 @@ class AccessoryCheckoutTest extends TestCase
             ->assertForbidden();
     }
 
-    public function testValidation()
+    public function testValidationWhenCheckingOutAccessory()
     {
         $this->actingAsForApi(User::factory()->checkoutAccessories()->create())
             ->postJson(route('api.accessories.checkout', Accessory::factory()->create()), [

--- a/tests/Feature/Api/Consumables/ConsumableCheckoutTest.php
+++ b/tests/Feature/Api/Consumables/ConsumableCheckoutTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Api\Consumables;
+
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class ConsumableCheckoutTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testCheckingOutConsumableRequiresCorrectPermission()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testValidationWhenCheckingOutConsumable()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testConsumableMustBeAvailableWhenCheckingOut()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testConsumableCanBeCheckedOut()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testUserSentNotificationUponCheckout()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testActionLogCreatedUponCheckout()
+    {
+        $this->markTestIncomplete();
+    }
+}

--- a/tests/Feature/Api/Consumables/ConsumableCheckoutTest.php
+++ b/tests/Feature/Api/Consumables/ConsumableCheckoutTest.php
@@ -2,6 +2,11 @@
 
 namespace Tests\Feature\Api\Consumables;
 
+use App\Models\Actionlog;
+use App\Models\Consumable;
+use App\Models\User;
+use App\Notifications\CheckoutConsumableNotification;
+use Illuminate\Support\Facades\Notification;
 use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
@@ -11,31 +16,81 @@ class ConsumableCheckoutTest extends TestCase
 
     public function testCheckingOutConsumableRequiresCorrectPermission()
     {
-        $this->markTestIncomplete();
+        $this->actingAsForApi(User::factory()->create())
+            ->postJson(route('api.consumables.checkout', Consumable::factory()->create()))
+            ->assertForbidden();
     }
 
     public function testValidationWhenCheckingOutConsumable()
     {
-        $this->markTestIncomplete();
+        $this->actingAsForApi(User::factory()->checkoutConsumables()->create())
+            ->postJson(route('api.consumables.checkout', Consumable::factory()->create()), [
+                // missing assigned_to
+            ])
+            ->assertStatusMessageIs('error');
     }
 
     public function testConsumableMustBeAvailableWhenCheckingOut()
     {
-        $this->markTestIncomplete();
+        $this->actingAsForApi(User::factory()->checkoutConsumables()->create())
+            ->postJson(route('api.consumables.checkout', Consumable::factory()->withoutItemsRemaining()->create()), [
+                'assigned_to' => User::factory()->create()->id,
+            ])
+            ->assertStatusMessageIs('error');
     }
 
     public function testConsumableCanBeCheckedOut()
     {
-        $this->markTestIncomplete();
+        $consumable = Consumable::factory()->create();
+        $user = User::factory()->create();
+
+        $this->actingAsForApi(User::factory()->checkoutConsumables()->create())
+            ->postJson(route('api.consumables.checkout', $consumable), [
+                'assigned_to' => $user->id,
+            ]);
+
+        $this->assertTrue($user->consumables->contains($consumable));
     }
 
     public function testUserSentNotificationUponCheckout()
     {
-        $this->markTestIncomplete();
+        Notification::fake();
+
+        $consumable = Consumable::factory()->requiringAcceptance()->create();
+
+        $user = User::factory()->create();
+
+        $this->actingAsForApi(User::factory()->checkoutConsumables()->create())
+            ->postJson(route('api.consumables.checkout', $consumable), [
+                'assigned_to' => $user->id,
+            ]);
+
+        Notification::assertSentTo($user, CheckoutConsumableNotification::class);
     }
 
     public function testActionLogCreatedUponCheckout()
-    {
-        $this->markTestIncomplete();
+    {$consumable = Consumable::factory()->create();
+        $actor = User::factory()->checkoutConsumables()->create();
+        $user = User::factory()->create();
+
+        $this->actingAsForApi($actor)
+            ->postJson(route('api.consumables.checkout', $consumable), [
+                'assigned_to' => $user->id,
+                'note' => 'oh hi there',
+            ]);
+
+        $this->assertEquals(
+            1,
+            Actionlog::where([
+                'action_type' => 'checkout',
+                'target_id' => $user->id,
+                'target_type' => User::class,
+                'item_id' => $consumable->id,
+                'item_type' => Consumable::class,
+                'user_id' => $actor->id,
+                'note' => 'oh hi there',
+            ])->count(),
+            'Log entry either does not exist or there are more than expected'
+        );
     }
 }

--- a/tests/Feature/Checkouts/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/AccessoryCheckoutTest.php
@@ -21,7 +21,7 @@ class AccessoryCheckoutTest extends TestCase
             ->assertForbidden();
     }
 
-    public function testValidation()
+    public function testValidationWhenCheckingOutAccessory()
     {
         $this->actingAs(User::factory()->checkoutAccessories()->create())
             ->post(route('accessories.checkout.store', Accessory::factory()->create()), [

--- a/tests/Feature/Checkouts/ConsumableCheckoutTest.php
+++ b/tests/Feature/Checkouts/ConsumableCheckoutTest.php
@@ -2,6 +2,11 @@
 
 namespace Tests\Feature\Checkouts;
 
+use App\Models\Actionlog;
+use App\Models\Consumable;
+use App\Models\User;
+use App\Notifications\CheckoutConsumableNotification;
+use Illuminate\Support\Facades\Notification;
 use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
@@ -11,31 +16,81 @@ class ConsumableCheckoutTest extends TestCase
 
     public function testCheckingOutConsumableRequiresCorrectPermission()
     {
-        $this->markTestIncomplete();
+        $this->actingAs(User::factory()->create())
+            ->post(route('consumables.checkout.store', Consumable::factory()->create()))
+            ->assertForbidden();
     }
 
     public function testValidationWhenCheckingOutConsumable()
     {
-        $this->markTestIncomplete();
+        $this->actingAs(User::factory()->checkoutConsumables()->create())
+            ->post(route('consumables.checkout.store', Consumable::factory()->create()), [
+                // missing assigned_to
+            ])
+            ->assertSessionHas('error');
     }
 
     public function testConsumableMustBeAvailableWhenCheckingOut()
     {
-        $this->markTestIncomplete();
+        $this->actingAs(User::factory()->checkoutConsumables()->create())
+            ->post(route('consumables.checkout.store', Consumable::factory()->withoutItemsRemaining()->create()), [
+                'assigned_to' => User::factory()->create()->id,
+            ])
+            ->assertSessionHas('error');
     }
 
     public function testConsumableCanBeCheckedOut()
     {
-        $this->markTestIncomplete();
+        $consumable = Consumable::factory()->create();
+        $user = User::factory()->create();
+
+        $this->actingAs(User::factory()->checkoutConsumables()->create())
+            ->post(route('consumables.checkout.store', $consumable), [
+                'assigned_to' => $user->id,
+            ]);
+
+        $this->assertTrue($user->consumables->contains($consumable));
     }
 
     public function testUserSentNotificationUponCheckout()
     {
-        $this->markTestIncomplete();
+        Notification::fake();
+
+        $consumable = Consumable::factory()->create();
+        $user = User::factory()->create();
+
+        $this->actingAs(User::factory()->checkoutConsumables()->create())
+            ->post(route('consumables.checkout.store', $consumable), [
+                'assigned_to' => $user->id,
+            ]);
+
+        Notification::assertSentTo($user, CheckoutConsumableNotification::class);
     }
 
     public function testActionLogCreatedUponCheckout()
     {
-        $this->markTestIncomplete();
+        $consumable = Consumable::factory()->create();
+        $actor = User::factory()->checkoutConsumables()->create();
+        $user = User::factory()->create();
+
+        $this->actingAs($actor)
+            ->post(route('consumables.checkout.store', $consumable), [
+                'assigned_to' => $user->id,
+                'note' => 'oh hi there',
+            ]);
+
+        $this->assertEquals(
+            1,
+            Actionlog::where([
+                'action_type' => 'checkout',
+                'target_id' => $user->id,
+                'target_type' => User::class,
+                'item_id' => $consumable->id,
+                'item_type' => Consumable::class,
+                'user_id' => $actor->id,
+                'note' => 'oh hi there',
+            ])->count(),
+            'Log entry either does not exist or there are more than expected'
+        );
     }
 }

--- a/tests/Feature/Checkouts/ConsumableCheckoutTest.php
+++ b/tests/Feature/Checkouts/ConsumableCheckoutTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Checkouts;
+
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class ConsumableCheckoutTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testCheckingOutConsumableRequiresCorrectPermission()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testValidationWhenCheckingOutConsumable()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testConsumableMustBeAvailableWhenCheckingOut()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testConsumableCanBeCheckedOut()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testUserSentNotificationUponCheckout()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testActionLogCreatedUponCheckout()
+    {
+        $this->markTestIncomplete();
+    }
+}


### PR DESCRIPTION
# Description

This PR fixes a bug where checkout notifications are not sent to users when a consumable is checked out via the API. Like in #14181, I added tests for the web and API controller methods but really only the api test for `testUserSentNotificationUponCheckout()` fails without the change in the controller (firing the `CheckoutableCheckedOut` event).

This PR follows up on #14181 and fixes #13782

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)