### PR TITLE
Fixed env var for backup config - related to #14964

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -139,7 +139,7 @@ return [
             'to' => env('MAIL_BACKUP_NOTIFICATION_ADDRESS', null),
 
             'from' => [
-                'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+                'address' => env('MAIL_FROM_ADDR', 'hello@example.com'),
                 'name' => env('MAIL_FROM_NAME', 'Example'),
             ],
         ],


### PR DESCRIPTION
We were using the incorrect mail variable in the backup config, `MAIL_FROM_ADDRESS `, vs `MAIL_FROM_ADDR`. Thanks for finding that, @triple-HA! 