### PR TITLE
Upgraded Signature-pad.js  && Fixed Resizing Canvas on mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19162,6 +19162,11 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true
         },
+        "signature_pad": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-4.2.0.tgz",
+            "integrity": "sha512-YLWysmaUBaC5wosAKkgbX7XI+LBv2w5L0QUcI6Jc4moHYzv9BUBJtAyNLpWzHjtjKTeWOH6bfP4a4pzf0UinfQ=="
+        },
         "simple-concat": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "papaparse": "^4.3.3",
         "select2": "4.0.13",
         "sheetjs": "^2.0.0",
+        "signature_pad": "^4.2.0",
         "tableexport.jquery.plugin": "1.28.0",
         "tether": "^1.4.0",
         "vue-resource": "^1.5.2",

--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -73,7 +73,6 @@
                                         <canvas style="width:100%;"></canvas>
                                         <input type="hidden" name="signature_output" id="signature_output">
                                     </div>
-                                    <button id="lock_button">Lock</button>
                                     <div class="col-md-12 col-sm-12 col-lg-12 col-xs-12 text-center">
                                         <button type="button" class="btn btn-sm btn-default clear" data-action="clear" id="clear_button">{{trans('general.clear_signature')}}</button>
                                     </div>
@@ -96,24 +95,6 @@
 
     <script nonce="{{ csrf_token() }}">
 
-        const rotate_btn = document.querySelector("#lock_button");
-        rotate_btn.addEventListener("click", () => {
-            log.textContent += `Lock pressed \n`;
-
-            const oppositeOrientation = screen.orientation.type.startsWith("portrait")
-                ? "landscape"
-                : "portrait";
-            screen.orientation
-                .lock(oppositeOrientation)
-                .then(() => {
-                    log.textContent = `Locked to ${oppositeOrientation}\n`;
-                })
-                .catch((error) => {
-                    log.textContent += `${error}\n`;
-
-                });
-        });
-
         var wrapper = document.getElementById("signature-pad"),
             clearButton = wrapper.querySelector("[data-action=clear]"),
             saveButton = wrapper.querySelector("[data-action=save]"),
@@ -123,18 +104,19 @@
         // Adjust canvas coordinate space taking into account pixel ratio,
         // to make it look crisp on mobile devices.
         // This also causes canvas to be cleared.
-        function resizeCanvas() {
-            // When zoomed out to less than 100%, for some very strange reason,
-            // some browsers report devicePixelRatio as less than 1
-            // and only part of the canvas is cleared then.
-            var ratio =  Math.max(window.devicePixelRatio || 1, 1);
-            canvas.width = canvas.offsetWidth * ratio;
-            canvas.height = canvas.offsetHeight * ratio;
-            canvas.getContext("2d").scale(ratio, ratio);
+        if (window.matchMedia("(min-width: 768px)").matches) {
+            function resizeCanvas() {
+                // When zoomed out to less than 100%, for some very strange reason,
+                // some browsers report devicePixelRatio as less than 1
+                // and only part of the canvas is cleared then.
+                var ratio = Math.max(window.devicePixelRatio || 1, 1);
+                canvas.width = canvas.offsetWidth * ratio;
+                canvas.height = canvas.offsetHeight * ratio;
+                canvas.getContext("2d").scale(ratio, ratio);
+            }
+            window.onresize = resizeCanvas;
+            resizeCanvas();
         }
-
-        window.onresize = resizeCanvas;
-        resizeCanvas();
 
         signaturePad = new SignaturePad(canvas);
 

--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -70,9 +70,10 @@
                                 <h3 style="padding-top: 20px">{{trans('general.sign_tos')}}</h3>
                                 <div id="signature-pad" class="m-signature-pad">
                                     <div class="m-signature-pad--body col-md-12 col-sm-12 col-lg-12 col-xs-12">
-                                        <canvas></canvas>
+                                        <canvas style="width:100%;"></canvas>
                                         <input type="hidden" name="signature_output" id="signature_output">
                                     </div>
+                                    <button id="lock_button">Lock</button>
                                     <div class="col-md-12 col-sm-12 col-lg-12 col-xs-12 text-center">
                                         <button type="button" class="btn btn-sm btn-default clear" data-action="clear" id="clear_button">{{trans('general.clear_signature')}}</button>
                                     </div>
@@ -94,6 +95,25 @@
 @section('moar_scripts')
 
     <script nonce="{{ csrf_token() }}">
+
+        const rotate_btn = document.querySelector("#lock_button");
+        rotate_btn.addEventListener("click", () => {
+            log.textContent += `Lock pressed \n`;
+
+            const oppositeOrientation = screen.orientation.type.startsWith("portrait")
+                ? "landscape"
+                : "portrait";
+            screen.orientation
+                .lock(oppositeOrientation)
+                .then(() => {
+                    log.textContent = `Locked to ${oppositeOrientation}\n`;
+                })
+                .catch((error) => {
+                    log.textContent += `${error}\n`;
+
+                });
+        });
+
         var wrapper = document.getElementById("signature-pad"),
             clearButton = wrapper.querySelector("[data-action=clear]"),
             saveButton = wrapper.querySelector("[data-action=save]"),


### PR DESCRIPTION
# Description
upgrades Signature-pad.js from 1.5->4.2.0

In order for the signature pad brush strokes to not look pixlated and for the user to be able to sign across the whole canvas on High DPI screens we need the `resizeCanvas()` method. This fix applies a media constraint to ignore resizing on 767px width and less. effectively not resizing on an ipad mini and smaller. 
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-04-09 at 10 35 02](https://github.com/snipe/snipe-it/assets/47435081/f6c3786a-1d43-4529-8e18-0b6c453a8141)

Fixes #14561 [sc-25246]

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
