### PR TITLE
Added 2FA reset log entry

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -663,6 +663,16 @@ class UsersController extends Controller
                 $user->two_factor_enrolled = 0;
                 $user->save();
 
+                // Log the reset
+                $logaction = new Actionlog();
+                $logaction->target_type = User::class;
+                $logaction->target_id = $user->id;
+                $logaction->item_type = User::class;
+                $logaction->item_id = $user->id;
+                $logaction->created_at = date('Y-m-d H:i:s');
+                $logaction->user_id = Auth::user()->id;
+                $logaction->logaction('2FA reset');
+
                 return response()->json(['message' => trans('admin/settings/general.two_factor_reset_success')], 200);
             } catch (\Exception $e) {
                 return response()->json(['message' => trans('admin/settings/general.two_factor_reset_error')], 500);

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -661,7 +661,7 @@ class UsersController extends Controller
                 $user = User::find($request->get('id'));
                 $user->two_factor_secret = null;
                 $user->two_factor_enrolled = 0;
-                $user->save();
+                $user->saveQuietly();
 
                 // Log the reset
                 $logaction = new Actionlog();

--- a/app/Presenters/ActionlogPresenter.php
+++ b/app/Presenters/ActionlogPresenter.php
@@ -38,9 +38,13 @@ class ActionlogPresenter extends Presenter
 
     public function icon()
     {
-        
+
         // User related icons
         if ($this->itemType() == 'user') {
+
+            if ($this->actionType()=='2fa reset') {
+                return 'fa-solid fa-mobile-screen';
+            }
 
             if ($this->actionType()=='create new') {
                 return 'fa-solid fa-user-plus';
@@ -61,6 +65,7 @@ class ActionlogPresenter extends Presenter
             if ($this->actionType()=='update') {
                 return 'fa-solid fa-user-pen';
             }
+
              return 'fa-solid fa-user';
         }
 

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -261,7 +261,7 @@ return [
     'two_factor_enrollment'        => 'Two-Factor Enrollment',
     'two_factor_enabled_text'        => 'Enable Two Factor',
     'two_factor_reset'        => 'Reset Two-Factor Secret',
-    'two_factor_reset_help'        => 'This will force the user to enroll their device with Google Authenticator again. This can be useful if their currently enrolled device is lost or stolen. ',
+    'two_factor_reset_help'        => 'This will force the user to enroll their device with their authenticator app again. This can be useful if their currently enrolled device is lost or stolen. ',
     'two_factor_reset_success'          => 'Two factor device successfully reset',
     'two_factor_reset_error'          => 'Two factor device reset failed',
     'two_factor_enabled_warning'        => 'Enabling two-factor if it is not currently enabled will immediately force you to authenticate with a Google Auth enrolled device. You will have the ability to enroll your device if one is not currently enrolled.',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    '2FA_reset'             => '2FA reset',
     'accessories'			=> 'Accessories',
     'activated'			    => 'Activated',
     'accepted_date'         => 'Date Accepted',

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -702,7 +702,7 @@ $(document).ready(function() {
         $("#two_factor_resetrow").removeClass('success');
         $("#two_factor_resetrow").removeClass('danger');
         $("#two_factor_resetstatus").html('');
-        $("#two_factor_reseticon").html('<i class="fas fa-spinner spin"></i>');
+        $("#two_factor_reseticon").html('<i class="fas fa-spinner spin"></i> ');
         $.ajax({
             url: '{{ route('api.users.two_factor_reset', ['id'=> $user->id]) }}',
             type: 'POST',
@@ -715,13 +715,12 @@ $(document).ready(function() {
 
             success: function (data) {
                 $("#two_factor_reseticon").html('');
-                $("#two_factor_resetstatus").html('<i class="fas fa-check text-success"></i>' + data.message);
+                $("#two_factor_resetstatus").html('<span class="text-success"><i class="fas fa-check"></i> ' + data.message + '</span>');
             },
 
             error: function (data) {
                 $("#two_factor_reseticon").html('');
-                $("#two_factor_reseticon").html('<i class="fas fa-exclamation-triangle text-danger"></i>');
-                $('#two_factor_resetstatus').text(data.message);
+                $("#two_factor_resetstatus").html('<span class="text-danger"><i class="fas fa-exclamation-triangle text-danger"></i> ' + data.message + '</span>');
             }
 
 

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -499,18 +499,21 @@
                                   </div>
                               @endif
 
-                              <!-- Reset Two Factor -->
-                              <div class="form-group">
-                                  <div class="col-md-8 col-md-offset-3 two_factor_resetrow">
-                                      <a class="btn btn-default btn-sm pull-left" id="two_factor_reset" style="margin-right: 10px;"> {{ trans('admin/settings/general.two_factor_reset') }}</a>
-                                      <span id="two_factor_reseticon"></span>
-                                      <span id="two_factor_resetresult"></span>
-                                      <span id="two_factor_resetstatus"></span>
+                              @if ((Auth::user()->isSuperUser()) && ($user->two_factor_active_and_enrolled()) && ($snipeSettings->two_factor_enabled!='0') && ($snipeSettings->two_factor_enabled!=''))
+                                  <!-- Reset Two Factor -->
+                                  <div class="form-group">
+                                      <div class="col-md-8 col-md-offset-3 two_factor_resetrow">
+                                          <a class="btn btn-default btn-sm pull-left" id="two_factor_reset" style="margin-right: 10px;"> {{ trans('admin/settings/general.two_factor_reset') }}</a>
+                                          <span id="two_factor_reseticon"></span>
+                                          <span id="two_factor_resetresult"></span>
+                                          <span id="two_factor_resetstatus"></span>
+                                      </div>
+                                      <div class="col-md-8 col-md-offset-3 two_factor_resetrow">
+                                          <p class="help-block">{{ trans('admin/settings/general.two_factor_reset_help') }}</p>
+                                      </div>
                                   </div>
-                                  <div class="col-md-8 col-md-offset-3 two_factor_resetrow">
-                                      <p class="help-block">{{ trans('admin/settings/general.two_factor_reset_help') }}</p>
-                                  </div>
-                              </div>
+                              @endif
+
                           @endif
 
                           <!-- Groups -->

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -597,7 +597,7 @@
                             </div>
                           </div>
                           
-                          @if ((Auth::user()->isSuperUser()) && ($snipeSettings->two_factor_enabled!='0') && ($snipeSettings->two_factor_enabled!=''))
+                          @if ((Auth::user()->isSuperUser()) && ($user->two_factor_active_and_enrolled()) && ($snipeSettings->two_factor_enabled!='0') && ($snipeSettings->two_factor_enabled!=''))
                           
                             <!-- 2FA reset -->
                             <div class="row">


### PR DESCRIPTION
This logs a 2FA reset request to the action log. I don't think this needs to be in the admin logs, since no sensitive data is conveyed.

It also handles an issue where the reset button was being displayed even when the user didn't have 2FA set up.

https://github.com/snipe/snipe-it/assets/197404/305f7330-4f53-4edf-b34c-2685a14d5f75


### Activity Report
<img width="1721" alt="Screenshot 2024-03-20 at 11 58 03 PM" src="https://github.com/snipe/snipe-it/assets/197404/d4e581dc-b9a4-42d1-a859-f06847550b23">
