### PR TITLE
Resolved Potential Issue when Deleting Personal Access Tokens

### DIFF
--- a/app/Livewire/PersonalAccessTokens.php
+++ b/app/Livewire/PersonalAccessTokens.php
@@ -49,6 +49,6 @@ class PersonalAccessTokens extends Component
     {
         //this needs safety (though the scope of auth::user might kind of do it...)
         //seems like it does, test more
-        Auth::user()->tokens()->find($tokenId)->delete();
+        Auth::user()->tokens()->find($tokenId)?->delete();
     }
 }

--- a/resources/views/livewire/personal-access-tokens.blade.php
+++ b/resources/views/livewire/personal-access-tokens.blade.php
@@ -48,7 +48,8 @@
                         </td>
                         <!-- Delete Button -->
                         <td style="vertical-align: middle;" class="text-right">
-                            <a class="action-link btn btn-danger btn-sm" wire:click="deleteToken('{{ $token->id }}')">
+                            <a class="action-link btn btn-danger btn-sm" wire:click="deleteToken('{{ $token->id }}')"
+                               wire:loading.attr="disabled">
                                 <i class="fas fa-trash"></i>
                             </a>
                         </td>


### PR DESCRIPTION
# Description
Fixes an issue in which a user could either double click the delete button and throw an error, or throw an error by editing their HTML and providing an un-deletable token ID

Chaining `?` also means an error won't throw if the user were to manually edit the ID to something invalid. 

Should probably start using `wire:loading.attr="disabled"` by default on Livewire buttons, will go through them next week. 

Fixes SC-26090

Had to enable "Slow 3G" in Chrome to test this locally. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)