### PR TITLE
Optimization for listings of large numbers of users

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -75,7 +75,7 @@ class UsersController extends Controller
             'users.autoassign_licenses',
             'users.website',
 
-        ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables', 'createdBy')
+        ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables', 'createdBy', 'managesUsers', 'managedLocations')
             ->withCount('assets as assets_count', 'licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count', 'managesUsers as manages_users_count', 'managedLocations as manages_locations_count');
 
 


### PR DESCRIPTION
When we list users, we were seeing a "1001 query problem" for some customers. It looks like the problem was that we determine if each user is "deletable" using the "isDeletable()" method in order to figure out if we can display a 'delete' action or not. That isDeletable() method asks whether the user manages any locations, or manages any other users (as well as a few other things). Those two relationships were not being eager-loaded, and thus were causing dependent queries to fire - each one of which was very fast, but on very long pages (500 or even 1000 users per page), could timeout.