### PR TITLE
Hide/Show encrypted values in hardware list

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -415,19 +415,24 @@
 
                                                     @if ($field->isFieldDecryptable($asset->{$field->db_column_name()} ))
                                                         @can('assets.view.encrypted_custom_fields')
-                                                            <span id="text-{{ $field->id }}-to-hide">********</span>
-                                                            <span class="js-copy-{{ $field->id }}" id="text-{{ $field->id }}-to-show" style="font-size: 0px;">
-                                                            @if (($field->format=='URL') && ($asset->{$field->db_column_name()}!=''))
-                                                                <a href="{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}" target="_new">{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}</a>
-                                                            @elseif (($field->format=='DATE') && ($asset->{$field->db_column_name()}!=''))
-                                                                {{ \App\Helpers\Helper::gracefulDecrypt($field, \App\Helpers\Helper::getFormattedDateObject($asset->{$field->db_column_name()}, 'date', false)) }}
-                                                            @else
-                                                                {{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}
-                                                            @endif
-                                                            </span>
-                                                            <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy-{{ $field->id }}" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
-                                                                <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
-                                                            </i>
+                                                            @php
+                                                                $fieldSize=strlen(Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()})) 
+                                                            @endphp
+                                                            @if ($fieldSize>0)
+                                                                <span id="text-{{ $field->id }}-to-hide">{{ str_repeat('*', $fieldSize) }}</span>
+                                                                <span class="js-copy-{{ $field->id }}" id="text-{{ $field->id }}-to-show" style="font-size: 0px;">
+                                                                @if (($field->format=='URL') && ($asset->{$field->db_column_name()}!=''))
+                                                                    <a href="{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}" target="_new">{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}</a>
+                                                                @elseif (($field->format=='DATE') && ($asset->{$field->db_column_name()}!=''))
+                                                                    {{ \App\Helpers\Helper::gracefulDecrypt($field, \App\Helpers\Helper::getFormattedDateObject($asset->{$field->db_column_name()}, 'date', false)) }}
+                                                                @else
+                                                                    {{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}
+                                                                @endif
+                                                                </span>
+                                                                <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy-{{ $field->id }}" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
+                                                                    <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
+                                                                </i>
+							    @endif
                                                         @else
                                                             {{ strtoupper(trans('admin/custom_fields/general.encrypted')) }}
                                                         @endcan

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1041,6 +1041,64 @@
                 });
             });
 
+            // Select encrypted custom fields to hide them in the asset list
+            $(document).ready(function() {
+                // Selector for elements with css-padlock class
+                var selector = 'td.css-padlock';
+
+                // Function to add original value to elements
+                function addValue($element) {
+                    // Get original value of the element
+                    var originalValue = $element.text().trim();
+
+                    // Show asterisks only for not empty values
+                    if (originalValue !== '') {
+                        // This is necessary to avoid loop because value is generated dynamically
+                        if (originalValue !== '' && originalValue !== asterisks) $element.attr('value', originalValue);
+
+                        // Hide the original value and show asterisks of the same length
+                        var asterisks = '*'.repeat(originalValue.length);
+                        $element.text(asterisks);
+
+                        // Add click event to show original text
+                        $element.click(function() {
+                            var $this = $(this);
+                            if ($this.text().trim() === asterisks) {
+                                $this.text($this.attr('value'));
+                            } else {
+                                $this.text(asterisks);
+                            }
+                        });
+                    }
+                }
+                // Add value to existing elements
+                $(selector).each(function() {
+                    addValue($(this));
+                });
+
+                // Function to handle mutations in the DOM because content is generated dynamically
+                var observer = new MutationObserver(function(mutations) {
+                    mutations.forEach(function(mutation) {
+                        // Check if new nodes have been inserted
+                        if (mutation.type === 'childList') {
+                            mutation.addedNodes.forEach(function(node) {
+                                if ($(node).is(selector)) {
+                                    addValue($(node));
+                                } else {
+                                    $(node).find(selector).each(function() {
+                                        addValue($(this));
+                                    });
+                                }
+                            });
+                        }
+                    });
+                });
+
+                // Configure the observer to observe changes in the DOM
+                var config = { childList: true, subtree: true };
+                observer.observe(document.body, config);
+            });
+
 
         </script>
 


### PR DESCRIPTION
# Description

In the past I added the option to show/hide encrypted custom fields in the asset page, but they are still shown in the hardware list. This pull request hide them. Clicking on the asterisks shows the decrypted value.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Loaded hardware list page and click on asterisks
- [X] Changed pages back and forth (in pagination) to check if it works

**Test Configuration**:
* PHP version: 8.0.30
* MySQL version: MariaDB 10.3.38
* Webserver version: Apache 2.4.58
* OS version: Ubuntu 20.04.6 LTS

# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
