### PR TITLE
Removed encrypted fields from label options

### DIFF
--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -28,7 +28,6 @@ class LabelsController extends Controller
      */
     public function show(string $labelName)
     {
-        $this->clearEncryptedLabelOptions();
         $labelName = str_replace('/', '\\', $labelName);
         $template = Label::find($labelName);
 
@@ -97,23 +96,4 @@ class LabelsController extends Controller
 
         return redirect()->route('home')->with('error', trans('admin/labels/message.does_not_exist'));
     }
-
-    private function clearEncryptedLabelOptions()
-    {
-
-        $customfields = CustomField::where('field_encrypted', 1)->get();
-        $selected_label_options = Setting::getSettings()->label2_fields;
-        if($selected_label_options != '') {
-        }
-        collect(explode(';', Setting::getSettings()->label2_fields))
-            ->filter()
-            ->each(function ($item) use ($customfields, $selected_label_options) {
-                if (!str_contains($item, $customfields->db_column)) {
-                    $selected_label_options .= $item;
-                }
-                DB::table('Settings')->update(['label2_fields' => $selected_label_options]);
-            });
-
-    }
-
 }

--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -14,6 +14,7 @@ use App\Models\Setting;
 use App\Models\Supplier;
 use App\Models\User;
 use App\View\Label as LabelView;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
 class LabelsController extends Controller
@@ -21,12 +22,13 @@ class LabelsController extends Controller
     /**
      * Returns the Label view with test data
      *
-     * @author Grant Le Roux <grant.leroux+snipe-it@gmail.com>
-     * @param  string  $labelName
+     * @param string $labelName
      * @return \Illuminate\Contracts\View\View
+     * @author Grant Le Roux <grant.leroux+snipe-it@gmail.com>
      */
     public function show(string $labelName)
     {
+        $this->clearEncryptedLabelOptions();
         $labelName = str_replace('/', '\\', $labelName);
         $template = Label::find($labelName);
 
@@ -95,4 +97,23 @@ class LabelsController extends Controller
 
         return redirect()->route('home')->with('error', trans('admin/labels/message.does_not_exist'));
     }
+
+    private function clearEncryptedLabelOptions()
+    {
+
+        $customfields = CustomField::where('field_encrypted', 1)->get();
+        $selected_label_options = Setting::getSettings()->label2_fields;
+        if($selected_label_options != '') {
+        }
+        collect(explode(';', Setting::getSettings()->label2_fields))
+            ->filter()
+            ->each(function ($item) use ($customfields, $selected_label_options) {
+                if (!str_contains($item, $customfields->db_column)) {
+                    $selected_label_options .= $item;
+                }
+                DB::table('Settings')->update(['label2_fields' => $selected_label_options]);
+            });
+
+    }
+
 }

--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -67,7 +67,7 @@ class LabelsController extends Controller
         $exampleAsset->model->category->id = 999999;
         $exampleAsset->model->category->name = trans('admin/labels/table.example_category');
 
-        $customFieldColumns = CustomField::all()->pluck('db_column');
+        $customFieldColumns = CustomField::where('field_encrypted', '=', 0)->pluck('db_column');
 
         collect(explode(';', Setting::getSettings()->label2_fields))
             ->filter()

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -790,10 +790,9 @@ class SettingsController extends Controller
      */
     public function getLabels()
     {
-        return view('settings.labels', [
-            'setting' => Setting::getSettings(),
-            'customFields' => CustomField::all(),
-        ]);
+        return view('settings.labels')
+            ->with('setting', Setting::getSettings())
+            ->with('customFields', CustomField::where('field_encrypted', '=', 0)->get());
     }
 
     /**

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -348,7 +348,9 @@
                             </optgroup>
                             <optgroup label="Custom Fields">
                                 @foreach($customFields as $customField)
+                                    @if($customField->field_encrypted != 1)
                                     <option value="{{ $customField->db_column }}">{{ $customField->name }}</option>
+                                    @endif
                                 @endforeach
                             </optgroup>
                         </select>

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -348,9 +348,7 @@
                             </optgroup>
                             <optgroup label="Custom Fields">
                                 @foreach($customFields as $customField)
-                                    @if($customField->field_encrypted != 1)
                                     <option value="{{ $customField->db_column }}">{{ $customField->name }}</option>
-                                    @endif
                                 @endforeach
                             </optgroup>
                         </select>

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -348,6 +348,7 @@
                             </optgroup>
                             <optgroup label="Custom Fields">
                                 @foreach($customFields as $customField)
+
                                     <option value="{{ $customField->db_column }}">{{ $customField->name }}</option>
                                 @endforeach
                             </optgroup>


### PR DESCRIPTION
# Description

Encrypted fields should not be on labels. The option to select an encrypted field has been removed.
If an encrypted fields have been selected before this fix, they will appear unreadable. Leading to people replacing their label option.

Fixes #[sc-25003]

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
