### PR TITLE
Fixed importer audit date validation issue

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -102,7 +102,7 @@ class AssetImporter extends ItemImporter
         $this->item['expected_checkin'] = trim($this->findCsvMatch($row, 'expected_checkin'));
         $this->item['last_audit_date'] = trim($this->findCsvMatch($row, 'last_audit_date'));
         $this->item['next_audit_date'] = trim($this->findCsvMatch($row, 'next_audit_date'));
-        $this->item['asset_eol_date'] = trim($this->findCsvMatch($row, 'next_audit_date'));
+        $this->item['asset_eol_date'] = trim($this->findCsvMatch($row, 'asset_eol_date'));
         $this->item['asset_tag'] = $asset_tag;
 
         // We need to save the user if it exists so that we can checkout to user later.

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -100,7 +100,7 @@ class Asset extends Depreciable
         'last_checkout'    => 'nullable|date_format:Y-m-d H:i:s',
         'last_checkin'     => 'nullable|date_format:Y-m-d H:i:s',
         'expected_checkin' => 'nullable|date',
-        'last_audit_date'  => 'nullable|date_format:Y-m-d H:i:s',
+        'last_audit_date'  => 'nullable',
         // 'next_audit_date'  => 'nullable|date|after:last_audit_date',
         'next_audit_date'  => 'nullable|date',
         'location_id'      => 'nullable|exists:locations,id',

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -984,6 +984,14 @@ class Asset extends Depreciable
         );
     }
 
+    protected function lastAuditDate(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null,
+            set: fn ($value) => $value ? Carbon::parse($value)->format('Y-m-d H:i:s') : null,
+        );
+    }
+
     protected function lastCheckout(): Attribute
     {
         return Attribute::make(


### PR DESCRIPTION
We were using an invalid field name for one of the field maps in the importer. I also pulled the date time validation from `last_audit_date`, since we use an accessor and a mutator nowadays, so we'll always get it as a date time or a null.