### PR TITLE
Add MayContainCustomFields Trait to Asset Update Request

### DIFF
--- a/app/Http/Requests/Traits/MayContainCustomFields.php
+++ b/app/Http/Requests/Traits/MayContainCustomFields.php
@@ -15,7 +15,6 @@ trait MayContainCustomFields
             $asset_model = AssetModel::find($this->model_id);
         }
         if ($this->method() == 'PATCH' || $this->method() == 'PUT') {
-            // this is dependent on the asset update request PR
             $asset_model = $this->asset;
         }
         // collect the custom fields in the request

--- a/app/Http/Requests/Traits/MayContainCustomFields.php
+++ b/app/Http/Requests/Traits/MayContainCustomFields.php
@@ -15,7 +15,7 @@ trait MayContainCustomFields
             $asset_model = AssetModel::find($this->model_id);
         }
         if ($this->method() == 'PATCH' || $this->method() == 'PUT') {
-            $asset_model = $this->asset;
+            $asset_model = $this->asset->model;
         }
         // collect the custom fields in the request
         $validator->after(function ($validator) use ($asset_model) {

--- a/app/Http/Requests/Traits/MayContainCustomFields.php
+++ b/app/Http/Requests/Traits/MayContainCustomFields.php
@@ -24,7 +24,7 @@ trait MayContainCustomFields
             });
             // if there are custom fields, find the one's that don't exist on the model's fieldset and add an error to the validator's error bag
             if (count($request_fields) > 0) {
-                $request_fields->diff($asset_model->fieldset->fields->pluck('db_column'))
+                $request_fields->diff($asset_model?->fieldset?->fields?->pluck('db_column'))
                         ->each(function ($request_field_name) use ($request_fields, $validator) {
                             if (CustomField::where('db_column', $request_field_name)->exists()) {
                                 $validator->errors()->add($request_field_name, trans('validation.custom.custom_field_not_found_on_model'));

--- a/app/Http/Requests/UpdateAssetRequest.php
+++ b/app/Http/Requests/UpdateAssetRequest.php
@@ -2,12 +2,14 @@
 
 namespace App\Http\Requests;
 
+use App\Http\Requests\Traits\MayContainCustomFields;
 use App\Models\Asset;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 
 class UpdateAssetRequest extends ImageUploadRequest
 {
+    use MayContainCustomFields;
     /**
      * Determine if the user is authorized to make this request.
      *

--- a/tests/Feature/Assets/Api/UpdateAssetTest.php
+++ b/tests/Feature/Assets/Api/UpdateAssetTest.php
@@ -269,6 +269,8 @@ class UpdateAssetTest extends TestCase
     {
         $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');
 
+        // hmm, for some reason this customfield isn't attached to a fieldset
+        // need to check out these factory methods...
         $field = CustomField::factory()->testEncrypted()->create();
         $asset = Asset::factory()->hasEncryptedCustomField($field)->create();
         $superuser = User::factory()->superuser()->create();

--- a/tests/Feature/Assets/Api/UpdateAssetTest.php
+++ b/tests/Feature/Assets/Api/UpdateAssetTest.php
@@ -457,6 +457,8 @@ class UpdateAssetTest extends TestCase
 
     public function testCustomFieldCannotBeUpdatedIfNotOnCurrentAssetModel()
     {
+        $this->markIncompleteIfMySQL('Custom Field Tests do not work in MySQL');
+
         $customField = CustomField::factory()->create();
         $customField2 = CustomField::factory()->create();
         $asset = Asset::factory()->hasMultipleCustomFields([$customField])->create();


### PR DESCRIPTION
# Description
What it says on the tin, also added some null safe checks and fixed an issue with the trait that wasn't being used yet. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Test written

**Test Configuration**:
* PHP version: 8.1
