### PR TITLE
Added assets endpoint for locations

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -5,8 +5,10 @@ namespace App\Http\Controllers\Api;
 use App\Helpers\Helper;
 use App\Http\Requests\ImageUploadRequest;
 use App\Http\Controllers\Controller;
+use App\Http\Transformers\AssetsTransformer;
 use App\Http\Transformers\LocationsTransformer;
 use App\Http\Transformers\SelectlistTransformer;
+use App\Models\Asset;
 use App\Models\Location;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -220,6 +222,15 @@ class LocationsController extends Controller
         }
 
         return response()->json(Helper::formatStandardApiResponse('error', null, $location->getErrors()));
+    }
+
+    public function assets(Request $request, Location $location) : JsonResponse | array
+    {
+        $this->authorize('view', Asset::class);
+        $this->authorize('view', $location);
+        $assets = Asset::where('assigned_to', '=', $location->id)->where('assigned_type', '=', Location::class)->with('model', 'model.category', 'assetstatus', 'location', 'company', 'defaultLoc');
+        $assets = $assets->get();
+        return (new AssetsTransformer)->transformAssets($assets, $assets->count(), $request);
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -712,7 +712,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
             Route::get('{location}/assets',
             [
                 Api\LocationsController::class, 
-                'getDataViewAssets'
+                'assets'
             ]
             )->name('api.locations.viewassets');
     

--- a/tests/Feature/Locations/Api/LocationsViewTest.php
+++ b/tests/Feature/Locations/Api/LocationsViewTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature\Consumables\Api;
+
+use App\Models\Location;
+use App\Models\Asset;
+use App\Models\User;
+use Tests\TestCase;
+
+class LocationsViewTest extends TestCase
+{
+    public function testViewingLocationRequiresPermission()
+    {
+        $location = Location::factory()->create();
+        $this->actingAsForApi(User::factory()->create())
+            ->getJson(route('api.locations.show', $location->id))
+            ->assertForbidden();
+    }
+
+    public function testViewingLocationAssetIndexRequiresPermission()
+    {
+        $location = Location::factory()->create();
+        Asset::factory()->count(3)->assignedToLocation($location)->create();
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(route('api.locations.viewassets', $location->id))
+            ->assertOk()
+            ->assertJsonStructure([
+                'total',
+                'rows',
+            ])
+            ->assertJson([
+                'total' => 3,
+            ]);
+    }
+}

--- a/tests/Feature/Locations/Api/LocationsViewTest.php
+++ b/tests/Feature/Locations/Api/LocationsViewTest.php
@@ -20,6 +20,14 @@ class LocationsViewTest extends TestCase
     public function testViewingLocationAssetIndexRequiresPermission()
     {
         $location = Location::factory()->create();
+        $this->actingAsForApi(User::factory()->create())
+            ->getJson(route('api.locations.viewassets', $location->id))
+            ->assertForbidden();
+    }
+
+    public function testViewingLocationAssetIndex()
+    {
+        $location = Location::factory()->create();
         Asset::factory()->count(3)->assignedToLocation($location)->create();
 
         $this->actingAsForApi(User::factory()->superuser()->create())


### PR DESCRIPTION
This was never documented, and I'm not even sure if it ever existed, but we had a route for it. `/locations/{id}/assets` now returns a list of assets assigned to that location.

(This was tripping a rollbar, so I wanted to get rid of it.)