### PR TITLE
Handle badly formatted `last_audit_date` in `StoreAssetRequest`

### DIFF
--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -29,19 +29,7 @@ class StoreAssetRequest extends ImageUploadRequest
             ? Company::getIdForCurrentUser($this->company_id)
             : $this->company_id;
 
-        if ($this->input('last_audit_date')) {
-            try {
-                $lastAuditDate = Carbon::parse($this->input('last_audit_date'));
-
-                $this->merge([
-                    'last_audit_date' => $lastAuditDate->startOfDay()->format('Y-m-d H:i:s'),
-                ]);
-            } catch (InvalidFormatException $e) {
-                // we don't need to do anything here...
-                // we'll keep the provided date in an
-                // invalid format so validation picks it up later
-            }
-        }
+        $this->formatLastAuditDate();
 
         $this->merge([
             'asset_tag' => $this->asset_tag ?? Asset::autoincrement_asset(),
@@ -63,5 +51,22 @@ class StoreAssetRequest extends ImageUploadRequest
         );
 
         return $rules;
+    }
+
+    private function formatLastAuditDate(): void
+    {
+        if ($this->input('last_audit_date')) {
+            try {
+                $lastAuditDate = Carbon::parse($this->input('last_audit_date'));
+
+                $this->merge([
+                    'last_audit_date' => $lastAuditDate->startOfDay()->format('Y-m-d H:i:s'),
+                ]);
+            } catch (InvalidFormatException $e) {
+                // we don't need to do anything here...
+                // we'll keep the provided date in an
+                // invalid format so validation picks it up later
+            }
+        }
     }
 }

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use App\Models\Asset;
 use App\Models\Company;
 use Carbon\Carbon;
+use Carbon\Exceptions\InvalidFormatException;
 use Illuminate\Support\Facades\Gate;
 
 class StoreAssetRequest extends ImageUploadRequest
@@ -29,9 +30,15 @@ class StoreAssetRequest extends ImageUploadRequest
             : $this->company_id;
 
         if ($this->input('last_audit_date')) {
-            $this->merge([
-                'last_audit_date' => Carbon::parse($this->input('last_audit_date'))->startOfDay()->format('Y-m-d H:i:s'),
-            ]);
+            try {
+                $lastAuditDate = Carbon::parse($this->input('last_audit_date'));
+
+                $this->merge([
+                    'last_audit_date' => $lastAuditDate->startOfDay()->format('Y-m-d H:i:s'),
+                ]);
+            } catch (InvalidFormatException $e) {
+                // we don't need to do anything here...
+            }
         }
 
         $this->merge([

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -29,7 +29,7 @@ class StoreAssetRequest extends ImageUploadRequest
             ? Company::getIdForCurrentUser($this->company_id)
             : $this->company_id;
 
-        $this->formatLastAuditDate();
+        $this->parseLastAuditDate();
 
         $this->merge([
             'asset_tag' => $this->asset_tag ?? Asset::autoincrement_asset(),
@@ -53,7 +53,7 @@ class StoreAssetRequest extends ImageUploadRequest
         return $rules;
     }
 
-    private function formatLastAuditDate(): void
+    private function parseLastAuditDate(): void
     {
         if ($this->input('last_audit_date')) {
             try {

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -38,6 +38,8 @@ class StoreAssetRequest extends ImageUploadRequest
                 ]);
             } catch (InvalidFormatException $e) {
                 // we don't need to do anything here...
+                // we'll keep the provided date in an
+                // invalid format so validation picks it up later
             }
         }
 

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -113,6 +113,20 @@ class AssetStoreTest extends TestCase
         $this->assertNull($asset->last_audit_date);
     }
 
+    public function testNonDateUsedForLastAuditDateReturnsValidationError()
+    {
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->postJson(route('api.assets.store'), [
+                'last_audit_date' => 'this-is-not-valid',
+                'asset_tag' => '1234',
+                'model_id' => AssetModel::factory()->create()->id,
+                'status_id' => Statuslabel::factory()->create()->id,
+            ])
+            ->assertStatusMessageIs('error');
+
+        $this->assertNotNull($response->json('messages.last_audit_date'));
+    }
+
     public function testArchivedDepreciateAndPhysicalCanBeNull()
     {
         $model = AssetModel::factory()->ipadModel()->create();


### PR DESCRIPTION
# Description

This PR follows up #14486 and handles users providing an non-dates for `last_audit_date`. The issue is Carbon will blow up trying to parse that field so I wrapped the parsing in a try/catch and if the value is not parsable I leave it alone so it can be picked up by the request's validation (the changes being made are in `prepareForValidation()`).

Huge thanks to @spencerrlongg for pointing this out.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)