### PR TITLE
Fixed FD-40296 - mobile uploads sometimes uploading with incorrect orientation

### DIFF
--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -109,10 +109,11 @@ class ImageUploadRequest extends Request
                     \Log::debug('Trying to upload to: '.$path.'/'.$file_name);
 
                     try {
-                        $upload = Image::make($image->getRealPath())->resize(null, $w, function ($constraint) {
+                        $upload = Image::make($image->getRealPath())->setFileInfoFromPath($image->getRealPath())->resize(null, $w, function ($constraint) {
                             $constraint->aspectRatio();
                             $constraint->upsize();
-                        });
+                        })->orientate();
+
                     } catch(NotReadableException $e) {
                         \Log::debug($e);
                         $validator = \Validator::make([], []);
@@ -138,10 +139,8 @@ class ImageUploadRequest extends Request
                         $cleanSVG = $sanitizer->sanitize($dirtySVG);
 
                         try {
-                            \Log::debug('Trying to upload to: '.$path.'/'.$file_name);
                             Storage::disk('public')->put($path.'/'.$file_name, $cleanSVG);
                         } catch (\Exception $e) {
-                            \Log::debug('Upload no workie :( ');
                             \Log::debug($e);
                         }
                     }


### PR DESCRIPTION
Very occasionally, we'd run into folks where the image they took on their iPhone (or other mobile device) appears rotated after upload because we were not orienting on EXIF data. This change *should* fix that. It's a bit harder for me to reproduce though, since it doesn't seem to happen all the time for me.

Note: Intervention v3 (unavailable to us until we're on Snipe-IT v7 because it requires >=8.1.0) treats this slightly differently so we may need to modify this again.  

Some other things I worked on that are not in the PR is a way to retrieve the EXIF data, but since we modify that image on upload (resizing it down), the original EXIF data would be lost, at least the "created by" part. So, I don't know if I want to log the original EXIF data separately in a new table, or not bother logging it at all. I don't know how important it is to most people, though a location exposed in the EXIF could potentially be useful.