### PR TITLE
Fixed ambiguous query on supplier_id in maintenances

### DIFF
--- a/app/Http/Controllers/Api/AssetMaintenancesController.php
+++ b/app/Http/Controllers/Api/AssetMaintenancesController.php
@@ -48,7 +48,7 @@ class AssetMaintenancesController extends Controller
         }
 
         if ($request->filled('supplier_id')) {
-            $maintenances->where('supplier_id', '=', $request->input('supplier_id'));
+            $maintenances->where('asset_maintenances.supplier_id', '=', $request->input('supplier_id'));
         }
 
         if ($request->filled('asset_maintenance_type')) {


### PR DESCRIPTION
Since `assets` and `asset_maintenances` both take a supplier id, this fix disambiguates the query