### PR TITLE
Add index to 'parent_id' for users with large number of locations

### DIFF
--- a/database/migrations/2024_05_27_143554_add_parent_id_index_to_locations.php
+++ b/database/migrations/2024_05_27_143554_add_parent_id_index_to_locations.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddParentIdIndexToLocations extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->index('parent_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            //
+            $table->dropIndex('locations_parent_id_index');
+        });
+    }
+}


### PR DESCRIPTION
Some users may have very large numbers of locations, which are configured in a complex hierarchy. Right now, we don't index the `parent_id` attribute of locations, because we generally don't have to. But for those users with the large number of locations, that can definitely cause some problems with locations listings.