### PR TITLE
Check for valid supplier in license view

### DIFF
--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -182,9 +182,13 @@
                       </strong>
                     </div>
                     <div class="col-md-9">
-                      <a href="{{ route('suppliers.show', $license->supplier_id) }}">
-                        {{ $license->supplier->name }}
-                      </a>
+                      @if ($license->supplier)
+                        <a href="{{ route('suppliers.show', $license->supplier_id) }}">
+                          {{ $license->supplier->name }}
+                        </a>
+                      @else
+                      {{ trans('general.deleted') }}
+                      @endif
                     </div>
                   </div>
                 @endif


### PR DESCRIPTION
Checks for valid supplier before trying to display it in license view. (This generally shouldn't happen unless people have manually edited the database.)