### PR TITLE
WIP - Use proper pagination for API calls

### DIFF
--- a/app/Http/Transformers/CategoriesTransformer.php
+++ b/app/Http/Transformers/CategoriesTransformer.php
@@ -5,22 +5,23 @@ namespace App\Http\Transformers;
 use App\Helpers\Helper;
 use App\Models\Category;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class CategoriesTransformer
 {
-    public function transformCategories(Collection $categorys, $total)
+    public function transformCategories(LengthAwarePaginator $paginator)
     {
         $array = [];
-        foreach ($categorys as $category) {
+        foreach ($paginator->items() as $category) {
             $array[] = self::transformCategory($category);
         }
 
-        return (new DatatablesTransformer)->transformDatatables($array, $total);
+        return (new DatatablesTransformer)->transformDatatables($array, $paginator);
     }
 
-    public function transformCategory(Category $category = null)
+    public function transformCategory(Category $category = null) : ?array
+
     {
 
         // We only ever use item_count for categories in this transformer, so it makes sense to keep it

--- a/app/Http/Transformers/DatatablesTransformer.php
+++ b/app/Http/Transformers/DatatablesTransformer.php
@@ -4,11 +4,18 @@ namespace App\Http\Transformers;
 
 class DatatablesTransformer
 {
-    public function transformDatatables($objects, $total = null)
+    public function transformDatatables($objects, $paginator)
     {
-        (isset($total)) ? $objects_array['total'] = $total : $objects_array['total'] = count($objects);
+        $objects_array['total'] = $paginator->total();
         $objects_array['rows'] = $objects;
+        $objects_array['meta'] = [
+                                    'per_page' => $paginator->perPage(),
+                                    'current_page' => $paginator->currentPage(),
+                                    'last_page' => $paginator->lastPage(),
+                                    'next_page_url' => $paginator->nextPageUrl(),
+                                    'prev_page_url' => $paginator->previousPageUrl(),
+                                ];
 
-        return $objects_array;
+        return ($objects_array);
     }
 }

--- a/app/Http/Transformers/DatatablesTransformer.php
+++ b/app/Http/Transformers/DatatablesTransformer.php
@@ -8,7 +8,7 @@ class DatatablesTransformer
     {
         $objects_array['total'] = $paginator->total();
         $objects_array['rows'] = $objects;
-        $objects_array['meta'] = [
+        $objects_array['meta']['pagination'] = [
                                     'per_page' => $paginator->perPage(),
                                     'current_page' => $paginator->currentPage(),
                                     'last_page' => $paginator->lastPage(),

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -31,7 +31,7 @@ class SettingsServiceProvider extends ServiceProvider
 
 
         // Make sure the limit is actually set, is an integer and does not exceed system limits
-        \App::singleton('api_limit_value', function () {
+        app()->singleton('api_limit_value', function () {
             $limit = config('app.max_results');
             $int_limit = intval(request('limit'));
 
@@ -43,9 +43,19 @@ class SettingsServiceProvider extends ServiceProvider
         });
 
         // Make sure the offset is actually set and is an integer
-        \App::singleton('api_offset_value', function () {
+        app()->singleton('api_offset_value', function () {
             $offset = intval(request('offset'));
             return $offset;
+        });
+
+
+        app()->singleton('per_page', function () {
+
+            if (request('limit')) {
+                return (int) request('limit');
+            }
+            return app('api_limit_value');
+
         });
 
 
@@ -55,115 +65,114 @@ class SettingsServiceProvider extends ServiceProvider
          */
 
         // Model paths and URLs
-
-
-        \App::singleton('eula_pdf_path', function () {
+        
+        app()->singleton('eula_pdf_path', function () {
             return 'eula_pdf_path/';
         });
 
-        \App::singleton('assets_upload_path', function () {
+        app()->singleton('assets_upload_path', function () {
             return 'assets/';
         });
 
-        \App::singleton('accessories_upload_path', function () {
+        app()->singleton('accessories_upload_path', function () {
             return 'public/uploads/accessories/';
         });
 
-        \App::singleton('models_upload_path', function () {
+        app()->singleton('models_upload_path', function () {
             return 'models/';
         });
 
-        \App::singleton('models_upload_url', function () {
+        app()->singleton('models_upload_url', function () {
             return 'models/';
         });
 
         // Categories
-        \App::singleton('categories_upload_path', function () {
+        app()->singleton('categories_upload_path', function () {
             return 'categories/';
         });
 
-        \App::singleton('categories_upload_url', function () {
+        app()->singleton('categories_upload_url', function () {
             return 'categories/';
         });
 
         // Locations
-        \App::singleton('locations_upload_path', function () {
+        app()->singleton('locations_upload_path', function () {
             return 'locations/';
         });
 
-        \App::singleton('locations_upload_url', function () {
+        app()->singleton('locations_upload_url', function () {
             return 'locations/';
         });
 
         // Users
-        \App::singleton('users_upload_path', function () {
+        app()->singleton('users_upload_path', function () {
             return 'avatars/';
         });
 
-        \App::singleton('users_upload_url', function () {
+        app()->singleton('users_upload_url', function () {
             return 'users/';
         });
 
         // Manufacturers
-        \App::singleton('manufacturers_upload_path', function () {
+        app()->singleton('manufacturers_upload_path', function () {
             return 'manufacturers/';
         });
 
-        \App::singleton('manufacturers_upload_url', function () {
+        app()->singleton('manufacturers_upload_url', function () {
             return 'manufacturers/';
         });
 
         // Suppliers
-        \App::singleton('suppliers_upload_path', function () {
+        app()->singleton('suppliers_upload_path', function () {
             return 'suppliers/';
         });
 
-        \App::singleton('suppliers_upload_url', function () {
+        app()->singleton('suppliers_upload_url', function () {
             return 'suppliers/';
         });
 
         // Departments
-        \App::singleton('departments_upload_path', function () {
+        app()->singleton('departments_upload_path', function () {
             return 'departments/';
         });
 
-        \App::singleton('departments_upload_url', function () {
+        app()->singleton('departments_upload_url', function () {
             return 'departments/';
         });
 
         // Company paths and URLs
-        \App::singleton('companies_upload_path', function () {
+        app()->singleton('companies_upload_path', function () {
             return 'companies/';
         });
 
-        \App::singleton('companies_upload_url', function () {
+        app()->singleton('companies_upload_url', function () {
             return 'companies/';
         });
 
         // Accessories paths and URLs
-        \App::singleton('accessories_upload_path', function () {
+        app()->singleton('accessories_upload_path', function () {
             return 'accessories/';
         });
 
-        \App::singleton('accessories_upload_url', function () {
+        app()->singleton('accessories_upload_url', function () {
             return 'accessories/';
         });
 
         // Consumables paths and URLs
-        \App::singleton('consumables_upload_path', function () {
+        app()->singleton('consumables_upload_path', function () {
             return 'consumables/';
         });
 
-        \App::singleton('consumables_upload_url', function () {
+        app()->singleton('consumables_upload_url', function () {
             return 'consumables/';
         });
 
         // Components paths and URLs
-        \App::singleton('components_upload_path', function () {
+        app()->singleton('components_upload_path', function () {
             return 'components/';
         });
 
-        \App::singleton('components_upload_url', function () {
+        app()->singleton('components_upload_url', function () {
             return 'components/';
         });
 


### PR DESCRIPTION
This is very much a work in progress. I started with something small, just Categories. This will require a bit of legwork, but I think this will make for a much better DX overall. We'll still allow existing scripts to use `offset` and `limit` in their queries, but we can now take `page` as a parameter as well. 

Still a lot more to do, but this changes the shape of the response to add the `meta` info at the end, so that if you *want* to switch to not having to math your way into figuring out the offsets and internal pagination as you're parsing the API, you don't have to anymore, but the old way should still work. 

Example response from `https://snipe-it.test/api/v1/categories?page=2&limit=3`:

```json
{
    "total": 15,
    "rows": [
        {
            "id": 4,
            "name": "Mobile Phones",
            "image": null,
            "category_type": "Asset",
            "has_eula": true,
            "use_default_eula": false,
            "eula": "<p>Est autem dolor sint nihil veritatis. Aspernatur est quis officia. Aut atque sed et reprehenderit numquam natus sed. Voluptas architecto aliquid totam animi perferendis.</p>",
            "checkin_email": true,
            "require_acceptance": false,
            "item_count": 67,
            "assets_count": 67,
            "accessories_count": 0,
            "consumables_count": 0,
            "components_count": 0,
            "licenses_count": 0,
            "created_at": {
                "datetime": "2024-07-18 04:55:49",
                "formatted": "Thu Jul 18, 2024 4:55AM"
            },
            "updated_at": {
                "datetime": "2024-07-18 04:55:49",
                "formatted": "Thu Jul 18, 2024 4:55AM"
            },
            "available_actions": {
                "update": true,
                "delete": false
            }
        },
        {
            "id": 5,
            "name": "Displays",
            "image": null,
            "category_type": "Asset",
            "has_eula": true,
            "use_default_eula": true,
            "eula": "<p>Natus nemo repellendus ab ipsa illo. Ipsam ducimus quis eum assumenda dolore tempora soluta. Id saepe accusamus eos autem et illo.</p>",
            "checkin_email": true,
            "require_acceptance": false,
            "item_count": 40,
            "assets_count": 40,
            "accessories_count": 0,
            "consumables_count": 0,
            "components_count": 0,
            "licenses_count": 0,
            "created_at": {
                "datetime": "2024-07-18 04:55:49",
                "formatted": "Thu Jul 18, 2024 4:55AM"
            },
            "updated_at": {
                "datetime": "2024-07-18 04:55:49",
                "formatted": "Thu Jul 18, 2024 4:55AM"
            },
            "available_actions": {
                "update": true,
                "delete": false
            }
        },
        {
            "id": 3,
            "name": "Tablets",
            "image": null,
            "category_type": "Asset",
            "has_eula": true,
            "use_default_eula": false,
            "eula": "<p>Perferendis deserunt explicabo qui voluptatem omnis. Magnam sit illo et optio odit animi. Aliquam qui similique provident ut repellat.</p>",
            "checkin_email": true,
            "require_acceptance": false,
            "item_count": 40,
            "assets_count": 40,
            "accessories_count": 0,
            "consumables_count": 0,
            "components_count": 0,
            "licenses_count": 1,
            "created_at": {
                "datetime": "2024-07-18 04:55:49",
                "formatted": "Thu Jul 18, 2024 4:55AM"
            },
            "updated_at": {
                "datetime": "2024-07-18 04:55:49",
                "formatted": "Thu Jul 18, 2024 4:55AM"
            },
            "available_actions": {
                "update": true,
                "delete": false
            }
        }
    ],
    "meta": {
        "per_page": 3,
        "current_page": 2,
        "last_page": 5,
        "next_page_url": "https://snipe-it.test/api/v1/categories?page=3",
        "prev_page_url": "https://snipe-it.test/api/v1/categories?page=1"
    }
}
```

Added bonus, this is sufficiently risky that I'll need to have TONS more tests set up for this before I'm letting to let this bird fly. 

The really dumb part though is that I still can't figure out why I had to mark that one test as incomplete because it always adds one more to the factory than the `count()` I tell it to. 

![cant-trust-the-system](https://github.com/user-attachments/assets/c9534674-c8ef-48b5-ab35-dbfaa796683b)
