### PR TITLE
First start at switching to regular html labels

### DIFF
--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -37,7 +37,9 @@
                                     @if ($accessory->name)
                                     <!-- accessory name -->
                                     <div class="form-group">
-                                        <label class="col-sm-3 control-label">{{ trans('admin/hardware/form.name') }}</label>
+                                        <label class="col-sm-3 control-label">
+                                            {{ trans('admin/hardware/form.name') }}
+                                        </label>
                                         <div class="col-md-6">
                                           <p class="form-control-static">{{ $accessory->name }}</p>
                                         </div>
@@ -54,7 +56,9 @@
                                     </div>
                             <!-- Checkout/Checkin Date -->
                             <div class="form-group{{ $errors->has('checkin_at') ? ' has-error' : '' }}">
-                                {{ Form::label('checkin_at', trans('admin/hardware/form.checkin_date'), array('class' => 'col-md-3 control-label')) }}
+                                <label for="checkin_at" class="col-md-3 control-label">
+                                    {{ trans('admin/hardware/form.checkin_date') }}
+                                </label>
                                 <div class="col-md-7">
                                     <div class="input-group col-md-5 required" style="padding-left: 0px;">
                                         <div class="input-group date" data-date-clear-btn="true" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-autoclose="true">

--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -61,7 +61,9 @@
         @if ($snipeSettings->allow_user_skin=='1')
         <!-- Skin -->
         <div class="form-group {{ $errors->has('skin') ? 'error' : '' }}">
-          <label for="website" class="col-md-3 control-label">{{ Form::label('skin', trans('general.skin')) }}</label>
+          <label for="skin" class="col-md-3 control-label">
+            {{ trans('general.skin') }}
+          </label>
           <div class="col-md-8">
             {!! Form::user_skin('skin', old('skin', $user->skin), 'select2') !!}
             {!! $errors->first('skin', '<span class="alert-msg">:message</span>') !!}

--- a/resources/views/hardware/audit.blade.php
+++ b/resources/views/hardware/audit.blade.php
@@ -35,7 +35,9 @@
 
                         <!-- Asset model -->
                             <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
-                                {{ Form::label('name', trans('admin/hardware/form.model'), array('class' => 'col-md-3 control-label')) }}
+                                <label class="col-sm-3 control-label">
+                                    {{ trans('admin/hardware/form.model') }}
+                                </label>
                                 <div class="col-md-8">
                                     <p class="form-control-static">
                                         @if (($asset->model) && ($asset->model->name))
@@ -57,7 +59,9 @@
 
                     <!-- Asset Name -->
                         <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
