### PR TITLE
Added validation for last_audit_date and next_audit_date

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -613,7 +613,7 @@ class AssetsController extends Controller
                 $asset->image = $asset->getImageUrl();
             }
 
-            return response()->json(Helper::formatStandardApiResponse('success', $asset, trans('admin/hardware/message.create.success')));
+            return response()->json(Helper::formatStandardApiResponse('success', (new AssetsTransformer)->transformAsset($asset), trans('admin/hardware/message.create.success')));
         }
 
         return response()->json(Helper::formatStandardApiResponse('error', null, $asset->getErrors()), 200);
@@ -692,7 +692,7 @@ class AssetsController extends Controller
                     $asset->image = $asset->getImageUrl();
                 }
 
-                return response()->json(Helper::formatStandardApiResponse('success', $asset, trans('admin/hardware/message.update.success')));
+                return response()->json(Helper::formatStandardApiResponse('success', (new AssetsTransformer)->transformAsset($asset), trans('admin/hardware/message.update.success')));
             }
 
             return response()->json(Helper::formatStandardApiResponse('error', null, $asset->getErrors()), 200);

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -97,6 +97,8 @@ class Asset extends Depreciable
         'warranty_months'  => 'nullable|numeric|digits_between:0,240',
         'last_checkout'    => 'nullable|date_format:Y-m-d H:i:s',
         'expected_checkin' => 'nullable|date',
+        'last_audit_date'  => 'nullable|date_format:Y-m-d H:i:s',
+        'next_audit_date'  => 'nullable|date|date_format:Y-m-d',
         'location_id'      => 'nullable|exists:locations,id',
         'rtd_location_id'  => 'nullable|exists:locations,id',
         'purchase_date'    => 'nullable|date|date_format:Y-m-d',

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -98,7 +98,7 @@ class Asset extends Depreciable
         'last_checkout'    => 'nullable|date_format:Y-m-d H:i:s',
         'expected_checkin' => 'nullable|date',
         'last_audit_date'  => 'nullable|date_format:Y-m-d H:i:s',
-        'next_audit_date'  => 'nullable|date|date_format:Y-m-d',
+        'next_audit_date'  => 'nullable|date|after:last_audit_date',
         'location_id'      => 'nullable|exists:locations,id',
         'rtd_location_id'  => 'nullable|exists:locations,id',
         'purchase_date'    => 'nullable|date|date_format:Y-m-d',


### PR DESCRIPTION
This should fix FD-41210, where the last audit date wasn't being correctly stored on API asset creation. I'm not 100% sure we want to add this though? We don't allow you to manually override that in the asset create/edit screen, since we want you to actually perform an audit, not just make dates up, but I can see a use case for both scenarios.