### PR TITLE
Fixed 1dbarcodes to populate based on settings

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -105,8 +105,8 @@ class Label implements View
                     }
                 }
 
-                if ($template->getSupport1DBarcode()) {
-                    if ($settings->alt_barcode_enabled) {
+                if ($settings->alt_barcode_enabled) {
+                    if ($template->getSupport1DBarcode()) {
                         $barcode1DType = $settings->label2_1d_type;
                         $barcode1DType = ($barcode1DType == 'default') ?
                             (($settings->alt_barcode_enabled) ? $settings->alt_barcode : null) :

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -107,10 +107,7 @@ class Label implements View
 
                 if ($settings->alt_barcode_enabled) {
                     if ($template->getSupport1DBarcode()) {
-                        $barcode1DType = $settings->label2_1d_type;
-                        $barcode1DType = ($barcode1DType == 'default') ?
-                            (($settings->alt_barcode_enabled) ? $settings->alt_barcode : null) :
-                            $barcode1DType;
+                        $barcode1DType = $settings->alt_barcode;
                         if ($barcode1DType != 'none') {
                             $assetData->put('barcode1d', (object)[
                                 'type' => $barcode1DType,

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -106,15 +106,17 @@ class Label implements View
                 }
 
                 if ($template->getSupport1DBarcode()) {
-                    $barcode1DType = $settings->label2_1d_type;
-                    $barcode1DType = ($barcode1DType == 'default') ? 
-                        (($settings->alt_barcode_enabled) ? $settings->alt_barcode : null) :
-                        $barcode1DType;
-                    if ($barcode1DType != 'none') {
-                        $assetData->put('barcode1d', (object)[
-                            'type' => $barcode1DType,
-                            'content' => $asset->asset_tag,
-                        ]);
+                    if ($settings->alt_barcode_enabled) {
+                        $barcode1DType = $settings->label2_1d_type;
+                        $barcode1DType = ($barcode1DType == 'default') ?
+                            (($settings->alt_barcode_enabled) ? $settings->alt_barcode : null) :
+                            $barcode1DType;
+                        if ($barcode1DType != 'none') {
+                            $assetData->put('barcode1d', (object)[
+                                'type' => $barcode1DType,
+                                'content' => $asset->asset_tag,
+                            ]);
+                        }
                     }
                 }
 


### PR DESCRIPTION
# Description

This applies a check to see if `alt_barcodes` are enabled or not. and it populates the label accordingly.
Getting rid of this warning:
<img width="401" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/ab2f1bb9-b4a8-4619-9598-bde091ad022c">


Fixes #FD-40875

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
