### PR TITLE
Fixes `last_audit_date` not being stored via API correctly

### DIFF
--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -28,11 +28,16 @@ class StoreAssetRequest extends ImageUploadRequest
             ? Company::getIdForCurrentUser($this->company_id)
             : $this->company_id;
 
+        if ($this->input('last_audit_date')) {
+            $this->merge([
+                'last_audit_date' => Carbon::parse($this->input('last_audit_date'))->startOfDay()->format('Y-m-d H:i:s'),
+            ]);
+        }
+
         $this->merge([
             'asset_tag' => $this->asset_tag ?? Asset::autoincrement_asset(),
             'company_id' => $idForCurrentUser,
             'assigned_to' => $assigned_to ?? null,
-            'last_audit_date' => Carbon::parse($this->input('last_audit_date'))->startOfDay()->format('Y-m-d H:i:s'),
         ]);
     }
 

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use App\Models\Asset;
 use App\Models\Company;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Gate;
 
 class StoreAssetRequest extends ImageUploadRequest
@@ -31,6 +32,7 @@ class StoreAssetRequest extends ImageUploadRequest
             'asset_tag' => $this->asset_tag ?? Asset::autoincrement_asset(),
             'company_id' => $idForCurrentUser,
             'assigned_to' => $assigned_to ?? null,
+            'last_audit_date' => Carbon::parse($this->input('last_audit_date'))->startOfDay()->format('Y-m-d H:i:s'),
         ]);
     }
 

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -97,6 +97,22 @@ class AssetStoreTest extends TestCase
         $this->assertEquals('00:00:00', $asset->last_audit_date->format('H:i:s'));
     }
 
+    public function testLastAuditDateCanBeNull()
+    {
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->postJson(route('api.assets.store'), [
+                // 'last_audit_date' => '2023-09-03 12:23:45',
+                'asset_tag' => '1234',
+                'model_id' => AssetModel::factory()->create()->id,
+                'status_id' => Statuslabel::factory()->create()->id,
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $asset = Asset::find($response['payload']['id']);
+        $this->assertNull($asset->last_audit_date);
+    }
+
     public function testArchivedDepreciateAndPhysicalCanBeNull()
     {
         $model = AssetModel::factory()->ipadModel()->create();

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -65,8 +65,7 @@ class AssetStoreTest extends TestCase
         $this->assertEquals('random_string', $asset->asset_tag);
         $this->assertEquals($userAssigned->id, $asset->assigned_to);
         $this->assertTrue($asset->company->is($company));
-        // I don't see this on the GUI side either, but it's in the docs so I'm guessing that's a mistake? It wasn't in the controller.
-        // $this->assertEquals('2023-09-03', $asset->last_audit_date);
+        $this->assertEquals('2023-09-03 00:00:00', $asset->last_audit_date->format('Y-m-d H:i:s'));
         $this->assertTrue($asset->location->is($location));
         $this->assertTrue($asset->model->is($model));
         $this->assertEquals('A New Asset', $asset->name);
@@ -80,6 +79,22 @@ class AssetStoreTest extends TestCase
         $this->assertTrue($asset->assetstatus->is($status));
         $this->assertTrue($asset->supplier->is($supplier));
         $this->assertEquals(10, $asset->warranty_months);
+    }
+
+    public function testSetsLastAuditDateToMidnightOfProvidedDate()
+    {
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->postJson(route('api.assets.store'), [
+                'last_audit_date' => '2023-09-03 12:23:45',
+                'asset_tag' => '1234',
+                'model_id' => AssetModel::factory()->create()->id,
+                'status_id' => Statuslabel::factory()->create()->id,
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $asset = Asset::find($response['payload']['id']);
+        $this->assertEquals('00:00:00', $asset->last_audit_date->format('H:i:s'));
     }
 
     public function testArchivedDepreciateAndPhysicalCanBeNull()


### PR DESCRIPTION
# Description

This PR updates the `StoreAssetRequest` to put `last_audit_date` in a state that is valid for saving. [The docs](https://snipe-it.readme.io/reference/hardware-create) say that `last_audit_date` can be passed as a `date` but under the hood it needs to be stored as a `datetime` (#14472 introduced that validation).

If `last_audit_date` is provided, this PR uses Carbon to parse it and format it with a timestamp (always `00:00:00` even if the user provided a full `datetime` since that is the behavior we had previously) so it is savable.


Fixes the failing test that was introduced in #14472

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)