### PR TITLE
Fixed #14482 - bad method call model restore from view

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -904,26 +904,17 @@
                                     @endcan
 
                                     @can('delete', $asset)
-                                        @if ($asset->deleted_at=='')
-                                            <div class="col-md-12" style="padding-top: 30px; padding-bottom: 30px;">
-                                                <button class="btn btn-block btn-danger delete-asset" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete', ['item' => $asset->asset_tag]) }}" data-target="#dataConfirmModal">{{ trans('general.delete') }} </button>
+                                        <div class="col-md-12" style="padding-top: 30px; padding-bottom: 30px;">
+                                            @if ($asset->deleted_at=='')
+                                                <button class="btn btn-sm btn-block btn-danger delete-asset" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $asset->asset_tag]) }}" data-target="#dataConfirmModal">{{ trans('general.delete') }} </button>
                                                 <span class="sr-only">{{ trans('general.delete') }}</span>
-                                            </div>
-                                        @endif
+                                            @else
+                                                <form method="POST" action="{{ route('restore/hardware', ['assetId' => $asset->id]) }}">
+                                                    @csrf
+                                                    <button class="btn btn-sm btn-warning col-md-12">{{ trans('general.restore') }}</button>
+                                                </form>
+                                           @endif
                                     @endcan
-
-                                @if ($asset->deleted_at!='')
-                                    <div class="text-center col-md-12" style="padding-top: 30px; padding-bottom: 30px;">
-                                        <form method="POST" action="{{ route('restore/hardware', ['assetId' => $asset->id]) }}">
-                                        @csrf 
-                                        <button class="btn btn-danger col-md-12">{{ trans('general.restore') }}</button>
-                                        </form>
-                                    </div>
-                                @endif
-
-                                @if  ($snipeSettings->qr_code=='1')
-                                    <img src="{{ config('app.url') }}/hardware/{{ $asset->id }}/qr_code" class="img-thumbnail pull-right" style="height: 100px; width: 100px; margin-right: 10px;" alt="QR code for {{ $asset->getDisplayNameAttribute() }}">
-                                @endif
 
                                 @if (($asset->assignedTo) && ($asset->deleted_at==''))
                                     <div style="text-align: left">
@@ -982,6 +973,13 @@
                                     </div>
 
                                 @endif
+
+                                @if  ($snipeSettings->qr_code=='1')
+                                    <div class="col-md-12" style="padding-top: 15px;">
+                                        <img src="{{ config('app.url') }}/hardware/{{ $asset->id }}/qr_code" class="img-thumbnail pull-right" style="height: 100px; width: 100px; margin-right: 10px;" alt="QR code for {{ $asset->getDisplayNameAttribute() }}">
+                                    </div>
+                                @endif
+
                             </div> <!-- div.col-md-4 -->
                         </div><!-- /row -->
                     </div><!-- /.tab-pane asset details -->

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -236,6 +236,12 @@
                         </li>
                     @endif
 
+                    @if ($model->created_at)
+                        <li>{{ trans('general.created_at') }}:
+                            {{ Helper::getFormattedDateObject($model->created_at, 'datetime', false) }}
+                        </li>
+                    @endif
+
                     @if ($model->min_amt)
                         <li>{{ trans('general.min_amt') }}:
                            {{$model->min_amt }}
@@ -313,11 +319,6 @@
                         </li>
                     @endif
 
-
-
-                    @if  ($model->deleted_at!='')
-                        <li><br /><a href="{{ route('models.restore.store', $model->id) }}" class="btn-flat large info ">{{ trans('admin/models/general.restore') }}</a></li>
-                    @endif
                 </ul>
 
                 @if ($model->note)
@@ -337,22 +338,32 @@
 
             @can('create', \App\Models\AssetModel::class)
             <div class="col-md-12" style="padding-bottom: 5px;">
-                <a href="{{ route('models.clone.create', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('admin/models/table.clone') }}</a>
+                <a href="{{ route('models.clone.create', $model->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('admin/models/table.clone') }}</a>
             </div>
             @endcan
 
             @can('delete', \App\Models\AssetModel::class)
                 @if ($model->assets_count > 0)
-
                     <div class="col-md-12" style="padding-bottom: 5px;">
-                        <button class="btn btn-block btn-sm btn-danger hidden-print disabled" data-tooltip="true"  data-placement="top" data-title="{{ trans('general.cannot_be_deleted') }}">{{ trans('general.delete') }}</button>
+                        <button class="btn btn-block btn-sm btn-primary hidden-print disabled" data-tooltip="true"  data-placement="top" data-title="{{ trans('general.cannot_be_deleted') }}">{{ trans('general.delete') }}</button>
                     </div>
                 @else
-                    <div class="col-md-12" style="padding-bottom: 10px;">
-                        <button class="btn btn-block btn-danger delete-asset" data-toggle="modal" title="{{ trans('general.delete_what', ['item'=> trans('general.asset_model')]) }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $model->name]) }}" data-target="#dataConfirmModal" data-tooltip="true"  data-placement="top" data-title="{{ trans('general.delete_what', ['item'=> trans('general.asset_model')]) }}">{{ trans('general.delete') }} </button>
-                        <span class="sr-only">{{ trans('general.delete') }}</span>
-                    </div>
+
                 @endif
+
+
+               <div class="text-center col-md-12" style="padding-top: 30px; padding-bottom: 30px;">
+                @if  ($model->deleted_at!='')
+                    <form method="POST" action="{{ route('models.restore.store', $model->id) }}">
+                        @csrf
+                        <button style="width: 100%;" class="btn btn-sm btn-warning hidden-print">{{ trans('button.restore') }}</button>
+                    </form>
+                @else
+                    <button class="btn btn-block btn-sm btn-danger delete-asset" data-toggle="modal" title="{{ trans('general.delete_what', ['item'=> trans('general.asset_model')]) }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $model->name]) }}" data-target="#dataConfirmModal" data-tooltip="true"  data-placement="top" data-title="{{ trans('general.delete_what', ['item'=> trans('general.asset_model')]) }}">{{ trans('general.delete') }} </button>
+                    <span class="sr-only">{{ trans('general.delete') }}</span>
+                @endif
+               </div>
+
            @endcan
         </div>
 </div> <!-- /.row -->


### PR DESCRIPTION
In fixing this issue, I also noticed that we were using inconsistent button styles between users, hardware, and models for the delete/clone/restore. This PR should fix that issue. (Still more work I want to do on styling the right column of the assets view page, but that's for another PR.

