### PR TITLE
Small layout tweaks to oauth page

### DIFF
--- a/resources/lang/en-US/account/general.php
+++ b/resources/lang/en-US/account/general.php
@@ -12,4 +12,5 @@ return array(
     'api_reference' => 'Please check the <a href="https://snipe-it.readme.io/reference" target="_blank">API reference</a> to find specific API endpoints and additional API documentation.',
     'profile_updated' => 'Account successfully updated',
     'no_tokens' => 'You have not created any personal access tokens.',
+    'expires' => 'Expires',
 );

--- a/resources/lang/en-US/account/general.php
+++ b/resources/lang/en-US/account/general.php
@@ -12,5 +12,4 @@ return array(
     'api_reference' => 'Please check the <a href="https://snipe-it.readme.io/reference" target="_blank">API reference</a> to find specific API endpoints and additional API documentation.',
     'profile_updated' => 'Account successfully updated',
     'no_tokens' => 'You have not created any personal access tokens.',
-    'expires' => 'Expires',
 );

--- a/resources/views/livewire/oauth-clients.blade.php
+++ b/resources/views/livewire/oauth-clients.blade.php
@@ -48,7 +48,11 @@
                             <th data-sortable="true">{{ trans('admin/settings/general.oauth_secret') }}</th>
                             <th data-sortable="true">{{ trans('general.created_at')  }}</th>
                             <th data-sortable="true">{{ trans('general.updated_at')  }}</th>
-                            <th data-sortable="true"><span class="sr-only">{{ trans('general.actions') }}</span></th>
+                            <th>
+                                <span class="sr-only">
+                                    {{ trans('general.actions') }}
+                                </span>
+                            </th>
                         </tr>
                     </thead>
                     <tbody>
@@ -90,7 +94,10 @@
                                     <a class="action-link btn btn-sm btn-warning"
                                        wire:click="editClient('{{ $client->id }}')"
                                        onclick="$('#modal-edit-client').modal('show');">
-                                        <i class="fas fa-pencil-alt" aria-hidden="true"></i><span class="sr-only">{{ trans('general.update') }}</span>
+                                        <i class="fas fa-pencil-alt" aria-hidden="true"></i>
+                                        <span class="sr-only">
+                                            {{ trans('general.update') }}
+                                        </span>
                                     </a>
 
                                     <a class="action-link btn btn-danger btn-sm" wire:click="deleteClient('{{ $client->id }}')">
@@ -115,21 +122,21 @@
                 <div>
                     <div class="box box-default">
                         <div class="box-header">
-                            <h2  class="box-title">
+                            <h2 class="box-title">
                                 {{ trans('admin/settings/general.oauth_authorized_apps') }}
                             </h2>
                         </div>
 
                         <div class="box-body">
                             <!-- Authorized Tokens -->
-                            <table data-cookie-id-table="AuthorizedAppsTale"
+                            <table data-cookie-id-table="AuthorizedAppsTable"
                                    data-pagination="true"
-                                   data-id-table="AuthorizedAppsTale"
+                                   data-id-table="AuthorizedAppsTable"
                                    data-toolbar="#AuthorizedAppsToolbar"
                                    data-side-pagination="client"
                                    data-sort-order="desc"
                                    data-sort-name="created_at"
-                                   id="AuthorizedAppsTale"
+                                   id="AuthorizedAppsTable"
                                    class="table table-striped snipe-table">
                                 <thead>
                                 <tr>
@@ -137,8 +144,12 @@
                                     <th data-sortable="true"> {{ trans('account/general.personal_access_token') }}</th>
                                     <th data-sortable="true">{{ trans('admin/settings/general.oauth_scopes')  }}</th>
                                     <th data-sortable="true">{{ trans('general.created_at')  }}</th>
-                                    <th data-sortable="true">{{ trans('account/general.expires')  }}</th>
-                                    <th></th>
+                                    <th data-sortable="true">{{ trans('general.expires') }}</th>
+                                    <th>
+                                        <span class="sr-only">
+                                            {{ trans('general.actions') }}
+                                        </span>
+                                    </th>
                                 </tr>
                                 </thead>
 

--- a/resources/views/livewire/oauth-clients.blade.php
+++ b/resources/views/livewire/oauth-clients.blade.php
@@ -32,14 +32,23 @@
                 @endif
 
             @if ($clients->count() > 0)
-                <table class="table table-striped snipe-table">
+                    <table data-cookie-id-table="OAuthClientsTable"
+                           data-pagination="true"
+                           data-id-table="OAuthClientsTable"
+                           data-side-pagination="client"
+                           data-sort-order="desc"
+                           data-sort-name="created_at"
+                           id="OAuthClientsTable"
+                           class="table table-striped snipe-table">
                     <thead>
                         <tr>
                             <th>{{ trans('general.id') }}</th>
