### PR TITLE
Added security.txt file

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,7 @@
+Contact: mailto:security@snipeitapp.com
+Expires: 2025-05-16T11:30:00.000Z
+Acknowledgments: https://snipeitapp.com/thanks
+Preferred-Languages: en-US, pt-PT, de-DE
+Canonical: https://github.com/snipe/snipe-it/blob/master/public/.well-known/security.txt
+Policy: https://snipeitapp.com/security
+Hiring: https://snipeitapp.com/company/careers


### PR DESCRIPTION
While we make our security posture and info pretty clear, it's common standard these days to include a [security.txt](https://securitytxt.org) file. I've opted not to bother with using a URL instead of an email address, since we surface our security reporting email address in 100 other places. 