### PR TITLE
Fixed backup notification translations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "phpspec/prophecy": "^1.10",
     "pragmarx/google2fa-laravel": "^1.3",
     "rollbar/rollbar-laravel": "^8.0",
-    "spatie/laravel-backup": "^8.0",
+    "spatie/laravel-backup": "^8.8",
     "spatie/laravel-ignition": "^2.0",
     "tecnickcom/tc-lib-barcode": "^1.15",
     "tecnickcom/tcpdf": "^6.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc24b4f3399cb2119c0587e2e542d5ad",
+    "content-hash": "23aaae0a08be87061067b5636f840a02",
     "packages": [
         {
             "name": "alek13/slack",
@@ -8084,16 +8084,16 @@
         },
         {
             "name": "spatie/laravel-backup",
-            "version": "8.6.0",
+            "version": "8.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-backup.git",
-                "reference": "c6a7607c0eea80efc2cf6628ffcd172f73a2088f"
+                "reference": "a9c2d2f726f4c60c2dc5d7c0c8380f72492638c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/c6a7607c0eea80efc2cf6628ffcd172f73a2088f",
-                "reference": "c6a7607c0eea80efc2cf6628ffcd172f73a2088f",
+                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/a9c2d2f726f4c60c2dc5d7c0c8380f72492638c2",
+                "reference": "a9c2d2f726f4c60c2dc5d7c0c8380f72492638c2",
                 "shasum": ""
             },
             "require": {
@@ -8167,7 +8167,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-backup/issues",
-                "source": "https://github.com/spatie/laravel-backup/tree/8.6.0"
+                "source": "https://github.com/spatie/laravel-backup/tree/8.8.1"
             },
             "funding": [
                 {
@@ -8179,7 +8179,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2024-02-06T20:39:11+00:00"
+            "time": "2024-06-04T11:31:33+00:00"
         },
         {
             "name": "spatie/laravel-ignition",

--- a/config/app.php
+++ b/config/app.php
@@ -112,7 +112,7 @@ return [
     |
     */
 
-    'fallback_locale' => 'en-US',
+    'fallback_locale' =>  env('FALLBACK_APP_LOCALE', 'en'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/backup.php
+++ b/config/backup.php
@@ -137,6 +137,11 @@ return [
 
         'mail' => [
             'to' => env('MAIL_BACKUP_NOTIFICATION_ADDRESS', null),
+
+            'from' => [
+                'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+                'name' => env('MAIL_FROM_NAME', 'Example'),
+            ],
         ],
 
         'slack' => [
@@ -151,6 +156,20 @@ return [
 
             'icon' => null,
 
+        ],
+
+        'discord' => [
+            'webhook_url' => '',
+
+            /*
+             * If this is an empty string, the name field on the webhook will be used.
+             */
+            'username' => '',
+
+            /*
+             * If this is an empty string, the avatar on the webhook will be used.
+             */
+            'avatar_url' => '',
         ],
     ],
 

--- a/resources/lang/vendor/backup/ar/notifications.php
+++ b/resources/lang/vendor/backup/ar/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'رسالة استثناء: :message',
+    'exception_trace' => 'تتبع الإستثناء: :trace',
+    'exception_message_title' => 'رسالة استثناء',
+    'exception_trace_title' => 'تتبع الإستثناء',
+
+    'backup_failed_subject' => 'أخفق النسخ الاحتياطي لل :application_name',
+    'backup_failed_body' => 'مهم: حدث خطأ أثناء النسخ الاحتياطي :application_name',
+
+    'backup_successful_subject' => 'نسخ احتياطي جديد ناجح ل :application_name',
+    'backup_successful_subject_title' => 'نجاح النسخ الاحتياطي الجديد!',
+    'backup_successful_body' => 'أخبار عظيمة، نسخة احتياطية جديدة ل :application_name تم إنشاؤها بنجاح على القرص المسمى :disk_name.',
+
+    'cleanup_failed_subject' => 'فشل تنظيف النسخ الاحتياطي للتطبيق :application_name .',
+    'cleanup_failed_body' => 'حدث خطأ أثناء تنظيف النسخ الاحتياطية ل :application_name',
+
+    'cleanup_successful_subject' => 'تنظيف النسخ الاحتياطية ل :application_name تمت بنجاح',
+    'cleanup_successful_subject_title' => 'تنظيف النسخ الاحتياطية تم بنجاح!',
+    'cleanup_successful_body' => 'تنظيف النسخ الاحتياطية ل :application_name على القرص المسمى :disk_name تم بنجاح.',
+
+    'healthy_backup_found_subject' => 'النسخ الاحتياطية ل :application_name على القرص :disk_name صحية',
+    'healthy_backup_found_subject_title' => 'النسخ الاحتياطية ل :application_name صحية',
+    'healthy_backup_found_body' => 'تعتبر النسخ الاحتياطية ل :application_name صحية. عمل جيد!',
+
+    'unhealthy_backup_found_subject' => 'مهم: النسخ الاحتياطية ل :application_name غير صحية',
+    'unhealthy_backup_found_subject_title' => 'مهم: النسخ الاحتياطية ل :application_name غير صحية. :problem',
+    'unhealthy_backup_found_body' => 'النسخ الاحتياطية ل :application_name على القرص :disk_name غير صحية.',
+    'unhealthy_backup_found_not_reachable' => 'لا يمكن الوصول إلى وجهة النسخ الاحتياطي. :error',
+    'unhealthy_backup_found_empty' => 'لا توجد نسخ احتياطية لهذا التطبيق على الإطلاق.',
+    'unhealthy_backup_found_old' => 'تم إنشاء أحدث النسخ الاحتياطية في :date وتعتبر قديمة جدا.',
+    'unhealthy_backup_found_unknown' => 'عذرا، لا يمكن تحديد سبب دقيق.',
+    'unhealthy_backup_found_full' => 'النسخ الاحتياطية تستخدم الكثير من التخزين. الاستخدام الحالي هو :disk_usage وهو أعلى من الحد المسموح به من :disk_limit.',
+
+    'no_backups_info' => 'لم يتم عمل نسخ احتياطية حتى الآن',
+    'application_name' => 'اسم التطبيق',
+    'backup_name' => 'اسم النسخ الاحتياطي',
+    'disk' => 'القرص',
+    'newest_backup_size' => 'أحدث حجم للنسخ الاحتياطي',
+    'number_of_backups' => 'عدد النسخ الاحتياطية',
+    'total_storage_used' => 'إجمالي مساحة التخزين المستخدمة',
+    'newest_backup_date' => 'أحدث تاريخ النسخ الاحتياطي',
+    'oldest_backup_date' => 'أقدم تاريخ نسخ احتياطي',
+];

--- a/resources/lang/vendor/backup/bg/notifications.php
+++ b/resources/lang/vendor/backup/bg/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Съобщение за изключение: :message',
+    'exception_trace' => 'Проследяване на изключение: :trace',
+    'exception_message_title' => 'Съобщение за изключение',
+    'exception_trace_title' => 'Проследяване на изключение',
+
+    'backup_failed_subject' => 'Неуспешно резервно копие на :application_name',
+    'backup_failed_body' => 'Важно: Възникна грешка при архивиране на :application_name',
+
+    'backup_successful_subject' => 'Успешно ново резервно копие на :application_name',
+    'backup_successful_subject_title' => 'Успешно ново резервно копие!',
+    'backup_successful_body' => 'Чудесни новини, ново резервно копие на :application_name беше успешно създадено на диска с име :disk_name.',
+
+    'cleanup_failed_subject' => 'Почистването на резервните копия на :application_name не бе успешно.',
+    'cleanup_failed_body' => 'Възникна грешка при почистването на резервните копия на :application_name',
+
+    'cleanup_successful_subject' => 'Почистването на архивите на :application_name е успешно',
+    'cleanup_successful_subject_title' => 'Почистването на резервните копия е успешно!',
+    'cleanup_successful_body' => 'Почистването на резервни копия на :application_name на диска с име :disk_name беше успешно.',
+
+    'healthy_backup_found_subject' => 'Резервните копия за :application_name на диск :disk_name са здрави',
+    'healthy_backup_found_subject_title' => 'Резервните копия за :application_name са здрави',
+    'healthy_backup_found_body' => 'Резервните копия за :application_name се считат за здрави. Добра работа!',
+
+    'unhealthy_backup_found_subject' => 'Важно: Резервните копия за :application_name не са здрави',
+    'unhealthy_backup_found_subject_title' => 'Важно: Резервните копия за :application_name не са здрави. :проблем',
+    'unhealthy_backup_found_body' => 'Резервните копия за :application_name на диск :disk_name не са здрави.',
+    'unhealthy_backup_found_not_reachable' => 'Дестинацията за резервни копия не може да бъде достигната. :грешка',
+    'unhealthy_backup_found_empty' => 'Изобщо няма резервни копия на това приложение.',
+    'unhealthy_backup_found_old' => 'Последното резервно копие, направено на :date, се счита за твърде старо.',
+    'unhealthy_backup_found_unknown' => 'За съжаление не може да се определи точна причина.',
+    'unhealthy_backup_found_full' => 'Резервните копия използват твърде много място за съхранение. Текущото използване е :disk_usage, което е по-високо от разрешеното ограничение на :disk_limit.',
+
+    'no_backups_info' => 'Все още не са правени резервни копия',
+    'application_name' => 'Име на приложението',
+    'backup_name' => 'Име на резервно копие',
+    'disk' => 'Диск',
+    'newest_backup_size' => 'Най-новият размер на резервно копие',
+    'number_of_backups' => 'Брой резервни копия',
+    'total_storage_used' => 'Общо използвано дисково пространство',
+    'newest_backup_date' => 'Най-нова дата на резервно копие',
+    'oldest_backup_date' => 'Най-старата дата на резервно копие',
+];

--- a/resources/lang/vendor/backup/bn/notifications.php
+++ b/resources/lang/vendor/backup/bn/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'এক্সসেপশন বার্তা: :message',
+    'exception_trace' => 'এক্সসেপশন ট্রেস: :trace',
+    'exception_message_title' => 'এক্সসেপশন message',
+    'exception_trace_title' => 'এক্সসেপশন ট্রেস',
+
+    'backup_failed_subject' => ':application_name এর ব্যাকআপ ব্যর্থ হয়েছে।',
+    'backup_failed_body' => 'গুরুত্বপূর্ণঃ :application_name ব্যাক আপ করার সময় একটি ত্রুটি ঘটেছে।',
+
+    'backup_successful_subject' => ':application_name এর নতুন ব্যাকআপ সফল হয়েছে।',
+    'backup_successful_subject_title' => 'নতুন ব্যাকআপ সফল হয়েছে!',
+    'backup_successful_body' => 'খুশির খবর, :application_name এর নতুন ব্যাকআপ :disk_name ডিস্কে সফলভাবে তৈরি হয়েছে।',
+
+    'cleanup_failed_subject' => ':application_name ব্যাকআপগুলি সাফ করতে ব্যর্থ হয়েছে।',
+    'cleanup_failed_body' => ':application_name ব্যাকআপগুলি সাফ করার সময় একটি ত্রুটি ঘটেছে।',
+
+    'cleanup_successful_subject' => ':application_name এর ব্যাকআপগুলি সফলভাবে সাফ করা হয়েছে।',
+    'cleanup_successful_subject_title' => 'ব্যাকআপগুলি সফলভাবে সাফ করা হয়েছে!',
+    'cleanup_successful_body' => ':application_name এর ব্যাকআপগুলি :disk_name ডিস্ক থেকে সফলভাবে সাফ করা হয়েছে।',
+
+    'healthy_backup_found_subject' => ':application_name এর ব্যাকআপগুলি :disk_name ডিস্কে স্বাস্থ্যকর অবস্থায় আছে।',
+    'healthy_backup_found_subject_title' => ':application_name এর ব্যাকআপগুলি স্বাস্থ্যকর অবস্থায় আছে।',
+    'healthy_backup_found_body' => ':application_name এর ব্যাকআপগুলি  স্বাস্থ্যকর বিবেচনা করা হচ্ছে। Good job!',
+
+    'unhealthy_backup_found_subject' => 'গুরুত্বপূর্ণঃ :application_name এর ব্যাকআপগুলি অস্বাস্থ্যকর অবস্থায় আছে।',
+    'unhealthy_backup_found_subject_title' => 'গুরুত্বপূর্ণঃ :application_name এর ব্যাকআপগুলি অস্বাস্থ্যকর অবস্থায় আছে। :problem',
+    'unhealthy_backup_found_body' => ':disk_name ডিস্কের :application_name এর ব্যাকআপগুলি অস্বাস্থ্যকর অবস্থায় আছে।',
+    'unhealthy_backup_found_not_reachable' => 'ব্যাকআপ গন্তব্যে পৌঁছানো যায় নি। :error',
+    'unhealthy_backup_found_empty' => 'এই অ্যাপ্লিকেশনটির কোনও ব্যাকআপ নেই।',
+    'unhealthy_backup_found_old' => 'সর্বশেষ ব্যাকআপ যেটি :date এই তারিখে করা হয়েছে, সেটি খুব পুরানো।',
+    'unhealthy_backup_found_unknown' => 'দুঃখিত, সঠিক কারণ নির্ধারণ করা সম্ভব হয়নি।',
+    'unhealthy_backup_found_full' => 'ব্যাকআপগুলি অতিরিক্ত স্টোরেজ ব্যবহার করছে। বর্তমান ব্যবহারের পরিমান :disk_usage যা অনুমোদিত সীমা :disk_limit এর বেশি।',
+
+    'no_backups_info' => 'কোনো ব্যাকআপ এখনও তৈরি হয়নি',
+    'application_name' => 'আবেদনের নাম',
+    'backup_name' => 'ব্যাকআপের নাম',
+    'disk' => 'ডিস্ক',
+    'newest_backup_size' => 'নতুন ব্যাকআপ আকার',
+    'number_of_backups' => 'ব্যাকআপের সংখ্যা',
+    'total_storage_used' => 'ব্যবহৃত মোট সঞ্চয়স্থান',
+    'newest_backup_date' => 'নতুন ব্যাকআপের তারিখ',
+    'oldest_backup_date' => 'পুরানো ব্যাকআপের তারিখ',
+];

--- a/resources/lang/vendor/backup/cs/notifications.php
+++ b/resources/lang/vendor/backup/cs/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Zpráva výjimky: :message',
+    'exception_trace' => 'Stopa výjimky: :trace',
+    'exception_message_title' => 'Zpráva výjimky',
+    'exception_trace_title' => 'Stopa výjimky',
+
+    'backup_failed_subject' => 'Záloha :application_name neuspěla',
+    'backup_failed_body' => 'Důležité: Při záloze :application_name se vyskytla chyba',
+
+    'backup_successful_subject' => 'Úspěšná nová záloha :application_name',
+    'backup_successful_subject_title' => 'Úspěšná nová záloha!',
+    'backup_successful_body' => 'Dobrá zpráva, na disku jménem :disk_name byla úspěšně vytvořena nová záloha :application_name.',
+
+    'cleanup_failed_subject' => 'Vyčištění záloh :application_name neuspělo.',
+    'cleanup_failed_body' => 'Při čištění záloh :application_name se vyskytla chyba',
+
+    'cleanup_successful_subject' => 'Vyčištění záloh :application_name úspěšné',
+    'cleanup_successful_subject_title' => 'Vyčištění záloh bylo úspěšné!',
+    'cleanup_successful_body' => 'Vyčištění záloh :application_name na disku jménem :disk_name bylo úspěšné.',
+
+    'healthy_backup_found_subject' => 'Zálohy pro :application_name na disku :disk_name jsou zdravé',
+    'healthy_backup_found_subject_title' => 'Zálohy pro :application_name jsou zdravé',
+    'healthy_backup_found_body' => 'Zálohy pro :application_name jsou považovány za zdravé. Dobrá práce!',
+
+    'unhealthy_backup_found_subject' => 'Důležité: Zálohy pro :application_name jsou nezdravé',
+    'unhealthy_backup_found_subject_title' => 'Důležité: Zálohy pro :application_name jsou nezdravé. :problem',
+    'unhealthy_backup_found_body' => 'Zálohy pro :application_name na disku :disk_name jsou nezdravé.',
+    'unhealthy_backup_found_not_reachable' => 'Nelze se dostat k cíli zálohy. :error',
+    'unhealthy_backup_found_empty' => 'Tato aplikace nemá vůbec žádné zálohy.',
+    'unhealthy_backup_found_old' => 'Poslední záloha vytvořená dne :date je považována za příliš starou.',
+    'unhealthy_backup_found_unknown' => 'Omlouváme se, nemůžeme určit přesný důvod.',
+    'unhealthy_backup_found_full' => 'Zálohy zabírají příliš mnoho místa na disku. Aktuální využití disku je :disk_usage, což je vyšší než povolený limit :disk_limit.',
+
+    'no_backups_info' => 'Zatím nebyly vytvořeny žádné zálohy',
+    'application_name' => 'Název aplikace',
+    'backup_name' => 'Název zálohy',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Velikost nejnovější zálohy',
+    'number_of_backups' => 'Počet záloh',
+    'total_storage_used' => 'Celková využitá kapacita úložiště',
+    'newest_backup_date' => 'Datum nejnovější zálohy',
+    'oldest_backup_date' => 'Datum nejstarší zálohy',
+];

--- a/resources/lang/vendor/backup/da/notifications.php
+++ b/resources/lang/vendor/backup/da/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Fejlbesked: :message',
+    'exception_trace' => 'Fejl trace: :trace',
+    'exception_message_title' => 'Fejlbesked',
+    'exception_trace_title' => 'Fejl trace',
+
+    'backup_failed_subject' => 'Backup af :application_name fejlede',
+    'backup_failed_body' => 'Vigtigt: Der skete en fejl under backup af :application_name',
+
+    'backup_successful_subject' => 'Ny backup af :application_name oprettet',
+    'backup_successful_subject_title' => 'Ny backup!',
+    'backup_successful_body' => 'Gode nyheder - der blev oprettet en ny backup af :application_name på disken :disk_name.',
+
+    'cleanup_failed_subject' => 'Oprydning af backups for :application_name fejlede.',
+    'cleanup_failed_body' => 'Der skete en fejl under oprydning af backups for :application_name',
+
+    'cleanup_successful_subject' => 'Oprydning af backups for :application_name gennemført',
+    'cleanup_successful_subject_title' => 'Backup oprydning gennemført!',
+    'cleanup_successful_body' => 'Oprydningen af backups for :application_name på disken :disk_name er gennemført.',
+
+    'healthy_backup_found_subject' => 'Alle backups for :application_name på disken :disk_name er OK',
+    'healthy_backup_found_subject_title' => 'Alle backups for :application_name er OK',
+    'healthy_backup_found_body' => 'Alle backups for :application_name er ok. Godt gået!',
+
+    'unhealthy_backup_found_subject' => 'Vigtigt: Backups for :application_name fejlbehæftede',
+    'unhealthy_backup_found_subject_title' => 'Vigtigt: Backups for :application_name er fejlbehæftede. :problem',
+    'unhealthy_backup_found_body' => 'Backups for :application_name på disken :disk_name er fejlbehæftede.',
+    'unhealthy_backup_found_not_reachable' => 'Backup destinationen kunne ikke findes. :error',
+    'unhealthy_backup_found_empty' => 'Denne applikation har ingen backups overhovedet.',
+    'unhealthy_backup_found_old' => 'Den seneste backup fra :date er for gammel.',
+    'unhealthy_backup_found_unknown' => 'Beklager, en præcis årsag kunne ikke findes.',
+    'unhealthy_backup_found_full' => 'Backups bruger for meget plads. Nuværende disk forbrug er :disk_usage, hvilket er mere end den tilladte grænse på :disk_limit.',
+
+    'no_backups_info' => 'Der blev ikke foretaget nogen sikkerhedskopier endnu',
+    'application_name' => 'Ansøgningens navn',
+    'backup_name' => 'Backup navn',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Nyeste backup-størrelse',
+    'number_of_backups' => 'Antal sikkerhedskopier',
+    'total_storage_used' => 'Samlet lagerplads brugt',
+    'newest_backup_date' => 'Nyeste backup-størrelse',
+    'oldest_backup_date' => 'Ældste backup-størrelse',
+];

--- a/resources/lang/vendor/backup/de/notifications.php
+++ b/resources/lang/vendor/backup/de/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Fehlermeldung: :message',
+    'exception_trace' => 'Fehlerverfolgung: :trace',
+    'exception_message_title' => 'Fehlermeldung',
+    'exception_trace_title' => 'Fehlerverfolgung',
+
+    'backup_failed_subject' => 'Backup von :application_name konnte nicht erstellt werden',
+    'backup_failed_body' => 'Wichtig: Beim Backup von :application_name ist ein Fehler aufgetreten',
+
+    'backup_successful_subject' => 'Erfolgreiches neues Backup von :application_name',
+    'backup_successful_subject_title' => 'Erfolgreiches neues Backup!',
+    'backup_successful_body' => 'Gute Nachrichten, ein neues Backup von :application_name wurde erfolgreich erstellt und in :disk_name gepeichert.',
+
+    'cleanup_failed_subject' => 'Aufräumen der Backups von :application_name schlug fehl.',
+    'cleanup_failed_body' => 'Beim aufräumen der Backups von :application_name ist ein Fehler aufgetreten',
+
+    'cleanup_successful_subject' => 'Aufräumen der Backups von :application_name backups erfolgreich',
+    'cleanup_successful_subject_title' => 'Aufräumen der Backups erfolgreich!',
+    'cleanup_successful_body' => 'Aufräumen der Backups von :application_name in :disk_name war erfolgreich.',
+
+    'healthy_backup_found_subject' => 'Die Backups von :application_name in :disk_name sind gesund',
+    'healthy_backup_found_subject_title' => 'Die Backups von :application_name sind Gesund',
+    'healthy_backup_found_body' => 'Die Backups von :application_name wurden als gesund eingestuft. Gute Arbeit!',
+
+    'unhealthy_backup_found_subject' => 'Wichtig: Die Backups für :application_name sind nicht gesund',
+    'unhealthy_backup_found_subject_title' => 'Wichtig: Die Backups für :application_name sind ungesund. :problem',
+    'unhealthy_backup_found_body' => 'Die Backups für :application_name in :disk_name sind ungesund.',
+    'unhealthy_backup_found_not_reachable' => 'Das Backup Ziel konnte nicht erreicht werden. :error',
+    'unhealthy_backup_found_empty' => 'Es gibt für die Anwendung noch gar keine Backups.',
+    'unhealthy_backup_found_old' => 'Das letzte Backup am :date ist zu lange her.',
+    'unhealthy_backup_found_unknown' => 'Sorry, ein genauer Grund konnte nicht gefunden werden.',
+    'unhealthy_backup_found_full' => 'Die Backups verbrauchen zu viel Platz. Aktuell wird :disk_usage belegt, dass ist höher als das erlaubte Limit von :disk_limit.',
+
+    'no_backups_info' => 'Bisher keine Backups vorhanden',
+    'application_name' => 'Applikationsname',
+    'backup_name' => 'Backup Name',
+    'disk' => 'Speicherort',
+    'newest_backup_size' => 'Neuste Backup-Größe',
+    'number_of_backups' => 'Anzahl Backups',
+    'total_storage_used' => 'Gesamter genutzter Speicherplatz',
+    'newest_backup_date' => 'Neustes Backup',
+    'oldest_backup_date' => 'Ältestes Backup',
+];

