### PR TITLE
Fixed #15005 - Improvements  on user merge

### DIFF
--- a/app/Console/Commands/MergeUsersByUsername.php
+++ b/app/Console/Commands/MergeUsersByUsername.php
@@ -51,7 +51,7 @@ class MergeUsersByUsername extends Command
 
             $bad_users = User::where('username', '=', trim($parts[0]))
                 ->whereNull('deleted_at')
-                ->with('assets', 'manager', 'userlog', 'licenses', 'consumables', 'accessories', 'managedLocations')
+                ->with('assets', 'manager', 'userlog', 'licenses', 'consumables', 'accessories', 'managedLocations','uploads', 'acceptances')
                 ->get();
 
 
@@ -103,6 +103,18 @@ class MergeUsersByUsername extends Command
                     $this->info('Updating managed location record '.$managedLocation->name.' to manager '.$user->id);
                     $managedLocation->manager_id = $user->id;
                     $managedLocation->save();
+                }
+
+                foreach ($bad_user->uploads as $upload) {
+                    $this->info('Updating upload log record '.$upload->id.' to user '.$user->id);
+                    $upload->item_id = $user->id;
+                    $upload->save();
+                }
+
+                foreach ($bad_user->acceptances as $acceptance) {
+                    $this->info('Updating acceptance log record '.$acceptance->id.' to user '.$user->id);
+                    $acceptance->item_id = $user->id;
+                    $acceptance->save();
                 }
 
                 // Mark the user as deleted

--- a/app/Console/Commands/MergeUsersByUsername.php
+++ b/app/Console/Commands/MergeUsersByUsername.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Events\UserMerged;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
@@ -121,6 +122,10 @@ class MergeUsersByUsername extends Command
                 $this->info('Marking the user as deleted');
                 $bad_user->deleted_at = Carbon::now()->timestamp;
                 $bad_user->save();
+
+                event(new UserMerged($bad_user, $user, null));
+
+
             }
         }
     }

--- a/app/Events/UserMerged.php
+++ b/app/Events/UserMerged.php
@@ -15,7 +15,7 @@ class UserMerged
      *
      * @return void
      */
