### PR TITLE
Re-enabled updating encrypted custom fields via API [sc-41465]

### DIFF
--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -353,9 +353,9 @@ class AssetFactory extends Factory
         return $this->state(['requestable' => false]);
     }
 
-    public function has_encrypted_custom_field()
+    public function hasEncryptedCustomField()
     {
-        return $this->state(['model_id' => AssetModel::where('name', 'asset with encrypted field')->first() ?? AssetModel::factory()->encrypted_field()]);
+        return $this->state(['model_id' => AssetModel::where('name', 'asset with encrypted field')->first() ?? AssetModel::factory()->withEncryptedField()]);
     }
 
 

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -356,8 +356,6 @@ class AssetFactory extends Factory
 
     public function hasEncryptedCustomField(CustomField $field = null)
     {
-        // @todo: update this so existing asset model is used if present on the asset
-        // (may have been created in a test case)
         return $this->state(function () use ($field) {
             return [
                 'model_id' => AssetModel::factory()->hasEncryptedCustomField($field),

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -353,6 +353,12 @@ class AssetFactory extends Factory
         return $this->state(['requestable' => false]);
     }
 
+    public function has_encrypted_custom_field()
+    {
+        return $this->state(['model_id' => AssetModel::where('name', 'asset with encrypted field')->first() ?? AssetModel::factory()->encrypted_field()]);
+    }
+
+
     /**
      * This allows bypassing model level validation if you want to purposefully
      * create an asset in an invalid state. Validation is turned back on

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -355,7 +355,9 @@ class AssetFactory extends Factory
 
     public function hasEncryptedCustomField()
     {
-        return $this->state(['model_id' => AssetModel::where('name', 'asset with encrypted field')->first() ?? AssetModel::factory()->withEncryptedField()]);
+        return $this->afterMaking(function (Asset $asset) {
+            $asset->model_id = AssetModel::factory()->withEncryptedField()->create()->id;
+        });
     }
 
 

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Asset;
 use App\Models\AssetModel;
+use App\Models\CustomField;
 use App\Models\Location;
 use App\Models\Statuslabel;
 use App\Models\Supplier;
@@ -353,10 +354,14 @@ class AssetFactory extends Factory
         return $this->state(['requestable' => false]);
     }
 
-    public function hasEncryptedCustomField()
+    public function hasEncryptedCustomField(CustomField $field = null)
     {
-        return $this->afterMaking(function (Asset $asset) {
-            $asset->model_id = AssetModel::factory()->withEncryptedField()->create()->id;
+        // @todo: update this so existing asset model is used if present on the asset
+        // (may have been created in a test case)
+        return $this->state(function () use ($field) {
+            return [
+                'model_id' => AssetModel::factory()->hasEncryptedCustomField($field),
+            ];
         });
     }
 

--- a/database/factories/AssetModelFactory.php
+++ b/database/factories/AssetModelFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\AssetModel;
+use App\Models\CustomField;
 use App\Models\CustomFieldset;
 use App\Models\Depreciation;
 use App\Models\Manufacturer;
@@ -429,4 +430,29 @@ class AssetModelFactory extends Factory
             ];
         });
     }
+
+    public function encrypted_field()
+    {
+        return $this->state(function () {
+            $field = CustomField::factory()->testEncrypted()->create(); // TODO - having to create and then 'find' the thing you just created is WEIRD
+            return [
+                'name' => 'asset with encrypted field',
+                'category_id' => function () {
+                    return Category::where('name', 'Mobile Phones')->first() ?? Category::factory()->assetMobileCategory();
+                },
+                'manufacturer_id' => function () {
+                    return Manufacturer::where('name', 'Apple')->first() ?? Manufacturer::factory()->apple();
+                },
+                'eol' => '12',
+                'depreciation_id' => function () {
+                    return Depreciation::where('name', 'Computer Depreciation')->first() ?? Depreciation::factory()->computer();
+                },
+                'image' => 'iphone12.jpeg',
+                'fieldset_id' => function () use ($field) {
+                    return CustomFieldset::where('name', 'Has Encrypted Custom Field')->first() ?? CustomFieldset::factory()->has_encrypted_custom_field()->hasAttached(CustomField::where('name', 'Test Encrypted')->first(), ['order' => 1, 'required' => 0], 'fields');
+                },
+            ];
+        });
+    }
+
 }

--- a/database/factories/AssetModelFactory.php
+++ b/database/factories/AssetModelFactory.php
@@ -431,7 +431,7 @@ class AssetModelFactory extends Factory
         });
     }
 
-    public function encrypted_field()
+    public function withEncryptedField()
     {
         return $this->state(function () {
             $field = CustomField::factory()->testEncrypted()->create(); // TODO - having to create and then 'find' the thing you just created is WEIRD

--- a/database/factories/AssetModelFactory.php
+++ b/database/factories/AssetModelFactory.php
@@ -436,18 +436,6 @@ class AssetModelFactory extends Factory
         return $this->state(function () {
             $field = CustomField::factory()->testEncrypted()->create(); // TODO - having to create and then 'find' the thing you just created is WEIRD
             return [
-                'name' => 'asset with encrypted field',
-                'category_id' => function () {
-                    return Category::where('name', 'Mobile Phones')->first() ?? Category::factory()->assetMobileCategory();
-                },
-                'manufacturer_id' => function () {
-                    return Manufacturer::where('name', 'Apple')->first() ?? Manufacturer::factory()->apple();
-                },
-                'eol' => '12',
-                'depreciation_id' => function () {
-                    return Depreciation::where('name', 'Computer Depreciation')->first() ?? Depreciation::factory()->computer();
-                },
-                'image' => 'iphone12.jpeg',
                 'fieldset_id' => function () use ($field) {
                     return CustomFieldset::where('name', 'Has Encrypted Custom Field')->first() ?? CustomFieldset::factory()->has_encrypted_custom_field()->hasAttached(CustomField::where('name', 'Test Encrypted')->first(), ['order' => 1, 'required' => 0], 'fields');
                 },

--- a/database/factories/AssetModelFactory.php
+++ b/database/factories/AssetModelFactory.php
@@ -431,16 +431,12 @@ class AssetModelFactory extends Factory
         });
     }
 
-    public function withEncryptedField()
+    public function hasEncryptedCustomField(CustomField $field = null)
     {
-        return $this->state(function () {
-            $field = CustomField::factory()->testEncrypted()->create(); // TODO - having to create and then 'find' the thing you just created is WEIRD
+        return $this->state(function () use ($field) {
             return [
-                'fieldset_id' => function () use ($field) {
-                    return CustomFieldset::where('name', 'Has Encrypted Custom Field')->first() ?? CustomFieldset::factory()->has_encrypted_custom_field()->hasAttached(CustomField::where('name', 'Test Encrypted')->first(), ['order' => 1, 'required' => 0], 'fields');
-                },
+                'fieldset_id' => CustomFieldset::factory()->hasEncryptedCustomField($field),
             ];
         });
     }
-
 }

--- a/database/factories/CustomFieldsetFactory.php
+++ b/database/factories/CustomFieldsetFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\CustomFieldset;
+use App\Models\CustomField;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class CustomFieldsetFactory extends Factory
@@ -40,6 +41,15 @@ class CustomFieldsetFactory extends Factory
         return $this->state(function () {
             return [
                 'name' => 'Laptops and Desktops',
+            ];
+        });
+    }
+
+    public function has_encrypted_custom_field()
+    {
+        return $this->state(function () {
+            return [
+                'name' => 'Has Encrypted Custom Field',
             ];
         });
     }

--- a/database/factories/CustomFieldsetFactory.php
+++ b/database/factories/CustomFieldsetFactory.php
@@ -45,12 +45,12 @@ class CustomFieldsetFactory extends Factory
         });
     }
 
-    public function has_encrypted_custom_field()
+    public function hasEncryptedCustomField(CustomField $field = null)
     {
-        return $this->state(function () {
-            return [
-                'name' => 'Has Encrypted Custom Field',
-            ];
+        return $this->afterCreating(function (CustomFieldset $fieldset) use ($field) {
+            $field = $field ?? CustomField::factory()->testEncrypted()->create();
+
+            $fieldset->fields()->attach($field, ['order' => '1', 'required' => false]);
         });
     }
 }

--- a/resources/lang/en-US/admin/hardware/message.php
+++ b/resources/lang/en-US/admin/hardware/message.php
@@ -17,6 +17,7 @@ return [
     'update' => [
         'error'   			=> 'Asset was not updated, please try again',
         'success' 			=> 'Asset updated successfully.',
+        'encrypted_warning' => 'Asset updated successfully, but encrypted custom fields were not due to permissions',
         'nothing_updated'	=>  'No fields were selected, so nothing was updated.',
         'no_assets_selected'  =>  'No assets were selected, so nothing was updated.',
         'assets_do_not_exist_or_are_invalid' => 'Selected assets cannot be updated.',

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -10,6 +10,7 @@ use App\Models\Location;
 use App\Models\Statuslabel;
 use App\Models\Supplier;
 use App\Models\User;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
@@ -500,7 +501,7 @@ class AssetStoreTest extends TestCase
             ->json();
 
         $asset = Asset::findOrFail($response['payload']['id']);
-        $this->assertEquals('This is encrypted field', \Crypt::decrypt($asset->{$field->db_column_name()}));
+        $this->assertEquals('This is encrypted field', Crypt::decrypt($asset->{$field->db_column_name()}));
     }
 
     public function testPermissionNeededToStoreEncryptedField()
@@ -527,6 +528,6 @@ class AssetStoreTest extends TestCase
             ->json();
 
         $asset = Asset::findOrFail($response['payload']['id']);
-        $this->assertEquals('This is encrypted field', \Crypt::decrypt($asset->{$field->db_column_name()}));
+        $this->assertEquals('This is encrypted field', Crypt::decrypt($asset->{$field->db_column_name()}));
     }
 }

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -485,7 +485,7 @@ class AssetStoreTest extends TestCase
     public function testEncryptedCustomField()
     {
         $field = CustomField::factory()->testEncrypted()->create();
-        $asset = Asset::factory()->has_encrypted_custom_field()->create();
+        $asset = Asset::factory()->hasEncryptedCustomField()->create();
         $superuser = User::factory()->superuser()->create();
         $normal_user = User::factory()->editAssets()->create();
 

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -498,7 +498,7 @@ class AssetStoreTest extends TestCase
             ->assertOk()
             ->json();
         $asset->refresh();
-        $this->assertEquals(\Crypt::decrypt($asset->{$field->db_column_name()}), 'This is encrypted field');
+        $this->assertEquals('This is encrypted field', \Crypt::decrypt($asset->{$field->db_column_name()}));
 
         //next, test that a 'normal' user *cannot* change the encrypted custom field
         $response = $this->actingAsForApi($normal_user)
@@ -510,7 +510,7 @@ class AssetStoreTest extends TestCase
             ->assertMessagesAre('Asset updated successfully, but encrypted custom fields were not due to permissions')
             ->json();
         $asset->refresh();
-        $this->assertEquals(\Crypt::decrypt($asset->{$field->db_column_name()}), 'This is encrypted field');
+        $this->assertEquals('This is encrypted field', \Crypt::decrypt($asset->{$field->db_column_name()}));
 
     }
 }

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -482,16 +482,10 @@ class AssetStoreTest extends TestCase
             });
     }
 
-    public function markIncompleteIfMySQL()
-    {
-        if (config('database.default') === 'mysql') {
-            $this->markTestIncomplete('Custom Fields tests do not work on MySQL');
-        }
-    }
-
     public function testEncryptedCustomFieldCanBeStored()
     {
-        $this->markIncompleteIfMySQL();
+        $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');
+
         $status = Statuslabel::factory()->create();
         $field = CustomField::factory()->testEncrypted()->create();
         $superuser = User::factory()->superuser()->create();

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -6,7 +6,6 @@ use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Company;
 use App\Models\CustomField;
-use App\Models\CustomFieldset;
 use App\Models\Location;
 use App\Models\Statuslabel;
 use App\Models\Supplier;
@@ -484,40 +483,50 @@ class AssetStoreTest extends TestCase
 
     public function testEncryptedCustomFieldCanBeStored()
     {
+        $status = Statuslabel::factory()->create();
         $field = CustomField::factory()->testEncrypted()->create();
-        $asset = Asset::factory()->hasEncryptedCustomField($field)->create();
         $superuser = User::factory()->superuser()->create();
+        $assetData = Asset::factory()->hasEncryptedCustomField($field)->make();
 
-        //first, test that an Admin user can save the encrypted custom field
         $response = $this->actingAsForApi($superuser)
-            // @todo: target store method
-            ->patchJson(route('api.assets.update', $asset->id), [
-                $field->db_column_name() => 'This is encrypted field'
+            ->postJson(route('api.assets.store'), [
+                $field->db_column_name() => 'This is encrypted field',
+                'model_id' => $assetData->model->id,
+                'status_id' => $status->id,
+                'asset_tag' => '1234',
             ])
             ->assertStatusMessageIs('success')
             ->assertOk()
             ->json();
-        $asset->refresh();
+
+        $asset = Asset::findOrFail($response['payload']['id']);
         $this->assertEquals('This is encrypted field', \Crypt::decrypt($asset->{$field->db_column_name()}));
     }
 
     public function testPermissionNeededToStoreEncryptedField()
     {
-        $field = CustomField::factory()->testEncrypted()->create();
-        $asset = Asset::factory()->hasEncryptedCustomField()->create();
-        $normal_user = User::factory()->editAssets()->create();
+        // @todo:
+        $this->markTestIncomplete();
 
-        //next, test that a 'normal' user *cannot* change the encrypted custom field
+        $status = Statuslabel::factory()->create();
+        $field = CustomField::factory()->testEncrypted()->create();
+        $normal_user = User::factory()->editAssets()->create();
+        $assetData = Asset::factory()->hasEncryptedCustomField($field)->make();
+
         $response = $this->actingAsForApi($normal_user)
-            // @todo: target store method
-            ->patchJson(route('api.assets.update', $asset->id), [
-                $field->db_column_name() => 'Some Other Value Entirely!'
+            ->postJson(route('api.assets.store'), [
+                $field->db_column_name() => 'Some Other Value Entirely!',
+                'model_id' => $assetData->model->id,
+                'status_id' => $status->id,
+                'asset_tag' => '1234',
             ])
+            // @todo: this is 403 unauthorized
             ->assertStatusMessageIs('success')
             ->assertOk()
             ->assertMessagesAre('Asset updated successfully, but encrypted custom fields were not due to permissions')
             ->json();
-        $asset->refresh();
+
+        $asset = Asset::findOrFail($response['payload']['id']);
         $this->assertEquals('This is encrypted field', \Crypt::decrypt($asset->{$field->db_column_name()}));
     }
 }

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -482,8 +482,16 @@ class AssetStoreTest extends TestCase
             });
     }
 
+    public function markIncompleteIfMySQL()
+    {
+        if (config('database.default') === 'mysql') {
+            $this->markTestIncomplete('Custom Fields tests do not work on MySQL');
+        }
+    }
+
     public function testEncryptedCustomFieldCanBeStored()
     {
+        $this->markIncompleteIfMySQL();
         $status = Statuslabel::factory()->create();
         $field = CustomField::factory()->testEncrypted()->create();
         $superuser = User::factory()->superuser()->create();

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -485,7 +485,7 @@ class AssetStoreTest extends TestCase
     public function testEncryptedCustomFieldCanBeStored()
     {
         $field = CustomField::factory()->testEncrypted()->create();
-        $asset = Asset::factory()->hasEncryptedCustomField()->create();
+        $asset = Asset::factory()->hasEncryptedCustomField($field)->create();
         $superuser = User::factory()->superuser()->create();
 
         //first, test that an Admin user can save the encrypted custom field

--- a/tests/Feature/Api/Assets/AssetUpdateTest.php
+++ b/tests/Feature/Api/Assets/AssetUpdateTest.php
@@ -12,7 +12,7 @@ class AssetUpdateTest extends TestCase
     public function testEncryptedCustomFieldCanBeUpdated()
     {
         $field = CustomField::factory()->testEncrypted()->create();
-        $asset = Asset::factory()->hasEncryptedCustomField()->create();
+        $asset = Asset::factory()->hasEncryptedCustomField($field)->create();
         $superuser = User::factory()->superuser()->create();
 
         //first, test that an Admin user can save the encrypted custom field
@@ -30,7 +30,7 @@ class AssetUpdateTest extends TestCase
     public function testPermissionNeededToUpdateEncryptedField()
     {
         $field = CustomField::factory()->testEncrypted()->create();
-        $asset = Asset::factory()->hasEncryptedCustomField()->create();
+        $asset = Asset::factory()->hasEncryptedCustomField($field)->create();
         $normal_user = User::factory()->editAssets()->create();
 
         $asset->{$field->db_column_name()} = \Crypt::encrypt("encrypted value should not change");

--- a/tests/Feature/Api/Assets/AssetUpdateTest.php
+++ b/tests/Feature/Api/Assets/AssetUpdateTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Api\Assets;
 use App\Models\Asset;
 use App\Models\CustomField;
 use App\Models\User;
+use Illuminate\Support\Facades\Crypt;
 use Tests\TestCase;
 
 class AssetUpdateTest extends TestCase
@@ -23,7 +24,7 @@ class AssetUpdateTest extends TestCase
             ->assertOk();
 
         $asset->refresh();
-        $this->assertEquals('This is encrypted field', \Crypt::decrypt($asset->{$field->db_column_name()}));
+        $this->assertEquals('This is encrypted field', Crypt::decrypt($asset->{$field->db_column_name()}));
     }
 
     public function testPermissionNeededToUpdateEncryptedField()
@@ -32,7 +33,7 @@ class AssetUpdateTest extends TestCase
         $asset = Asset::factory()->hasEncryptedCustomField($field)->create();
         $normal_user = User::factory()->editAssets()->create();
 
-        $asset->{$field->db_column_name()} = \Crypt::encrypt("encrypted value should not change");
+        $asset->{$field->db_column_name()} = Crypt::encrypt("encrypted value should not change");
         $asset->save();
 
         // test that a 'normal' user *cannot* change the encrypted custom field
@@ -45,6 +46,6 @@ class AssetUpdateTest extends TestCase
             ->assertMessagesAre('Asset updated successfully, but encrypted custom fields were not due to permissions');
 
         $asset->refresh();
-        $this->assertEquals("encrypted value should not change", \Crypt::decrypt($asset->{$field->db_column_name()}));
+        $this->assertEquals("encrypted value should not change", Crypt::decrypt($asset->{$field->db_column_name()}));
     }
 }

--- a/tests/Feature/Api/Assets/AssetUpdateTest.php
+++ b/tests/Feature/Api/Assets/AssetUpdateTest.php
@@ -3,15 +3,8 @@
 namespace Tests\Feature\Api\Assets;
 
 use App\Models\Asset;
-use App\Models\AssetModel;
-use App\Models\Company;
 use App\Models\CustomField;
-use App\Models\CustomFieldset;
-use App\Models\Location;
-use App\Models\Statuslabel;
-use App\Models\Supplier;
 use App\Models\User;
-use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
 class AssetUpdateTest extends TestCase

--- a/tests/Feature/Api/Assets/AssetUpdateTest.php
+++ b/tests/Feature/Api/Assets/AssetUpdateTest.php
@@ -10,8 +10,18 @@ use Tests\TestCase;
 
 class AssetUpdateTest extends TestCase
 {
+    // TODO - this 'helper' is duplicated in AssetStoreTest - we should extract it out if we can figure out how
+    public function markIncompleteIfMySQL()
+    {
+        if (config('database.default') === 'mysql') {
+            $this->markTestIncomplete('Custom Fields tests do not work on MySQL');
+        }
+    }
+
+
     public function testEncryptedCustomFieldCanBeUpdated()
     {
+        $this->markIncompleteIfMySQL();
         $field = CustomField::factory()->testEncrypted()->create();
         $asset = Asset::factory()->hasEncryptedCustomField($field)->create();
         $superuser = User::factory()->superuser()->create();
@@ -29,6 +39,7 @@ class AssetUpdateTest extends TestCase
 
     public function testPermissionNeededToUpdateEncryptedField()
     {
+        $this->markIncompleteIfMySQL();
         $field = CustomField::factory()->testEncrypted()->create();
         $asset = Asset::factory()->hasEncryptedCustomField($field)->create();
         $normal_user = User::factory()->editAssets()->create();

--- a/tests/Feature/Api/Assets/AssetUpdateTest.php
+++ b/tests/Feature/Api/Assets/AssetUpdateTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Api\Assets;
+
+use App\Models\Asset;
+use App\Models\AssetModel;
+use App\Models\Company;
+use App\Models\CustomField;
+use App\Models\CustomFieldset;
+use App\Models\Location;
+use App\Models\Statuslabel;
+use App\Models\Supplier;
+use App\Models\User;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class AssetUpdateTest extends TestCase
+{
+    public function testEncryptedCustomFieldCanBeUpdated()
+    {
+        $field = CustomField::factory()->testEncrypted()->create();
+        $asset = Asset::factory()->hasEncryptedCustomField()->create();
+        $superuser = User::factory()->superuser()->create();
+
+        //first, test that an Admin user can save the encrypted custom field
+        $response = $this->actingAsForApi($superuser)
+            ->patchJson(route('api.assets.update', $asset->id), [
+                $field->db_column_name() => 'This is encrypted field'
+            ])
+            ->assertStatusMessageIs('success')
+            ->assertOk()
+            ->json();
+        $asset->refresh();
+        $this->assertEquals(\Crypt::decrypt($asset->{$field->db_column_name()}), 'This is encrypted field');
+    }
+
+    public function testPermissionNeededToUpdateEncryptedField()
+    {
+        $field = CustomField::factory()->testEncrypted()->create();
+        $asset = Asset::factory()->hasEncryptedCustomField()->create();
+        $normal_user = User::factory()->editAssets()->create();
+
+        $asset->{$field->db_column_name()} = \Crypt::encrypt("encrypted value should not change");
+        $asset->save(); //is this needed?
+
+        //test that a 'normal' user *cannot* change the encrypted custom field
+        $response = $this->actingAsForApi($normal_user)
+            ->patchJson(route('api.assets.update', $asset->id), [
+                $field->db_column_name() => 'Some Other Value Entirely!'
+            ])
+            ->assertStatusMessageIs('success')
+            ->assertOk()
+            ->assertMessagesAre('Asset updated successfully, but encrypted custom fields were not due to permissions')
+            ->json();
+        $asset->refresh();
+        $this->assertEquals(\Crypt::decrypt($asset->{$field->db_column_name()}), "encrypted value should not change");
+
+    }
+}

--- a/tests/Feature/Api/Assets/AssetUpdateTest.php
+++ b/tests/Feature/Api/Assets/AssetUpdateTest.php
@@ -15,14 +15,13 @@ class AssetUpdateTest extends TestCase
         $asset = Asset::factory()->hasEncryptedCustomField($field)->create();
         $superuser = User::factory()->superuser()->create();
 
-        //first, test that an Admin user can save the encrypted custom field
-        $response = $this->actingAsForApi($superuser)
+        $this->actingAsForApi($superuser)
             ->patchJson(route('api.assets.update', $asset->id), [
                 $field->db_column_name() => 'This is encrypted field'
             ])
             ->assertStatusMessageIs('success')
-            ->assertOk()
-            ->json();
+            ->assertOk();
+
         $asset->refresh();
         $this->assertEquals('This is encrypted field', \Crypt::decrypt($asset->{$field->db_column_name()}));
     }
@@ -34,17 +33,17 @@ class AssetUpdateTest extends TestCase
         $normal_user = User::factory()->editAssets()->create();
 
         $asset->{$field->db_column_name()} = \Crypt::encrypt("encrypted value should not change");
-        $asset->save(); //is this needed?
+        $asset->save();
 
-        //test that a 'normal' user *cannot* change the encrypted custom field
-        $response = $this->actingAsForApi($normal_user)
+        // test that a 'normal' user *cannot* change the encrypted custom field
+        $this->actingAsForApi($normal_user)
             ->patchJson(route('api.assets.update', $asset->id), [
                 $field->db_column_name() => 'Some Other Value Entirely!'
             ])
             ->assertStatusMessageIs('success')
             ->assertOk()
-            ->assertMessagesAre('Asset updated successfully, but encrypted custom fields were not due to permissions')
-            ->json();
+            ->assertMessagesAre('Asset updated successfully, but encrypted custom fields were not due to permissions');
+
         $asset->refresh();
         $this->assertEquals("encrypted value should not change", \Crypt::decrypt($asset->{$field->db_column_name()}));
     }

--- a/tests/Feature/Api/Assets/AssetUpdateTest.php
+++ b/tests/Feature/Api/Assets/AssetUpdateTest.php
@@ -10,18 +10,10 @@ use Tests\TestCase;
 
 class AssetUpdateTest extends TestCase
 {
-    // TODO - this 'helper' is duplicated in AssetStoreTest - we should extract it out if we can figure out how
-    public function markIncompleteIfMySQL()
-    {
-        if (config('database.default') === 'mysql') {
-            $this->markTestIncomplete('Custom Fields tests do not work on MySQL');
-        }
-    }
-
-
     public function testEncryptedCustomFieldCanBeUpdated()
     {
-        $this->markIncompleteIfMySQL();
+        $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');
+
         $field = CustomField::factory()->testEncrypted()->create();
         $asset = Asset::factory()->hasEncryptedCustomField($field)->create();
         $superuser = User::factory()->superuser()->create();
@@ -39,7 +31,8 @@ class AssetUpdateTest extends TestCase
 
     public function testPermissionNeededToUpdateEncryptedField()
     {
-        $this->markIncompleteIfMySQL();
+        $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');
+
         $field = CustomField::factory()->testEncrypted()->create();
         $asset = Asset::factory()->hasEncryptedCustomField($field)->create();
         $normal_user = User::factory()->editAssets()->create();

--- a/tests/Feature/Api/Assets/AssetUpdateTest.php
+++ b/tests/Feature/Api/Assets/AssetUpdateTest.php
@@ -54,6 +54,5 @@ class AssetUpdateTest extends TestCase
             ->json();
         $asset->refresh();
         $this->assertEquals("encrypted value should not change", \Crypt::decrypt($asset->{$field->db_column_name()}));
-
     }
 }

--- a/tests/Feature/Api/Assets/AssetUpdateTest.php
+++ b/tests/Feature/Api/Assets/AssetUpdateTest.php
@@ -31,7 +31,7 @@ class AssetUpdateTest extends TestCase
             ->assertOk()
             ->json();
         $asset->refresh();
-        $this->assertEquals(\Crypt::decrypt($asset->{$field->db_column_name()}), 'This is encrypted field');
+        $this->assertEquals('This is encrypted field', \Crypt::decrypt($asset->{$field->db_column_name()}));
     }
 
     public function testPermissionNeededToUpdateEncryptedField()
@@ -53,7 +53,7 @@ class AssetUpdateTest extends TestCase
             ->assertMessagesAre('Asset updated successfully, but encrypted custom fields were not due to permissions')
             ->json();
         $asset->refresh();
-        $this->assertEquals(\Crypt::decrypt($asset->{$field->db_column_name()}), "encrypted value should not change");
+        $this->assertEquals("encrypted value should not change", \Crypt::decrypt($asset->{$field->db_column_name()}));
 
     }
 }

--- a/tests/Support/CanSkipTests.php
+++ b/tests/Support/CanSkipTests.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Support;
+
+trait CanSkipTests
+{
+    public function markIncompleteIfMySQL($message = 'Test skipped due to database driver being MySQL.')
+    {
+        if (config('database.default') === 'mysql') {
+            $this->markTestIncomplete($message);
+        }
+    }
+}

--- a/tests/Support/CustomTestMacros.php
+++ b/tests/Support/CustomTestMacros.php
@@ -87,5 +87,18 @@ trait CustomTestMacros
                 return $this;
             }
         );
+
+        TestResponse::macro(
+            'assertMessagesAre',
+            function (string $message) {
+                Assert::assertEquals(
+                    $message,
+                    $this['messages'],
+                    "Response messages was not {$message}"
+                );
+
+                return $this;
+            }
+        );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use RuntimeException;
 use Tests\Support\AssertsAgainstSlackNotifications;
+use Tests\Support\CanSkipTests;
 use Tests\Support\CustomTestMacros;
 use Tests\Support\InteractsWithAuthentication;
 use Tests\Support\InitializesSettings;
@@ -14,6 +15,7 @@ use Tests\Support\InitializesSettings;
 abstract class TestCase extends BaseTestCase
 {
     use AssertsAgainstSlackNotifications;
+    use CanSkipTests;
     use CreatesApplication;
     use CustomTestMacros;
     use InteractsWithAuthentication;


### PR DESCRIPTION
Some recent tweaks to the API code made it so that updates to encrypted custom fields were not correctly being encrypted, and, thus, not decrypted either.

This fixes that, and adds new tests to cover those possibilities.

Additionally, we decided to add some new parts - such as when you _try_ to update a custom field, but fail, because you don't have "admin" permissions. Now we still allow the request to succeed, but add a warning in the message. Tests now cover this possibility.

The one weird thing here is that there were *TWO* return statements in the API - one that, obviously, fired. And one that was being ignored. I decided to just simply delete the second one, since it was not actually being run, ever.

I think there are a lot of inefficiencies with how I've done the testing, and will probably tap @marcusmoore for some help on more Laravel-esque ways of setting those test factories up in a bit of a less-janky fashion going forward. But I'd still go with this for now, as it seems like it's more in the right direction.