--- a/resources/lang/vendor/backup/en/notifications.php
+++ b/resources/lang/vendor/backup/en/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Exception message: :message',
+    'exception_trace' => 'Exception trace: :trace',
+    'exception_message_title' => 'Exception message',
+    'exception_trace_title' => 'Exception trace',
+
+    'backup_failed_subject' => 'Failed backup of :application_name',
+    'backup_failed_body' => 'Important: An error occurred while backing up :application_name',
+
+    'backup_successful_subject' => 'Successful new backup of :application_name',
+    'backup_successful_subject_title' => 'Successful new backup!',
+    'backup_successful_body' => 'Great news, a new backup of :application_name was successfully created on the disk named :disk_name.',
+
+    'cleanup_failed_subject' => 'Cleaning up the backups of :application_name failed.',
+    'cleanup_failed_body' => 'An error occurred while cleaning up the backups of :application_name',
+
+    'cleanup_successful_subject' => 'Clean up of :application_name backups successful',
+    'cleanup_successful_subject_title' => 'Clean up of backups successful!',
+    'cleanup_successful_body' => 'The clean up of the :application_name backups on the disk named :disk_name was successful.',
+
+    'healthy_backup_found_subject' => 'The backups for :application_name on disk :disk_name are healthy',
+    'healthy_backup_found_subject_title' => 'The backups for :application_name are healthy',
+    'healthy_backup_found_body' => 'The backups for :application_name are considered healthy. Good job!',
+
+    'unhealthy_backup_found_subject' => 'Important: The backups for :application_name are unhealthy',
+    'unhealthy_backup_found_subject_title' => 'Important: The backups for :application_name are unhealthy. :problem',
+    'unhealthy_backup_found_body' => 'The backups for :application_name on disk :disk_name are unhealthy.',
+    'unhealthy_backup_found_not_reachable' => 'The backup destination cannot be reached. :error',
+    'unhealthy_backup_found_empty' => 'There are no backups of this application at all.',
+    'unhealthy_backup_found_old' => 'The latest backup made on :date is considered too old.',
+    'unhealthy_backup_found_unknown' => 'Sorry, an exact reason cannot be determined.',
+    'unhealthy_backup_found_full' => 'The backups are using too much storage. Current usage is :disk_usage which is higher than the allowed limit of :disk_limit.',
+
+    'no_backups_info' => 'No backups were made yet',
+    'application_name' => 'Application name',
+    'backup_name' => 'Backup name',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Newest backup size',
+    'number_of_backups' => 'Number of backups',
+    'total_storage_used' => 'Total storage used',
+    'newest_backup_date' => 'Newest backup date',
+    'oldest_backup_date' => 'Oldest backup date',
+];

