### PR TITLE
upgrade.php: If we're on windows, make sure we can load intermediate certificates

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -10,6 +10,12 @@ function url_get_contents ($Url) {
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $Url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    // If we're on windows, make sure we can load intermediate certificates in
+    // weird corporate environments.
+    // See:  https://github.com/curl/curl/commit/2d6333101a71129a6a802eb93f84a5ac89e34479
+    if (PHP_OS == "WINNT"){
+        curl_setopt($ch, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+    }
     $output = curl_exec($ch);
     curl_close($ch);
     return $output;


### PR DESCRIPTION
According to https://github.com/curl/curl/issues/12155 and https://github.com/curl/curl/commit/2d6333101a71129a6a802eb93f84a5ac89e34479

Some corporate Windows proxy (mis)configurations don't pass along
intermediate certificates in their TLS handshakes, breaking lots of
things that don't work around it.

This creates a problem in our curl calls when checking for
.upgrade_requirements.json, and seems to be the source of errors for a
few of our users: https://github.com/snipe/snipe-it/issues/14826#issuecomment-2197611342

In this change, we detect when running on windows environments and load
the curl option that works around this. Loading it in non-windows
environments throws an error, hence the check.