### PR TITLE
Added a check for the asset tag int size

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -111,6 +111,13 @@ class AssetsController extends Controller
         // differently
         $asset_tags = $request->input('asset_tags');
 
+        foreach($asset_tags as $asset_tag) {
+            if ($asset_tag > PHP_INT_MAX) {
+                // Handle the case where the input value is out of range
+                return redirect()->back()->with('error', trans('general.asset_tag_range_error'));
+            }
+        }
+
         $settings = Setting::getSettings();
 
         $success = false;

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -112,7 +112,7 @@ class AssetsController extends Controller
         $asset_tags = $request->input('asset_tags');
 
         foreach($asset_tags as $asset_tag) {
-            if ($asset_tag > PHP_INT_MAX) {
+            if ($asset_tag >= PHP_INT_MAX) {
                 // Handle the case where the input value is out of range
                 return redirect()->back()->with('error', trans('general.asset_tag_range_error'));
             }
@@ -364,8 +364,13 @@ class AssetsController extends Controller
             }
         }
 
-        // Update the asset data
         $asset_tag = $request->input('asset_tags');
+        // Update the asset data
+        if ($asset_tag[1] >= PHP_INT_MAX) {
+            // Handle the case where the input value is out of range
+            return redirect()->back()->with('error', trans('general.asset_tag_range_error'));
+        }
+
         $serial = $request->input('serials');
         $asset->name = $request->input('name');
         $asset->serial = $serial[1];

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -817,7 +817,6 @@ class Asset extends Depreciable
     {
         $settings = \App\Models\Setting::getSettings();
 
-
         if ($settings->auto_increment_assets == '1') {
             if ($settings->zerofill_count > 0) {
                 return $settings->auto_increment_prefix.self::zerofill($settings->next_auto_tag_base + $additional_increment, $settings->zerofill_count);

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -23,6 +23,7 @@ return [
     'asset_report'          => 'Asset Report',
     'asset_tag'				=> 'Asset Tag',
     'asset_tags'            => 'Asset Tags',
+    'asset_tag_range_error' => 'Asset Tag value is too large, choose a smaller value',
     'assets_available'		=> 'Assets available',
     'accept_assets'         => 'Accept Assets :name',
     'accept_assets_menu'    => 'Accept Assets',

--- a/tests/Feature/Api/Assets/AssetStoreTest.php
+++ b/tests/Feature/Api/Assets/AssetStoreTest.php
@@ -388,6 +388,35 @@ class AssetStoreTest extends TestCase
             ->assertOk()
             ->assertStatusMessageIs('success');
     }
+    public function testAssetTagsCanNotBeOutOfIntRange()
+    {
+        $model = AssetModel::factory()->create();
+        $status = Statuslabel::factory()->create();
+        $asset_tags = ['1234567890','922337203685477580800000000'];
+
+        $this->settings->disableAutoIncrement();
+
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->postJson(route('api.assets.store'), [
+                'asset_tag' => $asset_tags[0],
+                'model_id' => $model->id,
+                'status_id' => $status->id,
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success')
+            ->json();
+
+        Asset::find($response['payload']['id'])->delete();
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->postJson(route('api.assets.store'), [
+                'asset_tag' => $asset_tags[1],
+                'model_id' => $model->id,
+                'status_id' => $status->id,
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('error');
+    }
 
     public function testAnAssetCanBeCheckedOutToUserOnStore()
     {


### PR DESCRIPTION
# Description
Adds a check to see if an `asset_tag` is above the `PHP_INT_MAX`. if so, you are redirected back to the asset edit page you were on with the following error message.

<img width="1098" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/d5d83ad4-5549-4b8a-9c6f-50aa1f320265">

Fixes # [sc-25213]

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
