### PR TITLE
Fixed #14183  API /hardware/:id/checkin doesn't return Licenses 

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -906,6 +906,13 @@ class AssetsController extends Controller
             $originalValues['action_date'] = $checkin_at;
         }
 
+        if(!empty($asset->licenseseats->all())){
+            foreach ($asset->licenseseats as $seat){
+                $seat->assigned_to = null;
+                $seat->save();
+            }
+        }
+
         if ($asset->save()) {
             event(new CheckoutableCheckedIn($asset, $target, Auth::user(), $request->input('note'), $checkin_at, $originalValues));
 


### PR DESCRIPTION
# Description
When the user checkouts an asset that at the same time have licenses assigned, the system consider that the licenses are also assigned to that user. In the GUI, when the user checkin that asset, the licenses assigned to that asset remains assigned with the asset, but the user doesn't have the licenses assigned anymore.

In the API, if the asset is returned, the licenses are still assigned to the user. So in this PR I just replicate the behavior observed in the GUI.

@marcusmoore not trying to step in anybody steps, I was just around the neighborhood and take a shot. Let me know what you think.

Fixes #14183 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11