-                            {{ Form::label('name', trans('admin/hardware/form.name'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="name" class="col-sm-3 control-label">
+                                {{ trans('general.name') }}
+                            </label>
                             <div class="col-md-8">
                                 <p class="form-control-static">{{ $asset->name }}</p>
                             </div>
@@ -99,7 +103,9 @@
 
                         <!-- Next Audit -->
                         <div class="form-group{{ $errors->has('next_audit_date') ? ' has-error' : '' }}">
-                            {{ Form::label('name', trans('general.next_audit_date'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="next_audit_date" class="col-sm-3 control-label">
+                                {{ trans('general.next_audit_date') }}
+                            </label>
                             <div class="col-md-8">
                                 <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-clear-btn="true">
                                     <input type="text" class="form-control" placeholder="{{ trans('general.next_audit_date') }}" name="next_audit_date" id="next_audit_date" value="{{ old('next_audit_date', $next_audit_date) }}">
@@ -113,7 +119,9 @@
 
                         <!-- Note -->
                         <div class="form-group{{ $errors->has('note') ? ' has-error' : '' }}">
-                            {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="note" class="col-sm-3 control-label">
+                                {{ trans('general.notes') }}
+                            </label>
                             <div class="col-md-8">
                                 <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note', $asset->note) }}</textarea>
                                 {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -36,7 +36,9 @@
 
           <!-- Checkout/Checkin Date -->
               <div class="form-group {{ $errors->has('checkout_at') ? 'error' : '' }}">
-                  {{ Form::label('checkout_at', trans('admin/hardware/form.checkout_date'), array('class' => 'col-md-3 control-label')) }}
+                  <label for="checkout_at" class="col-sm-3 control-label">
+                      {{ trans('admin/hardware/form.checkout_date') }}
+                  </label>
                   <div class="col-md-8">
                       <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-date-clear-btn="true">
                           <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ old('checkout_at') }}">
@@ -48,7 +50,9 @@
 
               <!-- Expected Checkin Date -->
               <div class="form-group {{ $errors->has('expected_checkin') ? 'error' : '' }}">
-                  {{ Form::label('expected_checkin', trans('admin/hardware/form.expected_checkin'), array('class' => 'col-md-3 control-label')) }}
+                  <label for="expected_checkin" class="col-sm-3 control-label">
+                      {{ trans('admin/hardware/form.expected_checkin') }}
+                  </label>
                   <div class="col-md-8">
                       <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-start-date="0d" data-date-clear-btn="true">
                           <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ old('expected_checkin') }}">
@@ -61,7 +65,9 @@
 
           <!-- Note -->
           <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
-            {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
+              <label for="note" class="col-sm-3 control-label">
+                  {{ trans('general.notes') }}
+              </label>
             <div class="col-md-8">
               <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
               {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -33,15 +33,16 @@
             @if ($backto == 'user')
               <form class="form-horizontal" method="post" action="{{ route('hardware.checkin.store', array('assetId'=> $asset->id, 'backto'=>'user')) }}"  autocomplete="off">
             @else
-              <form class="form-horizontal" method="post"
-                    action="{{ route('hardware.checkin.store', array('assetId'=> $asset->id)) }}" autocomplete="off">
+              <form class="form-horizontal" method="post"  action="{{ route('hardware.checkin.store', array('assetId'=> $asset->id)) }}" autocomplete="off">
             @endif
                   {{csrf_field()}}
 
                   <!-- AssetModel name -->
                     <div class="form-group">
-                      {{ Form::label('model', trans('admin/hardware/form.model'), array('class' => 'col-md-3 control-label')) }}
-                      <div class="col-md-8">
+                        <label for="model" class="col-sm-3 control-label">
+                            {{ trans('admin/hardware/form.model') }}
+                        </label>
+                        <div class="col-md-8">
 
                         <p class="form-control-static">
                           @if (($asset->model) && ($asset->model->name))
@@ -63,16 +64,20 @@
 
                     <!-- Asset Name -->
                     <div class="form-group {{ $errors->has('name') ? 'error' : '' }}">
-                      {{ Form::label('name', trans('admin/hardware/form.name'), array('class' => 'col-md-3 control-label')) }}
-                      <div class="col-md-8">
-                        <input class="form-control" type="text" name="name" aria-label="name" id="name" value="{{ old('name', $asset->name) }}"/>
-                        {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                      </div>
+                        <label for="name" class="col-sm-3 control-label">
+                            {{ trans('general.name') }}
+                        </label>
+                          <div class="col-md-8">
+                            <input class="form-control" type="text" name="name" aria-label="name" id="name" value="{{ old('name', $asset->name) }}"/>
+                            {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                          </div>
                     </div>
 
                     <!-- Status -->
                     <div class="form-group {{ $errors->has('status_id') ? 'error' : '' }}">
-                      {{ Form::label('status_id', trans('admin/hardware/form.status'), array('class' => 'col-md-3 control-label')) }}
+                        <label for="status_id" class="col-sm-3 control-label">
+                            {{ trans('admin/hardware/form.status') }}
+                        </label>
                       <div class="col-md-8 required">
                         {{ Form::select('status_id', $statusLabel_list, '', array('class'=>'select2', 'style'=>'width:100%','id' =>'modal-statuslabel_types', 'aria-label'=>'status_id')) }}
                         {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
@@ -83,8 +88,9 @@
 
                   <!-- Checkout/Checkin Date -->
                     <div class="form-group{{ $errors->has('checkin_at') ? ' has-error' : '' }}">
-
-                      {{ Form::label('checkin_at', trans('admin/hardware/form.checkin_date'), array('class' => 'col-md-3 control-label')) }}
+                        <label for="checkin_at" class="col-sm-3 control-label">
+                            {{ trans('admin/hardware/form.checkin_date') }}
+                        </label>
 
                       <div class="col-md-8">
                         <div class="input-group col-md-5 required">
@@ -99,7 +105,9 @@
 
                     <!-- Note -->
                     <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
-                      {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
+                        <label for="note" class="col-sm-3 control-label">
+                            {{ trans('general.notes') }}
+                        </label>
                       <div class="col-md-8">
                         <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note', $asset->note) }}</textarea>
                         {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -28,7 +28,9 @@
                     {{csrf_field()}}
                         @if ($asset->company && $asset->company->name)
                             <div class="form-group">
-                                {{ Form::label('model', trans('general.company'), array('class' => 'col-md-3 control-label')) }}
+                                <label for="company" class="col-md-3 control-label">
+                                    {{ trans('general.company') }}
+                                </label>
                                 <div class="col-md-8">
                                     <p class="form-control-static">
                                         {{ $asset->company->name }}
@@ -39,7 +41,9 @@
 
                         <!-- AssetModel name -->
                         <div class="form-group">
-                            {{ Form::label('model', trans('admin/hardware/form.model'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="model" class="col-md-3 control-label">
+                                {{ trans('general.company') }}
+                            </label>
                             <div class="col-md-8">
                                 <p class="form-control-static">
                                     @if (($asset->model) && ($asset->model->name))
@@ -61,7 +65,10 @@
 
                         <!-- Asset Name -->
                         <div class="form-group {{ $errors->has('name') ? 'error' : '' }}">
-                            {{ Form::label('name', trans('admin/hardware/form.name'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="name" class="col-md-3 control-label">
+                                {{ trans('admin/hardware/form.name') }}
+                            </label>
+
                             <div class="col-md-8">
                                 <input class="form-control" type="text" name="name" id="name" value="{{ old('name', $asset->name) }}" tabindex="1">
                                 {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
@@ -70,7 +77,9 @@
 
                         <!-- Status -->
                         <div class="form-group {{ $errors->has('status_id') ? 'error' : '' }}">
-                            {{ Form::label('status_id', trans('admin/hardware/form.status'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="status_id" class="col-md-3 control-label">
+                                {{ trans('admin/hardware/form.status') }}
+                            </label>
                             <div class="col-md-7 required">
                                 {{ Form::select('status_id', $statusLabel_list, $asset->status_id, array('class'=>'select2', 'style'=>'width:100%','', 'aria-label'=>'status_id')) }}
                                 {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
@@ -90,7 +99,9 @@
 
                     <!-- Checkout/Checkin Date -->
                         <div class="form-group {{ $errors->has('checkout_at') ? 'error' : '' }}">
-                            {{ Form::label('checkout_at', trans('admin/hardware/form.checkout_date'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="checkout_at" class="col-md-3 control-label">
+                                {{ trans('admin/hardware/form.checkout_date') }}
+                            </label>
                             <div class="col-md-8">
                                 <div class="input-group date col-md-7" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-date-clear-btn="true">
                                     <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ old('checkout_at', date('Y-m-d')) }}">
@@ -102,7 +113,10 @@
 
                         <!-- Expected Checkin Date -->
                         <div class="form-group {{ $errors->has('expected_checkin') ? 'error' : '' }}">
-                            {{ Form::label('expected_checkin', trans('admin/hardware/form.expected_checkin'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="expected_checkin" class="col-md-3 control-label">
+                                {{ trans('admin/hardware/form.expected_checkin') }}
+                            </label>
+
                             <div class="col-md-8">
                                 <div class="input-group date col-md-7" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-start-date="0d" data-date-clear-btn="true">
                                     <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ old('expected_checkin') }}">
@@ -114,7 +128,9 @@
 
                         <!-- Note -->
                         <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
-                            {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="note" class="col-md-3 control-label">
+                                {{ trans('general.notes') }}
+                            </label>
                             <div class="col-md-8">
                                 <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note', $asset->note) }}</textarea>
                                 {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/kits/checkout.blade.php
+++ b/resources/views/kits/checkout.blade.php
@@ -27,7 +27,9 @@
 
           <!-- Checkout/Checkin Date -->
               <div class="form-group {{ $errors->has('checkout_at') ? 'error' : '' }}">
-                  {{ Form::label('name', trans('admin/hardware/form.checkout_date'), array('class' => 'col-md-3 control-label')) }}
+                  <label for="checkout_at" class="col-md-3 control-label">
+                      {{ trans('admin/hardware/form.checkout_date') }}
+                  </label>
                   <div class="col-md-8">
                       <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-date-clear-btn="true">
                           <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ Request::old('checkout_at') }}">
@@ -39,7 +41,9 @@
 
               <!-- Expected Checkin Date -->
               <div class="form-group {{ $errors->has('expected_checkin') ? 'error' : '' }}">
-                  {{ Form::label('name', trans('admin/hardware/form.expected_checkin'), array('class' => 'col-md-3 control-label')) }}
+                  <label for="expected_checkin" class="col-md-3 control-label">
+                      {{ trans('admin/hardware/form.expected_checkin') }}
+                  </label>
                   <div class="col-md-8">
                       <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-start-date="0d">
                           <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ Request::old('expected_checkin') }}">
@@ -52,7 +56,9 @@
 
           <!-- Note -->
           <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
-            {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
+              <label for="note" class="col-md-3 control-label">
+                  {{ trans('general.notes') }}
+              </label>
             <div class="col-md-8">
               <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note') }}</textarea>
               {!! $errors->first('note', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}

--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -18,7 +18,9 @@
     <!-- Site Name -->
     <div class="row">
       <div class="form-group col-lg-12 required {{ $errors->has('site_name') ? 'error' : '' }}">
-        {{ Form::label('site_name', trans('general.site_name')) }}
+        <label for="site_name">
+          {{ trans('general.site_name') }}
+        </label>
         {{ Form::text('site_name', Request::old('site_name'), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management')) }}
 
         {!! $errors->first('site_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -29,9 +31,10 @@
 
     <!-- Language -->
     <div class="form-group col-lg-6{{  (Helper::checkIfRequired(\App\Models\User::class, 'default_language')) ? ' required' : '' }} {{$errors->has('default_language') ? 'error' : ''}}">
-      {{ Form::label('locale', trans('admin/settings/general.default_language')) }}
+      <label for="locale">
+        {{ trans('admin/settings/general.default_language') }}
+      </label>
       {!! Form::locales('locale', Request::old('locale', "en-US"), 'select2') !!}
-
       {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
     </div>
 


### PR DESCRIPTION
Since in Laravel 11, we'll lose the `collective/html` package (it's been abandoned), I started going through the easy ones - labels. In doing so, I also found a bunch of mistakes where labels were actually incorrect, so I'm glad we're doing this anyway - it will make the product a lot more accessible to those with screen readers. 

The harder part will be replacing all of the drop-downs menus that we use all throughout the system, but that's a topic (and PR) for another day :)

There's a ton more to go, this is just a WIP. 