### PR TITLE
Change how we check forward-looking upgrade requirements

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -32,10 +32,6 @@ if ($argc > 1){
                 $branch = $argv[$arg];
                 $branch_override = true;
                 break;
-            case '-h':
-            case '-H':
-            case '--help':
-
             default: // for legacy support from before we started using --branch
                 $branch = $argv[$arg];
                 $branch_override = true;


### PR DESCRIPTION
# Description

In https://github.com/snipe/snipe-it/pull/14128 we added the capability
for the upgrade.php script to check version requirements _before_
downloading the new source, to help keep from breaking installations.

Turns out, `file_get_contents()` isn't a reliable way to grab a url, because
some systems have `allow_url_fopen` turned off in their PHP
configurations.

In this iteration, we swap that out for a curl function, while also
adding more error handling, the ability to entirely skip the
PHP version checks if for some reason you Just Can't query the upgrade
json correctly, as well as adding a lot of helpful text around the whole
issue.

Additionally, I've added some error checking around DB backups and
initial artisan down-ing, since shell_exec would happily march right
past any errors.


Fixes #14224
Fixes #14200