### PR TITLE
Nicer consumables layout

### DIFF
--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -216,6 +216,8 @@ class ConsumablesController extends Controller
         $consumable_to_close = $consumable;
         $consumable = clone $consumable_to_close;
         $consumable->id = null;
+        $consumable->image = null;
+        $consumable->user_id = null;
 
         return view('consumables/edit')->with('item', $consumable);
     }

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -200,7 +200,7 @@ class ConsumablesController extends Controller
      */
     public function show($consumableId = null)
     {
-        $consumable = Consumable::find($consumableId);
+        $consumable = Consumable::withCount('users as users_consumables')->find($consumableId);
         $this->authorize($consumable);
         if (isset($consumable->id)) {
             return view('consumables/view', compact('consumable'));

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -209,4 +209,14 @@ class ConsumablesController extends Controller
         return redirect()->route('consumables.index')
             ->with('error', trans('admin/consumables/message.does_not_exist'));
     }
+
+    public function clone(Consumable $consumable) : View
+    {
+        $this->authorize('create', $consumable);
+        $consumable_to_close = $consumable;
+        $consumable = clone $consumable_to_close;
+        $consumable->id = null;
+
+        return view('consumables/edit')->with('item', $consumable);
+    }
 }

--- a/app/Http/Transformers/ConsumablesTransformer.php
+++ b/app/Http/Transformers/ConsumablesTransformer.php
@@ -55,6 +55,7 @@ class ConsumablesTransformer
             'checkin' => Gate::allows('checkin', Consumable::class),
             'update' => Gate::allows('update', Consumable::class),
             'delete' => Gate::allows('delete', Consumable::class),
+            'clone' => (Gate::allows('create', Consumable::class) && ($consumable->deleted_at == '')),
         ];
         $array += $permissions_array;
 

--- a/resources/lang/en-US/admin/consumables/general.php
+++ b/resources/lang/en-US/admin/consumables/general.php
@@ -8,4 +8,5 @@ return array(
     'remaining' 			            => 'Remaining',
     'total' 			                => 'Total',
     'update'                            => 'Update Consumable',
+    'inventory_warning'                 => 'The inventory of this consumable is below the minimum amount of :min_count',
 );

