### PR TITLE
Add additional options to print all assigned view

### DIFF
--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -519,4 +519,13 @@ return [
     ],
     'no_requestable' => 'There are no requestable assets or asset models.',
 
+    'countable' => [
+        'accessories'  => ':count Accessory|:count Accessories',
+        'assets'  => ':count Asset|:count Assets',
+        'licenses'  => ':count License|:count Licenses',
+        'license_seats'  => ':count License Seat|:count License Seats',
+        'consumables'  => ':count Consumable|:count Consumables',
+        'components'  => ':count Component|:count Components',
+    ]
+
 ];

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -334,19 +334,34 @@
         </table>
     @endif
 
-    <table style="margin-top: 20px;">
-        <tr style="height: 100px;">
-            <td style="padding-right: 10px;">{{ trans('general.signed_off_by') }}:</td>
-            <td style="padding-right: 10px;">________________________________________________________</td>
-            <td style="padding-right: 10px;">{{ trans('general.date') }}:</td>
-            <td>________________________________________________________</td>
+    <table style="margin-top: 80px;">
+        <tr>
+            <td style="padding-right: 10px; vertical-align: top; font-weight: bold;">{{ trans('general.signed_off_by') }}:</td>
+            <td style="padding-right: 10px; vertical-align: top;">________________________________________________________</td>
+            <td style="padding-right: 10px; vertical-align: top;">________________________________________________________</td>
+            <td>_____________________</td>
+        </tr>
+        <tr style="height: 80px;">
+            <td></td>
+            <td style="padding-right: 10px; vertical-align: top;">Name</td>
+            <td style="padding-right: 10px; vertical-align: top;">Signature</td>
+            <td style="padding-right: 10px; vertical-align: top;">{{ trans('general.date') }}</td>
+        </tr>
+
+        <tr>
+            <td style="padding-right: 10px; vertical-align: top; font-weight: bold;">{{ trans('admin/users/table.manager') }}:</td>
+            <td style="padding-right: 10px; vertical-align: top;">________________________________________________________</td>
+            <td style="padding-right: 10px; vertical-align: top;">________________________________________________________</td>
+            <td>_____________________</td>
         </tr>
         <tr>
-            <td style="padding-right: 10px;">{{ trans('admin/users/table.manager') }}:</td>
-            <td style="padding-right: 10px;">________________________________________________________</td>
-            <td style="padding-right: 10px;">{{ trans('general.date') }}:</td>
-            <td>________________________________________________________</td>
+            <td></td>
+            <td style="padding-right: 10px; vertical-align: top;">Name</td>
+            <td style="padding-right: 10px; vertical-align: top;">Signature</td>
+            <td style="padding-right: 10px; vertical-align: top;">{{ trans('general.date') }}</td>
+            <td></td>
         </tr>
+
     </table>
 
 {{-- Javascript files --}}

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -86,7 +86,6 @@
 
         <div id="assets-toolbar">
             <h4>{{ trans_choice('general.countable.assets', $assets->count(), ['count' => $assets->count()]) }}
-                <small><a href="#" id="asset-showhide" class="hidden-print">(hide in print)</a></small>
             </h4>
         </div>
 

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -73,15 +73,19 @@
     @endif
 @endif
 
-<h3>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} {{ ($show_user->jobtitle!='' ? ' - '.$show_user->jobtitle : '') }}
+<h3>
+    {{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }}
+    {{ ($show_user->employee_num!='') ? ' (#'.$show_user->employee_num.') ' : '' }}
+    {{ ($show_user->jobtitle!='' ? ' - '.$show_user->jobtitle : '') }}
 </h3>
+<p></p>{{ trans('admin/users/general.all_assigned_list_generation')}} {{ Helper::getFormattedDateObject(now(), 'datetime', false) }}</body>
     @if ($assets->count() > 0)
         @php
             $counter = 1;
         @endphp
 
         <div id="assets-toolbar">
-            <h4>{{ trans('general.assets') }}</h4>
+            <h4>{{ trans_choice('general.countable.assets', $assets->count(), ['count' => $assets->count()]) }}</h4>
         </div>
 
         <table
@@ -171,7 +175,7 @@
 
     @if ($licenses->count() > 0)
         <div id="licenses-toolbar">
-            <h4>{{ trans('general.licenses') }}</h4>
+            <h4>{{ trans_choice('general.countable.licenses', $licenses->count(), ['count' => $licenses->count()]) }}</h4>
         </div>
 
         <table
