### PR TITLE
Add Label Template: Use with endless 62mm Brother printer rolls

### DIFF
--- a/app/Models/Labels/Label.php
+++ b/app/Models/Labels/Label.php
@@ -26,6 +26,17 @@ abstract class Label
     public abstract function getUnit();
 
     /**
+     * Returns the PDF rotation.
+     * 0, 90, 180, 270
+     * 0 is a sane default. Override when necessary.
+     *
+     * @return int
+     */
+    public function getRotation() {
+        return 0;
+    }
+
+    /**
      * Returns the label's width in getUnit() units
      * 
      * @return float

--- a/app/Models/Labels/Tapes/Brother/TZe_62mm_Landscape.php
+++ b/app/Models/Labels/Tapes/Brother/TZe_62mm_Landscape.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models\Labels\Tapes\Brother;
+
+use App\Helpers\Helper;
+use App\Models\Labels\Label;
+
+/*
+ * Rotated Label (print direction = landscape) for 62mm wide labels
+ */
+abstract class TZe_62mm_Landscape extends Label
+{
+    private const WIDTH        = 62.00;
+    private const MARGIN_SIDES =  1.50;
+    private const MARGIN_ENDS  =  1.50;
+
+    public function getWidth()        { return Helper::convertUnit(self::WIDTH, 'mm', $this->getUnit()); }
+    public function getMarginTop()    { return Helper::convertUnit(self::MARGIN_SIDES, 'mm', $this->getUnit()); }
+    public function getMarginBottom() { return Helper::convertUnit(self::MARGIN_SIDES, 'mm', $this->getUnit());}
+    public function getMarginLeft()   { return Helper::convertUnit(self::MARGIN_ENDS, 'mm', $this->getUnit()); }
+    public function getMarginRight()  { return Helper::convertUnit(self::MARGIN_ENDS, 'mm', $this->getUnit()); }
+    public function getRotation()     { return 90; }
+}

