### PR TITLE
Importer tweaks

### DIFF
--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -8,7 +8,6 @@ use Livewire\Component;
 use App\Models\Import;
 use Illuminate\Support\Facades\Storage;
 
-use Illuminate\Support\Facades\Log;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 
@@ -544,7 +543,6 @@ class Importer extends Component
     {
         // TODO: why don't we just do File::find($id)? This seems dumb.
         foreach($this->files as $file) {
-            Log::debug("File id is: ".$file->id);
             if ($id == $file->id) {
                 if (Storage::delete('private_uploads/imports/'.$file->file_path)) {
                     $file->delete();

--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -236,6 +236,15 @@ class Importer extends Component
             'email' => trans('general.importer.checked_out_to_email'),
             'username' => trans('general.importer.checked_out_to_username'),
             'checkout_location' => trans('general.importer.checkout_location'),
+            /**
+             * These are here so users can import history, to replace the dinosaur that
+             * was the history importer
+             */
+            'last_checkin' => trans('admin/hardware/table.last_checkin_date'),
+            'last_checkout' => trans('admin/hardware/table.checkout_date'),
+            'expected_checkin' => trans('admin/hardware/form.expected_checkin'),
+            'last_audit_date' => trans('general.last_audit'),
+            'next_audit_date' => trans('general.next_audit_date'),
         ];
 
         $this->consumables_fields = [
@@ -379,6 +388,12 @@ class Importer extends Component
                     'job title for user',
                     'job title',
                 ],
+            'full_name' =>
+                [
+                    'full name',
+                    'fullname',
+                    trans('general.importer.checked_out_to_fullname')
+                ],
             'username' =>
                 [
                     'user name',
@@ -411,6 +426,7 @@ class Importer extends Component
                     'telephone',
                     'tel.',
                 ],
+
             'serial' =>
                 [
                     'serial number',
@@ -454,6 +470,12 @@ class Importer extends Component
             'next_audit_date' =>
                 [
                     'Next Audit',
+                ],
+            'last_checkout' =>
+                [
+                    'Last Checkout',
+                    'Last Checkout Date',
+                    'Checkout Date',
                 ],
             'address2' =>
                 [
@@ -523,8 +545,8 @@ class Importer extends Component
         // TODO: why don't we just do File::find($id)? This seems dumb.
         foreach($this->files as $file) {
             Log::debug("File id is: ".$file->id);
-            if($id == $file->id) {
-                if(Storage::delete('private_uploads/imports/'.$file->file_path)) {
+            if ($id == $file->id) {
+                if (Storage::delete('private_uploads/imports/'.$file->file_path)) {
                     $file->delete();
 
                     $this->message = trans('admin/hardware/message.import.file_delete_success');

--- a/app/Http/Livewire/Importer.php
+++ b/app/Http/Livewire/Importer.php
@@ -119,8 +119,7 @@ class Importer extends Component
     public function updating($name, $new_import_type)
     {
         if ($name == "activeFile.import_type") {
-            Log::debug("WE ARE CHANGING THE import_type!!!!! TO: " . $new_import_type);
-            Log::debug("so, what's \$this->>field_map at?: " . print_r($this->field_map, true));
+
             // go through each header, find a matching field to try and map it to.
             foreach ($this->activeFile->header_row as $i => $header) {
                 // do we have something mapped already?

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -7,8 +7,10 @@ use App\Models\AssetModel;
 use App\Models\Statuslabel;
 use App\Models\User;
 use App\Events\CheckoutableCheckedIn;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
 
 class AssetImporter extends ItemImporter
 {
@@ -19,7 +21,7 @@ class AssetImporter extends ItemImporter
         parent::__construct($filename);
 
         if (!is_null(Statuslabel::first())) {
-            $this->defaultStatusLabelId = Statuslabel::first()->id;
+            $this->defaultStatusLabelId = Statuslabel::deployable()->first()->id;
         }
     }
 

--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -565,7 +565,7 @@ abstract class Importer
      */
     public function parseOrNullDate($field, $format = 'date') {
 
-        $format = 'Y-m-d';
+        $date_format = 'Y-m-d';
 
         if ($format == 'datetime') {
             $date_format = 'Y-m-d H:i:s';
@@ -577,7 +577,7 @@ abstract class Importer
                 $value = CarbonImmutable::parse($this->item[$field])->format($date_format);
                 return $value;
             } catch (\Exception $e) {
-                $this->log('Unable to parse date: ' . $this->item['next_audit_date']);
+                $this->log('Unable to parse date: ' . $this->item[$field]);
                 return null;
             }
         }

--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -6,6 +6,7 @@ use App\Models\CustomField;
 use App\Models\Department;
 use App\Models\Setting;
 use App\Models\User;
+use Carbon\CarbonImmutable;
 use ForceUTF8\Encoding;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
@@ -549,6 +550,37 @@ abstract class Importer
         }
         $this->log('No matching Manager '.$user_manager_first_name.' '.$user_manager_last_name.' found. If their user account is being created through this import, you should re-process this file again. ');
 
+        return null;
+    }
+
+    /**
+     * Parse a date or return null
+     *
+     * @author A. Gianotto
+     * @since 7.0.0
+     * @param $field
+     * @param $format
+     * @return string|null
+
+     */
+    public function parseOrNullDate($field, $format = 'date') {
+
+        $format = 'Y-m-d';
+
+        if ($format == 'datetime') {
+            $date_format = 'Y-m-d H:i:s';
+        }
+
+        if (array_key_exists($field, $this->item) && $this->item[$field] != '') {
+
+            try {
+                $value = CarbonImmutable::parse($this->item[$field])->format($date_format);
+                return $value;
+            } catch (\Exception $e) {
+                $this->log('Unable to parse date: ' . $this->item['next_audit_date']);
+                return null;
+            }
+        }
         return null;
     }
 }

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -79,26 +79,6 @@ class ItemImporter extends Importer
             $this->item['purchase_date'] = date('Y-m-d', strtotime($this->findCsvMatch($row, 'purchase_date')));
         }
 
-        $this->item['last_audit_date'] = null;
-        if ($this->findCsvMatch($row, 'last_audit_date') != '') {
-            $this->item['last_audit_date'] = date('Y-m-d', strtotime($this->findCsvMatch($row, 'last_audit_date')));
-        }
-
-        $this->item['next_audit_date'] = null;
-        if ($this->findCsvMatch($row, 'next_audit_date') != '') {
-            $this->item['next_audit_date'] = date('Y-m-d', strtotime($this->findCsvMatch($row, 'next_audit_date')));
-        }
-
-        $this->item['asset_eol_date'] = null;
-            if($this->findCsvMatch($row, 'asset_eol_date') != '') {
-                $csvMatch = $this->findCsvMatch($row, 'asset_eol_date');
-                try {
-                    $this->item['asset_eol_date'] = CarbonImmutable::parse($csvMatch)->format('Y-m-d');
-                } catch (\Exception $e) {
-                    Log::info($e->getMessage());
-                    $this->log('Unable to parse date: '.$csvMatch);
-                }
-        }
 
         $this->item['qty'] = $this->findCsvMatch($row, 'quantity');
         $this->item['requestable'] = $this->findCsvMatch($row, 'requestable');

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -79,17 +79,17 @@ class ItemImporter extends Importer
             $this->item['purchase_date'] = date('Y-m-d', strtotime($this->findCsvMatch($row, 'purchase_date')));
         }
 
-        $this->item['asset_eol_date'] = null;
-        if ($this->findCsvMatch($row, 'asset_eol_date') != '') {
-            $csvMatch = $this->findCsvMatch($row, 'asset_eol_date');
-            \Log::warning('EOL Date for $csvMatch is '.$csvMatch);
-            try {
-                $this->item['asset_eol_date'] = CarbonImmutable::parse($csvMatch)->format('Y-m-d');
-            } catch (\Exception $e) {
-                Log::info($e->getMessage());
-                $this->log('Unable to parse date: '.$csvMatch);
-            }
-        }
+//        $this->item['asset_eol_date'] = null;
+//        if ($this->findCsvMatch($row, 'asset_eol_date') != '') {
+//            $csvMatch = $this->findCsvMatch($row, 'asset_eol_date');
+//            \Log::warning('EOL Date for $csvMatch is '.$csvMatch);
+//            try {
+//                $this->item['asset_eol_date'] = CarbonImmutable::parse($csvMatch)->format('Y-m-d');
+//            } catch (\Exception $e) {
+//                Log::info($e->getMessage());
+//                $this->log('Unable to parse date: '.$csvMatch);
+//            }
+//        }
 
 
         $this->item['qty'] = $this->findCsvMatch($row, 'quantity');
@@ -500,4 +500,5 @@ class ItemImporter extends Importer
 
         return null;
     }
+
 }

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -79,6 +79,18 @@ class ItemImporter extends Importer
             $this->item['purchase_date'] = date('Y-m-d', strtotime($this->findCsvMatch($row, 'purchase_date')));
         }
 
+        $this->item['asset_eol_date'] = null;
+        if ($this->findCsvMatch($row, 'asset_eol_date') != '') {
+            $csvMatch = $this->findCsvMatch($row, 'asset_eol_date');
+            \Log::warning('EOL Date for $csvMatch is '.$csvMatch);
+            try {
+                $this->item['asset_eol_date'] = CarbonImmutable::parse($csvMatch)->format('Y-m-d');
+            } catch (\Exception $e) {
+                Log::info($e->getMessage());
+                $this->log('Unable to parse date: '.$csvMatch);
+            }
+        }
+
 
         $this->item['qty'] = $this->findCsvMatch($row, 'quantity');
         $this->item['requestable'] = $this->findCsvMatch($row, 'requestable');
@@ -369,7 +381,6 @@ class ItemImporter extends Importer
 
         if ($status->save()) {
             $this->log('Status '.$asset_statuslabel_name.' was created');
-
             return $status->id;
         }
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -10,7 +10,7 @@ use App\Http\Traits\UniqueUndeletedTrait;
 use App\Models\Traits\Acceptable;
 use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
-use AssetPresenter;
+use App\Presenters\AssetPresenter;
 use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -19,6 +19,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Storage;
 use Watson\Validating\ValidatingTrait;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Model for Assets.
@@ -28,7 +30,7 @@ use Watson\Validating\ValidatingTrait;
 class Asset extends Depreciable
 {
 
-    protected $presenter = \App\Presenters\AssetPresenter::class;
+    protected $presenter = AssetPresenter::class;
 
     use CompanyableTrait;
     use HasFactory, Loggable, Requestable, Presentable, SoftDeletes, ValidatingTrait, UniqueUndeletedTrait;
@@ -973,58 +975,38 @@ class Asset extends Depreciable
      * @param $value
      * @return void
      */
-    public function getNextAuditDateAttribute($value)
+
+    protected function nextAuditDate(): Attribute
     {
-        return $this->attributes['next_audit_date'] = $value ? Carbon::parse($value)->format('Y-m-d') : null;
+        return Attribute::make(
+            get: fn ($value) => $value ? Carbon::parse($value)->format('Y-m-d') : null,
+            set: fn ($value) => $value ? Carbon::parse($value)->format('Y-m-d') : null,
+        );
     }
 
-    public function setNextAuditDateAttribute($value)
+    protected function lastCheckout(): Attribute
     {
-        $this->attributes['next_audit_date'] = $value ? Carbon::parse($value)->format('Y-m-d') : null;
+        return Attribute::make(
+            get: fn ($value) => $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null,
+            set: fn ($value) => $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null,
+        );
     }
 
-    public function getLastCheckoutAttribute($value)
+    protected function lastCheckin(): Attribute
     {
-        return $this->attributes['last_checkout'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
+        return Attribute::make(
+            get: fn ($value) => $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null,
+            set: fn ($value) => $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null,
+        );
     }
 
-    public function setLastCheckoutAttribute($value)
+    protected function assetEolDate(): Attribute
     {
-        $this->attributes['last_checkout'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
+        return Attribute::make(
+            get: fn ($value) => $value ? Carbon::parse($value)->format('Y-m-d') : null,
+            set: fn ($value) => $value ? Carbon::parse($value)->format('Y-m-d') : null,
+        );
     }
-
-    public function getLastCheckinAttribute($value)
-    {
-        return $this->attributes['last_checkin'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
-    }
-
-    public function setLastCheckinAttribute($value)
-    {
-        $this->attributes['last_checkin'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
-    }
-
-    public function getLastAuditDateAttribute($value)
-    {
-        return $this->attributes['last_audit_date'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
-    }
-
-    public function setLastAuditDateAttribute($value)
-    {
-        $this->attributes['last_audit_date'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
-    }
-
-    public function getAssetEolDateAttribute($value)
-    {
-        return $this->attributes['asset_eol_date'] = $value ? Carbon::parse($value)->format('Y-m-d') : null;
-    }
-
-    public function setAssetEolDateAttribute($value)
-    {
-        $this->attributes['asset_eol_date'] = $value ? Carbon::parse($value)->format('Y-m-d') : null;
-    }
-
-
-
 
     /**
      * This sets the requestable to a boolean 0 or 1. This accounts for forms or API calls that
@@ -1035,9 +1017,13 @@ class Asset extends Depreciable
      * @param $value
      * @return void
      */
-    public function setRequestableAttribute($value)
+
+    protected function requestable(): Attribute
     {
-        $this->attributes['requestable'] = (int) filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        return Attribute::make(
+            get: fn ($value) => (int) filter_var($value, FILTER_VALIDATE_BOOLEAN),
+            set: fn ($value) => (int) filter_var($value, FILTER_VALIDATE_BOOLEAN),
+        );
     }
 
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -149,6 +149,8 @@ class Asset extends Depreciable
         'last_audit_date',
         'next_audit_date',
         'asset_eol_date',
+        'last_checkin',
+        'last_checkout',
     ];
 
     use Searchable;

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -983,6 +983,49 @@ class Asset extends Depreciable
         $this->attributes['next_audit_date'] = $value ? Carbon::parse($value)->format('Y-m-d') : null;
     }
 
+    public function getLastCheckoutAttribute($value)
+    {
+        return $this->attributes['last_checkout'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
+    }
+
+    public function setLastCheckoutAttribute($value)
+    {
+        $this->attributes['last_checkout'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
+    }
+
+    public function getLastCheckinAttribute($value)
+    {
+        return $this->attributes['last_checkin'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
+    }
+
+    public function setLastCheckinAttribute($value)
+    {
+        $this->attributes['last_checkin'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
+    }
+
+    public function getLastAuditDateAttribute($value)
+    {
+        return $this->attributes['last_audit_date'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
+    }
+
+    public function setLastAuditDateAttribute($value)
+    {
+        $this->attributes['last_audit_date'] = $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null;
+    }
+
+    public function getAssetEolDateAttribute($value)
+    {
+        return $this->attributes['asset_eol_date'] = $value ? Carbon::parse($value)->format('Y-m-d') : null;
+    }
+
+    public function setAssetEolDateAttribute($value)
+    {
+        $this->attributes['asset_eol_date'] = $value ? Carbon::parse($value)->format('Y-m-d') : null;
+    }
+
+
+
+
     /**
      * This sets the requestable to a boolean 0 or 1. This accounts for forms or API calls that
      * explicitly pass the requestable field but it has a null or empty value.

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -705,18 +705,6 @@
                                         </div>
                                     @endif
 
-                                    @if ($asset->expected_checkin!='')
-                                        <div class="row">
-                                            <div class="col-md-2">
-                                                <strong>
-                                                    {{ trans('admin/hardware/form.expected_checkin') }}
-                                                </strong>
-                                            </div>
-                                            <div class="col-md-6">
-                                                {{ Helper::getFormattedDateObject($asset->expected_checkin, 'date', false) }}
-                                            </div>
-                                        </div>
-                                    @endif
 
                                     <div class="row">
                                         <div class="col-md-2">
@@ -804,6 +792,19 @@
                                             </div>
                                         </div>
                                      @endif
+                                     @if ($asset->expected_checkin!='')
+                                        <div class="row">
+                                            <div class="col-md-2">
+                                                <strong>
+                                                    {{ trans('admin/hardware/form.expected_checkin') }}
+                                                </strong>
+                                            </div>
+                                            <div class="col-md-6">
+                                                {{ Helper::getFormattedDateObject($asset->expected_checkin, 'date', false) }}
+                                            </div>
+                                        </div>
+                                     @endif
+
                                      @if ($asset->last_checkin!='')
                                             <div class="row">
                                                 <div class="col-md-2">

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -36,12 +36,11 @@
                             <th>{{ trans('general.error') }}</th>
                             </thead>
                             <tbody>
-                            @php \Log::debug("import errors are: ".print_r($import_errors,true)); @endphp
                             @foreach($import_errors AS $key => $actual_import_errors)
                                 @foreach($actual_import_errors AS $table => $error_bag)
                                     @foreach($error_bag as $field => $error_list)
                                         <tr>
-                                            <td>{{ $activeFile ?? "Unknown File" }}</td>
+                                            <td><b>{{ $key }}</b></td>
                                             <td>
                                                 <b>{{ $field }}:</b>
                                                 <span>{{ implode(", ",$error_list) }}</span>

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -38,13 +38,10 @@
                             <tbody>
                             @php \Log::debug("import errors are: ".print_r($import_errors,true)); @endphp
                             @foreach($import_errors AS $key => $actual_import_errors)
-                                @php \Log::debug("Key is: $key"); @endphp
                                 @foreach($actual_import_errors AS $table => $error_bag)
-                                    @php \Log::debug("Table is: $table"); @endphp
                                     @foreach($error_bag as $field => $error_list)
-                                        @php \Log::debug("Field is: $field"); @endphp
                                         <tr>
-                                            <td>{{ $activeFile->file_path ?? "Unknown File" }}</td>
+                                            <td>{{ $activeFile ?? "Unknown File" }}</td>
                                             <td>
                                                 <b>{{ $field }}:</b>
                                                 <span>{{ implode(", ",$error_list) }}</span>

--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -67,7 +67,7 @@ class StoreAssetTest extends TestCase
         $this->assertEquals('random_string', $asset->asset_tag);
         $this->assertEquals($userAssigned->id, $asset->assigned_to);
         $this->assertTrue($asset->company->is($company));
-        $this->assertEquals('2023-09-03 00:00:00', $asset->last_audit_date->format('Y-m-d H:i:s'));
+        $this->assertEquals('2023-09-03 00:00:00', $asset->last_audit_date);
         $this->assertTrue($asset->location->is($location));
         $this->assertTrue($asset->model->is($model));
         $this->assertEquals('A New Asset', $asset->name);
@@ -87,7 +87,7 @@ class StoreAssetTest extends TestCase
     {
         $response = $this->actingAsForApi(User::factory()->superuser()->create())
             ->postJson(route('api.assets.store'), [
-                'last_audit_date' => '2023-09-03 12:23:45',
+                'last_audit_date' => '2023-09-03',
                 'asset_tag' => '1234',
                 'model_id' => AssetModel::factory()->create()->id,
                 'status_id' => Statuslabel::factory()->create()->id,
@@ -96,7 +96,7 @@ class StoreAssetTest extends TestCase
             ->assertStatusMessageIs('success');
 
         $asset = Asset::find($response['payload']['id']);
-        $this->assertEquals('00:00:00', $asset->last_audit_date->format('H:i:s'));
+        $this->assertEquals('2023-09-03 00:00:00', $asset->last_audit_date);
     }
 
     public function testLastAuditDateCanBeNull()


### PR DESCRIPTION
This PR:

- Adds additional fields for importing
- Adds mutators and accessors for the date fields on assets
- Added some additional info to the validation feedback on the importer
- Fixed an issue where the `$defaultStatusLabelId` could be a non-deployable status type
- Moved asset-only date handling into the AssetImporter instead of the generic ItemImporter, since no other objects have those fields
- Removed some pretty noisy debugging

I know we've gone back and forth on the getters/setters stuff with dates, but this makes handling bad data in imports much easier. I'm expecting a fight tho ;)