### PR TITLE
Bulk Edit Tests and Tweaks

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -13,6 +13,7 @@ use App\Models\Setting;
 use App\View\Label;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Session;
@@ -189,13 +190,11 @@ class BulkAssetsController extends Controller
      * Save bulk edits
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @return Redirect
      * @internal param array $assets
      * @since [v2.0]
      */
     public function update(Request $request)
     {
-        //dd($request->all());
         $this->authorize('update', Asset::class);
         $has_errors = 0;
         $error_array = array();
@@ -390,7 +389,7 @@ class BulkAssetsController extends Controller
                              * but it wasn't.
                              */
                             if ($decrypted_old != $this->update_array[$field->db_column]) {
-                                $asset->{$field->db_column} = \Crypt::encrypt($this->update_array[$field->db_column]);
+                                $asset->{$field->db_column} = Crypt::encrypt($this->update_array[$field->db_column]);
                             } else {
                                 /*
                                  * Remove the encrypted custom field from the update_array, since nothing changed

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -214,7 +214,7 @@ class BulkAssetsController extends Controller
         }
 
 
-        $assets = Asset::whereIn('id', array_keys($request->input('ids')))->get();
+        $assets = Asset::whereIn('id', $request->input('ids'))->get();
 
 
 

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -195,6 +195,7 @@ class BulkAssetsController extends Controller
      */
     public function update(Request $request)
     {
+        //dd($request->all());
         $this->authorize('update', Asset::class);
         $has_errors = 0;
         $error_array = array();

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -363,6 +363,15 @@ class AssetFactory extends Factory
         });
     }
 
