### PR TITLE
Small consumables optimizations

### DIFF
--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -28,7 +28,7 @@ class ConsumablesController extends Controller
     {
         $this->authorize('index', Consumable::class);
 
-        $consumables = Consumable::with('company', 'location', 'category', 'manufacturer')
+        $consumables = Consumable::with('company', 'location', 'category', 'supplier', 'manufacturer')
             ->withCount('users as consumables_users_count');
 
         if ($request->filled('search')) {

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Events\CheckoutableCheckedOut;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreConsumableRequest;
 use App\Http\Transformers\ConsumablesTransformer;
 use App\Http\Transformers\SelectlistTransformer;
 use App\Models\Company;
@@ -126,7 +127,7 @@ class ConsumablesController extends Controller
      * @since [v4.0]
      * @param  \App\Http\Requests\ImageUploadRequest $request
      */
-    public function store(ImageUploadRequest $request) : JsonResponse
+    public function store(StoreConsumableRequest $request) : JsonResponse
     {
         $this->authorize('create', Consumable::class);
         $consumable = new Consumable;
@@ -162,7 +163,7 @@ class ConsumablesController extends Controller
      * @param  \App\Http\Requests\ImageUploadRequest $request
      * @param  int $id
      */
-    public function update(ImageUploadRequest $request, $id) : JsonResponse
+    public function update(StoreConsumableRequest $request, $id) : JsonResponse
     {
         $this->authorize('update', Consumable::class);
         $consumable = Consumable::findOrFail($id);

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -4,12 +4,11 @@ namespace App\Http\Controllers\Consumables;
 
 use App\Events\CheckoutableCheckedOut;
 use App\Http\Controllers\Controller;
-use App\Models\Accessory;
 use App\Models\Consumable;
 use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Input;
+use \Illuminate\Contracts\View\View;
+use \Illuminate\Http\RedirectResponse;
 
 class ConsumableCheckoutController extends Controller
 {
@@ -20,13 +19,11 @@ class ConsumableCheckoutController extends Controller
      * @see ConsumableCheckoutController::store() method that stores the data.
      * @since [v1.0]
      * @param int $id
-     * @return \Illuminate\Contracts\View\View
-     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function create($id)
+    public function create($id) : View | RedirectResponse
     {
 
-        if ($consumable = Consumable::with('users')->find($id)) {
+        if ($consumable = Consumable::find($id)) {
 
             $this->authorize('checkout', $consumable);
 

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -182,7 +182,7 @@ class ConsumablesController extends Controller
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.not_found'));
         }
         $this->authorize($consumable);
-        $consumable->users()->detach();
+
         $consumable->delete();
         // Redirect to the locations management page
         return redirect()->route('consumables.index')->with('success', trans('admin/consumables/message.delete.success'));

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -182,6 +182,7 @@ class ConsumablesController extends Controller
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.not_found'));
         }
         $this->authorize($consumable);
+        $consumable->users()->detach();
         $consumable->delete();
         // Redirect to the locations management page
         return redirect()->route('consumables.index')->with('success', trans('admin/consumables/message.delete.success'));

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -8,8 +8,10 @@ use App\Http\Requests\ImageUploadRequest;
 use App\Models\Company;
 use App\Models\Consumable;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Http\RedirectResponse;
+use \Illuminate\Contracts\View\View;
+use App\Http\Requests\StoreConsumableRequest;
 
 /**
  * This controller handles all actions related to Consumables for
@@ -62,7 +64,7 @@ class ConsumablesController extends Controller
      * @return \Illuminate\Http\RedirectResponse
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function store(ImageUploadRequest $request)
+    public function store(StoreConsumableRequest $request)
     {
         $this->authorize('create', Consumable::class);
         $consumable = new Consumable();
@@ -99,10 +101,8 @@ class ConsumablesController extends Controller
      * @param  int $consumableId
      * @see ConsumablesController::postEdit() method that stores the form data.
      * @since [v1.0]
-     * @return \Illuminate\Contracts\View\View
-     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function edit($consumableId = null)
+    public function edit($consumableId = null) : View | RedirectResponse
     {
         if ($item = Consumable::find($consumableId)) {
             $this->authorize($item);
@@ -124,7 +124,7 @@ class ConsumablesController extends Controller
      * @see ConsumablesController::getEdit() method that stores the form data.
      * @since [v1.0]
      */
-    public function update(ImageUploadRequest $request, $consumableId = null)
+    public function update(StoreConsumableRequest $request, $consumableId = null)
     {
         if (is_null($consumable = Consumable::find($consumableId))) {
             return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.does_not_exist'));

--- a/app/Http/Requests/StoreConsumableRequest.php
+++ b/app/Http/Requests/StoreConsumableRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Consumable;
+use App\Models\Category;
+use Illuminate\Support\Facades\Gate;
+
+class StoreConsumableRequest extends ImageUploadRequest
+{
+
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('create', new Consumable);
+    }
+
+    public function prepareForValidation(): void
+    {
+
+        if ($this->category_id) {
+            if ($category = Category::find($this->category_id)) {
+                $this->merge([
+                    'category_type' => $category->category_type ?? null,
+                ]);
+            }
+        }
+
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return array_merge(
+            ['category_type' => 'in:consumable'],
+            parent::rules(),
+        );
+    }
+
+    public function messages(): array
+    {
+        $messages = ['category_type.in' => trans('admin/consumables/message.invalid_category_type')];
+        return $messages;
+    }
+
+    public function response(array $errors)
+    {
+        return $this->redirector->back()->withInput()->withErrors($errors, $this->errorBag);
+    }
+}

--- a/app/Models/ConsumableAssignment.php
+++ b/app/Models/ConsumableAssignment.php
@@ -3,12 +3,18 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Watson\Validating\ValidatingTrait;
 
 class ConsumableAssignment extends Model
 {
     use CompanyableTrait;
+    use ValidatingTrait;
 
     protected $table = 'consumables_users';
+
+    public $rules = [
+        'assigned_to'        => 'exists:users,id',
+    ];
 
     public function consumable()
     {

--- a/app/Models/ConsumableAssignment.php
+++ b/app/Models/ConsumableAssignment.php
@@ -13,7 +13,7 @@ class ConsumableAssignment extends Model
     protected $table = 'consumables_users';
 
     public $rules = [
-        'assigned_to'        => 'exists:users,id',
+        'assigned_to'        => 'required|exists:users,id',
     ];
 
     public function consumable()

--- a/app/Observers/ConsumableObserver.php
+++ b/app/Observers/ConsumableObserver.php
@@ -16,12 +16,26 @@ class ConsumableObserver
      */
     public function updated(Consumable $consumable)
     {
-        $logAction = new Actionlog();
-        $logAction->item_type = Consumable::class;
-        $logAction->item_id = $consumable->id;
-        $logAction->created_at = date('Y-m-d H:i:s');
-        $logAction->user_id = Auth::id();
-        $logAction->logaction('update');
+
+        $changed = [];
+        
+        foreach ($consumable->getRawOriginal() as $key => $value) {
+            // Check and see if the value changed
+            if ($consumable->getRawOriginal()[$key] != $consumable->getAttributes()[$key]) {
+                $changed[$key]['old'] = $consumable->getRawOriginal()[$key];
+                $changed[$key]['new'] = $consumable->getAttributes()[$key];
+            }
+        }
+
+        if (count($changed) > 0) {
+            $logAction = new Actionlog();
+            $logAction->item_type = Consumable::class;
+            $logAction->item_id = $consumable->id;
+            $logAction->created_at = date('Y-m-d H:i:s');
+            $logAction->user_id = Auth::id();
+            $logAction->log_meta = json_encode($changed);
+            $logAction->logaction('update');
+        }
     }
 
     /**

--- a/app/Observers/ConsumableObserver.php
+++ b/app/Observers/ConsumableObserver.php
@@ -70,14 +70,18 @@ class ConsumableObserver
     {
 
         $consumable->users()->detach();
+        $uploads = $consumable->uploads;
 
-        foreach ($consumable->uploads() as $file) {
+        foreach ($uploads as $file) {
             try {
-                Storage::disk('public')->delete('consumables/'.$file);
+                Storage::delete('private_uploads/consumables/'.$file->filename);
+                $file->delete();
             } catch (\Exception $e) {
                 Log::info($e);
             }
         }
+
+
 
         try {
             Storage::disk('public')->delete('consumables/'.$consumable->image);

--- a/app/Presenters/ActionlogPresenter.php
+++ b/app/Presenters/ActionlogPresenter.php
@@ -75,7 +75,7 @@ class ActionlogPresenter extends Presenter
         }
 
         if ($this->actionType()=='delete') {
-            return 'fa-solid fa-user-xmark';
+            return 'fa-solid fa-trash';
         }
 
         if ($this->actionType()=='update') {

--- a/resources/lang/en-US/admin/consumables/message.php
+++ b/resources/lang/en-US/admin/consumables/message.php
@@ -2,6 +2,7 @@
 
 return array(
 
+    'invalid_category_type' => 'The category must be a consumable category.',
     'does_not_exist' => 'Consumable does not exist.',
 
     'create' => array(

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -37,6 +37,25 @@
           </div>
           @endif
 
+          <!-- total -->
+          <div class="form-group">
+              <label class="col-sm-3 control-label">{{  trans('admin/components/general.total') }}</label>
+              <div class="col-md-6">
+                  <p class="form-control-static">{{ $consumable->qty }}</p>
+              </div>
+          </div>
+
+          <!-- remaining -->
+          <div class="form-group">
+              <label class="col-sm-3 control-label">{{  trans('admin/components/general.remaining') }}</label>
+              <div class="col-md-6">
+                  <p class="form-control-static">{{ $consumable->numRemaining() }}</p>
+              </div>
+          </div>
+
+
+
+
           <!-- User -->
             @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_to', 'required'=> 'true'])
 

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -176,6 +176,7 @@
                           <i class="fas fa-trash icon-white" aria-hidden="true"></i>
                           <span class="sr-only">{{ trans('general.delete') }}</span>
                         </a>
+
                       </td>
                     </tr>
                   @endforeach
@@ -254,6 +255,19 @@
                   </div>
                 @endif
 
+                @if ($consumable->notes)
+
+                  <div class="col-md-12">
+                    <strong>
+                      {{ trans('general.notes') }}:
+                    </strong>
+                  </div>
+                    <div class="col-md-12">
+                    {!! nl2br(Helper::parseEscapedMarkedownInline($consumable->notes)) !!}
+                    </div>
+
+                @endif
+
     @can('checkout', \App\Models\Consumable::class)
 
       <div class="col-md-12">
@@ -268,21 +282,23 @@
           </button>
         @endif
       </div>
+        @can('update', \App\Models\Consumable::class)
+            <div class="col-md-12">
+              <a href="{{ route('consumables.edit', $consumable->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('button.edit') }}</a>
+            </div>
+        @endcan
+
+          @can('delete', $consumable)
+            <div class="col-md-12" style="padding-top: 30px; padding-bottom: 30px;">
+              @if ($consumable->deleted_at=='')
+                <button class="btn btn-sm btn-block btn-danger delete-asset" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $consumable->id]) }}" data-target="#dataConfirmModal">{{ trans('general.delete') }}
+                </button>
+                <span class="sr-only">{{ trans('general.delete') }}</span>
+              @endif
+            </div>
+          @endcan
 
     @endcan
-
-    @if ($consumable->notes)
-
-    <div class="col-md-12">
-      <strong>
-        {{ trans('general.notes') }}:
-      </strong>
-              </div>
-    <div class="col-md-12">
-      {!! nl2br(Helper::parseEscapedMarkedownInline($consumable->notes)) !!}
-            </div>
-          </div>
-  @endif
 
     </div>
 
@@ -297,5 +313,16 @@
 @stop
 
 @section('moar_scripts')
+      <script>
+
+        $('#dataConfirmModal').on('show.bs.modal', function (event) {
+          var content = $(event.relatedTarget).data('content');
+          var title = $(event.relatedTarget).data('title');
+          $(this).find(".modal-body").text(content);
+          $(this).find(".modal-header").text(title);
+        });
+
+      </script>
+
 @include ('partials.bootstrap-table', ['exportFile' => 'consumable' . $consumable->name . '-export', 'search' => false])
 @stop

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -351,7 +351,7 @@
           @can('delete', $consumable)
             <div class="col-md-12" style="padding-top: 30px; padding-bottom: 30px;">
               @if ($consumable->deleted_at=='')
-                <button class="btn btn-sm btn-block btn-danger delete-asset" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $consumable->id]) }}" data-target="#dataConfirmModal">{{ trans('general.delete') }}
+                <button class="btn btn-sm btn-block btn-danger delete-asset" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $consumable->name]) }}" data-target="#dataConfirmModal">{{ trans('general.delete') }}
                 </button>
                 <span class="sr-only">{{ trans('general.delete') }}</span>
               @endif

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -45,6 +45,17 @@
           </li>
         @endcan
 
+      <li>
+        <a href="#history" data-toggle="tab">
+        <span class="hidden-lg hidden-md">
+          <i class="fas fa-history fa-2x" aria-hidden="true"></i>
+        </span>
+        <span class="hidden-xs hidden-sm">
+          {{ trans('general.history') }}
+        </span>
+        </a>
+      </li>
+
         @can('update', $consumable)
           <li class="pull-right">
             <a href="#" data-toggle="modal" data-target="#uploadFileModal">
@@ -95,7 +106,56 @@
         </div> <!-- close tab-pane div -->
 
 
-        @can('consumables.files', $consumable)
+        <div class="tab-pane fade" id="history">
+          <!-- checked out assets table -->
+          <div class="row">
+            <div class="col-md-12">
+              <table
+                      class="table table-striped snipe-table"
+                      id="consumableHistory"
+                      data-pagination="true"
+                      data-id-table="consumableHistory"
+                      data-search="true"
+                      data-side-pagination="server"
+                      data-show-columns="true"
+                      data-show-fullscreen="true"
+                      data-show-refresh="true"
+                      data-sort-order="desc"
+                      data-sort-name="created_at"
+                      data-show-export="true"
+                      data-export-options='{
+                         "fileName": "export-consumable-{{  $consumable->id }}-history",
+                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                       }'
+
+                      data-url="{{ route('api.activity.index', ['item_id' => $consumable->id, 'item_type' => 'consumable']) }}"
+                      data-cookie-id-table="assetHistory"
+                      data-cookie="true">
+                <thead>
+                <tr>
+                  <th data-visible="true" data-field="icon" style="width: 40px;" class="hidden-xs" data-formatter="iconFormatter">{{ trans('admin/hardware/table.icon') }}</th>
+                  <th data-visible="true" data-field="action_date" data-sortable="true" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
+                  <th data-visible="true" data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.admin') }}</th>
+                  <th data-visible="true" data-field="action_type">{{ trans('general.action') }}</th>
+                  <th class="col-sm-2" data-field="file" data-visible="false" data-formatter="fileUploadNameFormatter">{{ trans('general.file_name') }}</th>
+                  <th data-visible="true" data-field="item" data-formatter="polymorphicItemFormatter">{{ trans('general.item') }}</th>
+                  <th data-visible="true" data-field="target" data-formatter="polymorphicItemFormatter">{{ trans('general.target') }}</th>
+                  <th data-field="note">{{ trans('general.notes') }}</th>
+                  <th data-field="signature_file" data-visible="false"  data-formatter="imageFormatter">{{ trans('general.signature') }}</th>
+                  <th data-visible="false" data-field="file" data-visible="false"  data-formatter="fileUploadFormatter">{{ trans('general.download') }}</th>
+                  <th data-field="log_meta" data-visible="true" data-formatter="changeLogFormatter">{{ trans('admin/hardware/table.changed')}}</th>
+                  <th data-field="remote_ip" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_ip') }}</th>
+                  <th data-field="user_agent" data-visible="false" data-sortable="true">{{ trans('admin/settings/general.login_user_agent') }}</th>
+                  <th data-field="action_source" data-visible="false" data-sortable="true">{{ trans('general.action_source') }}</th>
+                </tr>
+                </thead>
+              </table>
+            </div>
+          </div> <!-- /.row -->
+        </div> <!-- /.tab-pane history -->
+
+
+      @can('consumables.files', $consumable)
           <div class="tab-pane" id="files">
 
             <div class="table-responsive">

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -976,7 +976,7 @@ dir="{{ in_array(app()->getLocale(),['ar-SA','fa-IR', 'he-IL']) ? 'rtl' : 'ltr' 
             // Reference: https://jqueryvalidation.org/validate/
             $('#create-form').validate({
                 ignore: 'input[type=hidden]',
-                errorClass: 'help-block form-error',
+                errorClass: 'alert-msg',
                 errorElement: 'span',
                 errorPlacement: function(error, element) {
                     $(element).hasClass('select2') || $(element).hasClass('js-data-ajax')

--- a/resources/views/partials/forms/edit/category-select.blade.php
+++ b/resources/views/partials/forms/edit/category-select.blade.php
@@ -25,4 +25,6 @@
 
 
     {!! $errors->first($fieldname, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+
+    {!! $errors->first('category_type', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
 </div>

--- a/resources/views/partials/forms/edit/minimum_quantity.blade.php
+++ b/resources/views/partials/forms/edit/minimum_quantity.blade.php
@@ -3,13 +3,13 @@
     <label for="min_amt" class="col-md-3 control-label">{{ trans('general.min_amt') }}</label>
     <div class="col-md-9{{  (Helper::checkIfRequired($item, 'min_amt')) ? ' required' : '' }}">
        <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control col-md-3" type="text" name="min_amt" id="min_amt" aria-label="min_amt" value="{{ old('min_amt', $item->min_amt) }}" />
+            <input class="form-control col-md-3" maxlength="5" type="text" name="min_amt" id="min_amt" aria-label="min_amt" value="{{ old('min_amt', $item->min_amt) }}" />
         </div>
             <div class="col-md-7" style="margin-left: -15px;">
+
                 <a href="#" data-tooltip="true" title="{{ trans('general.min_amt_help') }}"><i class="fas fa-info-circle" aria-hidden="true"></i>
                 <span class="sr-only">{{ trans('general.min_amt_help') }}</span>
             </a>
-
         </div>
         <div class="col-md-12">
            {!! $errors->first('min_amt', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/partials/forms/edit/quantity.blade.php
+++ b/resources/views/partials/forms/edit/quantity.blade.php
@@ -4,8 +4,10 @@
     <label for="qty" class="col-md-3 control-label">{{ trans('general.quantity') }}</label>
     <div class="col-md-7{{  (Helper::checkIfRequired($item, 'qty')) ? ' required' : '' }}">
        <div class="col-md-3" style="padding-left:0px">
-           <input class="form-control" type="text" name="qty" aria-label="qty" id="qty" value="{{ old('qty', $item->qty) }}" {!!  (Helper::checkIfRequired($item, 'qty')) ? ' required ' : '' !!}/>
+           <input class="form-control" maxlength="5" type="text" name="qty" aria-label="qty" id="qty" value="{{ old('qty', $item->qty) }}" {!!  (Helper::checkIfRequired($item, 'qty')) ? ' required ' : '' !!}/>
        </div>
+        <div class="col-md-12" style="padding-left:0px">
        {!! $errors->first('qty', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        </div>
    </div>
 </div>

--- a/tests/Feature/Categories/Api/IndexCategoriesTest.php
+++ b/tests/Feature/Categories/Api/IndexCategoriesTest.php
@@ -32,7 +32,6 @@ class IndexCategoriesTest extends TestCase
                     'limit' => '20',
                 ]))
             ->assertOk()
-            ->assertOk()
             ->assertJsonStructure([
                 'total',
                 'rows',

--- a/tests/Feature/Consumables/Api/ConsumableIndexTest.php
+++ b/tests/Feature/Consumables/Api/ConsumableIndexTest.php
@@ -54,4 +54,29 @@ class ConsumableIndexTest extends TestCase
             ->assertResponseDoesNotContainInRows($consumableA)
             ->assertResponseContainsInRows($consumableB);
     }
+
+    public function testConsumableIndexReturnsExpectedSearchResults()
+    {
+        Consumable::factory()->count(10)->create();
+        Consumable::factory()->count(1)->create(['name' => 'My Test Consumable']);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(
+                route('api.consumables.index', [
+                    'search' => 'My Test Consumable',
+                    'sort' => 'name',
+                    'order' => 'asc',
+                    'offset' => '0',
+                    'limit' => '20',
+                ]))
+            ->assertOk()
+            ->assertJsonStructure([
+                'total',
+                'rows',
+            ])
+            ->assertJson([
+                'total' => 1,
+            ]);
+
+    }
 }

--- a/tests/Feature/Consumables/Api/ConsumableUpdateTest.php
+++ b/tests/Feature/Consumables/Api/ConsumableUpdateTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature\Consumables\Api;
+
+use App\Models\Consumable;
+use App\Models\Category;
+use App\Models\User;
+use Tests\TestCase;
+
+class ConsumableUpdateTest extends TestCase
+{
+
+    public function testCanUpdateConsumableViaPatchWithoutCategoryType()
+    {
+        $consumable = Consumable::factory()->create();
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson(route('api.consumables.update', $consumable), [
+                'name' => 'Test Consumable',
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success')
+            ->assertStatus(200)
+            ->json();
+
+        $consumable->refresh();
+        $this->assertEquals('Test Consumable', $consumable->name, 'Name was not updated');
+
+    }
+
+    public function testCannotUpdateConsumableViaPatchWithInvalidCategoryType()
+    {
+        $category = Category::factory()->create(['category_type' => 'asset']);
+        $consumable = Consumable::factory()->create();
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->patchJson(route('api.consumables.update', $consumable), [
+                'name' => 'Test Consumable',
+                'category_id' => $category->id,
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('error')
+            ->assertStatus(200)
+            ->json();
+
+        $category->refresh();
+        $this->assertNotEquals('Test Consumable', $consumable->name, 'Name was not updated');
+        $this->assertNotEquals('consumable', $consumable->category_id, 'Category was not updated');
+
+    }
+
+}

--- a/tests/Feature/Consumables/Api/ConsumableViewTest.php
+++ b/tests/Feature/Consumables/Api/ConsumableViewTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\Consumables\Api;
+
+use App\Models\Company;
+use App\Models\Consumable;
+use App\Models\User;
+use Tests\TestCase;
+
+class ConsumableViewTest extends TestCase
+{
+    public function testConsumableViewAdheresToCompanyScoping()
+    {
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $consumableA = Consumable::factory()->for($companyA)->create();
+        $consumableB = Consumable::factory()->for($companyB)->create();
+
+        $superUser = $companyA->users()->save(User::factory()->superuser()->make());
+        $userInCompanyA = $companyA->users()->save(User::factory()->viewConsumables()->make());
+        $userInCompanyB = $companyB->users()->save(User::factory()->viewConsumables()->make());
+
+        $this->settings->disableMultipleFullCompanySupport();
+
+        $this->actingAsForApi($superUser)
+            ->getJson(route('api.consumables.show', $consumableA))
+            ->assertOk();
+
+        $this->actingAsForApi($userInCompanyA)
+            ->getJson(route('api.consumables.show', $consumableA))
+            ->assertOk();
+
+        $this->actingAsForApi($userInCompanyB)
+            ->getJson(route('api.consumables.show', $consumableB))
+            ->assertOk();
+
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $this->actingAsForApi($superUser)
+            ->getJson(route('api.consumables.show', $consumableA))
+            ->assertOk();
+
+        $this->actingAsForApi($userInCompanyA)
+            ->getJson(route('api.consumables.index'))
+            ->assertOk();
+
+        $this->actingAsForApi($userInCompanyB)
+            ->getJson(route('api.consumables.index'))
+            ->assertOk();
+    }
+}

--- a/tests/Feature/Consumables/Ui/ConsumableViewTest.php
+++ b/tests/Feature/Consumables/Ui/ConsumableViewTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature\Consumables\Ui;
+
+use App\Models\Consumable;
+use App\Models\User;
+use Tests\TestCase;
+
+class ConsumableViewTest extends TestCase
+{
+    public function testPermissionRequiredToViewConsumable()
+    {
+        $consumable = Consumable::factory()->create();
+        $this->actingAs(User::factory()->create())
+            ->get(route('consumables.show', $consumable))
+            ->assertForbidden();
+    }
+
+    public function testUserCanListConsumables()
+    {
+        $consumable = Consumable::factory()->create();
+        $this->actingAs(User::factory()->superuser()->create())
+            ->get(route('consumables.show', $consumable))
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
This came up today for a customer where someone on their team was playing around with the system and created a quarter of a million consumables checkouts, which exposed a few query optimizations we could do. Since I was in there, I also tightened up some of the layout (we hadn't noticed it looked weird before) and added some more tests. I also added in a form request to make sure we cannot change the category type to a non-consumable type, either by fiddling with the DOM or via API.

I also realized that when we delete a consumable, we weren't actually detaching those pivot table records. 😬 We also weren't capturing the log meta for editing consumables, which we now do.

Still plenty of work to be done here, of course, but this should make things a little tighter.