### PR TITLE
Add missing EXIF PHP library for Alpine Docker image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -29,6 +29,7 @@ RUN  apk add --no-cache \
         php81-sodium \
         php81-redis \
         php81-pecl-memcached \
+        php81-exif \
         curl \
         wget \
         vim \


### PR DESCRIPTION
We started using the EXIF library from PHP as of late in order to better handle images that have been uploaded from a phone. However, it seems that our Alpine docker image does not have EXIF support built in. This should add that.