### PR TITLE
Fixed label fields only showing first option

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -152,7 +152,6 @@ class Label implements View
 
                                 // At this point we are dealing with a row with multiple items being displayed.
 
-
                                 // The end result of this will be in this format:
                                 // {labelOne} {valueOne} | {labelTwo} {valueTwo} | {labelThree} {valueThree}
                                 $carry['value'] = trim(implode(' | ', [

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -142,6 +142,8 @@ class Label implements View
                         // Remove Duplicates
                         $toAdd = $field
                             ->filter(fn($o) => !$myFields->contains('dataSource', $o['dataSource']))
+                            // For fields that have multiple options, we need to combine them
+                            // into a single field so all values are displayed.
                             ->reduce(function ($previous, $current) {
                                 // On the first iteration we simply return the item.
                                 // If there is only one item to be processed for the row

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -155,10 +155,10 @@ class Label implements View
 
                                 // The end result of this will be in this format:
                                 // {labelOne} {valueOne} | {labelTwo} {valueTwo} | {labelThree} {valueThree}
-                                $carry['value'] = implode(' | ', [
+                                $carry['value'] = trim(implode(' | ', [
                                     implode(' ', [$carry['label'], $carry['value']]),
                                     implode(' ', [$item['label'], $item['value']]),
-                                ]);
+                                ]));
 
                                 // We'll set the label to an empty string since we
                                 // injected the label into the value field above.

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -142,28 +142,29 @@ class Label implements View
                         // Remove Duplicates
                         $toAdd = $field
                             ->filter(fn($o) => !$myFields->contains('dataSource', $o['dataSource']))
-                            ->reduce(function ($carry, $item) {
+                            ->reduce(function ($previous, $current) {
                                 // On the first iteration we simply return the item.
                                 // If there is only one item to be processed for the row
                                 // then this effectively skips everything below this if block.
-                                if (is_null($carry)){
-                                    return $item;
+                                if (is_null($previous)) {
+                                    return $current;
                                 }
 
                                 // At this point we are dealing with a row with multiple items being displayed.
+                                // We need to combine the label and value of the current item with the previous item.
 
                                 // The end result of this will be in this format:
                                 // {labelOne} {valueOne} | {labelTwo} {valueTwo} | {labelThree} {valueThree}
-                                $carry['value'] = trim(implode(' | ', [
-                                    implode(' ', [$carry['label'], $carry['value']]),
-                                    implode(' ', [$item['label'], $item['value']]),
+                                $previous['value'] = trim(implode(' | ', [
+                                    implode(' ', [$previous['label'], $previous['value']]),
+                                    implode(' ', [$current['label'], $current['value']]),
                                 ]));
 
                                 // We'll set the label to an empty string since we
                                 // injected the label into the value field above.
-                                $carry['label'] = '';
+                                $previous['label'] = '';
 
-                                return $carry;
+                                return $previous;
                             });
 
                         return $toAdd ? $myFields->push($toAdd) : $myFields;

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -142,7 +142,30 @@ class Label implements View
                         // Remove Duplicates
                         $toAdd = $field
                             ->filter(fn($o) => !$myFields->contains('dataSource', $o['dataSource']))
-                            ->first();
+                            ->reduce(function ($carry, $item) {
+                                // On the first iteration we simply return the item.
+                                // If there is only one item to be processed for the row
+                                // then this effectively skips everything below this if block.
+                                if (is_null($carry)){
+                                    return $item;
+                                }
+
+                                // At this point we are dealing with a row with multiple items being displayed.
+
+
+                                // The end result of this will be in this format:
+                                // {labelOne} {valueOne} | {labelTwo} {valueTwo} | {labelThree} {valueThree}
+                                $carry['value'] = implode(' | ', [
+                                    implode(' ', [$carry['label'], $carry['value']]),
+                                    implode(' ', [$item['label'], $item['value']]),
+                                ]);
+
+                                // We'll set the label to an empty string since we
+                                // injected the label into the value field above.
+                                $carry['label'] = '';
+
+                                return $carry;
+                            });
 
                         return $toAdd ? $myFields->push($toAdd) : $myFields;
                     }, new Collection());


### PR DESCRIPTION
# Description

This PR fixes an issue in the new label engine where only the first option was displayed per row.

## Issue
Given these field definitions:
![Field definitions showing multiple options in one row](https://github.com/snipe/snipe-it/assets/1141514/ec5e9364-bb4a-4fe7-becd-9fb8a4612806)

Printing labels would result in only the first field (CPU) being displayed:
![Previous label only showing one field being printed](https://github.com/snipe/snipe-it/assets/1141514/d785d412-2e26-40aa-bf6d-2caa2520eb17)

## Solution

With this PR all of the options are shown:
![Label with all fields being printed](https://github.com/snipe/snipe-it/assets/1141514/043cac97-e6a6-4e06-b3b7-9bc62a4c7479)

## Details

The fix takes "rows" with multiple options and reduces them into one string separated by `|` during the processing of the labels before they are passed to specific "write" methods.

---

## Side-note

Adding three fields like I did above makes the label pretty smushed. It's perfectly fine to either leave labels empty or only put a value in the first label and have it apply to the entire line:

<table>
<tr>
 <td>No labels
 <td>Label in first slot
<tr>
 <td> 

![no labels in settings](https://github.com/snipe/snipe-it/assets/1141514/7143656d-ce2c-44a1-8f4a-53fec0eee10c)

 <td>

![label in first slot in settings](https://github.com/snipe/snipe-it/assets/1141514/4e8b4f83-22cb-4558-8580-634eb273cd68)

<tr>
 <td>

![no labels](https://github.com/snipe/snipe-it/assets/1141514/cc2fca20-7fda-4d3f-93af-5ba8d2827b08)

 <td>

![label in first slot](https://github.com/snipe/snipe-it/assets/1141514/a10dcc3f-d32a-411b-a365-ad54102a6569)

</table>

Doing that means the entry in "Fields" isn't helpful though (`| | `):
![Field definitions](https://github.com/snipe/snipe-it/assets/1141514/e3015542-6143-42c1-9af4-5c03ae263a35)

We can improve that by tinkering with `getFieldLabel()` in `label2-field-definitions` but I didn't want to stray too far from the original issue. @snipe let me know if you think I should include an improvement in this PR.

---


Fixes #14589

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)