@@ -224,7 +228,7 @@
 
     @if ($accessories->count() > 0)
         <div id="accessories-toolbar">
-            <h4>{{ $accessories->count() }} {{ trans('general.accessories') }}</h4>
+            <h4>{{ trans_choice('general.countable.accessories', $accessories->count(), ['count' => $accessories->count()]) }}</h4>
         </div>
 
         <table
@@ -244,6 +248,7 @@
             <thead>
             <tr>
                 <th style="width: 20px;"></th>
+                <th data-field="accessory_image" data-sortable="true" data-searchable="false" data-visible="true">{{ trans('general.image') }}</th>
                 <th style="width: 40%;">{{ trans('general.name') }}</th>
                 <th style="width: 50%;">{{ trans('general.category') }}</th>
                 <th style="width: 10%;">{{ trans('admin/hardware/table.checkout_date') }}</th>
@@ -257,6 +262,11 @@
                 @if ($accessory)
                     <tr>
                         <td>{{ $acounter }}</td>
+                        <td>
+                            @if ($accessory->getImageUrl())
+                                <img src="{{ $accessory->getImageUrl() }}" class="thumbnail" style="max-height: 50px;">
+                            @endif
+                        </td>
                         <td>{{ ($accessory->manufacturer) ? $accessory->manufacturer->name : '' }} {{ $accessory->name }} {{ $accessory->model_number }}</td>
                         <td>{{ $accessory->category->name }}</td>
                         <td>{{ $accessory->pivot->created_at }}</td>
@@ -271,7 +281,7 @@
 
     @if ($consumables->count() > 0)
         <div id="consumables-toolbar">
-            <h4>{{ $consumables->count() }} {{ trans('general.consumables') }}</h4>
+            <h4>{{ trans_choice('general.countable.consumables', $consumables->count(), ['count' => $consumables->count()]) }}</h4>
         </div>
 
         <table
@@ -324,17 +334,17 @@
         </table>
     @endif
 
-    <br>
-    <br>
-    {{ trans('admin/users/general.all_assigned_list_generation')}} {{ Helper::getFormattedDateObject(now(), 'datetime', false) }}
-    <br>
-    <br>
-    <table>
-        <tr>
-            <td>{{ trans('general.signed_off_by') }}:</td>
+    <table style="margin-top: 20px;">
+        <tr style="height: 100px;">
+            <td style="padding-right: 10px;">{{ trans('general.signed_off_by') }}:</td>
+            <td style="padding-right: 10px;">________________________________________________________</td>
+            <td style="padding-right: 10px;">{{ trans('general.date') }}:</td>
             <td>________________________________________________________</td>
-            <td></td>
-            <td>{{ trans('general.date') }}:</td>
+        </tr>
+        <tr>
+            <td style="padding-right: 10px;">{{ trans('admin/users/table.manager') }}:</td>
+            <td style="padding-right: 10px;">________________________________________________________</td>
+            <td style="padding-right: 10px;">{{ trans('general.date') }}:</td>
             <td>________________________________________________________</td>
         </tr>
     </table>

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -37,6 +37,11 @@
             max-height: 40px;
         }
 
+        h4 {
+            margin-top: 20px;
+            margin-bottom: 10px;
+        }
+
     </style>
 
     <script nonce="{{ csrf_token() }}">
@@ -75,55 +80,58 @@
             $counter = 1;
         @endphp
 
-        <div id="toolbar">
-            poots
+        <div id="assets-toolbar">
+            <h4>{{ trans('general.assets') }}</h4>
         </div>
 
         <table
                 class="snipe-table table table-striped inventory"
-                id="inventory"
-                data-pagination="true"
-                data-id-table="modelFileHistory"
-                data-search="true"
+                id="AssetsAssigned"
+                data-pagination="false"
+                data-id-table="AssetsAssigned"
+                data-search="false"
                 data-side-pagination="client"
-                data-sortable="true"
+                data-sortable="false"
+                data-toolbar="#assets-toolbar"
                 data-show-columns="true"
-                data-show-fullscreen="true"
-                data-show-refresh="true"
                 data-sort-order="desc"
                 data-sort-name="created_at"
-                data-show-export="true"
-                data-cookie-id-table="assetFileHistory">
+                data-show-columns-toggle-all="true"
+                data-cookie-id-table="AssetsAssigned">
             <thead>
