### PR TITLE
Left Sidebar Was Not Respecting Theme

### DIFF
--- a/resources/assets/less/mixins.less
+++ b/resources/assets/less/mixins.less
@@ -131,7 +131,7 @@
     //Hover and active states
     &:hover > a, &.active > a {
       color: @sidebar-dark-hover-color;
-      background: @sidebar-dark-hover-bg;
+      background: @link-hover-border-color;
       border-left-color: @link-hover-border-color;
     }
     //First Level Submenu

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -370,7 +370,6 @@ input[type=text], input[type=search] {
 .fixed-table-body thead th .th-inner, .skin-purple-dark .sidebar-menu>li.active>a, .skin-purple .sidebar-menu>li:hover>a, .sidebar-toggle:hover {
   background-color: var(--header)!important;
 }
-
 .tab-content, .tab-pane {
   background-color: var(--back-main);
   color: var(--text-main);

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -368,8 +368,13 @@ input[type=text], input[type=search] {
   background-color: #5f5ca8;
 }
 .fixed-table-body thead th .th-inner, .skin-purple-dark .sidebar-menu>li.active>a, .skin-purple .sidebar-menu>li:hover>a, .sidebar-toggle:hover {
-  background-color: var(--header)!important;
+  background-color: #5f5ca8!important;
 }
+
+//.skin-purple-dark .sidebar-menu>li.active>a:hover {
+//  background-color: #5f5ca8;
+//}
+
 .tab-content, .tab-pane {
   background-color: var(--back-main);
   color: var(--text-main);

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -368,12 +368,8 @@ input[type=text], input[type=search] {
   background-color: #5f5ca8;
 }
 .fixed-table-body thead th .th-inner, .skin-purple-dark .sidebar-menu>li.active>a, .skin-purple .sidebar-menu>li:hover>a, .sidebar-toggle:hover {
-  background-color: #5f5ca8!important;
+  background-color: var(--header)!important;
 }
-
-//.skin-purple-dark .sidebar-menu>li.active>a:hover {
-//  background-color: #5f5ca8;
-//}
 
 .tab-content, .tab-pane {
   background-color: var(--back-main);


### PR DESCRIPTION
# Description
When hovering a category in the left sidebar, the hover effect was darkened, and was not taking the correct color.

old:
<img width="261" alt="Screenshot 2024-04-16 at 2 22 17 PM" src="https://github.com/snipe/snipe-it/assets/116301219/c9ae25f1-180f-4f09-a635-f855a9310ca3">

new:
<img width="249" alt="Screenshot 2024-04-16 at 2 21 42 PM" src="https://github.com/snipe/snipe-it/assets/116301219/a8a8d7e5-5ea1-4fe0-b56d-f0407bd2a45e">

Fixes # (issue)
[SC-25232](https://app.shortcut.com/grokability/story/25232/sidebar-takes-on-current-theme-color-only-after-clicking-on-an-option)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
visual check on themes


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
