### PR TITLE
Fixed: Header Dropdown Menus had no hover coloring in dark themes

### DIFF
--- a/resources/assets/less/skins/skin-black-dark.less
+++ b/resources/assets/less/skins/skin-black-dark.less
@@ -375,7 +375,7 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-black-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--text-main);
+  color: #FFFFFF;
 }
 .skin-black-dark .main-header .navbar .dropdown-menu li a:hover {
   background-color: #000000;

--- a/resources/assets/less/skins/skin-black-dark.less
+++ b/resources/assets/less/skins/skin-black-dark.less
@@ -375,7 +375,10 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-black-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--header);
+  color: var(--text-main);
+}
+.skin-black-dark .main-header .navbar .dropdown-menu li a:hover {
+  background-color: #000000;
 }
 .fixed-table-body thead th .th-inner, .skin-black-dark .sidebar-menu>li.active>a, .skin-black .sidebar-menu>li:hover>a, .sidebar-toggle:hover {
   background-color: var(--header)!important;

--- a/resources/assets/less/skins/skin-blue-dark.less
+++ b/resources/assets/less/skins/skin-blue-dark.less
@@ -361,7 +361,7 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-blue-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--text-main);
+  color: #FFFFFF;
 }
 .skin-blue-dark .main-header .navbar .dropdown-menu li a:hover {
   background-color: #3c8dbc;

--- a/resources/assets/less/skins/skin-blue-dark.less
+++ b/resources/assets/less/skins/skin-blue-dark.less
@@ -361,7 +361,10 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-blue-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--header);
+  color: var(--text-main);
+}
+.skin-blue-dark .main-header .navbar .dropdown-menu li a:hover {
+  background-color: #3c8dbc;
 }
 .fixed-table-body thead th .th-inner, .skin-blue-dark .sidebar-menu>li.active>a, .skin-blue .sidebar-menu>li:hover>a, .sidebar-toggle:hover {
   background-color: var(--header)!important;

--- a/resources/assets/less/skins/skin-green-dark.less
+++ b/resources/assets/less/skins/skin-green-dark.less
@@ -348,7 +348,7 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-green-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--text-main);
+  color: #FFFFFF;
 }
 .skin-green-dark .main-header .navbar .dropdown-menu li a:hover {
   background-color: #006300;

--- a/resources/assets/less/skins/skin-green-dark.less
+++ b/resources/assets/less/skins/skin-green-dark.less
@@ -348,7 +348,10 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-green-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--link);
+  color: var(--text-main);
+}
+.skin-green-dark .main-header .navbar .dropdown-menu li a:hover {
+  background-color: #006300;
 }
 .fixed-table-body thead th .th-inner, .skin-green-dark .sidebar-menu>li.active>a, .skin-green .sidebar-menu>li:hover>a, .sidebar-toggle:hover {
   background-color: var(--header)!important;

--- a/resources/assets/less/skins/skin-orange-dark.less
+++ b/resources/assets/less/skins/skin-orange-dark.less
@@ -359,7 +359,10 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-orange-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--header);
+  color: var(--text-main);
+}
+.skin-orange-dark .main-header .navbar .dropdown-menu li a:hover {
+  background-color: #ff8c00;
 }
 .fixed-table-body thead th .th-inner, .skin-orange-dark .sidebar-menu>li.active>a, .skin-orange .sidebar-menu>li:hover>a, .sidebar-toggle:hover {
   background-color: var(--header)!important;

--- a/resources/assets/less/skins/skin-orange-dark.less
+++ b/resources/assets/less/skins/skin-orange-dark.less
@@ -359,7 +359,7 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-orange-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--text-main);
+  color: #FFFFFF;
 }
 .skin-orange-dark .main-header .navbar .dropdown-menu li a:hover {
   background-color: #ff8c00;

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -362,7 +362,10 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-purple-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--header);
+  color: var(--text-main);
+}
+.skin-purple-dark .main-header .navbar .dropdown-menu li a:hover {
+  background-color: #5f5ca8;
 }
 .fixed-table-body thead th .th-inner, .skin-purple-dark .sidebar-menu>li.active>a, .skin-purple .sidebar-menu>li:hover>a, .sidebar-toggle:hover {
   background-color: var(--header)!important;

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -362,7 +362,7 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-purple-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--text-main);
+  color: #FFFFFF;
 }
 .skin-purple-dark .main-header .navbar .dropdown-menu li a:hover {
   background-color: #5f5ca8;

--- a/resources/assets/less/skins/skin-red-dark.less
+++ b/resources/assets/less/skins/skin-red-dark.less
@@ -363,7 +363,7 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-red-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--text-main);
+  color: #FFFFFF;
 }
 .skin-red-dark .main-header .navbar .dropdown-menu li a:hover {
   background-color: #c23320;

--- a/resources/assets/less/skins/skin-red-dark.less
+++ b/resources/assets/less/skins/skin-red-dark.less
@@ -363,7 +363,10 @@ input[type=text], input[type=search] {
   color: var(--text-main);
 }
 .skin-red-dark .main-header .navbar .dropdown-menu li a {
-  color: var(--header);
+  color: var(--text-main);
+}
+.skin-red-dark .main-header .navbar .dropdown-menu li a:hover {
+  background-color: #c23320;
 }
 .fixed-table-body thead th .th-inner, .skin-red-dark .sidebar-menu>li.active>a, .skin-red .sidebar-menu>li:hover>a, .sidebar-toggle:hover {
   background-color: var(--header)!important;

--- a/resources/assets/less/skins/skin-yellow-dark.less
+++ b/resources/assets/less/skins/skin-yellow-dark.less
@@ -355,6 +355,9 @@ input[type=text], input[type=search] {
 .skin-yellow-dark .main-header .navbar .dropdown-menu li a {
   color: var(--header);
 }
+.skin-yellow-dark .main-header .navbar .dropdown-menu li a:hover {
+  background-color: #ffcc32;
+}
 tr th div.th-inner {
   color:var(--text-main);
 }

--- a/resources/assets/less/skins/skin-yellow-dark.less
+++ b/resources/assets/less/skins/skin-yellow-dark.less
@@ -359,7 +359,7 @@ input[type=text], input[type=search] {
   background-color: #000000;
 }
 tr th div.th-inner {
-  color:var(--text-main);
+  color: #FFFFFF;
 }
 .tab-content, .tab-pane {
   background-color: var(--back-main);

--- a/resources/assets/less/skins/skin-yellow-dark.less
+++ b/resources/assets/less/skins/skin-yellow-dark.less
@@ -356,7 +356,7 @@ input[type=text], input[type=search] {
   color: var(--header);
 }
 .skin-yellow-dark .main-header .navbar .dropdown-menu li a:hover {
-  background-color: #ffcc32;
+  background-color: #000000;
 }
 tr th div.th-inner {
   color:var(--text-main);


### PR DESCRIPTION
# Description
When using a dark theme, the drop down menus in the header bar would not show color when the options were hovered, except within the last breakpoint that hides the left side bar. This fix adds that styling back in so it is consistent between all screen widths.

Fixes #14519

old
<img width="370" alt="Screenshot 2024-03-28 at 5 53 51 PM" src="https://github.com/snipe/snipe-it/assets/116301219/9a82ae06-1e9d-434b-b8aa-b6b1cee45eb8">

updated
<img width="242" alt="Screenshot 2024-03-28 at 5 17 40 PM" src="https://github.com/snipe/snipe-it/assets/116301219/3bf0b40f-d917-4846-9df9-46b52dd11b27">


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
visual testing on a throwaway test branch.


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
