### PR TITLE
Fixed title not appearing in new label engine

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -90,13 +90,9 @@ class Label implements View
                 $assetData->put('id', $asset->id);
                 $assetData->put('tag', $asset->asset_tag);
 
-                if ($template->getSupportTitle()) {
-
-                    if ($asset->company && !empty($settings->label2_title)) {
-                        $title = str_replace('{COMPANY}', $asset->company->name, $settings->label2_title);
-                        $settings->qr_text;
-                        $assetData->put('title', $title);
-                    }
+                if ($template->getSupportTitle() && !empty($settings->label2_title)) {
+                    $title = str_replace('{COMPANY}', data_get($asset, 'company.name'), $settings->label2_title);
+                    $assetData->put('title', $title);
                 }
 
                 if ($template->getSupportLogo()) {


### PR DESCRIPTION
# Description

This PR fixes a bug in the new label engine where a title would only be shown if the asset belongs to a company.

(In these examples the first two assets have a company while the third does not.)

Note that "My Title" is only displayed if the asset has a company:

![before](https://github.com/snipe/snipe-it/assets/1141514/d9b7d059-9e4a-4305-9860-1e85c7518040)


And with this fix applied:
![after](https://github.com/snipe/snipe-it/assets/1141514/d608c9f3-6ecd-4d1c-89e6-e1ebbf69721a)


Using `{COMPANY}` for the title is still working too (the last one just displays nothing like before):
![using company placeholder](https://github.com/snipe/snipe-it/assets/1141514/fb8a60a6-ad48-49e6-9d0f-dec6747acba2)

---

Fixes #13768

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)