-    public function __construct(User $from_user, User $to_user, User $admin)
+    public function __construct(User $from_user, User $to_user, ?User $admin)
     {
         $this->merged_from        = $from_user;
         $this->merged_to      = $to_user;

--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -42,7 +42,7 @@ class BulkUsersController extends Controller
             // Get the list of affected users
             $user_raw_array = request('ids');
             $users = User::whereIn('id', $user_raw_array)
-                ->with('groups', 'assets', 'licenses', 'accessories')->get();
+                ->with('assets', 'manager', 'userlog', 'licenses', 'consumables', 'accessories', 'managedLocations','uploads', 'acceptances')->get();
 
             // bulk edit, display the bulk edit form
             if ($request->input('bulk_actions') == 'edit') {

--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -317,7 +317,7 @@ class BulkUsersController extends Controller
 
         // Get the users
         $merge_into_user = User::find($request->input('merge_into_id'));
-        $users_to_merge = User::whereIn('id', $user_ids_to_merge)->with('assets', 'licenses', 'consumables','accessories', 'uploads', 'acceptances')->get();
+        $users_to_merge = User::whereIn('id', $user_ids_to_merge)->with('assets', 'manager', 'userlog', 'licenses', 'consumables', 'accessories', 'managedLocations','uploads', 'acceptances')->get();
         $admin = User::find(Auth::user()->id);
 
         // Walk users

--- a/app/Listeners/LogListener.php
+++ b/app/Listeners/LogListener.php
@@ -111,7 +111,7 @@ class LogListener
         $logaction->target_type = User::class;
         $logaction->action_type = 'merged';
         $logaction->note = trans('general.merged_log_this_user_from', $to_from_array);
-        $logaction->user_id = $event->admin->id;
+        $logaction->user_id = $event->admin->id ?? null;
         $logaction->save();
 
         // Add a record to the users being merged TO
@@ -122,7 +122,7 @@ class LogListener
         $logaction->item_type = User::class;
         $logaction->action_type = 'merged';
         $logaction->note = trans('general.merged_log_this_user_into', $to_from_array);
-        $logaction->user_id = $event->admin->id;
+        $logaction->user_id = $event->admin->id ?? null;
         $logaction->save();
 
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -498,7 +498,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      * Establishes the user -> acceptances relationship
      *
      * @author A. Gianotto <snipe@snipe.net>
-     * @since [v3.0]
+     * @since [v7.0.7]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
     public function acceptances()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -481,8 +481,6 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     /**
      * Establishes the user -> uploads relationship
      *
-     * @todo I don't think we use this?
-     *
      * @author A. Gianotto <snipe@snipe.net>
      * @since [v3.0]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
@@ -493,6 +491,21 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
             ->where('item_type', self::class)
             ->where('action_type', '=', 'uploaded')
             ->whereNotNull('filename')
+            ->orderBy('created_at', 'desc');
+    }
+
+    /**
+     * Establishes the user -> acceptances relationship
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since [v3.0]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function acceptances()
+    {
+        return $this->hasMany(\App\Models\Actionlog::class, 'target_id')
+            ->where('target_type', self::class)
+            ->where('action_type', '=', 'accepted')
             ->orderBy('created_at', 'desc');
     }
 

--- a/database/factories/ActionlogFactory.php
+++ b/database/factories/ActionlogFactory.php
@@ -105,4 +105,51 @@ class ActionlogFactory extends Factory
             ];
         });
     }
+
+    public function filesUploaded()
+    {
+        return $this->state(function () {
+
+            return [
+                'created_at'  => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get()),
+                'action_type' => 'uploaded',
+                'item_type'  => User::class,
+                'filename'  => $this->faker->unixTime('now'),
+            ];
+        });
+    }
+
+    public function acceptedSignature()
+    {
+        return $this->state(function () {
+
+            $asset = Asset::factory()->create();
+
+            return [
+                'created_at'  => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get()),
+                'action_type' => 'accepted',
+                'item_id' => $asset->id,
+                'item_type'  => Asset::class,
+                'target_type'  => User::class,
+                'accept_signature'  => $this->faker->unixTime('now'),
+            ];
+        });
+    }
+
+    public function acceptedEula()
+    {
+        return $this->state(function () {
+
+            $asset = Asset::factory()->create();
+
+            return [
+                'created_at'  => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get()),
+                'action_type' => 'accepted',
+                'item_id' => $asset->id,
+                'item_type'  => Asset::class,
+                'target_type'  => User::class,
+                'filename'  => $this->faker->unixTime('now'),
+            ];
+        });
+    }
 }

--- a/database/factories/ActionlogFactory.php
+++ b/database/factories/ActionlogFactory.php
@@ -152,4 +152,17 @@ class ActionlogFactory extends Factory
             ];
         });
     }
+
+    public function logUserUpdate()
+    {
+        return $this->state(function () {
+
+            return [
+                'created_at'  => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get()),
+                'action_type' => 'update',
+                'target_type'  => User::class,
+                'item_type'  => User::class,
+            ];
+        });
+    }
 }

--- a/database/factories/ActionlogFactory.php
+++ b/database/factories/ActionlogFactory.php
@@ -153,7 +153,7 @@ class ActionlogFactory extends Factory
         });
     }
 
-    public function logUserUpdate()
+    public function userUpdated()
     {
         return $this->state(function () {
 

--- a/database/factories/ConsumableFactory.php
+++ b/database/factories/ConsumableFactory.php
@@ -7,6 +7,7 @@ use App\Models\Company;
 use App\Models\Consumable;
 use App\Models\Manufacturer;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\Supplier;
 
@@ -114,6 +115,18 @@ class ConsumableFactory extends Factory
     {
         return $this->afterCreating(function (Consumable $consumable) {
             $consumable->category->update(['require_acceptance' => 1]);
+        });
+    }
+
+    public function checkedOutToUser(User $user = null)
+    {
+        return $this->afterCreating(function (Consumable $consumable) use ($user) {
+            $consumable->users()->attach($consumable->id, [
+                'consumable_id' => $consumable->id,
+                'created_at' => Carbon::now(),
+                'user_id' => 1,
+                'assigned_to' => $user->id ?? User::factory()->create()->id,
+            ]);
         });
     }
 }

--- a/database/factories/ConsumableFactory.php
+++ b/database/factories/ConsumableFactory.php
@@ -124,7 +124,7 @@ class ConsumableFactory extends Factory
             $consumable->users()->attach($consumable->id, [
                 'consumable_id' => $consumable->id,
                 'created_at' => Carbon::now(),
-                'user_id' => 1,
+                'user_id' => User::factory()->create()->id,
                 'assigned_to' => $user->id ?? User::factory()->create()->id,
             ]);
         });

--- a/resources/views/users/confirm-merge.blade.php
+++ b/resources/views/users/confirm-merge.blade.php
@@ -66,6 +66,10 @@
                                             <i class="fas fa-tint fa-fw" aria-hidden="true" style="font-size: 17px;"></i>
                                             <span class="sr-only">{{ trans('general.consumables') }}</span>
                                         </th>
+                                        <th class="col-md-1 text-right">
+                                            <i class="fas fa-paperclip fa-fw" aria-hidden="true" style="font-size: 17px;"></i>
+                                            <span class="sr-only">{{ trans('general.files') }}</span>
+                                        </th>
                                     </tr>
                                     </thead>
                                     <tbody>
@@ -93,16 +97,19 @@
                                                 @endforeach
                                             </td>
                                             <td class="text-right">
-                                                {{ number_format($user->assets()->count())  }}
+                                                {{ number_format($user->assets->count())  }}
                                             </td>
                                             <td class="text-right">
-                                                {{ number_format($user->accessories()->count())  }}
+                                                {{ number_format($user->accessories->count())  }}
                                             </td>
                                             <td class="text-right">
-                                                {{ number_format($user->licenses()->count())  }}
+                                                {{ number_format($user->licenses->count())  }}
                                             </td>
                                             <td class="text-right">
-                                                {{ number_format($user->consumables()->count())  }}
+                                                {{ number_format($user->consumables->count())  }}
+                                            </td>
+                                            <td class="text-right">
+                                                {{ number_format($user->uploads->count())  }}
                                             </td>
                                         </tr>
                                     @endforeach

--- a/tests/Feature/Console/MergeUsersTest.php
+++ b/tests/Feature/Console/MergeUsersTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature\Users\Console;
+
+use App\Models\Accessory;
+use App\Models\Asset;
+use App\Models\Consumable;
+use App\Models\LicenseSeat;
+use App\Models\User;
+use App\Models\Actionlog;
+use Tests\TestCase;
+
+
+class MergeUsersTest extends TestCase
+{
+    public function testAssetsAreTransferredOnUserMerge()
+    {
+        $user1 = User::factory()->create(['username' => 'user1']);
+        $user_to_merge_into = User::factory()->create(['username' => 'user1@example.com']);
+
+        Asset::factory()->count(3)->assignedToUser($user1)->create();
+        Asset::factory()->count(3)->assignedToUser($user_to_merge_into)->create();
+
+        $this->artisan('snipeit:merge-users')->assertExitCode(0);
+
+        $this->assertNotEquals(3, $user_to_merge_into->refresh()->assets->count());
+        $this->assertEquals(6, $user_to_merge_into->refresh()->assets->count());
+        $this->assertEquals(0, $user1->refresh()->assets->count());
+
+    }
+
+    public function testLicensesAreTransferredOnUserMerge(): void
+    {
+        $user1 = User::factory()->create(['username' => 'user1']);
+        $user_to_merge_into = User::factory()->create(['username' => 'user1@example.com']);
+
+        LicenseSeat::factory()->count(3)->create(['assigned_to' => $user1->id]);
+        LicenseSeat::factory()->count(3)->create(['assigned_to' => $user_to_merge_into->id]);
+
+        $this->assertEquals(3, $user_to_merge_into->refresh()->licenses->count());
+
+        $this->artisan('snipeit:merge-users')->assertExitCode(0);
+
+        $this->assertNotEquals(3, $user_to_merge_into->refresh()->licenses->count());
+        $this->assertEquals(6, $user_to_merge_into->refresh()->licenses->count());
+        $this->assertEquals(0, $user1->refresh()->licenses->count());
+
+    }
+
+    public function testAccessoriesTransferredOnUserMerge(): void
+    {
+        $user1 = User::factory()->create(['username' => 'user1']);
+        $user_to_merge_into = User::factory()->create(['username' => 'user1@example.com']);
+
+        Accessory::factory()->count(3)->checkedOutToUser($user1)->create();
+        Accessory::factory()->count(3)->checkedOutToUser($user_to_merge_into)->create();
+
+        $this->assertEquals(3, $user_to_merge_into->refresh()->accessories->count());
+
+        $this->artisan('snipeit:merge-users')->assertExitCode(0);
+
+        $this->assertNotEquals(3, $user_to_merge_into->refresh()->accessories->count());
+        $this->assertEquals(6, $user_to_merge_into->refresh()->accessories->count());
+        $this->assertEquals(0, $user1->refresh()->accessories->count());
+
+    }
+
+    public function testConsumablesTransferredOnUserMerge(): void
+    {
+        $user1 = User::factory()->create(['username' => 'user1']);
+        $user_to_merge_into = User::factory()->create(['username' => 'user1@example.com']);
+
+        Consumable::factory()->count(3)->checkedOutToUser($user1)->create();
+        Consumable::factory()->count(3)->checkedOutToUser($user_to_merge_into)->create();
+
+        $this->assertEquals(3, $user_to_merge_into->refresh()->consumables->count());
+
+        $this->artisan('snipeit:merge-users')->assertExitCode(0);
+
+        $this->assertNotEquals(3, $user_to_merge_into->refresh()->consumables->count());
+        $this->assertEquals(6, $user_to_merge_into->refresh()->consumables->count());
+        $this->assertEquals(0, $user1->refresh()->consumables->count());
+
+    }
+
+    public function testFilesAreTransferredOnUserMerge(): void
+    {
+        $user1 = User::factory()->create(['username' => 'user1']);
+        $user_to_merge_into = User::factory()->create(['username' => 'user1@example.com']);
+
+        Actionlog::factory()->count(3)->filesUploaded()->create(['item_id' => $user1->id]);
+        Actionlog::factory()->count(3)->filesUploaded()->create(['item_id' => $user_to_merge_into->id]);
+
+        $this->assertEquals(3, $user_to_merge_into->refresh()->uploads->count());
+
+        $this->artisan('snipeit:merge-users')->assertExitCode(0);
+
+        $this->assertNotEquals(3, $user_to_merge_into->refresh()->uploads->count());
+        $this->assertEquals(6, $user_to_merge_into->refresh()->uploads->count());
+        $this->assertEquals(0, $user1->refresh()->uploads->count());
+
+    }
+
+    public function testAcceptancesAreTransferredOnUserMerge(): void
+    {
+        $user1 = User::factory()->create(['username' => 'user1']);
+        $user_to_merge_into = User::factory()->create(['username' => 'user1@example.com']);
+
+        Actionlog::factory()->count(3)->acceptedSignature()->create(['target_id' => $user1->id]);
+        Actionlog::factory()->count(3)->acceptedSignature()->create(['target_id' => $user_to_merge_into->id]);
+
+        $this->assertEquals(3, $user_to_merge_into->refresh()->acceptances->count());
+
+        $this->artisan('snipeit:merge-users')->assertExitCode(0);
+
+        $this->assertNotEquals(3, $user_to_merge_into->refresh()->acceptances->count());
+        $this->assertEquals(6, $user_to_merge_into->refresh()->acceptances->count());
+        $this->assertEquals(0, $user1->refresh()->acceptances->count());
+
+    }
+
+    public function testUserUpdateHistoryIsTransferredOnUserMerge(): void
+    {
+        $user1 = User::factory()->create(['username' => 'user1']);
+        $user_to_merge_into = User::factory()->create(['username' => 'user1@example.com']);
+
+        Actionlog::factory()->count(3)->logUserUpdate()->create(['target_id' => $user1->id, 'item_id' => $user1->id]);
+        Actionlog::factory()->count(3)->logUserUpdate()->create(['target_id' => $user_to_merge_into->id, 'item_id' => $user_to_merge_into->id]);
+
+        $this->assertEquals(3, $user_to_merge_into->refresh()->userlog->count());
+
+        $this->artisan('snipeit:merge-users')->assertExitCode(0);
+
+        $this->assertNotEquals(3, $user_to_merge_into->refresh()->userlog->count());
+
+        // This needs to be 2 more than the otherwise expected because the merge action itself is logged for the two merging users
+        $this->assertEquals(11, $user_to_merge_into->refresh()->userlog->count());
+        $this->assertEquals(2, $user1->refresh()->userlog->count());
+
+    }
+
+
+}

--- a/tests/Feature/Console/MergeUsersTest.php
+++ b/tests/Feature/Console/MergeUsersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Users\Console;
+namespace Tests\Feature\Console;
 
 use App\Models\Accessory;
 use App\Models\Asset;
@@ -23,7 +23,6 @@ class MergeUsersTest extends TestCase
 
         $this->artisan('snipeit:merge-users')->assertExitCode(0);
 
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->assets->count());
         $this->assertEquals(6, $user_to_merge_into->refresh()->assets->count());
         $this->assertEquals(0, $user1->refresh()->assets->count());
 
@@ -41,7 +40,6 @@ class MergeUsersTest extends TestCase
 
         $this->artisan('snipeit:merge-users')->assertExitCode(0);
 
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->licenses->count());
         $this->assertEquals(6, $user_to_merge_into->refresh()->licenses->count());
         $this->assertEquals(0, $user1->refresh()->licenses->count());
 
@@ -59,7 +57,6 @@ class MergeUsersTest extends TestCase
 
         $this->artisan('snipeit:merge-users')->assertExitCode(0);
 
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->accessories->count());
         $this->assertEquals(6, $user_to_merge_into->refresh()->accessories->count());
         $this->assertEquals(0, $user1->refresh()->accessories->count());
 
@@ -77,7 +74,6 @@ class MergeUsersTest extends TestCase
 
         $this->artisan('snipeit:merge-users')->assertExitCode(0);
 
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->consumables->count());
         $this->assertEquals(6, $user_to_merge_into->refresh()->consumables->count());
         $this->assertEquals(0, $user1->refresh()->consumables->count());
 
@@ -95,7 +91,6 @@ class MergeUsersTest extends TestCase
 
         $this->artisan('snipeit:merge-users')->assertExitCode(0);
 
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->uploads->count());
         $this->assertEquals(6, $user_to_merge_into->refresh()->uploads->count());
         $this->assertEquals(0, $user1->refresh()->uploads->count());
 
@@ -113,7 +108,6 @@ class MergeUsersTest extends TestCase
 
         $this->artisan('snipeit:merge-users')->assertExitCode(0);
 
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->acceptances->count());
         $this->assertEquals(6, $user_to_merge_into->refresh()->acceptances->count());
         $this->assertEquals(0, $user1->refresh()->acceptances->count());
 
@@ -124,14 +118,12 @@ class MergeUsersTest extends TestCase
         $user1 = User::factory()->create(['username' => 'user1']);
         $user_to_merge_into = User::factory()->create(['username' => 'user1@example.com']);
 
-        Actionlog::factory()->count(3)->logUserUpdate()->create(['target_id' => $user1->id, 'item_id' => $user1->id]);
-        Actionlog::factory()->count(3)->logUserUpdate()->create(['target_id' => $user_to_merge_into->id, 'item_id' => $user_to_merge_into->id]);
+        Actionlog::factory()->count(3)->userUpdated()->create(['target_id' => $user1->id, 'item_id' => $user1->id]);
+        Actionlog::factory()->count(3)->userUpdated()->create(['target_id' => $user_to_merge_into->id, 'item_id' => $user_to_merge_into->id]);
 
         $this->assertEquals(3, $user_to_merge_into->refresh()->userlog->count());
 
         $this->artisan('snipeit:merge-users')->assertExitCode(0);
-
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->userlog->count());
 
         // This needs to be more than the otherwise expected because the merge action itself is logged for the two merging users
         $this->assertEquals(7, $user_to_merge_into->refresh()->userlog->count());

--- a/tests/Feature/Console/MergeUsersTest.php
+++ b/tests/Feature/Console/MergeUsersTest.php
@@ -133,9 +133,9 @@ class MergeUsersTest extends TestCase
 
         $this->assertNotEquals(3, $user_to_merge_into->refresh()->userlog->count());
 
-        // This needs to be 2 more than the otherwise expected because the merge action itself is logged for the two merging users
-        $this->assertEquals(11, $user_to_merge_into->refresh()->userlog->count());
-        $this->assertEquals(2, $user1->refresh()->userlog->count());
+        // This needs to be more than the otherwise expected because the merge action itself is logged for the two merging users
+        $this->assertEquals(7, $user_to_merge_into->refresh()->userlog->count());
+        $this->assertEquals(1, $user1->refresh()->userlog->count());
 
     }
 

--- a/tests/Feature/Users/Ui/MergeUserTest.php
+++ b/tests/Feature/Users/Ui/MergeUserTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Feature\Users\Ui;
+
+use App\Models\Asset;
+use App\Models\User;
+use App\Models\Actionlog;
+use Tests\TestCase;
+
+
+class MergeUserTest extends TestCase
+{
+    public function testAssetsAreTransferredOnUserMerge()
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $user_to_merge_into = User::factory()->create();
+
+        Asset::factory()->count(3)->assignedToUser($user1)->create();
+        Asset::factory()->count(3)->assignedToUser($user2)->create();
+        Asset::factory()->count(3)->assignedToUser($user_to_merge_into)->create();
+
+        $response = $this->actingAs(User::factory()->editUsers()->viewUsers()->create())
+            ->post(route('users.merge.save', $user1->id),
+                [
+                    'ids_to_merge' => [$user1->id, $user2->id],
+                    'merge_into_id' => $user_to_merge_into->id
+                ])
+            ->assertStatus(302)
+            ->assertRedirect(route('users.index'));
+
+        $this->followRedirects($response)->assertSee('Success');
+        $this->assertNotEquals(3, $user_to_merge_into->refresh()->assets->count());
+        $this->assertEquals(9, $user_to_merge_into->refresh()->assets->count());
+
+    }
+
+    public function testFilesAreTransferredOnUserMerge()
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $user_to_merge_into = User::factory()->create();
+
+        Actionlog::factory()->count(3)->filesUploaded()->create(['item_id' => $user1->id]);
+        Actionlog::factory()->count(3)->filesUploaded()->create(['item_id' => $user2->id]);
+        Actionlog::factory()->count(3)->filesUploaded()->create(['item_id' => $user_to_merge_into->id]);
+
+        $this->assertEquals(3, $user_to_merge_into->refresh()->uploads->count());
+
+        $response = $this->actingAs(User::factory()->editUsers()->viewUsers()->create())
+            ->post(route('users.merge.save', $user1->id),
+                [
+                    'ids_to_merge' => [$user1->id, $user2->id],
+                    'merge_into_id' => $user_to_merge_into->id
+                ])
+            ->assertStatus(302)
+            ->assertRedirect(route('users.index'));
+
+        $this->followRedirects($response)->assertSee('Success');
+        $this->assertNotEquals(3, $user_to_merge_into->refresh()->uploads->count());
+        $this->assertEquals(9, $user_to_merge_into->refresh()->uploads->count());
+
+    }
+
+    public function testAcceptancesAreTransferredOnUserMerge()
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $user_to_merge_into = User::factory()->create();
+
+        Actionlog::factory()->count(3)->acceptedSignature()->create(['target_id' => $user1->id]);
+        Actionlog::factory()->count(3)->acceptedSignature()->create(['target_id' => $user2->id]);
+        Actionlog::factory()->count(3)->acceptedSignature()->create(['target_id' => $user_to_merge_into->id]);
+
+        $this->assertEquals(3, $user_to_merge_into->refresh()->acceptances->count());
+
+        $response = $this->actingAs(User::factory()->editUsers()->viewUsers()->create())
+            ->post(route('users.merge.save', $user1->id),
+                [
+                    'ids_to_merge' => [$user1->id, $user2->id],
+                    'merge_into_id' => $user_to_merge_into->id
+                ])
+            ->assertStatus(302)
+            ->assertRedirect(route('users.index'));
+
+        $this->followRedirects($response)->assertSee('Success');
+        $this->assertNotEquals(3, $user_to_merge_into->refresh()->acceptances->count());
+        $this->assertEquals(9, $user_to_merge_into->refresh()->acceptances->count());
+
+    }
+
+}

--- a/tests/Feature/Users/Ui/MergeUsersTest.php
+++ b/tests/Feature/Users/Ui/MergeUsersTest.php
@@ -11,7 +11,7 @@ use App\Models\Actionlog;
 use Tests\TestCase;
 
 
-class MergeUserTest extends TestCase
+class MergeUsersTest extends TestCase
 {
     public function testAssetsAreTransferredOnUserMerge()
     {

--- a/tests/Feature/Users/Ui/MergeUsersTest.php
+++ b/tests/Feature/Users/Ui/MergeUsersTest.php
@@ -33,7 +33,6 @@ class MergeUsersTest extends TestCase
             ->assertRedirect(route('users.index'));
 
         $this->followRedirects($response)->assertSee('Success');
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->assets->count());
         $this->assertEquals(9, $user_to_merge_into->refresh()->assets->count());
         $this->assertEquals(0, $user1->refresh()->assets->count());
         $this->assertEquals(0, $user2->refresh()->assets->count());
@@ -62,7 +61,6 @@ class MergeUsersTest extends TestCase
             ->assertRedirect(route('users.index'));
 
         $this->followRedirects($response)->assertSee('Success');
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->licenses->count());
         $this->assertEquals(9, $user_to_merge_into->refresh()->licenses->count());
         $this->assertEquals(0, $user1->refresh()->licenses->count());
         $this->assertEquals(0, $user2->refresh()->licenses->count());
@@ -91,7 +89,6 @@ class MergeUsersTest extends TestCase
             ->assertRedirect(route('users.index'));
 
         $this->followRedirects($response)->assertSee('Success');
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->accessories->count());
         $this->assertEquals(9, $user_to_merge_into->refresh()->accessories->count());
         $this->assertEquals(0, $user1->refresh()->accessories->count());
         $this->assertEquals(0, $user2->refresh()->accessories->count());
@@ -120,7 +117,6 @@ class MergeUsersTest extends TestCase
             ->assertRedirect(route('users.index'));
 
         $this->followRedirects($response)->assertSee('Success');
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->consumables->count());
         $this->assertEquals(9, $user_to_merge_into->refresh()->consumables->count());
         $this->assertEquals(0, $user1->refresh()->consumables->count());
         $this->assertEquals(0, $user2->refresh()->consumables->count());
@@ -149,7 +145,6 @@ class MergeUsersTest extends TestCase
             ->assertRedirect(route('users.index'));
 
         $this->followRedirects($response)->assertSee('Success');
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->uploads->count());
         $this->assertEquals(9, $user_to_merge_into->refresh()->uploads->count());
         $this->assertEquals(0, $user1->refresh()->uploads->count());
         $this->assertEquals(0, $user2->refresh()->uploads->count());
@@ -178,7 +173,6 @@ class MergeUsersTest extends TestCase
             ->assertRedirect(route('users.index'));
 
         $this->followRedirects($response)->assertSee('Success');
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->acceptances->count());
         $this->assertEquals(9, $user_to_merge_into->refresh()->acceptances->count());
         $this->assertEquals(0, $user1->refresh()->acceptances->count());
         $this->assertEquals(0, $user2->refresh()->acceptances->count());
@@ -191,9 +185,9 @@ class MergeUsersTest extends TestCase
         $user2 = User::factory()->create();
         $user_to_merge_into = User::factory()->create();
 
-        Actionlog::factory()->count(3)->logUserUpdate()->create(['target_id' => $user1->id, 'item_id' => $user1->id]);
-        Actionlog::factory()->count(3)->logUserUpdate()->create(['target_id' => $user2->id, 'item_id' => $user2->id]);
-        Actionlog::factory()->count(3)->logUserUpdate()->create(['target_id' => $user_to_merge_into->id, 'item_id' => $user_to_merge_into->id]);
+        Actionlog::factory()->count(3)->userUpdated()->create(['target_id' => $user1->id, 'item_id' => $user1->id]);
+        Actionlog::factory()->count(3)->userUpdated()->create(['target_id' => $user2->id, 'item_id' => $user2->id]);
+        Actionlog::factory()->count(3)->userUpdated()->create(['target_id' => $user_to_merge_into->id, 'item_id' => $user_to_merge_into->id]);
 
         $this->assertEquals(3, $user_to_merge_into->refresh()->userlog->count());
 
@@ -207,7 +201,6 @@ class MergeUsersTest extends TestCase
             ->assertRedirect(route('users.index'));
 
         $this->followRedirects($response)->assertSee('Success');
-        $this->assertNotEquals(3, $user_to_merge_into->refresh()->userlog->count());
 
         // This needs to be 2 more than the otherwise expected because the merge action itself is logged for the two merging users
         $this->assertEquals(11, $user_to_merge_into->refresh()->userlog->count());


### PR DESCRIPTION
Okay, this should tweak the way the merging works in both the UI and the merge user script to do the following:

1. Change the user ID of uploaded files to the user being merged into
2. Change the user ID of any acceptances that might apply
3. Added a buttload of tests
4. Added the event listener for merges to the artisan command as well

The cli and the UI do slightly different things. The UI lets you select two or more users and select which one you want to merge the other(s) into. This is not so much a bulk thing, since if you accidentally duped 10k users, that would take a while, but it's handy for smaller numbers of mistakes, like if a person's name changed in SCIM/LDAP but it wasn't changed in Snipe-IT, so it ended up creating a new user.

The cli version is more for people who messed up their LDAP setup by not renaming all of their users to have usernames that are an email address before initiating LDAP or SCIM, thus duplicating their users. Sometimes people didn't realize that even happened, so both versions of the user could have things checked out to them, so we have to merge the two into one and delete the other.

That artisan command aims to look for all users that don't have an email formatted like an email address and tries to find the user that does have a user formatted as an email address to merge into.

This should also fix #15005