### PR TITLE
Resolves Issue with Asset Model Default Updates

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Input;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Validator;
 use Redirect;
@@ -513,9 +514,8 @@ class AssetModelsController extends Controller
 
         $validator = Validator::make($data, $rules);
 
-        // Okay, this is the problem. Seems to be failing every time, kind of makes sense because it looks like
-        // $rules is an empty array, but I need to wrap my head around this entire method a little more.
         if($validator->fails()){
+            Log::debug($validator->errors());
             return false;
         }
 

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -513,6 +513,8 @@ class AssetModelsController extends Controller
 
         $validator = Validator::make($data, $rules);
 
+        // Okay, this is the problem. Seems to be failing every time, kind of makes sense because it looks like
+        // $rules is an empty array, but I need to wrap my head around this entire method a little more.
         if($validator->fails()){
             return false;
         }

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -11,7 +11,6 @@ use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Input;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Validator;
 use Redirect;
@@ -515,7 +514,6 @@ class AssetModelsController extends Controller
         $validator = Validator::make($data, $rules);
 
         if($validator->fails()){
-            Log::debug($validator->errors());
             return false;
         }
 

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Gate;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
 use Watson\Validating\ValidatingTrait;
 
 class CustomFieldset extends Model
@@ -96,6 +98,11 @@ class CustomFieldset extends Model
             // temporary condition added to fix issue with model default updates in the gui
             if ($field->element != 'checkbox') {
                 $rules[$field->db_column_name()][] = 'not_array';
+            }
+            if ($field->element == 'checkbox') {
+                //Log::alert($field->formatFieldValuesAsArray());
+                $values = $field->formatFieldValuesAsArray();
+                //$rules[$field->db_column_name()] = 'checkboxes';
             }
         }
 

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -92,8 +92,11 @@ class CustomFieldset extends Model
 
             array_push($rule, $field->attributes['format']);
             $rules[$field->db_column_name()] = $rule;
-            //add not_array to rules for all fields
-            $rules[$field->db_column_name()][] = 'not_array';
+            // add not_array to rules for all fields
+            // condition added to fix issue with model default updates
+            if ($field->element != 'checkbox') {
+                $rules[$field->db_column_name()][] = 'not_array';
+            }
         }
 
         return $rules;

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -93,7 +93,7 @@ class CustomFieldset extends Model
             array_push($rule, $field->attributes['format']);
             $rules[$field->db_column_name()] = $rule;
             // add not_array to rules for all fields
-            // condition added to fix issue with model default updates
+            // temporary condition added to fix issue with model default updates in the gui
             if ($field->element != 'checkbox') {
                 $rules[$field->db_column_name()][] = 'not_array';
             }

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -2,9 +2,11 @@
 
 namespace App\Providers;
 
+use App\Models\CustomField;
 use App\Models\Department;
 use App\Models\Setting;
 use DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rule;
 use Validator;
@@ -293,6 +295,25 @@ class ValidationServiceProvider extends ServiceProvider
 
         Validator::extend('not_array', function ($attribute, $value, $parameters, $validator) {
             return !is_array($value);
+        });
+
+        Validator::extend('checkboxes', function ($attribute, $value, $parameters, $validator){
+            $options = CustomField::where('db_column', $attribute)->formatFieldValuesAsArray();
+            if(!is_array($value)) {
+                $exploded = explode(',', $value);
+                $valid = array_intersect($exploded, $options);
+                if(array_count_values($valid) > 0) {
+                    return true;
+                }
+            }
+            if(is_array($value)) {
+                $valid = array_intersect($value, $options);
+                if(array_count_values($valid) > 0) {
+                    return true;
+                }
+            }
+
+
         });
     }
 


### PR DESCRIPTION
# Description
This resolves an issue where updating an Asset Model's defaults would throw an incorrect and vague validation error - the issue has _something_ to do with the custom `not_array` validation rule on checkboxes. 

This is just a temporary fix to get the GUI functionality working again, the only regression this should introduce is the fact that you can now trigger an exception by submitting an array to a custom field checkbox via the API. 

I'm going to start working on a new branch today to properly validate checkboxes and fully resolve this issue, but wanted to get this in quickly to resolve the GUI issue. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)