-                <tr>
-                    <th colspan="8" id="assets">{{ trans('general.assets') }}</th>
-                </tr>
-            </thead>
-            <thead>
-                <tr>
-                    <th id="assetsh1" data-field="id" data-sortable="true" data-searchable="true" data-visible="true">#</th>
-                    <th id="assetsh2" data-field="asset_tag" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/table.asset_tag') }}</th>
-                    <th id="assetsh3" data-field="name" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.name') }}</th>
-                    <th id="assetsh4" data-field="category" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.category') }}</th>
-                    <th id="assetsh5" data-field="model" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.model') }}</th>
-                    <th id="assetsh6" data-field="serial" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.serial') }}</th>
-                    <th id="assetsh7" data-field="checkout_date" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
-                    <th id="assetsh8" data-field="signature" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.signature') }}</th>
-                </tr>
+
+                <th data-field="id" data-sortable="true" data-searchable="true" data-visible="true">#</th>
+                <th data-field="image" data-sortable="true" data-searchable="false" data-visible="true">{{ trans('general.image') }}</th>
+                <th data-field="asset_tag" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/table.asset_tag') }}</th>
+                <th data-field="name" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.name') }}</th>
+                <th data-field="category" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.category') }}</th>
+                <th data-field="model" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.model') }}</th>
+                <th data-field="location" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.location') }}</th>
+                <th data-field="serial" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.serial') }}</th>
+                <th data-field="checkout_date" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
+                <th data-field="signature" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.signature') }}</th>
+
             </thead>
             <tbody>
             @foreach ($assets as $asset)
 
                 <tr>
-                    <td>{{ $counter }}</td>
+                    <td data-sortable="false">{{ $counter }}</td>
+                    <td>
+                        @if ($asset->getImageUrl())
+                            <img src="{{ $asset->getImageUrl() }}" class="thumbnail" style="max-height: 50px;">
+                        @endif
+                    </td>
                     <td>{{ $asset->asset_tag }}</td>
                     <td>{{ $asset->name }}</td>
                     <td>{{ (($asset->model) && ($asset->model->category)) ? $asset->model->category->name : trans('general.invalid_category') }}</td>
                     <td>{{ ($asset->model) ? $asset->model->name : trans('general.invalid_model') }}</td>
+                    <td>{{ ($asset->location) ? $asset->location->name : '' }}</td>
+                    <td>{{ $asset->name }}</td>
                     <td>{{ $asset->serial }}</td>
                     <td>
                         {{ $asset->last_checkout }}</td>
-                    <td data-formatter="imageFormatter">
+                    <td>
                         @if (($asset->assetlog->first()) && ($asset->assetlog->first()->accept_signature!=''))
                             <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->first()->accept_signature }}">
                         @endif
@@ -137,9 +145,15 @@
 
                         <tr>
                             <td>{{ $counter }}.{{ $assignedCounter }}</td>
+                            <td data-formatter="imageFormatter">
+                                @if ($asset->getImageUrl())
+                                    <img src="{{ $asset->getImageUrl() }}" class="thumbnail" style="max-height: 50px;">
+                                @endif
+                            </td>
                             <td>{{ $asset->asset_tag }}</td>
                             <td>{{ $asset->name }}</td>
                             <td>{{ $asset->model->category->name }}</td>
+                            <td>{{ ($asset->location) ? $asset->location->name : '' }}</td>
                             <td>{{ $asset->model->name }}</td>
                             <td>{{ $asset->serial }}</td>
                             <td>{{ $asset->last_checkout }}</td>
@@ -159,13 +173,24 @@
     @endif
 
     @if ($licenses->count() > 0)
-        <br><br>
-        <table class="inventory">
-            <thead>
-            <tr>
-                <th colspan="4">{{ trans('general.licenses') }}</th>
-            </tr>
-            </thead>
+        <div id="licenses-toolbar">
+            <h4>{{ trans('general.licenses') }}</h4>
+        </div>
+
+        <table
+                class="snipe-table table table-striped inventory"
+                id="licensessAssigned"
+                data-toolbar="#licenses-toolbar"
+                data-pagination="false"
+                data-id-table="licensessAssigned"
+                data-search="false"
+                data-side-pagination="client"
+                data-sortable="false"
+                data-show-columns="true"
+                data-sort-order="desc"
+                data-sort-name="created_at"
+                data-show-columns-toggle-all="true"
+                data-cookie-id-table="licensessAssigned">
             <thead>
             <tr>
                 <th style="width: 20px;"></th>
