### PR TITLE
Added links on user table to tabs on show user page

### DIFF
--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -223,6 +223,7 @@ class UserPresenter extends Presenter
                 'class' => 'css-barcode',
                 'title' => trans('general.assets'),
                 'visible' => true,
+                'formatter' => 'linkNumberToUserAssetsFormatter',
             ],
             [
                 'field' => 'licenses_count',
@@ -232,6 +233,7 @@ class UserPresenter extends Presenter
                 'class' => 'css-license',
                 'title' => trans('general.licenses'),
                 'visible' => true,
+                'formatter' => 'linkNumberToUserLicensesFormatter',
             ],
             [
                 'field' => 'consumables_count',
@@ -241,6 +243,7 @@ class UserPresenter extends Presenter
                 'class' => 'css-consumable',
                 'title' => trans('general.consumables'),
                 'visible' => true,
+                'formatter' => 'linkNumberToUserConsumablesFormatter',
             ],
             [
                 'field' => 'accessories_count',
@@ -250,6 +253,7 @@ class UserPresenter extends Presenter
                 'class' => 'css-accessory',
                 'title' => trans('general.accessories'),
                 'visible' => true,
+                'formatter' => 'linkNumberToUserAccessoriesFormatter',
             ],
             [
                 'field' => 'manages_users_count',
@@ -259,6 +263,7 @@ class UserPresenter extends Presenter
                 'class' => 'css-users',
                 'title' => trans('admin/users/table.managed_users'),
                 'visible' => true,
+                'formatter' => 'linkNumberToUserManagedUsersFormatter',
             ],
             [
                 'field' => 'manages_locations_count',
@@ -268,6 +273,7 @@ class UserPresenter extends Presenter
                 'class' => 'css-location',
                 'title' => trans('admin/users/table.managed_locations'),
                 'visible' => true,
+                'formatter' => 'linkNumberToUserManagedLocationsFormatter',
             ],
             [
                 'field' => 'notes',

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -804,6 +804,38 @@
         }
     }
 
+    function linkToUserSectionBasedOnCount (count, id, section) {
+        if (count) {
+            return '<a href="{{ config('app.url') }}/users/' + id + '#' + section +'">' + count + '</a>';
+        }
+
+        return count;
+    }
+
+    function linkNumberToUserAssetsFormatter(value, row) {
+        return linkToUserSectionBasedOnCount(value, row.id, 'asset');
+    }
+
+    function linkNumberToUserLicensesFormatter(value, row) {
+        return linkToUserSectionBasedOnCount(value, row.id, 'licenses');
+    }
+
+    function linkNumberToUserConsumablesFormatter(value, row) {
+        return linkToUserSectionBasedOnCount(value, row.id, 'consumables');
+    }
+
+    function linkNumberToUserAccessoriesFormatter(value, row) {
+        return linkToUserSectionBasedOnCount(value, row.id, 'accessories');
+    }
+
+    function linkNumberToUserManagedUsersFormatter(value, row) {
+        return linkToUserSectionBasedOnCount(value, row.id, 'managed-users');
+    }
+
+    function linkNumberToUserManagedLocationsFormatter(value, row) {
+        return linkToUserSectionBasedOnCount(value, row.id, 'managed-locations');
+    }
+
     function labelPerPageFormatter(value, row, index, field) {
         if (row) {
             if (!row.hasOwnProperty('sheet_info')) { return 1; }


### PR DESCRIPTION
# Description

This PR updates the user table so that counts are linked and when clicked take you directly to the relevant tab on the show user page:

![User table showing counts linked](https://github.com/snipe/snipe-it/assets/1141514/8b3836bb-7c2e-4791-b403-c1f6083494fe)

![CleanShot 2024-07-01 at 14 08 12](https://github.com/snipe/snipe-it/assets/1141514/1b70356c-c525-4330-8e9c-a8d0295a8758)


If the count is `0` I chose to render plain text instead of a link but I'm totally open to always providing links.

The method names I used are pretty verbose but are (hopefully) helpful for knowing what format is going to be applied at a glance.

Addresses #15000 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
