### PR TITLE
Fixed barcodes crashing if asset was deleted

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -521,7 +521,7 @@ class AssetsController extends Controller
     public function getBarCode($assetId = null)
     {
         $settings = Setting::getSettings();
-        $asset = Asset::find($assetId);
+        $asset = Asset::withTrashed()->find($assetId);
         $barcode_file = public_path().'/uploads/barcodes/'.str_slug($settings->alt_barcode).'-'.str_slug($asset->asset_tag).'.png';
 
         if (isset($asset->id, $asset->asset_tag)) {

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -218,6 +218,12 @@
                   @endif
                 @endcan
 
+                @can('update', $user)
+                    <div class="col-md-12" style="padding-top: 5px;">
+                        <a href="{{ route('users.transfer', $user->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">Transfer Items</a>
+                    </div>
+                @endcan
+
                 @can('delete', $user)
                   @if ($user->deleted_at=='')
                     <div class="col-md-12" style="padding-top: 30px;">

--- a/routes/web/users.php
+++ b/routes/web/users.php
@@ -43,10 +43,26 @@ Route::group(['prefix' => 'users', 'middleware' => ['auth']], function () {
     Route::post(
         '{userId}/clone',
         [
-            Users\UsersController::class, 
+            Users\UsersController::class,
             'postCreate'
         ]
     )->name('users.clone.store');
+
+    Route::get(
+        '{userId}/transfer',
+        [
+            Users\UsersController::class,
+            'getTransfer'
+        ]
+    )->name('users.transfer.show');
+
+    Route::post(
+        '{userId}/transfer',
+        [
+            Users\UsersController::class,
+            'postTransfer'
+        ]
+    )->name('users.transfer.store');
 
     Route::post(
         '{userId}/restore',


### PR DESCRIPTION
While I'm not 100% sure how this situation would arise (unless someone is using the legacy barcode system, generated a list of barcodes, someone else deleted the asset, and they hit reload) we do see it pop up in the logs sometimes. This should fix RB-17822.