### PR TITLE
Removed "Edit Your Profile" button from View Assets page if user is not able to edit their profile

### DIFF
--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -101,13 +101,13 @@
                 <div class="col-md-12 text-center">
                   <img src="{{ $user->present()->gravatar() }}"  class=" img-thumbnail hidden-print" style="margin-bottom: 20px;" alt="{{ $user->present()->fullName() }}">
                 </div>
-
+                @can('self.profile')
                   <div class="col-md-12">
                     <a href="{{ route('profile') }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">
                       {{ trans('general.editprofile') }}
                     </a>
                   </div>
-
+                @endcan
                 <div class="col-md-12" style="padding-top: 5px;">
                   <a href="{{ route('account.password.index') }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print" target="_blank" rel="noopener">
                     {{ trans('general.changepassword') }}


### PR DESCRIPTION
# Description

This PR follows up #14951 by removing the `Edit Your Profile` on the view-assets page if self-profile-editing is disabled.

Before
![Before with Edit Your Profile button still on page](https://github.com/snipe/snipe-it/assets/1141514/686e602f-4cf1-4bc2-ade4-f5fb3194884f)

After
![After with Edit Your Profile button removed from page](https://github.com/snipe/snipe-it/assets/1141514/94251ab2-a32b-4abc-8dcc-6697183bbf2f)

Fixes #14993

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
