### PR TITLE
Fixed: 404 Error on Importer When Uploading a .csv Under Certain Circumstance

### DIFF
--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -135,8 +135,7 @@
                                                     </button>
                                                     <a href="#" wire:click="$set('activeFile',null)">
                                                     <button class="btn btn-sm btn-danger" wire:click="destroy({{ $currentFile->id }})">
-                                                        <i class="fas fa-trash icon-white" aria-hidden="true"></i><span class="sr-only"></span>
-                                                    </button>
+                                                        <i class="fas fa-trash icon-white" aria-hidden="true"></i><span class="sr-only"></span></button>
                                                     </a>
                                     			</td>
                                     		</tr>

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -133,8 +133,11 @@
                                                         <i class="fa-solid fa-list-check" aria-hidden="true"></i>
                                                         <span class="sr-only">{{ trans('general.import') }}</span>
                                                     </button>
+                                                    <a href="#" wire:click="$set('activeFile',null)">
                                                     <button class="btn btn-sm btn-danger" wire:click="destroy({{ $currentFile->id }})">
-                                                        <i class="fas fa-trash icon-white" aria-hidden="true"></i><span class="sr-only"></span></button>
+                                                        <i class="fas fa-trash icon-white" aria-hidden="true"></i><span class="sr-only"></span>
+                                                    </button>
+                                                    </a>
                                     			</td>
                                     		</tr>
 


### PR DESCRIPTION
# Description
In the importer, if a user would delete a file that was focused with the blue 'Map Fields and Process' button, attempting to import a file would return a 404 error.

<img width="771" alt="Screenshot 2024-02-06 at 3 47 15 PM" src="https://github.com/snipe/snipe-it/assets/116301219/67825f7b-e5f3-485a-b492-a5db957ce059">

This fix adds in a line/step to null out the active file that had just been selected when the user presses the 'Delete File' button

Fixes # SC-23516

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
This was tested locally by going through the steps that allowed me to reproduce the error and verify that the 404 error did not pop up.

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
