### PR TITLE
Fixed the way thresholds are totaled

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -744,7 +744,7 @@ class Helper
                 $items_array[$all_count]['type'] = 'consumables';
                 $items_array[$all_count]['percent'] = $percent;
                 $items_array[$all_count]['remaining'] = $avail;
-                $items_array[$all_count]['min_amt'] = $consumable->min_amt;
+                $items_array[$all_count]['min_amt'] = $alert_threshold;
                 $all_count++;
             }
         }
@@ -767,7 +767,7 @@ class Helper
                 $items_array[$all_count]['type'] = 'accessories';
                 $items_array[$all_count]['percent'] = $percent;
                 $items_array[$all_count]['remaining'] = $avail;
-                $items_array[$all_count]['min_amt'] = $accessory->min_amt;
+                $items_array[$all_count]['min_amt'] = $alert_threshold;
                 $all_count++;
             }
         }
@@ -790,7 +790,7 @@ class Helper
                 $items_array[$all_count]['type'] = 'components';
                 $items_array[$all_count]['percent'] = $percent;
                 $items_array[$all_count]['remaining'] = $avail;
-                $items_array[$all_count]['min_amt'] = $component->min_amt;
+                $items_array[$all_count]['min_amt'] = $alert_threshold;
                 $all_count++;
             }
         }
@@ -816,7 +816,7 @@ class Helper
                 $items_array[$all_count]['type'] = 'models';
                 $items_array[$all_count]['percent'] = $percent;
                 $items_array[$all_count]['remaining'] = $avail;
-                $items_array[$all_count]['min_amt'] = $asset_model->min_amt;
+                $items_array[$all_count]['min_amt'] = $alert_threshold;
                 $all_count++;
             }
         }
@@ -840,7 +840,7 @@ class Helper
                 $items_array[$all_count]['type'] = 'licenses';
                 $items_array[$all_count]['percent'] = $percent;
                 $items_array[$all_count]['remaining'] = $avail;
-                $items_array[$all_count]['min_amt'] = $license->min_amt;
+                $items_array[$all_count]['min_amt'] = $alert_threshold;
                 $all_count++;
             }
 

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -716,7 +716,7 @@ class Helper
      */
     public static function checkLowInventory()
     {
-        $alert_threshold = \App\Models\Setting::getSettings()->alert_threshold;
+        $default_alert_threshold = \App\Models\Setting::getSettings()->alert_threshold;
         $consumables = Consumable::withCount('consumableAssignments as consumable_assignments_count')->whereNotNull('min_amt')->get();
         $accessories = Accessory::withCount('users as users_count')->whereNotNull('min_amt')->get();
         $components = Component::whereNotNull('min_amt')->get();
@@ -728,7 +728,11 @@ class Helper
 
         foreach ($consumables as $consumable) {
             $avail = $consumable->numRemaining();
-            if ($avail < ($consumable->min_amt) + $alert_threshold) {
+            $alert_threshold = $default_alert_threshold;
+            if($consumable->min_amt != 0){
+                $alert_threshold= $consumable->min_amt;
+            }
+            if ($avail < $alert_threshold) {
                 if ($consumable->qty > 0) {
                     $percent = number_format((($avail / $consumable->qty) * 100), 0);
                 } else {
@@ -747,7 +751,11 @@ class Helper
 
         foreach ($accessories as $accessory) {
             $avail = $accessory->qty - $accessory->users_count;
-            if ($avail < ($accessory->min_amt) + $alert_threshold) {
+            $alert_threshold = $default_alert_threshold;
+            if($accessory->min_amt != 0){
+                $alert_threshold= $accessory->min_amt;
+            }
+            if ($avail < $alert_threshold) {
                 if ($accessory->qty > 0) {
                     $percent = number_format((($avail / $accessory->qty) * 100), 0);
                 } else {
@@ -766,7 +774,11 @@ class Helper
 
         foreach ($components as $component) {
             $avail = $component->numRemaining();
-            if ($avail < ($component->min_amt) + $alert_threshold) {
+            $alert_threshold = $default_alert_threshold;
+            if($component->min_amt != 0){
+                $alert_threshold= $component->min_amt;
+            }
+            if ($avail < $alert_threshold) {
                 if ($component->qty > 0) {
                     $percent = number_format((($avail / $component->qty) * 100), 0);
                 } else {
@@ -788,8 +800,12 @@ class Helper
             $asset = new Asset();
             $total_owned = $asset->where('model_id', '=', $asset_model->id)->count();
             $avail = $asset->where('model_id', '=', $asset_model->id)->whereNull('assigned_to')->count();
+            $alert_threshold = $default_alert_threshold;
 
-            if ($avail < ($asset_model->min_amt) + $alert_threshold) {
+            if($asset_model->min_amt != 0){
+                $alert_threshold= $asset_model->min_amt;
+            }
+            if ($avail < $alert_threshold) {
                 if ($avail > 0) {
                     $percent = number_format((($avail / $total_owned) * 100), 0);
                 } else {
@@ -807,7 +823,12 @@ class Helper
 
         foreach ($licenses as $license){
             $avail = $license->remaincount();
-            if ($avail < ($license->min_amt) + $alert_threshold) {
+            $alert_threshold = $default_alert_threshold;
+
+            if($license->min_amt != 0){
+                $alert_threshold= $license->min_amt;
+            }
+            if ($avail < $alert_threshold) {
                 if ($avail > 0) {
                     $percent = number_format((($avail / $license->min_amt) * 100), 0);
                 } else {


### PR DESCRIPTION
# Description

The way thresholds were being checked didn't make sense.  If a model/consumable/component/license/accessory had a min qty assigned for notification that was being added to a default threshold from settings:
`if ($avail < ($foo->min_amt) + $alert_threshold)`
When I set a threshold of 3 on a model it was actually being set to 8, because of the 5 from the settings threshold.

This changes thresholds to follow one or the other now rather than adding one to the other.
The settings threshold has been changed to:
`$default_alert_threshold`

and for each threshold check it goes:
`$alert_threshold = $default_alert_threshold;
            if($foo->min_amt != 0){
                $alert_threshold= $foo->min_amt;
            }`

Fixes #[sc-25227]

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
