### PR TITLE
Fixed alignment of dropdown menu for user in nav bar

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -688,6 +688,12 @@ th.css-accessory > .th-inner::before
   .sidebar-menu {
     margin-top:100px
   }
+  .navbar-custom-menu > .navbar-nav > li.dropdown.user.user-menu {
+    float:right;
+  }
+  .navbar-custom-menu > .navbar-nav > li > .dropdown-menu {
+    margin-right:-39px;
+  }
 }
 
 @media screen and (max-width: 1268px) and (min-width: 912px){


### PR DESCRIPTION
# Description
When the window was sized between 512px width and 912px the user dropdown menu did not align. This PR fixes that.
Before:
<img width="623" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/812ac3ea-7356-49da-a484-346a3d850e47">

After:
<img width="746" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/0df65219-6484-444a-bb68-bafbb27677f4">

Fixes #[sc-25188]

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
