### PR TITLE
Fixed #14781 - Fixed broken wrench icon on some browsers in manufacturer section

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -321,7 +321,7 @@
 
                                                     @if (($asset->model->manufacturer) && ($asset->model->manufacturer->warranty_lookup_url!=''))
                                                         <li>
-                                                            <i class="far fa-wrench" aria-hidden="true"></i>
+                                                            <i class="fa-solid fa-wrench" aria-hidden="true"></i>
                                                             <a href="{{ $asset->present()->dynamicWarrantyUrl() }}" target="_blank">
                                                                 {{ $asset->present()->dynamicWarrantyUrl() }}
                                                                 <i class="fa fa-external-link" aria-hidden="true"><span class="sr-only">{{ trans('admin/hardware/general.mfg_warranty_lookup', ['manufacturer' => $asset->model->manufacturer->name]) }}</span></i>


### PR DESCRIPTION
Small fix to update the fa icon reference so that the wrench icon shows up in Chrome, Edge, etc. (It already showed up okay in Safari, but this should fix it across the boards.)

Fixes #14781 