### PR TITLE
Better handle large downloads on backup API

### DIFF
--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -249,6 +249,7 @@ class SettingsController extends Controller
                         'filesize' => Setting::fileSizeConvert(Storage::size($backup_files[$f])),
                         'modified_value' => $file_timestamp,
                         'modified_display' => date($settings->date_display_format.' '.$settings->time_display_format, $file_timestamp),
+                        'backup_url' => config('app.url').'/settings/backups/download/'.basename($backup_files[$f]),
 
                     ];
                     $count++;
@@ -269,7 +270,7 @@ class SettingsController extends Controller
         $path = 'app/backups';
         if (Storage::exists($path.'/'.$file)) {
             $headers = ['ContentType' => 'application/zip'];
-            return Storage::download($path.'/'.$file, $file, $headers);
+            return response()->download($path.'/'.$file, $file, $headers);
         } else {
             return response()->json(Helper::formatStandardApiResponse('error', null,  trans('general.file_not_found')));
         }


### PR DESCRIPTION
This is an attempt to implement a fix mentioned in https://github.com/laravel/framework/issues/36249 for very large downloads, which can happen when downloading backups via the API on very large systems. 

This might not work as expected if backups are stored in S3, but that's perhaps for another PR where we detect which filesystem driver we're using. 