@@ -201,13 +226,24 @@
 
 
     @if ($accessories->count() > 0)
-        <br><br>
-        <table class="inventory">
-            <thead>
-            <tr>
-                <th colspan="4">{{ trans('general.accessories') }}</th>
-            </tr>
-            </thead>
+        <div id="accessories-toolbar">
+            <h4>{{ $accessories->count() }} {{ trans('general.accessories') }}</h4>
+        </div>
+
+        <table
+                class="snipe-table table table-striped inventory"
+                id="accessoriesAssigned"
+                data-toolbar="#accessories-toolbar"
+                data-pagination="false"
+                data-id-table="accessoriesAssigned"
+                data-search="false"
+                data-side-pagination="client"
+                data-sortable="false"
+                data-show-columns="true"
+                data-sort-order="desc"
+                data-sort-name="created_at"
+                data-show-columns-toggle-all="true"
+                data-cookie-id-table="accessoriesAssigned">
             <thead>
             <tr>
                 <th style="width: 20px;"></th>
@@ -237,13 +273,24 @@
     @endif
 
     @if ($consumables->count() > 0)
-        <br><br>
-        <table class="inventory">
-            <thead>
-            <tr>
-                <th colspan="4">{{ trans('general.consumables') }}</th>
-            </tr>
-            </thead>
+        <div id="consumables-toolbar">
+            <h4>{{ $consumables->count() }} {{ trans('general.consumables') }}</h4>
+        </div>
+
+        <table
+                class="snipe-table table table-striped inventory"
+                id="consumablesAssigned"
+                data-pagination="false"
+                data-toolbar="#consumables-toolbar"
+                data-id-table="consumablesAssigned"
+                data-search="false"
+                data-side-pagination="client"
+                data-sortable="false"
+                data-show-columns="true"
+                data-sort-order="desc"
+                data-sort-name="created_at"
+                data-show-columns-toggle-all="true"
+                data-cookie-id-table="consumablesAssigned">
             <thead>
             <tr>
                 <th style="width: 20px;"></th>
@@ -306,7 +353,7 @@
 
 @push('js')
 
