### PR TITLE
Fixed #14882 - Properly scope archived based on settings

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -288,7 +288,7 @@ class AssetModelsController extends Controller
     public function show($modelId = null)
     {
         $this->authorize('view', AssetModel::class);
-        $model = AssetModel::withTrashed()->withCount('assets')->find($modelId);
+        $model = AssetModel::withTrashed()->find($modelId);
 
         if (isset($model->id)) {
             return view('models/view', compact('model'));

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -42,8 +42,8 @@
                           <i class="fas fa-barcode fa-2x"></i>
                         </span>
                                     <span class="hidden-xs hidden-sm">
-                            {{ trans('general.assets') }}
-                                        {!! ($model->assets_count > 0 ) ? '<badge class="badge badge-secondary">'.number_format($model->assets_count).'</badge>' : '' !!}
+                                        {{ trans('general.assets') }}
+                                        {!! ($model->assets()->AssetsForShow()->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($model->assets()->AssetsForShow()->count()).'</badge>' : '' !!}
                         </span>
                     </a>
                 </li>


### PR DESCRIPTION
In asset models, we were not considering the "show archived in lists" setting when displaying the badge count. This should correct that issue.