### PR TITLE
Default Locale value changed to en-US

### DIFF
--- a/database/migrations/2024_03_18_221612_update_legacy_locale.php
+++ b/database/migrations/2024_03_18_221612_update_legacy_locale.php
@@ -18,6 +18,13 @@ class UpdateLegacyLocale extends Migration
             //
             $table->string('locale', 10)->nullable()->default('en-US')->change();
         });
+
+        Schema::table('settings', function (Blueprint $table) {
+            //
+            $table->string('locale', 10)->nullable()->default('en-US')->change();
+        });
+
+
     }
 
     /**
@@ -29,6 +36,10 @@ class UpdateLegacyLocale extends Migration
     {
         //
         Schema::table('users', function (Blueprint $table) {
+            //
+            $table->string('locale', 10)->nullable()->default(config('app.locale'))->change();
+        });
+        Schema::table('settings', function (Blueprint $table) {
             //
             $table->string('locale', 10)->nullable()->default(config('app.locale'))->change();
         });

--- a/database/migrations/2024_03_18_221612_update_legacy_locale.php
+++ b/database/migrations/2024_03_18_221612_update_legacy_locale.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class UpdateLegacyLocations extends Migration
+class UpdateLegacyLocale extends Migration
 {
     /**
      * Run the migrations.

--- a/database/migrations/2024_03_18_221612_update_legacy_locations.php
+++ b/database/migrations/2024_03_18_221612_update_legacy_locations.php
@@ -16,7 +16,7 @@ class UpdateLegacyLocations extends Migration
         //
         Schema::table('users', function (Blueprint $table) {
             //
-            $table->string('locale', 5)->nullable()->default(config('app.fallback_locale'))->change();
+            $table->string('locale', 10)->nullable()->default('en-US')->change();
         });
     }
 

--- a/database/migrations/2024_03_18_221612_update_legacy_locations.php
+++ b/database/migrations/2024_03_18_221612_update_legacy_locations.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateLegacyLocations extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+        Schema::table('users', function (Blueprint $table) {
+            //
+            $table->string('locale', 5)->nullable()->default(config('app.fallback_locale'))->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+        Schema::table('users', function (Blueprint $table) {
+            //
+            $table->string('locale', 10)->nullable()->default(config('app.locale'))->change();
+        });
+    }
+}


### PR DESCRIPTION
# Description
The default value for a locale coule be set to 'en'. This changes that default to be 'en-US' which is in line with the current standard.

Fixes # (issue)
SC-25079

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
created and ran migration, using tableplus to confirm the new default value of 'en-US' for the locale column

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
