### PR TITLE
Added serial and status label to asset maintenances page and API

### DIFF
--- a/app/Http/Controllers/Api/AssetMaintenancesController.php
+++ b/app/Http/Controllers/Api/AssetMaintenancesController.php
@@ -36,7 +36,8 @@ class AssetMaintenancesController extends Controller
     {
         $this->authorize('view', Asset::class);
 
-        $maintenances = AssetMaintenance::select('asset_maintenances.*')->with('asset', 'asset.model', 'asset.location', 'asset.defaultLoc', 'supplier', 'asset.company', 'admin');
+        $maintenances = AssetMaintenance::select('asset_maintenances.*')
+            ->with('asset', 'asset.model', 'asset.location', 'asset.defaultLoc', 'supplier', 'asset.company', 'admin');
 
         if ($request->filled('search')) {
             $maintenances = $maintenances->TextSearch($request->input('search'));
@@ -70,6 +71,7 @@ class AssetMaintenancesController extends Controller
                                 'notes',
                                 'asset_tag',
                                 'asset_name',
+                                'serial',
                                 'user_id',
                                 'supplier',
                                 'is_warranty',
@@ -89,6 +91,10 @@ class AssetMaintenancesController extends Controller
                 break;
             case 'asset_name':
                 $maintenances = $maintenances->OrderByAssetName($order);
+                break;
+            case 'serial':
+                \Log::debug('sort by serial');
+                $maintenances = $maintenances->OrderByAssetSerial($order);
                 break;
             default:
                 $maintenances = $maintenances->orderBy($sort, $order);

--- a/app/Http/Controllers/Api/AssetMaintenancesController.php
+++ b/app/Http/Controllers/Api/AssetMaintenancesController.php
@@ -37,7 +37,7 @@ class AssetMaintenancesController extends Controller
         $this->authorize('view', Asset::class);
 
         $maintenances = AssetMaintenance::select('asset_maintenances.*')
-            ->with('asset', 'asset.model', 'asset.location', 'asset.defaultLoc', 'supplier', 'asset.company', 'admin');
+            ->with('asset', 'asset.model', 'asset.location', 'asset.defaultLoc', 'supplier', 'asset.company',  'asset.assetstatus', 'admin');
 
         if ($request->filled('search')) {
             $maintenances = $maintenances->TextSearch($request->input('search'));
@@ -75,7 +75,9 @@ class AssetMaintenancesController extends Controller
                                 'user_id',
                                 'supplier',
                                 'is_warranty',
+                                'status_label',
                             ];
+
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
         $sort = in_array($request->input('sort'), $allowed_columns) ? e($request->input('sort')) : 'created_at';
 
@@ -93,8 +95,10 @@ class AssetMaintenancesController extends Controller
                 $maintenances = $maintenances->OrderByAssetName($order);
                 break;
             case 'serial':
-                \Log::debug('sort by serial');
                 $maintenances = $maintenances->OrderByAssetSerial($order);
+                break;
+            case 'status_label':
+                $maintenances = $maintenances->OrderStatusName($order);
                 break;
             default:
                 $maintenances = $maintenances->orderBy($sort, $order);

--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -161,17 +161,6 @@ class AssetMaintenancesController extends Controller
             return static::getInsufficientPermissionsRedirect();
         }
 
-        if ($assetMaintenance->completion_date == '0000-00-00') {
-            $assetMaintenance->completion_date = null;
-        }
-
-        if ($assetMaintenance->start_date == '0000-00-00') {
-            $assetMaintenance->start_date = null;
-        }
-
-        if ($assetMaintenance->cost == '0.00') {
-            $assetMaintenance->cost = null;
-        }
 
         // Prepare Improvement Type List
         $assetMaintenanceType = [

--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -150,13 +150,14 @@ class AssetMaintenancesController extends Controller
     {
         $this->authorize('update', Asset::class);
         // Check if the asset maintenance exists
+        $this->authorize('update', Asset::class);
+        // Check if the asset maintenance exists
         if (is_null($assetMaintenance = AssetMaintenance::find($assetMaintenanceId))) {
-            // Redirect to the improvement management page
-            return redirect()->route('maintenances.index')
-                           ->with('error', trans('admin/asset_maintenances/message.not_found'));
-        } elseif (! $assetMaintenance->asset) {
-            return redirect()->route('maintenances.index')
-                ->with('error', 'The asset associated with this maintenance does not exist.');
+            // Redirect to the asset maintenance management page
+            return redirect()->route('maintenances.index')->with('error', trans('admin/asset_maintenances/message.not_found'));
+        } elseif ((!$assetMaintenance->asset) || ($assetMaintenance->asset->deleted_at!='')) {
+            // Redirect to the asset maintenance management page
+            return redirect()->route('maintenances.index')->with('error', 'asset does not exist');
         } elseif (! Company::isCurrentUserHasAccess($assetMaintenance->asset)) {
             return static::getInsufficientPermissionsRedirect();
         }
@@ -192,8 +193,10 @@ class AssetMaintenancesController extends Controller
         // Check if the asset maintenance exists
         if (is_null($assetMaintenance = AssetMaintenance::find($assetMaintenanceId))) {
             // Redirect to the asset maintenance management page
-            return redirect()->route('maintenances.index')
-                           ->with('error', trans('admin/asset_maintenances/message.not_found'));
+            return redirect()->route('maintenances.index')->with('error', trans('admin/asset_maintenances/message.not_found'));
+        } elseif ((!$assetMaintenance->asset) || ($assetMaintenance->asset->deleted_at!='')) {
+                // Redirect to the asset maintenance management page
+                return redirect()->route('maintenances.index')->with('error', 'asset does not exist');
         } elseif (! Company::isCurrentUserHasAccess($assetMaintenance->asset)) {
             return static::getInsufficientPermissionsRedirect();
         }

--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -72,7 +72,7 @@ class AssetMaintenancesTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'update' => Gate::allows('update', Asset::class),
+            'update' => (Gate::allows('update', Asset::class) && ($assetmaintenance->asset->deleted_at=='')) ? true : false,
             'delete' => Gate::allows('delete', Asset::class),
         ];
 

--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -28,11 +28,19 @@ class AssetMaintenancesTransformer
                 'id' => (int) $assetmaintenance->asset->id,
                 'name'=> ($assetmaintenance->asset->name) ? e($assetmaintenance->asset->name) : null,
                 'asset_tag'=> e($assetmaintenance->asset->asset_tag),
-
+                'serial'=> e($assetmaintenance->asset->serial),
+                'deleted_at'=> e($assetmaintenance->asset->deleted_at),
+                'created_at'=> e($assetmaintenance->asset->created_at),
             ] : null,
             'model' => (($assetmaintenance->asset) && ($assetmaintenance->asset->model)) ? [
                 'id' => (int) $assetmaintenance->asset->model->id,
                 'name'=> ($assetmaintenance->asset->model->name) ? e($assetmaintenance->asset->model->name).' '.e($assetmaintenance->asset->model->model_number) : null,
+            ] : null,
+            'status_label' => ($assetmaintenance->asset->assetstatus) ? [
+                'id' => (int) $assetmaintenance->asset->assetstatus->id,
+                'name'=> e($assetmaintenance->asset->assetstatus->name),
+                'status_type'=> e($assetmaintenance->asset->assetstatus->getStatuslabelType()),
+                'status_meta' => e($assetmaintenance->asset->present()->statusMeta),
             ] : null,
             'company' => (($assetmaintenance->asset) && ($assetmaintenance->asset->company)) ? [
                 'id' => (int) $assetmaintenance->asset->company->id,

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1560,7 +1560,7 @@ class Asset extends Depreciable
              *
              * In short, this set of statements tells the query builder to ONLY query against an
              * actual field that's being passed if it doesn't meet known relational fields. This
-             * allows us to query custom fields directly in the assetsv table
+             * allows us to query custom fields directly in the assets table
              * (regardless of their name) and *skip* any fields that we already know can only be
              * searched through relational searches that we do earlier in this method.
              *

--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -62,7 +62,15 @@ class AssetMaintenance extends Model implements ICompanyableChild
      *
      * @var array
      */
-    protected $searchableAttributes = ['title', 'notes', 'asset_maintenance_type', 'cost', 'start_date', 'completion_date'];
+    protected $searchableAttributes =
+        [
+            'title',
+            'notes',
+            'asset_maintenance_type',
+            'cost',
+            'start_date',
+            'completion_date'
+        ];
 
     /**
      * The relations and their attributes that should be included when searching the model.
@@ -70,9 +78,10 @@ class AssetMaintenance extends Model implements ICompanyableChild
      * @var array
      */
     protected $searchableRelations = [
-        'asset'     => ['name', 'asset_tag'],
+        'asset'     => ['name', 'asset_tag', 'serial'],
         'asset.model'     => ['name', 'model_number'],
         'asset.supplier' => ['name'],
+        'asset.assetstatus' => ['name'],
         'supplier' => ['name'],
     ];
 
@@ -197,6 +206,7 @@ class AssetMaintenance extends Model implements ICompanyableChild
             ->orderBy('suppliers_maintenances.name', $order);
     }
 
+
     /**
      * Query builder scope to order on admin user
      *
@@ -238,5 +248,34 @@ class AssetMaintenance extends Model implements ICompanyableChild
     {
         return $query->leftJoin('assets', 'asset_maintenances.asset_id', '=', 'assets.id')
             ->orderBy('assets.name', $order);
+    }
+
+    /**
+     * Query builder scope to order on serial
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query  Query builder instance
+     * @param  string                              $order       Order
+     *
+     * @return \Illuminate\Database\Query\Builder          Modified query builder
+     */
+    public function scopeOrderByAssetSerial($query, $order)
+    {
+        return $query->leftJoin('assets', 'asset_maintenances.asset_id', '=', 'assets.id')
+            ->orderBy('assets.serial', $order);
+    }
+
+    /**
+     * Query builder scope to order on status label name
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query  Query builder instance
+     * @param  text                              $order         Order
+     *
+     * @return \Illuminate\Database\Query\Builder          Modified query builder
+     */
+    public function scopeOrderStatusName($query, $order)
+    {
+        return $query->join('assets as maintained_asset', 'asset_maintenances.asset_id', '=', 'maintained_asset.id')
+            ->leftjoin('status_labels as maintained_asset_status', 'maintained_asset_status.id', '=', 'maintained_asset.status_id')
+            ->orderBy('maintained_asset_status.name', $order);
     }
 }