--- a/resources/lang/en-US/button.php
+++ b/resources/lang/en-US/button.php
@@ -7,6 +7,7 @@ return [
     'checkin_and_delete'  	    => 'Checkin All / Delete User',
     'delete'  	                => 'Delete',
     'edit'    	                => 'Edit',
+    'clone'    	                => 'Clone',
     'restore' 	                => 'Restore',
     'remove'                    => 'Remove',
     'request'                   => 'Request',
@@ -21,4 +22,13 @@ return [
     'add_maintenance'           => 'Add Maintenance',
     'append'                    => 'Append',
     'new'                       => 'New',
+    'var' => [
+        'clone'     => 'Clone :item_type',
+        'edit'      => 'Edit :item_type',
+        'delete'    => 'Delete :item_type',
+        'restore'   => 'Delete :item_type',
+        'create'    => 'Create New :item_type',
+        'checkout'  => 'Checkout :item_type',
+        'checkin'   => 'Checkin :item_type',
+    ]
 ];

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -557,5 +557,6 @@ return [
     'close' => 'Close',
     'expires' => 'Expires',
     'map_fields'=> 'Map :item_type Field',
+    'remaining_var' => ':count Remaining',
 
 ];

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -330,7 +330,7 @@
                   <a href="{{ route('accessories.edit', $accessory->id) }}" style="margin-right:5px; width:100%" class="btn btn-primary btn-sm">{{ trans('admin/accessories/general.edit') }}</a>
                </div>
         @endcan
-        @can('update', \App\Models\Accessory::class)
+        @can('create', \App\Models\Accessory::class)
                 <div class="text-center" style="padding-top:5px;">
                     <a href="{{ route('clone/accessories', $accessory->id) }}" style="margin-right:5px; width:100%" class="btn btn-primary btn-sm">{{ trans('admin/accessories/general.clone') }}</a>
                 </div>

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -3,7 +3,7 @@
 {{-- Page title --}}
 @section('title')
   {{ $consumable->name }}
-  {{ trans('general.consumable') }}
+  {{ trans('general.consumable') }} -
   ({{ trans('general.remaining_var', ['count' => $consumable->numRemaining()])  }})
   @parent
 @endsection
@@ -38,10 +38,10 @@
             <li>
               <a href="#checkedout" data-toggle="tab">
                 <span class="hidden-lg hidden-md">
-                <i class="fas fa-info-circle fa-2x" aria-hidden="true"></i>
+                <i class="fas fa-users fa-2x" aria-hidden="true"></i>
                 </span>
-                    <span class="hidden-xs hidden-sm">{{ trans('general.users') }}
-                      {!! ($consumable->users->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($consumable->users->count()).'</badge>' : '' !!}
+                    <span class="hidden-xs hidden-sm">{{ trans('general.assigned') }}
+                      {!! ($consumable->users_consumables > 0 ) ? '<badge class="badge badge-secondary">'.number_format($consumable->users_consumables).'</badge>' : '' !!}
                     </span>
                   </a>
             </li>
@@ -190,6 +190,18 @@
                     </div>
                   @endif
 
+                  <!-- min amt -->
+                  @if ($consumable->min_amt)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.min_amt') }}
+                      </div>
+                      <div class="col-md-9">
+                        {{ $consumable->min_amt }}
+                      </div>
+                    </div>
+                  @endif
+
                   <!-- locationm -->
                   @if ($consumable->location)
                     <div class="row">
@@ -248,7 +260,7 @@
                         <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
                           <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
                         </i>
-                        
+
                       </div>
                     </div>
                   @endif

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -2,114 +2,500 @@
 
 {{-- Page title --}}
 @section('title')
- {{ $consumable->name }}
- {{ trans('general.consumable') }}
-@parent
-@stop
+  {{ $consumable->name }}
+  {{ trans('general.consumable') }}
+  ({{ trans('general.remaining_var', ['count' => $consumable->numRemaining()])  }})
+  @parent
+@endsection
 
 @section('header_right')
-<a href="{{ URL::previous() }}" class="btn btn-primary pull-right">
-  {{ trans('general.back') }}</a>
-@stop
-
+  <a href="{{ URL::previous() }}" class="btn btn-primary pull-right">
+    {{ trans('general.back') }}</a>
+@endsection
 
 {{-- Page content --}}
 @section('content')
 
-<div class="row">
-  <div class="col-md-9">
 
-    <!-- Custom Tabs -->
-    <div class="nav-tabs-custom">
-      <ul class="nav nav-tabs hidden-print">
 
-        <li class="active">
-          <a href="#checkedout" data-toggle="tab">
+
+  <div class="row">
+    <div class="col-md-12">
+      <div class="nav-tabs-custom">
+        <!-- Custom Tabs -->
+        <div class="nav-tabs-custom">
+          <ul class="nav nav-tabs hidden-print">
+
+            <li class="active">
+              <a href="#details" data-toggle="tab">
             <span class="hidden-lg hidden-md">
-            <i class="fas fa-info-circle fa-2x" aria-hidden="true"></i>
+            <i class="fas fa-info-circle fa-2x"></i>
             </span>
-            <span class="hidden-xs hidden-sm">{{ trans('admin/users/general.info') }}</span>
-          </a>
-        </li>
+                <span class="hidden-xs hidden-sm">{{ trans('admin/users/general.info') }}</span>
+              </a>
+            </li>
+
+            <li>
+              <a href="#checkedout" data-toggle="tab">
+                <span class="hidden-lg hidden-md">
+                <i class="fas fa-info-circle fa-2x" aria-hidden="true"></i>
+                </span>
+                    <span class="hidden-xs hidden-sm">{{ trans('general.users') }}
+                      {!! ($consumable->users->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($consumable->users->count()).'</badge>' : '' !!}
+                    </span>
+                  </a>
+            </li>
 
 
-        @can('consumables.files', $consumable)
-          <li>
-            <a href="#files" data-toggle="tab">
-            <span class="hidden-lg hidden-md">
-            <i class="far fa-file fa-2x" aria-hidden="true"></i></span>
-              <span class="hidden-xs hidden-sm">{{ trans('general.file_uploads') }}
-                {!! ($consumable->uploads->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($consumable->uploads->count()).'</badge>' : '' !!}
-            </span>
-            </a>
-          </li>
-        @endcan
+            @can('consumables.files', $consumable)
+              <li>
+                <a href="#files" data-toggle="tab">
+                <span class="hidden-lg hidden-md">
+                  <i class="far fa-file fa-2x" aria-hidden="true"></i>
+                </span>
+                <span class="hidden-xs hidden-sm">{{ trans('general.file_uploads') }}
+                    {!! ($consumable->uploads->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($consumable->uploads->count()).'</badge>' : '' !!}
+                  </span>
+                </a>
+              </li>
+            @endcan
 
-      <li>
-        <a href="#history" data-toggle="tab">
-        <span class="hidden-lg hidden-md">
-          <i class="fas fa-history fa-2x" aria-hidden="true"></i>
-        </span>
-        <span class="hidden-xs hidden-sm">
-          {{ trans('general.history') }}
-        </span>
-        </a>
-      </li>
+            <li>
+              <a href="#history" data-toggle="tab">
+                <span class="hidden-lg hidden-md">
+                  <i class="fas fa-history fa-2x" aria-hidden="true"></i>
+                </span>
+                <span class="hidden-xs hidden-sm">
+                  {{ trans('general.history') }}
+                </span>
+              </a>
+            </li>
 
-        @can('update', $consumable)
-          <li class="pull-right">
-            <a href="#" data-toggle="modal" data-target="#uploadFileModal">
-              <i class="fas fa-paperclip" aria-hidden="true"></i> {{ trans('button.upload') }}
-            </a>
-          </li>
-        @endcan
+            @can('update', $consumable)
+              <li class="pull-right">
+                <a href="#" data-toggle="modal" data-target="#uploadFileModal">
+                  <i class="fas fa-paperclip" aria-hidden="true"></i> {{ trans('button.upload') }}
+                </a>
+              </li>
+            @endcan
 
-      </ul>
+          </ul>
+        <div class="tab-content">
+          <div class="tab-pane active" id="details">
+            <div class="row">
 
-      <div class="tab-content">
+              <!-- Start button column -->
+              <div class="col-md-3 col-xs-12 col-sm-push-9">
 
-        <div class="tab-pane active" id="checkedout">
-              <div class="table-responsive">
+                @if ($consumable->image!='')
+                  <div class="col-md-12 text-center" style="padding-bottom: 20px;">
+                    <a href="{{ Storage::disk('public')->url('consumables/'.e($consumable->image)) }}" data-toggle="lightbox">
+                      <img src="{{ Storage::disk('public')->url('consumables/'.e($consumable->image)) }}" class="img-responsive img-thumbnail" alt="{{ $consumable->name }}"></a>
+                  </div>
+                @endif
 
-                <table
-                        data-cookie-id-table="consumablesCheckedoutTable"
-                        data-pagination="true"
-                        data-id-table="consumablesCheckedoutTable"
-                        data-search="false"
-                        data-side-pagination="server"
-                        data-show-columns="true"
-                        data-show-export="true"
-                        data-show-footer="true"
-                        data-show-refresh="true"
-                        data-sort-order="asc"
-                        data-sort-name="name"
-                        id="consumablesCheckedoutTable"
-                        class="table table-striped snipe-table"
-                        data-url="{{route('api.consumables.show.users', $consumable->id)}}"
-                        data-export-options='{
+                
+                @can('update', $consumable)
+                  <div class="col-md-12">
+                    <a href="{{ route('consumables.edit', $consumable->id) }}" style="margin-bottom:5px;"  class="btn btn-sm btn-block btn-primary hidden-print">{{ trans('button.edit') }}</a>
+                  </div>
+                @endcan
+
+                  @can('checkout', $consumable)
+                    @if ($consumable->numRemaining() > 0)
+                        <div class="col-md-12">
+                            <a href="{{ route('consumables.checkout.show', $consumable->id) }}" style="margin-bottom:5px;" class="btn btn-sm btn-block btn-primary hidden-print">
+                              {{ trans('general.checkout') }}
+                            </a>
+                        </div>
+                    @else
+                        <div class="col-md-12">
+                          <button style="margin-bottom:10px;" class="btn btn-block btn-primary btn-sm disabled">
+                            {{ trans('general.checkout') }}
+                          </button>
+                        </div>
+                    @endif
+                @endif
+
+
+                  @can('delete', $consumable)
+                    <div class="col-md-12" style="padding-top: 10px; padding-bottom: 20px">
+                      @if ($consumable->deleted_at=='')
+                        <button class="btn btn-sm btn-block btn-danger delete-asset" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $consumable->name]) }}" data-target="#dataConfirmModal">{{ trans('general.delete') }}
+                        </button>
+                        <span class="sr-only">{{ trans('general.delete') }}</span>
+                      @endif
+                    </div>
+                  @endcan
+              </div>
+
+              <!-- End button column -->
+
+              <div class="col-md-9 col-xs-12 col-sm-pull-3">
+
+                <div class="row-new-striped" style="margin: 0px;">
+
+                  <div class="row row-new-striped">
+                    <!-- name -->
+                    <div class="col-md-3 col-sm-2">
+                      {{ trans('admin/users/table.name') }}
+                    </div>
+                    <div class="col-md-9 col-sm-2">
+                      {{ $consumable->name }}
+                    </div>
+                  </div>
+
+                  <!-- company -->
+                  @if ($consumable->company)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.company') }}
+                      </div>
+                      <div class="col-md-9">
+                        {{ $consumable->company->name }}
+                      </div>
+                    </div>
+                  @endif
+
+                  <!-- category -->
+                  @if ($consumable->category)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.category') }}
+                      </div>
+                      <div class="col-md-9">
+                        {{ $consumable->category->name }}
+                      </div>
+                    </div>
+                  @endif
+
+
+                  <!-- remaining -->
+                  @if ($consumable->numRemaining())
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.remaining') }}
+                      </div>
+                      <div class="col-md-9">
+                        @if ($consumable->numRemaining() < (int) $consumable->min_amt)
+                          <i class="fas fa-exclamation-triangle text-orange"
+                             aria-hidden="true"
+                             data-tooltip="true"
+                             data-placement="top"
+                             title="{{ trans('admin/consumables/general.inventory_warning', ['min_count' => (int) $consumable->min_amt]) }}">
+                          </i>
+                        @endif
+                        {{ $consumable->numRemaining() }}
+                      </div>
+                    </div>
+                  @endif
+
+                  <!-- locationm -->
+                  @if ($consumable->location)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.location') }}
+                      </div>
+                      <div class="col-md-9">
+                        {{ $consumable->location->name }}
+                      </div>
+                    </div>
+                  @endif
+
+                  <!-- supplier -->
+                  @if ($consumable->supplier)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.supplier') }}
+                      </div>
+                      <div class="col-md-9">
+                        {{ $consumable->supplier->name }}
+                      </div>
+                    </div>
+                  @endif
+
+                  <!-- supplier -->
+                  @if ($consumable->manufacturer)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.manufacturer') }}
+                      </div>
+                      <div class="col-md-9">
+                        {{ $consumable->manufacturer->name }}
+                      </div>
+                    </div>
+                  @endif
+
+                  @if ($consumable->purchase_cost)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.purchase_cost') }}
+                      </div>
+                      <div class="col-md-9">
+                        {{ $snipeSettings->default_currency }}
+                        {{ Helper::formatCurrencyOutput($consumable->purchase_cost) }}
+                      </div>
+                    </div>
+                  @endif
+
+                  @if ($consumable->order_number)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.order_number') }}
+                      </div>
+                      <div class="col-md-9">
+                        <span class="js-copy">{{ $consumable->order_number  }}</span>
+                        <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
+                          <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
+                        </i>
+                        
+                      </div>
+                    </div>
+                  @endif
+
+                  @if ($consumable->item_no)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('admin/consumables/general.item_no') }}
+                      </div>
+                      <div class="col-md-9">
+
+                        <span class="js-copy">{{ $consumable->item_no  }}</span>
+                        <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
+                          <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
+                        </i>
+
+                      </div>
+                    </div>
+                  @endif
+
+                  @if ($consumable->model_number)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.model_no') }}
+                      </div>
+                      <div class="col-md-9">
+
+                        <span class="js-copy">{{ $consumable->model_number  }}</span>
+                        <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
+                          <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
+                        </i>
+
+                      </div>
+                    </div>
+                  @endif
+
+                  <!-- purchase date -->
+                  @if ($consumable->purchase_date)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.purchase_date') }}
+                      </div>
+                      <div class="col-md-9">
+                        {{ \App\Helpers\Helper::getFormattedDateObject($consumable->purchase_date, 'datetime', false) }}
+                      </div>
+                    </div>
+                  @endif
+
+                  @if ($consumable->created_at)
+                    <!-- created at -->
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.created_at') }}
+                      </div>
+                      <div class="col-md-9">
+                        {{ \App\Helpers\Helper::getFormattedDateObject($consumable->created_at, 'datetime')['formatted']}}
+                      </div>
+                    </div>
+                  @endif
+
+                  @if ($consumable->updated_at)
+                    <!-- created at -->
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.updated_at') }}
+                      </div>
+                      <div class="col-md-9">
+                        {{ \App\Helpers\Helper::getFormattedDateObject($consumable->updated_at, 'datetime')['formatted']}}
+                      </div>
+                    </div>
+                  @endif
+
+                  @if ($consumable->admin)
+                    <!-- created at -->
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('general.created_by') }}
+                      </div>
+                      <div class="col-md-9">
+
+                          @if ($consumable->admin->deleted_at == '')
+                            <a href="{{ route('users.show', ['user' => $consumable->admin]) }}">{{ $consumable->admin->present()->fullName }}</a>
+                          @else
+                            <del>{{ $consumable->admin->present()->fullName }}</del>
+                          @endif
+
+                      </div>
+                    </div>
+                  @endif
+
+                  @if ($consumable->notes)
+                    <!-- empty -->
+                    <div class="row">
+
+                      <div class="col-md-3">
+                        {{ trans('admin/users/table.notes') }}
+                      </div>
+                      <div class="col-md-9">
+                        {!! nl2br(Helper::parseEscapedMarkedownInline($consumable->notes)) !!}
+                      </div>
+
+                    </div>
+                  @endif
+                </div> <!--/end striped container-->
+              </div> <!-- end col-md-9 -->
+            </div> <!--/.row-->
+          </div><!-- /.tab-pane -->
+
+          <div class="tab-pane" id="checkedout">
+
+            <table
+                    data-cookie-id-table="consumablesCheckedoutTable"
+                    data-pagination="true"
+                    data-id-table="consumablesCheckedoutTable"
+                    data-search="false"
+                    data-side-pagination="server"
+                    data-show-columns="true"
+                    data-show-export="true"
+                    data-show-footer="true"
+                    data-show-refresh="true"
+                    data-sort-order="asc"
+                    data-sort-name="name"
+                    id="consumablesCheckedoutTable"
+                    class="table table-striped snipe-table"
+                    data-url="{{route('api.consumables.show.users', $consumable->id)}}"
+                    data-export-options='{
                 "fileName": "export-consumables-{{ str_slug($consumable->name) }}-checkedout-{{ date('Y-m-d') }}",
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                 }'>
-                  <thead>
-                  <tr>
-                    <th data-searchable="false" data-sortable="false" data-field="avatar" data-formatter="imageFormatter">{{ trans('general.image') }}</th>
-                    <th data-searchable="false" data-sortable="false" data-field="name" formatter="usersLinkFormatter">{{ trans('general.user') }}</th>
-                    <th data-searchable="false" data-sortable="false" data-field="created_at" data-formatter="dateDisplayFormatter">
-                      {{ trans('general.date') }}
-                    </th>
-                    <th data-searchable="false" data-sortable="false" data-field="note">{{ trans('general.notes') }}</th>
-                    <th data-searchable="false" data-sortable="false" data-field="admin">{{ trans('general.admin') }}</th>
-                  </tr>
-                  </thead>
-                </table>
-          </div>
-        </div> <!-- close tab-pane div -->
+              <thead>
+              <tr>
+                <th data-searchable="false" data-sortable="false" data-field="avatar" data-formatter="imageFormatter">{{ trans('general.image') }}</th>
+                <th data-searchable="false" data-sortable="false" data-field="name" formatter="usersLinkFormatter">{{ trans('general.user') }}</th>
+                <th data-searchable="false" data-sortable="false" data-field="created_at" data-formatter="dateDisplayFormatter">
+                  {{ trans('general.date') }}
+                </th>
+                <th data-searchable="false" data-sortable="false" data-field="note">{{ trans('general.notes') }}</th>
+                <th data-searchable="false" data-sortable="false" data-field="admin">{{ trans('general.admin') }}</th>
+              </tr>
+              </thead>
+            </table>
+
+          </div><!-- /checkedout -->
 
 
-        <div class="tab-pane fade" id="history">
-          <!-- checked out assets table -->
-          <div class="row">
-            <div class="col-md-12">
+          <div class="tab-pane" id="files">
+            <div class="row">
+
+              <div class="col-md-12 col-sm-12">
+                <div class="table-responsive">
+
+                    <table
+                            data-cookie-id-table="consumableUploadsTable"
+                            data-id-table="consumableUploadsTable"
+                            id="consumableUploadsTable"
+                            data-search="true"
+                            data-pagination="true"
+                            data-side-pagination="client"
+                            data-show-columns="true"
+                            data-show-export="true"
+                            data-show-footer="true"
+                            data-toolbar="#upload-toolbar"
+                            data-show-refresh="true"
+                            data-sort-order="asc"
+                            data-sort-name="name"
+                            class="table table-striped snipe-table"
+                            data-export-options='{
+                    "fileName": "export-consumables-uploads-{{ str_slug($consumable->name) }}-{{ date('Y-m-d') }}",
+                    "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","delete","download","icon"]
+                    }'>
+                      <thead>
+                      <tr>
+                        <th data-visible="true" data-field="icon" data-sortable="true">{{trans('general.file_type')}}</th>
+                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="image">{{ trans('general.image') }}</th>
+                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="filename" data-sortable="true">{{ trans('general.file_name') }}</th>
+                        <th class="col-md-1" data-searchable="true" data-visible="true" data-field="filesize">{{ trans('general.filesize') }}</th>
+                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="notes" data-sortable="true">{{ trans('general.notes') }}</th>
+                        <th class="col-md-1" data-searchable="true" data-visible="true" data-field="download">{{ trans('general.download') }}</th>
+                        <th class="col-md-2" data-searchable="true" data-visible="true" data-field="created_at" data-sortable="true">{{ trans('general.created_at') }}</th>
+                        <th class="col-md-1" data-searchable="true" data-visible="true" data-field="actions">{{ trans('table.actions') }}</th>
+                      </tr>
+                      </thead>
+                      <tbody>
+                      @if ($consumable->uploads->count() > 0)
+                        @foreach ($consumable->uploads as $file)
+                          <tr>
+                            <td>
+                              <i class="{{ Helper::filetype_icon($file->filename) }} icon-med" aria-hidden="true"></i>
+                              <span class="sr-only">{{ Helper::filetype_icon($file->filename) }}</span>
+
+                            </td>
+                            <td>
+                              @if ($file->filename)
+                                @if ( Helper::checkUploadIsImage($file->get_src('consumables')))
+                                  <a href="{{ route('show.consumablefile', ['consumableId' => $consumable->id, 'fileId' => $file->id, 'download' => 'false']) }}" data-toggle="lightbox" data-type="image"><img src="{{ route('show.consumablefile', ['consumableId' => $consumable->id, 'fileId' => $file->id]) }}" class="img-thumbnail" style="max-width: 50px;"></a>
+                                @endif
+                              @endif
+                            </td>
+                            <td>
+                              {{ $file->filename }}
+                            </td>
+                            <td data-value="{{ (Storage::exists('private_uploads/consumables/'.$file->filename) ? Storage::size('private_uploads/consumables/'.$file->filename) : '') }}">
+                              {{ @Helper::formatFilesizeUnits(Storage::exists('private_uploads/consumables/'.$file->filename) ? Storage::size('private_uploads/consumables/'.$file->filename) : '') }}
+                            </td>
+
+                            <td>
+                              @if ($file->note)
+                                {!! nl2br(Helper::parseEscapedMarkedownInline($file->note)) !!}
+                              @endif
+                            </td>
+                            <td>
+                              @if ($file->filename)
+                                <a href="{{ route('show.consumablefile', [$consumable->id, $file->id]) }}" class="btn btn-sm btn-default">
+                                  <i class="fas fa-download" aria-hidden="true"></i>
+                                  <span class="sr-only">{{ trans('general.download') }}</span>
+                                </a>
+
+                                <a href="{{ route('show.consumablefile', [$consumable->id, $file->id, 'inline' => 'true']) }}" class="btn btn-sm btn-default" target="_blank">
+                                  <i class="fa fa-external-link" aria-hidden="true"></i>
+                                </a>
+                              @endif
+                            </td>
+                            <td>{{ $file->created_at }}</td>
+                            <td>
+                              <a class="btn delete-asset btn-danger btn-sm" href="{{ route('delete/consumablefile', [$consumable->id, $file->id]) }}" data-content="{{ trans('general.delete_confirm', ['item' => $file->filename]) }}" data-title="{{ trans('general.delete') }}">
+                                <i class="fas fa-trash icon-white" aria-hidden="true"></i>
+                                <span class="sr-only">{{ trans('general.delete') }}</span>
+                              </a>
+
+                            </td>
+                          </tr>
+                        @endforeach
+                      @else
+                        <tr>
+                          <td colspan="8">{{ trans('general.no_results') }}</td>
+                        </tr>
+                      @endif
+                      </tbody>
+                    </table>
+                </div>
+              </div>
+            </div> <!--/ROW-->
+          </div><!--/FILES-->
+
+          <div class="tab-pane" id="history">
+            <div class="table-responsive">
+
               <table
                       class="table table-striped snipe-table"
                       id="consumableHistory"
