### PR TITLE
Fixed assigned to field in new label engine

### DIFF
--- a/app/Models/Labels/FieldOption.php
+++ b/app/Models/Labels/FieldOption.php
@@ -18,8 +18,14 @@ class FieldOption {
         // assignedTo directly on the asset is a special case where
         // we want to avoid returning the property directly
         // and instead return the entity's presented name.
-        if ($dataPath[0] === 'assignedTo'){
-            return $asset->assignedTo ?  $asset->assignedTo->present()->fullName() : null;
+        if ($dataPath[0] === 'assignedTo') {
+            if ($asset->relationLoaded('assignedTo')) {
+                // If the "assignedTo" relationship was eager loaded then the way to get the
+                // relationship changes from $asset->assignedTo to $asset->assigned.
+                return $asset->assigned ? $asset->assigned->present()->fullName() : null;
+            }
+
+            return $asset->assignedTo ? $asset->assignedTo->present()->fullName() : null;
         }
         
         return $dataPath->reduce(function ($myValue, $path) {

--- a/tests/Unit/Models/Labels/FieldOptionTest.php
+++ b/tests/Unit/Models/Labels/FieldOptionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Models\Labels;
+
+use App\Models\Asset;
+use App\Models\Labels\FieldOption;
+use App\Models\User;
+use Tests\TestCase;
+
+class FieldOptionTest extends TestCase
+{
+    public function testItDisplaysAssignedToProperly()
+    {
+        // "assignedTo" is a "special" value that can be used in the new label engine
+        $fieldOption = FieldOption::fromString('Assigned To=assignedTo');
+
+        $asset = Asset::factory()
+            ->assignedToUser(User::factory()->create(['first_name' => 'Luke', 'last_name' => 'Skywalker']))
+            ->create();
+
+        $this->assertEquals('Luke Skywalker', $fieldOption->getValue($asset));
+        // If the "assignedTo" relationship was eager loaded then the way to get the
+        // relationship changes from $asset->assignedTo to $asset->assigned.
+        $this->assertEquals('Luke Skywalker', $fieldOption->getValue(Asset::with('assignedTo')->find($asset->id)));
+    }
+}


### PR DESCRIPTION
# Description

This PR fixes the "Assigned To" field not being displayed on labels using the new label engine.

Here's an explanation of what happened: There was a recent change in the `BulkAssetsController` where we, rightfully, eager load the a few relationships including `assignedTo`:
https://github.com/snipe/snipe-it/blob/f270f307289c8fb59efdb140467c407288e70c1b/app/Http/Controllers/Assets/BulkAssetsController.php#L95

Interestingly, that means subsequent calls to `$asset->assignedTo` are `null` while `$asset->assigned` actually holds the relationship. 

![loaded relationships](https://github.com/snipe/snipe-it/assets/1141514/0b9240b2-0c2f-41f3-ab58-7bc7211094c7)

I think this is due to the "name" of the relationship being set to `assigned`: 
https://github.com/snipe/snipe-it/blob/0d3d172108be43850f0869e2d5cae857b3b32a6b/app/Models/Asset.php#L494-L497

For the fix: I wrote a test case and included a comment about why the extra `if` check was added but this fixes the issue.

![working labels](https://github.com/snipe/snipe-it/assets/1141514/040e6749-5929-4ba3-9261-f83950367add)

Fixes #14541 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)