### PR TITLE
Fixes Assets location not being resynced when Users location is updated via LDAP

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Models\Asset;
 use App\Models\Department;
 use App\Models\Group;
 use Illuminate\Console\Command;
@@ -390,6 +391,10 @@ class LdapSync extends Command
                         $user->location_id = $location->id;
                     }
                 }
+                $assets = Asset::whereColumn('assigned_to', '=', $user->id)->get();
+                    foreach($assets as $asset){
+                        $asset->location = $user->location_id;
+                    }
 
                 $user->ldap_import = 1;
 

--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -391,9 +391,11 @@ class LdapSync extends Command
                         $user->location_id = $location->id;
                     }
                 }
-                $assets = Asset::whereColumn('assigned_to', '=', $user->id)->get();
+                //updates assets location based on user's location
+                $assets = Asset::where('assigned_to', '=', $user->id)->get();
                     foreach($assets as $asset){
                         $asset->location_id = $user->location_id;
+                        $asset->save();
                     }
 
                 $user->ldap_import = 1;

--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -392,11 +392,7 @@ class LdapSync extends Command
                     }
                 }
                 //updates assets location based on user's location
-                $assets = Asset::where('assigned_to', '=', $user->id)->get();
-                    foreach($assets as $asset){
-                        $asset->location_id = $user->location_id;
-                        $asset->save();
-                    }
+                Asset::where('assigned_to', '=', $user->id)->update(['location_id' => $user->location_id]);
 
                 $user->ldap_import = 1;
 

--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -393,7 +393,7 @@ class LdapSync extends Command
                 }
                 $assets = Asset::whereColumn('assigned_to', '=', $user->id)->get();
                     foreach($assets as $asset){
-                        $asset->location = $user->location_id;
+                        $asset->location_id = $user->location_id;
                     }
 
                 $user->ldap_import = 1;


### PR DESCRIPTION
# Description

While syncing, if a user's location is update via LDAP this change now will grab all Assets that are assigned to the user and update their location as intended.
[SC-23242]
Fixes #

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
