### PR TITLE
Check that the array key exists in the label engine

### DIFF
--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -71,11 +71,13 @@ class LabelsController extends Controller
         collect(explode(';', Setting::getSettings()->label2_fields))
             ->filter()
             ->each(function ($item) use ($customFieldColumns, $exampleAsset) {
-                $pair = explode('=', $item);
-
-                if ($customFieldColumns->contains($pair[1])) {
-                    $exampleAsset->{$pair[1]} = "{{$pair[0]}}";
-                }
+               $pair = explode('=', $item);
+               
+                if (array_key_exists(1, $pair)) {
+                        if ($customFieldColumns->contains($pair[1])) {
+                            $exampleAsset->{$pair[1]} = "{{$pair[0]}}";
+                        }
+                    }
             });
 
         $settings = Setting::getSettings();


### PR DESCRIPTION
This fixes a 500 that would occur in very unusual circumstance, but we'd occasionally see it on the demo.