### PR TITLE
Fixes inconsistencies with generating labels

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -38,7 +38,7 @@ class Label implements View
         $settings = $this->data->get('settings');
         $assets = $this->data->get('assets');
         $offset = $this->data->get('offset');
-        $template = $this->data->get('template');
+        $template = LabelModel::find($settings->label2_template);
 
         // If disabled, pass to legacy view
         if ((!$settings->label2_enable) && (!$template)) {
@@ -47,13 +47,6 @@ class Label implements View
                 ->with('settings', $settings)
                 ->with('bulkedit', $this->data->get('bulkedit'))
                 ->with('count', $this->data->get('count'));
-        }
-
-        // If a specific template was set, use it, otherwise fall back to default
-        if (empty($template)) {
-            $template = LabelModel::find($settings->label2_template);
-        } elseif (is_string($template)) {
-            $template = LabelModel::find($template);
         }
 
         $template->validate();


### PR DESCRIPTION
# Description

When generating a label through the bulk-edit options. the template used was not being passed leading to a bad preview and a bad label. by setting the template from the settings rather that else/if'ing this eliminates that issue.

Fixes #FD-40806


## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
