### PR TITLE
Fixed start_date and end_date in user importer

### DIFF
--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -67,6 +67,7 @@ class UserImporter extends ItemImporter
         $this->item['vip'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'vip'))) ==1 ) ? '1' : 0;
         $this->item['autoassign_licenses'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'autoassign_licenses'))) ==1 ) ? '1' : 0;
 
+        $this->handleEmptyStringsForDates();
 
         $user_department = trim($this->findCsvMatch($row, 'department'));
         if ($this->shouldUpdateField($user_department)) {
@@ -178,5 +179,23 @@ class UserImporter extends ItemImporter
     public function sendWelcome($send = true)
     {
         $this->send_welcome = $send;
+    }
+
+    /**
+     * Since the findCsvMatch() method will set '' for columns that are present but empty,
+     * we need to set those empty strings to null to avoid passing bad data to the database
+     * (ie ending up with 0000-00-00 instead of the intended null).
+     *
+     * @return void
+     */
+    private function handleEmptyStringsForDates(): void
+    {
+        if ($this->item['start_date'] === '') {
+            $this->item['start_date'] = null;
+        }
+
+        if ($this->item['end_date'] === '') {
+            $this->item['end_date'] = null;
+        }
     }
 }


### PR DESCRIPTION
# Description

This PR fixes an issue involving start and end dates in the user importer. 

If a row being imported does not have a start or end date, whether that is due to it not being mapped or not being included in the import at all, the fields would end up in the database as `0000-00-00` instead of null. T

This is due to the `findCsvMatch` method returning an empty string if the column is present but empty and/or calling `trim` on null returning an empty string.

This PR simply changes `start_date` and `end_date` fields to null if they have been set to an empty string after the initial matching/mapping.

Fixes #15141

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)