### PR TITLE
Removed unsafe-inline and unsafe-eval

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -83,8 +83,8 @@ class SecurityHeaders
 
         if ((config('app.debug') != 'true') && (config('app.enable_csp') == 'true')) {
             $csp_policy[] = "default-src 'self'";
-            $csp_policy[] = "style-src 'self' 'unsafe-inline'";
-            $csp_policy[] = "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
+            $csp_policy[] = "style-src 'self'";
+            $csp_policy[] = "script-src 'self'";
             $csp_policy[] = "connect-src 'self'";
             $csp_policy[] = "object-src 'none'";
             $csp_policy[] = "font-src 'self' data:";


### PR DESCRIPTION
This removes the `unsafe-inline` and `unsafe-eval` CSP options. I think we had to use those because of vue, but since we don't use vue anymore, we can tighten those down a bit.