### PR TITLE
Fixed Bulk delete locations bug

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -235,7 +235,13 @@ class LocationsController extends Controller
     public function destroy($id)
     {
         $this->authorize('delete', Location::class);
-        $location = Location::findOrFail($id);
+        $location = Location::withCount('assignedAssets as assigned_assets_count')
+            ->withCount('assets as assets_count')
+            ->withCount('rtd_assets as rtd_assets_count')
+            ->withCount('children as children_count')
+            ->withCount('users as users_count')
+            ->findOrFail($id);
+
         if (! $location->isDeletable()) {
             return response()
                     ->json(Helper::formatStandardApiResponse('error', null, trans('admin/companies/message.assoc_users')));

--- a/app/Http/Controllers/LocationsController.php
+++ b/app/Http/Controllers/LocationsController.php
@@ -320,7 +320,12 @@ class LocationsController extends Controller
         $locations_raw_array = $request->input('ids');
 
         if ((is_array($locations_raw_array)) && (count($locations_raw_array) > 0)) {
-            $locations = Location::whereIn('id', $locations_raw_array)->get();
+            $locations = Location::whereIn('id', $locations_raw_array)
+                ->withCount('assignedAssets as assigned_assets_count')
+                ->withCount('assets as assets_count')
+                ->withCount('rtd_assets as rtd_assets_count')
+                ->withCount('children as children_count')
+                ->withCount('users as users_count')->get();
 
             $success_count = 0;
             $error_count = 0;

--- a/app/Http/Controllers/LocationsController.php
+++ b/app/Http/Controllers/LocationsController.php
@@ -351,7 +351,7 @@ class LocationsController extends Controller
             if ($error_count > 0) {
                 return redirect()
                     ->route('locations.index')
-                    ->with('warning', trans('general.bulk.partial_success',
+                    ->with('warning', trans('general.bulk.partial',
                         ['success' => $success_count, 'error' => $error_count, 'object_type' => trans('general.locations')]
                     ));
                 }

--- a/app/Http/Controllers/LocationsController.php
+++ b/app/Http/Controllers/LocationsController.php
@@ -351,7 +351,7 @@ class LocationsController extends Controller
             if ($error_count > 0) {
                 return redirect()
                     ->route('locations.index')
-                    ->with('warning', trans('general.bulk.partial',
+                    ->with('warning', trans('general.bulk.delete.partial',
                         ['success' => $success_count, 'error' => $error_count, 'object_type' => trans('general.locations')]
                     ));
                 }

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -106,11 +106,12 @@ class Location extends SnipeModel
      */
     public function isDeletable()
     {
+
         return Gate::allows('delete', $this)
-                && ($this->assets_count === 0)
-                && ($this->assigned_assets_count === 0)
-                && ($this->children_count === 0)
-                && ($this->users_count === 0);
+                && ($this->assets_count == 0)
+                && ($this->assigned_assets_count == 0)
+                && ($this->children_count == 0)
+                && ($this->users_count == 0);
     }
 
     /**

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -108,10 +108,10 @@ class Location extends SnipeModel
     {
 
         return Gate::allows('delete', $this)
-                && ($this->assets_count == 0)
-                && ($this->assigned_assets_count == 0)
-                && ($this->children_count == 0)
-                && ($this->users_count == 0);
+                && ($this->assets_count === 0)
+                && ($this->assigned_assets_count === 0)
+                && ($this->children_count === 0)
+                && ($this->users_count === 0);
     }
 
     /**


### PR DESCRIPTION
# Description

Fixes Bulk Delete Locations. the `isDeletable()` was coming back false, even though there were no assets, users or anything assigned to a location. The queries were changed recently and there were a couple more places that needed to be adjusted as well, the API Locations `destroy()` and the Locations `postBulkDeleteStore()` method
Also fixes a mis-targeted translation.
[sc-25100]
Fixes #14428

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
