### PR TITLE
Use more modern reference for input text

### DIFF
--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -62,7 +62,7 @@
                                 <div class="col-md-7">
                                     <div class="input-group col-md-5 required" style="padding-left: 0px;">
                                         <div class="input-group date" data-date-clear-btn="true" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-autoclose="true">
-                                            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkin_at" id="checkin_at" value="{{ Request::old('checkin_at', date('Y-m-d')) }}">
+                                            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkin_at" id="checkin_at" value="{{ old('checkin_at', date('Y-m-d')) }}">
                                             <span class="input-group-addon"><i class="fas fa-calendar"></i></span>
                                         </div>
                                         {!! $errors->first('checkin_at', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -137,7 +137,7 @@
               <!-- Encrypted  -->
               <div class="col-md-9 col-md-offset-3" id="encryption_section">
                   <label class="form-control">
-                      <input type="checkbox" value="1" name="field_encrypted" id="field_encrypted"{{ (Request::old('field_encrypted') || $field->field_encrypted) ? ' checked="checked"' : '' }}>
+                      <input type="checkbox" value="1" name="field_encrypted" id="field_encrypted"{{ (old('field_encrypted') || $field->field_encrypted) ? ' checked="checked"' : '' }}>
                       {{ trans('admin/custom_fields/general.encrypt_field') }}
                   </label>
               </div>

--- a/resources/views/depreciations/edit.blade.php
+++ b/resources/views/depreciations/edit.blade.php
@@ -17,7 +17,7 @@
     </label>
     <div class="col-md-7 col-sm-12 {{  (Helper::checkIfRequired($item, 'months')) ? ' required' : '' }}">
         <div class="col-md-7" style="padding-left:0px">
-            <input class="form-control" type="text" name="months" id="months" value="{{ Request::old('months', $item->months) }}" style="width: 80px;"{!!  (\App\Helpers\Helper::checkIfRequired($item, 'months')) ? ' required' : '' !!} />
+            <input class="form-control" type="text" name="months" id="months" value="{{ old('months', $item->months) }}" style="width: 80px;"{!!  (\App\Helpers\Helper::checkIfRequired($item, 'months')) ? ' required' : '' !!} />
             {!! $errors->first('months', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
         </div>
     </div>
@@ -29,7 +29,7 @@
         {{ trans('admin/depreciations/general.depreciation_min') }}
     </label>
     <div class="col-md-2" style="padding-left:0px">
-        <input class="form-control"  name="depreciation_min" id="depreciation_min" value="{{ Request::old('depreciation_min', $item->depreciation_min) }}" style="width: 80px; margin-left:15px" />
+        <input class="form-control"  name="depreciation_min" id="depreciation_min" value="{{ old('depreciation_min', $item->depreciation_min) }}" style="width: 80px; margin-left:15px" />
     </div>
     {!! $errors->first('depreciation_min', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
 </div>

--- a/resources/views/hardware/audit.blade.php
+++ b/resources/views/hardware/audit.blade.php
@@ -75,7 +75,7 @@
 
                             <div class="col-md-8 col-md-offset-3">
                                 <label class="form-control">
-                                    <input type="checkbox" value="1" name="update_location" {{ Request::old('update_location') == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/hardware/form.asset_location') }}
+                                    <input type="checkbox" value="1" name="update_location" {{ old('update_location') == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/hardware/form.asset_location') }}
                                 </label>
                                 <p class="help-block">{!! trans('help.audit_help') !!}</p>
                             </div>

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -78,7 +78,7 @@
         @if ($item->model && $item->model->fieldset)
         <?php $model = $item->model; ?>
         @endif
-        @if (Request::old('model_id'))
+        @if (old('model_id'))
             @php
                 $model = \App\Models\AssetModel::find(old('model_id'));
             @endphp

--- a/resources/views/hardware/history.blade.php
+++ b/resources/views/hardware/history.blade.php
@@ -87,7 +87,7 @@
                             <div class="form-group">
                                 <div class="col-sm-10 col-md-offset-2">
                                     <label class="form-control">
-                                        {{ Form::checkbox('match_firstnamelastname', '1', Request::old('match_firstnamelastname')) }}
+                                        {{ Form::checkbox('match_firstnamelastname', '1', old('match_firstnamelastname')) }}
                                         <!-- enclosing span needed for the checkbox CSS to work properly, since there's HTML in the label text -->
                                         <span>
                                             {!!  trans('admin/hardware/general.csv_import_match_f-l') !!}
@@ -100,7 +100,7 @@
                             <div class="form-group">
                                 <div class="col-sm-10 col-md-offset-2">
                                     <label class="form-control">
-                                        {{ Form::checkbox('match_flastname', '1', Request::old('match_flastname')) }}
+                                        {{ Form::checkbox('match_flastname', '1', old('match_flastname')) }}
                                         <!-- enclosing span needed for the checkbox CSS to work properly, since there's HTML in the label text -->
                                         <span>
                                         {!!  trans('admin/hardware/general.csv_import_match_initial_last') !!}
@@ -113,7 +113,7 @@
                             <div class="form-group">
                                 <div class="col-sm-10 col-md-offset-2">
                                     <label class="form-control">
-                                    {{ Form::checkbox('match_firstname', '1', Request::old('match_firstname')) }}
+                                    {{ Form::checkbox('match_firstname', '1', old('match_firstname')) }}
                                         <!-- enclosing span needed for the checkbox CSS to work properly, since there's HTML in the label text -->
                                         <span>
                                             {!! trans('admin/hardware/general.csv_import_match_first') !!}
@@ -126,7 +126,7 @@
                             <div class="form-group">
                                 <div class="col-sm-10 col-md-offset-2">
                                     <label class="form-control">
-                                        {{ Form::checkbox('match_email', '1', Request::old('match_email')) }}
+                                        {{ Form::checkbox('match_email', '1', old('match_email')) }}
                                         <!-- enclosing span needed for the checkbox CSS to work properly, since there's HTML in the label text -->
                                         <span>
                                         {!!  trans('admin/hardware/general.csv_import_match_email') !!}
@@ -139,7 +139,7 @@
                             <div class="form-group">
                                 <div class="col-sm-10 col-md-offset-2">
                                     <label class="form-control">
-                                        {{ Form::checkbox('match_username', '1', Request::old('match_username')) }}
+                                        {{ Form::checkbox('match_username', '1', old('match_username')) }}
                                         <!-- enclosing span needed for the checkbox CSS to work properly, since there's HTML in the label text -->
                                         <span>
                                             {!!  trans('admin/hardware/general.csv_import_match_username') !!}

--- a/resources/views/hardware/quickscan-checkin.blade.php
+++ b/resources/views/hardware/quickscan-checkin.blade.php
@@ -34,7 +34,7 @@
                         {{ Form::label('asset_tag', trans('general.asset_tag'), array('class' => 'col-md-3 control-label', 'id' => 'checkin_tag')) }}
                         <div class="col-md-9">
                             <div class="input-group date col-md-5" data-date-format="yyyy-mm-dd">
-                                <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ Request::old('asset_tag') }}">
+                                <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ old('asset_tag') }}">
 
                             </div>
                             {!! $errors->first('asset_tag', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -32,7 +32,7 @@
                             {{ Form::label('asset_tag', trans('general.asset_tag'), array('class' => 'col-md-3 control-label', 'id' => 'audit_tag')) }}
                             <div class="col-md-9">
                                 <div class="input-group date col-md-5" data-date-format="yyyy-mm-dd">
-                                    <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ Request::old('asset_tag') }}">
+                                    <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ old('asset_tag') }}">
 
                                 </div>
                                 {!! $errors->first('asset_tag', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/kits/accessory-edit.blade.php
+++ b/resources/views/kits/accessory-edit.blade.php
@@ -11,13 +11,13 @@
     <label for="quantity" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
     <div class="col-md-7 required">
         <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" />
+            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" />
         </div>
         {!! $errors->first('quantity', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
     </div>
 </div>
 
 <input type="hidden" name="pivot_id" value="{{$item->id}}">
-{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" /> --}}
+{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" /> --}}
 
 @stop

--- a/resources/views/kits/checkout.blade.php
+++ b/resources/views/kits/checkout.blade.php
@@ -32,7 +32,7 @@
                   </label>
                   <div class="col-md-8">
                       <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-end-date="0d" data-date-clear-btn="true">
-                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ Request::old('checkout_at') }}">
+                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="checkout_at" id="checkout_at" value="{{ old('checkout_at') }}">
                           <span class="input-group-addon"><i class="fas fa-calendar"></i></span>
                       </div>
                       {!! $errors->first('checkout_at', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
@@ -46,7 +46,7 @@
                   </label>
                   <div class="col-md-8">
                       <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-start-date="0d">
-                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ Request::old('expected_checkin') }}">
+                          <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="expected_checkin" id="expected_checkin" value="{{ old('expected_checkin') }}">
                           <span class="input-group-addon"><i class="fas fa-calendar"></i></span>
                       </div>
                       {!! $errors->first('expected_checkin', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
@@ -60,7 +60,7 @@
                   {{ trans('general.notes') }}
               </label>
             <div class="col-md-8">
-              <textarea class="col-md-6 form-control" id="note" name="note">{{ Request::old('note') }}</textarea>
+              <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
               {!! $errors->first('note', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
             </div>
           </div>

--- a/resources/views/kits/consumable-edit.blade.php
+++ b/resources/views/kits/consumable-edit.blade.php
@@ -12,13 +12,13 @@
     <label for="quantity" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
     <div class="col-md-7 required">
         <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" />
+            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" />
         </div>
         {!! $errors->first('quantity', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
     </div>
 </div>
 
 <input type="hidden" name="pivot_id" value="{{$item->id}}">
-{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" /> --}}
+{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" /> --}}
 
 @stop

--- a/resources/views/kits/license-edit.blade.php
+++ b/resources/views/kits/license-edit.blade.php
@@ -11,13 +11,13 @@
     <label for="quantity" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
     <div class="col-md-7 required">
         <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" />
+            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" />
         </div>
         {!! $errors->first('quantity', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
     </div>
 </div>
 
 <input type="hidden" name="pivot_id" value="{{$item->id}}">
-{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" /> --}}
+{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" /> --}}
 
 @stop

--- a/resources/views/kits/model-edit.blade.php
+++ b/resources/views/kits/model-edit.blade.php
@@ -11,13 +11,13 @@
     <label for="quantity" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
     <div class="col-md-7 required">
         <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" />
+            <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" />
         </div>
         {!! $errors->first('quantity', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
     </div>
 </div>
 
 <input type="hidden" name="pivot_id" value="{{$item->id}}">
-{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ Request::old('quantity', $item->quantity) }}" /> --}}
+{{-- <input class="form-control" type="text" name="quantity" id="quantity" value="{{ old('quantity', $item->quantity) }}" /> --}}
 
 @stop

--- a/resources/views/licenses/edit.blade.php
+++ b/resources/views/licenses/edit.blade.php
@@ -28,7 +28,7 @@
     <label for="seats" class="col-md-3 control-label">{{ trans('admin/licenses/form.seats') }}</label>
     <div class="col-md-7 col-sm-12 required">
         <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control" type="text" name="seats" id="seats" value="{{ Request::old('seats', $item->seats) }}" />
+            <input class="form-control" type="text" name="seats" id="seats" value="{{ old('seats', $item->seats) }}" />
         </div>
     </div>
     {!! $errors->first('seats', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}

--- a/resources/views/modals/location.blade.php
+++ b/resources/views/modals/location.blade.php
@@ -22,7 +22,7 @@
 
                 <div class="dynamic-form-row">
                     <div class="col-md-4 col-xs-12 country"><label for="modal-country">{{ trans('general.country') }}:</label></div>
-                    <div class="col-md-8 col-xs-12">{!! Form::countries('country', Request::old('country'), 'select2 country',"modal-country") !!}</div>
+                    <div class="col-md-8 col-xs-12">{!! Form::countries('country', old('country'), 'select2 country',"modal-country") !!}</div>
                 </div>
             </form>
         </div>

--- a/resources/views/modals/model.blade.php
+++ b/resources/views/modals/model.blade.php
@@ -37,7 +37,7 @@
 
                 <div class="dynamic-form-row">
                     <div class="col-md-4 col-xs-12"><label for="modal-fieldset_id">{{ trans('admin/models/general.fieldset') }}:</label></div>
-                    <div class="col-md-8 col-xs-12">{{ Form::select('fieldset_id', Helper::customFieldsetList(),Request::old('fieldset_id'), array('class'=>'select2', 'id'=>'modal-fieldset_id', 'style'=>'width:350px')) }}</div>
+                    <div class="col-md-8 col-xs-12">{{ Form::select('fieldset_id', Helper::customFieldsetList(),old('fieldset_id'), array('class'=>'select2', 'id'=>'modal-fieldset_id', 'style'=>'width:350px')) }}</div>
                 </div>
         </div>
         <div class="modal-footer">

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -9,17 +9,17 @@
               <!-- Listbox -->
               @if ($field->element=='listbox')
                    {{ Form::select($field->db_column_name(), $field->formatFieldValuesAsArray(),
-                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
+                  old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
 
               @elseif ($field->element=='textarea')
-                  <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>
+                  <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>
 
               @elseif ($field->element=='checkbox')
                     <!-- Checkboxes -->
                   @foreach ($field->formatFieldValuesAsArray() as $key => $value)
                       <div>
                           <label class="form-control">
-                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" {{  isset($item) ? (in_array($value, array_map('trim', explode(',', $item->{$field->db_column_name()}))) ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, array_map('trim', explode(',', $field->defaultValue($model->id)))) ? ' checked="checked"' : '')) }}>
+                              <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" {{  isset($item) ? (in_array($value, array_map('trim', explode(',', $item->{$field->db_column_name()}))) ? ' checked="checked"' : '') : (old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, array_map('trim', explode(',', $field->defaultValue($model->id)))) ? ' checked="checked"' : '')) }}>
                               {{ $value }}
                           </label>
                       </div>
@@ -30,7 +30,7 @@
 
               <div>
                   <label class="form-control">
-                      <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($value, explode(', ', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
+                      <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($value, explode(', ', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
                       {{ $value }}
                   </label>
               </div>
@@ -54,7 +54,7 @@
 
                 @else
                     @if (($field->field_encrypted=='0') || (Gate::allows('assets.view.encrypted_custom_fields')))
-                    <input type="text" value="{{ Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}" id="{{ $field->db_column_name() }}" class="form-control" name="{{ $field->db_column_name() }}" placeholder="Enter {{ strtolower($field->format) }} text">
+                    <input type="text" value="{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}" id="{{ $field->db_column_name() }}" class="form-control" name="{{ $field->db_column_name() }}" placeholder="Enter {{ strtolower($field->format) }} text">
                         @else
                             <input type="text" value="{{ strtoupper(trans('admin/custom_fields/general.encrypted')) }}" class="form-control disabled" disabled>
                     @endif

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -25,20 +25,20 @@
               <!-- Listbox -->
               @if ($field->element=='listbox')
                   {{ Form::select($field->db_column_name(), $field->formatFieldValuesAsArray(),
-                  Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
+                  old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
 
               @elseif ($field->element=='textarea')
                 @if($field->is_unique)
                     <input type="text" class="form-control" disabled value="{{ trans('/admin/hardware/form.bulk_update_custom_field_unique') }}">
                 @endif
                 @if(!$field->is_unique) 
-                    <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>
+                    <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>
                 @endif 
               @elseif ($field->element=='checkbox')
                     <!-- Checkboxes -->
                   @foreach ($field->formatFieldValuesAsArray() as $key => $value)
                       <label class="form-control">
-                          <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" {{  isset($item) ? (in_array($value, array_map('trim', explode(',', $item->{$field->db_column_name()}))) ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, array_map('trim', explode(',', $field->defaultValue($model->id)))) ? ' checked="checked"' : '')) }}>
+                          <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" {{  isset($item) ? (in_array($value, array_map('trim', explode(',', $item->{$field->db_column_name()}))) ? ' checked="checked"' : '') : (old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, array_map('trim', explode(',', $field->defaultValue($model->id)))) ? ' checked="checked"' : '')) }}>
                           {{ $value }}
                       </label>
 
@@ -47,7 +47,7 @@
             @foreach ($field->formatFieldValuesAsArray() as $value)
 
                   <label class="form-control">
-                      <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (Request::old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($value, explode(', ', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
+                      <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($value, explode(', ', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
                       {{ $value }}
                   </label>
 
@@ -75,7 +75,7 @@
                                 <input type="text" class="form-control" disabled value="{{trans('/admin/hardware/form.bulk_update_custom_field_unique')}}">
                             @endif  
                         @if(!$field->is_unique) 
-                                <input type="text" value="{{ Request::old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}" id="{{ $field->db_column_name() }}" class="form-control" name="{{ $field->db_column_name() }}" placeholder="Enter {{ strtolower($field->format) }} text">
+                                <input type="text" value="{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}" id="{{ $field->db_column_name() }}" class="form-control" name="{{ $field->db_column_name() }}" placeholder="Enter {{ strtolower($field->format) }} text">
                         @endif 
                             @else
                                 <input type="text" value="{{ strtoupper(trans('admin/custom_fields/general.encrypted')) }}" class="form-control disabled" disabled>

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -23,7 +23,7 @@
     <label for="eol" class="col-md-3 control-label">{{ trans('general.eol') }}</label>
     <div class="col-md-3 col-sm-4 col-xs-7">
         <div class="input-group">
-            <input class="form-control" type="text" name="eol" id="eol" value="{{ Request::old('eol', isset($item->eol)) ? $item->eol : ''  }}" />
+            <input class="form-control" type="text" name="eol" id="eol" value="{{ old('eol', isset($item->eol)) ? $item->eol : ''  }}" />
             <span class="input-group-addon">
                 {{ trans('general.months') }}
             </span>

--- a/resources/views/partials/forms/edit/accessory-select.blade.php
+++ b/resources/views/partials/forms/edit/accessory-select.blade.php
@@ -4,7 +4,7 @@
     <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
         <select class="js-data-ajax select2" data-endpoint="accessories" data-placeholder="{{ trans('general.select_accessory') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_accessory_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}>
 
-            @if ((!isset($unselect)) && ($accessory_id = Request::old($fieldname, (isset($accessory) ? $accessory->id  : (isset($item) ? $item->{$fieldname} : '')))))
+            @if ((!isset($unselect)) && ($accessory_id = old($fieldname, (isset($accessory) ? $accessory->id  : (isset($item) ? $item->{$fieldname} : '')))))
                 <option value="{{ $accessory_id }}" selected="selected">
                     {{ (\App\Models\Accessory::find($accessory_id)) ? \App\Models\Accessory::find($accessory_id)->present()->name : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/company-select.blade.php
+++ b/resources/views/partials/forms/edit/company-select.blade.php
@@ -22,7 +22,7 @@
         {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
         <div class="col-md-6">
             <select class="js-data-ajax" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" id="company_select"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
-                @if ($company_id = Request::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
+                @if ($company_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                     <option value="{{ $company_id }}" selected="selected">
                         {{ (\App\Models\Company::find($company_id)) ? \App\Models\Company::find($company_id)->name : '' }}
                     </option>

--- a/resources/views/partials/forms/edit/consumable-select.blade.php
+++ b/resources/views/partials/forms/edit/consumable-select.blade.php
@@ -4,7 +4,7 @@
     <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
         <select class="js-data-ajax select2" data-endpoint="consumables" data-placeholder="{{ trans('general.select_consumable') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_consumable_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}>
         
-            @if ((!isset($unselect)) && ($consumable_id = Request::old($fieldname, (isset($consumable) ? $consumable->id  : (isset($item) ? $item->{$fieldname} : '')))))
+            @if ((!isset($unselect)) && ($consumable_id = old($fieldname, (isset($consumable) ? $consumable->id  : (isset($item) ? $item->{$fieldname} : '')))))
                 <option value="{{ $consumable_id }}" selected="selected">
                     {{ (\App\Models\Consumable::find($consumable_id)) ? \App\Models\Consumable::find($consumable_id)->present()->name : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/kit-select.blade.php
+++ b/resources/views/partials/forms/edit/kit-select.blade.php
@@ -4,7 +4,7 @@
 
     <div class="col-md-7{{  ((isset($required)) && ($required=='true')) ? ' required' : '' }}">
         <select class="js-data-ajax" data-endpoint="kits" data-placeholder="{{ trans('partials/forms/general.placeholder_kit') }}" name="{{ $fieldname }}" style="width: 100%" id="kit_id_select">
-            @if ($kit_id = Request::old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
+            @if ($kit_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
                 <option value="{{ $kit_id }}" selected="selected">
                     {{ (\App\Models\User::find($kit_id)) ? \App\Models\User::find($kit_id)->present()->fullName : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/license-select.blade.php
+++ b/resources/views/partials/forms/edit/license-select.blade.php
@@ -4,7 +4,7 @@
     <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
         <select class="js-data-ajax select2" data-endpoint="licenses" data-placeholder="{{ trans('general.select_license') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_license_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}>
 
-            @if ((!isset($unselect)) && ($license_id = Request::old($fieldname, (isset($license) ? $license->id  : (isset($item) ? $item->{$fieldname} : '')))))
+            @if ((!isset($unselect)) && ($license_id = old($fieldname, (isset($license) ? $license->id  : (isset($item) ? $item->{$fieldname} : '')))))
                 <option value="{{ $license_id }}" selected="selected">
                     {{ (\App\Models\License::find($license_id)) ? \App\Models\License::find($license_id)->present()->fullName : '' }}
                 </option>

--- a/resources/views/partials/forms/edit/uploadLogo.blade.php
+++ b/resources/views/partials/forms/edit/uploadLogo.blade.php
@@ -48,7 +48,7 @@
 
     <div class="col-md-9 col-md-offset-3">
         <label id="{{ $logoId }}-deleteCheckbox" for="{{ $logoClearVariable }}" style="font-weight: normal" class="form-control">
-            {{ Form::checkbox($logoClearVariable, '1', Request::old($logoClearVariable)) }}
+            {{ Form::checkbox($logoClearVariable, '1', old($logoClearVariable)) }}
             Remove current {{ ucwords(str_replace('_', ' ', $logoVariable)) }} image
         </label>
     </div>

--- a/resources/views/partials/forms/edit/warranty.blade.php
+++ b/resources/views/partials/forms/edit/warranty.blade.php
@@ -3,7 +3,7 @@
     <label for="warranty_months" class="col-md-3 control-label">{{ trans('admin/hardware/form.warranty') }}</label>
     <div class="col-md-9">
         <div class="input-group col-md-3" style="padding-left: 0px;">
-            <input class="form-control" type="text" name="warranty_months" id="warranty_months" value="{{ Request::old('warranty_months', $item->warranty_months) }}" maxlength="3" />
+            <input class="form-control" type="text" name="warranty_months" id="warranty_months" value="{{ old('warranty_months', $item->warranty_months) }}" maxlength="3" />
             <span class="input-group-addon">{{ trans('admin/hardware/form.months') }}</span>
         </div>
         <div class="col-md-9" style="padding-left: 0px;">

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -44,7 +44,7 @@
                         <div class="form-group {{ $errors->has('alerts_enabled') ? 'error' : '' }}">
                             <div class="col-md-9 col-md-offset-3">
                                 <label class="form-control">
-                                    {{ Form::checkbox('alerts_enabled', '1', Request::old('alerts_enabled', $setting->alerts_enabled)) }}
+                                    {{ Form::checkbox('alerts_enabled', '1', old('alerts_enabled', $setting->alerts_enabled)) }}
                                     {{  trans('admin/settings/general.alerts_enabled') }}
                                 </label>
                             </div>
@@ -54,7 +54,7 @@
                         <div class="form-group {{ $errors->has('show_alerts_in_menu') ? 'error' : '' }}">
                             <div class="col-md-9 col-md-offset-3">
                                 <label class="form-control">
-                                    {{ Form::checkbox('show_alerts_in_menu', '1', Request::old('show_alerts_in_menu', $setting->show_alerts_in_menu)) }}
+                                    {{ Form::checkbox('show_alerts_in_menu', '1', old('show_alerts_in_menu', $setting->show_alerts_in_menu)) }}
                                     {{ trans('admin/settings/general.show_alerts_in_menu') }}
                                 </label>
                             </div>
@@ -122,7 +122,7 @@
                                 {{ Form::label('audit_interval', trans('admin/settings/general.audit_interval')) }}
                             </div>
                             <div class="input-group col-md-2">
-                                {{ Form::text('audit_interval', Request::old('audit_interval', $setting->audit_interval), array('class' => 'form-control','placeholder' => '12', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                                {{ Form::text('audit_interval', old('audit_interval', $setting->audit_interval), array('class' => 'form-control','placeholder' => '12', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
                                 <span class="input-group-addon">{{ trans('general.months') }}</span>
                             </div>
                             <div class="col-md-9 col-md-offset-3">
@@ -137,7 +137,7 @@
                                 {{ Form::label('audit_warning_days', trans('admin/settings/general.audit_warning_days')) }}
                             </div>
                             <div class="input-group col-md-2">
-                                {{ Form::text('audit_warning_days', Request::old('audit_warning_days', $setting->audit_warning_days), array('class' => 'form-control','placeholder' => '14', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                                {{ Form::text('audit_warning_days', old('audit_warning_days', $setting->audit_warning_days), array('class' => 'form-control','placeholder' => '14', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
                                 <span class="input-group-addon">{{ trans('general.days') }}</span>
 
 

--- a/resources/views/settings/barcodes.blade.php
+++ b/resources/views/settings/barcodes.blade.php
@@ -98,14 +98,14 @@
                             </div>
                             <div class="col-md-9">
                                 @if ($setting->qr_code == 1)
-                                    {{ Form::text('qr_text', Request::old('qr_text', $setting->qr_text), array('class' => 'form-control','placeholder' => 'Property of Your Company',
+                                    {{ Form::text('qr_text', old('qr_text', $setting->qr_text), array('class' => 'form-control','placeholder' => 'Property of Your Company',
                                     'rel' => 'txtTooltip',
                                     'title' =>'Extra text that you would like to display on your labels. ',
                                     'data-toggle' =>'tooltip',
                                     'data-placement'=>'top')) }}
                                     {!! $errors->first('qr_text', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @else
-                                    {{ Form::text('qr_text', Request::old('qr_text', $setting->qr_text), array('class' => 'form-control', 'disabled'=>'disabled','placeholder' => 'Property of Your Company')) }}
+                                    {{ Form::text('qr_text', old('qr_text', $setting->qr_text), array('class' => 'form-control', 'disabled'=>'disabled','placeholder' => 'Property of Your Company')) }}
                                     <p class="help-block">{{ trans('admin/settings/general.qr_help') }}</p>
                                 @endif
                             </div>

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -48,11 +48,11 @@
                             </div>
                             <div class="col-md-7 required">
                                 @if (config('app.lock_passwords')===true)
-                                    {{ Form::text('site_name', Request::old('site_name', $setting->site_name), array('class' => 'form-control', 'disabled'=>'disabled','placeholder' => 'Snipe-IT Asset Management')) }}
+                                    {{ Form::text('site_name', old('site_name', $setting->site_name), array('class' => 'form-control', 'disabled'=>'disabled','placeholder' => 'Snipe-IT Asset Management')) }}
                                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                 @else
                                     {{ Form::text('site_name',
-                                        Request::old('site_name', $setting->site_name), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management', 'required' => 'required')) }}
+                                        old('site_name', $setting->site_name), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management', 'required' => 'required')) }}
                                 @endif
                                 {!! $errors->first('site_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
@@ -205,10 +205,10 @@
                             </div>
                             <div class="col-md-9">
                                 @if (config('app.lock_passwords')===true)
-                                    {!! Form::select('support_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Request::old('support_footer', $setting->support_footer), ['class' => 'form-control select2 disabled', 'style'=>'width: 150px ;', 'disabled' => 'disabled']) !!}
+                                    {!! Form::select('support_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), old('support_footer', $setting->support_footer), ['class' => 'form-control select2 disabled', 'style'=>'width: 150px ;', 'disabled' => 'disabled']) !!}
                                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                 @else
-                                    {!! Form::select('support_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Request::old('support_footer', $setting->support_footer), array('class' => 'form-control select2', 'style'=>'width: 150px ;')) !!}
+                                    {!! Form::select('support_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), old('support_footer', $setting->support_footer), array('class' => 'form-control select2', 'style'=>'width: 150px ;')) !!}
                                 @endif
 
 
@@ -224,10 +224,10 @@
                             </div>
                             <div class="col-md-9">
                                 @if (config('app.lock_passwords')===true)
-                                    {!! Form::select('version_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Request::old('version_footer', $setting->version_footer), ['class' => 'form-control select2 disabled', 'style'=>'width: 150px ;', 'disabled' => 'disabled']) !!}
+                                    {!! Form::select('version_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), old('version_footer', $setting->version_footer), ['class' => 'form-control select2 disabled', 'style'=>'width: 150px ;', 'disabled' => 'disabled']) !!}
                                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                 @else
-                                    {!! Form::select('version_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), Request::old('version_footer', $setting->version_footer), array('class' => 'form-control select2', 'style'=>'width: 150px ;')) !!}
+                                    {!! Form::select('version_footer', array('on'=>'Enabled','off'=>'Disabled','admin'=>'Superadmin Only'), old('version_footer', $setting->version_footer), array('class' => 'form-control select2', 'style'=>'width: 150px ;')) !!}
                                 @endif
 
                                 <p class="help-block">{{ trans('admin/settings/general.version_footer_help') }}</p>
@@ -242,10 +242,10 @@
                             </div>
                             <div class="col-md-9">
                                 @if (config('app.lock_passwords')===true)
-                                    {{ Form::textarea('footer_text', Request::old('footer_text', $setting->footer_text), array('class' => 'form-control', 'rows' => '4', 'placeholder' => 'Optional footer text','disabled'=>'disabled')) }}
+                                    {{ Form::textarea('footer_text', old('footer_text', $setting->footer_text), array('class' => 'form-control', 'rows' => '4', 'placeholder' => 'Optional footer text','disabled'=>'disabled')) }}
                                     <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                 @else
-                                    {{ Form::textarea('footer_text', Request::old('footer_text', $setting->footer_text), array('class' => 'form-control','rows' => '4','placeholder' => 'Optional footer text')) }}
+                                    {{ Form::textarea('footer_text', old('footer_text', $setting->footer_text), array('class' => 'form-control','rows' => '4','placeholder' => 'Optional footer text')) }}
                                 @endif
                                 <p class="help-block">{!! trans('admin/settings/general.footer_text_help') !!}</p>
                                 {!! $errors->first('footer_text', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -64,7 +64,7 @@
                         </div>
                         <div class="col-md-9">
                             <label class="form-control">
-                                {{ Form::checkbox('require_accept_signature', '1', Request::old('require_accept_signature', $setting->require_accept_signature)) }}
+                                {{ Form::checkbox('require_accept_signature', '1', old('require_accept_signature', $setting->require_accept_signature)) }}
                                 {{ trans('general.yes') }}
                             </label>
                             {!! $errors->first('require_accept_signature', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -80,7 +80,7 @@
                             {{ Form::label('email_domain', trans('general.email_domain')) }}
                         </div>
                         <div class="col-md-9">
-                            {{ Form::text('email_domain', Request::old('email_domain', $setting->email_domain), array('class' => 'form-control','placeholder' => 'example.com')) }}
+                            {{ Form::text('email_domain', old('email_domain', $setting->email_domain), array('class' => 'form-control','placeholder' => 'example.com')) }}
                             <span class="help-block">{{ trans('general.email_domain_help')  }}</span>
                             {!! $errors->first('email_domain', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                         </div>
@@ -170,7 +170,7 @@
                            </div>
                            <div class="col-md-9">
                                <label class="form-control">
-                                   {{ Form::checkbox('unique_serial', '1', Request::old('unique_serial', $setting->unique_serial),array('class' => 'minimal')) }}
+                                   {{ Form::checkbox('unique_serial', '1', old('unique_serial', $setting->unique_serial),array('class' => 'minimal')) }}
                                    {{ trans('general.yes') }}
                                    {!! $errors->first('unique_serial', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                </label>
@@ -199,7 +199,7 @@
                            {{ Form::label('thumbnail_max_h', trans('admin/settings/general.thumbnail_max_h')) }}
                        </div>
                        <div class="col-md-9">
-                           {{ Form::text('thumbnail_max_h', Request::old('thumbnail_max_h', $setting->thumbnail_max_h), array('class' => 'form-control','placeholder' => '50', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                           {{ Form::text('thumbnail_max_h', old('thumbnail_max_h', $setting->thumbnail_max_h), array('class' => 'form-control','placeholder' => '50', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
                            <p class="help-block">{{ trans('admin/settings/general.thumbnail_max_h_help') }}</p>
                            {!! $errors->first('thumbnail_max_h', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                        </div>
@@ -309,7 +309,7 @@
                            </div>
                            <div class="col-md-9">
                                <label class="form-control">
-                               {{ Form::checkbox('show_assigned_assets', '1', Request::old('show_assigned_assets', $setting->show_assigned_assets),array('class' => 'minimal')) }}
+                               {{ Form::checkbox('show_assigned_assets', '1', old('show_assigned_assets', $setting->show_assigned_assets),array('class' => 'minimal')) }}
                                {{ trans('general.yes') }}
                                </label>
                                <p class="help-block">{{ trans('admin/settings/general.show_assigned_assets_help') }}</p>
@@ -347,7 +347,7 @@
                            <div class="col-md-9">
                                {{ Form::select('dash_chart_type', array(
                                    'name' => 'Status Label Name',
-                                   'type' => 'Status Label Type'), Request::old('dash_chart_type', $setting->dash_chart_type), ['class' =>'select2', 'style' => 'width: 80%']) }}
+                                   'type' => 'Status Label Type'), old('dash_chart_type', $setting->dash_chart_type), ['class' =>'select2', 'style' => 'width: 80%']) }}
                            </div>
                        </div>
 
@@ -362,7 +362,7 @@
                                     'default' => 'Linear (default)', 
                                     'half_1' => 'Half-year convention, always applied', 
                                     'half_2' => 'Half-year convention, applied with condition', 
-                                ), Request::old('username_format', $setting->depreciation_method), ['class' =>'select2', 'style' => 'width: 80%']) }}
+                                ), old('username_format', $setting->depreciation_method), ['class' =>'select2', 'style' => 'width: 80%']) }}
                            </div>
                        </div>
                        <!-- /.form-group -->
@@ -374,9 +374,9 @@
                            </div>
                            <div class="col-md-9">
                                @if (config('app.lock_passwords'))
-                                   {{ Form::text('privacy_policy_link', Request::old('privacy_policy_link', $setting->privacy_policy_link), array('class' => 'form-control disabled', 'disabled' => 'disabled')) }}
+                                   {{ Form::text('privacy_policy_link', old('privacy_policy_link', $setting->privacy_policy_link), array('class' => 'form-control disabled', 'disabled' => 'disabled')) }}
                                @else
-                                   {{ Form::text('privacy_policy_link', Request::old('privacy_policy_link', $setting->privacy_policy_link), array('class' => 'form-control')) }}
+                                   {{ Form::text('privacy_policy_link', old('privacy_policy_link', $setting->privacy_policy_link), array('class' => 'form-control')) }}
 
                                @endif
 

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -47,7 +47,7 @@
     <!-- CSRF Token -->
     {{csrf_field()}}
 
-    <input type="hidden" name="username" value="{{ Request::old('username', $user->username) }}">
+    <input type="hidden" name="username" value="{{ old('username', $user->username) }}">
 
     <!-- this is a hack to prevent Chrome from trying to autocomplete fields -->
     <input type="text" name="prevent_autofill" id="prevent_autofill" value="" style="display:none;" />
@@ -92,7 +92,7 @@
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
-                                {{ Form::checkbox('is_ad', '1', Request::old('is_ad', $setting->is_ad), [((config('app.lock_passwords')===true)) ? 'disabled ': '', 'class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                {{ Form::checkbox('is_ad', '1', old('is_ad', $setting->is_ad), [((config('app.lock_passwords')===true)) ? 'disabled ': '', 'class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('admin/settings/general.is_ad') }}
                                 </label>
                                 {!! $errors->first('is_ad', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -110,7 +110,7 @@
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
-                                {{ Form::checkbox('ldap_pw_sync', '1', Request::old('ldap_pw_sync', $setting->ldap_pw_sync), [((config('app.lock_passwords')===true)) ? 'disabled ': '', 'class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                {{ Form::checkbox('ldap_pw_sync', '1', old('ldap_pw_sync', $setting->ldap_pw_sync), [((config('app.lock_passwords')===true)) ? 'disabled ': '', 'class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('general.yes') }}
                                 </label>
 
@@ -129,7 +129,7 @@
                                 {{ Form::label('ad_domain', trans('admin/settings/general.ad_domain')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ad_domain', Request::old('ad_domain', $setting->ad_domain), ['class' => 'form-control','placeholder' => trans('general.example') .'example.com', $setting->demoMode]) }}
+                                {{ Form::text('ad_domain', old('ad_domain', $setting->ad_domain), ['class' => 'form-control','placeholder' => trans('general.example') .'example.com', $setting->demoMode]) }}
                                 <p class="help-block">{{ trans('admin/settings/general.ad_domain_help') }}</p>
                                 {!! $errors->first('ad_domain', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -144,7 +144,7 @@
                                 {{ Form::label('ad_append_domain', trans('admin/settings/general.ad_append_domain_label')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::checkbox('ad_append_domain', '1', Request::old('ad_append_domain', $setting->ad_append_domain),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                {{ Form::checkbox('ad_append_domain', '1', old('ad_append_domain', $setting->ad_append_domain),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                 {{ trans('admin/settings/general.ad_append_domain') }}
                                 <p class="help-block">{{ trans('admin/settings/general.ad_append_domain_help') }}</p>
                                 {!! $errors->first('ad_append_domain', '<span class="alert-msg">:message</span>') !!}
@@ -160,7 +160,7 @@
                                 {{ Form::label('ldap_client_tls_key', trans('admin/settings/general.ldap_client_tls_key')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::textarea('ldap_client_tls_key', Request::old('ldap_client_tls_key', $setting->ldap_client_tls_key), ['class' => 'form-control','placeholder' =>  trans('general.example') .'-----BEGIN RSA PRIVATE KEY-----'."\r\n1234567890\r\n-----END RSA PRIVATE KEY-----
+                                {{ Form::textarea('ldap_client_tls_key', old('ldap_client_tls_key', $setting->ldap_client_tls_key), ['class' => 'form-control','placeholder' =>  trans('general.example') .'-----BEGIN RSA PRIVATE KEY-----'."\r\n1234567890\r\n-----END RSA PRIVATE KEY-----
 ", $setting->demoMode]) }}
                                 {!! $errors->first('ldap_client_tls_key', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -175,7 +175,7 @@
                                 {{ Form::label('ldap_client_tls_cert', trans('admin/settings/general.ldap_client_tls_cert')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::textarea('ldap_client_tls_cert', Request::old('ldap_client_tls_cert', $setting->ldap_client_tls_cert), ['class' => 'form-control','placeholder' =>  trans('general.example') .'-----BEGIN CERTIFICATE-----'."\r\n1234567890\r\n-----END CERTIFICATE-----", $setting->demoMode]) }}
+                                {{ Form::textarea('ldap_client_tls_cert', old('ldap_client_tls_cert', $setting->ldap_client_tls_cert), ['class' => 'form-control','placeholder' =>  trans('general.example') .'-----BEGIN CERTIFICATE-----'."\r\n1234567890\r\n-----END CERTIFICATE-----", $setting->demoMode]) }}
                                 <p class="help-block">{{ trans('admin/settings/general.ldap_client_tls_cert_help') }}</p>
                                 {!! $errors->first('ldap_client_tls_cert', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -190,7 +190,7 @@
                                 {{ Form::label('ldap_server', trans('admin/settings/general.ldap_server')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_server', Request::old('ldap_server', $setting->ldap_server), ['class' => 'form-control','placeholder' =>  trans('general.example') .'ldap://ldap.example.com', $setting->demoMode]) }}
+                                {{ Form::text('ldap_server', old('ldap_server', $setting->ldap_server), ['class' => 'form-control','placeholder' =>  trans('general.example') .'ldap://ldap.example.com', $setting->demoMode]) }}
                                 <p class="help-block">{{ trans('admin/settings/general.ldap_server_help') }}</p>
                                 {!! $errors->first('ldap_server', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -206,7 +206,7 @@
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
-                                    {{ Form::checkbox('ldap_tls', '1', Request::old('ldap_tls', $setting->ldap_tls),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                    {{ Form::checkbox('ldap_tls', '1', old('ldap_tls', $setting->ldap_tls),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                     {{ trans('admin/settings/general.ldap_tls_help') }}
                                 </label>
                                 {!! $errors->first('ldap_tls', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -223,7 +223,7 @@
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
-                                    {{ Form::checkbox('ldap_server_cert_ignore', '1', Request::old('ldap_server_cert_ignore', $setting->ldap_server_cert_ignore),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                    {{ Form::checkbox('ldap_server_cert_ignore', '1', old('ldap_server_cert_ignore', $setting->ldap_server_cert_ignore),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
                                     {{ trans('admin/settings/general.ldap_server_cert_ignore') }}
                                 </label>
                                 {!! $errors->first('ldap_server_cert_ignore', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -240,7 +240,7 @@
                                 {{ Form::label('ldap_uname', trans('admin/settings/general.ldap_uname')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_uname', Request::old('ldap_uname', $setting->ldap_uname), ['class' => 'form-control','autocomplete' => 'off', 'placeholder' => trans('general.example') .'binduser@example.com', $setting->demoMode]) }}
+                                {{ Form::text('ldap_uname', old('ldap_uname', $setting->ldap_uname), ['class' => 'form-control','autocomplete' => 'off', 'placeholder' => trans('general.example') .'binduser@example.com', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_uname', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -268,7 +268,7 @@
                                 {{ Form::label('ldap_basedn', trans('admin/settings/general.ldap_basedn')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_basedn', Request::old('ldap_basedn', $setting->ldap_basedn), ['class' => 'form-control', 'placeholder' => trans('general.example') .'cn=users/authorized,dc=example,dc=com', $setting->demoMode]) }}
+                                {{ Form::text('ldap_basedn', old('ldap_basedn', $setting->ldap_basedn), ['class' => 'form-control', 'placeholder' => trans('general.example') .'cn=users/authorized,dc=example,dc=com', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_basedn', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -282,7 +282,7 @@
                                 {{ Form::label('ldap_filter', trans('admin/settings/general.ldap_filter')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_filter', Request::old('ldap_filter', $setting->ldap_filter), ['class' => 'form-control','placeholder' => trans('general.example') .'&(cn=*)', $setting->demoMode]) }}
+                                {{ Form::text('ldap_filter', old('ldap_filter', $setting->ldap_filter), ['class' => 'form-control','placeholder' => trans('general.example') .'&(cn=*)', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_filter', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -296,7 +296,7 @@
                                 {{ Form::label('ldap_username_field', trans('admin/settings/general.ldap_username_field')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_username_field', Request::old('ldap_username_field', $setting->ldap_username_field), ['class' => 'form-control','placeholder' => trans('general.example') .'samaccountname', $setting->demoMode]) }}
+                                {{ Form::text('ldap_username_field', old('ldap_username_field', $setting->ldap_username_field), ['class' => 'form-control','placeholder' => trans('general.example') .'samaccountname', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_username_field', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -310,7 +310,7 @@
                                 {{ Form::label('ldap_lname_field', trans('admin/settings/general.ldap_lname_field')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_lname_field', Request::old('ldap_lname_field', $setting->ldap_lname_field), ['class' => 'form-control','placeholder' => trans('general.example') .'sn', $setting->demoMode]) }}
+                                {{ Form::text('ldap_lname_field', old('ldap_lname_field', $setting->ldap_lname_field), ['class' => 'form-control','placeholder' => trans('general.example') .'sn', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_lname_field', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -324,7 +324,7 @@
                                 {{ Form::label('ldap_fname_field', trans('admin/settings/general.ldap_fname_field')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_fname_field', Request::old('ldap_fname_field', $setting->ldap_fname_field), ['class' => 'form-control', 'placeholder' => trans('general.example') .'givenname', $setting->demoMode]) }}
+                                {{ Form::text('ldap_fname_field', old('ldap_fname_field', $setting->ldap_fname_field), ['class' => 'form-control', 'placeholder' => trans('general.example') .'givenname', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_fname_field', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -338,7 +338,7 @@
                                 {{ Form::label('ldap_auth_filter_query', trans('admin/settings/general.ldap_auth_filter_query')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_auth_filter_query', Request::old('ldap_auth_filter_query', $setting->ldap_auth_filter_query), ['class' => 'form-control','placeholder' => trans('general.example') .'uid=', $setting->demoMode]) }}
+                                {{ Form::text('ldap_auth_filter_query', old('ldap_auth_filter_query', $setting->ldap_auth_filter_query), ['class' => 'form-control','placeholder' => trans('general.example') .'uid=', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_auth_filter_query', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -394,7 +394,7 @@
                                 {{ Form::label('ldap_active_flag', trans('admin/settings/general.ldap_active_flag')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_active_flag', Request::old('ldap_active_flag', $setting->ldap_active_flag), ['class' => 'form-control', $setting->demoMode]) }}
+                                {{ Form::text('ldap_active_flag', old('ldap_active_flag', $setting->ldap_active_flag), ['class' => 'form-control', $setting->demoMode]) }}
 
                                 <p class="help-block">{!! trans('admin/settings/general.ldap_activated_flag_help') !!}</p>
 
@@ -411,7 +411,7 @@
                                 {{ Form::label('ldap_emp_num', trans('admin/settings/general.ldap_emp_num')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_emp_num', Request::old('ldap_emp_num', $setting->ldap_emp_num), ['class' => 'form-control','placeholder' => trans('general.example') .'employeenumber/employeeid', $setting->demoMode]) }}
+                                {{ Form::text('ldap_emp_num', old('ldap_emp_num', $setting->ldap_emp_num), ['class' => 'form-control','placeholder' => trans('general.example') .'employeenumber/employeeid', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_emp_num', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -424,7 +424,7 @@
                                 {{ Form::label('ldap_dept', trans('admin/settings/general.ldap_dept')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_dept', Request::old('ldap_dept', $setting->ldap_dept), ['class' => 'form-control','placeholder' => trans('general.example') .'department', $setting->demoMode]) }}
+                                {{ Form::text('ldap_dept', old('ldap_dept', $setting->ldap_dept), ['class' => 'form-control','placeholder' => trans('general.example') .'department', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_dept', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -437,7 +437,7 @@
                                 {{ Form::label('ldap_dept', trans('admin/settings/general.ldap_manager')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_manager', Request::old('ldap_manager', $setting->ldap_manager), ['class' => 'form-control','placeholder' => trans('general.example') .'manager', $setting->demoMode]) }}
+                                {{ Form::text('ldap_manager', old('ldap_manager', $setting->ldap_manager), ['class' => 'form-control','placeholder' => trans('general.example') .'manager', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_manager', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -451,7 +451,7 @@
                                 {{ Form::label('ldap_email', trans('admin/settings/general.ldap_email')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_email', Request::old('ldap_email', $setting->ldap_email), ['class' => 'form-control','placeholder' => trans('general.example') .'mail', $setting->demoMode]) }}
+                                {{ Form::text('ldap_email', old('ldap_email', $setting->ldap_email), ['class' => 'form-control','placeholder' => trans('general.example') .'mail', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_email', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -465,7 +465,7 @@
                                 {{ Form::label('ldap_phone', trans('admin/settings/general.ldap_phone')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_phone', Request::old('ldap_phone', $setting->ldap_phone_field), ['class' => 'form-control','placeholder' => trans('general.example') .'telephonenumber', $setting->demoMode]) }}
+                                {{ Form::text('ldap_phone', old('ldap_phone', $setting->ldap_phone_field), ['class' => 'form-control','placeholder' => trans('general.example') .'telephonenumber', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_phone', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -479,7 +479,7 @@
                                 {{ Form::label('ldap_jobtitle', trans('admin/settings/general.ldap_jobtitle')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_jobtitle', Request::old('ldap_jobtitle', $setting->ldap_jobtitle), ['class' => 'form-control','placeholder' => trans('general.example') .'title', $setting->demoMode]) }}
+                                {{ Form::text('ldap_jobtitle', old('ldap_jobtitle', $setting->ldap_jobtitle), ['class' => 'form-control','placeholder' => trans('general.example') .'title', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_jobtitle', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -493,7 +493,7 @@
                                 {{ Form::label('ldap_country', trans('admin/settings/general.ldap_country')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_country', Request::old('ldap_country', $setting->ldap_country), ['class' => 'form-control','placeholder' => trans('general.example') .'c', $setting->demoMode]) }}
+                                {{ Form::text('ldap_country', old('ldap_country', $setting->ldap_country), ['class' => 'form-control','placeholder' => trans('general.example') .'c', $setting->demoMode]) }}
                                 {!! $errors->first('ldap_country', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
                                     <p class="text-warning"><i class="fas fa-lock" aria-hidden="true"></i> {{ trans('general.feature_disabled') }}</p>
@@ -506,7 +506,7 @@
                                 {{ Form::label('ldap_location', trans('admin/settings/general.ldap_location')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('ldap_location', Request::old('ldap_location', $setting->ldap_location), ['class' => 'form-control','placeholder' => trans('general.example') .'physicaldeliveryofficename', $setting->demoMode]) }}
+                                {{ Form::text('ldap_location', old('ldap_location', $setting->ldap_location), ['class' => 'form-control','placeholder' => trans('general.example') .'physicaldeliveryofficename', $setting->demoMode]) }}
                                 <p class="help-block">{!! trans('admin/settings/general.ldap_location_help') !!}</p>
                                 {!! $errors->first('ldap_location', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)
@@ -577,7 +577,7 @@
                                 {{ Form::label('custom_forgot_pass_url', trans('admin/settings/general.custom_forgot_pass_url')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::text('custom_forgot_pass_url', Request::old('custom_forgot_pass_url', $setting->custom_forgot_pass_url), ['class' => 'form-control','placeholder' => trans('general.example') .'https://my.ldapserver-forgotpass.com', $setting->demoMode]) }}
+                                {{ Form::text('custom_forgot_pass_url', old('custom_forgot_pass_url', $setting->custom_forgot_pass_url), ['class' => 'form-control','placeholder' => trans('general.example') .'https://my.ldapserver-forgotpass.com', $setting->demoMode]) }}
                                 <p class="help-block">{{ trans('admin/settings/general.custom_forgot_pass_url_help') }}</p>
                                 {!! $errors->first('custom_forgot_pass_url', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 @if (config('app.lock_passwords')===true)

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -46,7 +46,7 @@
                                 {{ Form::label('site_name', trans('admin/settings/general.default_language')) }}
                             </div>
                             <div class="col-md-5 col-xs-12">
-                                {!! Form::locales('locale', Request::old('locale', $setting->locale), 'select2') !!}
+                                {!! Form::locales('locale', old('locale', $setting->locale), 'select2') !!}
 
                                 {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
@@ -58,7 +58,7 @@
                                 {{ Form::label('name_display_format', trans('general.name_display_format')) }}
                             </div>
                             <div class="col-md-5 col-xs-12">
-                                {!! Form::name_display_format('name_display_format', Request::old('name_display_format', $setting->name_display_format), 'select2') !!}
+                                {!! Form::name_display_format('name_display_format', old('name_display_format', $setting->name_display_format), 'select2') !!}
 
                                 {!! $errors->first('name_display_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
@@ -72,10 +72,10 @@
                                 {{ Form::label('time_display_format', trans('general.time_and_date_display')) }}
                             </div>
                             <div class="col-md-5 col-xs-12">
-                                {!! Form::date_display_format('date_display_format', Request::old('date_display_format', $setting->date_display_format), 'select2') !!}
+                                {!! Form::date_display_format('date_display_format', old('date_display_format', $setting->date_display_format), 'select2') !!}
                             </div>
                             <div class="col-md-3 col-xs-12">
-                                {!! Form::time_display_format('time_display_format', Request::old('time_display_format', $setting->time_display_format), 'select2') !!}
+                                {!! Form::time_display_format('time_display_format', old('time_display_format', $setting->time_display_format), 'select2') !!}
                             </div>
                             
                             {!! $errors->first('time_display_format', '<div class="col-md-9 col-md-offset-3"><span class="alert-msg" aria-hidden="true">:message</span> </div>') !!}

--- a/resources/views/settings/purge-form.blade.php
+++ b/resources/views/settings/purge-form.blade.php
@@ -30,9 +30,9 @@
                     </div>
                     <div class="col-md-9{{ $errors->has('confirm_purge') ? 'error' : '' }}">
                         @if (config('app.lock_passwords')===true)
-                            {{ Form::text('confirm_purge', Request::old('confirm_purge'), array('class' => 'form-control', 'disabled'=>'true')) }}
+                            {{ Form::text('confirm_purge', old('confirm_purge'), array('class' => 'form-control', 'disabled'=>'true')) }}
                         @else
-                            {{ Form::text('confirm_purge', Request::old('confirm_purge'), array('class' => 'form-control')) }}
+                            {{ Form::text('confirm_purge', old('confirm_purge'), array('class' => 'form-control')) }}
                         @endif
 
                         @if (config('app.lock_passwords')===true)

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -43,7 +43,7 @@
                             </div>
                             <div class="col-md-9">
 
-                                {!! Form::two_factor_options('two_factor_enabled', Request::old('two_factor_enabled', $setting->two_factor_enabled), 'select2') !!}
+                                {!! Form::two_factor_options('two_factor_enabled', old('two_factor_enabled', $setting->two_factor_enabled), 'select2') !!}
                                 <p class="help-block">{{ trans('admin/settings/general.two_factor_enabled_warning') }}</p>
 
                                 @if (config('app.lock_passwords'))
@@ -60,7 +60,7 @@
                                 {{ Form::label('pwd_secure_min', trans('admin/settings/general.pwd_secure_min')) }}
                             </div>
                             <div class="col-md-9">
-                                {{ Form::text('pwd_secure_min', Request::old('pwd_secure_min', $setting->pwd_secure_min), array('class' => 'form-control',  'style'=>'width: 50px;')) }}
+                                {{ Form::text('pwd_secure_min', old('pwd_secure_min', $setting->pwd_secure_min), array('class' => 'form-control',  'style'=>'width: 50px;')) }}
 
                                 {!! $errors->first('pwd_secure_min', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 <p class="help-block">
@@ -137,7 +137,7 @@
                                     </p>
                                     <!-- Use custom remote user header name -->
                                     {{ Form::label('login_remote_user_header_name',  trans('admin/settings/general.login_remote_user_header_name_text')) }}
-                                    {{ Form::text('login_remote_user_header_name', Request::old('login_remote_user_header_name', $setting->login_remote_user_header_name),array('class' => 'form-control')) }}
+                                    {{ Form::text('login_remote_user_header_name', old('login_remote_user_header_name', $setting->login_remote_user_header_name),array('class' => 'form-control')) }}
                                     {!! $errors->first('login_remote_user_header_name', '<span class="alert-msg">:message</span>') !!}
                                     <p class="help-block">
                                         {{ trans('admin/settings/general.login_remote_user_header_name_help') }}

--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -21,7 +21,7 @@
         <label for="site_name">
           {{ trans('general.site_name') }}
         </label>
-        {{ Form::text('site_name', Request::old('site_name'), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management')) }}
+        {{ Form::text('site_name', old('site_name'), array('class' => 'form-control','placeholder' => 'Snipe-IT Asset Management')) }}
 
         {!! $errors->first('site_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>
@@ -34,14 +34,14 @@
       <label for="locale">
         {{ trans('admin/settings/general.default_language') }}
       </label>
-      {!! Form::locales('locale', Request::old('locale', "en-US"), 'select2') !!}
+      {!! Form::locales('locale', old('locale', "en-US"), 'select2') !!}
       {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
     </div>
 
     <!-- Currency -->
     <div class="form-group col-lg-6{{  (Helper::checkIfRequired(\App\Models\Setting::class, 'default_currency')) ? ' required' : '' }} {{$errors->has('default_currency') ? 'error' : ''}}">
       {{ Form::label('default_currency', trans('admin/settings/general.default_currency')) }}
-      {{ Form::text('default_currency', Request::old('default_currency'), array('class' => 'form-control','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+      {{ Form::text('default_currency', old('default_currency'), array('class' => 'form-control','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
 
       {!! $errors->first('default_currency', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
     </div>
@@ -72,14 +72,14 @@
 
     <div class="form-group col-lg-6{{  (Helper::checkIfRequired(\App\Models\User::class, 'auto_increment_prefix')) ? ' required' : '' }} {{ $errors->has('auto_increment_prefix') ? 'error' : '' }}">
       {{ Form::label('auto_increment_prefix', trans('admin/settings/general.auto_increment_prefix')) }}
-      {{ Form::text('auto_increment_prefix', Request::old('auto_increment_prefix'), array('class' => 'form-control')) }}
+      {{ Form::text('auto_increment_prefix', old('auto_increment_prefix'), array('class' => 'form-control')) }}
 
       {!! $errors->first('auto_increment_prefix', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
     </div>
 
     <div class="form-group col-lg-6{{  (Helper::checkIfRequired(\App\Models\User::class, 'zerofill_count')) ? ' required' : '' }} {{ $errors->has('zerofill_count') ? 'error' : '' }}">
       {{ Form::label('zerofill_count', trans('admin/settings/general.zerofill_count')) }}
-      {{ Form::text('zerofill_count', Request::old('zerofill_count', 5), array('class' => 'form-control')) }}
+      {{ Form::text('zerofill_count', old('zerofill_count', 5), array('class' => 'form-control')) }}
 
       {!! $errors->first('zerofill_count', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
     </div>
@@ -90,7 +90,7 @@
     <div class="row">
       <div class="form-group col-lg-6 required {{ $errors->has('email_domain') ? 'error' : '' }}">
         {{ Form::label('email_domain', trans('general.email_domain')) }}
-        {{ Form::text('email_domain', Request::old('email_domain'), array('class' => 'form-control','placeholder' => 'example.com')) }}
+        {{ Form::text('email_domain', old('email_domain'), array('class' => 'form-control','placeholder' => 'example.com')) }}
         <span class="help-block">{{ trans('general.email_domain_help')  }}</span>
 
         {!! $errors->first('email_domain', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}

--- a/resources/views/statuslabels/edit.blade.php
+++ b/resources/views/statuslabels/edit.blade.php
@@ -37,7 +37,7 @@
     {{ Form::label('color', trans('admin/statuslabels/table.color'), ['class' => 'col-md-3 control-label']) }}
     <div class="col-md-9">
         <div class="input-group color">
-            {{ Form::text('color', Request::old('color', $item->color), array('class' => 'form-control col-md-10', 'maxlength'=>'20')) }}
+            {{ Form::text('color', old('color', $item->color), array('class' => 'form-control col-md-10', 'maxlength'=>'20')) }}
             <div class="input-group-addon"><i></i></div>
         </div><!-- /.input group -->
         {!! $errors->first('color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -50,7 +50,7 @@
 <div class="form-group{{ $errors->has('notes') ? ' has-error' : '' }}">
     <div class="col-md-9 col-md-offset-3">
         <label class="form-control">
-            <input type="checkbox" value="1" name="show_in_nav" id="show_in_nav" {{ Request::old('show_in_nav', $item->show_in_nav) == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/statuslabels/table.show_in_nav') }}
+            <input type="checkbox" value="1" name="show_in_nav" id="show_in_nav" {{ old('show_in_nav', $item->show_in_nav) == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/statuslabels/table.show_in_nav') }}
         </label>
     </div>
 </div>
@@ -60,7 +60,7 @@
 
     <div class="col-md-9 col-md-offset-3">
         <label class="form-control">
-            <input type="checkbox" value="1" name="default_label" id="default_label" {{ Request::old('default_label', $item->default_label) == '1' ? ' checked="checked"' : '' }}>
+            <input type="checkbox" value="1" name="default_label" id="default_label" {{ old('default_label', $item->default_label) == '1' ? ' checked="checked"' : '' }}>
              {{ trans('admin/statuslabels/table.default_label') }}
         </label>
         <p class="help-block"> {{ trans('admin/statuslabels/table.default_label_help') }}</p>

--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -90,7 +90,7 @@
 
                   <tr>
                     <td colspan="7">
-                      {{ Form::select('status_id', $statuslabel_list , Request::old('status_id'), array('class'=>'select2', 'style'=>'width:250px')) }}
+                      {{ Form::select('status_id', $statuslabel_list , old('status_id'), array('class'=>'select2', 'style'=>'width:250px')) }}
                       <label>{{ trans('admin/users/general.update_user_assets_status') }}</label>
                     </td>
                   </tr>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -123,7 +123,7 @@
                     @else
                         <!-- insert the old username so we don't break validation -->
                          {{ trans('general.managed_ldap') }}
-                          <input type="hidden" name="username" value="{{ Request::old('username', $user->username) }}">
+                          <input type="hidden" name="username" value="{{ old('username', $user->username) }}">
                     @endif
                   </div>
 
@@ -246,7 +246,7 @@
                       name="email"
                       id="email"
                       maxlength="191"
-                      value="{{ Request::old('email', $user->email) }}"
+                      value="{{ old('email', $user->email) }}"
                       {{ ((config('app.lock_passwords') && ($user->id)) ? ' disabled' : '') }}
                       autocomplete="off"
                       readonly
@@ -322,7 +322,7 @@
                                           name="employee_num"
                                           maxlength="191"
                                           id="employee_num"
-                                          value="{{ Request::old('employee_num', $user->employee_num) }}"
+                                          value="{{ old('employee_num', $user->employee_num) }}"
                                   />
                                   {!! $errors->first('employee_num', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                               </div>
@@ -339,7 +339,7 @@
                                           maxlength="191"
                                           name="jobtitle"
                                           id="jobtitle"
-                                          value="{{ Request::old('jobtitle', $user->jobtitle) }}"
+                                          value="{{ old('jobtitle', $user->jobtitle) }}"
                                   />
                                   {!! $errors->first('jobtitle', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                               </div>


### PR DESCRIPTION
This just replaces `Request::old()` with the more modern `old()` for form input. 