### PR TITLE
Improved UI for fieldsets

### DIFF
--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -502,5 +502,6 @@ return [
     'action_source' => 'Action Source',
     'or' => 'or',
     'url'                   => 'URL',
+    'edit_fieldset' => 'Edit fieldset fields and options',
 
 ];

--- a/resources/views/custom_fields/fieldsets/view.blade.php
+++ b/resources/views/custom_fields/fieldsets/view.blade.php
@@ -77,7 +77,7 @@
                 @can('update', $custom_fieldset)
                 <form method="post" action="{{ route('fields.disassociate', [$field, $custom_fieldset->id]) }}">
                   @csrf 
-                  <button type="submit" class="btn btn-sm btn-danger">{{ trans('button.remove') }}</button>
+                  <button type="submit" class="btn btn-sm btn-danger"><i class="fa fa-trash icon-white" aria-hidden="true"></i></button>
                 </form>
                 @endcan
               </td>
@@ -90,35 +90,34 @@
               <td colspan="8">
                 {{ Form::open(['route' =>
                 ["fieldsets.associate",$custom_fieldset->id],
-                'class'=>'form-horizontal',
+                'class'=>'form-inline',
                 'id' => 'ordering']) }}
 
 
-                <div class="form-group col-md-4">
+                <div class="form-group">
                   <label for="field_id" class="sr-only">
                     {{ trans('admin/custom-field/general.add_field_to_fieldset')}}
                   </label>
-                  {{ Form::select("field_id",$custom_fields_list,"",['aria-label'=>'field_id', 'class'=>'select2']) }}
+                  {{ Form::select("field_id",$custom_fields_list,"",['aria-label'=>'field_id', 'class'=>'select2', 'style' => 'min-width:400px;']) }}
 
                 </div>
 
-                <div class="form-group col-md-2" style="vertical-align: middle;">
-
-                  <label class="form-control">
-                    {{ Form::checkbox('required', 'on', old('required'), array('aria-label'=>'required')) }}
-                    {{ trans('admin/custom_fields/general.required') }}
-                  </label>
-
-                </div>
-                <div class="form-group col-md-2" style="display: none;">
-
-                  {{ Form::text('order', $maxid, array('class' => 'form-control col-sm-1 col-md-1', 'style'=> 'width: 80px; padding-;right: 10px;', 'aria-label'=>'order', 'maxlength'=>'3', 'size'=>'3')) }}
+                <div class="form-group" style="display: none;">
+                  {{ Form::text('order', $maxid, array('aria-label'=>'order', 'maxlength'=>'3', 'size'=>'3')) }}
                   <label for="order">{{ trans('admin/custom_fields/general.order') }}</label>
                 </div>
 
-                <div class="form-group col-md-3">
-                  <button type="submit" class="btn btn-primary"> {{ trans('general.save') }}</button>
+                <div class="checkbox-inline">
+                    <label>
+                    {{ Form::checkbox('required', 'on', old('required')) }}
+                      <span style="padding-left: 10px;">{{ trans('admin/custom_fields/general.required') }}</span>
+                    </label>
                 </div>
+
+                <span style="padding-left: 10px;">
+                  <button type="submit" class="btn btn-primary"> {{ trans('general.save') }}</button>
+                </span>
+
                 {{ Form::close() }}
 
               </td>

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -73,7 +73,14 @@
                 <nobr>
 
                 @can('update', $fieldset)
-                  <a href="{{ route('fieldsets.edit', $fieldset->id) }}" class="btn btn-warning btn-sm">
+
+                  <a href="{{ route('fieldsets.show', ['fieldset' => $fieldset->id]) }}" data-tooltip="true" title="{{ trans('general.edit_fieldset') }}">
+                    <button type="submit" class="btn btn-info btn-sm">
+                      <i class="fa-regular fa-rectangle-list"></i>
+                    </button>
+                  </a>
+
+                  <a href="{{ route('fieldsets.edit', $fieldset->id) }}" class="btn btn-warning btn-sm" data-tooltip="true" title="{{ trans('general.update') }}">
                     <i class="fas fa-pencil-alt" aria-hidden="true"></i>
                     <span class="sr-only">{{ trans('button.edit') }}</span>
                   </a>
@@ -82,9 +89,9 @@
                 @can('delete', $fieldset)
                 {{ Form::open(['route' => array('fieldsets.destroy', $fieldset->id), 'method' => 'delete','style' => 'display:inline-block']) }}
                   @if($fieldset->models->count() > 0)
-                  <button type="submit" class="btn btn-danger btn-sm disabled" disabled><i class="fas fa-trash"></i></button>
+                  <button type="submit" class="btn btn-danger btn-sm disabled" data-tooltip="true" title="{{ trans('general.cannot_be_deleted') }}" disabled><i class="fas fa-trash"></i></button>
                   @else
-                  <button type="submit" class="btn btn-danger btn-sm"><i class="fas fa-trash"></i></button>
+                  <button type="submit" class="btn btn-danger btn-sm" data-tooltip="true" title="{{ trans('general.delete') }}"><i class="fas fa-trash"></i></button>
                   @endif
                 {{ Form::close() }}
                 @endcan
@@ -188,7 +195,7 @@
                 <nobr>
                   {{ Form::open(array('route' => array('fields.destroy', $field->id), 'method' => 'delete', 'style' => 'display:inline-block')) }}
                   @can('update', $field)
-                    <a href="{{ route('fields.edit', $field->id) }}" class="btn btn-warning btn-sm">
+                    <a href="{{ route('fields.edit', $field->id) }}" class="btn btn-warning btn-sm" data-tooltip="true" title="{{ trans('general.update') }}">
                       <i class="fas fa-pencil-alt" aria-hidden="true"></i>
                       <span class="sr-only">{{ trans('button.edit') }}</span>
                     </a>
@@ -197,11 +204,11 @@
                 @can('delete', $field)
 
                   @if($field->fieldset->count()>0)
-                    <button type="submit" class="btn btn-danger btn-sm disabled" disabled>
+                    <button type="submit" class="btn btn-danger btn-sm disabled" data-tooltip="true" title="{{ trans('general.cannot_be_deleted') }}" disabled>
                       <i class="fas fa-trash" aria-hidden="true"></i>
                       <span class="sr-only">{{ trans('button.delete') }}</span></button>
                   @else
-                    <button type="submit" class="btn btn-danger btn-sm">
+                    <button type="submit" class="btn btn-danger btn-sm" data-tooltip="true" title="{{ trans('general.delete') }}">
                       <i class="fas fa-trash" aria-hidden="true"></i>
                       <span class="sr-only">{{ trans('button.delete') }}</span>
                     </button>


### PR DESCRIPTION
It was previously a little confusing as to how to edit the fields that are in a fieldset. (Clicking on the edit icon only lets you edit the name.) I've added a new button to the UI and some tooltips, and also made that "Add field to fieldset" bottom menu a little nicer.

<img width="1679" alt="Screenshot 2024-02-15 at 2 15 02 PM" src="https://github.com/snipe/snipe-it/assets/197404/d1394215-d4f4-437c-a7d1-b08060540c12">


<img width="1632" alt="Screenshot 2024-02-15 at 2 14 38 PM" src="https://github.com/snipe/snipe-it/assets/197404/ada690db-fe16-48df-afab-2d13e62462c9">
