### PR TITLE
Show error when `assigned_to` not null but `assigned_type` is null

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -718,16 +718,21 @@ class AssetsController extends Controller
                 }
             }
 
+            if (($request->filled('assigned_user')) || ($request->filled('assigned_asset')) || ($request->filled('assigned_location'))) {
+                app('App\Http\Requests\AssetCheckoutRequest');
+            }
+
 
             if ($asset->save()) {
-                if (($request->filled('assigned_user')) && ($target = User::find($request->get('assigned_user')))) {
-                        $location = $target->location_id;
-                } elseif (($request->filled('assigned_asset')) && ($target = Asset::find($request->get('assigned_asset')))) {
-                    $location = $target->location_id;
 
-                    Asset::where('assigned_type', \App\Models\Asset::class)->where('assigned_to', $id)
-                        ->update(['location_id' => $target->location_id]);
-                } elseif (($request->filled('assigned_location')) && ($target = Location::find($request->get('assigned_location')))) {
+                if ($request->filled('assigned_user')) {
+                    $target = User::find($request->get('assigned_user'));
+                    $location = $target->location_id;
+                } elseif ($request->filled('assigned_asset')) {
+                    $target = Asset::find($request->get('assigned_asset'));
+                    $location = $target->location_id;
+                } elseif ($request->filled('assigned_location')) {
+                    $target = Location::find($request->get('assigned_location'));
                     $location = $target->id;
                 }
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -689,6 +689,8 @@ class AssetsController extends Controller
             }     
 
             $asset = $request->handleImages($asset);
+
+
             $model = AssetModel::find($asset->model_id);
             
             // Update custom fields

--- a/app/Http/Requests/AssetCheckoutRequest.php
+++ b/app/Http/Requests/AssetCheckoutRequest.php
@@ -24,11 +24,8 @@ class AssetCheckoutRequest extends Request
             $this->assigned_type = 'App\Models\Location';
         }
 
-        $this->replace([
-            'assigned_asset' => $this->assigned_asset,
-            'assigned_location' => $this->assigned_location,
-            'assigned_user' => $this->assigned_user,
-            'assigned_type' => $this->checkout_to_type,
+        $this->merge([
+            'assigned_type' => $this->assigned_type,
         ]);
     }
 

--- a/app/Http/Requests/AssetCheckoutRequest.php
+++ b/app/Http/Requests/AssetCheckoutRequest.php
@@ -14,6 +14,25 @@ class AssetCheckoutRequest extends Request
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        if (!empty($this->assigned_user)) {
+            $this->assigned_type =  'App\Models\User';
+        } elseif (!empty($this->assigned_asset)) {
+            $this->assigned_type =  'App\Models\Asset';
+        } elseif (!empty($this->assigned_location)) {
+            $this->assigned_type = 'App\Models\Location';
+        }
+
+        $this->replace([
+            'assigned_asset' => $this->assigned_asset,
+            'assigned_location' => $this->assigned_location,
+            'assigned_user' => $this->assigned_user,
+            'assigned_type' => $this->checkout_to_type,
+        ]);
+    }
+
+
     /**
      * Get the validation rules that apply to the request.
      *
@@ -22,13 +41,14 @@ class AssetCheckoutRequest extends Request
     public function rules()
     {
         $rules = [
-            'assigned_user'         => 'required_without_all:assigned_asset,assigned_location',
-            'assigned_asset'        => 'required_without_all:assigned_user,assigned_location',
-            'assigned_location'     => 'required_without_all:assigned_user,assigned_asset',
+            'assigned_user'         => ['required_without_all:assigned_asset,assigned_location','nullable','exists:users,id,deleted_at,NULL'],
+            'assigned_asset'        => ['required_without_all:assigned_user,assigned_location','nullable','exists:assets,id,deleted_at,NULL'],
+            'assigned_location'     => ['required_without_all:assigned_user,assigned_asset','nullable','exists:locations,id,deleted_at,NULL'],
             'status_id'             => 'exists:status_labels,id,deployable,1',
-            'checkout_to_type'      => 'required|in:asset,location,user',
         ];
 
         return $rules;
     }
+
+
 }

--- a/database/factories/LocationFactory.php
+++ b/database/factories/LocationFactory.php
@@ -25,4 +25,10 @@ class LocationFactory extends Factory
             'image' => rand(1, 9).'.jpg',
         ];
     }
+
+    public function deleted()
+    {
+        return $this->state(['deleted_at' => $this->faker->dateTime()]);
+    }
+
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -84,6 +84,11 @@ class UserFactory extends Factory
         return $this->appendPermission(['superuser' => '1']);
     }
 
+    public function deleted()
+    {
+        return $this->state(['deleted_at' => $this->faker->dateTime()]);
+    }
+
     public function admin()
     {
         return $this->state(function () {

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -446,8 +446,8 @@
         </div>
       </div> <!-- /box-body-->
     </div> <!--/box-default-->
-  </div><!--/col-md-8-->
-</div><!--/row-->
+
+
 
 
 

--- a/tests/Feature/Api/Assets/AssetUpdateTest.php
+++ b/tests/Feature/Api/Assets/AssetUpdateTest.php
@@ -170,27 +170,6 @@ class AssetUpdateTest extends TestCase
         $this->assertNull($asset->assigned_to);
         $this->assertNull($asset->assigned_type);
     }
-
-    public function testCheckinOnAssetUpdate()
-    {
-        $asset = Asset::factory()->assignedToUser()->create();
-        $user = User::factory()->editAssets()->create();
-
-        $response = $this->actingAsForApi($user)
-            ->patchJson(route('api.assets.update', ['hardware' => $asset->id]), [
-                'assigned_user' => '',
-            ])
-            ->assertOk()
-            ->assertStatusMessageIs('success')
-            ->json();
-        \Log::error($response);
-
-        $asset->refresh();
-        $this->assertNull($asset->assigned_to);
-        $this->assertNull($asset->assigned_type);
-
-
-    }
-
+    
 
 }


### PR DESCRIPTION
This is a slight re-think of #14458  by @spencerrlongg. I'd be curious for feedback on it.

Need to test:

- API calls still work as expected
- No adverse affects on Importer