### PR TITLE
Added exif to required extensions

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -248,6 +248,7 @@ $required_exts_array =
     [
         'bcmath',
         'curl',
+        'exif',
         'fileinfo',
         'gd|imagick',
         'json',


### PR DESCRIPTION
As of a few versions ago, we started requiring php-exif - which is *usually* installed by default but on some distros it isn't. This adds the dependency to the `upgrade.php` so we can shortcut the upgrade (as we do with other missing extensions) if it's not installed or not enabled.