-    <script src="{{ url(mix('js/dist/bootstrap-table.js')) }}"></script>
+<script src="{{ url(mix('js/dist/bootstrap-table.js')) }}"></script>
 
 <script>
     $('.snipe-table').bootstrapTable('destroy').each(function () {
@@ -335,7 +382,6 @@
             stickyHeader: true,
             stickyHeaderOffsetLeft: parseInt($('body').css('padding-left'), 10),
             stickyHeaderOffsetRight: parseInt($('body').css('padding-right'), 10),
-            locale: locale,
             undefinedText: '',
             iconsPrefix: 'fa',
             cookieStorage: '{{ config('session.bs_table_storage') }}',

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -3,9 +3,24 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title>{{ trans('general.assigned_to', ['name' => $show_user->present()->fullName()]) }} - {{ date('Y-m-d H:i', time()) }}</title>
+
+    <link rel="shortcut icon" type="image/ico" href="{{ ($snipeSettings) && ($snipeSettings->favicon!='') ?  Storage::disk('public')->url(e($snipeSettings->favicon)) : config('app.url').'/favicon.ico' }}">
+
+    {{-- stylesheets --}}
+    <link rel="stylesheet" href="{{ url(mix('css/dist/all.css')) }}">
+
+    <script nonce="{{ csrf_token() }}">
+        window.snipeit = {
+            settings: {
+                "per_page": 50
+            }
+        };
+    </script>
+
     <style>
         body {
             font-family: "Arial, Helvetica", sans-serif;
+            padding: 20px;
         }
         table.inventory {
             border: solid #000;
@@ -16,18 +31,22 @@
         @page {
             size: A4;
         }
-        table.inventory th, table.inventory td {
-            border: solid #000;
-            border-width: 0 1px 1px 0;
-            padding: 3px;
-            font-size: 12px;
-        }
+
 
         .print-logo {
             max-height: 40px;
         }
 
     </style>
+
+    <script nonce="{{ csrf_token() }}">
+        window.snipeit = {
+            settings: {
+                "per_page": 50
+            }
+        };
+    </script>
+
 </head>
 <body>
 
@@ -55,25 +74,44 @@
         @php
             $counter = 1;
         @endphp
-        <table class="inventory">
-            <thead>
-            <tr>
-                <th colspan="8">{{ trans('general.assets') }}</th>
-            </tr>
-            </thead>
-            <thead>
-            <tr>
-                <th style="width: 20px;"></th>
-                <th style="width: 20%;">{{ trans('admin/hardware/table.asset_tag') }}</th>
-                <th style="width: 20%;">{{ trans('general.name') }}</th>
-                <th style="width: 10%;">{{ trans('general.category') }}</th>
-                <th style="width: 20%;">{{ trans('admin/hardware/form.model') }}</th>
-                <th style="width: 20%;">{{ trans('admin/hardware/form.serial') }}</th>
-                <th style="width: 10%;">{{ trans('admin/hardware/table.checkout_date') }}</th>
-                <th data-formatter="imageFormatter" style="width: 20%;">{{ trans('general.signature') }}</th>
-            </tr>
-            </thead>
 
+        <div id="toolbar">
+            poots
+        </div>
+
+        <table
+                class="snipe-table table table-striped inventory"
+                id="inventory"
+                data-pagination="true"
+                data-id-table="modelFileHistory"
+                data-search="true"
+                data-side-pagination="client"
+                data-sortable="true"
+                data-show-columns="true"
+                data-show-fullscreen="true"
+                data-show-refresh="true"
+                data-sort-order="desc"
+                data-sort-name="created_at"
+                data-show-export="true"
+                data-cookie-id-table="assetFileHistory">
+            <thead>
+                <tr>
+                    <th colspan="8" id="assets">{{ trans('general.assets') }}</th>
+                </tr>
+            </thead>
+            <thead>
+                <tr>
+                    <th id="assetsh1" data-field="id" data-sortable="true" data-searchable="true" data-visible="true">#</th>
+                    <th id="assetsh2" data-field="asset_tag" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/table.asset_tag') }}</th>
+                    <th id="assetsh3" data-field="name" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.name') }}</th>
+                    <th id="assetsh4" data-field="category" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.category') }}</th>
+                    <th id="assetsh5" data-field="model" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.model') }}</th>
+                    <th id="assetsh6" data-field="serial" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.serial') }}</th>
+                    <th id="assetsh7" data-field="checkout_date" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
+                    <th id="assetsh8" data-field="signature" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.signature') }}</th>
+                </tr>
+            </thead>
+            <tbody>
             @foreach ($assets as $asset)
 
                 <tr>
@@ -85,13 +123,13 @@
                     <td>{{ $asset->serial }}</td>
                     <td>
                         {{ $asset->last_checkout }}</td>
-                    <td>
+                    <td data-formatter="imageFormatter">
                         @if (($asset->assetlog->first()) && ($asset->assetlog->first()->accept_signature!=''))
                             <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->first()->accept_signature }}">
                         @endif
                     </td>
                 </tr>
-                @if($settings->show_assigned_assets)
+                @if ($settings->show_assigned_assets)
                     @php
                         $assignedCounter = 1;
                     @endphp
@@ -116,6 +154,7 @@
                     $counter++
                 @endphp
             @endforeach
+            </tbody>
         </table>
     @endif
 
@@ -255,6 +294,97 @@
             <td>________________________________________________________</td>
         </tr>
     </table>
+
+{{-- Javascript files --}}
+<script src="{{ url(mix('js/dist/all.js')) }}" nonce="{{ csrf_token() }}"></script>
+<script defer src="{{ url(mix('js/dist/all-defer.js')) }}" nonce="{{ csrf_token() }}"></script>
+
+
+@push('css')
+    <link rel="stylesheet" href="{{ url(mix('css/dist/bootstrap-table.css')) }}">
+@endpush
+
+@push('js')
+
+    <script src="{{ url(mix('js/dist/bootstrap-table.js')) }}"></script>
+
+<script>
+    $('.snipe-table').bootstrapTable('destroy').each(function () {
+
+        console.log('BS table loaded');
+        data_export_options = $(this).attr('data-export-options');
+        export_options = data_export_options ? JSON.parse(data_export_options) : {};
+        export_options['htmlContent'] = false; // this is already the default; but let's be explicit about it
+        export_options['jspdf']= {"orientation": "l"};
+        // the following callback method is necessary to prevent XSS vulnerabilities
+        // (this is taken from Bootstrap Tables's default wrapper around jQuery Table Export)
+        export_options['onCellHtmlData'] = function (cell, rowIndex, colIndex, htmlData) {
+            if (cell.is('th')) {
+                return cell.find('.th-inner').text()
+            }
+            return htmlData
+        }
+        $(this).bootstrapTable({
+            classes: 'table table-responsive table-no-bordered',
+            ajaxOptions: {
+                headers: {
+                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                }
+            },
+            // reorderableColumns: true,
+            stickyHeader: true,
+            stickyHeaderOffsetLeft: parseInt($('body').css('padding-left'), 10),
+            stickyHeaderOffsetRight: parseInt($('body').css('padding-right'), 10),
+            locale: locale,
+            undefinedText: '',
+            iconsPrefix: 'fa',
+            cookieStorage: '{{ config('session.bs_table_storage') }}',
+            cookie: true,
+            cookieExpire: '2y',
+            mobileResponsive: true,
+            maintainSelected: true,
+            trimOnSearch: false,
+            showSearchClearButton: true,
+            paginationFirstText: "{{ trans('general.first') }}",
+            paginationLastText: "{{ trans('general.last') }}",
+            paginationPreText: "{{ trans('general.previous') }}",
+            paginationNextText: "{{ trans('general.next') }}",
+            pageList: ['10','20', '30','50','100','150','200'{!! ((config('app.max_results') > 200) ? ",'500'" : '') !!}{!! ((config('app.max_results') > 500) ? ",'".config('app.max_results')."'" : '') !!}],
+            pageSize: {{  (($snipeSettings->per_page!='') && ($snipeSettings->per_page > 0)) ? $snipeSettings->per_page : 20 }},
+            paginationVAlign: 'both',
+            queryParams: function (params) {
+                var newParams = {};
+                for(var i in params) {
+                    if(!keyBlocked(i)) { // only send the field if it's not in blockedFields
+                        newParams[i] = params[i];
+                    }
+                }
+                return newParams;
+            },
+            formatLoadingMessage: function () {
+                return '<h2><i class="fas fa-spinner fa-spin" aria-hidden="true"></i> {{ trans('general.loading') }} </h4>';
+            },
+            icons: {
+                advancedSearchIcon: 'fas fa-search-plus',
+                paginationSwitchDown: 'fa-caret-square-o-down',
+                paginationSwitchUp: 'fa-caret-square-o-up',
+                fullscreen: 'fa-expand',
+                columns: 'fa-columns',
+                refresh: 'fas fa-sync-alt',
+                export: 'fa-download',
+                clearSearch: 'fa-times'
+            },
+            exportOptions: export_options,
+
+            exportTypes: ['xlsx', 'excel', 'csv', 'pdf','json', 'xml', 'txt', 'sql', 'doc' ],
+            onLoadSuccess: function () {
+                $('[data-tooltip="true"]').tooltip(); // Needed to attach tooltips after ajax call
+            }
+
+        });
+    });
+</script>
+
 
 
 </body>

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -85,7 +85,9 @@
         @endphp
 
         <div id="assets-toolbar">
-            <h4>{{ trans_choice('general.countable.assets', $assets->count(), ['count' => $assets->count()]) }}</h4>
+            <h4>{{ trans_choice('general.countable.assets', $assets->count(), ['count' => $assets->count()]) }}
+                <small><a href="#" id="asset-showhide" class="hidden-print">(hide in print)</a></small>
+            </h4>
         </div>
 
         <table
@@ -95,7 +97,7 @@
                 data-id-table="AssetsAssigned"
                 data-search="false"
                 data-side-pagination="client"
-                data-sortable="false"
+                data-sortable="true"
                 data-toolbar="#assets-toolbar"
                 data-show-columns="true"
                 data-sort-order="desc"
@@ -103,16 +105,16 @@
                 data-show-columns-toggle-all="true"
                 data-cookie-id-table="AssetsAssigned">
             <thead>
-                <th data-field="asset_id" data-sortable="true" data-searchable="true" data-visible="true">#</th>
-                <th data-field="asset_image" data-sortable="true" data-searchable="false" data-visible="true">{{ trans('general.image') }}</th>
-                <th data-field="asset_tag" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/table.asset_tag') }}</th>
-                <th data-field="asset_name" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.name') }}</th>
-                <th data-field="asset_category" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.category') }}</th>
-                <th data-field="asset_model" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.model') }}</th>
-                <th data-field="asset_location" data-sortable="true" data-searchable="true" data-visible="false">{{ trans('general.location') }}</th>
-                <th data-field="asset_serial" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.serial') }}</th>
-                <th data-field="asset_checkout_date" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
-                <th data-field="signature" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.signature') }}</th>
+                <th data-field="asset_id" data-sortable="false" data-visible="true" data-switchable="false">#</th>
+                <th data-field="asset_image" data-sortable="true" data-visible="false" data-switchable="true">{{ trans('general.image') }}</th>
+                <th data-field="asset_tag" data-sortable="true" data-visible="true" data-switchable="false">{{ trans('admin/hardware/table.asset_tag') }}</th>
+                <th data-field="asset_name" data-sortable="true" data-visible="true">{{ trans('general.name') }}</th>
+                <th data-field="asset_category" data-sortable="true" data-visible="true">{{ trans('general.category') }}</th>
+                <th data-field="asset_model" data-sortable="true" data-visible="true">{{ trans('admin/hardware/form.model') }}</th>
+                <th data-field="asset_location" data-sortable="true" data-visible="false">{{ trans('general.location') }}</th>
+                <th data-field="asset_serial" data-sortable="true" data-visible="true">{{ trans('admin/hardware/form.serial') }}</th>
+                <th data-field="asset_checkout_date" data-sortable="true" data-visible="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
+                <th data-field="signature" data-sortable="true" data-visible="true">{{ trans('general.signature') }}</th>
             </thead>
             <tbody>
             @foreach ($assets as $asset)
@@ -186,7 +188,7 @@
                 data-id-table="licensessAssigned"
                 data-search="false"
                 data-side-pagination="client"
-                data-sortable="false"
+                data-sortable="true"
                 data-show-columns="true"
                 data-sort-order="desc"
                 data-sort-name="created_at"
@@ -194,10 +196,10 @@
                 data-cookie-id-table="licensessAssigned">
             <thead>
             <tr>
-                <th style="width: 20px;"></th>
-                <th style="width: 40%;">{{ trans('general.name') }}</th>
-                <th style="width: 50%;">{{ trans('admin/licenses/form.license_key') }}</th>
-                <th style="width: 10%;">{{ trans('admin/hardware/table.checkout_date') }}</th>
+                <th style="width: 20px;" data-sortable="false" data-switchable="false">#</th>
+                <th style="width: 40%;" data-sortable="true" data-switchable="false">{{ trans('general.name') }}</th>
+                <th style="width: 50%;" data-sortable="true">{{ trans('admin/licenses/form.license_key') }}</th>
+                <th style="width: 10%;" data-sortable="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
             </tr>
             </thead>
             @php
@@ -239,7 +241,7 @@
                 data-id-table="accessoriesAssigned"
                 data-search="false"
                 data-side-pagination="client"
-                data-sortable="false"
+                data-sortable="true"
                 data-show-columns="true"
                 data-sort-order="desc"
                 data-sort-name="created_at"
@@ -247,11 +249,11 @@
                 data-cookie-id-table="accessoriesAssigned">
             <thead>
             <tr>
-                <th style="width: 20px;"></th>
-                <th data-field="accessory_image" data-sortable="true" data-searchable="false" data-visible="true">{{ trans('general.image') }}</th>
-                <th style="width: 40%;">{{ trans('general.name') }}</th>
-                <th style="width: 50%;">{{ trans('general.category') }}</th>
-                <th style="width: 10%;">{{ trans('admin/hardware/table.checkout_date') }}</th>
+                <th style="width: 20px;" data-sortable="false" data-switchable="false">#</th>
+                <th data-field="accessory_image" data-sortable="true"  data-visible="true">{{ trans('general.image') }}</th>
+                <th style="width: 40%;" data-sortable="true" data-switchable="false">{{ trans('general.name') }}</th>
+                <th style="width: 50%;" data-sortable="true">{{ trans('general.category') }}</th>
+                <th style="width: 10%;" data-sortable="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
             </tr>
             </thead>
             @php
@@ -292,7 +294,7 @@
                 data-id-table="consumablesAssigned"
                 data-search="false"
                 data-side-pagination="client"
-                data-sortable="false"
+                data-sortable="true"
                 data-show-columns="true"
                 data-sort-order="desc"
                 data-sort-name="created_at"
@@ -300,10 +302,10 @@
                 data-cookie-id-table="consumablesAssigned">
             <thead>
             <tr>
-                <th style="width: 20px;"></th>
-                <th style="width: 40%;">{{ trans('general.name') }}</th>
-                <th style="width: 50%;">{{ trans('general.category') }}</th>
-                <th style="width: 10%;">{{ trans('admin/hardware/table.checkout_date') }}</th>
+                <th style="width: 20px;" data-sortable="false" data-switchable="false"></th>
+                <th style="width: 40%;" data-sortable="true" data-switchable="false">{{ trans('general.name') }}</th>
+                <th style="width: 50%;" data-sortable="true">{{ trans('general.category') }}</th>
+                <th style="width: 10%;" data-sortable="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
             </tr>
             </thead>
             @php

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -23,9 +23,8 @@
             padding: 20px;
         }
         table.inventory {
-            border: solid #000;
-            border-width: 1px 1px 1px 1px;
             width: 100%;
+            border: 1px solid #d3d3d3;
         }
 
         @page {
@@ -41,6 +40,7 @@
             margin-top: 20px;
             margin-bottom: 10px;
         }
