### PR TITLE
Removed initial check for assets, licenses, etc

### DIFF
--- a/resources/views/companies/view.blade.php
+++ b/resources/views/companies/view.blade.php
@@ -21,7 +21,7 @@
                             <i class="fas fa-barcode" aria-hidden="true"></i>
                             </span>
                             <span class="hidden-xs hidden-sm">{{ trans('general.assets') }}
-                                {!! (($company->assets) && ($company->assets()->AssetsForShow()->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($company->assets()->AssetsForShow()->count()).'</badge>' : '' !!}
+                                {!! ($company->assets()->AssetsForShow()->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($company->assets()->AssetsForShow()->count()).'</badge>' : '' !!}
 
                             </span>
                         </a>
@@ -33,7 +33,7 @@
                             <i class="far fa-save"></i>
                             </span>
                             <span class="hidden-xs hidden-sm">{{ trans('general.licenses') }}
-                                {!! (($company->licenses) && ($company->licenses->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($company->licenses->count()).'</badge>' : '' !!}
+                                {!! ($company->licenses->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($company->licenses->count()).'</badge>' : '' !!}
                             </span>
                         </a>
                     </li>
@@ -43,7 +43,7 @@
                             <span class="hidden-lg hidden-md">
                             <i class="far fa-keyboard"></i>
                             </span> <span class="hidden-xs hidden-sm">{{ trans('general.accessories') }}
-                                {!! (($company->accessories) && ($company->accessories->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($company->accessories->count()).'</badge>' : '' !!}
+                                {!! ($company->accessories->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($company->accessories->count()).'</badge>' : '' !!}
                             </span>
                         </a>
                     </li>
@@ -53,7 +53,7 @@
                             <span class="hidden-lg hidden-md">
                             <i class="fas fa-tint"></i></span>
                             <span class="hidden-xs hidden-sm">{{ trans('general.consumables') }}
-                                {!! (($company->consumables) && ($company->consumables->count() > 0 )) ? '<badge class="badge badge-secondary">'.number_format($company->consumables->count()).'</badge>' : '' !!}
+                                {!! ($company->consumables->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($company->consumables->count()).'</badge>' : '' !!}
                             </span>
                         </a>
                     </li>


### PR DESCRIPTION
For customers with a lot of assets, licenses, etc, the badge query can cause memory issues. This should optimize that query.