### PR TITLE
Fixed deprecation warning on category test

### DIFF
--- a/tests/Unit/CategoryTest.php
+++ b/tests/Unit/CategoryTest.php
@@ -20,7 +20,7 @@ class CategoryTest extends TestCase
          ];
         $errors = $a->getErrors();
         foreach ($fields as $field => $fieldTitle) {
-            $this->assertEquals($errors->get($field)[0], "The ${fieldTitle} field is required.");
+            $this->assertEquals($errors->get($field)[0], "The $fieldTitle field is required.");
         }
     }
 


### PR DESCRIPTION
Tiny fix to stop the annoying `Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /Users/snipe/Herd/snipe-it/tests/Unit/CategoryTest.php on line 23` warning we were getting when running tests.