+
 
     </style>
 
@@ -99,24 +99,22 @@
                 data-show-columns-toggle-all="true"
                 data-cookie-id-table="AssetsAssigned">
             <thead>
-
-                <th data-field="id" data-sortable="true" data-searchable="true" data-visible="true">#</th>
-                <th data-field="image" data-sortable="true" data-searchable="false" data-visible="true">{{ trans('general.image') }}</th>
+                <th data-field="asset_id" data-sortable="true" data-searchable="true" data-visible="true">#</th>
+                <th data-field="asset_image" data-sortable="true" data-searchable="false" data-visible="true">{{ trans('general.image') }}</th>
                 <th data-field="asset_tag" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/table.asset_tag') }}</th>
-                <th data-field="name" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.name') }}</th>
-                <th data-field="category" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.category') }}</th>
-                <th data-field="model" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.model') }}</th>
-                <th data-field="location" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.location') }}</th>
-                <th data-field="serial" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.serial') }}</th>
-                <th data-field="checkout_date" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
+                <th data-field="asset_name" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.name') }}</th>
+                <th data-field="asset_category" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.category') }}</th>
+                <th data-field="asset_model" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.model') }}</th>
+                <th data-field="asset_location" data-sortable="true" data-searchable="true" data-visible="false">{{ trans('general.location') }}</th>
+                <th data-field="asset_serial" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/form.serial') }}</th>
+                <th data-field="asset_checkout_date" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
                 <th data-field="signature" data-sortable="true" data-searchable="true" data-visible="true">{{ trans('general.signature') }}</th>
