### PR TITLE
Fixed checkout_date for licenses on print all assigned for users

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -337,7 +337,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function licenses()
     {
-        return $this->belongsToMany(\App\Models\License::class, 'license_seats', 'assigned_to', 'license_id')->withPivot('id', 'created_at');
+        return $this->belongsToMany(\App\Models\License::class, 'license_seats', 'assigned_to', 'license_id')->withPivot('id', 'created_at', 'updated_at');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -337,7 +337,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function licenses()
     {
-        return $this->belongsToMany(\App\Models\License::class, 'license_seats', 'assigned_to', 'license_id')->withPivot('id');
+        return $this->belongsToMany(\App\Models\License::class, 'license_seats', 'assigned_to', 'license_id')->withPivot('id', 'created_at');
     }
 
     /**

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -151,7 +151,7 @@
                             <i class="fa-lock" aria-hidden="true"></i> {{ str_repeat('x', 15) }}
                         @endcan
                     </td>
-                    <td>{{  $license->pivot->created_at }}</td>
+                    <td>{{  $license->pivot->updated_at }}</td>
                 </tr>
                 @php
                     $lcounter++


### PR DESCRIPTION
This fixes an issue where the updated_at date was not being included in the user->license relationship, so the checkout date was not being included in the "print all assigned". This acts a little different because of the (dumb) way we handle the license joins right now, where the join entry gets created, but it actually matters when it's updated, since the join record can exist unassigned. 