### PR TITLE
Prefaced fields with “users” for clarity

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -827,16 +827,16 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
 
 
         return $query->where('location_id','=', $location)
-            ->where('first_name', 'LIKE', '%' . $search . '%')
-            ->orWhere('email', 'LIKE', '%' . $search . '%')
-            ->orWhere('last_name', 'LIKE', '%' . $search . '%')
-            ->orWhere('permissions', 'LIKE', '%' . $search . '%')
-            ->orWhere('country', 'LIKE', '%' . $search . '%')
-            ->orWhere('phone', 'LIKE', '%' . $search . '%')
-            ->orWhere('jobtitle', 'LIKE', '%' . $search . '%')
-            ->orWhere('employee_num', 'LIKE', '%' . $search . '%')
-            ->orWhere('username', 'LIKE', '%' . $search . '%')
-            ->orwhereRaw('CONCAT(first_name," ",last_name) LIKE \''.$search.'%\'');
+            ->where('users.first_name', 'LIKE', '%' . $search . '%')
+            ->orWhere('users.email', 'LIKE', '%' . $search . '%')
+            ->orWhere('users.last_name', 'LIKE', '%' . $search . '%')
+            ->orWhere('users.permissions', 'LIKE', '%' . $search . '%')
+            ->orWhere('users.country', 'LIKE', '%' . $search . '%')
+            ->orWhere('users.phone', 'LIKE', '%' . $search . '%')
+            ->orWhere('users.jobtitle', 'LIKE', '%' . $search . '%')
+            ->orWhere('users.employee_num', 'LIKE', '%' . $search . '%')
+            ->orWhere('users.username', 'LIKE', '%' . $search . '%')
+            ->orwhereRaw('CONCAT(users.first_name," ",users.last_name) LIKE \''.$search.'%\'');
 
 
 


### PR DESCRIPTION
Saw this pop up in a Rollbar - this just clarifies the users table as the one we want to be sorting against in the left join in `scopeUserLocation()` to avoid ambiguity.