### PR TITLE
Updated testing helper name

### DIFF
--- a/tests/Feature/Notifications/AccessoryWebhookTest.php
+++ b/tests/Feature/Notifications/AccessoryWebhookTest.php
@@ -22,7 +22,7 @@ class AccessoryWebhookTest extends TestCase
     {
         Notification::fake();
 
-        $this->settings->enableWebhook();
+        $this->settings->enableSlackWebhook();
 
         event(new CheckoutableCheckedOut(
             Accessory::factory()->appleBtKeyboard()->create(),
@@ -60,7 +60,7 @@ class AccessoryWebhookTest extends TestCase
     {
         Notification::fake();
 
-        $this->settings->enableWebhook();
+        $this->settings->enableSlackWebhook();
 
         event(new CheckoutableCheckedIn(
             Accessory::factory()->appleBtKeyboard()->create(),

--- a/tests/Feature/Notifications/AssetWebhookTest.php
+++ b/tests/Feature/Notifications/AssetWebhookTest.php
@@ -33,7 +33,7 @@ class AssetWebhookTest extends TestCase
     {
         Notification::fake();
 
-        $this->settings->enableWebhook();
+        $this->settings->enableSlackWebhook();
 
         event(new CheckoutableCheckedOut(
             $this->createAsset(),
@@ -73,7 +73,7 @@ class AssetWebhookTest extends TestCase
     {
         Notification::fake();
 
-        $this->settings->enableWebhook();
+        $this->settings->enableSlackWebhook();
 
         event(new CheckoutableCheckedIn(
             $this->createAsset(),

--- a/tests/Feature/Notifications/ComponentWebhookTest.php
+++ b/tests/Feature/Notifications/ComponentWebhookTest.php
@@ -20,7 +20,7 @@ class ComponentWebhookTest extends TestCase
     {
         Notification::fake();
 
-        $this->settings->enableWebhook();
+        $this->settings->enableSlackWebhook();
 
         event(new CheckoutableCheckedOut(
             Component::factory()->ramCrucial8()->create(),
@@ -36,7 +36,7 @@ class ComponentWebhookTest extends TestCase
     {
         Notification::fake();
 
-        $this->settings->enableWebhook();
+        $this->settings->enableSlackWebhook();
 
         event(new CheckoutableCheckedIn(
             Component::factory()->ramCrucial8()->create(),

--- a/tests/Feature/Notifications/ConsumableWebhookTest.php
+++ b/tests/Feature/Notifications/ConsumableWebhookTest.php
@@ -20,7 +20,7 @@ class ConsumableWebhookTest extends TestCase
     {
         Notification::fake();
 
-        $this->settings->enableWebhook();
+        $this->settings->enableSlackWebhook();
 
         event(new CheckoutableCheckedOut(
             Consumable::factory()->cardstock()->create(),

--- a/tests/Feature/Notifications/LicenseWebhookTest.php
+++ b/tests/Feature/Notifications/LicenseWebhookTest.php
@@ -32,7 +32,7 @@ class LicenseWebhookTest extends TestCase
     {
         Notification::fake();
 
-        $this->settings->enableWebhook();
+        $this->settings->enableSlackWebhook();
 
         event(new CheckoutableCheckedOut(
             LicenseSeat::factory()->create(),
@@ -72,7 +72,7 @@ class LicenseWebhookTest extends TestCase
     {
         Notification::fake();
 
-        $this->settings->enableWebhook();
+        $this->settings->enableSlackWebhook();
 
         event(new CheckoutableCheckedIn(
             LicenseSeat::factory()->create(),

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -39,9 +39,10 @@ class Settings
         return $this->update(['full_multiple_companies_support' => 0]);
     }
 
-    public function enableWebhook(): Settings
+    public function enableSlackWebhook(): Settings
     {
         return $this->update([
+            'webhook_selected' => 'slack',
             'webhook_botname' => 'SnipeBot5000',
             'webhook_endpoint' => 'https://hooks.slack.com/services/NZ59/Q446/672N',
             'webhook_channel' => '#it',
@@ -51,6 +52,7 @@ class Settings
     public function disableWebhook(): Settings
     {
         return $this->update([
+            'webhook_selected' => '',
             'webhook_botname' => '',
             'webhook_endpoint' => '',
             'webhook_channel' => '',


### PR DESCRIPTION
# Description

Lately we've added more webhook targets besides just Slack. This PR updates the `->enableWebhook()` helper in our tests to `->enableSlackWebhook()` which accurately represents what settings are actually being toggled on when used.

## Type of change

- [x] Chore