### PR TITLE
Adds User email check when sending Asset acceptance reminder

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1178,6 +1178,10 @@ class ReportsController extends Controller
             }
         }
 
+        if ($assetItem->assignedTo->email == ''){
+            return redirect()->route('reports/unaccepted_assets')->with('error', trans('general.no_email'));
+        }
+
         return redirect()->route('reports/unaccepted_assets')->with('success', trans('admin/reports/general.reminder_sent'));
     }
 

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -201,6 +201,7 @@ return [
     'new_password'          => 'New Password',
     'next'					=> 'Next',
     'next_audit_date'		=> 'Next Audit Date',
+    'no_email'              => 'No email address associated with this user',
     'last_audit'		    => 'Last Audit',
     'new'					=> 'new!',
     'no_depreciation'		=> 'No Depreciation',


### PR DESCRIPTION
if you sent an asset acceptance reminder to a user and they didnt have an email it would default to sending the default notification you had setup under integrations. 

<img width="1114" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/e1855fcd-da9a-4c86-ba73-74fb68833858">


# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
