### PR TITLE
Reduce Extra Space in Header Dropdown

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -374,7 +374,7 @@
                                                 </a>
                                             </li>
                                         @endcan
-                                        <li class="divider"></li>
+                                        <li class="divider" style="margin-top: -1px; margin-bottom: -1px"></li>
                                         <li>
 
                                             <a href="{{ route('logout.get') }}"


### PR DESCRIPTION
# Description
There was an extra bit of space surrounding the dividing line in the header dropdown. This removes that space.

old:
<img width="262" alt="Screenshot 2024-04-09 at 5 52 57 PM" src="https://github.com/snipe/snipe-it/assets/116301219/33822fbf-9ab4-49ef-b284-e74fd4a2cb9e">

new:
<img width="236" alt="Screenshot 2024-04-09 at 5 53 25 PM" src="https://github.com/snipe/snipe-it/assets/116301219/60471ff2-5b50-49fd-ad02-2864606ec988">


Fixes # [SC-25288](https://app.shortcut.com/grokability/story/25288/dropdown-padding-needs-fixing)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Just took a look at it. This is a change on the default blade, and so doesn't need to have each theme checked.


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
