### PR TITLE
Return null if asset was hard-deleted/purged

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -521,31 +521,33 @@ class AssetsController extends Controller
     public function getBarCode($assetId = null)
     {
         $settings = Setting::getSettings();
-        $asset = Asset::withTrashed()->find($assetId);
-        $barcode_file = public_path().'/uploads/barcodes/'.str_slug($settings->alt_barcode).'-'.str_slug($asset->asset_tag).'.png';
+        if ($asset = Asset::withTrashed()->find($assetId)) {
+            $barcode_file = public_path().'/uploads/barcodes/'.str_slug($settings->alt_barcode).'-'.str_slug($asset->asset_tag).'.png';
 
-        if (isset($asset->id, $asset->asset_tag)) {
-            if (file_exists($barcode_file)) {
-                $header = ['Content-type' => 'image/png'];
+            if (isset($asset->id, $asset->asset_tag)) {
+                if (file_exists($barcode_file)) {
+                    $header = ['Content-type' => 'image/png'];
 
-                return response()->file($barcode_file, $header);
-            } else {
-                // Calculate barcode width in pixel based on label width (inch)
-                $barcode_width = ($settings->labels_width - $settings->labels_display_sgutter) * 200.000000000001;
+                    return response()->file($barcode_file, $header);
+                } else {
+                    // Calculate barcode width in pixel based on label width (inch)
+                    $barcode_width = ($settings->labels_width - $settings->labels_display_sgutter) * 200.000000000001;
 
-                $barcode = new \Com\Tecnick\Barcode\Barcode();
-                try {
-                    $barcode_obj = $barcode->getBarcodeObj($settings->alt_barcode, $asset->asset_tag, ($barcode_width < 300 ? $barcode_width : 300), 50);
-                    file_put_contents($barcode_file, $barcode_obj->getPngData());
+                    $barcode = new \Com\Tecnick\Barcode\Barcode();
+                    try {
+                        $barcode_obj = $barcode->getBarcodeObj($settings->alt_barcode, $asset->asset_tag, ($barcode_width < 300 ? $barcode_width : 300), 50);
+                        file_put_contents($barcode_file, $barcode_obj->getPngData());
 
-                    return response($barcode_obj->getPngData())->header('Content-type', 'image/png');
-                } catch (\Exception $e) {
-                    Log::debug('The barcode format is invalid.');
+                        return response($barcode_obj->getPngData())->header('Content-type', 'image/png');
+                    } catch (\Exception $e) {
+                        Log::debug('The barcode format is invalid.');
 
-                    return response(file_get_contents(public_path('uploads/barcodes/invalid_barcode.gif')))->header('Content-type', 'image/gif');
+                        return response(file_get_contents(public_path('uploads/barcodes/invalid_barcode.gif')))->header('Content-type', 'image/gif');
+                    }
                 }
             }
         }
+        return null;
     }
 
     /**


### PR DESCRIPTION
This fixes a crash if someone is trying to print barcodes on assets that were hard-deleted.