--- a/app/Models/Labels/Tapes/Brother/TZe_62mm_Landscape_A.php
+++ b/app/Models/Labels/Tapes/Brother/TZe_62mm_Landscape_A.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Models\Labels\Tapes\Brother;
+
+class TZe_62mm_Landscape_A extends TZe_62mm_Landscape
+{
+    public function getUnit()             { return 'mm'; }
+    public function getHeight()           { return 31.50; }
+    public function getSupportAssetTag()  { return true; }
+    public function getSupport1DBarcode() { return true; }
+    public function getSupport2DBarcode() { return true; }
+    public function getSupportFields()    { return 2; }
+    public function getSupportLogo()      { return true; }
+    public function getSupportTitle()     { return true; }
+
+    private const BARCODE1D_HEIGHT =   3.00;
+    private const BARCODE1D_MARGIN =   3.00;
+    private const BARCODE2D_SIZE   =  20.00;
+    private const BARCODE2D_MARGIN =   1.50;
+    private const TAG_SIZE         =   3.00;
+    private const LOGO_HEIGHT      =  10.00;
+    private const LOGO_MARGIN      =   1.50;
+    private const TITLE_SIZE       =   3.00;
+    private const TITLE_MARGIN     =   0.50;
+    private const LABEL_SIZE       =   2.00;
+    private const LABEL_MARGIN     = - 0.35;
+    private const FIELD_SIZE       =   3.00;
+    private const FIELD_MARGIN     =   0.10;
+
+    public function preparePDF($pdf) {}
+
+    public function write($pdf, $record) {
+        $pa = $this->getPrintableArea();
+
+        $currentX = $pa->x1;
+        $currentY = $pa->y1;
+
+        // Wide 1D barcode on top
+
+        if ($record->has('barcode1d')) {
+            static::write1DBarcode(
+                $pdf, $record->get('barcode1d')->content, $record->get('barcode1d')->type,
+                $currentX, $currentY, $pa->w, self::BARCODE1D_HEIGHT
+            );
+            $currentY = self::BARCODE1D_HEIGHT + self::BARCODE1D_MARGIN;
+        }
+
+        // Left column
+
+        if ($record->has('barcode2d')) {
+            $columnY = $currentY;
+            static::write2DBarcode(
+                $pdf, $record->get('barcode2d')->content, $record->get('barcode2d')->type,
+                $currentX, $columnY,
+                self::BARCODE2D_SIZE, self::BARCODE2D_SIZE
+            );
+            $columnY += self::BARCODE2D_SIZE + self::BARCODE2D_MARGIN;
+            static::writeText(
+                $pdf, $record->get('tag'),
+                $currentX, $columnY,
+                'freemono', 'b', self::TAG_SIZE, 'C',
+                self::BARCODE2D_SIZE, self::TAG_SIZE, true, 0
+            );
+            $currentX += self::BARCODE2D_SIZE + self::BARCODE2D_MARGIN;
+        }
+
+        // Right column
+        if ($record->get('logo')) {
+            static::writeImage(
+                $pdf, $record->get('logo'),
+                $currentX, $currentY,
+                $pa->w - $currentX, self::LOGO_HEIGHT,
+                'L', 'T', 300, true, false, 0
+            );
+            $currentY += self::LOGO_HEIGHT + self::LOGO_MARGIN;
+        }
+
+        if ($record->has('title')) {
+            static::writeText(
+                $pdf, $record->get('title'),
+                $currentX, $currentY,
+                'freesans', '', self::TITLE_SIZE, 'L',
+                $pa->w - $currentX, self::TITLE_SIZE, true, 0
+            );
+            $currentY += self::TITLE_SIZE + self::TITLE_MARGIN;
+        }
+
+        foreach ($record->get('fields') as $field) {
+            static::writeText(
+                $pdf, $field['label'],
+                $currentX, $currentY,
+                'freesans', '', self::LABEL_SIZE, 'L',
+                $pa->w - $currentX, self::LABEL_SIZE, true, 0, 0
+            );
+            $currentY += self::LABEL_SIZE + self::LABEL_MARGIN;
+
+            static::writeText(
+                $pdf, $field['value'],
+                $currentX, $currentY,
+                'freemono', 'B', self::FIELD_SIZE, 'L',
+                $pa->w - $currentX, self::FIELD_SIZE, true, 0, 0.3
+            );
+            $currentY += self::FIELD_SIZE + self::FIELD_MARGIN;
+        }
+    }
+}

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -54,7 +54,7 @@ class Label implements View
         $pdf = new TCPDF(
             $template->getOrientation(),
             $template->getUnit(),
-            [ $template->getWidth(), $template->getHeight() ]
+            [0 => $template->getWidth(), 1 => $template->getHeight(), 'Rotate' => $template->getRotation()]
         );
 
         // Reset parameters


### PR DESCRIPTION
# Description

I've added a label template for usage with endless Brother 62 mm label rolls (e.g. DK22212).
Because the label is printed with non-standard print flow (top-down instead of left-to-right), I've added a overridable function `Label#getRotation()` which can control TCPDFs `Rotate` format constructor argument (see https://stackoverflow.com/a/65296951/5885325). The default return value of this function is 0 in order to not break existing labels.

Here is a sample:
![image](https://github.com/snipe/snipe-it/assets/18245993/ff31aef9-40d8-49ec-8005-e7ce4d093015)
[100001.pdf](https://github.com/user-attachments/files/15825330/100001.pdf)

There is no associated issue. There are no changed dependencies. This PR can be cherry-picked to `develop` directly.

Disclaimer: This PR is raised on behalf of Peerox GmbH, the company I work for.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've tested this by generating a label using the Web UI via `docker compose` on Manjaro with Chromium 124.

The printer label format was created using `sudo brpapertoollpr_ql600 -P Brother_QL-600 -n SnipeIT-62mmL -w 62 -h 37`.

It is then printable via `Print using system dialog` -> `Orientation = Landscape`, `Paper size = SnipeIT-62mmL`.

Here is a picture of the result: 
![label](https://github.com/snipe/snipe-it/assets/18245993/2aac9513-c6a4-4b74-9972-82846356a419)

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation -> there is very few documentation on labels
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works -> there are no tests for labels
- [ ] New and existing unit tests pass locally with my changes -> there are no tests for labels
