### PR TITLE
Fixed accessory check in emails being sent when setting disabled

### DIFF
--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -67,30 +67,8 @@ class CheckinAccessoryNotification extends Notification
              * Send an email if the asset requires acceptance,
              * so the user can accept or decline the asset
              */
-            if (($this->item->requireAcceptance()) || ($this->item->getEula()) || ($this->item->checkin_email())) {
-                $notifyBy[] = 'mail';
-            }
-
-            /**
-             * Send an email if the asset requires acceptance,
-             * so the user can accept or decline the asset
-             */
-            if ($this->item->requireAcceptance()) {
-                \Log::debug('This accessory requires acceptance');
-            }
-
-            /**
-             * Send an email if the item has a EULA, since the user should always receive it
-             */
-            if ($this->item->getEula()) {
-                \Log::debug('This accessory has a EULA');
-            }
-
-            /**
-             * Send an email if an email should be sent at checkin/checkout
-             */
             if ($this->item->checkin_email()) {
-                \Log::debug('This accessory has a checkin_email()');
+                $notifyBy[] = 'mail';
             }
         }
 

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -63,10 +63,6 @@ class CheckinAccessoryNotification extends Notification
         if ($this->target instanceof User && $this->target->email != '') {
             \Log::debug('The target is a user');
 
-            /**
-             * Send an email if the asset requires acceptance,
-             * so the user can accept or decline the asset
-             */
             if ($this->item->checkin_email()) {
                 $notifyBy[] = 'mail';
             }

--- a/database/factories/AccessoryFactory.php
+++ b/database/factories/AccessoryFactory.php
@@ -142,7 +142,7 @@ class AccessoryFactory extends Factory
         });
     }
 
