### PR TITLE
Fixes #14692 - set default variables for sidebar totals

### DIFF
--- a/app/Http/Middleware/AssetCountForSidebar.php
+++ b/app/Http/Middleware/AssetCountForSidebar.php
@@ -18,6 +18,14 @@ class AssetCountForSidebar
      */
     public function handle($request, Closure $next)
     {
+        /**
+         * This needs to be set for the /setup process, since the tables might not exist yet
+         */
+        $total_due_for_checkin = 0;
+        $total_overdue_for_checkin = 0;
+        $total_due_for_audit = 0;
+        $total_overdue_for_audit = 0;
+
         try {
             $total_rtd_sidebar = Asset::RTD()->count();
             view()->share('total_rtd_sidebar', $total_rtd_sidebar);


### PR DESCRIPTION
This one slipped past me . The `AssetCountForSidebar` middleware does some quick counting queries and shares with them all views for easy access and totals in the sidebar. Unfortunately, since this middleware also fires during `/setup`, where the migrations might not have been run yet, you might run into a 500 error on setup (since we're querying tables that might not exist until the next screen (which is database migrations).

Fixes #14692