### PR TITLE
Create intermediate directories on restore if needed - Fixes [SC-25950]

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -466,6 +466,9 @@ class RestoreFromBackup extends Command
             $ugly_file_name = $za->statIndex($file_details['index'])['name'];
             $fp = $za->getStream($ugly_file_name);
             //$this->info("Weird problem, here are file details? ".print_r($file_details,true));
+            if (!is_dir($file_details['dest'])) {
+                mkdir($file_details['dest'], 0755, true); //0755 is what Laravel uses, so we do that
+            }
             $migrated_file = fopen($file_details['dest'].'/'.basename($pretty_file_name), 'w');
             while (($buffer = fgets($fp, SQLStreamer::$buffer_size)) !== false) {
                 fwrite($migrated_file, $buffer);


### PR DESCRIPTION
Most of the time, the appropriate subdirectories in the storage directory will already exist. But under some circumstances, they might not - and then the restore tool won't be able to restore files to those subdirectories.

This just creates those subdirectories if they don't already exist. I used the same permissions mask that Laravel uses internally.