### PR TITLE
Adds `snipeit:remove-explicit-eols` command

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -257,7 +257,7 @@ class LdapSync extends Command
 
             //If a sync option is not filled in on the LDAP settings don't populate the user field
             if($ldap_result_username  != null){
-                $user->username = $item[name'];
+                $user->username = $item['username'];
             }
             if($ldap_result_last_name != null){
                 $user->last_name = $item['lastname'];

--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -257,7 +257,7 @@ class LdapSync extends Command
 
             //If a sync option is not filled in on the LDAP settings don't populate the user field
             if($ldap_result_username  != null){
-                $user->username = $item['username'];
+                $user->username = $item[name'];
             }
             if($ldap_result_last_name != null){
                 $user->last_name = $item['lastname'];

--- a/app/Console/Commands/RemoveExplicitEols.php
+++ b/app/Console/Commands/RemoveExplicitEols.php
@@ -13,7 +13,7 @@ class RemoveExplicitEols extends Command
      *
      * @var string
      */
-    protected $signature = 'snipeit:remove-explicit-eols {--model_name=}';
+    protected $signature = 'snipeit:remove-explicit-eols {--model_name= : The name of the asset model to update (use "all" to update all models)}';
 
     /**
      * The console command description.
@@ -27,21 +27,29 @@ class RemoveExplicitEols extends Command
      */
     public function handle()
     {
-        $assetModel= AssetModel::where('name', '=', $this->option('model_name'))->first();
+        if ($this->option('model_name') == 'all') {
+            $assets = Asset::all();
+            $this->updateAssets($assets);
+        } else {
+            $assetModel = AssetModel::where('name', '=', $this->option('model_name'))->first();
 
-        if($assetModel){
-            $assets = Asset::where('model_id', '=', $assetModel->id)->get();
-
-            foreach ($assets as $asset) {
-                $asset->eol_explicit = 0;
-                $asset->asset_eol_date = null;
-                $asset->save();
+            if ($assetModel) {
+                $assets = Asset::where('model_id', '=', $assetModel->id)->get();
+                $this->updateAssets($assets);
+            } else {
+                $this->error('Asset model not found');
             }
+        }
+    }
 
-            $this->info($assets->count().' Assets updated successfully');
+    private function updateAssets($assets)
+    {
+        foreach ($assets as $asset) {
+            $asset->eol_explicit = 0;
+            $asset->asset_eol_date = null;
+            $asset->save();
         }
-        else {
-            $this->error('Asset model not found');
-        }
+
+        $this->info($assets->count() . ' Assets updated successfully');
     }
 }

--- a/app/Console/Commands/RemoveExplicitEols.php
+++ b/app/Console/Commands/RemoveExplicitEols.php
@@ -20,7 +20,7 @@ class RemoveExplicitEols extends Command
      *
      * @var string
      */
-    protected $description = 'remove explicit eols on assets with selected model so they may inherit the asset model eol';
+    protected $description = 'Removes explicit EOLs on assets with selected model so they may inherit the asset model EOL';
 
     /**
      * Execute the console command.

--- a/app/Console/Commands/RemoveExplicitEols.php
+++ b/app/Console/Commands/RemoveExplicitEols.php
@@ -20,7 +20,7 @@ class RemoveExplicitEols extends Command
      *
      * @var string
      */
-    protected $description = 'remove explicit eols on assets with selected model';
+    protected $description = 'remove explicit eols on assets with selected model so they may inherit the asset model eol';
 
     /**
      * Execute the console command.

--- a/app/Console/Commands/RemoveExplicitEols.php
+++ b/app/Console/Commands/RemoveExplicitEols.php
@@ -27,6 +27,8 @@ class RemoveExplicitEols extends Command
      */
     public function handle()
     {
+        $startTime = microtime(true);
+
         if ($this->option('model_name') == 'all') {
             $assets = Asset::all();
             $this->updateAssets($assets);
@@ -40,6 +42,9 @@ class RemoveExplicitEols extends Command
                 $this->error('Asset model not found');
             }
         }
+        $endTime = microtime(true);
+        $executionTime = ($endTime - $startTime);
+        $this->info('Command executed in ' . round($executionTime, 2) . ' seconds.');
     }
 
     private function updateAssets($assets)

--- a/app/Console/Commands/RemoveExplicitEols.php
+++ b/app/Console/Commands/RemoveExplicitEols.php
@@ -13,7 +13,7 @@ class RemoveExplicitEols extends Command
      *
      * @var string
      */
-    protected $signature = 'snipeit:remove-explicit-eols {--model_name=*}';
+    protected $signature = 'snipeit:remove-explicit-eols {--model_name=}';
 
     /**
      * The console command description.
@@ -31,11 +31,17 @@ class RemoveExplicitEols extends Command
 
         if($assetModel){
             $assets = Asset::where('model_id', '=', $assetModel->id)->get();
+
+            foreach ($assets as $asset) {
+                $asset->eol_explicit = 0;
+                $asset->asset_eol_date = null;
+                $asset->save();
+            }
+
+            $this->info($assets->count().' Assets updated successfully');
         }
         else {
             $this->error('Asset model not found');
         }
-
-        dd($assets);
     }
 }

--- a/app/Console/Commands/RemoveExplicitEols.php
+++ b/app/Console/Commands/RemoveExplicitEols.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Asset;
+use App\Models\AssetModel;
+use Illuminate\Console\Command;
+
+class RemoveExplicitEols extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:remove-explicit-eols {--model_name=*}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'remove explicit eols on assets with selected model';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $assetModel= AssetModel::where('name', '=', $this->option('model_name'))->first();
+
+        if($assetModel){
+            $assets = Asset::where('model_id', '=', $assetModel->id)->get();
+        }
+        else {
+            $this->error('Asset model not found');
+        }
+
+        dd($assets);
+    }
+}


### PR DESCRIPTION
# Description
This adds `snipeit:remove-explicit-eols` . This command allows you to provide the Asset model name and then removes the explicit EOLs that are applied to all assets with that model and updating them, this will refresh the assets with the Asset Model's EOL behavior.

This also adds an `"all"` option to update all assets.

Command Options Help:
<img width="779" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/1f7adc20-bc80-4b12-a070-1e1ad3668f0a">

Updating All Assets:
<img width="597" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/8db03a37-b40c-4474-8a2b-4f6dd4b938cd">

Updating one Model:
<img width="597" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/bb0fcabc-ef9a-449b-ae7b-bcfd929c8be3">

Error:
<img width="597" alt="image" src="https://github.com/snipe/snipe-it/assets/47435081/69bee6e7-7af8-4d93-baab-aa97bf2f3725">


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
