### PR TITLE
Fixed Array to string conversion exception in group create api endpoint

### DIFF
--- a/app/Http/Controllers/Api/GroupsController.php
+++ b/app/Http/Controllers/Api/GroupsController.php
@@ -68,7 +68,7 @@ class GroupsController extends Controller
 
         $group->name = $request->input('name');
         $group->created_by = Auth::user()->id;
-        $group->permissions = $request->input('permissions', $groupPermissions);
+        $group->permissions = json_encode($request->input('permissions', $groupPermissions));
 
         if ($group->save()) {
             return response()->json(Helper::formatStandardApiResponse('success', (new GroupsTransformer)->transformGroup($group), trans('admin/groups/message.success.create')));

--- a/tests/Feature/Api/Groups/GroupStoreTest.php
+++ b/tests/Feature/Api/Groups/GroupStoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\Groups;
 
+use App\Helpers\Helper;
 use App\Models\Group;
 use App\Models\User;
 use Tests\TestCase;
@@ -49,10 +50,15 @@ class GroupStoreTest extends TestCase
 
         $this->assertNotNull($group);
 
+        $this->assertEquals(
+            Helper::selectedPermissionsArray(config('permissions'), config('permissions')),
+            $group->decodePermissions(),
+            'Default group permissions were not set as expected',
+        );
+
         $this->actingAsForApi($superuser)
             ->getJson(route('api.groups.show',  ['group' => $group]))
             ->assertOk();
-
     }
 
     public function testStoringGroupWithInvalidPermissionDropsBadPermission()


### PR DESCRIPTION
# Description

This PR follows up #14775 and fixes a potential `Array to string conversion` exception being thrown when creating a group via the api.

The additional assertion is to ensure the default permissions are set when `permissions` is not passed in the request to the API.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)