### PR TITLE
FIXED: Checked in Assets Did Not Show in Custom Report when Selecting a Valid Checked Out Date 

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -879,7 +879,7 @@ class AssetsController extends Controller
         }
 
         $asset->expected_checkin = null;
-        $asset->last_checkout = null;
+        //$asset->last_checkout = null;
         $asset->last_checkin = now();
         $asset->assigned_to = null;
         $asset->assignedTo()->disassociate($asset);

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -67,7 +67,7 @@ class AssetCheckinController extends Controller
         }
 
         $asset->expected_checkin = null;
-        $asset->last_checkout = null;
+        //$asset->last_checkout = null;
         $asset->last_checkin = now();
         $asset->assigned_to = null;
         $asset->assignedTo()->disassociate($asset);

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -694,6 +694,14 @@ class ReportsController extends Controller
                 $checkout_end = \Carbon::parse($request->input('checkout_date_end'))->endOfDay();
 
                 $assets->whereBetween('assets.last_checkout', [$checkout_start, $checkout_end]);
+
+                $actionlogassets = Actionlog::where('action_type','=', 'checkout')->
+                                              where('item_type' 'LIKE' '%Asset%',)
+                                              whereBetween('created_at',[$checkout_start, $checkout_end])
+                                                  ->pluck('item_id');
+
+                $assets->whereIn('id',$actionlogassets);
+
                 //$assets->whereBetween('action_logs.created_at', [$checkout_start, $checkout_end]);
                 //action_logs bit was returning an ERR_INVALID_RESPONSE so I probably missed something
                 //sql query? -> WHERE (`action_type` = 'checkout') AND (`item_type` LIKE '%Asset%')

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -691,13 +691,11 @@ class ReportsController extends Controller
             //There can be multiple checkouts in a given time that we want to track.
             if (($request->filled('checkout_date_start')) && ($request->filled('checkout_date_end'))) {
                 $checkout_start = \Carbon::parse($request->input('checkout_date_start'))->startOfDay();
-                $checkout_end = \Carbon::parse($request->input('checkout_date_end'))->endOfDay();
+                $checkout_end = \Carbon::parse($request->input('checkout_date_end',now()))->endOfDay();
 
-                $assets->whereBetween('assets.last_checkout', [$checkout_start, $checkout_end]);
-
-                $actionlogassets = Actionlog::where('action_type','=', 'checkout')->
-                                              where('item_type' 'LIKE' '%Asset%',)
-                                              whereBetween('created_at',[$checkout_start, $checkout_end])
+                $actionlogassets = Actionlog::where('action_type','=', 'checkout')
+                                              ->where('item_type', 'LIKE', '%Asset%',)
+                                              ->whereBetween('action_date',[$checkout_start, $checkout_end])
                                                   ->pluck('item_id');
 
                 $assets->whereIn('id',$actionlogassets);

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -687,8 +687,6 @@ class ReportsController extends Controller
                 $assets->whereBetween('assets.created_at', [$created_start, $created_end]);
             }
 
-            //This should parse the action log, and not the hardware table.
-            //There can be multiple checkouts in a given time that we want to track.
             if (($request->filled('checkout_date_start')) && ($request->filled('checkout_date_end'))) {
                 $checkout_start = \Carbon::parse($request->input('checkout_date_start'))->startOfDay();
                 $checkout_end = \Carbon::parse($request->input('checkout_date_end',now()))->endOfDay();
@@ -699,14 +697,6 @@ class ReportsController extends Controller
                                                   ->pluck('item_id');
 
                 $assets->whereIn('id',$actionlogassets);
-
-                //$assets->whereBetween('action_logs.created_at', [$checkout_start, $checkout_end]);
-                //action_logs bit was returning an ERR_INVALID_RESPONSE so I probably missed something
-                //sql query? -> WHERE (`action_type` = 'checkout') AND (`item_type` LIKE '%Asset%')
-                // AND whereBetween('action_logs.created_at', [$checkout_start, $checkout_end]);
-                //    if ($action_logs->action_type == "checkout") {}
-
-
             }
 
             if (($request->filled('checkin_date_start'))) {

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -686,17 +686,27 @@ class ReportsController extends Controller
 
                 $assets->whereBetween('assets.created_at', [$created_start, $created_end]);
             }
+
+            //This should parse the action log, and not the hardware table.
+            //There can be multiple checkouts in a given time that we want to track.
             if (($request->filled('checkout_date_start')) && ($request->filled('checkout_date_end'))) {
                 $checkout_start = \Carbon::parse($request->input('checkout_date_start'))->startOfDay();
                 $checkout_end = \Carbon::parse($request->input('checkout_date_end'))->endOfDay();
 
                 $assets->whereBetween('assets.last_checkout', [$checkout_start, $checkout_end]);
+                //$assets->whereBetween('action_logs.created_at', [$checkout_start, $checkout_end]);
+                //action_logs bit was returning an ERR_INVALID_RESPONSE so I probably missed something
+                //sql query? -> WHERE (`action_type` = 'checkout') AND (`item_type` LIKE '%Asset%')
+                // AND whereBetween('action_logs.created_at', [$checkout_start, $checkout_end]);
+                //    if ($action_logs->action_type == "checkout") {}
+
+
             }
 
             if (($request->filled('checkin_date_start'))) {
                     $assets->whereBetween('last_checkin', [
                         Carbon::parse($request->input('checkin_date_start'))->startOfDay(),
-                        // use today's date is `checkin_date_end` is not provided
+                        // use today's date if `checkin_date_end` is not provided
                         Carbon::parse($request->input('checkin_date_end', now()))->endOfDay(),
                     ]);
             }


### PR DESCRIPTION
# Description
When running a custom report, and looking for assets that were checked out during a selected time period, if an asset had been checked in, it was not being included in the results. This was partially because we were nulling out the `Last Checkout ` date, but that would also only return when the asset was _last_ checked out, and could drop an asset out of the results if it had been checked out again more recently.

To remedy this, we now query the action log for all checkouts in a given time period, with that time period passed in via the date select fields on the custom report page, and return those assets.

Fixes #14242 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested locally, using different combinations of checked in and out assets

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
