### PR TITLE
Fixed uninitialized string offset error in labels in new label engine when field label was blank

### DIFF
--- a/app/Models/Labels/DefaultLabel.php
+++ b/app/Models/Labels/DefaultLabel.php
@@ -166,17 +166,9 @@ class DefaultLabel extends RectangleSheet
 
             foreach ($record->get('fields') as $field) {
 
-                $field_label = $field['label'];
-
-                // If the label field in the visible fields on the asset label is NOT blank,
-                // set the label to that value.
-                if ($field_label!='') {
-                    $field_label = $field_label.': ';
-                }
-
                 // Actually write the selected fields and their matching values
                 static::writeText(
-                    $pdf, $field_label . $field['value'],
+                    $pdf, (($field['label']) ? $field['label'].' ' : '') . $field['value'],
                     $textX1, $textY,
                     'freesans', '', $this->textSize, 'L',
                     $textW, $this->textSize,

--- a/app/Models/Labels/DefaultLabel.php
+++ b/app/Models/Labels/DefaultLabel.php
@@ -163,17 +163,21 @@ class DefaultLabel extends RectangleSheet
         // Fields
         $fieldsDone = 0;
         if ($fieldsDone < $this->getSupportFields()) {
-//            dd($record->get('fields'));
+
             foreach ($record->get('fields') as $field) {
-                static::writeText(
-                    $pdf, $field['label'][0]. ': ' . $field['value'],
-                    $textX1, $textY,
-                    'freesans', '', $this->textSize, 'L',
-                    $textW, $this->textSize,
-                    true, 0
-                );
-                $textY += $this->textSize + self::TEXT_MARGIN;
-                $fieldsDone++;
+                
+                if ((array_key_exists('label', $field)) && (is_array($field['label']))) {
+                    static::writeText(
+                        $pdf, $field['label'][0]. ': ' . $field['value'],
+                        $textX1, $textY,
+                        'freesans', '', $this->textSize, 'L',
+                        $textW, $this->textSize,
+                        true, 0
+                    );
+                    $textY += $this->textSize + self::TEXT_MARGIN;
+                    $fieldsDone++;
+                }
+
             }
         }
     }

--- a/app/Models/Labels/DefaultLabel.php
+++ b/app/Models/Labels/DefaultLabel.php
@@ -160,24 +160,31 @@ class DefaultLabel extends RectangleSheet
             $textY += $this->textSize + self::TEXT_MARGIN;
         }
 
-        // Fields
+        // Render the selected fields with their labels
         $fieldsDone = 0;
         if ($fieldsDone < $this->getSupportFields()) {
 
             foreach ($record->get('fields') as $field) {
-                
-                if ((array_key_exists('label', $field)) && (is_array($field['label']))) {
-                    static::writeText(
-                        $pdf, $field['label'][0]. ': ' . $field['value'],
-                        $textX1, $textY,
-                        'freesans', '', $this->textSize, 'L',
-                        $textW, $this->textSize,
-                        true, 0
-                    );
-                    $textY += $this->textSize + self::TEXT_MARGIN;
-                    $fieldsDone++;
+
+                $field_label = $field['label'];
+
+                // If the label field in the visible fields on the asset label is NOT blank,
+                // set the label to that value.
+                if ($field_label!='') {
+                    $field_label = $field_label.': ';
                 }
 
+                // Actually write the selected fields and their matching values
+                static::writeText(
+                    $pdf, $field_label . $field['value'],
+                    $textX1, $textY,
+                    'freesans', '', $this->textSize, 'L',
+                    $textW, $this->textSize,
+                    true, 0
+                );
+
+                $textY += $this->textSize + self::TEXT_MARGIN;
+                $fieldsDone++;
             }
         }
     }


### PR DESCRIPTION
<del>I haven't been able to see this happening in the wild, but I do see it on the demos. Should hopefully fix RB-3750</del>

Okay, this took a bit to track down, with the added bonus of being really hard to explain. For the purposes of this, "Asset Label" is the full asset label that gets printed out. "Field Label" refers to the label on the fields the user has selected that should appear on the Asset Label.

### tldr;

- You can now have blank Field Labels on your Asset Labels, so you only see the value of the field. It will no longer error out.
- We no longer shorten your Field Labels to the first character, but instead let the user determine what those labels should use.

### Potentially breaking change

Because we no longer shorten the label for you, and have removed the automatic colon, users may need to update their label settings to use just the first letter and the colon manually if that's what you want displayed on the Asset Labels.

### Full Explanation

This error (`ErrorException: Uninitialized string offset 0 in /home/serverpilot/apps/demo.snipeitapp.com/snipe-it/app/Models/Labels/DefaultLabel.php:169`) was occurring if a user added fields in the Field Definitions but the Field Label for those fields was left blank.

The quick workaround for this currently is below:

<img width="542" alt="Update_Label_Settings____Noon_com_-_IT_Asset_Management_System" src="https://github.com/snipe/snipe-it/assets/197404/08798119-809f-4334-95bd-983623a2e89e">

However that's dumb and people shouldn't have to do this. 

That particular error was triggering because in the code, we were using `$field['label'][0]` (for some reason) which would take *just* the first character of the Field Label - I presume to save space on small labels. I don't think we should be making that decision for people, however. If they want the first letter only, they can enter that as the Field Label.

When presented with a string with an array-type addition, for example `$string[0]` where `$string` is definitely a string and not an array, that array-treatment will pick the 0th character in the string. Likewise, `$string[1]` would pick the second character from the string (because the string array is 0-based array), and so on.

The error was being triggered because you can't pick the first character from a blank string. 

This *may* mean that folks will need to go back into their label settings and change something like "Company Name" to "C:" if that's what they want on their labels, however this is far more correct, IMHO, and it's an easy enough setting to change.

Fixed RB-17914 and RB-17913