### PR TITLE
First fix for user FMCS scoping

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -465,6 +465,7 @@ class UsersController extends Controller
             if (! Auth::user()->isSuperUser()) {
                 unset($permissions_array['superuser']);
             }
+
             $user->permissions = $permissions_array;
         }
 
@@ -487,6 +488,7 @@ class UsersController extends Controller
 
             // Check if the request has groups passed and has a value
             if ($request->filled('groups')) {
+
                 $validator = Validator::make($request->all(), [
                     'groups.*' => 'integer|exists:permission_groups,id',
                 ]);
@@ -494,10 +496,19 @@ class UsersController extends Controller
                 if ($validator->fails()){
                     return response()->json(Helper::formatStandardApiResponse('error', null, $user->getErrors()));
                 }
-                $user->groups()->sync($request->input('groups'));
+
+                // Only save groups if the user is a superuser
+                if (Auth::user()->isSuperUser()) {
+                    $user->groups()->sync($request->input('groups'));
+                }
+
             // The groups field has been passed but it is null, so we should blank it out
             } elseif ($request->has('groups')) {
-                $user->groups()->sync([]);
+                
+                // Only save groups if the user is a superuser
+                if (Auth::user()->isSuperUser()) {
+                    $user->groups()->sync($request->input('groups'));
+                }
             }
 
 

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -273,6 +273,7 @@ class UsersController extends Controller
             $users = $users->withTrashed();
         }
 
+        // Apply companyable scope
         $users = Company::scopeCompanyables($users);
 
 

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -131,7 +131,7 @@ final class Company extends SnipeModel
     public static function isCurrentUserHasAccess($companyable)
     {
         // When would this even happen tho??
-        if (!$companyable) {
+        if (is_null($companyable)) {
             return false;
         }
 

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -81,26 +81,6 @@ final class Company extends SnipeModel
         }
     }
 
-    /**
-     * Scoping table queries, determining if a logged in user is part of a company, and only allows
-     * that user to see items associated with that company
-     */
-    private static function scopeCompanyablesDirectly($query, $column = 'company_id', $table_name = null)
-    {
-        if (Auth::user()) {
-            $company_id = Auth::user()->company_id;
-        } else {
-            $company_id = null;
-        }
-
-        $table = ($table_name) ? $table_name."." : $query->getModel()->getTable().".";
-
-        if (\Schema::hasColumn($query->getModel()->getTable(), $column)) {
-             return $query->where($table.$column, '=', $company_id);
-        } else {
-            return $query->join('users as users_comp', 'users_comp.id', 'user_id')->where('users_comp.company_id', '=', $company_id);
-        }
-    }
 
     public static function getIdFromInput($unescaped_input)
     {
@@ -190,6 +170,10 @@ final class Company extends SnipeModel
                 && ($this->users()->count() === 0);
     }
 
+    /**
+     * @param $unescaped_input
+     * @return int|mixed|string|null
+     */
     public static function getIdForUser($unescaped_input)
     {
         if (! static::isFullMultipleCompanySupportEnabled() || Auth::user()->isSuperUser()) {
@@ -199,38 +183,6 @@ final class Company extends SnipeModel
         }
     }
 
