### PR TITLE
Set CSP headers to true by default

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -199,7 +199,7 @@ return [
     |
     */
 
-    'enable_csp' => env('ENABLE_CSP', false),
+    'enable_csp' => env('ENABLE_CSP', true),
 
 
     /*


### PR DESCRIPTION
We had been defaulting this to false because it was causing issues with vue, but we don't use vue anymore. While we mitigate the need for a CSP elsewhere in the application code, this should make it more compliant with common security scans.