### PR TITLE
Fixed missing `}`

### DIFF
--- a/app/Http/Controllers/ActionlogController.php
+++ b/app/Http/Controllers/ActionlogController.php
@@ -17,22 +17,24 @@ class ActionlogController extends Controller
 
         $disk = config('filesystems.default');
         switch (config("filesystems.disks.$disk.driver")) {
-        case 's3':
-            $file = 'private_uploads/signatures/'.$filename;
-            return redirect()->away(Storage::disk($disk)->temporaryUrl($file, now()->addMinutes(5)));
-        default:
-          $this->authorize('view', \App\Models\Asset::class);
-          $file = config('app.private_uploads').'/signatures/'.$filename;
-          $filetype = Helper::checkUploadIsImage($file);
+            case 's3':
+                $file = 'private_uploads/signatures/'.$filename;
+                return redirect()->away(Storage::disk($disk)->temporaryUrl($file, now()->addMinutes(5)));
+            default:
+                $this->authorize('view', \App\Models\Asset::class);
+                $file = config('app.private_uploads').'/signatures/'.$filename;
+                $filetype = Helper::checkUploadIsImage($file);
 
-          $contents = file_get_contents($file, false, stream_context_create(['http' => ['ignore_errors' => true]]));
-          if ($contents === false) {
-              Log::warning('File '.$file.' not found');
-              return false;
-          } else {
-              return Response::make($contents)->header('Content-Type', $filetype);
-          }
+                $contents = file_get_contents($file, false, stream_context_create(['http' => ['ignore_errors' => true]]));
+                if ($contents === false) {
+                    Log::warning('File '.$file.' not found');
+                    return false;
+                } else {
+                    return Response::make($contents)->header('Content-Type', $filetype);
+                }
+        }
     }
+
     public function getStoredEula($filename){
         $this->authorize('view', \App\Models\Asset::class);
         $file = config('app.private_uploads').'/eula-pdfs/'.$filename;


### PR DESCRIPTION
# Description

This PR adds a missing `}` in `ActionlogController`. It looks like it was introduced in a recent PR #14827.

I haven't actually tested the `s3` branch of the switch statement but the default branch works as expected.

For reference the `}` on line 35 is actually closing the `{` on line 19 and not the method like it should:
![Reference for mismatched brackets](https://github.com/snipe/snipe-it/assets/1141514/92128de0-eda5-49af-be48-7863e76db0f5)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)