### PR TITLE
Added ability to disallow profile editing

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -28,8 +28,8 @@ class ProfileController extends Controller
      */
     public function getIndex()
     {
+        $this->authorize('self.profile');
         $user = Auth::user();
-
         return view('account/profile', compact('user'));
     }
 
@@ -42,6 +42,7 @@ class ProfileController extends Controller
      */
     public function postIndex(ImageUploadRequest $request)
     {
+        $this->authorize('self.profile');
         $user = Auth::user();
         $user->first_name = $request->input('first_name');
         $user->last_name = $request->input('last_name');

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -351,9 +351,9 @@ class SettingsController extends Controller
         $setting->load_remote = $request->input('load_remote', 0);
         $setting->thumbnail_max_h = $request->input('thumbnail_max_h');
         $setting->privacy_policy_link = $request->input('privacy_policy_link');
-
         $setting->depreciation_method = $request->input('depreciation_method');
         $setting->dash_chart_type = $request->input('dash_chart_type');
+        $setting->profile_edit = $request->input('profile_edit', 0);
 
         if ($request->input('per_page') != '') {
             $setting->per_page = $request->input('per_page');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -204,6 +204,23 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return $this->checkPermissionSection('superuser');
     }
 
+
+    /**
+     * Checks if the can edit their own profile
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since [v6.3.4]
+     * @return bool
+     */
+    public function canEditProfile() : bool {
+
+        $setting = Setting::getSettings();
+        if ($setting->profile_edit == 1) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Checks if the user is deletable
      *

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -232,5 +232,12 @@ class AuthServiceProvider extends ServiceProvider
                 || $user->can('update', User::class)
                 || $user->can('create', User::class);  
         });
+
+
+        // This determines whether the user can edit their profile based on the setting in Admin > General
+        Gate::define('self.profile', function ($user) {
+            return $user->canEditProfile();
+        });
+
     }
 }

--- a/database/migrations/2024_06_24_130348_add_profile_edit_to_settings.php
+++ b/database/migrations/2024_06_24_130348_add_profile_edit_to_settings.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->boolean('profile_edit')->nullable()->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            if (Schema::hasColumn('settings', 'profile_edit')) {
+                $table->dropColumn('profile_edit');
+            }
+        });
+    }
+};

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -373,5 +373,7 @@ return [
     'database_driver' => 'Database Driver',
     'bs_table_storage' => 'Table Storage',
     'timezone' => 'Timezone',
+    'profile_edit'          => 'Edit Profile',
+    'profile_edit_help'          => 'Allow users to edit their own profiles.',
 
 ];

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -327,7 +327,6 @@ return [
     'labels' => 'Labels',
     'labels_title' => 'Update Label Settings',
     'labels_help' => 'Label sizes &amp; settings',
-    'purge' => 'Purge',
     'purge_keywords' => 'permanently delete',
     'purge_help' => 'Purge Deleted Records',
     'ldap_extension_warning' => 'It does not look like the LDAP extension is installed or enabled on this server. You can still save your settings, but you will need to enable the LDAP extension for PHP before LDAP syncing or login will work.',

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -353,12 +353,15 @@ dir="{{ in_array(app()->getLocale(),['ar-SA','fa-IR', 'he-IL']) ? 'rtl' : 'ltr' 
                                             </a></li>
 
 
+                                        @can('self.profile')
                                         <li>
                                             <a href="{{ route('profile') }}">
                                                 <i class="fas fa-user fa-fw" aria-hidden="true"></i>
                                                 {{ trans('general.editprofile') }}
                                             </a>
                                         </li>
+                                        @endcan
+
                                         <li>
                                             <a href="{{ route('account.password.index') }}">
                                                 <i class="fa-solid fa-asterisk fa-fw" aria-hidden="true"></i>

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -113,6 +113,22 @@
                         </div>
                     </div>
 
+                       <!-- user profile edit checkbox -->
+                       <div class="form-group">
+                           <div class="col-md-3">
+                               <label>
+                                   {{ trans('admin/settings/general.profile_edit') }}
+                               </label>
+                           </div>
+                           <div class="col-md-8">
+                               <label class="form-control">
+                                   <input type="checkbox" value="1" name="profile_edit" {{ (old('profile_edit', $setting->profile_edit)) == '1' ? ' checked="checked"' : '' }} aria-label="profile_edit">
+                                   {{ trans('admin/settings/general.profile_edit_help') }}
+                               </label>
+
+                           </div>
+                       </div>
+
                        <!-- Load images in emails -->
                        <div class="form-group {{ $errors->has('show_images_in_email') ? 'error' : '' }}">
                            <div class="col-md-3">


### PR DESCRIPTION
While it doesn't come up too often, some Snipe-IT users have requested that we make an option where users cannot edit their own profiles. This PR does that by adding a DB column and a setting to Admin > General.

This removes the option from non-superadmins's top-right menu.
