### PR TITLE
Remove city as required field on location modal

### DIFF
--- a/resources/views/modals/location.blade.php
+++ b/resources/views/modals/location.blade.php
@@ -17,7 +17,7 @@
 
                 <div class="dynamic-form-row">
                     <div class="col-md-4 col-xs-12"><label for="modal-city">{{ trans('general.city') }}:</label></div>
-                    <div class="col-md-8 col-xs-12 required"><input type='text' name="city" id='modal-city' class="form-control"></div>
+                    <div class="col-md-8 col-xs-12"><input type='text' name="city" id='modal-city' class="form-control"></div>
                 </div>
 
                 <div class="dynamic-form-row">


### PR DESCRIPTION
This fixes a UI bug where city was showing as a required field on the locations modal when it is not actually required.


https://github.com/snipe/snipe-it/assets/197404/e4faf819-0d78-42e6-9e80-eade13c3a1a8


Todo: We should revisit these and see if we can use the `Helper::checkIfRequired($item, 'name')` logic here that introspects into the model.