### PR TITLE
Removed escaping on notes for file uploads

### DIFF
--- a/app/Http/Controllers/AssetModelsFilesController.php
+++ b/app/Http/Controllers/AssetModelsFilesController.php
@@ -38,7 +38,7 @@ class AssetModelsFilesController extends Controller
 
                 $file_name = $request->handleFile('private_uploads/assetmodels/','model-'.$model->id,$file);
 
-                $model->logUpload($file_name, e($request->get('notes')));
+                $model->logUpload($file_name, $request->get('notes'));
             }
 
             return redirect()->back()->with('success', trans('general.file_upload_success'));

--- a/app/Http/Controllers/Assets/AssetFilesController.php
+++ b/app/Http/Controllers/Assets/AssetFilesController.php
@@ -38,7 +38,7 @@ class AssetFilesController extends Controller
             foreach ($request->file('file') as $file) {
                 $file_name = $request->handleFile('private_uploads/assets/','hardware-'.$asset->id, $file);
                 
-                $asset->logUpload($file_name, e($request->get('notes')));
+                $asset->logUpload($file_name, $request->get('notes'));
             }
 
             return redirect()->back()->with('success', trans('admin/hardware/message.upload.success'));


### PR DESCRIPTION
Looks like we were encoding the DB value of the notes on the asset model and asset file uploads. We already encode on the way out, so this was causing double-encoding.

<img width="1690" alt="Screenshot 2024-04-22 at 2 57 28 PM" src="https://github.com/snipe/snipe-it/assets/197404/5aa81211-0973-40a6-a849-1f3da541f40e">