-    public static function scopeCompanyables($query, $column = 'company_id', $table_name = null)
-    {
-        // If not logged in and hitting this, assume we are on the command line and don't scope?'
-        if (! static::isFullMultipleCompanySupportEnabled() || (Auth::check() && Auth::user()->isSuperUser()) || (! Auth::check())) {
-            return $query;
-        } else {
-            return static::scopeCompanyablesDirectly($query, $column, $table_name);
-        }
-    }
-
-    public static function scopeCompanyableChildren(array $companyable_names, $query)
-    {
-        if (count($companyable_names) == 0) {
-            throw new Exception('No Companyable Children to scope');
-        } elseif (! static::isFullMultipleCompanySupportEnabled() || (Auth::check() && Auth::user()->isSuperUser())) {
-            return $query;
-        } else {
-            $f = function ($q) {
-                static::scopeCompanyablesDirectly($q);
-            };
-
-            $q = $query->where(function ($q) use ($companyable_names, $f) {
-                $q2 = $q->whereHas($companyable_names[0], $f);
-
-                for ($i = 1; $i < count($companyable_names); $i++) {
-                    $q2 = $q2->orWhereHas($companyable_names[$i], $f);
-                }
-            });
-
-            return $q;
-        }
-    }
 
     public function users()
     {
@@ -261,4 +213,100 @@ final class Company extends SnipeModel
     {
         return $this->hasMany(Component::class, 'company_id');
     }
+
+    /**
+     * START COMPANY SCOPING FOR FMCS
+     */
+
+    /**
+     * Scoping table queries, determining if a logged in user is part of a company, and only allows the user to access items associated with that company if FMCS is enabled.
+     *
+     * This method is the one that the CompanyableTrait uses to contrain queries automatically, however that trait CANNOT be
+     * applied to the user's model, since it causes an infinite loop against the authenticated user.
+     *
+     * @todo - refactor that trait to handle the user's model as well.
+     *
+     * @author [A. Gianotto] <snipe@snipe.net>
+     * @param $query
+     * @param $column
+     * @param $table_name
+     * @return mixed
+     */
+    public static function scopeCompanyables($query, $column = 'company_id', $table_name = null)
+    {
+        // If not logged in and hitting this, assume we are on the command line and don't scope?'
+        if (! static::isFullMultipleCompanySupportEnabled() || (Auth::check() && Auth::user()->isSuperUser()) || (! Auth::check())) {
+            \Log::debug('Skip scoping in scopeCompanyableChildren. User is not logged in or is a superadmin');
+            return $query;
+        } else {
+            \Log::debug('Fire scopeCompanyablesDirectly.');
+            return static::scopeCompanyablesDirectly($query, $column, $table_name);
+        }
+    }
+
+    /**
+     * Scoping table queries, determining if a logged in user is part of a company, and only allows
+     * that user to see items associated with that company
+     */
+    private static function scopeCompanyablesDirectly($query, $column = 'company_id', $table_name = null)
+    {
+        // Get the company ID of the logged in user, or set it to null if there is no company assicoated with the user
+        if (Auth::user()) {
+            \Log::debug('Admin company is: '.Auth::user()->company_id);
+            $company_id = Auth::user()->company_id;
+        } else {
+            $company_id = null;
+        }
+
+        // Dynamically get the table name if it's not passed in, based on the model we're querying against
+        $table = ($table_name) ? $table_name."." : $query->getModel()->getTable().".";
+         \Log::debug('Model is: '.$query->getModel());
+
+        \Log::debug('Table is: '.$table);
+
+        // If the column exists in the table, use it to scope the query
+        if (\Schema::hasColumn($query->getModel()->getTable(), $column)) {
+            return $query->where($table.$column, '=', $company_id);
+        } else {
+            return $query->join('users as users_comp', 'users_comp.id', 'user_id')->where('users_comp.company_id', '=', $company_id);
+        }
+    }
+
+    /**
+     * I legit do not know what this method does, but we can't remove it (yet).
+     *
+     * This gets invoked by CompanyableChildScope, but I'm not sure what it does.
+     *
+     * @author [A. Gianotto] <snipe@snipe.net>
+     * @param array $companyable_names
+     * @param $query
+     * @return mixed
+     */
+    public static function scopeCompanyableChildren(array $companyable_names, $query)
+    {
+        \Log::debug('Company Names in scopeCompanyableChildren: '.print_r($companyable_names, true));
+
+        if (count($companyable_names) == 0) {
+            throw new Exception('No Companyable Children to scope');
+        } elseif (! static::isFullMultipleCompanySupportEnabled() || (Auth::check() && Auth::user()->isSuperUser())) {
+            \Log::debug('Skip scoping in scopeCompanyableChildren. User is not logged in or is a superadmin');
+            return $query;
+        } else {
+            $f = function ($q) {
+                \Log::debug('scopeCompanyablesDirectly firing ');
+                static::scopeCompanyablesDirectly($q);
+            };
+
+            $q = $query->where(function ($q) use ($companyable_names, $f) {
+                $q2 = $q->whereHas($companyable_names[0], $f);
+
+                for ($i = 1; $i < count($companyable_names); $i++) {
+                    $q2 = $q2->orWhereHas($companyable_names[$i], $f);
+                }
+            });
+
+            return $q;
+        }
+    }
+
 }

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -131,7 +131,7 @@ final class Company extends SnipeModel
     public static function isCurrentUserHasAccess($companyable)
     {
         // When would this even happen tho??
-        if (is_null($companyable)) {
+        if (!$companyable) {
             return false;
         }
 

--- a/app/Models/CompanyableTrait.php
+++ b/app/Models/CompanyableTrait.php
@@ -5,8 +5,13 @@ namespace App\Models;
 trait CompanyableTrait
 {
     /**
-     * Boot the companyable trait for a model.
+     * This trait is used to scope models to the current company. To use this scope on companyable models,
+     * we use the "use Companyable;" statement at the top of the mode.
      *
+     * We CANNOT USE THIS ON USERS, as it causes an infinite loop and prevents users from logging in, since this scope will be
+     * applied to the currently logged in (or logging in) user in addition to the user model for viewing lists of users.
+     *
+     * @see \App\Models\Company\Company::scopeCompanyables()
      * @return void
      */
     public static function bootCompanyableTrait()

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -53,6 +53,16 @@ abstract class SnipePermissionsPolicy
         }
 
         /**
+         * If we got here by $this→authorize('something', $actualModel) then we can continue on Il but if we got here
+         * via $this→authorize('something', Model::class) then calling Company:: isCurrentUserHasAccess($item) gets weird.
+         * Bail out here by returning "nothing" and allow the relevant method lower in this class to be called and handle authorization.
+         */
+        if (!$item instanceof Model){
+            return;
+        }
+
+
+        /**
          * The Company::isCurrentUserHasAccess() method from the company model handles the check for FMCS already so we
          * don't have to do that here.
          */

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -36,7 +36,7 @@ abstract class SnipePermissionsPolicy
     public function before(User $user, $ability, $item)
     {
         /**
-         * If an admin, they can do all asset related tasks, but constrained by FMCSA company access.
+         * If an admin, they can do all item related tasks, but ARE constrained by FMCSA company access.
          * That scoping happens on the model level (except for the Users model) via the Companyable trait.
          *
          * This does lead to some inconsistencies in the responses, since attempting to edit assets,

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -93,21 +93,28 @@ class AuthServiceProvider extends ServiceProvider
         Passport::personalAccessTokensExpireIn(Carbon::now()->addYears(config('passport.expiration_years')));
         Passport::withCookieSerialization();
 
-        // --------------------------------
-        // BEFORE ANYTHING ELSE
-        // --------------------------------
-        // If this condition is true, ANYTHING else below will be assumed
-        // to be true. This can cause weird blade behavior.
+
+        /**
+         * BEFORE ANYTHING ELSE
+         *
+         * If this condition is true, ANYTHING else below will be assumed to be true.
+         * This is where we set the superadmin permission to allow superadmins to be able to do everything within the system.
+         *
+         */
         Gate::before(function ($user) {
             if ($user->isSuperUser()) {
                 return true;
             }
         });
 
-        // --------------------------------
-        // GENERAL GATES
-        // These control general sections of the admin
-        // --------------------------------
+
+        /**
+         * GENERAL GATES
+         *
+         * These control general sections of the admin. These definitions are used in our blades via @can('blah) and also
+         * use in our controllers to determine if a user has access to a certain area.
+         */
+
         Gate::define('admin', function ($user) {
             if ($user->hasAccess('admin')) {
                 return true;

--- a/resources/lang/en-US/admin/licenses/message.php
+++ b/resources/lang/en-US/admin/licenses/message.php
@@ -3,7 +3,7 @@
 return array(
 
     'does_not_exist' => 'License does not exist or you do not have permission to view it.',
-    'user_does_not_exist' => 'User does not exist.',
+    'user_does_not_exist' => 'User does not exist or you do not have permission to view them.',
     'asset_does_not_exist' 	=> 'The asset you are trying to associate with this license does not exist.',
     'owner_doesnt_match_asset' => 'The asset you are trying to associate with this license is owned by somene other than the person selected in the assigned to dropdown.',
     'assoc_users'	 => 'This license is currently checked out to a user and cannot be deleted. Please check the license in first, and then try deleting again. ',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -508,6 +508,8 @@ return [
     'url'                   => 'URL',
     'edit_fieldset' => 'Edit fieldset fields and options',
     'permission_denied_superuser_demo' => 'Permission denied. You cannot update user information for superadmins on the demo.',
+    'pwd_reset_not_sent' => 'User is not activated, is LDAP synced, or does not have an email address',
+    'error_sending_email' => 'Error sending email',
     'bulk' => [
             'delete' =>
                 [

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -507,6 +507,7 @@ return [
     'or' => 'or',
     'url'                   => 'URL',
     'edit_fieldset' => 'Edit fieldset fields and options',
+    'permission_denied_superuser_demo' => 'Permission denied. You cannot update user information for superadmins on the demo.',
     'bulk' => [
             'delete' =>
                 [

--- a/tests/Feature/Api/Users/UpdateUserApiTest.php
+++ b/tests/Feature/Api/Users/UpdateUserApiTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\Users;
 
+use App\Models\Company;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -57,5 +58,69 @@ class UpdateUserApiTest extends TestCase
             ]);
 
         $this->assertEquals(0, $user->refresh()->activated);
+    }
+
+    public function testUsersScopedToCompanyDuringUpdateWhenMultipleFullCompanySupportEnabled()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $companyA = Company::factory()->create(['name'=>'Company A']);
+        $companyB = Company::factory()->create(['name'=>'Company B']);
+
+        $adminA = User::factory(['company_id' => $companyA->id])->admin()->create();
+        $adminB = User::factory(['company_id' => $companyB->id])->admin()->create();
+        $adminNoCompany = User::factory(['company_id' => null])->admin()->create();
+
+        // Create a user that belongs to company B
+        $userA = User::factory()->create(['activated' => true, 'company_id' => $companyA->id]);
+        $userB = User::factory()->create(['activated' => true, 'company_id' => $companyB->id]);
+        $userNoCompany = User::factory()->create(['activated' => true, 'company_id' => null]);
+
+        // Admin for Company A should allow updating user from Company A
+        $this->actingAsForApi($adminA)
+            ->patchJson(route('api.users.update', $userA))
+            ->assertStatus(200);
+
+        // Admin for Company A should get denied updating user from Company B
+        $this->actingAsForApi($adminA)
+            ->patchJson(route('api.users.update', $userB))
+            ->assertStatus(403);
+
+        // Admin for Company A should get denied updating user without a company
+        $this->actingAsForApi($adminA)
+            ->patchJson(route('api.users.update', $userNoCompany))
+            ->assertStatus(403);
+
+        // Admin for Company B should allow updating user from Company B
+        $this->actingAsForApi($adminB)
+            ->patchJson(route('api.users.update', $userB))
+            ->assertStatus(200);
+
+        // Admin for Company B should get denied updating user from Company A
+        $this->actingAsForApi($adminB)
+            ->patchJson(route('api.users.update', $userA))
+            ->assertStatus(403);
+
+        // Admin for Company B should get denied updating user without a company
+        $this->actingAsForApi($adminB)
+            ->patchJson(route('api.users.update', $userNoCompany))
+            ->assertStatus(403);
+
+        // Admin without a company should allow updating user without a company
+        $this->actingAsForApi($adminNoCompany)
+            ->patchJson(route('api.users.update', $userNoCompany))
+            ->assertStatus(200);
+
+        // Admin without a company should get denied updating user from Company A
+        $this->actingAsForApi($adminNoCompany)
+            ->patchJson(route('api.users.update', $userA))
+            ->assertStatus(403);
+
+        // Admin without a company should get denied updating user from Company B
+        $this->actingAsForApi($adminNoCompany)
+            ->patchJson(route('api.users.update', $userB))
+            ->assertStatus(403);
+
+
     }
 }

--- a/tests/Feature/Api/Users/UpdateUserApiTest.php
+++ b/tests/Feature/Api/Users/UpdateUserApiTest.php
@@ -71,56 +71,55 @@ class UpdateUserApiTest extends TestCase
         $adminB = User::factory(['company_id' => $companyB->id])->admin()->create();
         $adminNoCompany = User::factory(['company_id' => null])->admin()->create();
 
-        // Create a user that belongs to company B
-        $userA = User::factory()->create(['activated' => true, 'company_id' => $companyA->id]);
-        $userB = User::factory()->create(['activated' => true, 'company_id' => $companyB->id]);
-        $userNoCompany = User::factory()->create(['activated' => true, 'company_id' => null]);
+        // Create users that belongs to company A and B and one that is unscoped
+        $scoped_user_in_companyA = User::factory()->create(['activated' => true, 'company_id' => $companyA->id]);
+        $scoped_user_in_companyB = User::factory()->create(['activated' => true, 'company_id' => $companyB->id]);
+        $scoped_user_in_no_company = User::factory()->create(['activated' => true, 'company_id' => null]);
 
         // Admin for Company A should allow updating user from Company A
         $this->actingAsForApi($adminA)
-            ->patchJson(route('api.users.update', $userA))
+            ->patchJson(route('api.users.update', $scoped_user_in_companyA))
             ->assertStatus(200);
 
         // Admin for Company A should get denied updating user from Company B
         $this->actingAsForApi($adminA)
-            ->patchJson(route('api.users.update', $userB))
+            ->patchJson(route('api.users.update', $scoped_user_in_companyB))
             ->assertStatus(403);
 
         // Admin for Company A should get denied updating user without a company
         $this->actingAsForApi($adminA)
-            ->patchJson(route('api.users.update', $userNoCompany))
+            ->patchJson(route('api.users.update', $scoped_user_in_no_company))
             ->assertStatus(403);
 
         // Admin for Company B should allow updating user from Company B
         $this->actingAsForApi($adminB)
-            ->patchJson(route('api.users.update', $userB))
+            ->patchJson(route('api.users.update', $scoped_user_in_companyB))
             ->assertStatus(200);
 
         // Admin for Company B should get denied updating user from Company A
         $this->actingAsForApi($adminB)
-            ->patchJson(route('api.users.update', $userA))
+            ->patchJson(route('api.users.update', $scoped_user_in_companyA))
             ->assertStatus(403);
 
         // Admin for Company B should get denied updating user without a company
         $this->actingAsForApi($adminB)
-            ->patchJson(route('api.users.update', $userNoCompany))
+            ->patchJson(route('api.users.update', $scoped_user_in_no_company))
             ->assertStatus(403);
 
         // Admin without a company should allow updating user without a company
         $this->actingAsForApi($adminNoCompany)
-            ->patchJson(route('api.users.update', $userNoCompany))
+            ->patchJson(route('api.users.update', $scoped_user_in_no_company))
             ->assertStatus(200);
 
         // Admin without a company should get denied updating user from Company A
         $this->actingAsForApi($adminNoCompany)
-            ->patchJson(route('api.users.update', $userA))
+            ->patchJson(route('api.users.update', $scoped_user_in_companyA))
             ->assertStatus(403);
 
         // Admin without a company should get denied updating user from Company B
         $this->actingAsForApi($adminNoCompany)
-            ->patchJson(route('api.users.update', $userB))
+            ->patchJson(route('api.users.update', $scoped_user_in_companyB))
             ->assertStatus(403);
-
 
     }
 }

--- a/tests/Feature/Api/Users/UpdateUserApiTest.php
+++ b/tests/Feature/Api/Users/UpdateUserApiTest.php
@@ -72,9 +72,9 @@ class UpdateUserApiTest extends TestCase
         $adminNoCompany = User::factory(['company_id' => null])->admin()->create();
 
         // Create users that belongs to company A and B and one that is unscoped
-        $scoped_user_in_companyA = User::factory()->create(['activated' => true, 'company_id' => $companyA->id]);
-        $scoped_user_in_companyB = User::factory()->create(['activated' => true, 'company_id' => $companyB->id]);
-        $scoped_user_in_no_company = User::factory()->create(['activated' => true, 'company_id' => null]);
+        $scoped_user_in_companyA = User::factory()->create(['company_id' => $companyA->id]);
+        $scoped_user_in_companyB = User::factory()->create(['company_id' => $companyB->id]);
+        $scoped_user_in_no_company = User::factory()->create(['company_id' => null]);
 
         // Admin for Company A should allow updating user from Company A
         $this->actingAsForApi($adminA)


### PR DESCRIPTION
This corrects some of the scoping we were doing around users for exporting lists, editing, etc and adds a lot more info around FMCS in the code (because it's always miserable to try to detangle that hot mess.)

We cannot use the standard CompanyableTrait that we use everywhere else on the user model because it's a **global scope**, and that causes an infinite loop by Laravel as it tries to add that scope onto the user model of the currently logged in user, in addition to the users listings/view/etc. This took me way too long to remember, but it explains why we handle the scoping on the User model slightly differently.

I also moved the scoping methods in the Company model to the bottom of the file, to keep it consistent with the way we handle query scopes elsewhere.

I'd like to continue working on a better way to handle this so that we get the same benefits of the CompanyableTrait without all the complex manual query scoping we have to do for the User model now, but this solves the immediate issue.

### How to test:

Create a company, "Brand Spankin New", and three users:

- `spankinadmin1` (admin with "Brand Spankin New" as their company)
- `nospankadmin2` (admin without any company)
- `spankuser1` (regular user with "Brand Spankin New" as their company)
- `spankin` asset (asset belonging to "Brand Spankin New")

Easiest way to test this is using three browsers so you have three different sessions. Make sure you have Full Multiple Company Support enabled.

#### `spankinadmin1`:
 - `spankinadmin1` - can only see all of the assets and users within "Brand Spankin New"
 - If you fuzz the url to change the `/users/{:id}` to a user you know doesn't belong to "Brand Spankin New", you should get kicked back with a not found error.
- You should be able to view/edit/clone/delete users and assets within "Brand Spankin New"
- Exporting the user list (via the Export button above the table) should ONLY show users that belong to "Brand Spankin New"

#### `nospankadmin2`:
 - `spankinadmin1` - can only see all of the assets and users without a company assigned
 - If you fuzz the url to change the `/users/{:id}` to a user you know does have a company association, you should get kicked back with a not found error.
- You should be able to view/edit/clone/delete users and assets that have no companies associated
- Exporting the user list (via the Export button above the table) should ONLY show users belonging to no company

Regular superadmins should of course have access to everything they would normally have access to.

Fixes #14539, Fixes [[sc-25183](https://app.shortcut.com/grokability/story/25183)], [sc-25258]