### PR TITLE
Adds a minimal amount of validation around asset_tags in AssetsController

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -102,6 +102,10 @@ class AssetsController extends Controller
     {
         $this->authorize(Asset::class);
 
+        // There are a lot more rules to add here but prevents
+        // errors around `asset_tags` not being present below.
+        $this->validate($request, ['asset_tags' => ['required', 'array']]);
+
         // Handle asset tags - there could be one, or potentially many.
         // This is only necessary on create, not update, since bulk editing is handled
         // differently


### PR DESCRIPTION
# Description

This PR introduces a tiny bit of validation around the `asset_tags` field in the `AssetsController`'s `store` method.

We saw a few exceptions pop up in the demo, most likely some someone manually messing with the form, and this gives a little more protection from 500s being thrown from this method.

## Type of change

- [x] Bug fix (ish) (non-breaking change which fixes an issue)