--- a/resources/lang/vendor/backup/es/notifications.php
+++ b/resources/lang/vendor/backup/es/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Mensaje de la excepción: :message',
+    'exception_trace' => 'Traza de la excepción: :trace',
+    'exception_message_title' => 'Mensaje de la excepción',
+    'exception_trace_title' => 'Traza de la excepción',
+
+    'backup_failed_subject' => 'Copia de seguridad de :application_name fallida',
+    'backup_failed_body' => 'Importante: Ocurrió un error al realizar la copia de seguridad de :application_name',
+
+    'backup_successful_subject' => 'Se completó con éxito la copia de seguridad de :application_name',
+    'backup_successful_subject_title' => '¡Nueva copia de seguridad creada con éxito!',
+    'backup_successful_body' => 'Buenas noticias, una nueva copia de seguridad de :application_name fue creada con éxito en el disco llamado :disk_name.',
+
+    'cleanup_failed_subject' => 'La limpieza de copias de seguridad de :application_name falló.',
+    'cleanup_failed_body' => 'Ocurrió un error mientras se realizaba la limpieza de copias de seguridad de :application_name',
+
+    'cleanup_successful_subject' => 'La limpieza de copias de seguridad de :application_name se completó con éxito',
+    'cleanup_successful_subject_title' => '!Limpieza de copias de seguridad completada con éxito!',
+    'cleanup_successful_body' => 'La limpieza de copias de seguridad de :application_name en el disco llamado :disk_name se completo con éxito.',
+
+    'healthy_backup_found_subject' => 'Las copias de seguridad de :application_name en el disco :disk_name están en buen estado',
+    'healthy_backup_found_subject_title' => 'Las copias de seguridad de :application_name están en buen estado',
+    'healthy_backup_found_body' => 'Las copias de seguridad de :application_name se consideran en buen estado. ¡Buen trabajo!',
+
+    'unhealthy_backup_found_subject' => 'Importante: Las copias de seguridad de :application_name están en mal estado',
+    'unhealthy_backup_found_subject_title' => 'Importante: Las copias de seguridad de :application_name están en mal estado. :problem',
+    'unhealthy_backup_found_body' => 'Las copias de seguridad de :application_name en el disco :disk_name están en mal estado.',
+    'unhealthy_backup_found_not_reachable' => 'No se puede acceder al destino de la copia de seguridad. :error',
+    'unhealthy_backup_found_empty' => 'No existe ninguna copia de seguridad de esta aplicación.',
+    'unhealthy_backup_found_old' => 'La última copia de seguriad hecha en :date es demasiado antigua.',
+    'unhealthy_backup_found_unknown' => 'Lo siento, no es posible determinar la razón exacta.',
+    'unhealthy_backup_found_full' => 'Las copias de seguridad  están ocupando demasiado espacio. El espacio utilizado actualmente es :disk_usage el cual es mayor que el límite permitido de :disk_limit.',
+
+    'no_backups_info' => 'Aún no se hicieron copias de seguridad',
+    'application_name' => 'Nombre de la aplicación',
+    'backup_name' => 'Nombre de la copia de seguridad',
+    'disk' => 'Disco',
+    'newest_backup_size' => 'Tamaño de copia de seguridad más reciente',
+    'number_of_backups' => 'Número de copias de seguridad',
+    'total_storage_used' => 'Almacenamiento total utilizado',
+    'newest_backup_date' => 'Fecha de la copia de seguridad más reciente',
+    'oldest_backup_date' => 'Fecha de la copia de seguridad más antigua',
+];

--- a/resources/lang/vendor/backup/fa/notifications.php
+++ b/resources/lang/vendor/backup/fa/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'پیغام خطا: :message',
+    'exception_trace' => 'جزییات خطا: :trace',
+    'exception_message_title' => 'پیغام خطا',
+    'exception_trace_title' => 'جزییات خطا',
+
+    'backup_failed_subject' => 'پشتیبان‌گیری :application_name با خطا مواجه شد.',
+    'backup_failed_body' => 'پیغام مهم: هنگام پشتیبان‌گیری از :application_name خطایی رخ داده است. ',
+
+    'backup_successful_subject' => 'نسخه پشتیبان جدید :application_name با موفقیت ساخته شد.',
+    'backup_successful_subject_title' => 'پشتیبان‌گیری موفق!',
+    'backup_successful_body' => 'خبر خوب، به تازگی نسخه پشتیبان :application_name روی دیسک :disk_name با موفقیت ساخته شد. ',
+
+    'cleanup_failed_subject' => 'پاک‌‌سازی نسخه پشتیبان :application_name انجام نشد.',
+    'cleanup_failed_body' => 'هنگام پاک‌سازی نسخه پشتیبان :application_name خطایی رخ داده است.',
+
+    'cleanup_successful_subject' => 'پاک‌سازی نسخه پشتیبان :application_name با موفقیت انجام شد.',
+    'cleanup_successful_subject_title' => 'پاک‌سازی نسخه پشتیبان!',
+    'cleanup_successful_body' => 'پاک‌سازی نسخه پشتیبان :application_name روی دیسک :disk_name با موفقیت انجام شد.',
+
+    'healthy_backup_found_subject' => 'نسخه پشتیبان :application_name روی دیسک :disk_name سالم بود.',
+    'healthy_backup_found_subject_title' => 'نسخه پشتیبان :application_name سالم بود.',
+    'healthy_backup_found_body' => 'نسخه پشتیبان :application_name به نظر سالم میاد. دمت گرم!',
+
+    'unhealthy_backup_found_subject' => 'خبر مهم: نسخه پشتیبان :application_name سالم نبود.',
+    'unhealthy_backup_found_subject_title' => 'خبر مهم: نسخه پشتیبان :application_name سالم نبود. :problem',
+    'unhealthy_backup_found_body' => 'نسخه پشتیبان :application_name روی دیسک :disk_name سالم نبود.',
+    'unhealthy_backup_found_not_reachable' => 'مقصد پشتیبان‌گیری در دسترس نبود. :error',
+    'unhealthy_backup_found_empty' => 'برای این برنامه هیچ نسخه پشتیبانی وجود ندارد.',
+    'unhealthy_backup_found_old' => 'آخرین نسخه پشتیبان برای تاریخ :date است، که به نظر خیلی قدیمی میاد. ',
+    'unhealthy_backup_found_unknown' => 'متاسفانه دلیل دقیقی قابل تعیین نیست.',
+    'unhealthy_backup_found_full' => 'نسخه‌های پشتیبان حجم زیادی اشغال کرده‌اند. میزان دیسک استفاده‌شده :disk_usage است که از میزان مجاز :disk_limit فراتر رفته است. ',
+
+    'no_backups_info' => 'هنوز نسخه پشتیبان تهیه نشده است',
+    'application_name' => 'نام نرم‌افزار',
+    'backup_name' => 'نام نسخه پشتیبان',
+    'disk' => 'دیسک',
+    'newest_backup_size' => 'اندازه جدیدترین نسخه پشتیبان',
+    'number_of_backups' => 'تعداد نسخه‌های پشتیبان',
+    'total_storage_used' => 'کل فضای ذخیره‌سازی استفاده‌شده',
+    'newest_backup_date' => 'تاریخ جدیدترین نسخه پشتیبان',
+    'oldest_backup_date' => 'تاریخ قدیمی‌ترین نسخه پشتیبان',
+];

--- a/resources/lang/vendor/backup/fi/notifications.php
+++ b/resources/lang/vendor/backup/fi/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Virheilmoitus: :message',
+    'exception_trace' => 'Virhe, jäljitys: :trace',
+    'exception_message_title' => 'Virheilmoitus',
+    'exception_trace_title' => 'Virheen jäljitys',
+
+    'backup_failed_subject' => ':application_name varmuuskopiointi epäonnistui',
+    'backup_failed_body' => 'HUOM!: :application_name varmuuskoipionnissa tapahtui virhe',
+
+    'backup_successful_subject' => ':application_name varmuuskopioitu onnistuneesti',
+    'backup_successful_subject_title' => 'Uusi varmuuskopio!',
+    'backup_successful_body' => 'Hyviä uutisia! :application_name on varmuuskopioitu levylle :disk_name.',
+
+    'cleanup_failed_subject' => ':application_name varmuuskopioiden poistaminen epäonnistui.',
+    'cleanup_failed_body' => ':application_name varmuuskopioiden poistamisessa tapahtui virhe.',
+
+    'cleanup_successful_subject' => ':application_name varmuuskopiot poistettu onnistuneesti',
+    'cleanup_successful_subject_title' => 'Varmuuskopiot poistettu onnistuneesti!',
+    'cleanup_successful_body' => ':application_name varmuuskopiot poistettu onnistuneesti levyltä :disk_name.',
+
+    'healthy_backup_found_subject' => ':application_name varmuuskopiot levyllä :disk_name ovat kunnossa',
+    'healthy_backup_found_subject_title' => ':application_name varmuuskopiot ovat kunnossa',
+    'healthy_backup_found_body' => ':application_name varmuuskopiot ovat kunnossa. Hieno homma!',
+
+    'unhealthy_backup_found_subject' => 'HUOM!: :application_name varmuuskopiot ovat vialliset',
+    'unhealthy_backup_found_subject_title' => 'HUOM!: :application_name varmuuskopiot ovat vialliset. :problem',
+    'unhealthy_backup_found_body' => ':application_name varmuuskopiot levyllä :disk_name ovat vialliset.',
+    'unhealthy_backup_found_not_reachable' => 'Varmuuskopioiden kohdekansio ei ole saatavilla. :error',
+    'unhealthy_backup_found_empty' => 'Tästä sovelluksesta ei ole varmuuskopioita.',
+    'unhealthy_backup_found_old' => 'Viimeisin varmuuskopio, luotu :date, on liian vanha.',
+    'unhealthy_backup_found_unknown' => 'Virhe, tarkempaa tietoa syystä ei valitettavasti ole saatavilla.',
+    'unhealthy_backup_found_full' => 'Varmuuskopiot vievät liikaa levytilaa. Tällä hetkellä käytössä :disk_usage, mikä on suurempi kuin sallittu tilavuus (:disk_limit).',
+
+    'no_backups_info' => 'Varmuuskopioita ei vielä tehty',
+    'application_name' => 'Sovelluksen nimi',
+    'backup_name' => 'Varmuuskopion nimi',
+    'disk' => 'Levy',
+    'newest_backup_size' => 'Uusin varmuuskopion koko',
+    'number_of_backups' => 'Varmuuskopioiden määrä',
+    'total_storage_used' => 'Käytetty tallennustila yhteensä',
+    'newest_backup_date' => 'Uusin varmuuskopion koko',
+    'oldest_backup_date' => 'Vanhin varmuuskopion koko',
+];

