### PR TITLE
Fix permissions on storage dir for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ RUN \
       && ln -fs "/var/lib/snipeit/keys/ldap_client_tls.cert" "/var/www/html/storage/ldap_client_tls.cert" \
       && ln -fs "/var/lib/snipeit/keys/ldap_client_tls.key" "/var/www/html/storage/ldap_client_tls.key" \
       && chown docker "/var/lib/snipeit/keys/" \
-      && chown -h docker "/var/www/html/storage/" \
+      && chown -Rh docker "/var/www/html/storage/" \
       && chmod +x /var/www/html/artisan \
       && echo "Finished setting up application in /var/www/html"
 


### PR DESCRIPTION
# Description

Fixes [#12299](https://github.com/snipe/snipe-it/issues/12299) where currently there is no recursive permissions set on /var/www/html/storage/ during build time. As a result this requires users to run an exec into the container and change the permissions before they are able to initiate the setup. Without this a 500 error is thrown and little is evident in the docker logs as to what the issue is.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Built and ran container locally and was able to enter setup without needing to gain a shell into the container to adjust the permissions of the storage directory

**Test Configuration**:
docker container built on Ubuntu 23.10 
Docker version 26.1.3

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
