### PR TITLE
Load settings in `SendUpcomingAuditReport` command

### DIFF
--- a/app/Console/Commands/SendUpcomingAuditReport.php
+++ b/app/Console/Commands/SendUpcomingAuditReport.php
@@ -43,7 +43,7 @@ class SendUpcomingAuditReport extends Command
      */
     public function handle()
     {
-
+        $settings = Setting::getSettings();
         $interval = $settings->audit_warning_days ?? 0;
         $today = Carbon::now();
         $interval_date = $today->copy()->addDays($interval);

--- a/app/Console/Commands/SendUpcomingAuditReport.php
+++ b/app/Console/Commands/SendUpcomingAuditReport.php
@@ -48,7 +48,6 @@ class SendUpcomingAuditReport extends Command
         $today = Carbon::now();
         $interval_date = $today->copy()->addDays($interval);
 
-        $settings = Setting::getSettings();
         $assets = Asset::whereNull('deleted_at')->DueOrOverdueForAudit($settings)->orderBy('assets.next_audit_date', 'desc')->get();
         $this->info($assets->count().' assets must be audited in on or before '.$interval_date.' is deadline');
 


### PR DESCRIPTION
# Description

This PR adds `$settings = Setting::getSettings();` to the top of `SendUpcomingAuditReport` so `audit_warning_days` can be referenced properly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)