### PR TITLE
Updated alpine to the latest version (3.13.10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2379,9 +2379,9 @@
             }
         },
         "alpinejs": {
-            "version": "3.13.5",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.13.5.tgz",
-            "integrity": "sha512-1d2XeNGN+Zn7j4mUAKXtAgdc4/rLeadyTMWeJGXF5DzwawPBxwTiBhFFm6w/Ei8eJxUZeyNWWSD9zknfdz1kEw==",
+            "version": "3.13.10",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.13.10.tgz",
+            "integrity": "sha512-86RB307VWICex0vG15Eq0x058cNNsvS57ohrjN6n/TJAVSFV+zXOK/E34nNHDHc6Poq+yTNCLqEzPqEkRBTMRQ==",
             "requires": {
                 "@vue/reactivity": "~3.1.1"
             }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "acorn-import-assertions": "^1.9.0",
         "admin-lte": "^2.4.18",
         "ajv": "^6.12.6",
-        "alpinejs": "3.13.5",
+        "alpinejs": "^3.13.10",
         "blueimp-file-upload": "^9.34.0",
         "bootstrap": "^3.4.1",
         "bootstrap-colorpicker": "^2.5.3",

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -209,7 +209,9 @@
                     array.splice(newIndex, 0, array.splice(oldIndex, 1)[0]);
                 },
 
-                get valueString() { return this.toString(this.fields); },
+                get valueString() {
+                    return this.getCombinedString(this.fields);
+                },
                 onTest: function(a) {
                     console.log('test', a);
                 },
@@ -229,7 +231,7 @@
                                 })
                         }));
                 },
-                toString: function(fields) {
+                getCombinedString: function (fields) {
                     return fields
                         .map(field => field.options
                             .map(option => option.label + '=' + option.datasource)


### PR DESCRIPTION
# Description

In order to get the label preview working for anything past 3.13.5 I needed to change the `toString` method name . I'm thinking Alpine started taking over that method in 3.13.6 (I didn't dig too deeply).

I'm opening this as a draft for now pending more local testing.

I'm targeting develop but can move it to the v7 branch if needed.

## Type of change

- [x] Dependency update