### PR TITLE
Don't save next autoincrement base if it's going to fail, next

### DIFF
--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -92,7 +92,7 @@ class AssetObserver
 
                 // only modify the 'next' one if it's *bigger* than the stored base
                 //
-                if($next_asset_tag > $settings->next_auto_tag_base) {
+                if ($next_asset_tag > $settings->next_auto_tag_base && $next_asset_tag < PHP_INT_MAX) {
                     $settings->next_auto_tag_base = $next_asset_tag;
                     $settings->save();
                 }

--- a/tests/Unit/AssetTest.php
+++ b/tests/Unit/AssetTest.php
@@ -6,6 +6,7 @@ use App\Models\AssetModel;
 use App\Models\Category;
 use Carbon\Carbon;
 use Tests\TestCase;
+use App\Models\Setting;
 
 class AssetTest extends TestCase
 {
@@ -134,6 +135,40 @@ class AssetTest extends TestCase
         $this->assertModelExists($final);
         $this->assertEquals($final->asset_tag, $final_result);
     }
+
+    public function testAutoIncrementBIG()
+    {
+        $this->settings->enableAutoIncrement();
+
+        // we have to do this by hand to 'simulate' two web pages being open at the same time
+        $a = Asset::factory()->make(['asset_tag' => Asset::autoincrement_asset()]);
+        $b = Asset::factory()->make(['asset_tag' => 'ABCD' . (PHP_INT_MAX - 1)]);
+
+        $this->assertTrue($a->save());
+        $this->assertTrue($b->save());
+        \Log::error("A asset tag is: " . $a->asset_tag);
+        $matches = [];
+        preg_match('/\d+/', $a->asset_tag, $matches);
+        \Log::error("digits are: " . $matches[0]);
+        $this->assertEquals(Setting::getSettings()->next_auto_tag_base, $matches[0] + 1, "Next auto increment number should be the last normally-saved one plus one, but isn't");
+    }
+
+    public function testAutoIncrementAlmostBIG()
+    {
+        // TODO: this looks pretty close to the one above, could we maybe squish them together?
+        $this->settings->enableAutoIncrement();
+
+        // we have to do this by hand to 'simulate' two web pages being open at the same time
+        $a = Asset::factory()->make(['asset_tag' => Asset::autoincrement_asset()]);
+        $b = Asset::factory()->make(['asset_tag' => 'ABCD' . (PHP_INT_MAX - 2)]);
+
+        $this->assertTrue($a->save());
+        $this->assertTrue($b->save());
+        $matches = [];
+        preg_match('/\d+/', $b->asset_tag, $matches); //this is *b*, not *a* - slight difference from above test
+        $this->assertEquals(Setting::getSettings()->next_auto_tag_base, $matches[0] + 1, "Next auto increment number should be the last normally-saved one plus one, but isn't");
+    }
+
 
     public function testWarrantyExpiresAttribute()
     {


### PR DESCRIPTION
This one of those "one line PR's with x paragraphs of explanation" - 

So the problem we have is that some users want to use autoincrementing asset tags, by default - but also, sometimes, they want to save serial numbers as asset tags too.

Sometimes those serial numbers can be very long strings of digits. And those strings of digits can, sometimes, can arithmetically be larger that `PHP_INT_MAX` - which also is the same as MySQL's `BIGINIT` (signed `BIGINT` to be specific).

This change just makes it so that it will *not* save the 'next autoincrement tag' if it's going to be greater than, or equal to, `PHP_INT_MAX`. Just to give that some perspective, that number is: `9,223,372,036,854,775,807`.

When people are doing autoincrements, we've typically seen those done as 6 digit numbers, maybe 7. I could even understand up to, maybe, 9 or so. But `PHP_INT_MAX` is 19 digits wide. You probably don't mean that as your next autoincrement number.

Because this is under the newer, more carefully guarded branch, it will *only* be invoked when `auto_increment` is turned *on*, the prefixes *match* to what the auto-incrementer is configured for, and everything *after* the prefix is nothing but pure digits. That seems all pretty safe and reasonable to me.

I did not touch the 'legacy branch' of this code - the `else` - which tries to guess next autoincrement by doing a simple increment (+1) on whatever the value that was trying to be saved. In trying to keep the code simple, I felt like that might have been an OK compromise to make - but one problem we've run into in the past is when someone does not have autoincrement turned on, but wants to turn it on later - I'm willing to leave this problem here, and make them change the next_autoincrement base to a reasonable number. But we can revisit this decision if this change is not extensive enough.

This does *NOT* fix people who already have this problem - they will have to change their next_autoincrement value to some kind of 'reasonable value'. But once they've done that, they can use weirdly-long serial numbers as their asset tags and not have to worry about it mucking up their next autoincrement. Or so I think. Please double-check me on this.