### PR TITLE
Fixed Labels: bulk actions are handled before sorting

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -93,6 +93,54 @@ class BulkAssetsController extends Controller
 
         $assets = Asset::with('assignedTo', 'location', 'model')->whereIn('assets.id', $asset_ids);
 
+        $assets = $assets->get();
+
+        $models = $assets->unique('model_id');
+        $modelNames = [];
+        foreach($models as $model) {
+            $modelNames[] = $model->model->name;
+        }
+
+        if ($request->filled('bulk_actions')) {
+
+
+            switch ($request->input('bulk_actions')) {
+                case 'labels':
+                    $this->authorize('view', Asset::class);
+
+                    return (new Label)
+                        ->with('assets', $assets)
+                        ->with('settings', Setting::getSettings())
+                        ->with('bulkedit', true)
+                        ->with('count', 0);
+
+                case 'delete':
+                    $this->authorize('delete', Asset::class);
+                    $assets->each(function ($assets) {
+                        $this->authorize('delete', $assets);
+                    });
+
+                    return view('hardware/bulk-delete')->with('assets', $assets);
+
+                case 'restore':
+                    $this->authorize('update', Asset::class);
+                    $assets = Asset::withTrashed()->find($asset_ids);
+                    $assets->each(function ($asset) {
+                        $this->authorize('delete', $asset);
+                    });
+                    return view('hardware/bulk-restore')->with('assets', $assets);
+
+                case 'edit':
+                    $this->authorize('update', Asset::class);
+
+                    return view('hardware/bulk')
+                        ->with('assets', $asset_ids)
+                        ->with('statuslabel_list', Helper::statusLabelList())
+                        ->with('models', $models->pluck(['model']))
+                        ->with('modelNames', $modelNames);
+            }
+        }
+
         switch ($sort_override) {
             case 'model':
                 $assets->OrderModels($order);
@@ -126,54 +174,6 @@ class BulkAssetsController extends Controller
             default:
                 $assets->orderBy($column_sort, $order);
                 break;
-        }
-
-        $assets = $assets->get();
-
-        $models = $assets->unique('model_id');
-        $modelNames = [];
-        foreach($models as $model) {
-            $modelNames[] = $model->model->name;
-        }
-
-        if ($request->filled('bulk_actions')) {
-
-
-            switch ($request->input('bulk_actions')) {
-                case 'labels':
-                    $this->authorize('view', Asset::class);
-
-                    return (new Label)
-                        ->with('assets', $assets)
-                        ->with('settings', Setting::getSettings())
-                        ->with('bulkedit', true)
-                        ->with('count', 0);
-
-                case 'delete':
-                    $this->authorize('delete', Asset::class);
-                    $assets->each(function ($assets) {
-                        $this->authorize('delete', $assets);
-                    });
-
-                    return view('hardware/bulk-delete')->with('assets', $assets);
-                   
-                case 'restore':
-                    $this->authorize('update', Asset::class);
-                    $assets = Asset::withTrashed()->find($asset_ids);
-                    $assets->each(function ($asset) {
-                        $this->authorize('delete', $asset);
-                    });
-                    return view('hardware/bulk-restore')->with('assets', $assets);
-
-                case 'edit':
-                    $this->authorize('update', Asset::class);
-
-                    return view('hardware/bulk')
-                        ->with('assets', $asset_ids)
-                        ->with('statuslabel_list', Helper::statusLabelList())
-                        ->with('models', $models->pluck(['model']))
-                        ->with('modelNames', $modelNames);
-            }
         }
 
         return redirect()->back()->with('error', 'No action selected');


### PR DESCRIPTION
# Description

This moves the bulk actions to the top of the stack and the sorting overrides to the bottom. Data was getting tangled when sorted first and then sent to the label engine. the scopeFooOrder would replace the the asset->ids with the Foo->ids instead potentially. So, if your last sort (that worked) was locations, asset.name would be location.name, asset.id for qrcodes would actually be the location.id causing bad links. None of that sorting manipulation is required for labels.

It was rough coming to this conclusion. But here we are lol.

Fixes #SC-24941 FD-40486

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