@@ -151,238 +537,32 @@
                 </thead>
               </table>
             </div>
-          </div> <!-- /.row -->
-        </div> <!-- /.tab-pane history -->
-
-
-      @can('consumables.files', $consumable)
-          <div class="tab-pane" id="files">
-
-            <div class="table-responsive">
-              <table
-                      data-cookie-id-table="consumableUploadsTable"
-                      data-id-table="consumableUploadsTable"
-                      id="consumableUploadsTable"
-                      data-search="true"
-                      data-pagination="true"
-                      data-side-pagination="client"
-                      data-show-columns="true"
-                      data-show-export="true"
-                      data-show-footer="true"
-                      data-toolbar="#upload-toolbar"
-                      data-show-refresh="true"
-                      data-sort-order="asc"
-                      data-sort-name="name"
-                      class="table table-striped snipe-table"
-                      data-export-options='{
-                    "fileName": "export-consumables-uploads-{{ str_slug($consumable->name) }}-{{ date('Y-m-d') }}",
-                    "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","delete","download","icon"]
-                    }'>
-                <thead>
-                <tr>
-                  <th data-visible="true" data-field="icon" data-sortable="true">{{trans('general.file_type')}}</th>
-                  <th class="col-md-2" data-searchable="true" data-visible="true" data-field="image">{{ trans('general.image') }}</th>
-                  <th class="col-md-2" data-searchable="true" data-visible="true" data-field="filename" data-sortable="true">{{ trans('general.file_name') }}</th>
-                  <th class="col-md-1" data-searchable="true" data-visible="true" data-field="filesize">{{ trans('general.filesize') }}</th>
-                  <th class="col-md-2" data-searchable="true" data-visible="true" data-field="notes" data-sortable="true">{{ trans('general.notes') }}</th>
-                  <th class="col-md-1" data-searchable="true" data-visible="true" data-field="download">{{ trans('general.download') }}</th>
-                  <th class="col-md-2" data-searchable="true" data-visible="true" data-field="created_at" data-sortable="true">{{ trans('general.created_at') }}</th>
-                  <th class="col-md-1" data-searchable="true" data-visible="true" data-field="actions">{{ trans('table.actions') }}</th>
-                </tr>
-                </thead>
-                <tbody>
-                @if ($consumable->uploads->count() > 0)
-                  @foreach ($consumable->uploads as $file)
-                    <tr>
-                      <td>
-                        <i class="{{ Helper::filetype_icon($file->filename) }} icon-med" aria-hidden="true"></i>
-                        <span class="sr-only">{{ Helper::filetype_icon($file->filename) }}</span>
-
-                      </td>
-                      <td>
-                        @if ($file->filename)
-                          @if ( Helper::checkUploadIsImage($file->get_src('consumables')))
-                            <a href="{{ route('show.consumablefile', ['consumableId' => $consumable->id, 'fileId' => $file->id, 'download' => 'false']) }}" data-toggle="lightbox" data-type="image"><img src="{{ route('show.consumablefile', ['consumableId' => $consumable->id, 'fileId' => $file->id]) }}" class="img-thumbnail" style="max-width: 50px;"></a>
-                          @endif
-                        @endif
-                      </td>
-                      <td>
-                        {{ $file->filename }}
-                      </td>
-                      <td data-value="{{ (Storage::exists('private_uploads/consumables/'.$file->filename) ? Storage::size('private_uploads/consumables/'.$file->filename) : '') }}">
-                        {{ @Helper::formatFilesizeUnits(Storage::exists('private_uploads/consumables/'.$file->filename) ? Storage::size('private_uploads/consumables/'.$file->filename) : '') }}
-                      </td>
-
-                      <td>
-                        @if ($file->note)
-                          {!! nl2br(Helper::parseEscapedMarkedownInline($file->note)) !!}
-                        @endif
-                      </td>
-                      <td>
-                        @if ($file->filename)
-                          <a href="{{ route('show.consumablefile', [$consumable->id, $file->id]) }}" class="btn btn-sm btn-default">
-                            <i class="fas fa-download" aria-hidden="true"></i>
-                            <span class="sr-only">{{ trans('general.download') }}</span>
-                          </a>
-
-                          <a href="{{ route('show.consumablefile', [$consumable->id, $file->id, 'inline' => 'true']) }}" class="btn btn-sm btn-default" target="_blank">
-                            <i class="fa fa-external-link" aria-hidden="true"></i>
-                          </a>
-                        @endif
-                      </td>
-                      <td>{{ $file->created_at }}</td>
-                      <td>
-                        <a class="btn delete-asset btn-danger btn-sm" href="{{ route('delete/consumablefile', [$consumable->id, $file->id]) }}" data-content="{{ trans('general.delete_confirm', ['item' => $file->filename]) }}" data-title="{{ trans('general.delete') }}">
-                          <i class="fas fa-trash icon-white" aria-hidden="true"></i>
-                          <span class="sr-only">{{ trans('general.delete') }}</span>
-                        </a>
-
-                      </td>
-                    </tr>
-                  @endforeach
-                @else
-                  <tr>
-                    <td colspan="8">{{ trans('general.no_results') }}</td>
-                  </tr>
-                @endif
-                </tbody>
-              </table>
-            </div>
-          </div> <!-- /.tab-pane -->
-        @endcan
-
-      </div>
-    </div>
-
+          </div><!-- /.tab-pane -->
+      </div><!-- /.tab-content -->
+    </div><!-- nav-tabs-custom -->
   </div>
 
