### PR TITLE
Fixed checkin option from appearing

### DIFF
--- a/resources/views/partials/forms/redirect_submit_options.blade.php
+++ b/resources/views/partials/forms/redirect_submit_options.blade.php
@@ -5,7 +5,7 @@
             <select class="redirect-options form-control" name="redirect_option">
                 <option {{(Session::get('redirect_option')=="0" || (Session::get('redirect_option')=="2" && $checkin)) ? 'selected' : ''}} value="0">{{trans('admin/hardware/form.redirect_to_all', ['type' => $table_name])}}</option>
                 <option {{Session::get('redirect_option')=="1" ? 'selected' : ''}} value="1">{{trans('admin/hardware/form.redirect_to_type', ['type' => $type])}}</option>
-                <option {{Session::get('redirect_option')=="2" && !$checkin ? 'selected' : ''}}{{$checkin ? 'disabled' : ''}} value="2" >{{trans('admin/hardware/form.redirect_to_checked_out_to')}}</option>
+                <option {{Session::get('redirect_option')=="2" && !$checkin ? 'selected' : ''}}{{$checkin ? 'disabled hidden' : ''}} value="2" >{{trans('admin/hardware/form.redirect_to_checked_out_to')}}</option>
             </select>
         </div>
 </div> <!-- /.box-->

--- a/resources/views/partials/forms/redirect_submit_options.blade.php
+++ b/resources/views/partials/forms/redirect_submit_options.blade.php
@@ -5,7 +5,7 @@
             <select class="redirect-options form-control" name="redirect_option">
                 <option {{(Session::get('redirect_option')=="0" || (Session::get('redirect_option')=="2" && $checkin)) ? 'selected' : ''}} value="0">{{trans('admin/hardware/form.redirect_to_all', ['type' => $table_name])}}</option>
                 <option {{Session::get('redirect_option')=="1" ? 'selected' : ''}} value="1">{{trans('admin/hardware/form.redirect_to_type', ['type' => $type])}}</option>
-                <option {{(Session::get('redirect_option')=="2" && !$checkin) ? 'selected' : ''}} value="2" >{{trans('admin/hardware/form.redirect_to_checked_out_to')}}</option>
+                <option {{Session::get('redirect_option')=="2" && !$checkin ? 'selected' : ''}}{{$checkin ? 'disabled' : ''}} value="2" >{{trans('admin/hardware/form.redirect_to_checked_out_to')}}</option>
             </select>
         </div>
 </div> <!-- /.box-->


### PR DESCRIPTION
# Description

This fixes the checkin options, going to checked out to should not be an option during the checkin process. 
It is disabled now during checkin:
<img width="838" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/5c1da4a8-1742-4ab1-ac3d-a25ab1c600d0">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
