### PR TITLE
Added `/backups/latest` to API endpoint

### DIFF
--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -229,6 +229,12 @@ class SettingsController extends Controller
     }
 
 
+    /**
+     * Lists backup files
+     *
+     * @author [A. Gianotto]
+     * @return array | JsonResponse
+     */
     public function listBackups() {
         $settings = Setting::getSettings();
         $path = 'app/backups';

--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -148,7 +148,7 @@ class SettingsController extends Controller
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v3.0]
-     * @return Redirect
+     * @return JsonResponse
      */
     public function ajaxTestEmail()
     {
@@ -170,7 +170,7 @@ class SettingsController extends Controller
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v5.0.0]
-     * @return Response
+     * @return JsonResponse
      */
     public function purgeBarcodes()
     {
@@ -211,7 +211,7 @@ class SettingsController extends Controller
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v5.0.0]
      * @param  \Illuminate\Http\Request  $request
-     * @return array
+     * @return array | JsonResponse
      */
     public function showLoginAttempts(Request $request)
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -828,6 +828,13 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
                 ]
             )->name('api.settings.backups.index');
 
+            Route::get('backups/download/latest',
+                [
+                    Api\SettingsController::class,
+                    'downloadLatestBackup'
+                ]
+            )->name('api.settings.backups.latest');
+
             Route::get('backups/download/{file}',
                 [
                     Api\SettingsController::class,


### PR DESCRIPTION
This addition will be helpful for folks who have automated their backup downloads, saving them the step of getting the list of downloads and instead just giving them the latest one. 