### PR TITLE
Fixes #14010 Adds Components and Licenses logs to Assets history view

### DIFF
--- a/app/Http/Controllers/Api/ReportsController.php
+++ b/app/Http/Controllers/Api/ReportsController.php
@@ -33,7 +33,12 @@ class ReportsController extends Controller
 
         if (($request->filled('item_type')) && ($request->filled('item_id'))) {
             $actionlogs = $actionlogs->where('item_id', '=', $request->input('item_id'))
-                ->where('item_type', '=', 'App\\Models\\'.ucwords($request->input('item_type')));
+                ->where('item_type', '=', 'App\\Models\\'.ucwords($request->input('item_type')))
+                ->orWhere(function($query) use ($request)
+                {
+                    $query->where('target_id', '=', $request->input('item_id'))
+                    ->where('target_type', '=', 'App\\Models\\'.ucwords($request->input('item_type')));
+                });
         }
 
         if ($request->filled('action_type')) {


### PR DESCRIPTION
# Description
When retrieven the Asset's log actions in the asset view, only actions performed by the asset where shown. But if we have checkins/checkouts of licenses or components to that same asset those aren't even when the system does logs them.

I tweak the eloquent query in the report controller so the asset history tab view also show those actions. 

Fixes #14010 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.0.31
* Webserver version: PHP dev server
* OS version: Debian 11
