### PR TITLE
Fixed incorrect translation path for edit profile confirmation message

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -67,7 +67,7 @@ class ProfileController extends Controller
 
 
         if ($user->save()) {
-            return redirect()->route('profile')->with('success', trans('account.general.profile_updated'));
+            return redirect()->route('profile')->with('success', trans('account/general.profile_updated'));
         }
 
         return redirect()->back()->withInput()->withErrors($user->getErrors());

--- a/resources/lang/en-US/account/general.php
+++ b/resources/lang/en-US/account/general.php
@@ -2,12 +2,10 @@
 
 return array(
     'personal_api_keys' => 'Personal API Keys',
-    'api_key_warning' => 'When generating an API token, be sure to copy it down immediately as they
-                    will not be visible to you again.',
+    'api_key_warning' => 'When generating an API token, be sure to copy it down immediately as they will not be visible to you again.',
     'api_base_url' => 'Your API base url is located at:',
     'api_base_url_endpoint' => '/&lt;endpoint&gt;',
     'api_token_expiration_time' => 'API tokens are set to expire in:',
-    'api_reference' => 'Please check the <a href="https://snipe-it.readme.io/reference" target="_blank">API reference</a> to
-                    find specific API endpoints and additional API documentation.',
+    'api_reference' => 'Please check the <a href="https://snipe-it.readme.io/reference" target="_blank">API reference</a> to find specific API endpoints and additional API documentation.',
     'profile_updated' => 'Account successfully updated',
 );


### PR DESCRIPTION
Happened to notice we were using the wrong path for the "Account successfully updated" translation. This is now fixed.