### PR TITLE
Feat: add no-interactive flag for `upgrade.php`

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -19,6 +19,7 @@ $app_environment = 'develop';
 $skip_php_checks = false;
 $branch = 'master';
 $branch_override = false;
+$no_interactive = false;
 
 // Check for branch or other overrides
 if ($argc > 1){
@@ -31,6 +32,9 @@ if ($argc > 1){
                 $arg++;
                 $branch = $argv[$arg];
                 $branch_override = true;
+                break;
+            case '--no-interactive':
+                $no_interactive = true;
                 break;
             default: // for legacy support from before we started using --branch
                 $branch = $argv[$arg];
@@ -81,7 +85,13 @@ if($upgrade_requirements){
     echo "Found PHP requirements, will check for PHP > $php_min_works and < $php_max_wontwork\n";
 }
 // done fetching requirements
-$yesno = readline("\nProceed with upgrade? [Y/n]: ");
+
+if (!$no_interactive) {
+    $yesno = readline("\nProceed with upgrade? [Y/n]: ");
+} else {
+    $yesno = "yes";
+}
+
 if ($yesno == "yes" || $yesno == "YES" ||$yesno == "y" ||$yesno == "Y"){
     # don't do anything
 } else {


### PR DESCRIPTION
Having a no-interactive flag is useful because attempting to automate snipe-it upgrades is currently very janky. You have to either:
  a) read the prompts and pass in the input (the "correct" way)
  a) pipe in input, e.g. `yes` and hope no new prompts are added.

With a `no-interactive` flag, this can be fixed by both allowing new prompts to be added without conflict
to user prompts, but also allowing automated upgrades (you could choose to crash, or assign defaults).

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Feature addition to `upgrade.php`, no issue found that could be relevant in fixing.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run `upgrade.php` and `upgrade.php --no-interactive` on any SnipeIT supported php version. `--no-interactive` runs the upgrade without needing the confirmation prompt.

**Test Configuration**:
* PHP version: 8.1
* MySQL version: 15.1
* Webserver version: 6.3.4
* OS version: Debian 11


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
