### PR TITLE
Fixed z-index of date-picker

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -889,5 +889,5 @@ input[type="radio"]:checked::before {
   margin-left: .25em;
 }
 .datepicker.dropdown-menu {
-  z-index: 1030;
+  z-index: 1030 !important;
 }

--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -888,3 +888,6 @@ input[type="radio"]:checked::before {
 .separator:not(:empty)::after {
   margin-left: .25em;
 }
+.datepicker.dropdown-menu {
+  z-index: 1030 !important;
+}

--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -889,5 +889,5 @@ input[type="radio"]:checked::before {
   margin-left: .25em;
 }
 .datepicker.dropdown-menu {
-  z-index: 1030 !important;
+  z-index: 1030;
 }


### PR DESCRIPTION
# Description
The date-picker's z-index was off and placing the calendar underneath the nav bar. This fix puts it on top. This uses `!important` to get this done. 
Before:
<img width="1100" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/6246ee46-78c4-48bc-b7ee-9dc281ab2cc6">
After:
<img width="1100" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/2aca4862-05a4-4f0a-8f2f-00ed787ab1f2">


Fixes #SC-24152

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
