### PR TITLE
Fixed #15037 - Removed custom fieldsets on auditing - it’s not used (yet)

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -905,26 +905,7 @@ class AssetsController extends Controller
         if ($request->input('update_location') == '1') {
             $asset->location_id = $request->input('location_id');
         }
-
-        if (($asset->model->fieldset)) {
-            foreach ($asset->model->fieldset->fields as $field) {
-                if ($field->field_encrypted == '1') {
-                    if (Gate::allows('admin')) {
-                        if (is_array($request->input($field->db_column))) {
-                            $asset->{$field->db_column} = Crypt::encrypt(implode(', ', $request->input($field->db_column)));
-                        } else {
-                            $asset->{$field->db_column} = Crypt::encrypt($request->input($field->db_column));
-                        }
-                    }
-                } else {
-                    if (is_array($request->input($field->db_column))) {
-                        $asset->{$field->db_column} = implode(', ', $request->input($field->db_column));
-                    } else {
-                        $asset->{$field->db_column} = $request->input($field->db_column);
-                    }
-                }
-            }
-        }
+        
 
         /**
          * Invoke Watson Validating to check the asset itself and check to make sure it saved correctly.


### PR DESCRIPTION
There was a regression introduced where we were apparently trying to handle custom field values on an audit, but we don't have the UI for that at this time so it was overwriting the custom field values on auditing. This at least removes that logic for now. 