### PR TITLE
Removed extra div from User Details.

### DIFF
--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -1099,7 +1099,6 @@
       </div><!-- /.tab-content -->
     </div><!-- nav-tabs-custom -->
   </div>
-</div>
 
   @can('update', \App\Models\User::class)
     @include ('modals.upload-file', ['item_type' => 'user', 'item_id' => $user->id])


### PR DESCRIPTION
# Description
Another extra div causing the footer to spill out.
Before:
<img width="350" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/ac2cdd90-eef8-4010-9b76-6c224d934969">
After:
<img width="350" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/5c751d04-648d-41d4-99c5-0614bf6069af">
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