-
             </thead>
             <tbody>
             @foreach ($assets as $asset)
 
                 <tr>
-                    <td data-sortable="false">{{ $counter }}</td>
+                    <td>{{ $counter }}</td>
                     <td>
                         @if ($asset->getImageUrl())
                             <img src="{{ $asset->getImageUrl() }}" class="thumbnail" style="max-height: 50px;">
@@ -127,10 +125,9 @@
                     <td>{{ (($asset->model) && ($asset->model->category)) ? $asset->model->category->name : trans('general.invalid_category') }}</td>
                     <td>{{ ($asset->model) ? $asset->model->name : trans('general.invalid_model') }}</td>
                     <td>{{ ($asset->location) ? $asset->location->name : '' }}</td>
-                    <td>{{ $asset->name }}</td>
                     <td>{{ $asset->serial }}</td>
                     <td>
-                        {{ $asset->last_checkout }}</td>
+                        {{ Helper::getFormattedDateObject($asset->last_checkout, 'datetime', false) }}</td>
                     <td>
                         @if (($asset->assetlog->first()) && ($asset->assetlog->first()->accept_signature!=''))
                             <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->first()->accept_signature }}">


### PR DESCRIPTION
This modifies the "print all assigned" to use the Bootstrap Tables javascript, so users can show/hide the columns they want to show/hide for their print view.

It also pluralizes the asset, license, etc text in a new block in general for re-use elsewhere.

### Previous

<img width="1647" alt="Screenshot 2024-03-18 at 1 34 01 PM" src="https://github.com/snipe/snipe-it/assets/197404/6f1a20c9-ff2c-462a-8a53-ffd7de0b45d1">

### New - With images/locations:

<img width="1647" alt="Screenshot 2024-03-18 at 1 32 06 PM" src="https://github.com/snipe/snipe-it/assets/197404/aa98e60d-9e08-465b-a843-d0b7f3b37353">

### New - Without:
<img width="1643" alt="Screenshot 2024-03-18 at 1 32 20 PM" src="https://github.com/snipe/snipe-it/assets/197404/879f998d-71c9-4d0d-92d5-430416437fc8">
