### PR TITLE
Nicer handling of erroring when filename+log do not match

### DIFF
--- a/app/Http/Controllers/Users/UserFilesController.php
+++ b/app/Http/Controllers/Users/UserFilesController.php
@@ -96,7 +96,7 @@ class UserFilesController extends Controller
                 return redirect()->back()->with('success', trans('admin/users/message.deletefile.success'));
             }
 
-            return redirect()->back()->with('success', trans('admin/users/message.user_not_found', ['id' => $userId]));
+            return redirect()->back()->with('error', trans('admin/users/general.log_does_not_exist'));
 
         }
 

--- a/app/Http/Controllers/Users/UserFilesController.php
+++ b/app/Http/Controllers/Users/UserFilesController.php
@@ -87,13 +87,11 @@ class UserFilesController extends Controller
 
                 $full_filename = $rel_path.'/'.$log->filename;
 
-                if (file_exists($full_filename)) {
-                    Storage::delete($rel_path.'/'.$log->filename);
+                if (Storage::exists($rel_path.'/'.$full_filename)) {
+                    Storage::delete($rel_path.'/'.$full_filename);
+                    $log->delete();
                     return redirect()->back()->with('success', trans('admin/users/message.deletefile.success'));
                 }
-
-                $log->delete();
-                return redirect()->back()->with('success', trans('admin/users/message.deletefile.success'));
             }
 
             return redirect()->back()->with('error', trans('admin/users/general.log_does_not_exist'));

--- a/app/Http/Controllers/Users/UserFilesController.php
+++ b/app/Http/Controllers/Users/UserFilesController.php
@@ -83,19 +83,20 @@ class UserFilesController extends Controller
             $this->authorize('delete', $user);
             $rel_path = 'private_uploads/users';
 
+
             if ($log = Actionlog::find($fileId)) {
-
-                $full_filename = $rel_path.'/'.$log->filename;
-
-                if (Storage::exists($rel_path.'/'.$full_filename)) {
-                    Storage::delete($rel_path.'/'.$full_filename);
-                    $log->delete();
+                $filename = $log->filename;
+                $log->delete();
+                
+                if (Storage::exists($rel_path.'/'.$filename)) {
+                    Storage::delete($rel_path.'/'.$filename);
                     return redirect()->back()->with('success', trans('admin/users/message.deletefile.success'));
                 }
+
             }
 
-            return redirect()->back()->with('error', trans('admin/users/general.log_does_not_exist'));
-
+            // The log record doesn't exist somehow
+            return redirect()->back()->with('success', trans('admin/users/message.deletefile.success'));
         }
 
         return redirect()->route('users.index')->with('error', trans('admin/users/message.user_not_found', ['id' => $userId]));


### PR DESCRIPTION
This is a bit of a fringe case, but sometimes it happens that in the `User > User Files` section, there is a file that exists but no matching file on the server, or vice versa. This is usually due to a restore or manually edited data, but we weren't accounting for it before and would 500. Now we give a nice error message.