### PR TITLE
Fixed a coupled test namespaces

### DIFF
--- a/tests/Feature/Departments/Api/CreateDepartmentsTest.php
+++ b/tests/Feature/Departments/Api/CreateDepartmentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Department\Api;
+namespace Tests\Feature\Departments\Api;
 
 use App\Models\AssetModel;
 use App\Models\Department;

--- a/tests/Feature/Locations/Ui/IndexLocationsTest.php
+++ b/tests/Feature/Locations/Ui/IndexLocationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\AssetModels\Ui;
+namespace Tests\Feature\Locations\Ui;
 
 use App\Models\User;
 use Tests\TestCase;


### PR DESCRIPTION
# Description

This PR fixes a couple bad mis-spelled namespaces I noticed on `composer install`:

```
Class Tests\Feature\Department\Api\CreateDepartmentsTest located in ./tests/Feature/Departments/Api/CreateDepartmentsTest.php does not comply with psr-4 autoloading standard (rule: Tests\ => ./tests). Skipping.
Class Tests\Feature\AssetModels\Ui\IndexLocationsTest located in ./tests/Feature/Locations/Ui/IndexLocationsTest.php does not comply with psr-4 autoloading standard (rule: Tests\ => ./tests). Skipping.
```

The tests would still run but this PR just rids of the warning.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) (ish)