+    public function hasMultipleCustomFields(array $fields = null): self
+    {
+        return $this->state(function () use ($fields) {
+            return [
+                'model_id' => AssetModel::factory()->hasMultipleCustomFields($fields),
+            ];
+        });
+    }
+
 
     /**
      * This allows bypassing model level validation if you want to purposefully

--- a/database/factories/AssetModelFactory.php
+++ b/database/factories/AssetModelFactory.php
@@ -439,4 +439,13 @@ class AssetModelFactory extends Factory
             ];
         });
     }
+
+    public function hasMultipleCustomFields(array $fields = null)
+    {
+        return $this->state(function () use ($fields) {
+            return [
+                'fieldset_id' => CustomFieldset::factory()->hasMultipleCustomFields($fields),
+            ];
+        });
+    }
 }

--- a/database/factories/CustomFieldsetFactory.php
+++ b/database/factories/CustomFieldsetFactory.php
@@ -56,10 +56,8 @@ class CustomFieldsetFactory extends Factory
 
     public function hasMultipleCustomFields(array $fields = null): self
     {
-        return $this->afterCreating(function (CustomFieldset $fieldset) {
+        return $this->afterCreating(function (CustomFieldset $fieldset) use ($fields) {
             if (empty($fields)) {
-                //why are there two after creating and why does it break if i remove one
-                return $this->afterCreating(function (CustomFieldset $fieldset) {
                     $mac_address = CustomField::factory()->macAddress()->create();
                     $ram = CustomField::factory()->ram()->create();
                     $cpu = CustomField::factory()->cpu()->create();
@@ -67,7 +65,6 @@ class CustomFieldsetFactory extends Factory
                     $fieldset->fields()->attach($mac_address, ['order' => '1', 'required' => false]);
                     $fieldset->fields()->attach($ram, ['order' => '2', 'required' => false]);
                     $fieldset->fields()->attach($cpu, ['order' => '3', 'required' => false]);
-                });
             } else {
                 foreach ($fields as $field) {
                     $fieldset->fields()->attach($field, ['order' => '1', 'required' => false]);

--- a/database/factories/CustomFieldsetFactory.php
+++ b/database/factories/CustomFieldsetFactory.php
@@ -53,4 +53,25 @@ class CustomFieldsetFactory extends Factory
             $fieldset->fields()->attach($field, ['order' => '1', 'required' => false]);
         });
     }
+
+    public function hasMultipleCustomFields(array $fields = null): self
+    {
+        return $this->afterCreating(function (CustomFieldset $fieldset) {
+            if (empty($fields)) {
+                return $this->afterCreating(function (CustomFieldset $fieldset) {
+                    $mac_address = CustomField::factory()->macAddress()->create();
+                    $ram = CustomField::factory()->ram()->create();
+                    $cpu = CustomField::factory()->cpu()->create();
+
+                    $fieldset->fields()->attach($mac_address, ['order' => '1', 'required' => false]);
+                    $fieldset->fields()->attach($ram, ['order' => '2', 'required' => false]);
+                    $fieldset->fields()->attach($cpu, ['order' => '3', 'required' => false]);
+                });
+            } else {
+                foreach ($fields as $field) {
+                    $fieldset->fields()->attach($field, ['order' => '1', 'required' => false]);
+                }
+            }
+        });
+    }
 }

--- a/database/factories/CustomFieldsetFactory.php
+++ b/database/factories/CustomFieldsetFactory.php
@@ -58,6 +58,7 @@ class CustomFieldsetFactory extends Factory
     {
         return $this->afterCreating(function (CustomFieldset $fieldset) {
             if (empty($fields)) {
+                //why are there two after creating and why does it break if i remove one
                 return $this->afterCreating(function (CustomFieldset $fieldset) {
                     $mac_address = CustomField::factory()->macAddress()->create();
                     $ram = CustomField::factory()->ram()->create();

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -196,8 +196,8 @@
 
           @include("models/custom_fields_form_bulk_edit",["models" => $models])
 
-          @foreach ($assets as $key => $value)
-            <input type="hidden" name="ids[{{ $value }}]" value="1">
+          @foreach($assets as $asset)
+            <input type="hidden" name="ids[]" value="{{ $asset }}">
           @endforeach
         </div> <!--/.box-body-->
 

--- a/tests/Feature/Assets/AssetsBulkEditTest.php
+++ b/tests/Feature/Assets/AssetsBulkEditTest.php
@@ -82,18 +82,18 @@ class AssetsBulkEditTest extends TestCase
     {
         $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');
 
-        $mac_address = CustomField::factory()->macAddress()->create();
-        $ram = CustomField::factory()->ram()->create();
-        $cpu = CustomField::factory()->cpu()->create();
+        CustomField::factory()->macAddress()->create();
+        CustomField::factory()->ram()->create();
+        CustomField::factory()->cpu()->create();
+
+        $mac_address = CustomField::where('name', 'MAC Address')->first();
+        $ram = CustomField::where('name', 'RAM')->first();
+        $cpu = CustomField::where('name', 'CPU')->first();
 
         $assets = Asset::factory()->count(10)->hasMultipleCustomFields([$mac_address, $ram, $cpu])->create([
             $ram->db_column => 8,
             $cpu->db_column => '2.1',
         ]);
-
-        // seems like the fieldset is random, so bulkedit isn't working because assets don't have the "correct" fieldset
-        // look into more tomorrow
-        dd(Asset::find(1)->model->fieldset);
 
         $id_array = $assets->pluck('id')->toArray();
 
@@ -105,7 +105,7 @@ class AssetsBulkEditTest extends TestCase
 
         Asset::findMany($id_array)->each(function (Asset $asset) use ($ram, $cpu, $mac_address) {
             $this->assertEquals(16, $asset->{$ram->db_column});
-            $this->assertEquals('4.1', $asset->{$ram->db_column});
+            $this->assertEquals('4.1', $asset->{$cpu->db_column});
         });
     }
 }

--- a/tests/Feature/Assets/AssetsBulkEditTest.php
+++ b/tests/Feature/Assets/AssetsBulkEditTest.php
@@ -3,27 +3,78 @@
 namespace Tests\Feature\Assets;
 
 use App\Models\Asset;
+use App\Models\AssetModel;
+use App\Models\Company;
+use App\Models\Statuslabel;
+use App\Models\Supplier;
 use App\Models\User;
 use Carbon\Carbon;
 use Tests\TestCase;
 
 class AssetsBulkEditTest extends TestCase
 {
-    public function testBulkEditAsset()
+    public function testBulkEditAssetsAcceptsAllPossibleAttributes()
     {
-        $assets = Asset::factory()->count(10)->create(['purchase_date' => '2023-01-01']);
+        // sets up all needed models and attributes on the assets
+        // this test does not deal with custom fields - will be dealt with in separate cases
+        $status1 = Statuslabel::factory()->create();
+        $status2 = Statuslabel::factory()->create();
+        $model1 = AssetModel::factory()->create();
+        $model2 = AssetModel::factory()->create();
+        $supplier1 = Supplier::factory()->create();
+        $supplier2 = Supplier::factory()->create();
+        $company1 = Company::factory()->create();
+        $company2 = Company::factory()->create();
+        $assets = Asset::factory()->count(10)->create([
+            'purchase_date'    => '2023-01-01',
+            'expected_checkin' => '2023-01-01',
+            'status_id'        => $status1->id,
+            'model_id'         => $model1->id,
+            // skipping locations on this test, it deserves it's own test
+            'purchase_cost'    => 1234.90,
+            'supplier_id'      => $supplier1->id,
+            'company_id'       => $company1->id,
+            'order_number'     => '123456',
+            'warranty_months'  => 24,
+            'next_audit_date'  => '2024-06-01',
+            'requestable'      => false
+        ]);
 
+        // gets the ids together to submit to the endpoint
         $id_array = $assets->pluck('id')->toArray();
 
+        // submits the ids and new values for each attribute
         $response = $this->actingAs(User::factory()->editAssets()->create())->post(route('hardware/bulksave'), [
-            'ids'           => array_values($id_array),
-            'purchase_date' => '2024-01-01'
+            'ids'              => $id_array,
+            'purchase_date'    => '2024-01-01',
+            'expected_checkin' => '2024-01-01',
+            'status_id'        => $status2->id,
+            'model_id'         => $model2->id,
+            'purchase_cost'    => 5678.92,
+            'supplier_id'      => $supplier2->id,
+            'company_id'       => $company2->id,
+            'order_number'     => '7890',
+            'warranty_months'  => 36,
+            'next_audit_date'  => '2025-01-01',
+            'requestable'      => true
         ])
             ->assertStatus(302)
             ->assertSessionHasNoErrors();
 
-        Asset::findMany($id_array)->each(function (Asset $asset) {
+        // asserts that each asset has the updated values
+        Asset::findMany($id_array)->each(function (Asset $asset) use ($status2, $model2, $supplier2, $company2) {
             $this->assertEquals('2024-01-01', $asset->purchase_date->format('Y-m-d'));
+            $this->assertEquals('2024-01-01', $asset->expected_checkin->format('Y-m-d'));
+            $this->assertEquals($status2->id, $asset->status_id);
+            $this->assertEquals($model2->id, $asset->model_id);
+            $this->assertEquals(5678.92, $asset->purchase_cost);
+            $this->assertEquals($supplier2->id, $asset->supplier_id);
+            $this->assertEquals($company2->id, $asset->company_id);
+            $this->assertEquals(7890, $asset->order_number);
+            $this->assertEquals(36, $asset->warranty_months);
+            $this->assertEquals('2025-01-01', $asset->next_audit_date->format('Y-m-d'));
+            // shouldn't requestable be cast as a boolean???
+            $this->assertEquals(1, $asset->requestable);
         });
 
         $this->assertDatabaseHas('assets', [

--- a/tests/Feature/Assets/AssetsBulkEditTest.php
+++ b/tests/Feature/Assets/AssetsBulkEditTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature\Assets;
+
+use App\Models\Asset;
+use App\Models\User;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class AssetsBulkEditTest extends TestCase
+{
+    public function testBulkEditAsset()
+    {
+        $assets = Asset::factory()->count(10)->create(['purchase_date' => '2023-01-01']);
+
+        $id_array = $assets->pluck('id')->toArray();
+
+        $response = $this->actingAs(User::factory()->editAssets()->create())->post(route('hardware/bulksave'), [
+            'ids'           => array_values($id_array),
+            'purchase_date' => '2024-01-01'
+        ])
+            ->assertStatus(302)
+            ->assertSessionHasNoErrors();
+
+        Asset::findMany($id_array)->each(function (Asset $asset) {
+            $this->assertEquals('2024-01-01', $asset->purchase_date->format('Y-m-d'));
+        });
+
+        $this->assertDatabaseHas('assets', [
+            'purchase_date' => '2024-01-01'
+        ]);
+    }
+}

--- a/tests/Feature/Assets/AssetsBulkEditTest.php
+++ b/tests/Feature/Assets/AssetsBulkEditTest.php
@@ -86,17 +86,17 @@ class AssetsBulkEditTest extends TestCase
         $ram = CustomField::factory()->ram()->create();
         $cpu = CustomField::factory()->cpu()->create();
 
-        $assets = Asset::factory()->laptopMbp()->count(10)->hasMultipleCustomFields([$mac_address, $ram, $cpu])->create([
+        $assets = Asset::factory()->count(10)->hasMultipleCustomFields([$mac_address, $ram, $cpu])->create([
             $ram->db_column => 8,
             $cpu->db_column => '2.1',
         ]);
 
+        // seems like the fieldset is random, so bulkedit isn't working because assets don't have the "correct" fieldset
+        // look into more tomorrow
+        dd(Asset::find(1)->model->fieldset);
+
         $id_array = $assets->pluck('id')->toArray();
 
-        // submits the ids and new values for each attribute
-        $asset = Asset::find(1);
-
-        $this->assertEquals(8, $asset->{$ram->db_column});
         $this->actingAs(User::factory()->editAssets()->create())->post(route('hardware/bulksave'), [
             'ids'           => $id_array,
             $ram->db_column => 16,


### PR DESCRIPTION
# Description
This introduces some bulk edit tests, includes some tweaks to factories, an extra gate, and the flipping of keys and values in an array. 

The key value flip is because the array was originally 
`'id' => 'key'`
but now is properly 
`'key' => 'id'`
   
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
These _are_ tests. 😄 


**Test Configuration**:
* PHP version: 8.1
* MySQL version: 8.2
