### PR TITLE
Added signature to user print report for Accessories and Consumables

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -256,6 +256,7 @@
                 <th style="width: 40%;" data-sortable="true" data-switchable="false">{{ trans('general.name') }}</th>
                 <th style="width: 50%;" data-sortable="true">{{ trans('general.category') }}</th>
                 <th style="width: 10%;" data-sortable="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
+                <th style="width: 10%;" data-sortable="true">{{ trans('general.signature') }}</th>
             </tr>
             </thead>
             @php
@@ -274,6 +275,9 @@
                         <td>{{ ($accessory->manufacturer) ? $accessory->manufacturer->name : '' }} {{ $accessory->name }} {{ $accessory->model_number }}</td>
                         <td>{{ $accessory->category->name }}</td>
                         <td>{{ $accessory->pivot->created_at }}</td>
+                        <td><img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $accessory->assetlog->first()->accept_signature }}"></td>
+
+
                     </tr>
                     @php
                         $acounter++

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -275,9 +275,9 @@
                         <td>{{ ($accessory->manufacturer) ? $accessory->manufacturer->name : '' }} {{ $accessory->name }} {{ $accessory->model_number }}</td>
                         <td>{{ $accessory->category->name }}</td>
                         <td>{{ $accessory->pivot->created_at }}</td>
+                        @if (($accessory->assetlog->first()) && ($accessory->assetlog->first()->accept_signature!=''))
                         <td><img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $accessory->assetlog->first()->accept_signature }}"></td>
-
-
+                        @endif
                     </tr>
                     @php
                         $acounter++

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -275,9 +275,12 @@
                         <td>{{ ($accessory->manufacturer) ? $accessory->manufacturer->name : '' }} {{ $accessory->name }} {{ $accessory->model_number }}</td>
                         <td>{{ $accessory->category->name }}</td>
                         <td>{{ $accessory->pivot->created_at }}</td>
-                        @if (($accessory->assetlog->first()) && ($accessory->assetlog->first()->accept_signature!=''))
-                        <td><img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $accessory->assetlog->first()->accept_signature }}"></td>
-                        @endif
+
+                        <td>
+                            @if (($accessory->assetlog->first()) && ($accessory->assetlog->first()->accept_signature!=''))
+                            <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $accessory->assetlog->first()->accept_signature }}">
+                            @endif
+                        </td>
                     </tr>
                     @php
                         $acounter++

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -315,6 +315,8 @@
                 <th style="width: 40%;" data-sortable="true" data-switchable="false">{{ trans('general.name') }}</th>
                 <th style="width: 50%;" data-sortable="true">{{ trans('general.category') }}</th>
                 <th style="width: 10%;" data-sortable="true">{{ trans('admin/hardware/table.checkout_date') }}</th>
+                <th style="width: 10%;" data-sortable="true">{{ trans('general.signature') }}</th>
+
             </tr>
             </thead>
             @php
@@ -336,6 +338,11 @@
                             </td>
                             <td>{{ ($consumable->category) ? $consumable->category->name : ' invalid/deleted category' }} </td>
                             <td>{{  $consumable->pivot->created_at }}</td>
+                            <td>
+                                @if (($consumable->assetlog->first()) && ($consumable->assetlog->first()->accept_signature!=''))
+                                    <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $consumable->assetlog->first()->accept_signature }}">
+                                @endif
+                            </td>
                     </tr>
                     @php
                         $ccounter++


### PR DESCRIPTION
# Description
Added the signature for accessory and consumable acceptances to users' print all report.
<img width="2537" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/377b0ec1-2cd2-47bf-a2c1-e9c87b302f97">
Fixes # (issue)
[sc-25118]
## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
