### PR TITLE
Added email, phone icons

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -73,6 +73,7 @@ class UsersController extends Controller
             'users.end_date',
             'users.vip',
             'users.autoassign_licenses',
+            'users.website',
 
         ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables', 'createdBy',)
             ->withCount('assets as assets_count', 'licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count');
@@ -254,6 +255,7 @@ class UsersController extends Controller
                         'start_date',
                         'end_date',
                         'autoassign_licenses',
+                        'website',
                     ];
 
                 $sort = in_array($request->get('sort'), $allowed_columns) ? $request->get('sort') : 'first_name';

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -123,6 +123,15 @@ class UserPresenter extends Presenter
                 'formatter'    => 'phoneFormatter',
             ],
             [
+                'field' => 'website',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('general.website'),
+                'visible' => false,
+                'formatter'    => 'externalLinkFormatter',
+            ],
+            [
                 'field' => 'address',
                 'searchable' => true,
                 'sortable' => true,

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -438,6 +438,8 @@ return [
     'auto_incrementing_asset_tags_disabled_so_tags_required' => 'Generating auto-incrementing asset tags is disabled so all rows need to have the "Asset Tag" column populated.',
     'auto_incrementing_asset_tags_enabled_so_now_assets_will_be_created' => 'Note: Generating auto-incrementing asset tags is enabled so assets will be created for rows that do not have "Asset Tag" populated. Rows that do have "Asset Tag" populated will be updated with the provided information.',
     'send_welcome_email_to_users'   => ' Send Welcome Email for new Users?',
+    'send_email'                => 'Send Email',
+    'call'                      => 'Call number',
     'back_before_importing'     => 'Backup before importing?',
     'csv_header_field'          => 'CSV Header Field',
     'import_field'              => 'Import Field',

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -409,7 +409,7 @@
                                                     </strong>
                                                 </div>
                                                 <div class="col-md-6{{ (($field->format=='URL') && ($asset->{$field->db_column_name()}!='')) ? ' ellipsis': '' }}">
-                                                    @if ($field->field_encrypted=='1')
+                                                    @if (($field->field_encrypted=='1') && ($asset->{$field->db_column_name()}!=''))
                                                         <i class="fas fa-lock" data-tooltip="true" data-placement="top" title="{{ trans('admin/custom_fields/general.value_encrypted') }}"></i>
                                                     @endif
 
@@ -950,7 +950,7 @@
                                             @endif
 
                                             @if (isset($asset->location))
-                                                <li>{{ $asset->location->name }}</li>
+                                                <li><i class="fas fa-map-marker-alt" aria-hidden="true"></i> {{ $asset->location->name }}</li>
                                                 <li>{{ $asset->location->address }}
                                                     @if ($asset->location->address2!='')
                                                         {{ $asset->location->address2 }}

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -548,9 +548,9 @@
                     if (row.custom_fields[field_column_plain].field_format=='URL') {
                         return '<a href="' + row.custom_fields[field_column_plain].value + '" target="_blank" rel="noopener">' + row.custom_fields[field_column_plain].value + '</a>';
                     } else if (row.custom_fields[field_column_plain].field_format=='BOOLEAN') {
-                        return (row.custom_fields[field_column_plain].value == 1) ? "<span class='fas fa-check-circle' style='color:green' />" : "<span class='fas fa-times-circle' style='color:red' />";
+                        return (row.custom_fields[field_column_plain].value == 1) ? "<span class='fas fa-check-circle' style='color:green'>" : "<span class='fas fa-times-circle' style='color:red' />";
                     } else if (row.custom_fields[field_column_plain].field_format=='EMAIL') {
-                        return '<a href="mailto:' + row.custom_fields[field_column_plain].value + '">' + row.custom_fields[field_column_plain].value + '</a>';
+                        return '<a href="mailto:' + row.custom_fields[field_column_plain].value + '" style="white-space: nowrap" data-tooltip="true" title="{{ trans('general.send_email') }}"><i class="fa-regular fa-envelope" aria-hidden="true"></i> ' + row.custom_fields[field_column_plain].value + '</a>';
                     }
                 }
                 return row.custom_fields[field_column_plain].value;
@@ -570,7 +570,7 @@
 
         if (value) {
             if ((value.indexOf("{") === -1) || (value.indexOf("}") ===-1)) {
-                return '<nobr><a href="' + value + '" target="_blank" title="External link to ' + value + '" data-tooltip="true" ><i class="fa fa-external-link"></i> ' + value + '</a></nobr>';
+                return '<nobr><a href="' + value + '" target="_blank" title="External link to ' + value + '" data-tooltip="true"><i class="fa fa-external-link"></i> ' + value + '</a></nobr>';
             }
             return value;
         }
@@ -625,7 +625,7 @@
     // Create a linked phone number in the table list
     function phoneFormatter(value) {
         if (value) {
-            return  '<a href="tel:' + value + '">' + value + '</a>';
+            return  '<span style="white-space: nowrap;"><a href="tel:' + value + '" data-tooltip="true" title="{{ trans('general.call') }}"><i class="fa-solid fa-phone" aria-hidden="true"></i> ' + value + '</a></span>';
         }
     }
 
@@ -634,7 +634,7 @@
         if ((row) && (row!=undefined)) {
             return '<a href="{{ config('app.url') }}/locations/' + row.id + '">' + row.name + '</a>';
         } else if (value.rtd_location) {
-            return '<a href="{{ config('app.url') }}/locations/' + value.rtd_location.id + '" data-tooltip="true" title="Default Location">' + value.rtd_location.name + '</a>';
+            return '<a href="{{ config('app.url') }}/locations/' + value.rtd_location.id + '">' + value.rtd_location.name + '</a>';
         }
 
     }
