### PR TITLE
Improved Docker environment settings: implement `PHP_UPLOAD_LIMIT` for Alpine images

### DIFF
--- a/docker/entrypoint_alpine.sh
+++ b/docker/entrypoint_alpine.sh
@@ -39,6 +39,14 @@ chown -R apache:root /var/lib/snipeit/data/*
 chown -R apache:root /var/lib/snipeit/dumps
 chown -R apache:root /var/lib/snipeit/keys
 
+# Fix php settings
+if [ ! -z "${PHP_UPLOAD_LIMIT}" ]
+then
+    echo "Changing upload limit to ${PHP_UPLOAD_LIMIT}"
+    sed -i "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_LIMIT}M/" /etc/php*/php.ini
+    sed -i "s/^post_max_size.*/post_max_size = ${PHP_UPLOAD_LIMIT}M/" /etc/php*/php.ini
+fi
+
 # If the Oauth DB files are not present copy the vendor files over to the db migrations
 if [ ! -f "/var/www/html/database/migrations/*create_oauth*" ]
 then


### PR DESCRIPTION
# Description

PHP_UPLOAD_LIMIT settings as Docker variable is not implemented in [official Alpine Docker image](https://hub.docker.com/layers/snipe/snipe-it/v7.0.9-alpine/images/sha256-d2b2b82fec0efebea87f78db86d1ba9a4b37e662c7afbdab876454e2f96f1cf4?context=explore) .
Alpine version uses [docker/entrypoint_alpine.sh](https://github.com/snipe/snipe-it/blob/2f8306cba83f5d9649b4cbd3c2b94fcc819933bc/docker/entrypoint_alpine.sh) instead of [docker/startup.sh](https://github.com/snipe/snipe-it/blob/2f8306cba83f5d9649b4cbd3c2b94fcc819933bc/docker/startup.sh), but the [relevant PHP fix](https://github.com/snipe/snipe-it/blob/2f8306cba83f5d9649b4cbd3c2b94fcc819933bc/docker/startup.sh#L59-L65) is not ported to Alpine entrypoint.
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on a running instance, patching  the `/entrypoint.sh`.
- [x] Reproduce the existing issue:
  -  Setup a minimal setup using docker compose and `snipe/snipe-it:latest-alpine` image.
  - Add `PHP_UPLOAD_LIMIT=100` as environment variable for snipeit service, in Docker compose file.
  - After setup, login and try to upload a file bigger than 8MB. --> upload will fail.
  - Inside the container, run:
    ```bash
    $grep  _max_.*size /etc/php81/php.ini
    post_max_size = 8M
    upload_max_filesize = 2M
    ```
- [x] Test fixed version:
  - Copy `docker/entrypoint_alpine.sh` from this PR and mount it as `/entrypoint.sh` inside the container. Check permissions to be `750`.
  - Run ` docker compose down. && docker compose up -d && docker compose logs -f`: no new warnings appear
  - Login and try to upload a file bigger than 8MB. --> upload will succeed.
  - Inside the container, run:
    ```bash
    $grep  _max_.*size /etc/php81/php.ini
    post_max_size = 100M
    upload_max_filesize = 100M
    ```
**Test Configuration**:
* PHP version: Docker Alpine Image
* MySQL version: Docker image
* Webserver version: Docker Alpine Image
* OS version: Docker Alpine Image


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
