### PR TITLE
Fixed Select2 functionality in User bulk check-in Delete User

### DIFF
--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -131,14 +131,15 @@
 
 
   $(":submit").attr("disabled", "disabled");
-    $("[name='status_id']").on('select2:select', function (e) {
-        if (e.params.data.id != ""){
-            console.log(e.params.data.id);
-            $(":submit").removeAttr("disabled");
-        }
-        else {
-            $(":submit").attr("disabled", "disabled");
-        }
-    });
+  //The line below needs to be here because in mobile view the status_id select2 forgets its select2 so this makes it function properly.
+   $("[name='status_id']").select2();
+   $("[name='status_id']").on('select2:select', function (e) {
+     if (e.params.data.id != "") {
+       console.log(e.params.data.id);
+       $(":submit").removeAttr("disabled");
+     } else {
+       $(":submit").attr("disabled", "disabled");
+     }
+   });
 </script>
 @stop


### PR DESCRIPTION
# Description

This is a weird one...when this page is sized to mobile, the select2 box forgets/fails at being select2. So by adding `$("[name='status_id']").select2();` It sort of reminds it (persists it?) that it is a select2 and it functions properly.

*MAGIC*

Fixes #FD-40290

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