-    public function checkedOut(User $user = null)
+    public function checkedOutToUser(User $user = null)
     {
         return $this->afterCreating(function (Accessory $accessory) use ($user) {
             $accessory->users()->attach($accessory->id, [

--- a/database/factories/AccessoryFactory.php
+++ b/database/factories/AccessoryFactory.php
@@ -145,8 +145,6 @@ class AccessoryFactory extends Factory
     public function checkedOut(User $user = null)
     {
         return $this->afterCreating(function (Accessory $accessory) use ($user) {
-            $accessory->decrement('qty');
-
             $accessory->users()->attach($accessory->id, [
                 'accessory_id' => $accessory->id,
                 'created_at' => Carbon::now(),

--- a/database/factories/AccessoryFactory.php
+++ b/database/factories/AccessoryFactory.php
@@ -8,6 +8,7 @@ use App\Models\Location;
 use App\Models\Manufacturer;
 use App\Models\Supplier;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class AccessoryFactory extends Factory
@@ -138,6 +139,18 @@ class AccessoryFactory extends Factory
     {
         return $this->afterCreating(function ($accessory) {
             $accessory->category->update(['require_acceptance' => 1]);
+        });
+    }
+
+    public function checkedOut()
+    {
+        return $this->afterCreating(function (Accessory $accessory) {
+            $accessory->users()->attach($accessory->id, [
+                'accessory_id' => $accessory->id,
+                'created_at' => Carbon::now(),
+                'user_id' => 1,
+                'assigned_to' => User::factory()->create()->id,
+            ]);
         });
     }
 }

--- a/database/factories/AccessoryFactory.php
+++ b/database/factories/AccessoryFactory.php
@@ -142,14 +142,16 @@ class AccessoryFactory extends Factory
         });
     }
 
-    public function checkedOut()
+    public function checkedOut(User $user = null)
     {
-        return $this->afterCreating(function (Accessory $accessory) {
+        return $this->afterCreating(function (Accessory $accessory) use ($user) {
+            $accessory->decrement('qty');
+
             $accessory->users()->attach($accessory->id, [
                 'accessory_id' => $accessory->id,
                 'created_at' => Carbon::now(),
                 'user_id' => 1,
-                'assigned_to' => User::factory()->create()->id,
+                'assigned_to' => $user->id ?? User::factory()->create()->id,
             ]);
         });
     }

--- a/tests/Feature/Checkins/AccessoryCheckinTest.php
+++ b/tests/Feature/Checkins/AccessoryCheckinTest.php
@@ -6,7 +6,6 @@ use App\Events\CheckoutableCheckedIn;
 use App\Models\Accessory;
 use App\Models\User;
 use App\Notifications\CheckinAccessoryNotification;
-use App\Notifications\CheckinAssetNotification;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
 use Tests\Support\InteractsWithSettings;

--- a/tests/Feature/Checkins/AccessoryCheckinTest.php
+++ b/tests/Feature/Checkins/AccessoryCheckinTest.php
@@ -19,7 +19,7 @@ class AccessoryCheckinTest extends TestCase
     public function testCheckingInAccessoryRequiresCorrectPermission()
     {
         $this->actingAs(User::factory()->create())
-            ->post(route('accessories.checkin.store', Accessory::factory()->checkedOut()->create()))
+            ->post(route('accessories.checkin.store', Accessory::factory()->checkedOutToUser()->create()))
             ->assertForbidden();
     }
 
@@ -28,7 +28,7 @@ class AccessoryCheckinTest extends TestCase
         Event::fake([CheckoutableCheckedIn::class]);
 
         $user = User::factory()->create();
-        $accessory = Accessory::factory()->checkedOut($user)->create();
+        $accessory = Accessory::factory()->checkedOutToUser($user)->create();
 
         $this->assertTrue($accessory->users->contains($user));
 
@@ -45,7 +45,7 @@ class AccessoryCheckinTest extends TestCase
         Notification::fake();
 
         $user = User::factory()->create();
-        $accessory = Accessory::factory()->checkedOut($user)->create();
+        $accessory = Accessory::factory()->checkedOutToUser($user)->create();
 
         $accessory->category->update(['checkin_email' => true]);
 
@@ -69,7 +69,7 @@ class AccessoryCheckinTest extends TestCase
         Notification::fake();
 
         $user = User::factory()->create();
-        $accessory = Accessory::factory()->checkedOut($user)->create();
+        $accessory = Accessory::factory()->checkedOutToUser($user)->create();
 
         $accessory->category->update(['checkin_email' => false]);
 

--- a/tests/Feature/Checkins/AccessoryCheckinTest.php
+++ b/tests/Feature/Checkins/AccessoryCheckinTest.php
@@ -2,8 +2,13 @@
 
 namespace Tests\Feature\Checkins;
 
+use App\Events\CheckoutableCheckedIn;
 use App\Models\Accessory;
 use App\Models\User;
+use App\Notifications\CheckinAccessoryNotification;
+use App\Notifications\CheckinAssetNotification;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
 use Tests\Support\InteractsWithSettings;
 use Tests\TestCase;
 
@@ -20,16 +25,66 @@ class AccessoryCheckinTest extends TestCase
 
     public function testAccessoryCanBeCheckedIn()
     {
-        $this->markTestIncomplete();
+        Event::fake([CheckoutableCheckedIn::class]);
+
+        $user = User::factory()->create();
+        $accessory = Accessory::factory()->checkedOut($user)->create();
+
+        $this->assertTrue($accessory->users->contains($user));
+
+        $this->actingAs(User::factory()->checkinAccessories()->create())
+            ->post(route('accessories.checkin.store', $accessory->users->first()->pivot->id));
+
+        $this->assertFalse($accessory->fresh()->users->contains($user));
+
+        Event::assertDispatched(CheckoutableCheckedIn::class, 1);
     }
 
     public function testEmailSentToUserIfSettingEnabled()
     {
-        $this->markTestIncomplete();
+        Notification::fake();
+
+        $user = User::factory()->create();
+        $accessory = Accessory::factory()->checkedOut($user)->create();
+
+        $accessory->category->update(['checkin_email' => true]);
+
+        event(new CheckoutableCheckedIn(
+            $accessory,
+            $user,
+            User::factory()->checkinAccessories()->create(),
+            '',
+        ));
+
+        Notification::assertSentTo(
+            [$user],
+            function (CheckinAccessoryNotification $notification, $channels) {
+                return in_array('mail', $channels);
+            },
+        );
     }
 
     public function testEmailNotSentToUserIfSettingDisabled()
     {
-        $this->markTestIncomplete();
+        Notification::fake();
+
+        $user = User::factory()->create();
+        $accessory = Accessory::factory()->checkedOut($user)->create();
+
+        $accessory->category->update(['checkin_email' => false]);
+
+        event(new CheckoutableCheckedIn(
+            $accessory,
+            $user,
+            User::factory()->checkinAccessories()->create(),
+            '',
+        ));
+
+        Notification::assertNotSentTo(
+            [$user],
+            function (CheckinAccessoryNotification $notification, $channels) {
+                return in_array('mail', $channels);
+            },
+        );
     }
 }

--- a/tests/Feature/Checkins/AccessoryCheckinTest.php
+++ b/tests/Feature/Checkins/AccessoryCheckinTest.php
@@ -17,8 +17,10 @@ class AccessoryCheckinTest extends TestCase
 
     public function testCheckingInAccessoryRequiresCorrectPermission()
     {
+        $accessory = Accessory::factory()->checkedOutToUser()->create();
+
         $this->actingAs(User::factory()->create())
-            ->post(route('accessories.checkin.store', Accessory::factory()->checkedOutToUser()->create()))
+            ->post(route('accessories.checkin.store', $accessory->users->first()->pivot->id))
             ->assertForbidden();
     }
 

--- a/tests/Feature/Checkins/AccessoryCheckinTest.php
+++ b/tests/Feature/Checkins/AccessoryCheckinTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Checkins;
+
+use App\Models\Accessory;
+use App\Models\User;
+use Tests\Support\InteractsWithSettings;
+use Tests\TestCase;
+
+class AccessoryCheckinTest extends TestCase
+{
+    use InteractsWithSettings;
+
+    public function testCheckingInAccessoryRequiresCorrectPermission()
+    {
+        $this->actingAs(User::factory()->create())
+            ->post(route('accessories.checkin.store', Accessory::factory()->checkedOut()->create()))
+            ->assertForbidden();
+    }
+
+    public function testAccessoryCanBeCheckedIn()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testEmailSentToUserIfSettingEnabled()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testEmailNotSentToUserIfSettingDisabled()
+    {
+        $this->markTestIncomplete();
+    }
+}


### PR DESCRIPTION
# Description

This PR fixes a bug where check in emails were being sent for accessories even though the accessory category has the option disabled.

---

Users were receiving check in emails even though the "Send email to user on checkin/checkout" option was unchecked for the accessories' category:

![CleanShot 2024-02-12 at 16 27 04@2x](https://github.com/snipe/snipe-it/assets/1141514/a2da2a8a-4588-4bdf-b5ab-f3306d1f7ae4)

---

Fixes #14237

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)