### PR TITLE
Proposing another label template

### DIFF
--- a/app/Models/Labels/DefaultLabelAlternate.php
+++ b/app/Models/Labels/DefaultLabelAlternate.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace App\Models\Labels;
+
+use App\Helpers\Helper;
+use App\Models\Setting;
+
+class DefaultLabelAlternate extends RectangleSheet
+{
+    private const LOGO_MARGIN = 0.05;
+    private const TEXT_MARGIN = 0.04;
+    private const ASSET_TAG_OVERLAP = 3 / 5; // Tag number and 1D barcode overlap amount (1 = no overlap)
+
+    private float $textSize;
+
+    private float $labelWidth;
+    private float $labelHeight;
+
+    private float $labelSpacingH;
+    private float $labelSpacingV;
+
+    private float $pageMarginTop;
+    private float $pageMarginBottom;
+    private float $pageMarginLeft;
+    private float $pageMarginRight;
+
+    private float $pageWidth;
+    private float $pageHeight;
+
+    private int $columns;
+    private int $rows;
+
+
+    public function __construct() {
+        $settings = Setting::getSettings();
+
+        $this->textSize = Helper::convertUnit($settings->labels_fontsize, 'pt', 'in');
+
+        $this->labelWidth  = $settings->labels_width;
+        $this->labelHeight = $settings->labels_height;
+
+        $this->labelSpacingH = $settings->labels_display_sgutter;
+        $this->labelSpacingV = $settings->labels_display_bgutter;
+
+        $this->pageMarginTop    = $settings->labels_pmargin_top;
+        $this->pageMarginBottom = $settings->labels_pmargin_bottom;
+        $this->pageMarginLeft   = $settings->labels_pmargin_left;
+        $this->pageMarginRight  = $settings->labels_pmargin_right;
+
+        $this->pageWidth  = $settings->labels_pagewidth;
+        $this->pageHeight = $settings->labels_pageheight;
+
+        $usableWidth = $this->pageWidth - $this->pageMarginLeft - $this->pageMarginRight;
+        $usableHeight = $this->pageHeight - $this->pageMarginTop - $this->pageMarginBottom;
+
+        $this->columns = ($usableWidth + $this->labelSpacingH) / ($this->labelWidth + $this->labelSpacingH);
+        $this->rows = ($usableHeight + $this->labelSpacingV) / ($this->labelHeight + $this->labelSpacingV);
+
+        // Make sure the columns and rows are never zero, since that scenario should never happen
+        if ($this->columns == 0) {
+            $this->columns = 1;
+        }
+
+        if ($this->rows == 0) {
+            $this->rows = 1;
+        }
+
+    }
+
+    public function getUnit()   { return 'in'; }
+
+    public function getPageWidth()  { return $this->pageWidth; }
+    public function getPageHeight() { return $this->pageHeight; }
+
+    public function getPageMarginTop()    { return $this->pageMarginTop; }
+    public function getPageMarginBottom() { return $this->pageMarginBottom; }
+    public function getPageMarginLeft()   { return $this->pageMarginLeft; }
+    public function getPageMarginRight()  { return $this->pageMarginRight; }
+
+    public function getColumns() { return $this->columns; }
+    public function getRows()    { return $this->rows; }
+    public function getLabelBorder() { return 0; }
+
+    public function getLabelWidth()  { return $this->labelWidth; }
+    public function getLabelHeight() { return $this->labelHeight; }
+
+    public function getLabelMarginTop()    { return 0; }
+    public function getLabelMarginBottom() { return 0; }
+    public function getLabelMarginLeft()   { return 0; }
+    public function getLabelMarginRight()  { return 0; }
+
+    public function getLabelColumnSpacing() { return $this->labelSpacingH; }
+    public function getLabelRowSpacing()    { return $this->labelSpacingV; }
+
+    public function getSupportAssetTag()  { return true; }
+    public function getSupport1DBarcode() { return true; }
+    public function getSupport2DBarcode() { return true; }
+    public function getSupportFields()    { return 5; }
+    public function getSupportTitle()     { return true; }
+    public function getSupportLogo()      { return true; }
+
+    public function preparePDF($pdf) {}
+
+    public function write($pdf, $record) {
+
+        $asset = $record->get('asset');
+        $settings = Setting::getSettings();
+
+        $textY = 0;// Default if no title
+        $textX = 0;// Default if no logo
+        $titleW = $this->getLabelWidth();// Default if no logo
+
+        $BARCODE1D_SIZE = $this->getLabelHeight() * 0.15; // % of label height
+        $BARCODE2D_SIZE = $this->getLabelHeight() * 0.55; // % of label height
+
+        ## 1D Barcode ##
+        $barcode1D['height'] = $BARCODE1D_SIZE;
+        $barcode1D['width'] = $this->getLabelWidth() - ($this->pageMarginRight + $this->pageMarginLeft)* 2;
+
+        if ($record->get('barcode1d')) {
+            static::write1DBarcode(
+                $pdf, $record->get('barcode1d')->content, $record->get('barcode1d')->type,
+                $this->pageMarginLeft, $this->getLabelHeight() - $barcode1D['height'],
+                $barcode1D['width'], $barcode1D['height']
+            );
+        }
+
+        ## Logo ##
+        if ($record->get('logo')) {
+            // Calculate the available height for the logo
+            $availableHeight = $this->getLabelHeight() - $BARCODE2D_SIZE - $barcode1D['height'] - self::LOGO_MARGIN * 2;
+
+            // Get the aspect ratio of the logo
+            $imageInfo = getimagesize($record->get('logo'));
+            $aspectRatio = $imageInfo[0] / $imageInfo[1];
+
+            // Calculate the width of the logo based on the aspect ratio and the available height
+            $calculatedLogoWidth = $aspectRatio * $availableHeight;
+
+            // Write the logo image with the calculated width and maintain aspect ratio
+            static::writeImage(
+                $pdf, $record->get('logo'),
+                0, 0,
+                $calculatedLogoWidth, null,
+                'L', 'T', 300, true, false, 0
+            );
+
+            $textX += $calculatedLogoWidth + self::LOGO_MARGIN;
+            $titleW -= $calculatedLogoWidth + self::LOGO_MARGIN;
+        }
+
+        ## Title ##
+        if ($record->get('title')) {
+            static::writeText(
+                $pdf, $record->get('title'),
+                $textX, 0,
+                'freesans', 'b', $this->textSize, 'C',
+                $titleW, $this->textSize,
+                true, 0
+            );
+            $textY += $this->textSize;
+        }
+
+        // Calculate the y-position for the 2D barcode
+        $barcode2DY = ($record->get('logo'))
+            ? $this->getLabelHeight() - $barcode1D['height'] - $BARCODE2D_SIZE - self::LOGO_MARGIN
+            : ($this->getLabelHeight() - $barcode1D['height'] - $BARCODE2D_SIZE + $textY) / 2 - self::TEXT_MARGIN;
+
+        ## 2D Barcode ##
+        if ($record->get('barcode2d')) {
+            static::write2DBarcode(
+                $pdf, $record->get('barcode2d')->content, $record->get('barcode2d')->type,
+                0, $barcode2DY,
+                $BARCODE2D_SIZE, $BARCODE2D_SIZE
+            );
+        }
+
+        ## Fields ##
+        $fields = $record->get('fields');
+        $assetTagSet = isset($field['dataSource']) ? ($field['dataSource'] === 'asset_tag') : false;// Check if asset_tag field is set
+        $fieldCount = ($assetTagSet) ? count($fields) + 1 : count($fields);// Count should exclude asset_tag field
+        $totalFieldsHeight = $fieldCount * ($this->textSize + self::TEXT_MARGIN);// Calculate the total height occupied by the fields
+
+        // Calculate the y-position to center the fields vertically within the label, between the title and barcode1D
+        $centerY = ($this->getLabelHeight() + ($textY - self::TEXT_MARGIN) - $barcode1D['height'] - $totalFieldsHeight) / 2;
+
+        // Using TCPDF function to get string length (in inches) to determine longest strings
+        $maxLabelWidth = $maxValueWidth = 0;
+        $pdf->SetFont('freemono', 'b', $settings->labels_fontsize);
+        foreach ($fields as $field) {
+            $maxLabelWidth = max($maxLabelWidth, $pdf->GetStringWidth($field['label']));
+            $maxValueWidth = max($maxValueWidth, $pdf->GetStringWidth($field['value']));
+        }
+
+        // Calculate available width on the label for the fields
+        $availableWidth = $this->getLabelWidth() - $BARCODE2D_SIZE - $this->pageMarginRight - $this->pageMarginLeft - self::TEXT_MARGIN;
+
+        // Calculate combined width and scale factor
+        $combinedWidth = $maxLabelWidth + $maxValueWidth + self::TEXT_MARGIN;
+        $scaleFactor = ($combinedWidth > $availableWidth) ? ($availableWidth / $combinedWidth) : 1.0;
+
+        // Apply scale factor to widths
+        $maxLabelWidth *= $scaleFactor;
+        $maxValueWidth *= $scaleFactor;
+
+        // Calculate starting positions for label and value columns
+        $labelStartX = $BARCODE2D_SIZE + self::TEXT_MARGIN;
+        $valueStartX = $labelStartX + $maxLabelWidth;
+
+        // Iterate over all the fields and write the fields to the label
+        for ($fieldsDone = 0; $fieldsDone < min($this->getSupportFields(), $fieldCount); $fieldsDone++) {
+            $field = $fields[$fieldsDone];
+            $currentY = $centerY + $fieldsDone * ($this->textSize + self::TEXT_MARGIN);
+
+            // If asset tag is set, write it centered above the barcode
+            if ($field['dataSource'] === 'asset_tag') {
+                // Calculate the X and Y position for centering the text
+                $tagX = ($this->getLabelWidth() - $pdf->GetStringWidth($field['value'])) / 2;
+                $tagY = $this->getLabelHeight() - $barcode1D['height'] - $this->textSize * self::ASSET_TAG_OVERLAP;
+
+                // Write the text centered on the label
+                static::writeText(
+                    $pdf, $field['value'],
+                    $tagX, $tagY,
+                    'freemono', 'b', $this->textSize, 'C',
+                    $pdf->GetStringWidth($field['value']), null, false, 0, null,true
+                );
+
+                // Adjust centerY to account for the asset tag height
+                $centerY -= $this->textSize - self::TEXT_MARGIN;
+
+            } else {// Write the rest of the fields
+                // Write label text
+                if ($field['label']) {
+                    static::writeText(
+                        $pdf, $field['label'],
+                        $labelStartX, $currentY,
+                        'freemono', 'b', $this->textSize, 'R',
+                        $maxLabelWidth, null, true, 0
+                    );
+                }
+
+                // Write value text
+                static::writeText(
+                    $pdf, $field['value'],
+                    ($field['label']) ? $valueStartX + self::TEXT_MARGIN : $labelStartX, $currentY,
+                    'freemono', 'b', $this->textSize, ($field['label']) ? 'L' : 'C',
+                    ($field['label']) ? $maxValueWidth : $availableWidth, null, true, 0
+                );
+            }
+        }
+
+    }
+
+}
+
+?>

