### PR TITLE
Capitalize `N` instead of `y` since no is default

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -87,7 +87,7 @@ if($upgrade_requirements){
 // done fetching requirements
 
 if (!$no_interactive) {
-    $yesno = readline("\nProceed with upgrade? [Y/n]: ");
+    $yesno = readline("\nProceed with upgrade? [y/N]: ");
 } else {
     $yesno = "yes";
 }


### PR DESCRIPTION
# Description
A user is presented with the following prompt during upgrade:
```
Proceed with upgrade? [Y/n]: 
```
In this prompt, the `Y` is capitalized which implies that if nothing is entered, `Y` will be assumed. However if you enter nothing, the default behavior is as if `N` was entered and so `N` should be capitalized instead.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I ran the upgrade command and provided no input, the default result was as if I were to enter "n".

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Relates to #14668 