-
-  <div class="col-md-3">
-
-        <div class="box box-default">
-          <div class="box-body">
-            <div class="row">
-              <div class="col-md-12">
-
-
-                @if ($consumable->image!='')
-                <div class="col-md-12 text-center">
-                  <a href="{{ Storage::disk('public')->url('consumables/'.e($consumable->image)) }}" data-toggle="lightbox">
-                      <img src="{{ Storage::disk('public')->url('consumables/'.e($consumable->image)) }}" class="img-responsive img-thumbnail" alt="{{ $consumable->name }}"></a>
-                </div>
-                @endif
-
-                @if ($consumable->purchase_date)
-                  <div class="col-md-12">
-                    <strong>{{ trans('general.purchase_date') }}: </strong>
-                    {{ Helper::getFormattedDateObject($consumable->purchase_date, 'date', false) }}
-                  </div>
-                @endif
-
-                @if ($consumable->purchase_cost)
-                  <div class="col-md-12">
-                    <strong>{{ trans('general.purchase_cost') }}:</strong>
-                    {{ $snipeSettings->default_currency }}
-                    {{ Helper::formatCurrencyOutput($consumable->purchase_cost) }}
-                  </div>
-                @endif
-
-                @if ($consumable->item_no)
-                  <div class="col-md-12">
-                    <strong>{{ trans('admin/consumables/general.item_no') }}:</strong>
-                    {{ $consumable->item_no }}
-                  </div>
-                @endif
-
-                @if ($consumable->model_number)
-                  <div class="col-md-12">
-                    <strong>{{ trans('general.model_no') }}:</strong>
-                    {{ $consumable->model_number }}
-                  </div>
-                @endif
-
-                @if ($consumable->manufacturer)
-                  <div class="col-md-12">
-                    <strong>{{ trans('general.manufacturer') }}:</strong>
-                    <a href="{{ route('manufacturers.show', $consumable->manufacturer->id) }}">{{ $consumable->manufacturer->name }}</a>
-                  </div>
-                @endif
-
-                @if ($consumable->order_number)
-                  <div class="col-md-12">
-                    <strong>{{ trans('general.order_number') }}:</strong>
-                    {{ $consumable->order_number }}
-                  </div>
-                @endif
-
-                @if ($consumable->notes)
-
-                  <div class="col-md-12">
-                    <strong>
-                      {{ trans('general.notes') }}:
-                    </strong>
-                  </div>
-                    <div class="col-md-12">
-                    {!! nl2br(Helper::parseEscapedMarkedownInline($consumable->notes)) !!}
-                    </div>
-
-                @endif
-
-    @can('checkout', \App\Models\Consumable::class)
-
-      <div class="col-md-12">
-        <br><br>
-        @if ($consumable->numRemaining() > 0)
-          <a href="{{ route('consumables.checkout.show', $consumable->id) }}" style="margin-bottom:10px; width:100%" class="btn btn-primary btn-sm">
-            {{ trans('general.checkout') }}
-          </a>
-        @else
-          <button style="margin-bottom:10px; width:100%" class="btn btn-primary btn-sm disabled">
-            {{ trans('general.checkout') }}
-          </button>
-        @endif
-      </div>
-        @can('update', \App\Models\Consumable::class)
-            <div class="col-md-12">
-              <a href="{{ route('consumables.edit', $consumable->id) }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">{{ trans('button.edit') }}</a>
-            </div>
-        @endcan
-
-          @can('delete', $consumable)
-            <div class="col-md-12" style="padding-top: 30px; padding-bottom: 30px;">
-              @if ($consumable->deleted_at=='')
-                <button class="btn btn-sm btn-block btn-danger delete-asset" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $consumable->name]) }}" data-target="#dataConfirmModal">{{ trans('general.delete') }}
-                </button>
-                <span class="sr-only">{{ trans('general.delete') }}</span>
-              @endif
-            </div>
-          @endcan
-
-    @endcan
-
-    </div>
-
-  </div> <!-- /.col-md-3-->
-</div> <!-- /.row-->
+  @can('update', \App\Models\User::class)
+    @include ('modals.upload-file', ['item_type' => 'consumable', 'item_id' => $consumable->id])
+  @endcan
 
 
 