--- a/app/Models/Labels/DefaultLabelAlternate.php
+++ b/app/Models/Labels/DefaultLabelAlternate.php
@@ -110,8 +110,8 @@ class DefaultLabelAlternate extends RectangleSheet
         $textX = 0;// Default if no logo
         $titleW = $this->getLabelWidth();// Default if no logo
 
-        $BARCODE1D_SIZE = $this->getLabelHeight() * 0.15; // % of label height
-        $BARCODE2D_SIZE = $this->getLabelHeight() * 0.55; // % of label height
+        $BARCODE1D_SIZE = $this->getLabelHeight() * 0.18; // % of label height
+        $BARCODE2D_SIZE = $this->getLabelHeight() * 0.48; // % of label height
 
         ## 1D Barcode ##
         $barcode1D['height'] = $BARCODE1D_SIZE;

--- a/app/Models/Labels/Label.php
+++ b/app/Models/Labels/Label.php
@@ -190,7 +190,7 @@ abstract class Label
      * @param  int     $border  Thickness of border. Default = 0.
      * @param  int     $spacing Letter spacing. Default = 0.
      */
-    public final function writeText(TCPDF $pdf, $text, $x, $y, $font=null, $style=null, $size=null, $align='L', $width=null, $height=null, $squash=false, $border=0, $spacing=0) {
+    public final function writeText(TCPDF $pdf, $text, $x, $y, $font=null, $style=null, $size=null, $align='L', $width=null, $height=null, $squash=false, $border=0, $spacing=0, $whiteBg=false) {
         $prevFamily = $pdf->getFontFamily();
         $prevStyle = $pdf->getFontStyle();
         $prevSizePt = $pdf->getFontSizePt();
@@ -228,6 +228,12 @@ abstract class Label
             });
         }
         $cellHeight = !empty($height) ? $height : Helper::convertUnit($fontSizePt, 'pt', $this->getUnit());