-                            <th>{{ trans('general.name') }}</th>
-                            <th>{{ trans('admin/settings/general.oauth_redirect_url') }}</th>
-                            <th>{{ trans('admin/settings/general.oauth_secret') }}</th>
-                            <th><span class="sr-only">{{ trans('general.actions') }}</span></th>
+                            <th data-sortable="true">{{ trans('general.name') }}</th>
+                            <th data-sortable="true">{{ trans('admin/settings/general.oauth_redirect_url') }}</th>
+                            <th data-sortable="true">{{ trans('admin/settings/general.oauth_secret') }}</th>
+                            <th data-sortable="true">{{ trans('general.created_at')  }}</th>
+                            <th data-sortable="true">{{ trans('general.updated_at')  }}</th>
+                            <th data-sortable="true"><span class="sr-only">{{ trans('general.actions') }}</span></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -57,12 +66,22 @@
 
                                 <!-- Redirect -->
                                 <td>
-                                    {{ $client->redirect }}
+                                    <code>{{ $client->redirect }}</code>
                                 </td>
 
                                 <!-- Secret -->
                                 <td>
                                     <code>{{ $client->secret }}</code>
+                                </td>
+
+                                <td>
+                                    {{ $client->created_at ? Helper::getFormattedDateObject($client->created_at, 'datetime', false) : '' }}
+                                </td>
+
+                                <td>
+                                    @if ($client->created_at != $client->updated_at)
+                                        {{ $client->updated_at ? Helper::getFormattedDateObject($client->updated_at, 'datetime', false) : '' }}
+                                    @endif
                                 </td>
 
                                 <!-- Edit / Delete Button -->
@@ -77,8 +96,8 @@
                                     <a class="action-link btn btn-danger btn-sm" wire:click="deleteClient('{{ $client->id }}')">
                                         <i class="fas fa-trash" aria-hidden="true"></i>
                                         <span class="sr-only">
-                                                    {{ trans('general.delete') }}
-                                                </span>
+                                            {{ trans('general.delete') }}
+                                        </span>
                                     </a>
                                 </td>
                             </tr>
@@ -96,18 +115,29 @@
                 <div>
                     <div class="box box-default">
                         <div class="box-header">
-                            <h2>
+                            <h2  class="box-title">
                                 {{ trans('admin/settings/general.oauth_authorized_apps') }}
                             </h2>
                         </div>
 
                         <div class="box-body">
                             <!-- Authorized Tokens -->
-                            <table class="table table-striped snipe-table">
+                            <table data-cookie-id-table="AuthorizedAppsTale"
+                                   data-pagination="true"
+                                   data-id-table="AuthorizedAppsTale"
+                                   data-toolbar="#AuthorizedAppsToolbar"
+                                   data-side-pagination="client"
+                                   data-sort-order="desc"
+                                   data-sort-name="created_at"
+                                   id="AuthorizedAppsTale"
+                                   class="table table-striped snipe-table">
                                 <thead>
                                 <tr>
-                                    <th>{{ trans('general.name') }}</th>
-                                    <th>{{ trans('admin/settings/general.oauth_scopes')  }}</th>
+                                    <th data-sortable="true">{{ trans('general.name') }}</th>
+                                    <th data-sortable="true"> {{ trans('account/general.personal_access_token') }}</th>
+                                    <th data-sortable="true">{{ trans('admin/settings/general.oauth_scopes')  }}</th>
+                                    <th data-sortable="true">{{ trans('general.created_at')  }}</th>
+                                    <th data-sortable="true">{{ trans('account/general.expires')  }}</th>
                                     <th></th>
                                 </tr>
                                 </thead>
@@ -120,6 +150,10 @@
                                             {{ $token->client->name }}
                                         </td>
 
+                                        <td>
+                                            {{ $token->name }}
+                                        </td>
+
                                         <!-- Scopes -->
                                         <td>
                                             @if(!$token->scopes)
@@ -129,6 +163,13 @@
                                             @endif
                                         </td>
 
+                                        <td>
+                                            {{ $token->created_at ? Helper::getFormattedDateObject($token->created_at, 'datetime', false) : '' }}
+                                        </td>
+
+                                        <td>
+                                            {{ $token->expires_at ? Helper::getFormattedDateObject($token->expires_at, 'datetime', false) : '' }}
+                                        </td>
                                         <!-- Revoke Button -->
                                         <td>
                                             <a class="btn btn-sm btn-danger pull-right"
@@ -353,5 +394,9 @@
 
     </script>
 </div>
+
+@section('moar_scripts')
+    @include ('partials.bootstrap-table')
+@endsection
 
 


### PR DESCRIPTION
This just adds some basic sorting and some additional info to the oauth page.

I'm not sure the way we're handling that page is entirely correct, since we're returning only the tokens and apps that the logged in user has created, but it makes sense to have that be a more general page so a superadmin can see all of the tokens, apps, etc. 

This doesn't change that functionality, just makes a little easier to sort on and adds more details.

### Before
<img width="1489" alt="Screenshot 2024-07-13 at 6 14 15 PM" src="https://github.com/user-attachments/assets/23d79ed3-59d2-4b67-8e40-69724d739655">


### After

<img width="1488" alt="Screenshot 2024-07-13 at 6 14 42 PM" src="https://github.com/user-attachments/assets/3eb6eb19-dea5-460c-962d-f189d08c86bd">
