### PR TITLE
Added "select" option to top of data sources in new label engine

### DIFF
--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -245,6 +245,7 @@ return [
     'select_all'            => 'Select All',
     'search'				=> 'Search',
     'select_category'       => 'Select a Category',
+    'select_datasource' => 'Select a Datasource',
     'select_department'     => 'Select a Department',
     'select_depreciation'	=> 'Select a Depreciation Type',
     'select_location'		=> 'Select a Location',

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -306,6 +306,7 @@
                         <label style="grid-area: source-title">DataSource</label>
                         <select style="grid-area: source-field" x-model="option.datasource">
                             <optgroup label="Asset">
+                                <option value="" disabled>{{ trans('general.select_datasource') }}</option>
                                 <option value="asset_tag">{{trans('admin/hardware/table.asset_tag')}}</option>
                                 <option value="name">{{trans('admin/hardware/form.name')}}</option>
                                 <option value="serial">{{trans('admin/hardware/table.serial')}}</option>


### PR DESCRIPTION
# Description

This PR fixes a bug where `Asset Tag` appeared to be selected as the default data source but was actually being stored as an empty string in the new label engine. 

Previously: If you were to Click the `+` for a Field Option and see the DataSource says "Asset Tag" you would probably think "awesome! That's exactly what I want!" then hit the save button and wonder why asset tags weren't being printed on labels.

![Example](https://github.com/snipe/snipe-it/assets/1141514/cca3f144-8ad1-49ad-8086-200d54fe63d2)
> Hitting save right after this gif ends means no asset tags would show up on labels 😢 

This PR fixes this issue by adding a default (and disabled) "Select a DataSource" option to the top of the list so users have to select an option and thus it will be stored as expected.

![New select](https://github.com/snipe/snipe-it/assets/1141514/f966684b-26b8-4ea7-bbd8-2a8dafd1b85d)

![Expanded](https://github.com/snipe/snipe-it/assets/1141514/d2530168-e264-4267-9779-2f012ff8ec2f)

Side-note: I didn't nail down the exact issue. The value in dev tools seems to be set correctly. Selecting another option and then selecting "Asset Tag" from the list fixes the issue too. There is a lot of alpine running on the page though so it might be something there?

Fixes #14585

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)