--- a/resources/lang/vendor/backup/fr/notifications.php
+++ b/resources/lang/vendor/backup/fr/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Message de l\'exception : :message',
+    'exception_trace' => 'Trace de l\'exception : :trace',
+    'exception_message_title' => 'Message de l\'exception',
+    'exception_trace_title' => 'Trace de l\'exception',
+
+    'backup_failed_subject' => 'Échec de la sauvegarde de :application_name',
+    'backup_failed_body' => 'Important : Une erreur est survenue lors de la sauvegarde de :application_name',
+
+    'backup_successful_subject' => 'Succès de la sauvegarde de :application_name',
+    'backup_successful_subject_title' => 'Sauvegarde créée avec succès !',
+    'backup_successful_body' => 'Bonne nouvelle, une nouvelle sauvegarde de :application_name a été créée avec succès sur le disque nommé :disk_name.',
+
+    'cleanup_failed_subject' => 'Le nettoyage des sauvegardes de :application_name a echoué.',
+    'cleanup_failed_body' => 'Une erreur est survenue lors du nettoyage des sauvegardes de :application_name',
+
+    'cleanup_successful_subject' => 'Succès du nettoyage des sauvegardes de :application_name',
+    'cleanup_successful_subject_title' => 'Sauvegardes nettoyées avec succès !',
+    'cleanup_successful_body' => 'Le nettoyage des sauvegardes de :application_name sur le disque nommé :disk_name a été effectué avec succès.',
+
+    'healthy_backup_found_subject' => 'Les sauvegardes pour :application_name sur le disque :disk_name sont saines',
+    'healthy_backup_found_subject_title' => 'Les sauvegardes pour :application_name sont saines',
+    'healthy_backup_found_body' => 'Les sauvegardes pour :application_name sont considérées saines. Bon travail !',
+
+    'unhealthy_backup_found_subject' => 'Important : Les sauvegardes pour :application_name sont corrompues',
+    'unhealthy_backup_found_subject_title' => 'Important : Les sauvegardes pour :application_name sont corrompues. :problem',
+    'unhealthy_backup_found_body' => 'Les sauvegardes pour :application_name sur le disque :disk_name sont corrompues.',
+    'unhealthy_backup_found_not_reachable' => 'La destination de la sauvegarde n\'est pas accessible. :error',
+    'unhealthy_backup_found_empty' => 'Il n\'y a aucune sauvegarde pour cette application.',
+    'unhealthy_backup_found_old' => 'La dernière sauvegarde du :date est considérée trop vieille.',
+    'unhealthy_backup_found_unknown' => 'Désolé, une raison exacte ne peut être déterminée.',
+    'unhealthy_backup_found_full' => 'Les sauvegardes utilisent trop d\'espace disque. L\'utilisation actuelle est de :disk_usage alors que la limite autorisée est de :disk_limit.',
+
+    'no_backups_info' => 'Aucune sauvegarde n\'a encore été effectuée',
+    'application_name' => 'Nom de l\'application',
+    'backup_name' => 'Nom de la sauvegarde',
+    'disk' => 'Disque',
+    'newest_backup_size' => 'Taille de la sauvegarde la plus récente',
+    'number_of_backups' => 'Nombre de sauvegardes',
+    'total_storage_used' => 'Stockage total utilisé',
+    'newest_backup_date' => 'Date de la sauvegarde la plus récente',
+    'oldest_backup_date' => 'Date de la sauvegarde la plus ancienne',
+];

--- a/resources/lang/vendor/backup/he/notifications.php
+++ b/resources/lang/vendor/backup/he/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'הודעת חריגה: :message',
+    'exception_trace' => 'מעקב חריגה: :trace',
+    'exception_message_title' => 'הודעת חריגה',
+    'exception_trace_title' => 'מעקב חריגה',
+
+    'backup_failed_subject' => 'כשל בגיבוי של :application_name',
+    'backup_failed_body' => 'חשוב: אירעה שגיאה במהלך גיבוי היישום :application_name',
+
+    'backup_successful_subject' => 'גיבוי חדש מוצלח של :application_name',
+    'backup_successful_subject_title' => 'גיבוי חדש מוצלח!',
+    'backup_successful_body' => 'חדשות טובות, גיבוי חדש של :application_name נוצר בהצלחה על הדיסק בשם :disk_name.',
+
+    'cleanup_failed_subject' => 'נכשל בניקוי הגיבויים של :application_name',
+    'cleanup_failed_body' => 'אירעה שגיאה במהלך ניקוי הגיבויים של :application_name',
+
+    'cleanup_successful_subject' => 'ניקוי הגיבויים של :application_name בוצע בהצלחה',
+    'cleanup_successful_subject_title' => 'ניקוי הגיבויים בוצע בהצלחה!',
+    'cleanup_successful_body' => 'ניקוי הגיבויים של :application_name על הדיסק בשם :disk_name בוצע בהצלחה.',
+
+    'healthy_backup_found_subject' => 'הגיבויים של :application_name על הדיסק :disk_name תקינים',
+    'healthy_backup_found_subject_title' => 'הגיבויים של :application_name תקינים',
+    'healthy_backup_found_body' => 'הגיבויים של :application_name נחשבים לתקינים. עבודה טובה!',
+
+    'unhealthy_backup_found_subject' => 'חשוב: הגיבויים של :application_name אינם תקינים',
+    'unhealthy_backup_found_subject_title' => 'חשוב: הגיבויים של :application_name אינם תקינים. :problem',
+    'unhealthy_backup_found_body' => 'הגיבויים של :application_name על הדיסק :disk_name אינם תקינים.',
+    'unhealthy_backup_found_not_reachable' => 'לא ניתן להגיע ליעד הגיבוי. :error',
+    'unhealthy_backup_found_empty' => 'אין גיבויים של היישום הזה בכלל.',
+    'unhealthy_backup_found_old' => 'הגיבוי האחרון שנעשה בתאריך :date נחשב כישן מדי.',
+    'unhealthy_backup_found_unknown' => 'מצטערים, לא ניתן לקבוע סיבה מדויקת.',
+    'unhealthy_backup_found_full' => 'הגיבויים משתמשים בשטח אחסון רב מידי. שימוש הנוכחי הוא :disk_usage, שגבול המותר הוא :disk_limit.',
+
+    'no_backups_info' => 'לא נעשו עדיין גיבויים',
+    'application_name' => 'שם היישום',
+    'backup_name' => 'שם הגיבוי',
+    'disk' => 'דיסק',
+    'newest_backup_size' => 'גודל הגיבוי החדש ביותר',
+    'number_of_backups' => 'מספר הגיבויים',
+    'total_storage_used' => 'סך האחסון המופעל',
+    'newest_backup_date' => 'תאריך הגיבוי החדש ביותר',
+    'oldest_backup_date' => 'תאריך הגיבוי הישן ביותר',
+];

--- a/resources/lang/vendor/backup/hi/notifications.php
+++ b/resources/lang/vendor/backup/hi/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'अपवाद संदेश: :message',
+    'exception_trace' => 'अपवाद निशान: :trace',
+    'exception_message_title' => 'अपवादी संदेश',
+    'exception_trace_title' => 'अपवाद निशान',
+
+    'backup_failed_subject' => ':application_name का बैकअप असफल रहा',
+    'backup_failed_body' => 'जरूरी सुचना: :application_name का बैकअप लेते समय असफल रहे',
+
+    'backup_successful_subject' => ':application_name का बैकअप सफल रहा',
+    'backup_successful_subject_title' => 'बैकअप सफल रहा!',
+    'backup_successful_body' => 'खुशखबर, :application_name का बैकअप :disk_name पर संग्रहित करने मे सफल रहे.',
+
+    'cleanup_failed_subject' => ':application_name के बैकअप की सफाई असफल रही.',
+    'cleanup_failed_body' => ':application_name के बैकअप की सफाई करते समय कुछ बाधा आयी है.',
+
+    'cleanup_successful_subject' => ':application_name के बैकअप की सफाई सफल रही',
+    'cleanup_successful_subject_title' => 'बैकअप की सफाई सफल रही!',
+    'cleanup_successful_body' => ':application_name का बैकअप जो :disk_name नाम की डिस्क पर संग्रहित है, उसकी सफाई सफल रही.',
+
+    'healthy_backup_found_subject' => ':disk_name नाम की डिस्क पर संग्रहित :application_name के बैकअप स्वस्थ है',
+    'healthy_backup_found_subject_title' => ':application_name के सभी बैकअप स्वस्थ है',
+    'healthy_backup_found_body' => 'बहुत बढ़िया! :application_name के सभी बैकअप स्वस्थ है.',
+
+    'unhealthy_backup_found_subject' => 'जरूरी सुचना :  :application_name के बैकअप अस्वस्थ है',
+    'unhealthy_backup_found_subject_title' => 'जरूरी सुचना : :application_name के बैकअप :problem के बजेसे अस्वस्थ है',
+    'unhealthy_backup_found_body' => ':disk_name नाम की डिस्क पर संग्रहित :application_name के बैकअप अस्वस्थ है',
+    'unhealthy_backup_found_not_reachable' => ':error के बजेसे बैकअप की मंजिल तक पोहोच नहीं सकते.',
+    'unhealthy_backup_found_empty' => 'इस एप्लीकेशन का कोई भी बैकअप नहीं है.',
+    'unhealthy_backup_found_old' => 'हालहीमें :date को लिया हुआ बैकअप बहुत पुराना है.',
+    'unhealthy_backup_found_unknown' => 'माफ़ कीजिये, सही कारण निर्धारित नहीं कर सकते.',
+    'unhealthy_backup_found_full' => 'सभी बैकअप बहुत ज्यादा जगह का उपयोग कर रहे है. फ़िलहाल सभी बैकअप :disk_usage जगह का उपयोग कर रहे है, जो की :disk_limit अनुमति सीमा से अधिक का है.',
+
+    'no_backups_info' => 'अभी तक कोई बैकअप नहीं बनाया गया था',
+    'application_name' => 'आवेदन का नाम',
+    'backup_name' => 'बैकअप नाम',
+    'disk' => 'डिस्क',
+    'newest_backup_size' => 'नवीनतम बैकअप आकार',
+    'number_of_backups' => 'बैकअप की संख्या',
+    'total_storage_used' => 'उपयोग किया गया कुल संग्रहण',
+    'newest_backup_date' => 'नवीनतम बैकअप आकार',
+    'oldest_backup_date' => 'सबसे पुराना बैकअप आकार',
+];

--- a/resources/lang/vendor/backup/hr/notifications.php
+++ b/resources/lang/vendor/backup/hr/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Greška: :message',
+    'exception_trace' => 'Praćenje greške: :trace',
+    'exception_message_title' => 'Greška',
+    'exception_trace_title' => 'Praćenje greške',
+
+    'backup_failed_subject' => 'Neuspješno sigurnosno kopiranje za :application_name',
+    'backup_failed_body' => 'Važno: Došlo je do greške prilikom sigurnosnog kopiranja za :application_name',
+
+    'backup_successful_subject' => 'Uspješno sigurnosno kopiranje za :application_name',
+    'backup_successful_subject_title' => 'Uspješno sigurnosno kopiranje!',
+    'backup_successful_body' => 'Nova sigurnosna kopija za :application_name je uspješno spremljena na disk :disk_name.',
+
+    'cleanup_failed_subject' => 'Neuspješno čišćenje sigurnosnih kopija za :application_name',
+    'cleanup_failed_body' => 'Došlo je do greške prilikom čišćenja sigurnosnih kopija za :application_name',
+
+    'cleanup_successful_subject' => 'Uspješno čišćenje sigurnosnih kopija za :application_name',
+    'cleanup_successful_subject_title' => 'Uspješno čišćenje sigurnosnih kopija!',
+    'cleanup_successful_body' => 'Sigurnosne kopije za :application_name su uspješno očišćene s diska :disk_name.',
+
+    'healthy_backup_found_subject' => 'Sigurnosne kopije za :application_name na disku :disk_name su zdrave',
+    'healthy_backup_found_subject_title' => 'Sigurnosne kopije za :application_name su zdrave',
+    'healthy_backup_found_body' => 'Sigurnosne kopije za :application_name se smatraju zdravima. Svaka čast!',
+
+    'unhealthy_backup_found_subject' => 'Važno: Sigurnosne kopije za :application_name su nezdrave',
+    'unhealthy_backup_found_subject_title' => 'Važno: Sigurnosne kopije za :application_name su nezdrave. :problem',
+    'unhealthy_backup_found_body' => 'Sigurnosne kopije za :application_name na disku :disk_name su nezdrave.',
+    'unhealthy_backup_found_not_reachable' => 'Destinacija sigurnosne kopije nije dohvatljiva. :error',
+    'unhealthy_backup_found_empty' => 'Nijedna sigurnosna kopija ove aplikacije ne postoji.',
+    'unhealthy_backup_found_old' => 'Zadnja sigurnosna kopija generirana na datum :date smatra se prestarom.',
+    'unhealthy_backup_found_unknown' => 'Isprike, ali nije moguće odrediti razlog.',
+    'unhealthy_backup_found_full' => 'Sigurnosne kopije zauzimaju previše prostora. Trenutno zauzeće je :disk_usage što je više od dozvoljenog ograničenja od :disk_limit.',
+
+    'no_backups_info' => 'Nema sigurnosnih kopija',
+    'application_name' => 'Naziv aplikacije',
+    'backup_name' => 'Naziv sigurnosne kopije',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Veličina najnovije sigurnosne kopije',
+    'number_of_backups' => 'Broj sigurnosnih kopija',
+    'total_storage_used' => 'Ukupno zauzeće',
+    'newest_backup_date' => 'Najnovija kopija na datum',
+    'oldest_backup_date' => 'Najstarija kopija na datum',
+];

