### PR TITLE
Fixed #15094 - wrong translation string for model on checkout

### DIFF
--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -42,7 +42,7 @@
                         <!-- AssetModel name -->
                         <div class="form-group">
                             <label for="model" class="col-md-3 control-label">
-                                {{ trans('general.company') }}
+                                {{ trans('admin/hardware/form.model') }}
                             </label>
                             <div class="col-md-8">
                                 <p class="form-control-static">


### PR DESCRIPTION
Fixes #15094 where we were using the wrong translation for the "asset model" on checkout.