### PR TITLE
Hide/Show ecnrypted values when click on the lock icon

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -410,12 +410,13 @@
                                                 </div>
                                                 <div class="col-md-6{{ (($field->format=='URL') && ($asset->{$field->db_column_name()}!='')) ? ' ellipsis': '' }}">
                                                     @if (($field->field_encrypted=='1') && ($asset->{$field->db_column_name()}!=''))
-                                                        <i class="fas fa-lock" data-tooltip="true" data-placement="top" title="{{ trans('admin/custom_fields/general.value_encrypted') }}"></i>
+                                                        <i class="fas fa-lock" data-tooltip="true" data-placement="top" title="{{ trans('admin/custom_fields/general.value_encrypted') }}" onclick="showHideEncValue(this)" id="text-{{ $field->id }}"></i>
                                                     @endif
 
                                                     @if ($field->isFieldDecryptable($asset->{$field->db_column_name()} ))
                                                         @can('assets.view.encrypted_custom_fields')
-							    <span class="js-copy-{{ $field->id }}">
+                                                            <span id="text-{{ $field->id }}-to-hide">********</span>
+                                                            <span class="js-copy-{{ $field->id }}" id="text-{{ $field->id }}-to-show" style="font-size: 0px;">
                                                             @if (($field->format=='URL') && ($asset->{$field->db_column_name()}!=''))
                                                                 <a href="{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}" target="_new">{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}</a>
                                                             @elseif (($field->format=='DATE') && ($asset->{$field->db_column_name()}!=''))
@@ -427,7 +428,7 @@
                                                             <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy-{{ $field->id }}" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
                                                                 <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
                                                             </i>
-							@else
+                                                        @else
                                                             {{ strtoupper(trans('admin/custom_fields/general.encrypted')) }}
                                                         @endcan
 

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -964,8 +964,7 @@
                 var clickedElement = $(e.trigger);
                 // Get the target element selector from data attribute
                 var targetSelector = clickedElement.data('data-clipboard-target');
-                // Find the target element
-                var targetEl = $(targetSelector);
+                // Show the alert that the content was copied
                 clickedElement.tooltip('hide').attr('data-original-title', '{{ trans('general.copied') }}').tooltip('show');
             });
 
@@ -978,6 +977,23 @@
                 ignore: 'input[type=hidden]'
             });
 
+
+            function showHideEncValue(e) {
+                // Use element id to find the text element to hide / show
+                var targetElement = e.id+"-to-show";
+                var hiddenElement = e.id+"-to-hide";
+                if($(e).hasClass('fa-lock')) {
+                    $(e).removeClass('fa-lock').addClass('fa-unlock');
+                    // Show the encrypted custom value and hide the element with asterisks
+                    document.getElementById(targetElement).style.fontSize = "100%";
+                    document.getElementById(hiddenElement).style.display = "none";
+                } else {
+                    $(e).removeClass('fa-unlock').addClass('fa-lock');
+                    // ClipboardJS can't copy display:none elements so use a trick to hide the value
+                    document.getElementById(targetElement).style.fontSize = "0px";
+                    document.getElementById(hiddenElement).style.display = "";
+                 }
+             }
 
             $(function () {
 


### PR DESCRIPTION
# Description

Encrypted values can have sensitive or private information that the user may not want to show while using the application for security reason. The change shows or hides the value when the user clicks on the lock icon. Even if the value is hidden, it is possible to copy it. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have tested in my on-premise installation:
- [X] clicked on icon many times, copied the value both if hidden or showed
- [X] tried with both Firefox and Chrome to avoid different behaviors with font-size set to 0 px

**Test Configuration**:
* PHP version: 8.0.30
* MySQL version: MariaDB 10.3.38
* Webserver version: Apache 2.4.58
* OS version: Ubuntu 20.04.6 LTS


# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
