### PR TITLE
Downgrade alpine to 3.13.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2379,9 +2379,9 @@
             }
         },
         "alpinejs": {
-            "version": "3.13.7",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.13.7.tgz",
-            "integrity": "sha512-rcTyjTANbsePq1hb7eSekt3qjI94HLGeO6JaRjCssCVbIIc+qBrc7pO5S/+2JB6oojIibjM6FA+xRI3zhGPZIg==",
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.13.5.tgz",
+            "integrity": "sha512-1d2XeNGN+Zn7j4mUAKXtAgdc4/rLeadyTMWeJGXF5DzwawPBxwTiBhFFm6w/Ei8eJxUZeyNWWSD9zknfdz1kEw==",
             "requires": {
                 "@vue/reactivity": "~3.1.1"
             }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "acorn-import-assertions": "^1.9.0",
         "admin-lte": "^2.4.18",
         "ajv": "^6.12.6",
-        "alpinejs": "^3.13.6",
+        "alpinejs": "3.13.5",
         "blueimp-file-upload": "^9.34.0",
         "bootstrap": "^3.4.1",
         "bootstrap-colorpicker": "^2.5.3",

--- a/public/js/dist/all-defer.js
+++ b/public/js/dist/all-defer.js
@@ -211,8 +211,8 @@
       });
     });
   }
-  function destroyTree(root, walker = walk) {
-    walker(root, (el) => {
+  function destroyTree(root) {
+    walk(root, (el) => {
       cleanupAttributes(el);
       cleanupElement(el);
     });
@@ -413,7 +413,7 @@
       if (name == Symbol.unscopables)
         return false;
       return objects.some(
-        (obj) => Object.prototype.hasOwnProperty.call(obj, name) || Reflect.has(obj, name)
+        (obj) => Object.prototype.hasOwnProperty.call(obj, name)
       );
     },
     get({ objects }, name, thisProxy) {
@@ -421,7 +421,7 @@
         return collapseProxies;
       return Reflect.get(
         objects.find(
-          (obj) => Reflect.has(obj, name)
+          (obj) => Object.prototype.hasOwnProperty.call(obj, name)
         ) || {},
         name,
         thisProxy
@@ -451,8 +451,6 @@
     let recurse = (obj, basePath = "") => {
       Object.entries(Object.getOwnPropertyDescriptors(obj)).forEach(([key, { value, enumerable }]) => {
         if (enumerable === false || value === void 0)
-          return;
-        if (typeof value === "object" && value !== null && value.__v_skip)
           return;
         let path = basePath === "" ? key : `${basePath}.${key}`;
         if (typeof value === "object" && value !== null && value._x_interceptor) {
@@ -1621,7 +1619,7 @@ ${expression ? 'Expression: "' + expression + '"\n\n' : ""}`, el);
     get raw() {
       return raw;
     },
-    version: "3.13.7",
+    version: "3.13.5",
     flushAndStopDeferringMutations,
     dontAutoEvaluateFunctions,
     disableEffectScheduling,
@@ -2425,10 +2423,12 @@ ${expression ? 'Expression: "' + expression + '"\n\n' : ""}`, el);
   });
   function getArrayOfRefObject(el) {
     let refObjects = [];
-    findClosest(el, (i) => {
-      if (i._x_refs)
-        refObjects.push(i._x_refs);
-    });
+    let currentEl = el;
+    while (currentEl) {
+      if (currentEl._x_refs)
+        refObjects.push(currentEl._x_refs);
+      currentEl = currentEl.parentNode;
+    }
     return refObjects;
   }
 
@@ -3088,21 +3088,13 @@ ${expression ? 'Expression: "' + expression + '"\n\n' : ""}`, el);
       if (isObject2(items)) {
         items = Object.entries(items).map(([key, value]) => {
           let scope2 = getIterationScopeVariables(iteratorNames, value, key, items);
-          evaluateKey((value2) => {
-            if (keys.includes(value2))
-              warn("Duplicate key on x-for", el);
-            keys.push(value2);
-          }, { scope: { index: key, ...scope2 } });
+          evaluateKey((value2) => keys.push(value2), { scope: { index: key, ...scope2 } });
           scopes.push(scope2);
         });
       } else {
         for (let i = 0; i < items.length; i++) {
           let scope2 = getIterationScopeVariables(iteratorNames, items[i], i, items);
-          evaluateKey((value) => {
-            if (keys.includes(value))
-              warn("Duplicate key on x-for", el);
-            keys.push(value);
-          }, { scope: { index: i, ...scope2 } });
+          evaluateKey((value) => keys.push(value), { scope: { index: i, ...scope2 } });
           scopes.push(scope2);
         }
       }
@@ -3150,7 +3142,7 @@ ${expression ? 'Expression: "' + expression + '"\n\n' : ""}`, el);
         let marker = document.createElement("div");
         mutateDom(() => {
           if (!elForSpot)
-            warn(`x-for ":key" is undefined or invalid`, templateEl, keyForSpot, lookup);
+            warn(`x-for ":key" is undefined or invalid`, templateEl);
           elForSpot.after(marker);
           elInSpot.after(elForSpot);
           elForSpot._x_currentIfEl && elForSpot.after(elForSpot._x_currentIfEl);
@@ -3177,7 +3169,7 @@ ${expression ? 'Expression: "' + expression + '"\n\n' : ""}`, el);
         };
         mutateDom(() => {
           lastEl.after(clone2);
-          skipDuringClone(() => initTree(clone2))();
+          initTree(clone2);
         });
         if (typeof key === "object") {
           warn("x-for key cannot be an object, it must be a string or an integer", templateEl);
@@ -3261,7 +3253,7 @@ ${expression ? 'Expression: "' + expression + '"\n\n' : ""}`, el);
       addScopeToNode(clone2, {}, el);
       mutateDom(() => {
         el.after(clone2);
-        skipDuringClone(() => initTree(clone2))();
+        initTree(clone2);
       });
       el._x_currentIfEl = clone2;
       el._x_undoIf = () => {

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -33,7 +33,7 @@
     "/js/build/vendor.js": "/js/build/vendor.js?id=a2b971da417306a63385c8098acfe4af",
     "/js/dist/bootstrap-table.js": "/js/dist/bootstrap-table.js?id=857da5daffd13e0553510e5ccd410c79",
     "/js/dist/all.js": "/js/dist/all.js?id=13bdb521e0c745d7f81dae3fb110b650",
-    "/js/dist/all-defer.js": "/js/dist/all-defer.js?id=18d36546bdad8285c229008df799b343",
+    "/js/dist/all-defer.js": "/js/dist/all-defer.js?id=19ccc62a8f1ea103dede4808837384d4",
     "/css/dist/skins/skin-green.min.css": "/css/dist/skins/skin-green.min.css?id=0a82a6ae6bb4e58fe62d162c4fb50397",
     "/css/dist/skins/skin-green-dark.min.css": "/css/dist/skins/skin-green-dark.min.css?id=d419cb63a12dc175d71645c876bfc2ab",
     "/css/dist/skins/skin-black.min.css": "/css/dist/skins/skin-black.min.css?id=76482123f6c70e866d6b971ba91de7bb",


### PR DESCRIPTION
Turns out the jump from Alpine.js 3.13.5 to 3.13.6 broke the UI on the new label engine. We'll go through and try to figure out what we need to change so we can upgrade again.