### PR TITLE
Added ability to filter in user's assigned assets by category ID and model ID

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -560,7 +560,26 @@ class UsersController extends Controller
     {
         $this->authorize('view', User::class);
         $this->authorize('view', Asset::class);
-        $assets = Asset::where('assigned_to', '=', $id)->where('assigned_type', '=', User::class)->with('model')->get();
+        $assets = Asset::where('assigned_to', '=', $id)->where('assigned_type', '=', User::class)->with('model');
+
+
+        // Filter on category ID
+        if ($request->filled('category_id')) {
+            $assets = $assets->InCategory($request->input('category_id'));
+        }
+
+
+        // Filter on model ID
+        if ($request->filled('model_id')) {
+
+            $model_ids = $request->input('model_id');
+            if (!is_array($model_ids)) {
+                $model_ids = array($model_ids);
+            }
+            $assets = $assets->InModelList($model_ids);
+        }
+
+        $assets = $assets->get();
 
         return (new AssetsTransformer)->transformAssets($assets, $assets->count(), $request);
     }


### PR DESCRIPTION
This adds additional filters to the user's asset API endpoint that should let the API return filtered results showing only a user's assets that match a particular category or model ID.

In going through this work, I realize we have some inconsistencies in how we reference our query scopes. Many of them are quite old, and the notion of adding scopes to search on names *in addition to* ID numbers wasn't on our radar back then. 

In v7, I hope to refactor those scope names so that they're a little clearer when the scope is looking at an ID or looking for a name search.