### PR TITLE
Fix #13515: Cannot restore backup

### DIFF
--- a/config/version.php
+++ b/config/version.php
@@ -6,5 +6,5 @@ return array (
   'prerelease_version' => '',
   'hash_version' => 'g9a5c1b812',
   'full_hash' => 'v6.3.2-160-g9a5c1b812',
-  'branch' => 'develop',
+  'branch' => 'master',
 );

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -17,16 +17,23 @@ else
 fi
 
 # create data directories
+# Note: Keep in sync with expected directories by the app
+# https://github.com/snipe/snipe-it/blob/master/app/Console/Commands/RestoreFromBackup.php#L232
 for dir in \
   'data/private_uploads' \
   'data/private_uploads/assets' \
+  'data/private_uploads/accessories' \
   'data/private_uploads/audits' \
+  'data/private_uploads/components' \
+  'data/private_uploads/consumables' \
+  'data/private_uploads/eula-pdfs' \
   'data/private_uploads/imports' \
   'data/private_uploads/assetmodels' \
   'data/private_uploads/users' \
   'data/private_uploads/licenses' \
   'data/private_uploads/signatures' \
   'data/uploads/accessories' \
+  'data/uploads/assets' \
   'data/uploads/avatars' \
   'data/uploads/barcodes' \
   'data/uploads/categories' \


### PR DESCRIPTION


# Description

The restore process fails when using Docker image `snipe/snipe-it:v6.2.3`.

From `snipeit-logs/laravel.log`
```
[2024-03-05 23:30:41] production.ERROR: fopen(public/uploads/assets/assets): Failed to open stream: No such file or directory {"userId":1,"exception":"[object] (ErrorException(
code: 0): fopen(public/uploads/assets/assets): Failed to open stream: No such file or directory at /var/www/html/app/Console/Commands/RestoreFromBackup.php:304)
[stacktrace]
#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 /var/www/html/app/Console/Commands/RestoreFromBackup.php(304): fopen()
#2 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(36): App\\Console\\Commands\\RestoreFromBackup->handle()
#3 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/Util.php(40): Illuminate\\Container\\BoundMethod::Illuminate\\Container\\{closure}()
#4 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(93): Illuminate\\Container\\Util::unwrapIfClosure()
#5 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(37): Illuminate\\Container\\BoundMethod::callBoundMethod()
#6 /var/www/html/vendor/laravel/framework/src/Illuminate/Container/Container.php(653): Illuminate\\Container\\BoundMethod::call()
#7 /var/www/html/vendor/laravel/framework/src/Illuminate/Console/Command.php(136): Illuminate\\Container\\Container->call()
#8 /var/www/html/vendor/symfony/console/Command/Command.php(298): Illuminate\\Console\\Command->execute()
#9 /var/www/html/vendor/laravel/framework/src/Illuminate/Console/Command.php(121): Symfony\\Component\\Console\\Command\\Command->run()
#10 /var/www/html/vendor/symfony/console/Application.php(1024): Illuminate\\Console\\Command->run()
#11 /var/www/html/vendor/symfony/console/Application.php(299): Symfony\\Component\\Console\\Application->doRunCommand()
#12 /var/www/html/vendor/symfony/console/Application.php(171): Symfony\\Component\\Console\\Application->doRun()
#13 /var/www/html/vendor/laravel/framework/src/Illuminate/Console/Application.php(94): Symfony\\Component\\Console\\Application->run()
#14 /var/www/html/vendor/laravel/framework/src/Illuminate/Console/Application.php(186): Illuminate\\Console\\Application->run()
#15 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(263): Illuminate\\Console\\Application->call()
#16 /var/www/html/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php(261): Illuminate\\Foundation\\Console\\Kernel->call()
.
..
...
#80 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(167): App\\Http\\Middleware\\NoSessionStore->handle()
#81 /var/www/html/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(103): Illuminate\\Pipeline\\Pipeline->Illuminate\\Pipeline\\{closure}()
#82 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(142): Illuminate\\Pipeline\\Pipeline->then()
#83 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(111): Illuminate\\Foundation\\Http\\Kernel->sendRequestThroughRouter()
#84 /var/www/html/public/index.php(52): Illuminate\\Foundation\\Http\\Kernel->handle()
#85 {main}
"}
```

I believe the reason is the [RestoreFromBackup.php](https://github.com/snipe/snipe-it/blob/master/app/Console/Commands/RestoreFromBackup.php#L232) expects a set of directories some of which are not being created by the [docker/startup.sh](https://github.com/snipe/snipe-it/blob/master/docker/startup.sh#L20) script. So when the `RestoreFromBackup.php` tried to copy files to the destination directories which does not exists, it throws an exception.

This change creates the directories expected by [RestoreFromBackup.php](https://github.com/snipe/snipe-it/blob/master/app/Console/Commands/RestoreFromBackup.php#L232).

**Note**: I am not sure why some of the directories exists in both `private_uploads` and `uploads` while others do not e.g. accessories, assets, components etc.

Fixes #13515 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Start a container using the docker image `snipe/snipe-it:v6.2.3`
```
docker run --rm -d \
    --name "snipe-it" \
    --publish=80:80 \
    --user="$(id -u):$(id -g)" \
    --volume ./snipeit-vol:/var/lib/snipeit \
    --volume ./snipeit-logs:/var/www/html/storage/logs \
    --env-file=my_snipeit_env \
    snipe/snipe-it:v6.2.3
```
Restore from a backup zip which will fail partially i.e. files are not restored correctly.

For manual fix, run below command in the `snipeit-vol` directory on the host and run restore again which should be successful.
```shell
mkdir -p uploads/assets private_uploads/accessories private_uploads/components private_uploads/consumables private_uploads/eula-pdfs
```

**Test Configuration**:
Docker image: `snipe/snipe-it:v6.2.3`

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
