### PR TITLE
Possible fix for #14915 - error on import when status label is not provided and no deployable statuses can be found 

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -20,7 +20,7 @@ class AssetImporter extends ItemImporter
     {
         parent::__construct($filename);
 
-        $this->defaultStatusLabelId = Statuslabel::first();
+        $this->defaultStatusLabelId = Statuslabel::first()->id;
         
         if (!is_null(Statuslabel::deployable()->first())) {
             $this->defaultStatusLabelId = Statuslabel::deployable()->first()->id;

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -20,7 +20,9 @@ class AssetImporter extends ItemImporter
     {
         parent::__construct($filename);
 
-        if (!is_null(Statuslabel::first())) {
+        $this->defaultStatusLabelId = Statuslabel::first();
+        
+        if (!is_null(Statuslabel::deployable()->first())) {
             $this->defaultStatusLabelId = Statuslabel::deployable()->first()->id;
         }
     }


### PR DESCRIPTION
I'm not 100% sure this is the best way to handle this tbh, but if you don't provide us with a status label, it's tough for us to "guess" which status label you want, but we still need one, since all assets require that.

This should make it so that we get *a* status label so we have a value, and then try to pick a deployable one. This should only fire if you have no provided a status label in your CSV import.

Possible fix for #14915.