--- a/app/Presenters/AssetMaintenancesPresenter.php
+++ b/app/Presenters/AssetMaintenancesPresenter.php
@@ -42,6 +42,19 @@ class AssetMaintenancesPresenter extends Presenter
                 'title' => trans('admin/hardware/table.asset_tag'),
                 'formatter' => 'assetTagLinkFormatter',
             ], [
+                'field' => 'serial',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/hardware/table.serial'),
+                'formatter' => 'assetSerialLinkFormatter',
+            ], [
+                'field' => 'status_label',
+                'searchable' => true,
+                'sortable' => true,
+                'title' => trans('admin/hardware/table.status'),
+                'visible' => true,
+                'formatter' => 'statuslabelsLinkObjFormatter',
+            ], [
                 'field' => 'model',
                 'searchable' => true,
                 'sortable' => true,

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -459,6 +459,7 @@ return [
     'no_autoassign_licenses_help' => 'Do not include user for bulk-assigning through the license UI or cli tools.',
     'modal_confirm_generic'      => 'Are you sure?',
     'cannot_be_deleted'      => 'This item cannot be deleted',
+    'cannot_be_edited'      => 'This item cannot be edited.',
     'undeployable_tooltip'      => 'This item cannot be checked out. Check the quantity remaining.',
     'serial_number'        => 'Serial Number',
     'item_notes' => ':item Notes',

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -872,11 +872,13 @@
 
 
                                     @can('update', $asset)
+                                        @if ($asset->deleted_at=='')
                                         <div class="col-md-12" style="padding-top: 5px;">
                                             <a href="{{ route('hardware.edit', $asset->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">
                                                 {{ trans('admin/hardware/general.edit') }}
                                             </a>
                                         </div>
+                                        @endif
                                     @endcan
 
                                     @can('create', $asset)

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -623,6 +623,9 @@
 
     function assetTagLinkFormatter(value, row) {
         if ((row.asset) && (row.asset.id)) {
+            if (row.asset.deleted_at!='') {
+                return '<span style="white-space: nowrap;"><i class="fas fa-times text-danger"></i><span class="sr-only">deleted</span> <del><a href="{{ config('app.url') }}/hardware/' + row.asset.id + '" data-tooltip="true" title="{{ trans('admin/hardware/general.deleted') }}">' + row.asset.asset_tag + '</a></del></span>';
+            }
             return '<a href="{{ config('app.url') }}/hardware/' + row.asset.id + '">' + row.asset.asset_tag + '</a>';
         }
         return '';
@@ -640,7 +643,17 @@
         if ((row.asset) && (row.asset.name)) {
             return '<a href="{{ config('app.url') }}/hardware/' + row.asset.id + '">' + row.asset.name + '</a>';
         }
+    }
 
+    function assetSerialLinkFormatter(value, row) {
+
+        if ((row.asset) && (row.asset.serial)) {
+            if (row.asset.deleted_at!='') {
+                return '<span style="white-space: nowrap;"><i class="fas fa-times text-danger"></i><span class="sr-only">deleted</span> <del><a href="{{ config('app.url') }}/hardware/' + row.asset.id + '" data-tooltip="true" title="{{ trans('admin/hardware/general.deleted') }}">' + row.asset.serial + '</a></del></span>';
+            }
+            return '<a href="{{ config('app.url') }}/hardware/' + row.asset.id + '">' + row.asset.serial + '</a>';
+        }
+        return '';
     }
 
     function trueFalseFormatter(value) {

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -296,6 +296,10 @@
 
             if ((row.available_actions) && (row.available_actions.update === true)) {
                 actions += '<a href="{{ config('app.url') }}/' + dest + '/' + row.id + '/edit" class="actions btn btn-sm btn-warning" data-tooltip="true" title="{{ trans('general.update') }}"><i class="fas fa-pencil-alt" aria-hidden="true"></i><span class="sr-only">{{ trans('general.update') }}</span></a>&nbsp;';
+            } else {
+                if ((row.available_actions) && (row.available_actions.update != true)) {
+                    actions += '<span data-tooltip="true" title="{{ trans('general.cannot_be_edited') }}"><a class="btn btn-warning btn-sm disabled" onClick="return false;"><i class="fas fa-pencil-alt"></i></a></span>&nbsp;';
+                }
             }
 
             if ((row.available_actions) && (row.available_actions.delete === true)) {


### PR DESCRIPTION
This adds the serial number of the asset and the status label to the asset maintenance page, and also better indicates maintenances on deleted assets, with support for sorting on both status label name and serial.

<img width="1669" alt="Screenshot 2024-02-14 at 10 01 12 AM" src="https://github.com/snipe/snipe-it/assets/197404/d3e70056-269a-47d2-8794-353881bce884">
<img width="1660" alt="Screenshot 2024-02-14 at 10 13 02 AM" src="https://github.com/snipe/snipe-it/assets/197404/5c485e4d-98f0-4944-a109-799adffd4fa8">
<img width="1664" alt="Screenshot 2024-02-14 at 10 13 11 AM" src="https://github.com/snipe/snipe-it/assets/197404/0ebc5647-7bb7-4a65-a537-17e5f892e54c">
<img width="1666" alt="Screenshot 2024-02-14 at 10 13 20 AM" src="https://github.com/snipe/snipe-it/assets/197404/f7cbd8f8-a582-43f9-80da-3ff42a6b0eec">
<img width="1662" alt="Screenshot 2024-02-14 at 10 13 48 AM" src="https://github.com/snipe/snipe-it/assets/197404/5b032be6-db7c-47f5-b0f4-2e741d46c3e2">
<img width="1670" alt="Screenshot 2024-02-14 at 10 16 42 AM" src="https://github.com/snipe/snipe-it/assets/197404/9cfe6ff2-2461-440f-ae84-3a49e894723f">
<img width="1664" alt="Screenshot 2024-02-14 at 10 16 52 AM" src="https://github.com/snipe/snipe-it/assets/197404/2f9fe7ee-6062-4cc4-8094-91bb9a98a8ce">

