### PR TITLE
Fixed  ldap location syncing incorrect locations for users.

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -390,7 +390,7 @@ class LdapSync extends Command
                         $user->location_id = $location->id;
                     }
                 }
-
+                $location = null;
                 $user->ldap_import = 1;
 
                 $errors = '';


### PR DESCRIPTION
# Description

This change clears out the `$location` variable before syncing the next user. It is created if a new location is made. and it stays populated for the next user, which is unnecessary and wrong. This change clears the variable before the next user is synced and syncs locations correctly now.

Fixes #14506 [sc-25238]

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