+
+        // Draw a white background if requested
+        if ($whiteBg) {
+            $pdf->SetFillColor(255, 255, 255); // Set the background color to white
+            $pdf->Rect($x, $y, $cellWidth, $cellHeight, 'F'); // Draw the rectangle with white background
+        }
 
         if ($border) {
             $prevLineWidth = $pdf->getLineWidth();

--- a/app/Models/Labels/Label.php
+++ b/app/Models/Labels/Label.php
@@ -189,6 +189,7 @@ abstract class Label
      * @param  bool    $squash  Squash text if it's too big
      * @param  int     $border  Thickness of border. Default = 0.
      * @param  int     $spacing Letter spacing. Default = 0.
+     * @param  bool    $whiteBg Draw a white background behind the text. Default = false.
      */
     public final function writeText(TCPDF $pdf, $text, $x, $y, $font=null, $style=null, $size=null, $align='L', $width=null, $height=null, $squash=false, $border=0, $spacing=0, $whiteBg=false) {
         $prevFamily = $pdf->getFontFamily();


### PR DESCRIPTION
# Description

Proposing an additional label template and layout to provide users with more options. This label template dynamically adjusts field sizes for optimal display, particularly suited for "landscape" aspect ratios. This is a derivative of the DefaultLabel template, and should allow for some dynamic resizing of the page and label dimensions.

Please note there is also a minor change to the `public final function writeText()`. I've added a new input at the end called `$whiteBg=false` that allows text boxes to render with a white background. I'm including this change in this PR because of the dependency.

## Type of change
- [x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
I have tested a variety of different scenarios in my test environment. I've tested with and without logo, title, barcode, etc. I've tested different numbers of fields, different logo sizes, and so forth.

**Test Configuration**:
* PHP version: PHP 8.1.2-1ubuntu2.14
* MySQL version: mariadb from 11.3.2-MariaDB, client 15.2 for debian-linux-gnu (x86_64)
* Webserver version: Apache/2.4.52 (Ubuntu)
* OS version: Ubuntu 22.04.4 LTS

# Checklist:
- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
