### PR TITLE
Add storage path permissions test

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
@@ -106,17 +107,7 @@ class SettingsController extends Controller
             $start_settings['owner_is_admin'] = false;
         }
 
-        if ((is_writable(storage_path()))
-            && (is_writable(storage_path().'/framework'))
-            && (is_writable(storage_path().'/framework/cache'))
-            && (is_writable(storage_path().'/framework/sessions'))
-            && (is_writable(storage_path().'/framework/views'))
-            && (is_writable(storage_path().'/logs'))
-        ) {
-            $start_settings['writable'] = true;
-        } else {
-            $start_settings['writable'] = false;
-        }
+        $start_settings['writable'] = $this->storagePathIsWritable();
 
         $start_settings['gd'] = extension_loaded('gd');
 
@@ -143,6 +134,19 @@ class SettingsController extends Controller
             Log::debug($e->getMessage());
             return true;
         }
+    }
+
+    /**
+     * Determine if the app storage path is writable.
+     */
+    protected function storagePathIsWritable(): bool
+    {
+        return File::isWritable(storage_path())                  &&
+            File::isWritable(storage_path('framework'))          &&
+            File::isWritable(storage_path('framework/cache'))    &&
+            File::isWritable(storage_path('framework/sessions')) &&
+            File::isWritable(storage_path('framework/views'))    &&
+            File::isWritable(storage_path('logs'));
     }
 
     /**

--- a/tests/Feature/Settings/ShowSetUpPageTest.php
+++ b/tests/Feature/Settings/ShowSetUpPageTest.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Client\Response;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
@@ -266,5 +267,38 @@ class ShowSetUpPageTest extends TestCase
         $this->getSetUpPageResponse()->assertOk();
 
         $this->assertSeeAppUrlMisconfigurationErrorMessage();
+    }
+
+    public function testWillSeeDirectoryPermissionErrorWhenStoragePathIsNotWritable(): void
+    {
+        File::shouldReceive('isWritable')->andReturn(false);
+
+        $this->getSetUpPageResponse()->assertOk();
+
+        $this->assertSeeDirectoryPermissionError();
+    }
+
+    protected function assertSeeDirectoryPermissionError(bool $shouldSee = true): void
+    {
+        $storagePath = storage_path();
+
+        $errorMessage = "Uh-oh. Your <code>{$storagePath}</code> directory (or sub-directories within) are not writable by the web-server. Those directories need to be writable by the web server in order for the app to work.";
+        $successMessage = 'Yippee! Your app storage directory seems writable';
+
+        if ($shouldSee) {
+            self::$latestResponse->assertSee($errorMessage, false)->assertDontSee($successMessage, false);
+            return;
+        }
+
+        self::$latestResponse->assertSee($successMessage, false)->assertDontSee($errorMessage,false);
+    }
+
+    public function testWillNotSeeDirectoryPermissionErrorWhenStoragePathIsWritable(): void
+    {
+        File::shouldReceive('isWritable')->andReturn(true);
+
+        $this->getSetUpPageResponse()->assertOk();
+
+        $this->assertSeeDirectoryPermissionError(false);
     }
 }


### PR DESCRIPTION
# Description

Add storage path permissions test for SettingsController@getSetupIndex

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
