### PR TITLE
Fixed attempting to run bulk actions on an empty asset collection

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -14,6 +14,7 @@ use App\View\Label;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Session;
 use App\Http\Requests\AssetCheckoutRequest;
 use App\Models\CustomField;
@@ -94,6 +95,11 @@ class BulkAssetsController extends Controller
         $assets = Asset::with('assignedTo', 'location', 'model')->whereIn('assets.id', $asset_ids);
 
         $assets = $assets->get();
+
+        if ($assets->isEmpty()) {
+            Log::debug('No assets were found for the provided IDs', ['ids' => $asset_ids]);
+            return redirect()->back()->with('error', trans('admin/hardware/message.update.assets_do_not_exist_or_are_invalid'));
+        }
 
         $models = $assets->unique('model_id');
         $modelNames = [];

--- a/resources/lang/en-US/admin/hardware/message.php
+++ b/resources/lang/en-US/admin/hardware/message.php
@@ -19,6 +19,7 @@ return [
         'success' 			=> 'Asset updated successfully.',
         'nothing_updated'	=>  'No fields were selected, so nothing was updated.',
         'no_assets_selected'  =>  'No assets were selected, so nothing was updated.',
+        'assets_do_not_exist_or_are_invalid' => 'Selected assets cannot be updated.',
     ],
 
     'restore' => [


### PR DESCRIPTION
# Description

This PR fixes a very sporadic issue we were seeing in the demo when generating labels. We would run the query to get assets which would, seemingly, return an empty collection and cause problems in code down the line. I think it was most likely caused by the demo being reset.

I added a check to make sure assets were returned and bail out in the same way we do in other parts of the controller. Let me know if the error message should be improved.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)