### PR TITLE
Fixes 500 when depreciation is active but no purchase date

### DIFF
--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -158,17 +158,20 @@ class Depreciable extends SnipeModel
 
     public function time_until_depreciated()
     {
-        // @link http://www.php.net/manual/en/class.datetime.php
-        $d1 = new \DateTime();
-        $d2 = $this->depreciated_date();
+        if ($this->depreciated_date()) {
+            // @link http://www.php.net/manual/en/class.datetime.php
+            $d1 = new \DateTime();
+            $d2 = $this->depreciated_date();
 
-        // @link http://www.php.net/manual/en/class.dateinterval.php
-        $interval = $d1->diff($d2);
-        if (! $interval->invert) {
-            return $interval;
-        } else {
-            return new \DateInterval('PT0S'); //null interval (zero seconds from now)
+            // @link http://www.php.net/manual/en/class.dateinterval.php
+            $interval = $d1->diff($d2);
+            if (! $interval->invert) {
+                return $interval;
+            } else {
+                return new \DateInterval('PT0S'); //null interval (zero seconds from now)
+            }
         }
+        return false;
     }
 
     public function depreciated_date()

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -50,7 +50,7 @@ class License extends Depreciable
         'category_id' => 'required|exists:categories,id',
         'company_id' => 'integer|nullable',
         'purchase_cost'=> 'numeric|nullable|gte:0',
-        'purchase_date'   => 'date_format:Y-m-d|nullable|max:10',
+        'purchase_date'   => 'date_format:Y-m-d|nullable|max:10|required_with:depreciation_id',
         'expiration_date'   => 'date_format:Y-m-d|nullable|max:10',
         'termination_date'   => 'date_format:Y-m-d|nullable|max:10',
         'min_amt'   => 'numeric|nullable|gte:0',

--- a/tests/Feature/Licenses/Ui/CreateLicenseTest.php
+++ b/tests/Feature/Licenses/Ui/CreateLicenseTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\Consumables\Ui;
+
+use App\Models\AssetModel;
+use App\Models\Category;
+use App\Models\License;
+use App\Models\Depreciation;
+use App\Models\User;
+use Tests\TestCase;
+
+class CreateLicenseTest extends TestCase
+{
+    public function testPermissionRequiredToViewLicense()
+    {
+        $license = License::factory()->create();
+        $this->actingAs(User::factory()->create())
+            ->get(route('licenses.create', $license))
+            ->assertForbidden();
+    }
+
+
+
+    public function testLicenseWithoutPurchaseDateFailsValidation()
+    {
+        $response = $this->actingAs(User::factory()->superuser()->create())
+            ->from(route('licenses.create'))
+            ->post(route('licenses.store'), [
+                'name' => 'Test Invalid License',
+                'seats' => '10',
+                'category_id' => Category::factory()->forLicenses()->create()->id,
+                'depreciation_id' => Depreciation::factory()->create()->id
+            ]);
+        $response->assertStatus(302);
+        $response->assertRedirect(route('licenses.create'));
+        $response->assertInvalid(['purchase_date']);
+        $response->assertSessionHasErrors(['purchase_date']);
+        $this->followRedirects($response)->assertSee(trans('general.error'));
+        $this->assertFalse(AssetModel::where('name', 'Test Invalid License')->exists());
+
+    }
+}

--- a/tests/Feature/Licenses/Ui/LicenseViewTest.php
+++ b/tests/Feature/Licenses/Ui/LicenseViewTest.php
@@ -16,17 +16,7 @@ class LicenseViewTest extends TestCase
             ->get(route('licenses.show', $license))
             ->assertForbidden();
     }
-
-
-    public function testLicenseWithNoPurchaseDateDoesNotTriggerDepreciation()
-    {
-        $depreciation = Depreciation::factory()->create(['months' => 12]);
-        $license = License::factory()->create(['depreciation_id' => $depreciation->id, 'purchase_date' => null]);
-        $this->actingAs(User::factory()->superuser()->create())
-            ->get(route('licenses.show', $license))
-            ->assertOk();
-    }
-
+    
     public function testLicenseWithPurchaseDateDepreciatesCorrectly()
     {
         $depreciation = Depreciation::factory()->create(['months' => 12]);

--- a/tests/Feature/Licenses/Ui/LicenseViewTest.php
+++ b/tests/Feature/Licenses/Ui/LicenseViewTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Consumables\Ui;
+
+use App\Models\License;
+use App\Models\Depreciation;
+use App\Models\User;
+use Tests\TestCase;
+
+class LicenseViewTest extends TestCase
+{
+    public function testPermissionRequiredToViewLicense()
+    {
+        $license = License::factory()->create();
+        $this->actingAs(User::factory()->create())
+            ->get(route('licenses.show', $license))
+            ->assertForbidden();
+    }
+
+
+    public function testLicenseWithNoPurchaseDateDoesNotTriggerDepreciation()
+    {
+        $depreciation = Depreciation::factory()->create(['months' => 12]);
+        $license = License::factory()->create(['depreciation_id' => $depreciation->id, 'purchase_date' => null]);
+        $this->actingAs(User::factory()->superuser()->create())
+            ->get(route('licenses.show', $license))
+            ->assertOk();
+    }
+
+    public function testLicenseWithPurchaseDateDepreciatesCorrectly()
+    {
+        $depreciation = Depreciation::factory()->create(['months' => 12]);
+        $license = License::factory()->create(['depreciation_id' => $depreciation->id, 'purchase_date' => '2020-01-01']);
+        $this->actingAs(User::factory()->superuser()->create())
+            ->get(route('licenses.show', $license))
+            ->assertOk()
+            ->assertSee([
+                '2021-01-01'
+            ], false);
+    }
+}


### PR DESCRIPTION
If a user had a license with a depreciation but no purchase date, the system would 500.

This adds validation to make sure that doesn't happen, and also more gracefully fails.

Oh, and tests.