### PR TITLE
Added LDAP group tag to LDAP tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -45,8 +45,21 @@ DB_PASSWORD={}
 
 Now you are ready to run the entire test suite from your terminal:
 
-`php artisan test`
+```shell
+php artisan test
+````
 
 To run individual test files, you can pass the path to the test that you want to run:
 
-`php artisan test tests/Unit/AccessoryTest.php`
+```shell
+php artisan test tests/Unit/AccessoryTest.php
+```
+
+Some tests, like ones concerning LDAP, are marked with the `@group` annotation. Those groups can be run, or excluded, using the `--group` or `--exclude-group` flags:
+
+```shell
+php artisan test --group=ldap
+
+php artisan test --exclude-group=ldap
+```
+This can be helpful if a set of tests are failing because you don't have an extension, like LDAP, installed.

--- a/tests/Unit/LdapTest.php
+++ b/tests/Unit/LdapTest.php
@@ -7,6 +7,9 @@ use Exception;
 use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
+/**
+ * @group ldap
+ */
 class LdapTest extends TestCase
 {
     use InteractsWithSettings;


### PR DESCRIPTION
# Description

This PR simply adds the `@group` annotation to the LDAP tests so they can be skipped by developers that do not the LDAP extension installed.

```shell
php artisan test --exclude-group=ldap
```

Of course there are other opportunities for grouping tests but this focuses on just LDAP.

## Type of change

- [x] Chore