### PR TITLE
Undo `optimize` command in test after it is completed

### DIFF
--- a/tests/Feature/Console/OptimizeTest.php
+++ b/tests/Feature/Console/OptimizeTest.php
@@ -2,13 +2,17 @@
 
 namespace Tests\Feature\Console;
 
-use Illuminate\Support\Facades\Artisan;
 use Tests\TestCase;
 
 class OptimizeTest extends TestCase
 {
     public function testOptimizeSucceeds()
     {
+        $this->beforeApplicationDestroyed(function () {
+            $this->artisan('config:clear');
+            $this->artisan('route:clear');
+        });
+
         $this->artisan('optimize')->assertSuccessful();
     }
 }


### PR DESCRIPTION
# Description

This PR follows up on the test introduced in #15082 by cleaning up the cached config and routes that are generated when running the `artisan optimize` command after the test is run since it can cause some unexpected behavior on local environments.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)