### PR TITLE
Possible fix for proxy/reverse proxy

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,6 +21,7 @@ use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\URL;
 
 /**
  * This service provider handles setting the observers on models
@@ -31,7 +32,7 @@ use Illuminate\Support\Facades\Log;
 class AppServiceProvider extends ServiceProvider
 {
     /**
-     * Custom email array validation
+     * Bootstrap application services.
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v3.0]
@@ -39,19 +40,24 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(UrlGenerator $url)
     {
-        if (env('APP_FORCE_TLS')) {
-            if (strpos(env('APP_URL'), 'https') === 0) {
-                $url->forceScheme('https');
-            } else {
-                Log::debug("'APP_FORCE_TLS' is set to true, but 'APP_URL' does not start with 'https://'. Will not force TLS on connections.");
-            }
+        /**
+         * This is a workaround for proxies/reverse proxies that don't always pass the proper headers.
+         *
+         * Here, we check if the APP_URL starts with https://, which we should always honor,
+         * regardless of how well the proxy or network is configured.
+         *
+         * We'll force the https scheme if the APP_URL starts with https://, or if APP_FORCE_TLS is set to true.
+         *
+         */
+        if ((strpos(env('APP_URL'), 'https://') === 0) || (env('APP_FORCE_TLS'))) {
+            $url->forceScheme('https');
         }
 
         // TODO - isn't it somehow 'gauche' to check the environment directly; shouldn't we be using config() somehow?
         if ( ! env('APP_ALLOW_INSECURE_HOSTS')) {  // unless you set APP_ALLOW_INSECURE_HOSTS, you should PROHIBIT forging domain parts of URL via Host: headers
             $url_parts = parse_url(config('app.url'));
             if ($url_parts && array_key_exists('scheme', $url_parts) && array_key_exists('host', $url_parts)) { // check for the *required* parts of a bare-minimum URL
-                \URL::forceRootUrl(config('app.url'));
+                URL::forceRootUrl(config('app.url'));
             } else {
                 Log::error("Your APP_URL in your .env is misconfigured - it is: ".config('app.url').". Many things will work strangely unless you fix it.");
             }


### PR DESCRIPTION
This should override Symfony's parsing of URLs to prevent folks from having to add the `APP_FORCE_TLS=true` to their `.env` when they are running behind a proxy/reverse proxy. I'm still not 100% sure why this change was needed when it wasn't in previous versions, but I think this will fix the issue.  

This will still let you force override (for whatever possible reason) if your URL schema is not https (which you definitely shouldn't do, in general), but it basically changes things so that if you state your APP_URL to be `https://`, we WILL enforce secure urls.

Many thanks to @uberbrady and all of the amazing folks in the PHP Portugal Telegram group for helping us rubberduck this.

![rubber-ducking](https://github.com/snipe/snipe-it/assets/197404/45b8e70a-faf8-44bd-9d07-f7fde361b940)