### PR TITLE
Fixed `purchase_cost` not being allowed to be a string when creating asset via api

### DIFF
--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use App\Models\Asset;
 use App\Models\Company;
+use App\Models\Setting;
 use Carbon\Carbon;
 use Carbon\Exceptions\InvalidFormatException;
 use Illuminate\Support\Facades\Gate;
@@ -47,7 +48,7 @@ class StoreAssetRequest extends ImageUploadRequest
     {
         $modelRules = (new Asset)->getRules();
 
-        if (is_string($this->input('purchase_cost'))) {
+        if (Setting::getSettings()->digit_separator === '1.234,56' && is_string($this->input('purchase_cost'))) {
             // If purchase_cost was submitted as a string with a comma separator
             // then we need to ignore the normal numeric rules.
             // Since the original rules still live on the model they will be run

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -45,8 +45,14 @@ class StoreAssetRequest extends ImageUploadRequest
      */
     public function rules(): array
     {
+        $modelRules = (new Asset)->getRules();
+
+        $modelRules['purchase_cost'] = array_filter(explode('|', $modelRules['purchase_cost']), function ($rule) {
+            return $rule !== 'numeric' && $rule !== 'gte:0';
+        });
+
         $rules = array_merge(
-            (new Asset)->getRules(),
+            $modelRules,
             parent::rules(),
         );
 

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -47,9 +47,7 @@ class StoreAssetRequest extends ImageUploadRequest
     {
         $modelRules = (new Asset)->getRules();
 
-        $modelRules['purchase_cost'] = array_filter(explode('|', $modelRules['purchase_cost']), function ($rule) {
-            return $rule !== 'numeric' && $rule !== 'gte:0';
-        });
+        $modelRules['purchase_cost'] = $this->removeNumericRulesFromPurchaseCost($modelRules['purchase_cost']);
 
         $rules = array_merge(
             $modelRules,
@@ -74,5 +72,17 @@ class StoreAssetRequest extends ImageUploadRequest
                 // invalid format so validation picks it up later
             }
         }
+    }
+
+    private function removeNumericRulesFromPurchaseCost($purchaseCost)
+    {
+        // If rule is in "|" format then turn it into an array
+        if (is_string($purchaseCost)) {
+            $purchaseCost = explode('|', $purchaseCost);
+        }
+
+        return array_filter($purchaseCost, function ($rule) {
+            return $rule !== 'numeric' && $rule !== 'gte:0';
+        });
     }
 }

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -47,12 +47,14 @@ class StoreAssetRequest extends ImageUploadRequest
     {
         $modelRules = (new Asset)->getRules();
 
-        // If purchase_cost was submitted as a string with a comma separator
-        // then we need to ignore the normal numeric rules.
-        // Since the original rules still live on the model they will be run
-        // right before saving (and after purchase_cost has been
-        // converted to a float via setPurchaseCostAttribute).
-        $modelRules = $this->removeNumericRulesFromPurchaseCost($modelRules);
+        if (is_string($this->input('purchase_cost'))) {
+            // If purchase_cost was submitted as a string with a comma separator
+            // then we need to ignore the normal numeric rules.
+            // Since the original rules still live on the model they will be run
+            // right before saving (and after purchase_cost has been
+            // converted to a float via setPurchaseCostAttribute).
+            $modelRules = $this->removeNumericRulesFromPurchaseCost($modelRules);
+        }
 
         return array_merge(
             $modelRules,

--- a/tests/Unit/Helpers/HelperTest.php
+++ b/tests/Unit/Helpers/HelperTest.php
@@ -16,4 +16,13 @@ class HelperTest extends TestCase
     {
         $this->assertIsString(Helper::defaultChartColors(-1));
     }
+
+    public function testParseCurrencyMethod()
+    {
+        $this->settings->set(['default_currency' => 'USD']);
+        $this->assertSame(12.34, Helper::ParseCurrency('USD 12.34'));
+
+        $this->settings->set(['digit_separator' => '1.234,56']);
+        $this->assertSame(12.34, Helper::ParseCurrency('12,34'));
+    }
 }


### PR DESCRIPTION
# Description

## The Issue
This PR fixes a recent and accidental breaking change that was introduced to the asset creation api endpoint.

Even though `purchase_cost` is [documented](https://snipe-it.readme.io/reference/hardware-create) to be a sent as a float, the endpoint would accept strings. This was helpful for users that have `digit_separator` set to comma separated and sent in values like `"12,45"` as a string.

### The Cause
We recently introduced the `StoreAssetRequest` form request to the asset creation api endpoint and that moved validation "up the stack". It uses the existing rules on the asset model which includes `numeric|gte:0` for `purchase_cost`. Prior to the introduction of `StoreAssetRequest`, sending `purchase_cost` as a string resulted in the field being converted to a float via the `setPurchaseCostAttribute()` method on `SnipeModel` which `Asset` extends so model level validation would pass. But now, since the validation is happening "higher in the stack", the property doesn't have the chance to get converted to a float and thus validation fails.

## The Solution
I updated `StoreAssetRequest` to check if the application's `digit_separator` setting is "comma-separated" and removes the `numeric|gte:0` from the validation rules if so. This allows validation to pass at the request level while still ensuring it is numeric at the model level (the removal in this PR is only in the request).

Fixes #14635

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)