### PR TITLE
Added validation around `pwd_secure_complexity`

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -20,6 +20,7 @@ use DB;
 use enshrined\svgSanitize\Sanitizer;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
 use Image;
 use Input;
 use Redirect;
@@ -499,6 +500,19 @@ class SettingsController extends Controller
      */
     public function postSecurity(Request $request)
     {
+        $this->validate($request, [
+            'pwd_secure_complexity' => 'array',
+            'pwd_secure_complexity.*' => [
+                Rule::in([
+                    'disallow_same_pwd_as_user_fields',
+                    'letters',
+                    'numbers',
+                    'symbols',
+                    'case_diff',
+                ])
+            ]
+        ]);
+
         if (is_null($setting = Setting::getSettings())) {
             return redirect()->to('admin')->with('error', trans('admin/settings/message.update.error'));
         }

--- a/resources/lang/en-US/validation.php
+++ b/resources/lang/en-US/validation.php
@@ -151,4 +151,10 @@ return [
 
     'attributes' => [],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Generic Validation Messages
+    |--------------------------------------------------------------------------
+    */
+    'invalid_value_in_field' => 'Invalid value included in this field',
 ];

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -106,7 +106,7 @@
                                 </label>
 
                                 @if ($errors->has('pwd_secure_complexity.*'))
-                                    <span class="alert-msg">Invalid value included in this field</span>
+                                    <span class="alert-msg">{{ trans('validation.invalid_value_in_field') }}</span>
                                 @endif
                                 <p class="help-block">
                                     {{ trans('admin/settings/general.pwd_secure_complexity_help') }}

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -74,12 +74,11 @@
 
 
                         <!-- Common Passwords -->
-                        <div class="form-group">
+                        <div class="form-group {{ $errors->has('pwd_secure_complexity.*') ? 'error' : '' }}">
                             <div class="col-md-3">
                                 {{ Form::label('pwd_secure_complexity', trans('admin/settings/general.pwd_secure_complexity')) }}
                             </div>
                             <div class="col-md-9">
-
                                 <label class="form-control">
                                     <span class="sr-only">{{ trans('admin/settings/general.pwd_secure_uncommon') }}</span>
                                     {{ Form::checkbox('pwd_secure_uncommon', '1', old('pwd_secure_uncommon', $setting->pwd_secure_uncommon),array( 'aria-label'=>'pwd_secure_uncommon')) }}
@@ -106,6 +105,9 @@
                                     {{ trans('admin/settings/general.pwd_secure_complexity_case_diff') }}
                                 </label>
 
+                                @if ($errors->has('pwd_secure_complexity.*'))
+                                    <span class="alert-msg">Invalid value included in this field</span>
+                                @endif
                                 <p class="help-block">
                                     {{ trans('admin/settings/general.pwd_secure_complexity_help') }}
                                 </p>


### PR DESCRIPTION
# Description

This PR adds a small amount of validation around the `pwd_secure_complexity` field when updating settings to ensure unexpected data is not stored.

This will only pop up if users manually change the html of the form but adds a layer of protection:
![Screenshot of error messages on settings page](https://github.com/snipe/snipe-it/assets/1141514/512b48a5-11d0-49d0-9858-10ecd898e449)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)