--- a/resources/lang/vendor/backup/id/notifications.php
+++ b/resources/lang/vendor/backup/id/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Pesan pengecualian: :message',
+    'exception_trace' => 'Jejak pengecualian: :trace',
+    'exception_message_title' => 'Pesan pengecualian',
+    'exception_trace_title' => 'Jejak pengecualian',
+
+    'backup_failed_subject' => 'Gagal backup :application_name',
+    'backup_failed_body' => 'Penting: Sebuah error terjadi ketika membackup :application_name',
+
+    'backup_successful_subject' => 'Backup baru sukses dari :application_name',
+    'backup_successful_subject_title' => 'Backup baru sukses!',
+    'backup_successful_body' => 'Kabar baik, sebuah backup baru dari :application_name sukses dibuat pada disk bernama :disk_name.',
+
+    'cleanup_failed_subject' => 'Membersihkan backup dari :application_name yang gagal.',
+    'cleanup_failed_body' => 'Sebuah error teradi ketika membersihkan backup dari :application_name',
+
+    'cleanup_successful_subject' => 'Sukses membersihkan backup :application_name',
+    'cleanup_successful_subject_title' => 'Sukses membersihkan backup!',
+    'cleanup_successful_body' => 'Pembersihan backup :application_name pada disk bernama :disk_name telah sukses.',
+
+    'healthy_backup_found_subject' => 'Backup untuk :application_name pada disk :disk_name sehat',
+    'healthy_backup_found_subject_title' => 'Backup untuk :application_name sehat',
+    'healthy_backup_found_body' => 'Backup untuk :application_name dipertimbangkan sehat. Kerja bagus!',
+
+    'unhealthy_backup_found_subject' => 'Penting: Backup untuk :application_name tidak sehat',
+    'unhealthy_backup_found_subject_title' => 'Penting: Backup untuk :application_name tidak sehat. :problem',
+    'unhealthy_backup_found_body' => 'Backup untuk :application_name pada disk :disk_name tidak sehat.',
+    'unhealthy_backup_found_not_reachable' => 'Tujuan backup tidak dapat terjangkau. :error',
+    'unhealthy_backup_found_empty' => 'Tidak ada backup pada aplikasi ini sama sekali.',
+    'unhealthy_backup_found_old' => 'Backup terakhir dibuat pada :date dimana dipertimbahkan sudah sangat lama.',
+    'unhealthy_backup_found_unknown' => 'Maaf, sebuah alasan persisnya tidak dapat ditentukan.',
+    'unhealthy_backup_found_full' => 'Backup menggunakan terlalu banyak kapasitas penyimpanan. Penggunaan terkini adalah :disk_usage dimana lebih besar dari batas yang diperbolehkan yaitu :disk_limit.',
+
+    'no_backups_info' => 'Belum ada backup yang dibuat',
+    'application_name' => 'Nama aplikasi',
+    'backup_name' => 'Nama cadangan',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Ukuran cadangan terbaru',
+    'number_of_backups' => 'Jumlah cadangan',
+    'total_storage_used' => 'Total penyimpanan yang digunakan',
+    'newest_backup_date' => 'Ukuran cadangan terbaru',
+    'oldest_backup_date' => 'Ukuran cadangan tertua',
+];

--- a/resources/lang/vendor/backup/it/notifications.php
+++ b/resources/lang/vendor/backup/it/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Messaggio dell\'eccezione: :message',
+    'exception_trace' => 'Traccia dell\'eccezione: :trace',
+    'exception_message_title' => 'Messaggio dell\'eccezione',
+    'exception_trace_title' => 'Traccia dell\'eccezione',
+
+    'backup_failed_subject' => 'Fallito il backup di :application_name',
+    'backup_failed_body' => 'Importante: Si è verificato un errore durante il backup di :application_name',
+
+    'backup_successful_subject' => 'Creato nuovo backup di :application_name',
+    'backup_successful_subject_title' => 'Nuovo backup creato!',
+    'backup_successful_body' => 'Grande notizia, un nuovo backup di :application_name è stato creato con successo sul disco :disk_name.',
+
+    'cleanup_failed_subject' => 'Pulizia dei backup di :application_name fallita.',
+    'cleanup_failed_body' => 'Si è verificato un errore durante la pulizia dei backup di :application_name',
+
+    'cleanup_successful_subject' => 'Pulizia dei backup di :application_name avvenuta con successo',
+    'cleanup_successful_subject_title' => 'Pulizia dei backup avvenuta con successo!',
+    'cleanup_successful_body' => 'La pulizia dei backup di :application_name sul disco :disk_name è avvenuta con successo.',
+
+    'healthy_backup_found_subject' => 'I backup per :application_name sul disco :disk_name sono sani',
+    'healthy_backup_found_subject_title' => 'I backup per :application_name sono sani',
+    'healthy_backup_found_body' => 'I backup per :application_name sono considerati sani. Bel Lavoro!',
+
+    'unhealthy_backup_found_subject' => 'Importante: i backup per :application_name sono corrotti',
+    'unhealthy_backup_found_subject_title' => 'Importante: i backup per :application_name sono corrotti. :problem',
+    'unhealthy_backup_found_body' => 'I backup per :application_name sul disco :disk_name sono corrotti.',
+    'unhealthy_backup_found_not_reachable' => 'Impossibile raggiungere la destinazione di backup. :error',
+    'unhealthy_backup_found_empty' => 'Non esiste alcun backup di questa applicazione.',
+    'unhealthy_backup_found_old' => 'L\'ultimo backup fatto il :date è considerato troppo vecchio.',
+    'unhealthy_backup_found_unknown' => 'Spiacenti, non è possibile determinare una ragione esatta.',
+    'unhealthy_backup_found_full' => 'I backup utilizzano troppa memoria. L\'utilizzo corrente è :disk_usage che è superiore al limite consentito di :disk_limit.',
+
+    'no_backups_info' => 'Non sono stati ancora effettuati backup',
+    'application_name' => 'Nome dell\'applicazione',
+    'backup_name' => 'Nome di backup',
+    'disk' => 'Disco',
+    'newest_backup_size' => 'Dimensione backup più recente',
+    'number_of_backups' => 'Numero di backup',
+    'total_storage_used' => 'Spazio di archiviazione totale utilizzato',
+    'newest_backup_date' => 'Data del backup più recente',
+    'oldest_backup_date' => 'Data del backup più vecchio',
+];

--- a/resources/lang/vendor/backup/ja/notifications.php
+++ b/resources/lang/vendor/backup/ja/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => '例外のメッセージ: :message',
+    'exception_trace' => '例外の追跡: :trace',
+    'exception_message_title' => '例外のメッセージ',
+    'exception_trace_title' => '例外の追跡',
+
+    'backup_failed_subject' => ':application_name のバックアップに失敗しました。',
+    'backup_failed_body' => '重要: :application_name のバックアップ中にエラーが発生しました。',
+
+    'backup_successful_subject' => ':application_name のバックアップに成功しました。',
+    'backup_successful_subject_title' => 'バックアップに成功しました！',
+    'backup_successful_body' => '朗報です。ディスク :disk_name へ :application_name のバックアップが成功しました。',
+
+    'cleanup_failed_subject' => ':application_name のバックアップ削除に失敗しました。',
+    'cleanup_failed_body' => ':application_name のバックアップ削除中にエラーが発生しました。',
+
+    'cleanup_successful_subject' => ':application_name のバックアップ削除に成功しました。',
+    'cleanup_successful_subject_title' => 'バックアップ削除に成功しました！',
+    'cleanup_successful_body' => 'ディスク :disk_name に保存された :application_name のバックアップ削除に成功しました。',
+
+    'healthy_backup_found_subject' => 'ディスク :disk_name への :application_name のバックアップは正常です。',
+    'healthy_backup_found_subject_title' => ':application_name のバックアップは正常です。',
+    'healthy_backup_found_body' => ':application_name へのバックアップは正常です。いい仕事してますね！',
+
+    'unhealthy_backup_found_subject' => '重要: :application_name のバックアップに異常があります。',
+    'unhealthy_backup_found_subject_title' => '重要: :application_name のバックアップに異常があります。 :problem',
+    'unhealthy_backup_found_body' => ':disk_name への :application_name のバックアップに異常があります。',
+    'unhealthy_backup_found_not_reachable' => 'バックアップ先にアクセスできませんでした。 :error',
+    'unhealthy_backup_found_empty' => 'このアプリケーションのバックアップは見つかりませんでした。',
+    'unhealthy_backup_found_old' => ':date に保存された直近のバックアップが古すぎます。',
+    'unhealthy_backup_found_unknown' => '申し訳ございません。予期せぬエラーです。',
+    'unhealthy_backup_found_full' => 'バックアップがディスク容量を圧迫しています。現在の使用量 :disk_usage　は、許可された限界値 :disk_limit を超えています。',
+
+    'no_backups_info' => 'バックアップはまだ作成されていません',
+    'application_name' => 'アプリケーション名',
+    'backup_name' => 'バックアップ名',
+    'disk' => 'ディスク',
+    'newest_backup_size' => '最新のバックアップサイズ',
+    'number_of_backups' => 'バックアップ数',
+    'total_storage_used' => '使用された合計ストレージ',
+    'newest_backup_date' => '最新のバックアップ日時',
+    'oldest_backup_date' => '最も古いバックアップ日時',
+];

--- a/resources/lang/vendor/backup/ko/notifications.php
+++ b/resources/lang/vendor/backup/ko/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => '예외 메시지: :message',
+    'exception_trace' => '예외 추적: :trace',
+    'exception_message_title' => '예외 메시지',
+    'exception_trace_title' => '예외 추적',
+
+    'backup_failed_subject' => ':application_name 백업 실패',
+    'backup_failed_body' => '중요: :application_name 백업 중 오류 발생',
+
+    'backup_successful_subject' => ':application_name 백업 성공',
+    'backup_successful_subject_title' => '백업이 성공적으로 완료되었습니다!',
+    'backup_successful_body' => '좋은 소식입니다. :disk_name 디스크에 :application_name 백업이 성공적으로 완료되었습니다.',
+
+    'cleanup_failed_subject' => ':application_name 백업 정리 실패',
+    'cleanup_failed_body' => ':application_name 백업 정리 중 오류 발생',
+
+    'cleanup_successful_subject' => ':application_name 백업 정리 성공',
+    'cleanup_successful_subject_title' => '백업 정리가 성공적으로 완료되었습니다!',
+    'cleanup_successful_body' => ':disk_name 디스크에 저장된 :application_name 백업 정리가 성공적으로 완료되었습니다.',
+
+    'healthy_backup_found_subject' => ':application_name 백업은 정상입니다.',
+    'healthy_backup_found_subject_title' => ':application_name 백업은 정상입니다.',
+    'healthy_backup_found_body' => ':application_name 백업은 정상입니다. 수고하셨습니다!',
+
+    'unhealthy_backup_found_subject' => '중요: :application_name 백업에 문제가 있습니다.',
+    'unhealthy_backup_found_subject_title' => '중요: :application_name 백업에 문제가 있습니다. :problem',
+    'unhealthy_backup_found_body' => ':disk_name 디스크에 :application_name 백업에 문제가 있습니다.',
+    'unhealthy_backup_found_not_reachable' => '백업 위치에 액세스할 수 없습니다. :error',
+    'unhealthy_backup_found_empty' => '이 애플리케이션에는 백업이 없습니다.',
+    'unhealthy_backup_found_old' => ':date에 저장된 최신 백업이 너무 오래되었습니다.',
+    'unhealthy_backup_found_unknown' => '죄송합니다. 예기치 않은 오류가 발생했습니다.',
+    'unhealthy_backup_found_full' => '백업이 디스크 공간을 다 차지하고 있습니다. 현재 사용량 :disk_usage는 허용 한도 :disk_limit을 초과합니다.',
+
+    'no_backups_info' => '아직 백업이 생성되지 않았습니다.',
+    'application_name' => '애플리케이션 이름',
+    'backup_name' => '백업 이름',
+    'disk' => '디스크',
+    'newest_backup_size' => '최신 백업 크기',
+    'number_of_backups' => '백업 수',
+    'total_storage_used' => '총 사용 스토리지',
+    'newest_backup_date' => '최신 백업 날짜',
+    'oldest_backup_date' => '가장 오래된 백업 날짜',
+];

