### PR TITLE
Fixed extension requirement checking in upgrade script

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -282,17 +282,22 @@ foreach ($required_exts_array as $required_ext) {
             // Split the either/ors by their pipe and put them into an array
             $require_either = explode("|", $required_ext);
 
+            $has_one_required_ext = false;
+
             // Now loop through the either/or array and see whether any of the options match
             foreach ($require_either as $require_either_value) {
 
                 if (in_array($require_either_value, $loaded_exts_array)) {
                     $ext_installed .=  '√ '.$require_either_value." is installed!\n";
-                    break;
-                // If no match, add it to the string for errors
-                } else {
-                    $ext_missing .=  '✘ MISSING PHP EXTENSION: '.str_replace("|", " OR ", $required_ext)."\n";
+                    $has_one_required_ext = true;
                     break;
                 }
+            }
+
+            // If no match, add it to the string for errors
+            if (!$has_one_required_ext) {
+                $ext_missing .= '✘ MISSING PHP EXTENSION: '.str_replace("|", " OR ", $required_ext)."\n";
+                break;
             }
 
         // If this isn't an either/or option, just add it to the string of errors conventionally


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Fixes #14972

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this locally by copying out the relevant part of the `upgrade.php` script into a new script and running it in isolation:

<details>

<summary>Original Isolated Script:</summary>

```php
echo "Checking Required PHP extensions... \n\n";

// Get the list of installed extensions
$loaded_exts_array = get_loaded_extensions();

// The PHP extensions PHP is *required* to have enabled in order to run
$required_exts_array =
    [
        'bcmath',
        'curl',
        'exif',
        'fileinfo',
        'gd|imagick',
        'json',
        'ldap',
        'mbstring',
        'mysqli|pgsql',
        'openssl',
        'PDO',
        'sodium',
        'tokenizer',
        'xml',
        'zip',
    ];

$recommended_exts_array =
    [
        'sodium', //note that extensions need to be in BOTH the $required_exts_array and this one to be 'optional'
    ];
$ext_missing = '';
$ext_installed = '';

// Loop through the required extensions
foreach ($required_exts_array as $required_ext) {

    // If we don't find the string in the array....
    if (!in_array($required_ext, $loaded_exts_array)) {

        // Let's check for any options with pipes in them - those mean you can have either or
        if (strpos($required_ext, '|')) {

            // Split the either/ors by their pipe and put them into an array
            $require_either = explode("|", $required_ext);

            // Now loop through the either/or array and see whether any of the options match
            foreach ($require_either as $require_either_value) {

                if (in_array($require_either_value, $loaded_exts_array)) {
                    $ext_installed .=  '√ '.$require_either_value." is installed!\n";
                    break;
                // If no match, add it to the string for errors
                } else {
                    $ext_missing .=  '✘ MISSING PHP EXTENSION: '.str_replace("|", " OR ", $required_ext)."\n";
                    break;
                }
            }

        // If this isn't an either/or option, just add it to the string of errors conventionally
        } elseif (!in_array($required_ext, $recommended_exts_array)){
            $ext_missing .=  '✘ MISSING PHP EXTENSION: '.$required_ext."\n";
        } else {
            $ext_installed .= '- '.$required_ext." is *NOT* installed, but is recommended...\n";
        }

    // The required extension string was found in the array of installed extensions - yay!
    } else {
        $ext_installed .=  '√ '.$required_ext." is installed!\n";
    }
}

// Print out a useful error message and abort the install
if ($ext_missing!='') {
    echo "--------------------------------------------------------\n";
    echo "You have the following extensions installed: \n";
    echo "--------------------------------------------------------\n";

    foreach ($loaded_exts_array as $loaded_ext) {
       echo "- ".$loaded_ext."\n";
    }

    echo "--------------------- !! ERROR !! ----------------------\n";
    echo $ext_missing;
    echo "--------------------------------------------------------\n";
    echo "ABORTING THE INSTALLER  \n";
    echo "Please install the extensions above and re-run this script.\n";
    echo "--------------------------------------------------------\n";
    exit(1);
} else {
    echo $ext_installed."\n";

}
```

</details>

To confirm the issue I added `'not_real_extension|gd|imagick',` to `$required_exts_array` and ran the script:

![CleanShot 2024-06-27 at 12 45 18@2x](https://github.com/snipe/snipe-it/assets/1141514/25c2be46-b27f-4b9e-b427-211077d64c31)

I made the adjustments in this PR and was able to see `not_real_extension` didn't throw the error and `gd` was accepted:

![CleanShot 2024-06-27 at 12 46 21@2x](https://github.com/snipe/snipe-it/assets/1141514/6ee7e518-8108-44bb-9ad8-037bf7288b0e)

To make sure I didn't accidentally break the script I added `'one|two',` to `$required_exts_array` and it gave an error like expected:

![CleanShot 2024-06-27 at 12 47 34@2x](https://github.com/snipe/snipe-it/assets/1141514/5a522f82-952f-47f1-ba00-3ef0cad54ff3)


From there I copy/pasted the wrapping `foreach ($required_exts_array as $required_ext) {` from my isolated script into `upgrade.php`. **BUT!** I didn't run `upgrade.php` because I didn't want to actually do the "upgrade" on my local system.

This is the final result of my isolated script I copied from for reference:

<details>

<summary>Original Isolated Script:</summary>

```php
<?php

echo "Checking Required PHP extensions... \n\n";

// Get the list of installed extensions
$loaded_exts_array = get_loaded_extensions();

// The PHP extensions PHP is *required* to have enabled in order to run
$required_exts_array =
    [
        'bcmath',
        'curl',
        'exif',
        'fileinfo',
        'one|two',
        'not_real_extension|gd|imagick',
        'json',
        'ldap',
        'mbstring',
        'mysqli|pgsql',
        'openssl',
        'PDO',
        'sodium',
        'tokenizer',
        'xml',
        'zip',
    ];

$recommended_exts_array =
    [
        'sodium', //note that extensions need to be in BOTH the $required_exts_array and this one to be 'optional'
    ];
$ext_missing = '';
$ext_installed = '';

// Loop through the required extensions
foreach ($required_exts_array as $required_ext) {

    // If we don't find the string in the array....
    if (!in_array($required_ext, $loaded_exts_array)) {

        // Let's check for any options with pipes in them - those mean you can have either or
        if (strpos($required_ext, '|')) {

            // Split the either/ors by their pipe and put them into an array
            $require_either = explode("|", $required_ext);

            $has_one_required_ext = false;

            // Now loop through the either/or array and see whether any of the options match
            foreach ($require_either as $require_either_value) {

                if (in_array($require_either_value, $loaded_exts_array)) {
                    $ext_installed .=  '√ '.$require_either_value." is installed!\n";
                    $has_one_required_ext = true;
                    break;
                }
            }

            // If no match, add it to the string for errors
            if (!$has_one_required_ext) {
                $ext_missing .=  '✘ MISSING PHP EXTENSION: '.str_replace("|", " OR ", $required_ext)."\n";
                break;
            }

            // If this isn't an either/or option, just add it to the string of errors conventionally
        } elseif (!in_array($required_ext, $recommended_exts_array)){
            $ext_missing .=  '✘ MISSING PHP EXTENSION: '.$required_ext."\n";
        } else {
            $ext_installed .= '- '.$required_ext." is *NOT* installed, but is recommended...\n";
        }

        // The required extension string was found in the array of installed extensions - yay!
    } else {
        $ext_installed .=  '√ '.$required_ext." is installed!\n";
    }
}

// Print out a useful error message and abort the install
if ($ext_missing!='') {
    echo "--------------------------------------------------------\n";
    echo "You have the following extensions installed: \n";
    echo "--------------------------------------------------------\n";

    foreach ($loaded_exts_array as $loaded_ext) {
        echo "- ".$loaded_ext."\n";
    }

    echo "--------------------- !! ERROR !! ----------------------\n";
    echo $ext_missing;
    echo "--------------------------------------------------------\n";
    echo "ABORTING THE INSTALLER  \n";
    echo "Please install the extensions above and re-run this script.\n";
    echo "--------------------------------------------------------\n";
    exit(1);
} else {
    echo $ext_installed."\n";

}
```

</details>