### PR TITLE
Fixes #14289: /reports/activity API endpoint returns too many results due to orwhere

### DIFF
--- a/app/Http/Controllers/Api/ReportsController.php
+++ b/app/Http/Controllers/Api/ReportsController.php
@@ -32,13 +32,16 @@ class ReportsController extends Controller
         }
 
         if (($request->filled('item_type')) && ($request->filled('item_id'))) {
-            $actionlogs = $actionlogs->where('item_id', '=', $request->input('item_id'))
+            $actionlogs = $actionlogs->where(function($query) use ($request)
+            {
+                $query->where('item_id', '=', $request->input('item_id'))
                 ->where('item_type', '=', 'App\\Models\\'.ucwords($request->input('item_type')))
                 ->orWhere(function($query) use ($request)
                 {
                     $query->where('target_id', '=', $request->input('item_id'))
                     ->where('target_type', '=', 'App\\Models\\'.ucwords($request->input('item_type')));
                 });
+            });
         }
 
         if ($request->filled('action_type')) {


### PR DESCRIPTION
# Description

Currently the /reports/activity API returns too many (and incorrect) results when using params item_id and item_type + some other param.  This change wraps the item_id + item_type logic in a where clause so the additional params that get appended do not merge with that logic.

Fixes #14289

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

See https://github.com/snipe/snipe-it/issues/14289

**Test Configuration**:
* PHP version: 8.1.2
* MySQL version: 8.0.36
* Webserver version: apache
* OS version: Ubuntu 22.04


# Checklist:

- [x ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
