### PR TITLE
Fixes #15067 - updated ldap sync locale to use `app()->getLocale()`

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -251,7 +251,7 @@ class LdapSync extends Command
                     // Creating a new user.
                     $user = new User;
                     $user->password = $user->noPassword();
-                    $item['locale'] = app()->getLocale();
+                    $user->locale = app()->getLocale();
                     $user->activated = 1; // newly created users can log in by default, unless AD's UAC is in use, or an active flag is set (below)
                     $item['createorupdate'] = 'created';
                 }

--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -232,6 +232,7 @@ class LdapSync extends Command
                 $item['department'] = $results[$i][$ldap_result_dept][0] ?? '';
                 $item['manager'] = $results[$i][$ldap_result_manager][0] ?? '';
                 $item['location'] = $results[$i][$ldap_result_location][0] ?? '';
+                $item['locale'] = app()->getLocale();
 
                 // ONLY if you are using the "ldap_location" option *AND* you have an actual result
                 if ($ldap_result_location && $item['location']) {

--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -232,7 +232,6 @@ class LdapSync extends Command
                 $item['department'] = $results[$i][$ldap_result_dept][0] ?? '';
                 $item['manager'] = $results[$i][$ldap_result_manager][0] ?? '';
                 $item['location'] = $results[$i][$ldap_result_location][0] ?? '';
-                $item['locale'] = app()->getLocale();
 
                 // ONLY if you are using the "ldap_location" option *AND* you have an actual result
                 if ($ldap_result_location && $item['location']) {
@@ -252,6 +251,7 @@ class LdapSync extends Command
                     // Creating a new user.
                     $user = new User;
                     $user->password = $user->noPassword();
+                    $item['locale'] = app()->getLocale();
                     $user->activated = 1; // newly created users can log in by default, unless AD's UAC is in use, or an active flag is set (below)
                     $item['createorupdate'] = 'created';
                 }

--- a/app/Http/Middleware/CheckLocale.php
+++ b/app/Http/Middleware/CheckLocale.php
@@ -45,7 +45,7 @@ class CheckLocale
 
         }
         
-        \App::setLocale(Helper::mapLegacyLocale($language));
+        app()->setLocale(Helper::mapLegacyLocale($language));
         return $next($request);
     }
 }

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -229,6 +229,7 @@ class Ldap extends Model
         $item['department'] = $ldapattributes[$ldap_result_dept][0] ?? '';
         $item['manager'] = $ldapattributes[$ldap_result_manager][0] ?? '';
         $item['location'] = $ldapattributes[$ldap_result_location][0] ?? '';
+        $item['locale'] = app()->getLocale();
 
         return $item;
     }
@@ -239,7 +240,7 @@ class Ldap extends Model
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v3.0]
      * @param $ldapatttibutes
-     * @return array|bool
+     * @return User | bool
      */
     public static function createUserFromLdap($ldapatttibutes, $password)
     {
@@ -252,6 +253,7 @@ class Ldap extends Model
             $user->last_name = $item['lastname'];
             $user->username = $item['username'];
             $user->email = $item['email'];
+            $user->locale = $item['locale'];
             $user->password = $user->noPassword();
 
             if (Setting::getSettings()->ldap_pw_sync == '1') {


### PR DESCRIPTION
We were previously not setting a locale for imported/updated LDAP users, which would default them to `en-US`. This means that if the `.env` `APP_LOCALE` was set to something like `de-DE`, the user, on creation, would get created with `en-US`. This should fix this by using the `app()->getLocale()` value for the newly created user.  This will NOT update existing users who are *already* synced with LDAP, as they may have already been manually updated and we won't want to override that.

Should fix #15067.