### PR TITLE
Fixed ReportsController to not try to return a serial if the item doesn’t exist

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -295,7 +295,7 @@ class ReportsController extends Controller
                         $actionlog->present()->actionType(),
                         e($actionlog->itemType()),
                         ($actionlog->itemType() == 'user') ? $actionlog->filename : $item_name,
-                        ($actionlog->item->serial) ? $actionlog->item->serial : null,
+                        ($actionlog->item) ? $actionlog->item->serial : null,
                         ($actionlog->item->model) ? htmlspecialchars($actionlog->item->model->name, ENT_NOQUOTES) : null,
                         ($actionlog->item->model) ? $actionlog->item->model->model_number : null,
                         $target_name,


### PR DESCRIPTION
We found a few cases where this was crashing the report.