### PR TITLE
Guard against checking require acceptance on non-existent relationship in accessory model

### DIFF
--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -305,7 +305,7 @@ class Accessory extends SnipeModel
      */
     public function requireAcceptance()
     {
-        return $this->category->require_acceptance;
+        return $this->category->require_acceptance ?? false;
     }
 
     /**


### PR DESCRIPTION
# Description

This PR fixes the super rare case where an accessory does not have a category (bad data) and an exception is thrown when trying to check if the accessory requires acceptance.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)