### PR TITLE
fix(ActionlogController): correct signature image for s3 bucket

### DIFF
--- a/app/Http/Controllers/ActionlogController.php
+++ b/app/Http/Controllers/ActionlogController.php
@@ -14,18 +14,23 @@ class ActionlogController extends Controller
         // file_get_contents, so we set the error reporting for just this class
         error_reporting(0);
 
-        $this->authorize('view', \App\Models\Asset::class);
-        $file = config('app.private_uploads').'/signatures/'.$filename;
-        $filetype = Helper::checkUploadIsImage($file);
+        $disk = config('filesystems.default');
+        switch (config("filesystems.disks.$disk.driver")) {
+        case 's3':
+            $file = 'private_uploads/signatures/'.$filename;
+            return redirect()->away(Storage::disk($disk)->temporaryUrl($file, now()->addMinutes(5)));
+        default:
+          $this->authorize('view', \App\Models\Asset::class);
+          $file = config('app.private_uploads').'/signatures/'.$filename;
+          $filetype = Helper::checkUploadIsImage($file);
 
-        $contents = file_get_contents($file, false, stream_context_create(['http' => ['ignore_errors' => true]]));
-        if ($contents === false) {
-            Log::warning('File '.$file.' not found');
-            return false;
-        } else {
-            return Response::make($contents)->header('Content-Type', $filetype);
-        }
-       
+          $contents = file_get_contents($file, false, stream_context_create(['http' => ['ignore_errors' => true]]));
+          if ($contents === false) {
+              Log::warning('File '.$file.' not found');
+              return false;
+          } else {
+              return Response::make($contents)->header('Content-Type', $filetype);
+          }
     }
     public function getStoredEula($filename){
         $this->authorize('view', \App\Models\Asset::class);


### PR DESCRIPTION
# Description

This proposal fix issue #10097

## Type of change

Signature log is actually possible with an s3 bucket, but the fronted application do not send the correct URL.

# How Has This Been Tested?

Tested on eks context with docker image `snipe/snipe-it:v6.3.0` (php 8.1.2-1ubuntu2.14)

# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