-@can('consumables.files', \App\Models\Consumable::class)
-  @include ('modals.upload-file', ['item_type' => 'consumable', 'item_id' => $consumable->id])
-@endcan
 @stop
 
 @section('moar_scripts')
-      <script>
 
-        $('#dataConfirmModal').on('show.bs.modal', function (event) {
-          var content = $(event.relatedTarget).data('content');
-          var title = $(event.relatedTarget).data('title');
-          $(this).find(".modal-body").text(content);
-          $(this).find(".modal-header").text(title);
-        });
+        <script>
 
-      </script>
+          $('#dataConfirmModal').on('show.bs.modal', function (event) {
+            var content = $(event.relatedTarget).data('content');
+            var title = $(event.relatedTarget).data('title');
+            $(this).find(".modal-body").text(content);
+            $(this).find(".modal-header").text(title);
+          });
 
-@include ('partials.bootstrap-table', ['exportFile' => 'consumable' . $consumable->name . '-export', 'search' => false])
-@stop
+        </script>
+
+
+  @include ('partials.bootstrap-table', ['simple_view' => true])
+@endsection

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -101,6 +101,14 @@
                   </div>
                 @endcan
 
+                  @can('create', Consumable::class)
+
+                    <div class="col-md-12">
+                      <a href="{{ route('consumables.clone.create', $consumable->id) }}" style="margin-bottom:5px;"  class="btn btn-sm btn-block btn-primary hidden-print">{{ trans('button.var.clone', ['item_type' => trans('general.consumable')]) }}</a>
+                    </div>
+
+                  @endcan
+
                   @can('checkout', $consumable)
                     @if ($consumable->numRemaining() > 0)
                         <div class="col-md-12">

--- a/routes/web/consumables.php
+++ b/routes/web/consumables.php
@@ -31,6 +31,10 @@ Route::group(['prefix' => 'consumables', 'middleware' => ['auth']], function () 
         [Consumables\ConsumablesFilesController::class, 'show']
     )->name('show.consumablefile');
 
+    Route::get('{consumable}/clone',
+        [Consumables\ConsumablesController::class, 'clone']
+    )->name('consumables.clone.create');
+    
 
 });
     


### PR DESCRIPTION
This just tightens up the layout a bit and also adds a clone option.

<img width="1507" alt="Screenshot 2024-07-20 at 5 00 13 PM" src="https://github.com/user-attachments/assets/c1e64b28-18b0-493f-9452-2ccb26810776">


<img width="1501" alt="Screenshot 2024-07-20 at 4 42 36 PM" src="https://github.com/user-attachments/assets/da65b114-790a-49fc-afa6-88f288702b0f">

<img width="463" alt="Screenshot 2024-07-20 at 4 42 48 PM" src="https://github.com/user-attachments/assets/81af367d-cd77-407a-81f6-d8a18cc9d071">