--- a/resources/lang/vendor/backup/nl/notifications.php
+++ b/resources/lang/vendor/backup/nl/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Fout bericht: :message',
+    'exception_trace' => 'Fout trace: :trace',
+    'exception_message_title' => 'Fout bericht',
+    'exception_trace_title' => 'Fout trace',
+
+    'backup_failed_subject' => 'Back-up van :application_name mislukt',
+    'backup_failed_body' => 'Belangrijk: Er ging iets fout tijdens het maken van een back-up van :application_name',
+
+    'backup_successful_subject' => 'Succesvolle nieuwe back-up van :application_name',
+    'backup_successful_subject_title' => 'Succesvolle nieuwe back-up!',
+    'backup_successful_body' => 'Goed nieuws, een nieuwe back-up van :application_name was succesvol aangemaakt op de schijf genaamd :disk_name.',
+
+    'cleanup_failed_subject' => 'Het opschonen van de back-ups van :application_name is mislukt.',
+    'cleanup_failed_body' => 'Er ging iets fout tijdens het opschonen van de back-ups van :application_name',
+
+    'cleanup_successful_subject' => 'Opschonen van :application_name back-ups was succesvol.',
+    'cleanup_successful_subject_title' => 'Opschonen van back-ups was succesvol!',
+    'cleanup_successful_body' => 'Het opschonen van de :application_name back-ups op de schijf genaamd :disk_name was succesvol.',
+
+    'healthy_backup_found_subject' => 'De back-ups voor :application_name op schijf :disk_name zijn gezond',
+    'healthy_backup_found_subject_title' => 'De back-ups voor :application_name zijn gezond',
+    'healthy_backup_found_body' => 'De back-ups voor :application_name worden als gezond beschouwd. Goed gedaan!',
+
+    'unhealthy_backup_found_subject' => 'Belangrijk: De back-ups voor :application_name zijn niet meer gezond',
+    'unhealthy_backup_found_subject_title' => 'Belangrijk: De back-ups voor :application_name zijn niet gezond. :problem',
+    'unhealthy_backup_found_body' => 'De back-ups voor :application_name op schijf :disk_name zijn niet gezond.',
+    'unhealthy_backup_found_not_reachable' => 'De back-upbestemming kon niet worden bereikt. :error',
+    'unhealthy_backup_found_empty' => 'Er zijn geen back-ups van deze applicatie beschikbaar.',
+    'unhealthy_backup_found_old' => 'De laatste back-up gemaakt op :date is te oud.',
+    'unhealthy_backup_found_unknown' => 'Sorry, een exacte reden kon niet worden bepaald.',
+    'unhealthy_backup_found_full' => 'De back-ups gebruiken te veel opslagruimte. Momenteel wordt er :disk_usage gebruikt wat hoger is dan de toegestane limiet van :disk_limit.',
+
+    'no_backups_info' => 'Er zijn nog geen back-ups gemaakt',
+    'application_name' => 'Naam van de toepassing',
+    'backup_name' => 'Back-upnaam',
+    'disk' => 'Schijf',
+    'newest_backup_size' => 'Nieuwste back-upgrootte',
+    'number_of_backups' => 'Aantal back-ups',
+    'total_storage_used' => 'Totale gebruikte opslagruimte',
+    'newest_backup_date' => 'Datum nieuwste back-up',
+    'oldest_backup_date' => 'Datum oudste back-up',
+];

--- a/resources/lang/vendor/backup/no/notifications.php
+++ b/resources/lang/vendor/backup/no/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Exception: :message',
+    'exception_trace' => 'Exception trace: :trace',
+    'exception_message_title' => 'Exception',
+    'exception_trace_title' => 'Exception trace',
+
+    'backup_failed_subject' => 'Backup feilet for :application_name',
+    'backup_failed_body' => 'Viktg: En feil oppstod under backing av :application_name',
+
+    'backup_successful_subject' => 'Gjennomført backup av :application_name',
+    'backup_successful_subject_title' => 'Gjennomført backup!',
+    'backup_successful_body' => 'Gode nyheter, en ny backup av :application_name ble opprettet på disken :disk_name.',
+
+    'cleanup_failed_subject' => 'Opprydding av backup for :application_name feilet.',
+    'cleanup_failed_body' => 'En feil oppstod under opprydding av backups for :application_name',
+
+    'cleanup_successful_subject' => 'Opprydding av backup for :application_name gjennomført',
+    'cleanup_successful_subject_title' => 'Opprydding av backup gjennomført!',
+    'cleanup_successful_body' => 'Oppryddingen av backup for :application_name på disken :disk_name har blitt gjennomført.',
+
+    'healthy_backup_found_subject' => 'Alle backups for :application_name på disken :disk_name er OK',
+    'healthy_backup_found_subject_title' => 'Alle backups for :application_name er OK',
+    'healthy_backup_found_body' => 'Alle backups for :application_name er ok. Godt jobba!',
+
+    'unhealthy_backup_found_subject' => 'Viktig: Backups for :application_name ikke OK',
+    'unhealthy_backup_found_subject_title' => 'Viktig: Backups for :application_name er ikke OK. :problem',
+    'unhealthy_backup_found_body' => 'Backups for :application_name på disken :disk_name er ikke OK.',
+    'unhealthy_backup_found_not_reachable' => 'Kunne ikke finne backup-destinasjonen. :error',
+    'unhealthy_backup_found_empty' => 'Denne applikasjonen mangler backups.',
+    'unhealthy_backup_found_old' => 'Den siste backupem fra :date er for gammel.',
+    'unhealthy_backup_found_unknown' => 'Beklager, kunne ikke finne nøyaktig årsak.',
+    'unhealthy_backup_found_full' => 'Backups bruker for mye lagringsplass. Nåværende diskbruk er :disk_usage, som er mer enn den tillatte grensen på :disk_limit.',
+
+    'no_backups_info' => 'Ingen sikkerhetskopier ble gjort ennå',
+    'application_name' => 'Programnavn',
+    'backup_name' => 'Navn på sikkerhetskopi',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Nyeste backup-størrelse',
+    'number_of_backups' => 'Antall sikkerhetskopier',
+    'total_storage_used' => 'Total lagring brukt',
+    'newest_backup_date' => 'Nyeste backup-størrelse',
+    'oldest_backup_date' => 'Eldste sikkerhetskopistørrelse',
+];

--- a/resources/lang/vendor/backup/pl/notifications.php
+++ b/resources/lang/vendor/backup/pl/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Błąd: :message',
+    'exception_trace' => 'Zrzut błędu: :trace',
+    'exception_message_title' => 'Błąd',
+    'exception_trace_title' => 'Zrzut błędu',
+
+    'backup_failed_subject' => 'Tworzenie kopii zapasowej aplikacji :application_name nie powiodło się',
+    'backup_failed_body' => 'Ważne: Wystąpił błąd podczas tworzenia kopii zapasowej aplikacji :application_name',
+
+    'backup_successful_subject' => 'Pomyślnie utworzono kopię zapasową aplikacji :application_name',
+    'backup_successful_subject_title' => 'Nowa kopia zapasowa!',
+    'backup_successful_body' => 'Wspaniała wiadomość, nowa kopia zapasowa aplikacji :application_name została pomyślnie utworzona na dysku o nazwie :disk_name.',
+
+    'cleanup_failed_subject' => 'Czyszczenie kopii zapasowych aplikacji :application_name nie powiodło się.',
+    'cleanup_failed_body' => 'Wystąpił błąd podczas czyszczenia kopii zapasowej aplikacji :application_name',
+
+    'cleanup_successful_subject' => 'Kopie zapasowe aplikacji :application_name zostały pomyślnie wyczyszczone',
+    'cleanup_successful_subject_title' => 'Kopie zapasowe zostały pomyślnie wyczyszczone!',
+    'cleanup_successful_body' => 'Czyszczenie kopii zapasowych aplikacji :application_name na dysku :disk_name zakończone sukcesem.',
+
+    'healthy_backup_found_subject' => 'Kopie zapasowe aplikacji :application_name na dysku :disk_name są poprawne',
+    'healthy_backup_found_subject_title' => 'Kopie zapasowe aplikacji :application_name są poprawne',
+    'healthy_backup_found_body' => 'Kopie zapasowe aplikacji :application_name są poprawne. Dobra robota!',
+
+    'unhealthy_backup_found_subject' => 'Ważne: Kopie zapasowe aplikacji :application_name są niepoprawne',
+    'unhealthy_backup_found_subject_title' => 'Ważne: Kopie zapasowe aplikacji :application_name są niepoprawne. :problem',
+    'unhealthy_backup_found_body' => 'Kopie zapasowe aplikacji :application_name na dysku :disk_name są niepoprawne.',
+    'unhealthy_backup_found_not_reachable' => 'Miejsce docelowe kopii zapasowej nie jest osiągalne. :error',
+    'unhealthy_backup_found_empty' => 'W aplikacji nie ma żadnej kopii zapasowych tej aplikacji.',
+    'unhealthy_backup_found_old' => 'Ostatnia kopia zapasowa wykonania dnia :date jest zbyt stara.',
+    'unhealthy_backup_found_unknown' => 'Niestety, nie można ustalić dokładnego błędu.',
+    'unhealthy_backup_found_full' => 'Kopie zapasowe zajmują zbyt dużo miejsca. Obecne użycie dysku :disk_usage jest większe od ustalonego limitu :disk_limit.',
+
+    'no_backups_info' => 'Nie utworzono jeszcze kopii zapasowych',
+    'application_name' => 'Nazwa aplikacji',
+    'backup_name' => 'Nazwa kopii zapasowej',
+    'disk' => 'Dysk',
+    'newest_backup_size' => 'Najnowszy rozmiar kopii zapasowej',
+    'number_of_backups' => 'Liczba kopii zapasowych',
+    'total_storage_used' => 'Całkowite wykorzystane miejsce',
+    'newest_backup_date' => 'Najnowszy rozmiar kopii zapasowej',
+    'oldest_backup_date' => 'Najstarszy rozmiar kopii zapasowej',
+];

