### PR TITLE
Lower log level to warning on webhook failure

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -69,9 +69,9 @@ class CheckoutableListener
               }
             }
         } catch (ClientException $e) {
-            Log::info("Exception caught during checkout notification: " . $e->getMessage());
+            Log::warning("Exception caught during checkout notification: " . $e->getMessage());
         } catch (Exception $e) {
-            Log::info("Exception caught during checkout notification: " . $e->getMessage());
+            Log::warning("Exception caught during checkout notification: " . $e->getMessage());
         }
     }
 
@@ -124,9 +124,9 @@ class CheckoutableListener
             }
 
         } catch (ClientException $e) {
-            Log::info("Exception caught during checkout notification: " . $e->getMessage());
+            Log::warning("Exception caught during checkout notification: " . $e->getMessage());
         } catch (Exception $e) {
-            Log::info("Exception caught during checkin notification: " . $e->getMessage());
+            Log::warning("Exception caught during checkin notification: " . $e->getMessage());
         }
     }      
 

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -69,9 +69,9 @@ class CheckoutableListener
               }
             }
         } catch (ClientException $e) {
-            Log::debug("Exception caught during checkout notification: " . $e->getMessage());
+            Log::info("Exception caught during checkout notification: " . $e->getMessage());
         } catch (Exception $e) {
-            Log::error("Exception caught during checkout notification: " . $e->getMessage());
+            Log::info("Exception caught during checkout notification: " . $e->getMessage());
         }
     }
 
@@ -124,9 +124,9 @@ class CheckoutableListener
             }
 
         } catch (ClientException $e) {
-            Log::debug("Exception caught during checkout notification: " . $e->getMessage());
+            Log::info("Exception caught during checkout notification: " . $e->getMessage());
         } catch (Exception $e) {
-            Log::error("Exception caught during checkin notification: " . $e->getMessage());
+            Log::info("Exception caught during checkin notification: " . $e->getMessage());
         }
     }      
 


### PR DESCRIPTION
We (correctly, at least in theory) the log level `error` in the exception handler for when a webhook fails, but this was largely just crapping all over our Rollbars. I've dropped that log level down to `warning` so that it will still show up in logs but won't be so noisy in rollbar.