### PR TITLE
Added GitHub workflow for tests in Postgres

### DIFF
--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -1,0 +1,80 @@
+name: Tests in Postgres
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    services:
+      postgresql:
+        image: postgres:14
+        env:
+          POSTGRES_DB: snipeit
+          POSTGRES_USER: snipeit
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "8.2"
+
+    name: PHP ${{ matrix.php-version }}
+
+    steps:
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php-version }}"
+          coverage: none
+
+      - uses: actions/checkout@v4
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Copy .env
+        run: |
+          cp -v .env.testing.example .env
+          cp -v .env.testing.example .env.testing
+
+      - name: Install Dependencies
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: Setup Laravel
+        env:
+          DB_CONNECTION: pgsql
+          DB_DATABASE: snipeit
+          DB_PORT: ${{ job.services.postgresql.ports[5432] }}
+          DB_USERNAME: snipeit
+          DB_PASSWORD: password
+        run: |
+          php artisan key:generate
+          php artisan migrate --force
+          php artisan passport:install
+          chmod -R 777 storage bootstrap/cache
+
+      - name: Execute tests (Unit and Feature tests) via PHPUnit
+        env:
+          DB_CONNECTION: pgsql
+          DB_DATABASE: snipeit
+          DB_PORT: ${{ job.services.postgresql.ports[5432] }}
+          DB_USERNAME: snipeit
+          DB_PASSWORD: password
+        run: php artisan test --parallel

--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -1,11 +1,6 @@
 name: Tests in Postgres
 
-on:
-  push:
-    branches:
-      - master
-      - develop
-  pull_request:
+on: workflow_dispatch
 
 jobs:
   tests:

--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       postgresql:
-        image: postgres:14
+        image: postgres
         env:
           POSTGRES_DB: snipeit
           POSTGRES_USER: snipeit


### PR DESCRIPTION
# Description

This PR adds a GitHub workflow to run the test suite in Postgres. (Keeping in mind Postgres is not officially supported)

Unlike our existing testing Actions that run on PR opening, commits to open PRs, or merges to develop and master I set this one to run when [manually triggered](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow). This because I don't want our PR and commits lists to be full of ❌s in addition to flooding author notifications due to failing tests due to an unsupported database.

---

Until the artifacts are purged, the tests are are failing in are viewable [here](https://github.com/snipe/snipe-it/actions/runs/9407458699/job/25913245650?pr=14843).

---

## Type of change

- [x] Chore