### PR TITLE
Added console command to encrypt previously unencrypted fields

### DIFF
--- a/app/Console/Commands/ToggleCustomfieldEncryption.php
+++ b/app/Console/Commands/ToggleCustomfieldEncryption.php
@@ -22,7 +22,7 @@ class ToggleCustomfieldEncryption extends Command
      *
      * @var string
      */
-    protected $description = 'This command should be used to convert an unencypted custom field into a custom field and encrypt the associated data in the assets table for that column.';
+    protected $description = 'This command should be used to convert an unencrypted custom field into a custom field and encrypt the associated data in the assets table for that column.';
 
     /**
      * Create a new command instance.
@@ -44,7 +44,7 @@ class ToggleCustomfieldEncryption extends Command
         $fieldname = $this->argument('fieldname');
 
         if ($field = CustomField::where('db_column', $fieldname)->first()) {
-            
+
             // If the field is not encrypted, make it encrypted and encrypt the data in the assets table for the
             // corresponding field.
             if ($field->field_encrypted == 0) {

--- a/app/Console/Commands/ToggleCustomfieldEncryption.php
+++ b/app/Console/Commands/ToggleCustomfieldEncryption.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Asset;
+use App\Models\CustomField;
+use Illuminate\Console\Command;
+
+class ToggleCustomfieldEncryption extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:customfield-encryption
+                             {fieldname : the db_column_name of the field}';
+
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This command should be used to convert an unencypted custom field into a custom field and encrypt the associated data in the assets table for that column.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $fieldname = $this->argument('fieldname');
+
+        if ($field = CustomField::where('db_column', $fieldname)->first()) {
+            
+            // If the field is not encrypted, make it encrypted and encrypt the data in the assets table for the
+            // corresponding field.
+            if ($field->field_encrypted == 0) {
+                $assets = Asset::whereNotNull($field->db_column)->get();
+
+                foreach ($assets as $asset) {
+                    $asset->{$field->db_column} = encrypt($asset->{$field->db_column});
+                    $asset->save();
+                }
+
+                $field->field_encrypted = 1;
+                $field->save();
+
+            // This field is already encrypted. Do nothing.
+            } else {
+                $this->error('The custom field ' . $fieldname.' is already encrypted. No action was taken.');
+            }
+
+        } else {
+            $this->error('No matching results for unencrypted custom fields with db_column name: ' . $fieldname.'. Please check the fieldname.');
+        }
+
+    }
+}

--- a/app/Console/Commands/ToggleCustomfieldEncryption.php
+++ b/app/Console/Commands/ToggleCustomfieldEncryption.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Models\Asset;
 use App\Models\CustomField;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 
 class ToggleCustomfieldEncryption extends Command
 {
@@ -47,22 +48,26 @@ class ToggleCustomfieldEncryption extends Command
 
             // If the field is not encrypted, make it encrypted and encrypt the data in the assets table for the
             // corresponding field.
-            if ($field->field_encrypted == 0) {
-                $assets = Asset::whereNotNull($field->db_column)->get();
+            DB::transaction(function () use ($field) {
 
-                foreach ($assets as $asset) {
-                    $asset->{$field->db_column} = encrypt($asset->{$field->db_column});
-                    $asset->save();
+                if ($field->field_encrypted == 0) {
+                    $assets = Asset::whereNotNull($field->db_column)->get();
+
+                    foreach ($assets as $asset) {
+                        $asset->{$field->db_column} = encrypt($asset->{$field->db_column});
+                        $asset->save();
+                    }
+
+                    $field->field_encrypted = 1;
+                    $field->save();
+
+                // This field is already encrypted. Do nothing.
+                } else {
+                    $this->error('The custom field ' . $field->db_column.' is already encrypted. No action was taken.');
                 }
+            });
 
-                $field->field_encrypted = 1;
-                $field->save();
-
-            // This field is already encrypted. Do nothing.
-            } else {
-                $this->error('The custom field ' . $fieldname.' is already encrypted. No action was taken.');
-            }
-
+        // No matching column name found
         } else {
             $this->error('No matching results for unencrypted custom fields with db_column name: ' . $fieldname.'. Please check the fieldname.');
         }


### PR DESCRIPTION
This is a request from a customer where they have a lot of data in a custom field that they'd like to convert into an encrypted custom field. This is right now just a one-off console command, but I think we can add options to it down the line, and also possibly have it run the reverse way and convert an encrypted field into an unencrypted field.