@@ -646,7 +646,7 @@
     function assetTagLinkFormatter(value, row) {
         if ((row.asset) && (row.asset.id)) {
             if (row.asset.deleted_at!='') {
-                return '<span style="white-space: nowrap;"><i class="fas fa-times text-danger"></i><span class="sr-only">deleted</span> <del><a href="{{ config('app.url') }}/hardware/' + row.asset.id + '" data-tooltip="true" title="{{ trans('admin/hardware/general.deleted') }}">' + row.asset.asset_tag + '</a></del></span>';
+                return '<span style="white-space: nowrap;"><i class="fas fa-times text-danger"></i><span class="sr-only">{{ trans('admin/hardware/general.deleted') }}</span> <del><a href="{{ config('app.url') }}/hardware/' + row.asset.id + '" data-tooltip="true" title="{{ trans('admin/hardware/general.deleted') }}">' + row.asset.asset_tag + '</a></del></span>';
             }
             return '<a href="{{ config('app.url') }}/hardware/' + row.asset.id + '">' + row.asset.asset_tag + '</a>';
         }
@@ -700,7 +700,7 @@
 
     function emailFormatter(value) {
         if (value) {
-            return '<a href="mailto:' + value + '">' + value + '</a>';
+            return '<a href="mailto:' + value + '" style="white-space: nowrap" data-tooltip="true" title="{{ trans('general.send_email') }}"><i class="fa-regular fa-envelope" aria-hidden="true"></i> ' + value + '</a>';
         }
     }
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -431,19 +431,19 @@
                         {{ trans('admin/users/table.email') }}
                       </div>
                       <div class="col-md-9">
-                        <a href="mailto:{{ $user->email }}">{{ $user->email }}</a>
+                        <a href="mailto:{{ $user->email }}" data-tooltip="true" title="{{ trans('general.send_email') }}"><i class="fa-regular fa-envelope" aria-hidden="true"></i> {{ $user->email }}</a>
                       </div>
                     </div>
                     @endif
 
-                    @if ($user->phone)
+                    @if ($user->website)
                      <!-- website -->
                      <div class="row">
                       <div class="col-md-3">
                         {{ trans('general.website') }}
                       </div>
                       <div class="col-md-9">
-                          <a href="{{ $user->website }}" target="_blank">{{ $user->website }}</a>
+                          <a href="{{ $user->website }}" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> {{ $user->website }}</a>
                       </div>
                     </div>
                     @endif
@@ -455,7 +455,7 @@
                           {{ trans('admin/users/table.phone') }}
                         </div>
                         <div class="col-md-9">
-                          <a href="tel:{{ $user->phone }}">{{ $user->phone }}</a>
+                          <a href="tel:{{ $user->phone }}" data-tooltip="true" title="{{ trans('general.call') }}"><i class="fa-solid fa-phone" aria-hidden="true"></i> {{ $user->phone }}</a>
                         </div>
                       </div>
                     @endif


### PR DESCRIPTION
When email addresses are used as usernames, it's less clear that clicking on the email address in the list view will open a mail client window, while clicking on the same email address in the username column will take you to the user's profile.

This adds some icons and tooltips to help the user know what happens if they click on non-standard links like phone, email, etc.

<img width="1125" alt="Screenshot 2024-02-22 at 2 49 08 PM" src="https://github.com/snipe/snipe-it/assets/197404/a251f120-3565-45d0-815a-166e3ea70be2">
<img width="1127" alt="Screenshot 2024-02-22 at 2 49 20 PM" src="https://github.com/snipe/snipe-it/assets/197404/4d5b2ce5-66cb-4301-8078-93ff8d1b63c7">
<img width="1121" alt="Screenshot 2024-02-22 at 2 49 33 PM" src="https://github.com/snipe/snipe-it/assets/197404/47644c48-d026-462d-a53c-f96e03342956">
<img width="1116" alt="Screenshot 2024-02-22 at 2 49 44 PM" src="https://github.com/snipe/snipe-it/assets/197404/6e056d4b-36d7-4842-9cac-5cf5c435c1eb">
