### PR TITLE
Fixed ambiguous id clause in custom report

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -696,7 +696,7 @@ class ReportsController extends Controller
                                               ->whereBetween('action_date',[$checkout_start, $checkout_end])
                                                   ->pluck('item_id');
 
-                $assets->whereIn('id',$actionlogassets);
+                $assets->whereIn('assets.id',$actionlogassets);
             }
 
             if (($request->filled('checkin_date_start'))) {


### PR DESCRIPTION
This PR fixes an issue that would be triggered if you used the checkout_date range in the custom report, since we were not clarifying what table's ids we wanted to examine. 

An example of the query before:

```php
[2024-04-04 14:26:25] local.DEBUG: select `assets`.* from `assets` where `assets`.`location_id` in (?, ?, ?, ?) and `assets`.`company_id` in (?) and `assets`.`status_id` in (?) and `id` in (?, ?, ?) and exists (select * from `status_labels` where `assets`.`status_id` = `status_labels`.`id` and `archived` = ? and `status_labels`.`deleted_at` is null) and `assets`.`deleted_at` is null
```

And then after:

```php
[2024-04-04 14:26:25] local.DEBUG: select `assets`.* from `assets` where `assets`.`location_id` in (?, ?, ?, ?) and `assets`.`company_id` in (?) and `assets`.`status_id` in (?) and `assets`.`id` in (?, ?, ?) and exists (select * from `status_labels` where `assets`.`status_id` = `status_labels`.`id` and `archived` = ? and `status_labels`.`deleted_at` is null) and `assets`.`deleted_at` is null
```

Fixes FD-41211 and RB-17967