### PR TITLE
Added skip backup to upgrader, warn on deprecated mail setting

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -198,6 +198,10 @@ foreach ($env as $line_num => $line) {
 
         }
 
+        if ($env_key == 'MAIL_ENCRYPTION') {
+            $env_good .= '! Your .env still contains MAIL_ENCRYPTION (set to '.$env_value.'). This setting has been deprecated. You might need to add MAIL_TLS_VERIFY_PEER=false to your .env to make your mail work as expected.'."\n";
+        }
+
 
     }
 


### PR DESCRIPTION
I'm not sure if this is how we want to handle this exactly, and the upgrader is always notoriously difficult to test (since it upgrades itself in the process, but this was a quick stab at trying to 1) warn folks about the older mail setting and 2) allow folks to skip the backup if their backups aren't configured correctly. 