### PR TITLE
Added audit dates to label options

### DIFF
--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -313,6 +313,8 @@
                                 <option value="order_number">{{trans('admin/hardware/form.order')}}</option>
                                 <option value="purchase_date">{{trans('admin/hardware/table.purchase_date')}}</option>
                                 <option value="assignedTo">{{trans('admin/hardware/table.assigned_to')}}</option>
+                                <option value="last_audit_date">{{trans('general.last_audit')}}</option>
+                                <option value="next_audit_date">{{trans('general.next_audit_date')}}</option>
                             </optgroup>
                             <optgroup label="Asset Model">
                                 <option value="model.name">{{trans('admin/models/table.name')}}</option>


### PR DESCRIPTION
# Description

This adds `last_audit_date` and `next_audit_date` columns as options for labels.
<img width="785" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/689d4e77-2529-4338-a810-54b23be53a21">

<img width="785" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/6da8ca56-51d5-4479-a72d-297865d66700">

Fixes #14556

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
