### PR TITLE
Use the `pwd_secure_min` value (plus 5) for generated password

### DIFF
--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -678,7 +678,7 @@ $(document).ready(function() {
         'bind': 'click',
         'passwordElement': '#password',
         'displayElement': '#generated-password',
-        'passwordLength': 16,
+        'passwordLength': {{ ($settings->pwd_secure_min + 5) }},
         'uppercase': true,
         'lowercase': true,
         'numbers':   true,

--- a/tests/Feature/Checkouts/Ui/ComponentsCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/ComponentsCheckoutTest.php
@@ -7,7 +7,7 @@ use App\Models\Component;
 use App\Models\User;
 use Tests\TestCase;
 
-class ComponentCheckoutTest extends TestCase
+class ComponentsCheckoutTest extends TestCase
 {
     public function testCheckingOutComponentRequiresCorrectPermission()
     {


### PR DESCRIPTION
A user in MacAdmins mentioned that our password generation on the user create doesn't respect the `pwd_secure_min`. The default was 16, but if you had a password requirement of higher than that, it would generate a password that was too short.

This now takes the `pwd_secure_min` value and adds 5 (for good measure) for the length of password  that gets generated. 