### PR TITLE
Refactor group syncing on user edit API endpoint

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -475,7 +475,7 @@ class UsersController extends Controller
         if ($request->has('permissions')) {
             $permissions_array = $request->input('permissions');
 
-            // Strip out the superuser permission if the API user isn't a superadmin
+            // Strip out the individual superuser permission if the API user isn't a superadmin
             if (! Auth::user()->isSuperUser()) {
                 unset($permissions_array['superuser']);
             }
@@ -493,32 +493,20 @@ class UsersController extends Controller
           
         if ($user->save()) {
 
-            // Check if the request has groups passed and has a value
-            if ($request->filled('groups')) {
+            // Check if the request has groups passed and has a value, AND that the user us a superuser
+            if (($request->has('groups')) && (Auth::user()->isSuperUser())) {
 
                 $validator = Validator::make($request->all(), [
                     'groups.*' => 'integer|exists:permission_groups,id',
                 ]);
-                
-                if ($validator->fails()){
+
+                $user->groups()->sync($request->input('groups'));
+
+                if ($validator->fails()) {
                     return response()->json(Helper::formatStandardApiResponse('error', null, $user->getErrors()));
                 }
 
-                // Only save groups if the user is a superuser
-                if (Auth::user()->isSuperUser()) {
-                    $user->groups()->sync($request->input('groups'));
-                }
-
-            // The groups field has been passed but it is null, so we should blank it out
-            } elseif ($request->has('groups')) {
-                
-                // Only save groups if the user is a superuser
-                if (Auth::user()->isSuperUser()) {
-                    $user->groups()->sync($request->input('groups'));
-                }
             }
-
-
             return response()->json(Helper::formatStandardApiResponse('success', (new UsersTransformer)->transformUser($user), trans('admin/users/message.success.update')));
         }
 

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -496,17 +496,20 @@ class UsersController extends Controller
             // Check if the request has groups passed and has a value, AND that the user us a superuser
             if (($request->has('groups')) && (Auth::user()->isSuperUser())) {
 
-                $validator = Validator::make($request->all(), [
+                $validator = Validator::make($request->only('groups'), [
                     'groups.*' => 'integer|exists:permission_groups,id',
                 ]);
 
-                $user->groups()->sync($request->input('groups'));
-
                 if ($validator->fails()) {
-                    return response()->json(Helper::formatStandardApiResponse('error', null, $user->getErrors()));
+                    return response()->json(Helper::formatStandardApiResponse('error', null, $validator->errors()));
                 }
 
+                // Sync the groups since the user is a superuser and the groups pass validation
+                $user->groups()->sync($request->input('groups'));
+
+
             }
+
             return response()->json(Helper::formatStandardApiResponse('success', (new UsersTransformer)->transformUser($user), trans('admin/users/message.success.update')));
         }
 

--- a/resources/views/groups/view.blade.php
+++ b/resources/views/groups/view.blade.php
@@ -52,7 +52,7 @@
             @if (is_array($group->decodePermissions()))
             <ul class="list-unstyled">
                 @foreach ($group->decodePermissions() as $permission_name => $permission)
-                   <li>{!! ($permission == '1') ? '<i class="fas fa-check text-success" aria-hidden="true"></i><span class="sr-only">GRANTED: </span>' :  '<i class="fas fa-times text-danger" aria-hidden="true"></i><span class="sr-only">DENIED: </span>' !!} {{ e(str_replace('.', ': ', ucwords($permission_name))) }} </li>
+                   <li>{!! ($permission == '1') ? '<i class="fas fa-check text-success" aria-hidden="true"></i><span class="sr-only">'.trans('general.yes').': </span>' :  '<i class="fas fa-times text-danger" aria-hidden="true"></i><span class="sr-only">'.trans('general.no').': </span>' !!} {{ e(str_replace('.', ': ', ucwords($permission_name))) }} </li>
                 @endforeach
 
             </ul>

--- a/tests/Feature/Api/Users/UpdateUserApiTest.php
+++ b/tests/Feature/Api/Users/UpdateUserApiTest.php
@@ -139,7 +139,7 @@ class UpdateUserApiTest extends TestCase
             ]);
 
         $this->actingAsForApi($superUser)
-            ->patchJson(route('api.users.update', $userToUpdateByToUpdateuserBySuperuser), [
+            ->patchJson(route('api.users.update', $userToUpdateByToUserBySuperuser), [
                 'groups' => [$groupToJoin->id],
             ]);
 

--- a/tests/Feature/Api/Users/UpdateUserApiTest.php
+++ b/tests/Feature/Api/Users/UpdateUserApiTest.php
@@ -235,12 +235,11 @@ class UpdateUserApiTest extends TestCase
         $groupA = Group::factory()->create(['name'=>'Group A']);
         $groupB = Group::factory()->create(['name'=>'Group B']);
 
-        $response = $this->actingAsForApi($superUser)
+        $this->actingAsForApi($superUser)
             ->patchJson(route('api.users.update', $user), [
                 'groups' => [$groupA->id, $groupB->id],
             ])->json();
 
-        \Log::error($response);
         $this->assertTrue($user->refresh()->groups->contains($groupA));
         $this->assertTrue($user->refresh()->groups->contains($groupB));
     }

--- a/tests/Feature/Api/Users/UpdateUserApiTest.php
+++ b/tests/Feature/Api/Users/UpdateUserApiTest.php
@@ -127,27 +127,27 @@ class UpdateUserApiTest extends TestCase
     {
         $groupToJoin = Group::factory()->create();
 
-        $normalUser = User::factory()->editUsers()->create();
+        $userWhoCanEditUsers = User::factory()->editUsers()->create();
         $superUser = User::factory()->superuser()->create();
 
-        $oneUserToUpdate = User::factory()->create();
-        $anotherUserToUpdate = User::factory()->create();
+        $userToUpdateByToUpdateuserWhoCanEditUsers = User::factory()->create();
+        $userToUpdateByToUpdateuserBySuperuser = User::factory()->create();
 
-        $this->actingAsForApi($normalUser)
-            ->patchJson(route('api.users.update', $oneUserToUpdate), [
+        $this->actingAsForApi($userWhoCanEditUsers)
+            ->patchJson(route('api.users.update', $userToUpdateByToUpdateuserWhoCanEditUsers), [
                 'groups' => [$groupToJoin->id],
             ]);
 
         $this->actingAsForApi($superUser)
-            ->patchJson(route('api.users.update', $anotherUserToUpdate), [
+            ->patchJson(route('api.users.update', $userToUpdateByToUpdateuserBySuperuser), [
                 'groups' => [$groupToJoin->id],
             ]);
 
-        $this->assertFalse(
-            $oneUserToUpdate->refresh()->groups->contains($groupToJoin),
+        $this->assertFalse($userToUpdateByToUpdateuserWhoCanEditUsers->refresh()->groups->contains($groupToJoin),
             'Non-super-user was able to modify user group'
         );
-        $this->assertTrue($anotherUserToUpdate->refresh()->groups->contains($groupToJoin));
+
+        $this->assertTrue($userToUpdateByToUpdateuserBySuperuser->refresh()->groups->contains($groupToJoin));
     }
 
     public function testUserGroupsCanBeClearedBySuperUser()
@@ -175,4 +175,58 @@ class UpdateUserApiTest extends TestCase
         $this->assertTrue($oneUserToUpdate->refresh()->groups->contains($joinedGroup));
         $this->assertFalse($anotherUserToUpdate->refresh()->groups->contains($joinedGroup));
     }
+
+    public function testNonSuperuserCannotUpdateOwnGroups()
+    {
+        $groupToJoin = Group::factory()->create();
+
+        $user = User::factory()->editUsers()->create();
+
+        $this->actingAsForApi($user)
+            ->patchJson(route('api.users.update', $user), [
+                'groups' => [$groupToJoin->id],
+            ]);
+
+
+        $this->assertFalse($user->refresh()->groups->contains($groupToJoin),
+            'Non-super-user was able to modify user group'
+        );
+
+    }
+
+    public function testNonSuperuserCannotUpdateGroups()
+    {
+        $user = User::factory()->editUsers()->create();
+        $group = Group::factory()->create();
+        $user->groups()->sync([$group->id]);
+        $newGroupToJoin = Group::factory()->create();
+
+        $this->actingAsForApi($user)
+            ->patchJson(route('api.users.update', $user), [
+                'groups' => [$newGroupToJoin->id],
+            ]);
+
+
+        $this->assertFalse($user->refresh()->groups->contains($newGroupToJoin),
+            'Non-super-user was able to modify user group membership'
+        );
+
+        $this->assertTrue($user->refresh()->groups->contains($group));
+
+    }
+
+    public function testUsersGroupsAreNotClearedIfNoGroupPassedBySuperUser()
+    {
+        $user = User::factory()->create();
+        $superUser = User::factory()->superuser()->create();
+
+        $group = Group::factory()->create();
+        $user->groups()->sync([$group->id]);
+
+        $this->actingAsForApi($superUser)
+            ->patchJson(route('api.users.update', $user), []);
+
+        $this->assertTrue($user->refresh()->groups->contains($group));
+    }
+
 }

--- a/tests/Feature/Api/Users/UpdateUserApiTest.php
+++ b/tests/Feature/Api/Users/UpdateUserApiTest.php
@@ -147,7 +147,7 @@ class UpdateUserApiTest extends TestCase
             'Non-super-user was able to modify user group'
         );
 
-        $this->assertTrue($userToUpdateByToUpdateuserBySuperuser->refresh()->groups->contains($groupToJoin));
+        $this->assertTrue($userToUpdateByToUserBySuperuser->refresh()->groups->contains($groupToJoin));
     }
 
     public function testUserGroupsCanBeClearedBySuperUser()

--- a/tests/Feature/Api/Users/UpdateUserApiTest.php
+++ b/tests/Feature/Api/Users/UpdateUserApiTest.php
@@ -134,7 +134,7 @@ class UpdateUserApiTest extends TestCase
         $userToUpdateByToUserBySuperuser = User::factory()->create();
 
         $this->actingAsForApi($userWhoCanEditUsers)
-            ->patchJson(route('api.users.update', $userToUpdateByToUpdateuserWhoCanEditUsers), [
+            ->patchJson(route('api.users.update', $userToUpdateByUserWhoCanEditUsers), [
                 'groups' => [$groupToJoin->id],
             ]);
 

--- a/tests/Feature/Api/Users/UpdateUserApiTest.php
+++ b/tests/Feature/Api/Users/UpdateUserApiTest.php
@@ -130,8 +130,8 @@ class UpdateUserApiTest extends TestCase
         $userWhoCanEditUsers = User::factory()->editUsers()->create();
         $superUser = User::factory()->superuser()->create();
 
-        $userToUpdateByToUpdateuserWhoCanEditUsers = User::factory()->create();
-        $userToUpdateByToUpdateuserBySuperuser = User::factory()->create();
+        $userToUpdateByUserWhoCanEditUsers = User::factory()->create();
+        $userToUpdateByToUserBySuperuser = User::factory()->create();
 
         $this->actingAsForApi($userWhoCanEditUsers)
             ->patchJson(route('api.users.update', $userToUpdateByToUpdateuserWhoCanEditUsers), [

--- a/tests/Feature/Api/Users/UpdateUserApiTest.php
+++ b/tests/Feature/Api/Users/UpdateUserApiTest.php
@@ -143,7 +143,7 @@ class UpdateUserApiTest extends TestCase
                 'groups' => [$groupToJoin->id],
             ]);
 
-        $this->assertFalse($userToUpdateByToUpdateuserWhoCanEditUsers->refresh()->groups->contains($groupToJoin),
+        $this->assertFalse($userToUpdateByUserWhoCanEditUsers->refresh()->groups->contains($groupToJoin),
             'Non-super-user was able to modify user group'
         );
 


### PR DESCRIPTION
This tightens up the code around syncing user group membership when using the API and adds a bunch of tests for conditions we weren't testing before. 