### PR TITLE
Added tests around getIdForCurrentUser method

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -113,6 +113,14 @@ final class Company extends SnipeModel
         }
     }
 
+    /**
+     * Get the company id for the current user taking into
+     * account the full multiple company support setting
+     * and if the current user is a super user.
+     *
+     * @param $unescaped_input
+     * @return int|mixed|string|null
+     */
     public static function getIdForCurrentUser($unescaped_input)
     {
         if (! static::isFullMultipleCompanySupportEnabled()) {

--- a/tests/Unit/Models/Company/CompanyTest.php
+++ b/tests/Unit/Models/Company/CompanyTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Unit;
+namespace Tests\Unit\Models\Company;
 
 use App\Models\Company;
 use App\Models\User;

--- a/tests/Unit/Models/Company/GetIdForCurrentUserTest.php
+++ b/tests/Unit/Models/Company/GetIdForCurrentUserTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit\Models\Company;
+
+use App\Models\Company;
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class GetIdForCurrentUserTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testReturnsProvidedValueWhenFullCompanySupportDisabled()
+    {
+        $this->settings->disableMultipleFullCompanySupport();
+
+        $this->actingAs(User::factory()->create());
+        $this->assertEquals(1000, Company::getIdForCurrentUser(1000));
+    }
+
+    public function testReturnsProvidedValueForSuperUsersWhenFullCompanySupportEnabled()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $this->actingAs(User::factory()->superuser()->create());
+        $this->assertEquals(2000, Company::getIdForCurrentUser(2000));
+    }
+
+    public function testReturnsNonSuperUsersCompanyIdWhenFullCompanySupportEnabled()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $this->actingAs(User::factory()->forCompany(['id' => 2000])->create());
+        $this->assertEquals(2000, Company::getIdForCurrentUser(1000));
+    }
+
+    public function testReturnsProvidedValueForNonSuperUserWithoutCompanyIdWhenFullCompanySupportEnabled()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $this->actingAs(User::factory()->create(['company_id' => null]));
+        $this->assertEquals(1000, Company::getIdForCurrentUser(1000));
+    }
+}


### PR DESCRIPTION
# Description

This PR simply adds some tests around the Company model's `getIdForCurrentUser()` method. I was a little confused when I first looked at the method so having some tests around it can provide some clarity about its behavior as well as make sure we don't unintentionally break that behavior in the future.

## Type of change

- [x] other - added tests