### PR TITLE
Switch to bulk updating to handle audit interval updates

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -28,6 +28,7 @@ use App\Http\Requests\SlackSettingsRequest;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Validator;
+use Carbon\Carbon;
 
 /**
  * This controller handles all actions related to Settings for
@@ -636,21 +637,21 @@ class SettingsController extends Controller
         // Check if the audit interval has changed - if it has, we want to update ALL of the assets audit dates
         if ($request->input('audit_interval') != $setting->audit_interval) {
 
-            // Be careful - this could be a negative number
+            // This could be a negative number if the user is trying to set the audit interval to a lower number than it was before
             $audit_diff_months = ((int)$request->input('audit_interval') - (int)($setting->audit_interval));
-            
-            // Grab all assets that have an existing next_audit_date, chunking to handle very large datasets
-            Asset::whereNotNull('next_audit_date')->chunk(200, function ($assets) use ($audit_diff_months) {
 
-                // Update assets' next_audit_date values
-                foreach ($assets as $asset) {
-                    if ($asset->next_audit_date != '') {
-                        $old_next_audit = new \DateTime($asset->next_audit_date);
-                        $asset->next_audit_date = $old_next_audit->modify($audit_diff_months . ' month')->format('Y-m-d');
-                        $asset->forceSave();
-                    }
-                }
-            });
+            // Batch update the dates. We have to use this method to avoid time limit exceeded errors on very large datasets,
+            // but it DOES mean this change doesn't get logged in the action logs, since it skips the observer.
+            // @see https://stackoverflow.com/questions/54879160/laravel-observer-not-working-on-bulk-insert
+            $affected = Asset::whereNotNull('next_audit_date')
+                ->whereNull('deleted_at')
+                ->update(
+                    ['next_audit_date' => DB::raw('DATE_ADD(`next_audit_date`, INTERVAL '.$audit_diff_months.' MONTH)')]
+            );
+
+            \Log::debug($affected .' assets affected by audit interval update');
+
+            
         }
 
         $alert_email = rtrim($request->input('alert_email'), ',');

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -646,7 +646,7 @@ class SettingsController extends Controller
             $affected = Asset::whereNotNull('next_audit_date')
                 ->whereNull('deleted_at')
                 ->update(
-                    ['next_audit_date' => DB::raw('DATE_ADD(`next_audit_date`, INTERVAL '.$audit_diff_months.' MONTH)')]
+                    ['next_audit_date' => DB::raw('DATE_ADD(next_audit_date, INTERVAL '.$audit_diff_months.' MONTH)')]
             );
 
             \Log::debug($affected .' assets affected by audit interval update');


### PR DESCRIPTION
In the previous behavior, when you change the audit interval, it would loop through the assets and update the relative new `next_audit_date` as needed based on the new interval value.

This switches to using a mass update and `DB::raw()` - which I normally hate doing, but for users with 40k assets, anything else (short of building in a queueing system) simply won't work.

I don't love that this doesn't hit the observer, so you won't see these as edits to the asset in the asset history, but if you're editing 10k assets, that might junk up your history report anyway.