### PR TITLE
Fixed #14812 - added consumables to individual inventory report

### DIFF
--- a/app/Console/Commands/SendCurrentInventoryToUsers.php
+++ b/app/Console/Commands/SendCurrentInventoryToUsers.php
@@ -43,7 +43,7 @@ class SendCurrentInventoryToUsers extends Command
 
         $count = 0;
         foreach ($users as $user) {
-            if (($user->assets->count() > 0) || ($user->accessories->count() > 0) || ($user->licenses->count() > 0)) {
+            if (($user->assets->count() > 0) || ($user->accessories->count() > 0) || ($user->licenses->count() > 0) || ($user->consumables->count() > 0)) {
                 $count++;
                 $user->notify((new CurrentInventory($user)));
             }

--- a/app/Notifications/CurrentInventory.php
+++ b/app/Notifications/CurrentInventory.php
@@ -43,6 +43,7 @@ class CurrentInventory extends Notification
                 'assets'  => $this->user->assets,
                 'accessories'  => $this->user->accessories,
                 'licenses'  => $this->user->licenses,
+                'consumables'  => $this->user->consumables,
             ])
             ->subject(trans('mail.inventory_report'));
 

--- a/resources/views/notifications/markdown/user-inventory.blade.php
+++ b/resources/views/notifications/markdown/user-inventory.blade.php
@@ -56,6 +56,19 @@
 </table>
 @endif
 
+@if ($consumables->count() > 0)
+## {{ $consumables->count() }} {{ trans('general.consumables') }}
+
+<table width="100%">
+<tr><th align="left">{{ trans('mail.name') }} </th> <th></th> </tr>
+@foreach($consumables as $consumable)
+<tr>
+<td>{{ $consumable->name }}</td>
+</tr>
+@endforeach
+</table>
+@endif
+
 
 @endcomponent
 


### PR DESCRIPTION
This adds consumables to the "Email list of all assigned" email that gets sent out when you click that button on the user page. 

I do worry that this is a feature many people won't want, since you can't check consumables back in (since they are assumed to be, well, consumed) and those emails could get quite long. 

Fixes #14812