### PR TITLE
Dynamically show models/assets on requestable page

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -111,6 +111,7 @@ class AssetsController extends Controller
             'requests_counter',
             'byod',
             'asset_eol_date',
+            'requestable',
         ];
 
         $filter = [];

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -37,6 +37,7 @@ class AssetsTransformer
                 'name'=> e($asset->model->name),
             ] : null,
             'byod' => ($asset->byod ? true : false),
+            'requestable' => ($asset->requestable ? true : false),
 
             'model_number' => (($asset->model) && ($asset->model->model_number)) ? e($asset->model->model_number) : null,
             'eol' => (($asset->asset_eol_date != '') && ($asset->purchase_date != '')) ? Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date).' months' : null,

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -196,6 +196,14 @@ class AssetPresenter extends Presenter
                 'title' => trans('admin/hardware/form.warranty_expires'),
                 'formatter' => 'dateDisplayFormatter',
             ], [
+                'field' => 'requestable',
+                'searchable' => false,
+                'sortable' => true,
+                'visible' => false,
+                'title' => trans('admin/hardware/general.requestable'),
+                'formatter' => 'trueFalseFormatter',
+
+            ], [
                 'field' => 'notes',
                 'searchable' => true,
                 'sortable' => true,

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -516,5 +516,6 @@ return [
                 'partial'   =>  'Deleted :success_count :object_type, but :error_count :object_type could not be deleted',
              ],
     ],
+    'no_requestable' => 'There are no requestable assets or asset models.',
 
 ];

--- a/resources/views/account/requestable-assets.blade.php
+++ b/resources/views/account/requestable-assets.blade.php
@@ -16,20 +16,37 @@
 <div class="row">
     <div class="col-md-12">
 
+
+        @if (($assets->count() < 1) && ($models->count() < 1))
+
+            <div class="col-md-12">
+                <div class="alert alert-info fade in">
+                    <i class="fas fa-info-circle faa-pulse animated"></i>
+                    <strong>{{ trans('general.notification_info') }}: </strong>
+                    {{ trans('general.no_requestable') }}
+                </div>
+            </div>
+
+        @else
         <div class="nav-tabs-custom">
             <ul class="nav nav-tabs">
+                @if ($assets->count() > 0)
                 <li class="active">
                     <a href="#assets" data-toggle="tab" title="{{ trans('general.assets') }}">{{ trans('general.assets') }}
                         <badge class="badge badge-secondary"> {{ $assets->count()}}</badge>
                     </a>               
                 </li>
+                @endif
+                @if ($models->count() > 0)
                 <li>
                     <a href="#models" data-toggle="tab" title="{{ trans('general.asset_models') }}">{{ trans('general.asset_models') }}
                         <badge class="badge badge-secondary"> {{ $models->count()}}</badge>
                     </a>                   
                 </li>
+                @endif
             </ul>
             <div class="tab-content">
+                @if ($assets->count() > 0)
                 <div class="tab-pane fade in active" id="assets">
                     <div class="row">
                         <div class="col-md-12">
@@ -76,15 +93,15 @@
                                         </thead>
                                     </table>
                                 </div>
+                            </div>
+                        </div>
                     </div>
-                </div>
-            </div>
+                @endif
 
-                <div class="tab-pane fade" id="models">
+                @if ($models->count() > 0)
+                <div class="tab-pane fade in {{ ($assets->count() > 0) ? 'active' : '' }}" id="models">
                     <div class="row">
                         <div class="col-md-12">
-
-                            @if ($models->count() > 0)
                             <h2>{{ trans('general.requestable_models') }}</h2>
                                 <table
                                         name="requested-assets"
@@ -145,18 +162,15 @@
                                 </tbody>
                             </table>
 
-                            @else
-                                <div class="alert alert-info alert-block">
-                                    <i class="fas fa-info-circle"></i>
-                                    {{ trans('general.no_results') }}
-                                </div>
-                            @endif
                         </div>
                     </div>
                 </div>
+                @endif
 
             </div> <!-- .tab-content-->
         </div> <!-- .nav-tabs-custom -->
+
+        @endif
     </div> <!-- .col-md-12> -->
 </div> <!-- .row -->
 @stop

--- a/resources/views/account/requestable-assets.blade.php
+++ b/resources/views/account/requestable-assets.blade.php
@@ -99,7 +99,7 @@
                 @endif
 
                 @if ($models->count() > 0)
-                <div class="tab-pane fade in {{ ($assets->count() > 0) ? 'active' : '' }}" id="models">
+                <div class="tab-pane fade in {{ ($assets->count() == 0) ? 'active' : '' }}" id="models">
                     <div class="row">
                         <div class="col-md-12">
                             <h2>{{ trans('general.requestable_models') }}</h2>

--- a/resources/views/account/requestable-assets.blade.php
+++ b/resources/views/account/requestable-assets.blade.php
@@ -102,7 +102,6 @@
                 <div class="tab-pane fade in {{ ($assets->count() == 0) ? 'active' : '' }}" id="models">
                     <div class="row">
                         <div class="col-md-12">
-                            <h2>{{ trans('general.requestable_models') }}</h2>
                                 <table
                                         name="requested-assets"
                                         data-toolbar="#toolbar"


### PR DESCRIPTION
This PR dynamically shows/hides assets and models available for requesting based on the count. 

<img width="1676" alt="Screenshot 2024-02-28 at 3 00 19 PM" src="https://github.com/snipe/snipe-it/assets/197404/b48c6425-243d-4bd1-acf0-c93d93785de3">
<img width="1676" alt="Screenshot 2024-02-28 at 3 01 12 PM" src="https://github.com/snipe/snipe-it/assets/197404/f5fc6108-84df-44a8-86f4-19ad82327535">
<img width="1676" alt="Screenshot 2024-02-28 at 3 01 33 PM" src="https://github.com/snipe/snipe-it/assets/197404/21e5ee8f-a555-47ab-ad1a-f7faff839e8e">