### PR TITLE
Fixes CVE-2024-27354 and CVE-2024-27355 in phpseclib/phpseclib

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7137,16 +7137,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.34",
+            "version": "3.0.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "56c79f16a6ae17e42089c06a2144467acc35348a"
+                "reference": "cfa2013d0f68c062055180dd4328cc8b9d1f30b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/56c79f16a6ae17e42089c06a2144467acc35348a",
-                "reference": "56c79f16a6ae17e42089c06a2144467acc35348a",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/cfa2013d0f68c062055180dd4328cc8b9d1f30b8",
+                "reference": "cfa2013d0f68c062055180dd4328cc8b9d1f30b8",
                 "shasum": ""
             },
             "require": {
@@ -7227,7 +7227,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.34"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.37"
             },
             "funding": [
                 {
@@ -7243,7 +7243,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-27T11:13:31+00:00"
+            "time": "2024-03-03T02:14:58+00:00"
         },
         {
             "name": "phpspec/prophecy",


### PR DESCRIPTION
# Description
```
❯ ddev composer audit
Found 2 security vulnerability advisories affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | phpseclib/phpseclib                                                              |
| Severity          | high                                                                             |
| CVE               | CVE-2024-27354                                                                   |
| Title             | phpseclib a large prime can cause a denial of service                            |
| URL               | https://github.com/advisories/GHSA-hg35-mp25-qf6h                                |
| Affected versions | >=3.0.0,<3.0.36|>=2.0.0,<2.0.47|>=1.0.0,<1.0.23                                  |
| Reported at       | 2024-03-02T00:31:33+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | phpseclib/phpseclib                                                              |
| Severity          | high                                                                             |
| CVE               | CVE-2024-27355                                                                   |
| Title             | phpseclib does not properly limit the ASN1 OID length                            |
| URL               | https://github.com/advisories/GHSA-jr22-8qgm-4q87                                |
| Affected versions | >=2.0.0,<2.0.47|>=3.0.0,<3.0.36|<1.0.23                                          |
| Reported at       | 2024-03-02T00:31:33+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```ddev composer audit```

**Test Configuration**:
* PHP version: 7.4
* MySQL version: 8.0
* Webserver version: Apache
* OS version: Ubuntu probably


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
