### PR TITLE
Fixes Potential Exception

### DIFF
--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -70,7 +70,7 @@ class CheckoutAcceptance extends Model
      */
     public function isCheckedOutTo(User $user)
     {
-        return $this->assignedTo->is($user);
+        return $this->assignedTo?->is($user);
     }
 
     /**

--- a/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\CheckoutAcceptances\Ui;
 
 use App\Models\Accessory;
+use App\Models\Asset;
 use App\Models\CheckoutAcceptance;
+use App\Models\User;
 use App\Notifications\AcceptanceAssetAcceptedNotification;
 use App\Notifications\AcceptanceAssetDeclinedNotification;
 use Notification;
@@ -75,5 +77,26 @@ class AccessoryAcceptanceTest extends TestCase
                 return true;
             }
         );
+    }
+
+    public function testUserIsNotAbleToAcceptAnAssetAssignedToADifferentUser()
+    {
+        Notification::fake();
+
+        $otherUser = User::factory()->create();
+
+        $acceptance = CheckoutAcceptance::factory()
+            ->pending()
+            ->for(Asset::factory()->laptopMbp(), 'checkoutable')
+            ->create();
+
+        $request = $this->actingAs($otherUser)
+            ->post(route('account.store-acceptance', $acceptance), ['asset_acceptance' => 'accepted'])
+            //->assertSessionHasNoErrors();
+            //->dd()
+            ->assertSessionHasNoErrors();
+
+        $this->assertNotNull($acceptance->fresh()->accepted_at);
+
     }
 }

--- a/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
@@ -90,13 +90,10 @@ class AccessoryAcceptanceTest extends TestCase
             ->for(Asset::factory()->laptopMbp(), 'checkoutable')
             ->create();
 
-        $request = $this->actingAs($otherUser)
+        $this->actingAs($otherUser)
             ->post(route('account.store-acceptance', $acceptance), ['asset_acceptance' => 'accepted'])
-            //->assertSessionHasNoErrors();
-            //->dd()
-            ->assertSessionHasNoErrors();
+            ->assertSessionHas(['error' => trans('admin/users/message.error.incorrect_user_accepted')]);
 
-        $this->assertNotNull($acceptance->fresh()->accepted_at);
-
+        $this->assertNull($acceptance->fresh()->accepted_at);
     }
 }


### PR DESCRIPTION
# Description
Fixes an issue where `assignedTo` could be null resulting in an exception when `->is()` is called. 

Fixes SC-23212

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Test included

**Test Configuration**:
* PHP version: 8.1
* MySQL version 8.2
