### PR TITLE
Added #14821: Add Filter by Asset Tag in Custom Reports

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -672,6 +672,10 @@ class ReportsController extends Controller
                 $assets->where('assets.order_number', $request->input('by_order_number'));
             }
 
+            if ($request->filled('by_asset_tag')) {
+                $assets->where('assets.asset_tag', $request->input('by_asset_tag'));
+            }
+
             if ($request->filled('by_status_id')) {
                 $assets->whereIn('assets.status_id', $request->input('by_status_id'));
             }

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -288,6 +288,14 @@
             @include ('partials.forms.edit.category-select', ['translated_name' => trans('general.category'), 'fieldname' => 'by_category_id', 'hide_new' => 'true', 'category_type' => 'asset'])
               @include ('partials.forms.edit.status-select', ['translated_name' => trans('admin/hardware/form.status'), 'fieldname' => 'by_status_id[]', 'multiple' => 'true', 'hide_new' => 'true'])
 
+            <!-- Asset Tag -->
+            <div class="form-group">
+              <label for="by_asset_tag" class="col-md-3 control-label">{{ trans('general.asset_tag') }}</label>
+              <div class="col-md-7">
+                <input class="form-control" type="text" name="by_asset_tag" value="" aria-label="by_asset_tag">
+              </div>
+            </div>
+
             <!-- Order Number -->
             <div class="form-group">
               <label for="by_order_number" class="col-md-3 control-label">{{ trans('general.order_number') }}</label>


### PR DESCRIPTION
This PR adds an "Asset Tag" text input field to the create custom asset reports page and the if condition in the Reportscontroller to allow the creation of a report for a specific asset defined by the asset tag.
It only works for one asset tag at a time.

Fixes #14821 only adds the workaround mentioned in the Issue, the rest is still relevant.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested by creating a custom report for a specific asset tag.

**Test Configuration**:
* PHP version: 8.2.20
* MySQL version: mariadb  Ver 15.1 Distrib 10.11.6-MariaDB
* Webserver version: Apache/2.4.59 (Debian)
* OS version: Debian GNU/Linux 12 (bookworm) Release 12.6

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
