### PR TITLE
Fixed #14895 and #14919 - set SAML baseurl to a sensible default for docker users and users behind a reverse proxy

### DIFF
--- a/app/Services/Saml.php
+++ b/app/Services/Saml.php
@@ -163,6 +163,7 @@ class Saml
             OneLogin_Saml2_Utils::setProxyVars(request()->isFromTrustedProxy());
 
             data_set($settings, 'sp.entityId', config('app.url'));
+            data_set($settings, 'baseurl', config('app.url') . '/saml');
             data_set($settings, 'sp.assertionConsumerService.url', route('saml.acs'));
             data_set($settings, 'sp.singleLogoutService.url', route('saml.sls'));
             data_set($settings, 'sp.x509cert', $setting->saml_sp_x509cert);


### PR DESCRIPTION
For users who are running Snipe-IT behind a reverse-proxy, the SAML implementation guesses an incorrect `baseurl` (as http:// rather than https://). This change sets it to a default based on the `APP_URL` - which we rely on elsewhere, as well as here within the SAML code itself. So this _should_ be pretty safe.