### PR TITLE
Added #14979: add checkout to location and assets functionality to accessories

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -92,7 +92,7 @@ class SQLStreamer {
         $parser->line_aware_piping(); // <----- THIS is doing the heavy lifting!
 
         $check_tables = ['settings' => null, 'migrations' => null /* 'assets' => null */]; //TODO - move to statics?
-        //can't use 'users' because the 'accessories_users' table?
+        //can't use 'users' because the 'accessories_checkout' table?
         // can't use 'assets' because 'ver1_components_assets'
         foreach($check_tables as $check_table => $_ignore) {
             foreach ($parser->tablenames as $tablename => $_count) {

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -721,7 +721,7 @@ class Helper
     {
         $alert_threshold = \App\Models\Setting::getSettings()->alert_threshold;
         $consumables = Consumable::withCount('consumableAssignments as consumable_assignments_count')->whereNotNull('min_amt')->get();
-        $accessories = Accessory::withCount('users as users_count')->whereNotNull('min_amt')->get();
+        $accessories = Accessory::withCount('checkouts as checkouts_count')->whereNotNull('min_amt')->get();
         $components = Component::whereNotNull('min_amt')->get();
         $asset_models = AssetModel::where('min_amt', '>', 0)->get();
         $licenses = License::where('min_amt', '>', 0)->get();
@@ -749,7 +749,7 @@ class Helper
         }
 
         foreach ($accessories as $accessory) {
-            $avail = $accessory->qty - $accessory->users_count;
+            $avail = $accessory->qty - $accessory->checkouts_count;
             if ($avail < ($accessory->min_amt) + $alert_threshold) {
                 if ($accessory->qty > 0) {
                     $percent = number_format((($avail / $accessory->qty) * 100), 0);

--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -144,12 +144,12 @@ class AccessoriesController extends Controller
      */
     public function update(ImageUploadRequest $request, $accessoryId = null) : RedirectResponse
     {
-        if ($accessory = Accessory::withCount('users as users_count')->find($accessoryId)) {
+        if ($accessory = Accessory::withCount('checkouts as checkouts_count')->find($accessoryId)) {
 
             $this->authorize($accessory);
 
             $validator = Validator::make($request->all(), [
-                "qty" => "required|numeric|min:$accessory->users_count"
+                "qty" => "required|numeric|min:$accessory->checkouts_count"
             ]);
 
             if ($validator->fails()) {
@@ -233,7 +233,7 @@ class AccessoriesController extends Controller
      */
     public function show($accessoryID = null) : View | RedirectResponse
     {
-        $accessory = Accessory::withCount('users as users_count')->find($accessoryID);
+        $accessory = Accessory::withCount('checkouts as checkouts_count')->find($accessoryID);
         $this->authorize('view', $accessory);
         if (isset($accessory->id)) {
             return view('accessories/view', compact('accessory'));

--- a/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckoutController.php
@@ -4,9 +4,11 @@ namespace App\Http\Controllers\Accessories;
 
 use App\Events\CheckoutableCheckedOut;
 use App\Helpers\Helper;
+use App\Http\Controllers\CheckInOutRequest;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AccessoryCheckoutRequest;
 use App\Models\Accessory;
+use App\Models\AccessoryCheckout;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -16,6 +18,9 @@ use \Illuminate\Http\RedirectResponse;
 
 class AccessoryCheckoutController extends Controller
 {
+
+    use CheckInOutRequest;
+
     /**
      * Return the form to checkout an Accessory to a user.
      *
@@ -25,7 +30,7 @@ class AccessoryCheckoutController extends Controller
     public function create($id) : View | RedirectResponse
     {
 
-        if ($accessory = Accessory::withCount('users as users_count')->find($id)) {
+        if ($accessory = Accessory::withCount('checkouts as checkouts_count')->find($id)) {
 
             $this->authorize('checkout', $accessory);
 
@@ -58,30 +63,32 @@ class AccessoryCheckoutController extends Controller
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @param Request $request
-     * @param  int $accessory
+     * @param  Accessory $accessory
      */
     public function store(AccessoryCheckoutRequest $request, Accessory $accessory) : RedirectResponse
     {
-
+        
         $this->authorize('checkout', $accessory);
-        $accessory->assigned_to = $request->input('assigned_to');
-        $user = User::find($request->input('assigned_to'));
-        $accessory->checkout_qty = $request->input('checkout_qty', 1);
 
+        $target = $this->determineCheckoutTarget();
+        
+        $accessory->checkout_qty = $request->input('checkout_qty', 1);
+        
         for ($i = 0; $i < $accessory->checkout_qty; $i++) {
-            $accessory->users()->attach($accessory->id, [
+            AccessoryCheckout::create([
                 'accessory_id' => $accessory->id,
                 'created_at' => Carbon::now(),
                 'user_id' => Auth::id(),
-                'assigned_to' => $request->input('assigned_to'),
+                'assigned_to' => $target->id,
+                'assigned_type' => $target::class,
                 'note' => $request->input('note'),
             ]);
         }
-        event(new CheckoutableCheckedOut($accessory, $user, auth()->user(), $request->input('note')));
+        event(new CheckoutableCheckedOut($accessory,  $target, auth()->user(), $request->input('note')));
 
         // Set this as user since we only allow checkout to user for this item type
-        $request->request->add(['checkout_to_type' => 'user']);
-        $request->request->add(['assigned_user' => $user->id]);
+        $request->request->add(['checkout_to_type' => request('checkout_to_type')]);
+        $request->request->add(['assigned_user' => $target->id]);
 
         session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => $request->get('checkout_to_type')]);
 

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -314,7 +314,7 @@ class AccessoriesController extends Controller
      */
     public function checkin(Request $request, $accessoryUserId = null)
     {
-        if (is_null($accessory_checkout = DB::table('accessories_checkout')->find($accessoryUserId))) {
+        if (is_null($accessory_checkout = AccessoryCheckout::find($accessoryUserId))) {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/accessories/message.does_not_exist')));
         }
 
@@ -324,7 +324,7 @@ class AccessoriesController extends Controller
         $logaction = $accessory->logCheckin(User::find($accessory_checkout->assigned_to), $request->input('note'));
 
         // Was the accessory updated?
-        if (DB::table('accessories_checkout')->where('id', '=', $accessory_checkout->id)->delete()) {
+        if ($accessory_checkout->delete()) {
             if (! is_null($accessory_checkout->assigned_to)) {
                 $user = User::find($accessory_checkout->assigned_to);
             }

--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -219,7 +219,7 @@ class BulkUsersController extends Controller
 
         $users = User::whereIn('id', $user_raw_array)->get();
         $assets = Asset::whereIn('assigned_to', $user_raw_array)->where('assigned_type', \App\Models\User::class)->get();
-        $accessories = DB::table('accessories_users')->whereIn('assigned_to', $user_raw_array)->get();
+        $accessories = DB::table('accessories_checkout')->whereIn('assigned_to', $user_raw_array)->get();
         $licenses = DB::table('license_seats')->whereIn('assigned_to', $user_raw_array)->get();
         $consumables = DB::table('consumables_users')->whereIn('assigned_to', $user_raw_array)->get();
 

--- a/app/Http/Requests/AccessoryCheckoutRequest.php
+++ b/app/Http/Requests/AccessoryCheckoutRequest.php
@@ -44,13 +44,10 @@ class AccessoryCheckoutRequest extends ImageUploadRequest
 
         return array_merge(
             [
-                'assigned_to'  => [
-                    'required',
-                    'integer',
-                    'exists:users,id,deleted_at,NULL',
-                    'not_array'
-                ],
-
+                'assigned_user'         => 'required_without_all:assigned_asset,assigned_location',
+                'assigned_asset'        => 'required_without_all:assigned_user,assigned_location',
+                'assigned_location'     => 'required_without_all:assigned_user,assigned_asset',
+                
                 'number_remaining_after_checkout' => [
                     'min:0',
                     'required',

--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -205,11 +205,11 @@ class ActionlogsTransformer
 
 
 
-    public function transformCheckedoutActionlog (Collection $accessories_users, $total)
+    public function transformCheckedoutActionlog (Collection $accessories_checkout, $total)
     {
 
         $array = array();
-        foreach ($accessories_users as $user) {
+        foreach ($accessories_checkout as $user) {
             $array[] = (new UsersTransformer)->transformUser($user);
         }
         return (new DatatablesTransformer)->transformDatatables($array, $total);

--- a/app/Models/AccessoryCheckout.php
+++ b/app/Models/AccessoryCheckout.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Models;
+
+use App\Helpers\Helper;
+use App\Models\Traits\Acceptable;
+use App\Models\Traits\Searchable;
+use App\Presenters\Presentable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Storage;
+use Watson\Validating\ValidatingTrait;
+
+/**
+ * Model for Accessories.
+ *
+ * @version    v1.0
+ */
+class AccessoryCheckout extends Model
+{
+    use Searchable;
+
+    protected $fillable = ['user_id', 'accessory_id', 'assigned_to', 'assigned_type', 'note'];
+    protected $table = 'accessories_checkout';
+    
+    /**
+     * Establishes the accessory checkout -> accessory relationship
+     *
+     * @author [A. Kroeger]
+     * @since [v7.0.9]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function accessory()
+    {
+        return $this->hasOne(\App\Models\Accessory::class, 'accessory_id');
+    }
+
+    /**
+     * Establishes the accessory checkout -> user relationship
+     *
+     * @author [A. Kroeger]
+     * @since [v7.0.9]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function user()
+    {
+        return $this->hasOne(\App\Models\User::class, 'user_id');
+    }
+
+    /**
+     * Get the target this asset is checked out to
+     *
+     * @author [A. Kroeger]
+     * @since [v7.0]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function assignedTo()
+    {
+        return $this->morphTo('assigned', 'assigned_type', 'assigned_to')->withTrashed();
+    }
+
+    /**
+     * Gets the lowercased name of the type of target the asset is assigned to
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v4.0]
+     * @return string
+     */
+    public function assignedType()
+    {
+        return $this->assigned_type ? strtolower(class_basename($this->assigned_type)) : null;
+    }
+
+    /**
+     * Determines whether the accessory is checked out to a user
+     *
+     * Even though we allow allow for checkout to things beyond users
+     * this method is an easy way of seeing if we are checked out to a user.
+     *
+     * @author [A. Kroeger]
+     * @since [v7.0]
+     */
+    public function checkedOutToUser(): bool
+    {
+      return $this->assignedType() === Asset::USER;
+    }
+
+    public function scopeUserAssigned(Builder $query): void
+    {
+        $query->where('assigned_type', '=', User::class);
+    }
+
+    /**
+     * Run additional, advanced searches.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @param  array  $terms The search terms
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function advancedTextSearch(Builder $query, array $terms)
+    {
+
+        $userQuery = User::where(function ($query) use ($terms) {
+            foreach ($terms as $term) {
+                $search_str = '%' . $term . '%';
+                $query->where('first_name', 'like', $search_str)
+                    ->orWhere('last_name', 'like', $search_str)
+                    ->orWhere('note', 'like', $search_str);
+            }
+        })->select('id');
+
+        $locationQuery = Location::where(function ($query) use ($terms) {
+            foreach ($terms as $term) {
+                $search_str = '%' . $term . '%';
+                $query->where('name', 'like', $search_str);
+            }
+        })->select('id');
+
+        $assetQuery = Asset::where(function ($query) use ($terms) {
+            foreach ($terms as $term) {
+                $search_str = '%' . $term . '%';
+                $query->where('name', 'like', $search_str);
+            }
+        })->select('id');
+
+        $query->where(function ($query) use ($userQuery) {
+            $query->where('assigned_type', User::class)
+            ->whereIn('assigned_to', $userQuery);
+        })->orWhere(function($query) use ($locationQuery) {
+            $query->where('assigned_type', Location::class)
+            ->whereIn('assigned_to', $locationQuery);
+        })->orWhere(function($query) use ($assetQuery) {
+            $query->where('assigned_type', Asset::class)
+            ->whereIn('assigned_to', $assetQuery);
+        })->orWhere(function($query) use ($terms) {
+            foreach ($terms as $term) {
+                $search_str = '%' . $term . '%';
+                $query->where('note', 'like', $search_str);
+            }
+        });
+
+        return $query;
+    }
+
+
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -331,7 +331,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function accessories()
     {
-        return $this->belongsToMany(\App\Models\Accessory::class, 'accessories_users', 'assigned_to', 'accessory_id')
+        return $this->belongsToMany(\App\Models\Accessory::class, 'accessories_checkout', 'assigned_to', 'accessory_id')
             ->withPivot('id', 'created_at', 'note')->withTrashed()->orderBy('accessory_id');
     }
 

--- a/app/Presenters/AccessoryPresenter.php
+++ b/app/Presenters/AccessoryPresenter.php
@@ -90,7 +90,7 @@ class AccessoryPresenter extends Presenter
                 'visible' => false,
                 'title' => trans('admin/accessories/general.remaining'),
             ],[
-                'field' => 'users_count',
+                'field' => 'checkouts_count',
                 'searchable' => false,
                 'sortable' => true,
                 'visible' => true,

--- a/database/factories/AccessoryFactory.php
+++ b/database/factories/AccessoryFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Accessory;
+use App\Models\AccessoryCheckout;
 use App\Models\Category;
 use App\Models\Location;
 use App\Models\Manufacturer;
@@ -125,11 +126,12 @@ class AccessoryFactory extends Factory
         })->afterCreating(function ($accessory) {
             $user = User::factory()->create();
 
-            $accessory->users()->attach($accessory->id, [
+            $accessory->checkouts()->create([
                 'accessory_id' => $accessory->id,
-                'created_at' => now(),
+                'created_at' => Carbon::now(),
                 'user_id' => $user->id,
                 'assigned_to' => $user->id,
+                'assigned_type' => User::class,
                 'note' => '',
             ]);
         });
@@ -145,11 +147,12 @@ class AccessoryFactory extends Factory
     public function checkedOutToUser(User $user = null)
     {
         return $this->afterCreating(function (Accessory $accessory) use ($user) {
-            $accessory->users()->attach($accessory->id, [
+            $accessory->checkouts()->create([
                 'accessory_id' => $accessory->id,
                 'created_at' => Carbon::now(),
                 'user_id' => 1,
                 'assigned_to' => $user->id ?? User::factory()->create()->id,
+                'assigned_type' => User::class,
             ]);
         });
     }

--- a/database/migrations/2024_07_26_143301_add_checkout_for_all_types_to_accessories.php
+++ b/database/migrations/2024_07_26_143301_add_checkout_for_all_types_to_accessories.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('accessories_users')) {
+            Schema::rename('accessories_users', 'accessories_checkout');
+
+            Schema::table('accessories_checkout', function (Blueprint $table) {
+                if (!Schema::hasColumn('accessories_checkout', 'assigned_type')) {
+                    $table->string('assigned_type')->nullable();
+                }
+            });
+        }
+        
+        DB::update('update '.DB::getTablePrefix().'accessories_checkout set assigned_type = \'App\\\\Models\\\\User\' where assigned_type is null', []);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('accessories_checkout')) {
+            Schema::rename('accessories_checkout', 'accessories_users');
+        }
+    }
+};

--- a/database/migrations/2024_07_26_143301_add_checkout_for_all_types_to_accessories.php
+++ b/database/migrations/2024_07_26_143301_add_checkout_for_all_types_to_accessories.php
@@ -33,6 +33,10 @@ return new class extends Migration
     public function down(): void
     {
         if (Schema::hasTable('accessories_checkout')) {
+            Schema::table('accessories_checkout', function (Blueprint $table) {
+                $table->dropColumn('assigned_type');   
+            });
+
             Schema::rename('accessories_checkout', 'accessories_users');
         }
     }

--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -66,7 +66,14 @@
              </div>
           <!-- User -->
 
-          @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_to', 'required'=> 'true'])
+          @include ('partials.forms.checkout-selector', ['user_select' => 'true','asset_select' => 'true', 'location_select' => 'true'])
+
+          @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_user', 'required'=> 'true'])
+
+          <!-- We have to pass unselect here so that we don't default to the asset that's being checked out. We want that asset to be pre-selected everywhere else. -->
+          @include ('partials.forms.edit.asset-select', ['translated_name' => trans('general.asset'), 'fieldname' => 'assigned_asset', 'unselect' => 'true', 'style' => 'display:none;', 'required'=>'true'])
+
+          @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'assigned_location', 'style' => 'display:none;', 'required'=>'true'])
 
              <!-- Checkout QTY -->
              <div class="form-group {{ $errors->has('checkout_qty') ? 'error' : '' }} ">

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -68,9 +68,9 @@
                           <div class="row">
                               <div class="col-md-12">
                                 <table
-                                    data-cookie-id-table="usersTable"
+                                    data-cookie-id-table="checkoutsTable"
                                     data-pagination="true"
-                                    data-id-table="usersTable"
+                                    data-id-table="checkoutsTable"
                                     data-search="true"
                                     data-side-pagination="server"
                                     data-show-columns="true"
@@ -78,16 +78,16 @@
                                     data-show-export="true"
                                     data-show-refresh="true"
                                     data-sort-order="asc"
-                                    id="usersTable"
+                                    id="checkoutsTable"
                                     class="table table-striped snipe-table"
                                     data-url="{{ route('api.accessories.checkedout', $accessory->id) }}"
                                     data-export-options='{
-                                    "fileName": "export-accessories-{{ str_slug($accessory->name) }}-users-{{ date('Y-m-d') }}",
+                                    "fileName": "export-accessories-{{ str_slug($accessory->name) }}-checkouts-{{ date('Y-m-d') }}",
                                     "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                                     }'>
                                 <thead>
                                     <tr>
-                                    <th data-searchable="false" data-formatter="usersLinkFormatter" data-sortable="false" data-field="name">{{ trans('general.user') }}</th>
+                                    <th data-searchable="false" data-formatter="polymorphicItemFormatter" data-sortable="false" data-field="assigned_to">{{ trans('general.checked_out_to') }}</th>
                                     <th data-searchable="false" data-sortable="false" data-field="checkout_notes">{{ trans('general.notes') }}</th>
                                     <th data-searchable="false" data-formatter="dateDisplayFormatter" data-sortable="false" data-field="last_checkout">{{ trans('admin/hardware/table.checkout_date') }}</th>
                                     <th data-searchable="false" data-sortable="false" data-field="actions" data-formatter="accessoriesInOutFormatter">{{ trans('table.actions') }}</th>
@@ -314,7 +314,7 @@
               <strong>{{ trans('general.checked_out') }}</strong>
           </div>
           <div class="col-md-9">
-              {{ $accessory->users_count }}
+              {{ $accessory->checkouts_count }}
           </div>
       </div>
 </div>
@@ -337,7 +337,7 @@
         @endcan
 
         @can('delete', $accessory)
-            @if ($accessory->users_count == 0)
+            @if ($accessory->checkouts_count == 0)
                 <div class="text-center" style="padding-top:5px;">
                     <button class="btn btn-block btn-danger delete-asset" style="padding-top:5px;" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.delete_confirm_no_undo', ['item' => $accessory->name]) }}" data-target="#dataConfirmModal">
                     {{ trans('general.delete') }}

--- a/tests/Feature/Checkins/Ui/AccessoryCheckinTest.php
+++ b/tests/Feature/Checkins/Ui/AccessoryCheckinTest.php
@@ -17,7 +17,7 @@ class AccessoryCheckinTest extends TestCase
         $accessory = Accessory::factory()->checkedOutToUser()->create();
 
         $this->actingAs(User::factory()->create())
-            ->post(route('accessories.checkin.store', $accessory->users->first()->pivot->id))
+            ->post(route('accessories.checkin.store', $accessory->checkouts->first()->id))
             ->assertForbidden();
     }
 
@@ -28,12 +28,12 @@ class AccessoryCheckinTest extends TestCase
         $user = User::factory()->create();
         $accessory = Accessory::factory()->checkedOutToUser($user)->create();
 
-        $this->assertTrue($accessory->users->contains($user));
+        $this->assertTrue($accessory->checkouts()->where('assigned_type', User::class)->where('assigned_to', $user->id)->count() > 0);
 
         $this->actingAs(User::factory()->checkinAccessories()->create())
-            ->post(route('accessories.checkin.store', $accessory->users->first()->pivot->id));
+            ->post(route('accessories.checkin.store', $accessory->checkouts->first()->id));
 
-        $this->assertFalse($accessory->fresh()->users->contains($user));
+        $this->assertFalse($accessory->fresh()->checkouts()->where('assigned_type', User::class)->where('assigned_to', $user->id)->count() > 0);
 
         Event::assertDispatched(CheckoutableCheckedIn::class, 1);
     }

--- a/tests/Feature/Checkouts/Ui/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/AccessoryCheckoutTest.php
@@ -40,7 +40,8 @@ class AccessoryCheckoutTest extends TestCase
         $response = $this->actingAs(User::factory()->viewAccessories()->checkoutAccessories()->create())
             ->from(route('accessories.checkout.show', $accessory))
             ->post(route('accessories.checkout.store', $accessory), [
-                'assigned_to' => User::factory()->create()->id,
+                'assigned_user' => User::factory()->create()->id,
+                'checkout_to_type' => 'user',
             ])
             ->assertStatus(302)
             ->assertSessionHas('errors')
@@ -56,11 +57,12 @@ class AccessoryCheckoutTest extends TestCase
 
         $this->actingAs(User::factory()->checkoutAccessories()->create())
             ->post(route('accessories.checkout.store', $accessory), [
-                'assigned_to' => $user->id,
+                'assigned_user' => $user->id,
+                'checkout_to_type' => 'user',
                 'note' => 'oh hi there',
             ]);
 
-        $this->assertTrue($accessory->users->contains($user));
+        $this->assertTrue($accessory->checkouts()->where('assigned_type', User::class)->where('assigned_to', $user->id)->count() > 0);
 
         $this->assertDatabaseHas('action_logs', [
             'action_type' => 'checkout',
@@ -80,12 +82,13 @@ class AccessoryCheckoutTest extends TestCase
         $this->actingAs(User::factory()->checkoutAccessories()->create())
             ->from(route('accessories.checkout.show', $accessory))
             ->post(route('accessories.checkout.store', $accessory), [
-                'assigned_to' => $user->id,
+                'assigned_user' => $user->id,
+                'checkout_to_type' => 'user',
                 'checkout_qty' => 3,
                 'note' => 'oh hi there',
             ]);
 
-        $this->assertTrue($accessory->users->contains($user));
+        $this->assertTrue($accessory->checkouts()->where('assigned_type', User::class)->where('assigned_to', $user->id)->count() > 0);
 
         $this->assertDatabaseHas('action_logs', [
             'action_type' => 'checkout',
@@ -107,7 +110,8 @@ class AccessoryCheckoutTest extends TestCase
         $this->actingAs(User::factory()->checkoutAccessories()->create())
             ->from(route('accessories.checkout.show', $accessory))
             ->post(route('accessories.checkout.store', $accessory), [
-                'assigned_to' => $user->id,
+                'assigned_user' => $user->id,
+                'checkout_to_type' => 'user',
             ]);
 
         Notification::assertSentTo($user, CheckoutAccessoryNotification::class);
@@ -122,7 +126,8 @@ class AccessoryCheckoutTest extends TestCase
         $this->actingAs($actor)
             ->from(route('accessories.checkout.show', $accessory))
             ->post(route('accessories.checkout.store', $accessory), [
-                'assigned_to' => $user->id,
+                'assigned_user' => $user->id,
+                'checkout_to_type' => 'user',
                 'note' => 'oh hi there',
             ]);
 

--- a/tests/Feature/Checkouts/Ui/AccessoryCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/AccessoryCheckoutTest.php
@@ -207,7 +207,8 @@ class AccessoryCheckoutTest extends TestCase
         $this->actingAs(User::factory()->admin()->create())
             ->from(route('accessories.index'))
             ->post(route('accessories.checkout.store', $accessory), [
-                'assigned_to' =>  User::factory()->create()->id,
+                'assigned_user' => User::factory()->create()->id,
+                'checkout_to_type' => 'user',
                 'redirect_option' => 'index',
                 'assigned_qty' => 1,
             ])
@@ -222,7 +223,8 @@ class AccessoryCheckoutTest extends TestCase
         $this->actingAs(User::factory()->admin()->create())
             ->from(route('accessories.index'))
             ->post(route('accessories.checkout.store' , $accessory), [
-                'assigned_to' =>  User::factory()->create()->id,
+                'assigned_user' => User::factory()->create()->id,
+                'checkout_to_type' => 'user',
                 'redirect_option' => 'item',
                 'assigned_qty' => 1,
             ])
@@ -239,7 +241,8 @@ class AccessoryCheckoutTest extends TestCase
         $this->actingAs(User::factory()->admin()->create())
             ->from(route('accessories.index'))
             ->post(route('accessories.checkout.store' , $accessory), [
-                'assigned_to' =>  $user->id,
+                'assigned_user' => $user->id,
+                'checkout_to_type' => 'user',
                 'redirect_option' => 'target',
                 'assigned_qty' => 1,
             ])


### PR DESCRIPTION
Added #14979: add checkout functionality to accessories

# Description

Currently it is just possible to checkout accessories to a user and not to a location or asset like it is possible for assets. This would cover many use cases where a workplace definition can be done with a location or an assignment of accessories to a room. There are several uses case descriptions in the linked issues (see below). 

Added #14665 
Added #12381 
Added #12452 
Added #11820
Added #10956 
Added #5140  (parts of it)
Added #14979 (parts of it)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tests\Feature\Checkouts\Ui\AccessoryCheckoutTest::testAccessoryCanBeCheckedOutToLocationWithQuantity
- [x] Tests\Feature\Checkouts\Ui\AccessoryCheckoutTest::testAccessoryCanBeCheckedOutToAssetWithQuantity

**Test Configuration**:
* PHP version: 8.3.9
* MariaDB version - 10.11
* Webserver version - php server
* OS version - Mac OS 

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
