### PR TITLE
Fixed #10224: fix route names for optimize command

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -549,28 +549,28 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
               Api\AssetFilesController::class,
               'store'
           ]
-        )->name('api.assets.files');
+        )->name('api.assets.files.store');
 
         Route::get('{asset_id}/files',
           [
               Api\AssetFilesController::class,
               'list'
           ]
-        )->name('api.assets.files');
+        )->name('api.assets.files.index');
 
         Route::get('{asset_id}/file/{file_id}',
           [
               Api\AssetFilesController::class,
               'show'
           ]
-        )->name('api.assets.file');
+        )->name('api.assets.files.show');
 
         Route::delete('{asset_id}/file/{file_id}',
           [
               Api\AssetFilesController::class,
               'destroy'
           ]
-        )->name('api.assets.file');
+        )->name('api.assets.files.destroy');
 
       });
 

--- a/tests/Feature/Assets/Api/AssetFilesTest.php
+++ b/tests/Feature/Assets/Api/AssetFilesTest.php
@@ -22,7 +22,7 @@ class AssetFilesTest extends TestCase
 	//Upload a file
 	$this->actingAsForApi($user)
             ->post(
-               route('api.assets.files', ['asset_id' => $asset[0]["id"]]), [
+               route('api.assets.files.store', ['asset_id' => $asset[0]["id"]]), [
 		       'file' => [UploadedFile::fake()->create("test.jpg", 100)]
 	       ])
 	       ->assertOk();
@@ -41,7 +41,7 @@ class AssetFilesTest extends TestCase
 	// List the files
 	$this->actingAsForApi($user)
             ->getJson(
-		    route('api.assets.files', ['asset_id' => $asset[0]["id"]]))
+		    route('api.assets.files.index', ['asset_id' => $asset[0]["id"]]))
                 ->assertOk()
 		->assertJsonStructure([
                     'status',
@@ -63,7 +63,7 @@ class AssetFilesTest extends TestCase
 	//Upload a file
 	$this->actingAsForApi($user)
             ->post(
-               route('api.assets.files', ['asset_id' => $asset[0]["id"]]), [
+               route('api.assets.files.store', ['asset_id' => $asset[0]["id"]]), [
 		       'file' => [UploadedFile::fake()->create("test.jpg", 100)]
 	       ])
 	       ->assertOk();
@@ -71,13 +71,13 @@ class AssetFilesTest extends TestCase
 	// List the files to get the file ID
 	$result = $this->actingAsForApi($user)
             ->getJson(
-		    route('api.assets.files', ['asset_id' => $asset[0]["id"]]))
+		    route('api.assets.files.index', ['asset_id' => $asset[0]["id"]]))
                 ->assertOk();
 
 	// Get the file
 	$this->actingAsForApi($user)
             ->get(
-               route('api.assets.file', [
+               route('api.assets.files.show', [
                    'asset_id' => $asset[0]["id"],
                    'file_id' => $result->decodeResponseJson()->json()["payload"][0]["id"],
 	       ]))
@@ -97,7 +97,7 @@ class AssetFilesTest extends TestCase
 	//Upload a file
 	$this->actingAsForApi($user)
             ->post(
-               route('api.assets.files', ['asset_id' => $asset[0]["id"]]), [
+               route('api.assets.files.store', ['asset_id' => $asset[0]["id"]]), [
 		       'file' => [UploadedFile::fake()->create("test.jpg", 100)]
 	       ])
 	       ->assertOk();
@@ -105,13 +105,13 @@ class AssetFilesTest extends TestCase
 	// List the files to get the file ID
 	$result = $this->actingAsForApi($user)
             ->getJson(
-		    route('api.assets.files', ['asset_id' => $asset[0]["id"]]))
+		    route('api.assets.files.index', ['asset_id' => $asset[0]["id"]]))
                 ->assertOk();
 
 	// Delete the file
 	$this->actingAsForApi($user)
             ->delete(
-               route('api.assets.file', [
+               route('api.assets.files.destroy', [
                    'asset_id' => $asset[0]["id"],
                    'file_id' => $result->decodeResponseJson()->json()["payload"][0]["id"],
 	       ]))

--- a/tests/Feature/Console/OptimizeTest.php
+++ b/tests/Feature/Console/OptimizeTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class OptimizeTest extends TestCase
+{
+    public function testOptimizeSucceeds()
+    {
+        $this->artisan('optimize')->assertSuccessful();
+    }
+}


### PR DESCRIPTION
# Description

Fixes some duplicate route names in `routes/api.php` for the `Api\AssetFilesController`:
- `api.assets.files` was used for both `list` and `store`
- `api.assets.file` was used for both `show` and `destroy`

This led to `artisan route:cache` and `artisan optimize` to fail (also see #11595 which fixed this for web routes).

This PR also introduces a new `OptimizeTest` to ensure that `artisan optimize` runs successfully. 

Fixes #10224

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] `Tests\Feature\Console\OptimizeTest`
