### PR TITLE
Allow cloning of deleted assets

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -576,26 +576,20 @@ class AssetsController extends Controller
      * @since [v1.0]
      * @return \Illuminate\Contracts\View\View
      */
-    public function getClone($assetId = null)
+    public function getClone(Asset $asset)
     {
-        // Check if the asset exists
-        if (is_null($asset_to_clone = Asset::find($assetId))) {
-            // Redirect to the asset management page
-            return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.does_not_exist'));
-        }
-
-        $this->authorize('create', $asset_to_clone);
-
-        $asset = clone $asset_to_clone;
-        $asset->id = null;
-        $asset->asset_tag = '';
-        $asset->serial = '';
-        $asset->assigned_to = '';
+        $this->authorize('create', $asset);
+        $cloned = clone $asset;
+        $cloned->id = null;
+        $cloned->asset_tag = '';
+        $cloned->serial = '';
+        $cloned->assigned_to = '';
+        $cloned->deleted_at = '';
 
         return view('hardware/edit')
             ->with('statuslabel_list', Helper::statusLabelList())
             ->with('statuslabel_types', Helper::statusTypeList())
-            ->with('item', $asset);
+            ->with('item', $cloned);
     }
 
     /**

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -36,7 +36,7 @@
                 </div>
             </div>
         @endif
-            
+
         <div class="col-md-12">
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs hidden-print">
@@ -197,32 +197,31 @@
                                     @endif
                                 @endif
 
-
-                                @can('update', $asset)
-                                    @if ($asset->deleted_at=='')
+                                @if ($asset->deleted_at=='')
+                                    @can('update', $asset)
                                         <div class="col-md-12" style="padding-top: 5px;">
                                             <a href="{{ route('hardware.edit', $asset->id) }}" class="btn btn-sm btn-primary btn-block hidden-print">
                                                 {{ trans('admin/hardware/general.edit') }}
                                             </a>
                                         </div>
-                                    @endif
-                                @endcan
+                                    @endcan
+
+                                    @can('audit', \App\Models\Asset::class)
+                                        <div class="col-md-12" style="padding-top: 5px;">
+                                        <span class="tooltip-wrapper"{!! (!$asset->model ? ' data-tooltip="true" title="'.trans('admin/hardware/general.model_invalid_fix').'"' : '') !!}>
+                                            <a href="{{ route('asset.audit.create', $asset->id)  }}" class="btn btn-sm btn-primary btn-block hidden-print{{ (!$asset->model ? ' disabled' : '') }}">
+                                             {{ trans('general.audit') }}
+                                        </a>
+                                        </span>
+                                        </div>
+                                    @endcan
+                                @endif
 
                                 @can('create', $asset)
                                     <div class="col-md-12" style="padding-top: 5px;">
                                         <a href="{{ route('clone/hardware', $asset->id) }}" class="btn btn-sm btn-primary btn-block hidden-print">
                                             {{ trans('admin/hardware/general.clone') }}
                                         </a>
-                                    </div>
-                                @endcan
-
-                                @can('audit', \App\Models\Asset::class)
-                                    <div class="col-md-12" style="padding-top: 5px;">
-                                            <span class="tooltip-wrapper"{!! (!$asset->model ? ' data-tooltip="true" title="'.trans('admin/hardware/general.model_invalid_fix').'"' : '') !!}>
-                                                <a href="{{ route('asset.audit.create', $asset->id)  }}" class="btn btn-sm btn-primary btn-block hidden-print{{ (!$asset->model ? ' disabled' : '') }}">
-                                                 {{ trans('general.audit') }}
-                                            </a>
-                                            </span>
                                     </div>
                                 @endcan
 

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -78,17 +78,14 @@ Route::group(
             [AssetsController::class, 'getAssetBySerial']
         )->where('any', '.*')->name('findbyserial/hardware');
 
-        Route::get('{assetId}/clone',
+        Route::get('{asset}/clone',
             [AssetsController::class, 'getClone']
-        )->name('clone/hardware');
+        )->name('clone/hardware')->withTrashed();
 
         Route::get('{assetId}/label',
             [AssetsController::class, 'getLabel']
         )->name('label/hardware');
-
-        Route::post('{assetId}/clone', 
-            [AssetsController::class, 'postCreate']
-        );
+        
 
         Route::get('{assetId}/checkout',
             [AssetCheckoutController::class, 'create']

--- a/tests/Feature/Assets/Ui/CloneAssetTest.php
+++ b/tests/Feature/Assets/Ui/CloneAssetTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Feature\Assets\Ui;
+
+use App\Models\Asset;
+use App\Models\User;
+use Tests\TestCase;
+
+class CloneAssetTest extends TestCase
+{
+    public function testPermissionRequiredToCreateAssetModel()
+    {
+        $asset = Asset::factory()->create();
+        $this->actingAs(User::factory()->create())
+            ->get(route('clone/hardware', $asset))
+            ->assertForbidden();
+    }
+
+    public function testPageCanBeAccessed(): void
+    {
+        $asset = Asset::factory()->create();
+        $response = $this->actingAs(User::factory()->createAssets()->create())
+            ->get(route('clone/hardware', $asset));
+        $response->assertStatus(200);
+    }
+
+    public function testAssetCanBeCloned()
+    {
+        $asset_to_clone = Asset::factory()->create(['name'=>'Asset to clone']);
+        $this->actingAs(User::factory()->createAssets()->create())
+            ->get(route('clone/hardware', $asset_to_clone))
+            ->assertOk()
+            ->assertSee([
+                'Asset to clone'
+            ], false);;
+    }
+}

--- a/tests/Feature/Assets/Ui/CloneAssetTest.php
+++ b/tests/Feature/Assets/Ui/CloneAssetTest.php
@@ -32,6 +32,6 @@ class CloneAssetTest extends TestCase
             ->assertOk()
             ->assertSee([
                 'Asset to clone'
-            ], false);;
+            ], false);
     }
 }


### PR DESCRIPTION
This cleans up a bit of confusing UI and also now allows users to clone deleted assets. We were inconsistent with our UI, allowing the clone button on the "Deleted Assets" page, but would just return an "asset not found" error, so it should have been disabled, or it should have worked. 

I can see scenarios where you might want to clone a deleted item, so this PR makes it so that clicking "clone" on that asset will now bring up a normal clone page.