### PR TITLE
Fix memory-hog query in AssetCountForSidebar middleware

### DIFF
--- a/app/Http/Middleware/AssetCountForSidebar.php
+++ b/app/Http/Middleware/AssetCountForSidebar.php
@@ -35,7 +35,7 @@ class AssetCountForSidebar
         }
 
         try {
-            $total_assets = Asset::all()->count();
+            $total_assets = Asset::count();
             if ($settings->show_archived_in_list != '1') {
                 $total_assets -= Asset::Archived()->count();
             }


### PR DESCRIPTION
https://github.com/snipe/snipe-it/pull/14702/files introduced a bug
where instead of doing a quick `select count(*)` of assets, it did a `select *` of
assets, moving the count from the database to the PHP process.

This caused OOM issues in memory-constrained environments with lots of
assets, and also presented a speed issue even when memory limited were
increased.

Additionally, given this populates the sidebar, this was likely an issue
on every page load that included the sidebar.

The fix is simply removing the `all()->`, ending up with Asset::count(),
which yields the desired `select count(*)` DB query.