### PR TITLE
Make sure the category is still valid before displaying on view assets

### DIFF
--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -521,7 +521,7 @@
                     @else
                       ------------
                     @endcan
-                    <td>{{ $license->category->name }}</td>
+                    <td>{{ ($license->category) ? $license->category->name : trans('general.deleted') }}</td>
                   </tr>
                 @endforeach
                 </tbody>


### PR DESCRIPTION
This largely only affects the demo. This just makes sure the license category is still valid before trying to display it. 