--- a/resources/lang/vendor/backup/pt-BR/notifications.php
+++ b/resources/lang/vendor/backup/pt-BR/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Mensagem de exceção: :message',
+    'exception_trace' => 'Rastreamento de exceção: :trace',
+    'exception_message_title' => 'Mensagem de exceção',
+    'exception_trace_title' => 'Rastreamento de exceção',
+
+    'backup_failed_subject' => 'Falha no backup da aplicação :application_name',
+    'backup_failed_body' => 'Importante: Ocorreu um erro ao fazer o backup da aplicação :application_name',
+
+    'backup_successful_subject' => 'Backup realizado com sucesso: :application_name',
+    'backup_successful_subject_title' => 'Backup Realizado com sucesso!',
+    'backup_successful_body' => 'Boas notícias, um novo backup da aplicação :application_name foi criado no disco :disk_name.',
+
+    'cleanup_failed_subject' => 'Falha na limpeza dos backups da aplicação :application_name.',
+    'cleanup_failed_body' => 'Um erro ocorreu ao fazer a limpeza dos backups da aplicação :application_name',
+
+    'cleanup_successful_subject' => 'Limpeza dos backups da aplicação :application_name concluída!',
+    'cleanup_successful_subject_title' => 'Limpeza dos backups concluída!',
+    'cleanup_successful_body' => 'A limpeza dos backups da aplicação :application_name no disco :disk_name foi concluída.',
+
+    'healthy_backup_found_subject' => 'Os backups da aplicação :application_name no disco :disk_name estão em dia',
+    'healthy_backup_found_subject_title' => 'Os backups da aplicação :application_name estão em dia',
+    'healthy_backup_found_body' => 'Os backups da aplicação :application_name estão em dia. Bom trabalho!',
+
+    'unhealthy_backup_found_subject' => 'Importante: Os backups da aplicação :application_name não estão em dia',
+    'unhealthy_backup_found_subject_title' => 'Importante: Os backups da aplicação :application_name não estão em dia. :problem',
+    'unhealthy_backup_found_body' => 'Os backups da aplicação :application_name no disco :disk_name não estão em dia.',
+    'unhealthy_backup_found_not_reachable' => 'O destino dos backups não pode ser alcançado. :error',
+    'unhealthy_backup_found_empty' => 'Não existem backups para essa aplicação.',
+    'unhealthy_backup_found_old' => 'O último backup realizado em :date é considerado muito antigo.',
+    'unhealthy_backup_found_unknown' => 'Desculpe, a exata razão não pode ser encontrada.',
+    'unhealthy_backup_found_full' => 'Os backups estão usando muito espaço de armazenamento. A utilização atual é de :disk_usage, o que é maior que o limite permitido de :disk_limit.',
+
+    'no_backups_info' => 'Nenhum backup foi feito ainda',
+    'application_name' => 'Nome da Aplicação',
+    'backup_name' => 'Nome de backup',
+    'disk' => 'Disco',
+    'newest_backup_size' => 'Tamanho do backup mais recente',
+    'number_of_backups' => 'Número de backups',
+    'total_storage_used' => 'Armazenamento total usado',
+    'newest_backup_date' => 'Data do backup mais recente',
+    'oldest_backup_date' => 'Data do backup mais antigo',
+];

--- a/resources/lang/vendor/backup/pt/notifications.php
+++ b/resources/lang/vendor/backup/pt/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Mensagem de exceção: :message',
+    'exception_trace' => 'Rasto da exceção: :trace',
+    'exception_message_title' => 'Mensagem de exceção',
+    'exception_trace_title' => 'Rasto da exceção',
+
+    'backup_failed_subject' => 'Falha no backup da aplicação :application_name',
+    'backup_failed_body' => 'Importante: Ocorreu um erro ao executar o backup da aplicação :application_name',
+
+    'backup_successful_subject' => 'Backup realizado com sucesso: :application_name',
+    'backup_successful_subject_title' => 'Backup Realizado com Sucesso!',
+    'backup_successful_body' => 'Boas notícias, foi criado um novo backup no disco :disk_name referente à aplicação :application_name.',
+
+    'cleanup_failed_subject' => 'Falha na limpeza dos backups da aplicação :application_name.',
+    'cleanup_failed_body' => 'Ocorreu um erro ao executar a limpeza dos backups da aplicação :application_name',
+
+    'cleanup_successful_subject' => 'Limpeza dos backups da aplicação :application_name concluída!',
+    'cleanup_successful_subject_title' => 'Limpeza dos backups concluída!',
+    'cleanup_successful_body' => 'Concluída a limpeza dos backups da aplicação :application_name no disco :disk_name.',
+
+    'healthy_backup_found_subject' => 'Os backups da aplicação :application_name no disco :disk_name estão em dia',
+    'healthy_backup_found_subject_title' => 'Os backups da aplicação :application_name estão em dia',
+    'healthy_backup_found_body' => 'Os backups da aplicação :application_name estão em dia. Bom trabalho!',
+
+    'unhealthy_backup_found_subject' => 'Importante: Os backups da aplicação :application_name não estão em dia',
+    'unhealthy_backup_found_subject_title' => 'Importante: Os backups da aplicação :application_name não estão em dia. :problem',
+    'unhealthy_backup_found_body' => 'Os backups da aplicação :application_name no disco :disk_name não estão em dia.',
+    'unhealthy_backup_found_not_reachable' => 'O destino dos backups não pode ser alcançado. :error',
+    'unhealthy_backup_found_empty' => 'Não existem backups para essa aplicação.',
+    'unhealthy_backup_found_old' => 'O último backup realizado em :date é demasiado antigo.',
+    'unhealthy_backup_found_unknown' => 'Desculpe, impossível determinar a razão exata.',
+    'unhealthy_backup_found_full' => 'Os backups estão a utilizar demasiado espaço de armazenamento. A utilização atual é de :disk_usage, o que é maior que o limite permitido de :disk_limit.',
+
+    'no_backups_info' => 'Nenhum backup foi feito ainda',
+    'application_name' => 'Nome da Aplicação',
+    'backup_name' => 'Nome de backup',
+    'disk' => 'Disco',
+    'newest_backup_size' => 'Tamanho de backup mais recente',
+    'number_of_backups' => 'Número de backups',
+    'total_storage_used' => 'Armazenamento total usado',
+    'newest_backup_date' => 'Data de backup mais recente',
+    'oldest_backup_date' => 'Data de backup mais antiga',
+];

--- a/resources/lang/vendor/backup/ro/notifications.php
+++ b/resources/lang/vendor/backup/ro/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Cu excepția mesajului: :message',
+    'exception_trace' => 'Urmă excepţie: :trace',
+    'exception_message_title' => 'Mesaj de excepție',
+    'exception_trace_title' => 'Urmă excepţie',
+
+    'backup_failed_subject' => 'Nu s-a putut face copie de rezervă pentru :application_name',
+    'backup_failed_body' => 'Important: A apărut o eroare în timpul generării copiei de rezervă pentru :application_name',
+
+    'backup_successful_subject' => 'Copie de rezervă efectuată cu succes pentru :application_name',
+    'backup_successful_subject_title' => 'O nouă copie de rezervă a fost efectuată cu succes!',
+    'backup_successful_body' => 'Vești bune, o nouă copie de rezervă pentru :application_name a fost creată cu succes pe discul cu numele :disk_name.',
+
+    'cleanup_failed_subject' => 'Curățarea copiilor de rezervă pentru :application_name nu a reușit.',
+    'cleanup_failed_body' => 'A apărut o eroare în timpul curățirii copiilor de rezervă pentru :application_name',
+
+    'cleanup_successful_subject' => 'Curățarea copiilor de rezervă pentru :application_name a fost făcută cu succes',
+    'cleanup_successful_subject_title' => 'Curățarea copiilor de rezervă a fost făcută cu succes!',
+    'cleanup_successful_body' => 'Curățarea copiilor de rezervă pentru :application_name de pe discul cu numele :disk_name a fost făcută cu succes.',
+
+    'healthy_backup_found_subject' => 'Copiile de rezervă pentru :application_name de pe discul :disk_name sunt în regulă',
+    'healthy_backup_found_subject_title' => 'Copiile de rezervă pentru :application_name sunt în regulă',
+    'healthy_backup_found_body' => 'Copiile de rezervă pentru :application_name sunt considerate în regulă. Bună treabă!',
+
+    'unhealthy_backup_found_subject' => 'Important: Copiile de rezervă pentru :application_name nu sunt în regulă',
+    'unhealthy_backup_found_subject_title' => 'Important: Copiile de rezervă pentru :application_name nu sunt în regulă. :problem',
+    'unhealthy_backup_found_body' => 'Copiile de rezervă pentru :application_name de pe discul :disk_name nu sunt în regulă.',
+    'unhealthy_backup_found_not_reachable' => 'Nu se poate ajunge la destinația copiilor de rezervă. :error',
+    'unhealthy_backup_found_empty' => 'Nu există copii de rezervă ale acestei aplicații.',
+    'unhealthy_backup_found_old' => 'Cea mai recentă copie de rezervă făcută la :date este considerată prea veche.',
+    'unhealthy_backup_found_unknown' => 'Ne pare rău, un motiv exact nu poate fi determinat.',
+    'unhealthy_backup_found_full' => 'Copiile de rezervă folosesc prea mult spațiu de stocare. Utilizarea curentă este de :disk_usage care este mai mare decât limita permisă de :disk_limit.',
+
+    'no_backups_info' => 'Nu s-au făcut încă copii de rezervă',
+    'application_name' => 'Numele aplicatiei',
+    'backup_name' => 'Numele de rezervă',
+    'disk' => 'Disc',
+    'newest_backup_size' => 'Cea mai nouă dimensiune de rezervă',
+    'number_of_backups' => 'Număr de copii de rezervă',
+    'total_storage_used' => 'Spațiu total de stocare utilizat',
+    'newest_backup_date' => 'Cea mai nouă dimensiune de rezervă',
+    'oldest_backup_date' => 'Cea mai veche dimensiune de rezervă',
+];

--- a/resources/lang/vendor/backup/ru/notifications.php
+++ b/resources/lang/vendor/backup/ru/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Сообщение об ошибке: :message',
+    'exception_trace' => 'Сведения об ошибке: :trace',
+    'exception_message_title' => 'Сообщение об ошибке',
+    'exception_trace_title' => 'Сведения об ошибке',
+
+    'backup_failed_subject' => 'Не удалось сделать резервную копию :application_name',
+    'backup_failed_body' => 'Внимание: Произошла ошибка во время резервного копирования :application_name',
+
+    'backup_successful_subject' => 'Успешно создана новая резервная копия :application_name',
+    'backup_successful_subject_title' => 'Успешно создана новая резервная копия!',
+    'backup_successful_body' => 'Отличная новость, новая резервная копия :application_name успешно создана и сохранена на диск :disk_name.',
+
+    'cleanup_failed_subject' => 'Не удалось очистить резервные копии :application_name',
+    'cleanup_failed_body' => 'Произошла ошибка при очистке резервных копий :application_name',
+
+    'cleanup_successful_subject' => 'Очистка от резервных копий :application_name прошла успешно',
+    'cleanup_successful_subject_title' => 'Очистка резервных копий прошла успешно!',
+    'cleanup_successful_body' => 'Очистка от старых резервных копий :application_name на диске :disk_name прошла успешно.',
+
+    'healthy_backup_found_subject' => 'Резервные копии :application_name с диска :disk_name исправны',
+    'healthy_backup_found_subject_title' => 'Резервные копии :application_name исправны',
+    'healthy_backup_found_body' => 'Резервные копии :application_name считаются исправными. Хорошая работа!',
+
+    'unhealthy_backup_found_subject' => 'Внимание: резервные копии :application_name неисправны',
+    'unhealthy_backup_found_subject_title' => 'Внимание: резервные копии для :application_name неисправны. :problem',
+    'unhealthy_backup_found_body' => 'Резервные копии для :application_name на диске :disk_name неисправны.',
+    'unhealthy_backup_found_not_reachable' => 'Не удается достичь места назначения резервной копии. :error',
+    'unhealthy_backup_found_empty' => 'Резервные копии для этого приложения отсутствуют.',
+    'unhealthy_backup_found_old' => 'Последнее резервное копирование созданное :date является устаревшим.',
+    'unhealthy_backup_found_unknown' => 'Извините, точная причина не может быть определена.',
+    'unhealthy_backup_found_full' => 'Резервные копии используют слишком много памяти. Используется :disk_usage что выше допустимого предела: :disk_limit.',
+
+    'no_backups_info' => 'Резервных копий еще не было',
+    'application_name' => 'Имя приложения',
+    'backup_name' => 'Имя резервной копии',
+    'disk' => 'Диск',
+    'newest_backup_size' => 'Размер последней резервной копии',
+    'number_of_backups' => 'Количество резервных копий',
+    'total_storage_used' => 'Общий объем используемого хранилища',
+    'newest_backup_date' => 'Дата последней резервной копии',
+    'oldest_backup_date' => 'Дата самой старой резервной копии',
+];

