### PR TITLE
Fixed admin boxes alignment

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -714,6 +714,11 @@ th.css-location > .th-inner::before {
     margin-top:50px
   }
 }
+@media screen and (max-width: 1318px) and (min-width: 1200px){
+  .box{
+    height:170px;
+  }
+}
 
 .ellipsis {
   overflow: hidden;


### PR DESCRIPTION
# Description
When the language chosen requires more space it breaks the order of the setting boxes. This sets a height of 170px between `(max-width: 1318px) and (min-width: 1200px)` 

Before:
![image](https://github.com/user-attachments/assets/8e561718-7854-4aca-84db-03a51ab86f1e)

After:
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/4a857830-9259-44c8-828e-b5abeb1ffe56">

Fixes #15191 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
