### PR TITLE
Added some  style changes in label field selector for the `DefaultLabel` template

### DIFF
--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -261,13 +261,18 @@
         <h1 class="l2fd-title" style="grid-area: fields-title">Fields</h1>
         <div class="l2fd-list" style="grid-area: fields-list">
             <template x-for="(field, index) in fields">
-                <div 
-                    x-bind:key="'field-' + index" 
+                <div
+                    x-data="{
+                                template: '{{ $template }}'
+                            }"
+                    x-bind:key="'field-' + index"
                     x-bind:class="{
                         'l2fd-listitem': true,
                         'selected': selectedField === field
                     }"
-                    x-on:click="selectedField = field" >
+                    x-bind:style="index < 4 && template === 'DefaultLabel' ? 'background-color:#EEEEEE;' : ''"
+                    x-on:click="selectedField = field"
+                    >
                     <label><span x-text="index+1"></span>: <span x-text="getFieldLabel(field)"></span></label>
                 </div>
             </template>

--- a/resources/views/partials/label2-field-definitions.blade.php
+++ b/resources/views/partials/label2-field-definitions.blade.php
@@ -270,7 +270,7 @@
                         'l2fd-listitem': true,
                         'selected': selectedField === field
                     }"
-                    x-bind:style="index < 4 && template === 'DefaultLabel' ? 'background-color:#EEEEEE;' : ''"
+                    x-bind:style="index < 4 && template === 'DefaultLabel' ? 'background-color:#EEEEEE;' : 'background-color:#FFF;'"
                     x-on:click="selectedField = field"
                     >
                     <label><span x-text="index+1"></span>: <span x-text="getFieldLabel(field)"></span></label>

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -216,7 +216,7 @@
                                     {{ Form::label('label2_fields', trans('admin/settings/general.label2_fields')) }}
                                 </div>
                                 <div class="col-md-9">
-                                    @include('partials.label2-field-definitions', [ 'name' => 'label2_fields', 'value' => old('label2_fields', $setting->label2_fields), 'customFields' => $customFields ])
+                                    @include('partials.label2-field-definitions', [ 'name' => 'label2_fields', 'value' => old('label2_fields', $setting->label2_fields), 'customFields' => $customFields, 'template' => $setting->label2_template])
                                     {!! $errors->first('label2_fields', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                     <p class="help-block">{{ trans('admin/settings/general.label2_fields_help') }}</p>
                                 </div>


### PR DESCRIPTION
# Description
if the`DefaultLabel` template is selected the top four field options created will be highlighted to indicate these are the only fields that will show. The highlight disappears for other templates.
<img width="700" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/b8f9cc96-7d04-4718-970b-8a33a8e8dc36">

https://github.com/snipe/snipe-it/assets/47435081/16e6bf28-1f2a-4bf4-9978-583ece5a23ee


Fixes #[sc-25690]

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