--- a/resources/lang/vendor/backup/tr/notifications.php
+++ b/resources/lang/vendor/backup/tr/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Hata mesajı: :message',
+    'exception_trace' => 'Hata izleri: :trace',
+    'exception_message_title' => 'Hata mesajı',
+    'exception_trace_title' => 'Hata izleri',
+
+    'backup_failed_subject' => 'Yedeklenemedi :application_name',
+    'backup_failed_body' => 'Önemli: Yedeklenirken bir hata oluştu :application_name',
+
+    'backup_successful_subject' => 'Başarılı :application_name yeni yedeklemesi',
+    'backup_successful_subject_title' => 'Başarılı bir yeni yedekleme!',
+    'backup_successful_body' => 'Harika bir haber, :application_name ait yeni bir yedekleme :disk_name adlı diskte başarıyla oluşturuldu.',
+
+    'cleanup_failed_subject' => ':application_name yedeklemeleri temizlenmesi başarısız.',
+    'cleanup_failed_body' => ':application_name yedeklerini temizlerken bir hata oluştu ',
+
+    'cleanup_successful_subject' => ':application_name yedeklemeleri temizlenmesi başarılı.',
+    'cleanup_successful_subject_title' => 'Yedeklerin temizlenmesi başarılı!',
+    'cleanup_successful_body' => ':application_name yedeklemeleri temizlenmesi, :disk_name diskinden silindi',
+
+    'healthy_backup_found_subject' => ':application_name yedeklenmesi, :disk_name adlı diskte sağlıklı',
+    'healthy_backup_found_subject_title' => ':application_name yedeklenmesi sağlıklı',
+    'healthy_backup_found_body' => ':application_name için yapılan yedeklemeler sağlıklı sayılır. Aferin!',
+
+    'unhealthy_backup_found_subject' => 'Önemli: :application_name için yedeklemeler sağlıksız',
+    'unhealthy_backup_found_subject_title' => 'Önemli: :application_name için yedeklemeler sağlıksız. :problem',
+    'unhealthy_backup_found_body' => 'Yedeklemeler: :application_name disk: :disk_name sağlıksız.',
+    'unhealthy_backup_found_not_reachable' => 'Yedekleme hedefine ulaşılamıyor. :error',
+    'unhealthy_backup_found_empty' => 'Bu uygulamanın yedekleri yok.',
+    'unhealthy_backup_found_old' => ':date tarihinde yapılan en son yedekleme çok eski kabul ediliyor.',
+    'unhealthy_backup_found_unknown' => 'Üzgünüm, kesin bir sebep belirlenemiyor.',
+    'unhealthy_backup_found_full' => 'Yedeklemeler çok fazla depolama alanı kullanıyor. Şu anki kullanım: :disk_usage, izin verilen sınırdan yüksek: :disk_limit.',
+
+    'no_backups_info' => 'Henüz yedekleme yapılmadı',
+    'application_name' => 'Uygulama Adı',
+    'backup_name' => 'Yedek adı',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'En yeni yedekleme boyutu',
+    'number_of_backups' => 'Yedekleme sayısı',
+    'total_storage_used' => 'Kullanılan toplam depolama alanı',
+    'newest_backup_date' => 'En yeni yedekleme tarihi',
+    'oldest_backup_date' => 'En eski yedekleme tarihi',
+];

--- a/resources/lang/vendor/backup/uk/notifications.php
+++ b/resources/lang/vendor/backup/uk/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Повідомлення про помилку: :message',
+    'exception_trace' => 'Деталі помилки: :trace',
+    'exception_message_title' => 'Повідомлення помилки',
+    'exception_trace_title' => 'Деталі помилки',
+
+    'backup_failed_subject' => 'Не вдалось зробити резервну копію :application_name',
+    'backup_failed_body' => 'Увага: Трапилась помилка під час резервного копіювання :application_name',
+
+    'backup_successful_subject' => 'Успішне резервне копіювання :application_name',
+    'backup_successful_subject_title' => 'Успішно створена резервна копія!',
+    'backup_successful_body' => 'Чудова новина, нова резервна копія :application_name успішно створена і збережена на диск :disk_name.',
+
+    'cleanup_failed_subject' => 'Не вдалось очистити резервні копії :application_name',
+    'cleanup_failed_body' => 'Сталася помилка під час очищення резервних копій :application_name',
+
+    'cleanup_successful_subject' => 'Успішне очищення від резервних копій :application_name',
+    'cleanup_successful_subject_title' => 'Очищення резервних копій пройшло вдало!',
+    'cleanup_successful_body' => 'Очищенно від старих резервних копій :application_name на диску :disk_name пойшло успішно.',
+
+    'healthy_backup_found_subject' => 'Резервна копія :application_name з диску :disk_name установлена',
+    'healthy_backup_found_subject_title' => 'Резервна копія :application_name установлена',
+    'healthy_backup_found_body' => 'Резервна копія :application_name успішно установлена. Хороша робота!',
+
+    'unhealthy_backup_found_subject' => 'Увага: резервна копія :application_name не установилась',
+    'unhealthy_backup_found_subject_title' => 'Увага: резервна копія для :application_name не установилась. :problem',
+    'unhealthy_backup_found_body' => 'Резервна копія для :application_name на диску :disk_name не установилась.',
+    'unhealthy_backup_found_not_reachable' => 'Резервна копія не змогла установитись. :error',
+    'unhealthy_backup_found_empty' => 'Резервні копії для цього додатку відсутні.',
+    'unhealthy_backup_found_old' => 'Останнє резервне копіювання створено :date є застарілим.',
+    'unhealthy_backup_found_unknown' => 'Вибачте, але ми не змогли визначити точну причину.',
+    'unhealthy_backup_found_full' => 'Резервні копії використовують занадто багато пам`яті. Використовується :disk_usage що вище за допустиму межу :disk_limit.',
+
+    'no_backups_info' => 'Резервних копій ще не було зроблено',
+    'application_name' => 'Назва програми',
+    'backup_name' => 'Резервне ім’я',
+    'disk' => 'Диск',
+    'newest_backup_size' => 'Найновіший розмір резервної копії',
+    'number_of_backups' => 'Кількість резервних копій',
+    'total_storage_used' => 'Загальний обсяг використаного сховища',
+    'newest_backup_date' => 'Найновіший розмір резервної копії',
+    'oldest_backup_date' => 'Найстаріший розмір резервної копії',
+];

--- a/resources/lang/vendor/backup/zh-CN/notifications.php
+++ b/resources/lang/vendor/backup/zh-CN/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => '异常信息: :message',
+    'exception_trace' => '异常跟踪: :trace',
+    'exception_message_title' => '异常信息',
+    'exception_trace_title' => '异常跟踪',
+
+    'backup_failed_subject' => ':application_name 备份失败',
+    'backup_failed_body' => '重要说明：备份 :application_name 时发生错误',
+
+    'backup_successful_subject' => ':application_name 备份成功',
+    'backup_successful_subject_title' => '备份成功！',
+    'backup_successful_body' => '好消息, :application_name 备份成功，位于磁盘 :disk_name 中。',
+
+    'cleanup_failed_subject' => '清除 :application_name 的备份失败。',
+    'cleanup_failed_body' => '清除备份 :application_name 时发生错误',
+
+    'cleanup_successful_subject' => '成功清除 :application_name 的备份',
+    'cleanup_successful_subject_title' => '成功清除备份！',
+    'cleanup_successful_body' => '成功清除 :disk_name 磁盘上 :application_name 的备份。',
+
+    'healthy_backup_found_subject' => ':disk_name 磁盘上 :application_name 的备份是健康的',
+    'healthy_backup_found_subject_title' => ':application_name 的备份是健康的',
+    'healthy_backup_found_body' => ':application_name 的备份是健康的。干的好！',
+
+    'unhealthy_backup_found_subject' => '重要说明：:application_name 的备份不健康',
+    'unhealthy_backup_found_subject_title' => '重要说明：:application_name 备份不健康。 :problem',
+    'unhealthy_backup_found_body' => ':disk_name 磁盘上 :application_name 的备份不健康。',
+    'unhealthy_backup_found_not_reachable' => '无法访问备份目标。 :error',
+    'unhealthy_backup_found_empty' => '根本没有此应用程序的备份。',
+    'unhealthy_backup_found_old' => '最近的备份创建于 :date ，太旧了。',
+    'unhealthy_backup_found_unknown' => '对不起，确切原因无法确定。',
+    'unhealthy_backup_found_full' => '备份占用了太多存储空间。当前占用了 :disk_usage ，高于允许的限制 :disk_limit。',
+
+    'no_backups_info' => '尚未进行任何备份',
+    'application_name' => '应用名称',
+    'backup_name' => '备份名称',
+    'disk' => '磁盘',
+    'newest_backup_size' => '最新备份大小',
+    'number_of_backups' => '备份数量',
+    'total_storage_used' => '使用的总存储量',
+    'newest_backup_date' => '最新备份大小',
+    'oldest_backup_date' => '最旧的备份大小',
+];

--- a/resources/lang/vendor/backup/zh-TW/notifications.php
+++ b/resources/lang/vendor/backup/zh-TW/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => '異常訊息: :message',
+    'exception_trace' => '異常追蹤: :trace',
+    'exception_message_title' => '異常訊息',
+    'exception_trace_title' => '異常追蹤',
+
+    'backup_failed_subject' => ':application_name 備份失敗',
+    'backup_failed_body' => '重要說明：備份 :application_name 時發生錯誤',
+
+    'backup_successful_subject' => ':application_name 備份成功',
+    'backup_successful_subject_title' => '備份成功！',
+    'backup_successful_body' => '好消息, :application_name 備份成功，位於磁碟 :disk_name 中。',
+
+    'cleanup_failed_subject' => '清除 :application_name 的備份失敗。',
+    'cleanup_failed_body' => '清除備份 :application_name 時發生錯誤',
+
+    'cleanup_successful_subject' => '成功清除 :application_name 的備份',
+    'cleanup_successful_subject_title' => '成功清除備份！',
+    'cleanup_successful_body' => '成功清除 :disk_name 磁碟上 :application_name 的備份。',
+
+    'healthy_backup_found_subject' => ':disk_name 磁碟上 :application_name 的備份是健康的',
+    'healthy_backup_found_subject_title' => ':application_name 的備份是健康的',
+    'healthy_backup_found_body' => ':application_name 的備份是健康的。幹的好！',
+
+    'unhealthy_backup_found_subject' => '重要說明：:application_name 的備份不健康',
+    'unhealthy_backup_found_subject_title' => '重要說明：:application_name 備份不健康。 :problem',
+    'unhealthy_backup_found_body' => ':disk_name 磁碟上 :application_name 的備份不健康。',
+    'unhealthy_backup_found_not_reachable' => '無法訪問備份目標。 :error',
+    'unhealthy_backup_found_empty' => '根本沒有此應用程序的備份。',
+    'unhealthy_backup_found_old' => '最近的備份創建於 :date ，太舊了。',
+    'unhealthy_backup_found_unknown' => '對不起，確切原因無法確定。',
+    'unhealthy_backup_found_full' => '備份佔用了太多存儲空間。當前佔用了 :disk_usage ，高於允許的限制 :disk_limit。',
+
+    'no_backups_info' => '尚未進行任何備份',
+    'application_name' => '應用名稱',
+    'backup_name' => '備份名稱',
+    'disk' => '磁碟',
+    'newest_backup_size' => '最新備份大小',
+    'number_of_backups' => '備份數量',
+    'total_storage_used' => '使用的總存儲量',
+    'newest_backup_date' => '最新備份大小',
+    'oldest_backup_date' => '最早的備份大小',
+];


### PR DESCRIPTION
This is a bit messy, unfortunately, and I'm not sure this is the right approach.

First off, we missed publishing the language files from the latest version of spatie/laravel-backup, so this fixes that. We're also now back in the position where we're fighting with the two-letter code for locales vs the longer abbreviations. Both (all three, actually, `en`, `en-US`, and `en_US` are RFC compliant, but that's a whole other conversation. Ugh. See https://github.com/snipe/snipe-it/issues/14173 for more of that saga.

We opted to go the longer way to fix the way Symfony handles `trans_choice`, we did a bunch of migrations and mapping and so on. 

The issue we have now is that package vendors don't all agree on what format should be used. Laravel already has the notion of a `fallback_locale` (set in the `app.config`) where it will try to look for translations in a secondary place. We normally default this to `en-US`, but this - for right now - would also solve this translation issue. I'm just not sure if there's a better way to do it. I have an issue open right now on spatie/laravel-backup to see if they have a better approach, but this PR as it is now should not introduce any new issues, but instead just let people set their own fallback without having to mess with the `config/app.php` code directly. 

This PR makes that `fallback_locale` into an env var, `FALLBACK_APP_LOCALE`, which will still fall back to `en-US` unless it's overridden in the `.env`. 

I don't love this solution, or the fact that we keep running into it, but this should fix the issue for now. 

Should fix #14917