### PR TITLE
Switch dockerfile to using php8.2 instead of 8.1 due to Alpine changes

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,34 +2,34 @@ FROM alpine:3.19
 # Apache + PHP
 RUN  apk add --no-cache \
         apache2 \
-        php81 \
-        php81-common \
-        php81-apache2 \
-        php81-curl \
-        php81-ldap \
-        php81-mysqli \
-        php81-gd \
-        php81-xml \
-        php81-mbstring \
-        php81-zip \
-        php81-ctype \
-        php81-tokenizer \
-        php81-pdo_mysql \
-        php81-openssl \
-        php81-bcmath \
-        php81-phar \
-        php81-json \
-        php81-iconv \
-        php81-fileinfo \
-        php81-simplexml \
-        php81-session \
-        php81-dom \
-        php81-xmlwriter \
-        php81-xmlreader \
-        php81-sodium \
-        php81-redis \
-        php81-pecl-memcached \
-        php81-exif \
+        php82 \
+        php82-common \
+        php82-apache2 \
+        php82-curl \
+        php82-ldap \
+        php82-mysqli \
+        php82-gd \
+        php82-xml \
+        php82-mbstring \
+        php82-zip \
+        php82-ctype \
+        php82-tokenizer \
+        php82-pdo_mysql \
+        php82-openssl \
+        php82-bcmath \
+        php82-phar \
+        php82-json \
+        php82-iconv \
+        php82-fileinfo \
+        php82-simplexml \
+        php82-session \
+        php82-dom \
+        php82-xmlwriter \
+        php82-xmlreader \
+        php82-sodium \
+        php82-redis \
+        php82-pecl-memcached \
+        php82-exif \
         curl \
         wget \
         vim \
@@ -42,7 +42,7 @@ COPY docker/column-statistics.cnf /etc/mysql/conf.d/column-statistics.cnf
 # Where apache's PID lives
 RUN mkdir -p /run/apache2 && chown apache:apache /run/apache2
 
-RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php81/php.ini
+RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php82/php.ini
 COPY  docker/000-default-2.4.conf /etc/apache2/conf.d/default.conf
 
 # Enable mod_rewrite


### PR DESCRIPTION
Snyk wanted to auto-upgrade our version of Alpine which we use for Docker. But that seemed to break the Docker build.

It turns out that Alpine changed the php 8.1 APK to be called `php81` instead of `php`. Switching everything to PHP v8.2 seems to restore the `php` command and the build works again.