### PR TITLE
Added #14411: Add company to LDAP sync

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -10,6 +10,7 @@ use App\Models\Ldap;
 use App\Models\User;
 use App\Models\Location;
 use Log;
+use App\Models\Company;
 
 class LdapSync extends Command
 {
@@ -67,6 +68,7 @@ class LdapSync extends Command
         $ldap_result_manager = Setting::getSettings()->ldap_manager;
         $ldap_default_group = Setting::getSettings()->ldap_default_group;
         $search_base = Setting::getSettings()->ldap_base_dn;
+        $ldap_result_company = Setting::getSettings()->ldap_company;
 
         try {
             $ldapconn = Ldap::connectToLdap();
@@ -232,6 +234,7 @@ class LdapSync extends Command
                 $item['department'] = $results[$i][$ldap_result_dept][0] ?? '';
                 $item['manager'] = $results[$i][$ldap_result_manager][0] ?? '';
                 $item['location'] = $results[$i][$ldap_result_location][0] ?? '';
+                $item['company'] = $results[$i][$ldap_result_company][0] ?? '';
 
                 // ONLY if you are using the "ldap_location" option *AND* you have an actual result
                 if ($ldap_result_location && $item['location']) {
@@ -241,6 +244,10 @@ class LdapSync extends Command
                 }
                 $department = Department::firstOrCreate([
                     'name' => $item['department'],
+                ]);
+
+                $company = Company::firstOrCreate([
+                    'name' => $item['company'],
                 ]);
 
                 $user = User::where('username', $item['username'])->first();
@@ -285,6 +292,9 @@ class LdapSync extends Command
             }
             if($ldap_result_location != null){
                 $user->location_id = $location ? $location->id : null;
+            }
+            if($ldap_result_company != null){
+                $user->company_id = $company->id ;
             }
 
             if($ldap_result_manager != null){

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -956,6 +956,7 @@ class SettingsController extends Controller
             $setting->ldap_dept = $request->input('ldap_dept');
             $setting->ldap_client_tls_cert   = $request->input('ldap_client_tls_cert');
             $setting->ldap_client_tls_key    = $request->input('ldap_client_tls_key');
+            $setting->ldap_company = $request->input('ldap_company');
 
 
         }

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -216,6 +216,7 @@ class Ldap extends Model
         $ldap_result_location = Setting::getSettings()->ldap_location;
         $ldap_result_dept = Setting::getSettings()->ldap_dept;
         $ldap_result_manager = Setting::getSettings()->ldap_manager;
+	$ldap_result_company = Setting::getSettings()->ldap_company;
         // Get LDAP user data
         $item = [];
         $item['username'] = $ldapattributes[$ldap_result_username][0] ?? '';
@@ -229,6 +230,7 @@ class Ldap extends Model
         $item['department'] = $ldapattributes[$ldap_result_dept][0] ?? '';
         $item['manager'] = $ldapattributes[$ldap_result_manager][0] ?? '';
         $item['location'] = $ldapattributes[$ldap_result_location][0] ?? '';
+        $item['company'] = $ldapattributes[$ldap_result_company][0] ?? '';
 
         return $item;
     }

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -357,6 +357,7 @@ class Setting extends Model
             'ldap_manager',
             'ldap_country',
             'ldap_location',
+            'ldap_company',
             ])->first()->getAttributes();
 
         return collect($ldapSettings);

--- a/database/migrations/2024_02_22_143018_ldap_sync_company.php
+++ b/database/migrations/2024_02_22_143018_ldap_sync_company.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class LdapSyncCompany extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function ($table) {
+            $table->string('ldap_company')->nullable()->default(null);
+	});
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('ldap_company');
+	});
+    }
+}

--- a/resources/lang/de-DE/admin/settings/general.php
+++ b/resources/lang/de-DE/admin/settings/general.php
@@ -363,5 +363,6 @@ return [
     'database_driver' => 'Datenbanktreiber',
     'bs_table_storage' => 'Tabellen Speicher',
     'timezone' => 'Zeitzone',
+    'ldap_company' => 'LDAP Firma',
 
 ];

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -363,5 +363,6 @@ return [
     'database_driver' => 'Database Driver',
     'bs_table_storage' => 'Table Storage',
     'timezone' => 'Timezone',
+    'ldap_company' => 'LDAP Company',
 
 ];

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -500,6 +500,7 @@
                                 @endif
                             </div>
                         </div>
+                        
                         <!-- LDAP Location -->
                         <div class="form-group {{ $errors->has('ldap_location') ? 'error' : '' }}">
                             <div class="col-md-3">
@@ -509,6 +510,20 @@
                                 {{ Form::text('ldap_location', Request::old('ldap_location', $setting->ldap_location), ['class' => 'form-control','placeholder' => trans('general.example') .'physicaldeliveryofficename', $setting->demoMode]) }}
                                 <p class="help-block">{!! trans('admin/settings/general.ldap_location_help') !!}</p>
                                 {!! $errors->first('ldap_location', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                @if (config('app.lock_passwords')===true)
+                                    <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
+                                @endif
+                            </div>
+                        </div>
+                        
+                        <!-- LDAP Company -->
+                        <div class="form-group {{ $errors->has('ldap_company') ? 'error' : '' }}">
+                            <div class="col-md-3">
+                                {{ Form::label('ldap_company', trans('admin/settings/general.ldap_company')) }}
+                            </div>
+                            <div class="col-md-8">
+                                {{ Form::text('ldap_company', Request::old('ldap_company', $setting->ldap_company), ['class' => 'form-control','placeholder' => trans('general.example') .'company', $setting->demoMode]) }}
+                                {!! $errors->first('ldap_company', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
                                 @endif


### PR DESCRIPTION
# Description

Users must be assigned to their company to see the correct assets when using full multiple-company support. This pull request adds the option to sync the company via LDAP.

Fixes #14411

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Sync tested via Web Interface
- [x] Sync tested via CLI

**Test Configuration**:
* PHP version: 8.2.7
* MySQL version: Ver 15.1 Distrib 10.11.6-MariaDB
* Webserver version: Apache/2.4.57
* OS version: Debian GNU/Linux 12 (bookworm) Version 12.5


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
