### PR TITLE
Removed unneeded validation message

### DIFF
--- a/app/Http/Livewire/SlackSettingsForm.php
+++ b/app/Http/Livewire/SlackSettingsForm.php
@@ -31,9 +31,7 @@ class SlackSettingsForm extends Component
         'webhook_channel'                       => 'required_with:webhook_endpoint|starts_with:#|nullable',
         'webhook_botname'                       => 'string|nullable',
     ];
-    public $messages = [
-        'webhook_endpoint.starts_with'          => 'your webhook endpoint should begin with http://, https:// or other protocol.',
-    ];
+    
 
     public function mount() {
         $this->webhook_text= [


### PR DESCRIPTION
This just removes the custom `starts_with` validation message. It's not needed since the generic `validation.starts_with` will cover that use-case (same as the `starts_with` for the channel name, etc.)

https://github.com/snipe/snipe-it/blob/ea2d54b0f78ab37d91c9d177582790aeee40d7ee/resources/lang/en-US/validation.php#L69

### Before (untranslated):

<img width="1094" alt="Screenshot 2024-03-07 at 11 45 35 PM" src="https://github.com/snipe/snipe-it/assets/197404/ed7b63a9-773b-44b7-9898-b97f52b35627">


### After (using our standard `starts_with` validation message):

<img width="1087" alt="Screenshot 2024-03-07 at 11 52 33 PM" src="https://github.com/snipe/snipe-it/assets/197404/42637eae-b04a-4b7d-ae97-5a2b536741de">
