### PR TITLE
Fixes #14701 - wrong total asset count

### DIFF
--- a/app/Http/Middleware/AssetCountForSidebar.php
+++ b/app/Http/Middleware/AssetCountForSidebar.php
@@ -21,21 +21,32 @@ class AssetCountForSidebar
         /**
          * This needs to be set for the /setup process, since the tables might not exist yet
          */
+        $total_assets = 0;
         $total_due_for_checkin = 0;
         $total_overdue_for_checkin = 0;
         $total_due_for_audit = 0;
         $total_overdue_for_audit = 0;
 
         try {
-            $total_rtd_sidebar = Asset::RTD()->count();
-            view()->share('total_rtd_sidebar', $total_rtd_sidebar);
+            $settings = Setting::getSettings();
+            view()->share('settings', $settings);
         } catch (\Exception $e) {
             \Log::debug($e);
         }
 
         try {
-            $total_assets = Asset::RTD()->count();
+            $total_assets = Asset::all()->count();
+            if ($settings->show_archived_in_list != '1') {
+                $total_assets -= Asset::Archived()->count();
+            }
             view()->share('total_assets', $total_assets);
+        } catch (\Exception $e) {
+            \Log::debug($e);
+        }
+
+        try {
+            $total_rtd_sidebar = Asset::RTD()->count();
+            view()->share('total_rtd_sidebar', $total_rtd_sidebar);
         } catch (\Exception $e) {
             \Log::debug($e);
         }
@@ -71,13 +82,6 @@ class AssetCountForSidebar
         try {
             $total_byod_sidebar = Asset::where('byod', '=', '1')->count();
             view()->share('total_byod_sidebar', $total_byod_sidebar);
-        } catch (\Exception $e) {
-            \Log::debug($e);
-        }
-
-        try {
-            $settings = Setting::getSettings();
-            view()->share('settings', $settings);
         } catch (\Exception $e) {
             \Log::debug($e);
         }


### PR DESCRIPTION
# Description

The total asset count in the sidenav shows the ready to deploy count instead of the total count. Fix this by adjusting the query to all assets. Also respect the setting for archived assets. Add a default value for total assets, since we are now using the settings-variable, which is not available during the setup process.

While at it, move the block for total assets before the ready to deploy assets to match the ordering of the sidenav.

Fixes #14701 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
