### PR TITLE
Adds Dashboard view to permissions

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -26,7 +26,7 @@ class DashboardController extends Controller
     public function index()
     {
         // Show the page
-        if (Auth::user()->hasAccess('admin')) {
+        if (Auth::user()->hasAccess('admin') || Auth::user()->hasAccess('dashboard')) {
             $asset_stats = null;
 
             $counts['asset'] = \App\Models\Asset::count();

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -145,6 +145,11 @@ class AuthServiceProvider extends ServiceProvider
                 return true;
             }
         });
+        Gate::define('dashboard', function ($user) {
+            if ($user->hasAccess('dashboard')) {
+                return true;
+            }
+        });
 
 
         Gate::define('licenses.files', function ($user) {

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -35,6 +35,14 @@ return [
             'display'    => true,
         ],
     ],
+    'Dash Board' => [
+        [
+            'permission' => 'dashboard',
+            'label'      => 'View',
+            'note'       => 'This will allow users to view the dash board.',
+            'display'    => true,
+        ],
+    ],
 
     'Reports' => [
         [

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -418,14 +418,14 @@
                 <section class="sidebar">
                     <!-- sidebar menu: : style can be found in sidebar.less -->
                     <ul class="sidebar-menu" data-widget="tree">
-                        @can('admin')
+                        @canany(['admin', 'dashboard'])
                             <li {!! (\Request::route()->getName()=='home' ? ' class="active"' : '') !!} class="firstnav">
                                 <a href="{{ route('home') }}">
                                     <i class="fas fa-tachometer-alt fa-fw" aria-hidden="true"></i>
                                     <span>{{ trans('general.dashboard') }}</span>
                                 </a>
                             </li>
-                        @endcan
+                        @endcanany
                         @can('index', \App\Models\Asset::class)
                             <li class="treeview{{ ((Request::is('statuslabels/*') || Request::is('hardware*')) ? ' active' : '') }}">
                                 <a href="#"><i class="fas fa-barcode fa-fw" aria-hidden="true"></i>


### PR DESCRIPTION
# Description
Adds a permission to view the Dashboard. You are able to see the dashboard and the counts of assets, licenses consumables etc. but are only allowed to see the more specific details if you have permissions. ie. Locations, Categories.

<img width="1468" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/891f5bcb-97c2-45df-965a-cb3a9dacb789">

In this example of the dashboard I've given permissions to view locations
<img width="1130" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/f63782a3-10e8-4c45-8979-62a67bc5678e">


Fixes #12190 [sc-15649]

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
