### PR TITLE
REMOVED: Dark Theme Button Text Coloring

### DIFF
--- a/resources/assets/less/skins/skin-black-dark.less
+++ b/resources/assets/less/skins/skin-black-dark.less
@@ -70,7 +70,7 @@
 
   &.btn-primary, .btn-primary:link {
     background-color: darken(@black, 10%);
-    border-color: darken(@black, 20%);
+    border-color: #FFF;
     color: #fff;
   }
 

--- a/resources/assets/less/skins/skin-blue-dark.less
+++ b/resources/assets/less/skins/skin-blue-dark.less
@@ -245,7 +245,6 @@ body {
 }
 .btn-primary:hover {
   background-color: var(--button-primary);
-  color: var(--link)!important;
 }
 #componentsTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);

--- a/resources/assets/less/skins/skin-green-dark.less
+++ b/resources/assets/less/skins/skin-green-dark.less
@@ -236,7 +236,6 @@ body {
 }
 .btn-primary:hover {
   background-color: var(--button-primary);
-  color: var(--link)!important;
 }
 #componentsTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);

--- a/resources/assets/less/skins/skin-orange-dark.less
+++ b/resources/assets/less/skins/skin-orange-dark.less
@@ -243,7 +243,6 @@ a:link.btn-default{
 }
 .btn-primary:hover {
   background-color: var(--button-primary);
-  color: var(--link)!important;
 }
 #componentsTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -246,7 +246,6 @@ body {
 }
 .btn-primary:hover {
   background-color: var(--button-primary);
-  color: var(--link)!important;
 }
 #componentsTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);

--- a/resources/assets/less/skins/skin-red-dark.less
+++ b/resources/assets/less/skins/skin-red-dark.less
@@ -247,7 +247,6 @@ body {
 }
 .btn-primary:hover {
   background-color: var(--button-primary);
-  color: var(--link)!important;
 }
 #componentsTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);

--- a/resources/assets/less/skins/skin-yellow-dark.less
+++ b/resources/assets/less/skins/skin-yellow-dark.less
@@ -55,7 +55,7 @@
 
   &.btn-primary, .btn-primary:link {
     background-color: var(--button-default);
-    border-color: var(--button-default);
+    border-color: #000000;
     color: #545454;
   }
 


### PR DESCRIPTION
# Description
Dark theme buttons when hovered became unreadable.
This removes that hover effect so the text remains readable.
The 'click' effect remains so a user will know that they clicked the button.

Additionally, a white border was added to the dark black theme buttons, and a black border was added to the dark yellow theme buttons

This affects the header search bar magnifying glass, the Back, and the Save buttons.


<img width="184" alt="Screenshot 2024-04-18 at 7 43 46 PM" src="https://github.com/snipe/snipe-it/assets/116301219/95d4f19d-b209-4dfe-98c7-f47792786eb4">
<img width="173" alt="Screenshot 2024-04-18 at 7 44 03 PM" src="https://github.com/snipe/snipe-it/assets/116301219/e3c16c83-7592-4acd-a455-e26e33478675">
<img width="164" alt="Screenshot 2024-04-18 at 7 43 19 PM" src="https://github.com/snipe/snipe-it/assets/116301219/26412b78-da6f-45fe-b26f-429fff08d3b5">
<img width="214" alt="Screenshot 2024-04-18 at 7 44 12 PM" src="https://github.com/snipe/snipe-it/assets/116301219/a8f3b948-195d-4d66-9d57-2d9696c2de0a">
<img width="141" alt="Screenshot 2024-04-18 at 7 43 08 PM" src="https://github.com/snipe/snipe-it/assets/116301219/ba63b6e6-6894-496a-9648-54763abc5c36">
<img width="224" alt="Screenshot 2024-04-18 at 7 44 25 PM" src="https://github.com/snipe/snipe-it/assets/116301219/016dba63-7bf3-4858-b9b9-7a0c4300a463">
<img width="205" alt="Screenshot 2024-04-18 at 7 42 55 PM" src="https://github.com/snipe/snipe-it/assets/116301219/13ce7071-b565-4a30-8c58-ecee50ecbadf">
<img width="188" alt="Screenshot 2024-04-18 at 7 44 36 PM" src="https://github.com/snipe/snipe-it/assets/116301219/0f65d033-0ec8-43ec-b45b-039b4fd1f998">
<img width="147" alt="Screenshot 2024-04-18 at 7 42 38 PM" src="https://github.com/snipe/snipe-it/assets/116301219/d84571c8-8cb8-4cef-9838-9667317e0a36">
<img width="183" alt="Screenshot 2024-04-18 at 7 44 49 PM" src="https://github.com/snipe/snipe-it/assets/116301219/db3e414c-53a0-4026-96c2-66d4429ab529">
<img width="242" alt="Screenshot 2024-04-18 at 7 42 18 PM" src="https://github.com/snipe/snipe-it/assets/116301219/d3a36c25-2784-49db-a004-a8c0ef507739">
<img width="160" alt="Screenshot 2024-04-18 at 7 45 00 PM" src="https://github.com/snipe/snipe-it/assets/116301219/553c08ce-ce7e-45af-b9d6-395eaec19ac3">
<img width="195" alt="Screenshot 2024-04-18 at 7 41 43 PM" src="https://github.com/snipe/snipe-it/assets/116301219/0c19041c-ff2a-4425-9ae2-0ba48a25ec9f">
<img width="156" alt="Screenshot 2024-04-18 at 7 45 13 PM" src="https://github.com/snipe/snipe-it/assets/116301219/4d41262d-da42-4e27-9c53-a5d1b1affbb8">



Fixes # [SC-23235](https://app.shortcut.com/grokability/story/25235/hovering-buttons-causes-some-situations-in-which-they-are-unreadable-theme-dependant)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Visually tested in local instance

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
