### PR TITLE
Fixed inconsistent attributes order in Print All Assigned report

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -151,20 +151,25 @@
 
                         <tr>
                             <td>{{ $counter }}.{{ $assignedCounter }}</td>
-                            <td data-formatter="imageFormatter">
+                            <td>
                                 @if ($asset->getImageUrl())
                                     <img src="{{ $asset->getImageUrl() }}" class="thumbnail" style="max-height: 50px;">
                                 @endif
                             </td>
                             <td>{{ $asset->asset_tag }}</td>
                             <td>{{ $asset->name }}</td>
-                            <td>{{ $asset->model->category->name }}</td>
+                            <td>{{ (($asset->model) && ($asset->model->category)) ? $asset->model->category->name : trans('general.invalid_category') }}</td>
+                            <td>{{ ($asset->model) ? $asset->model->name : trans('general.invalid_model') }}</td>
                             <td>{{ ($asset->defaultLoc) ? $asset->defaultLoc->name : '' }}</td>
                             <td>{{ ($asset->location) ? $asset->location->name : '' }}</td>
-                            <td>{{ $asset->model->name }}</td>
                             <td>{{ $asset->serial }}</td>
-                            <td>{{ $asset->last_checkout }}</td>
-                            <td><img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->first()->accept_signature }}"></td>
+                            <td>
+                                {{ Helper::getFormattedDateObject($asset->last_checkout, 'datetime', false) }}</td>
+                            <td>
+                                @if (($asset->assetlog->first()) && ($asset->assetlog->first()->accept_signature!=''))
+                                    <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->first()->accept_signature }}">
+                                @endif
+                            </td>
                         </tr>
                         @php
                             $assignedCounter++


### PR DESCRIPTION
# Description

This issue affects the "Print All Assigned" report generated for a user.

There was an error in the field orders of assets and associated assets, resulting on having the default location in the "model" column for the associated assets. I also replicated to assignedAssets the control functions on the field values as applied on assets.

Before patch:
![FIX_before-patch](https://github.com/snipe/snipe-it/assets/292081/85505a27-4df9-4b5e-9d1c-42f1c321b3af)
After patch:
![FIX_after-patch](https://github.com/snipe/snipe-it/assets/292081/b47c1c10-680f-49f0-9cf0-0a55dcec4200)


## Type of change

- [x] Bug fix

# How Has This Been Tested?

1. Load the report for an existing user having assets and associated assets
2. Toggle all columns to show them all
3. Verify the assigned assets attributes appear correctly

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
