### PR TITLE
Added EULAs in print user's assets

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -33,7 +33,6 @@
             size: A4;
         }
 
-
         .print-logo {
             max-height: 40px;
         }
@@ -42,8 +41,6 @@
             margin-top: 20px;
             margin-bottom: 10px;
         }
-
-
     </style>
 
     <script nonce="{{ csrf_token() }}">
@@ -80,7 +77,10 @@
     {{ ($show_user->employee_num!='') ? ' (#'.$show_user->employee_num.') ' : '' }}
     {{ ($show_user->jobtitle!='' ? ' - '.$show_user->jobtitle : '') }}
 </h3>
-<p></p>{{ trans('admin/users/general.all_assigned_list_generation')}} {{ Helper::getFormattedDateObject(now(), 'datetime', false) }}</body>
+<p></p>{{ trans('admin/users/general.all_assigned_list_generation')}} {{ Helper::getFormattedDateObject(now(), 'datetime', false) }}
+
+</body>
+
     @if ($assets->count() > 0)
         @php
             $counter = 1;
@@ -120,7 +120,9 @@
             </thead>
             <tbody>
             @foreach ($assets as $asset)
-
+                @php
+                    if ($asset->model->category->getEula()) $eulas[] = $asset->model->category->getEula()
+                @endphp
                 <tr>
                     <td>{{ $counter }}</td>
                     <td>
@@ -148,7 +150,6 @@
                         $assignedCounter = 1;
                     @endphp
                     @foreach ($asset->assignedAssets as $asset)
-
                         <tr>
                             <td>{{ $counter }}.{{ $assignedCounter }}</td>
                             <td>
@@ -216,7 +217,9 @@
             @endphp
 
             @foreach ($licenses as $license)
-
+                @php
+                    if ($license->category->getEula()) $eulas[] = $license->category->getEula()
+                @endphp
                 <tr>
                     <td>{{ $lcounter }}</td>
                     <td>{{ $license->name }}</td>
@@ -272,6 +275,9 @@
 
             @foreach ($accessories as $accessory)
                 @if ($accessory)
+                    @php
+                        if ($accessory->category->getEula()) $eulas[] = $accessory->category->getEula()
+                    @endphp
                     <tr>
                         <td>{{ $acounter }}</td>
                         <td>
@@ -332,10 +338,11 @@
 
             @foreach ($consumables as $consumable)
                 @if ($consumable)
+                    @php
+                        if ($consumable->category->getEula()) $eulas[] = $consumable->category->getEula()
+                    @endphp
                     <tr>
                         <td>{{ $ccounter }}</td>
-
-
                         <td>
                         @if ($consumable->deleted_at!='')
                             <td>{{ ($consumable->manufacturer) ? $consumable->manufacturer->name : '' }}  {{ $consumable->name }} {{ $consumable->model_number }}</td>
@@ -359,12 +366,32 @@
         </table>
     @endif
 
+    <p></p>
+    <div class="pull-right">
+        <button class="btn btn-default hidden-print" type="button" data-toggle="collapse" data-target="#eula-row" aria-expanded="false" aria-controls="eula-row" title="EULAs">
+            <i class="fa fa-eye-slash"></i>
+        </button>
+    </div>
+
     <table style="margin-top: 80px;">
+        <tr class="collapse" id="eula-row">
+            <td style="padding-right: 10px; vertical-align: top; font-weight: bold;">EULA</td>
+            <td style="padding-right: 10px; vertical-align: top; padding-bottom: 80px;" colspan="3">
+                @php
+                    if (!empty($eulas)) $eulas = array_unique($eulas);
+                @endphp
+                @if (!empty($eulas))
+                    @foreach ($eulas as $key => $eula)
+                        {!! $eula !!}
+                    @endforeach
+                @endif
+            </td>
+		</tr>
         <tr>
             <td style="padding-right: 10px; vertical-align: top; font-weight: bold;">{{ trans('general.signed_off_by') }}:</td>
-            <td style="padding-right: 10px; vertical-align: top;">________________________________________________________</td>
-            <td style="padding-right: 10px; vertical-align: top;">________________________________________________________</td>
-            <td>_____________________</td>
+            <td style="padding-right: 10px; vertical-align: top;">______________________________________</td>
+            <td style="padding-right: 10px; vertical-align: top;">______________________________________</td>
+            <td>_____________</td>
         </tr>
         <tr style="height: 80px;">
             <td></td>
@@ -372,12 +399,11 @@
             <td style="padding-right: 10px; vertical-align: top;">Signature</td>
             <td style="padding-right: 10px; vertical-align: top;">{{ trans('general.date') }}</td>
         </tr>
-
         <tr>
             <td style="padding-right: 10px; vertical-align: top; font-weight: bold;">{{ trans('admin/users/table.manager') }}:</td>
-            <td style="padding-right: 10px; vertical-align: top;">________________________________________________________</td>
-            <td style="padding-right: 10px; vertical-align: top;">________________________________________________________</td>
-            <td>_____________________</td>
+            <td style="padding-right: 10px; vertical-align: top;">______________________________________</td>
+            <td style="padding-right: 10px; vertical-align: top;">______________________________________</td>
+            <td>_____________</td>
         </tr>
         <tr>
             <td></td>
@@ -391,11 +417,6 @@
 
 {{-- Javascript files --}}
 <script src="{{ url(mix('js/dist/all.js')) }}" nonce="{{ csrf_token() }}"></script>
-
-
-
-
-
 
 <script src="{{ url(mix('js/dist/bootstrap-table.js')) }}"></script>
 
@@ -474,8 +495,6 @@
         });
     });
 </script>
-
-
 
 </body>
 </html>


### PR DESCRIPTION
Added EULAs when we want to print all assets assigned to a users and ask him/her to sign.

# Description

When we assign assets to a user after on-boarding we deliver a sheet with all his/her assets and ask to sign for confirmation. But there are no EULAs on it, so I added them for each category of asset provided. Hope this can be useful for all users.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Assigned more assets of the same category to be sure not to have EULAs replicated
- [X] Assigned assets of a category with no EULA to be sure no errors occur
- [X] Assigned assets of a category with default EULA to be sure no errors occur

**Test Configuration**:
* PHP version: 8.0.30
* MySQL version: MariaDB 10.3.38
* Webserver version: Apache 2.4.58
* OS version: Ubuntu 20.04.6 LTS

# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes