### PR TITLE
Fixed label preview window position

### DIFF
--- a/resources/views/partials/label2-preview.blade.php
+++ b/resources/views/partials/label2-preview.blade.php
@@ -2,7 +2,7 @@
     @push('css')
         <style>
             :root {
-                --l2p-height: 400px;
+                --l2p-height: 200px;
                 --l2p-background-color: aliceblue;
             }
 

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -66,9 +66,7 @@
 
                             <!-- Template -->
                             <div class="form-group{{ $errors->has('label2_template') ? ' has-error' : '' }}">
-                                <div class="col-md-9 col-md-offset-3">
-                                    @include('partials.label2-preview')
-                                </div>
+
                                 <div class="col-md-9 col-md-offset-3">
                                     <table
                                         data-click-to-select="true"
@@ -209,7 +207,9 @@
                                     <p class="help-block">{{ trans('admin/settings/general.label2_2d_target_help') }}</p>
                                 </div>
                             </div>
-
+                            <div class="col-md-9 col-md-offset-3" style="margin-bottom: 10px;">
+                                @include('partials.label2-preview')
+                            </div>
                             <!-- Fields -->
                             <div class="form-group {{ $errors->has('label2_fields') ? 'error' : '' }}">
                                 <div class="col-md-3 text-right">

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -66,7 +66,7 @@
 
                             <!-- Template -->
                             <div class="form-group{{ $errors->has('label2_template') ? ' has-error' : '' }}">
-                                <div class="col-md-3 col-md-offset-3">
+                                <div class="col-md-9 col-md-offset-3">
                                     @include('partials.label2-preview')
                                 </div>
                                 <div class="col-md-9 col-md-offset-3">

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -66,10 +66,10 @@
 
                             <!-- Template -->
                             <div class="form-group{{ $errors->has('label2_template') ? ' has-error' : '' }}">
-                                <div class="col-md-3">
+                                <div class="col-md-3 col-md-offset-3">
                                     @include('partials.label2-preview')
                                 </div>
-                                <div class="col-md-9">
+                                <div class="col-md-9 col-md-offset-3">
                                     <table
                                         data-click-to-select="true"
                                         data-columns="{{ \App\Presenters\LabelPresenter::dataTableLayout() }}"

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -90,7 +90,11 @@
                                     ></table>
                                     <script>
                                         document.addEventListener('DOMContentLoaded', () => {
+                                            const chosenLabel = "{{ old('label2_template', $chosenLabel ?? '') }}";
                                             $('#label2TemplateTable').on('load-success.bs.table', (e) => {
+                                                if (chosenLabel) {
+                                                    $('input[name="label2_template"][value="' + chosenLabel + '"]').prop('checked', true);
+                                                }
                                                 let form = document.getElementById('settingsForm');
                                                 form.dispatchEvent(new Event('change'));
                                             });


### PR DESCRIPTION
# Description
This adjusts the label preview window from being cramped on the side to being uniform with the rest of the form.
Also it moves it down to be above the field definitions. This should be a nice quality of life adjustment to prevent you from scrolling up to take a look at the preview when you make an adjustment to the fields.

Also now the label currently chosen is remembered and selected from the table so a preview is loaded automatically.

Before:
<img width="882" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/d39313a9-10ee-401a-8184-a5a5a4599b4b">

After:
<img width="882" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/c7584860-6c51-4aeb-95b4-72a4ad6db9e4">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
