### PR TITLE
Fixed missing print user assigned filter

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -6,6 +6,8 @@
 
     <link rel="shortcut icon" type="image/ico" href="{{ ($snipeSettings) && ($snipeSettings->favicon!='') ?  Storage::disk('public')->url(e($snipeSettings->favicon)) : config('app.url').'/favicon.ico' }}">
 
+    <link rel="stylesheet" href="{{ url(mix('css/dist/bootstrap-table.css')) }}">
+
     {{-- stylesheets --}}
     <link rel="stylesheet" href="{{ url(mix('css/dist/all.css')) }}">
 
@@ -386,18 +388,16 @@
 <script src="{{ url(mix('js/dist/all.js')) }}" nonce="{{ csrf_token() }}"></script>
 
 
-@push('css')
-    <link rel="stylesheet" href="{{ url(mix('css/dist/bootstrap-table.css')) }}">
-@endpush
 
-@push('js')
+
+
 
 <script src="{{ url(mix('js/dist/bootstrap-table.js')) }}"></script>
 
 <script>
     $('.snipe-table').bootstrapTable('destroy').each(function () {
-
         console.log('BS table loaded');
+
         data_export_options = $(this).attr('data-export-options');
         export_options = data_export_options ? JSON.parse(data_export_options) : {};
         export_options['htmlContent'] = false; // this is already the default; but let's be explicit about it
@@ -469,7 +469,7 @@
         });
     });
 </script>
-@endpush
+
 
 
 </body>


### PR DESCRIPTION
# Description



A `@endpush` was added recently and seems to have been the culprit for losing the print assigned filter.
So because the print page does not load a layout, using `@push/@endpush` does not work. I removed these and we were able to get the filter to appear again.
<img width="897" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/8f378994-bacb-4b7c-8eda-f34cadb1bc8e">

Shoutout to @marcusmoore for his big brain.

Fixes #FD-42986

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
