### PR TITLE
Fixed (temp) put route

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -576,6 +576,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
     // this would probably keep working with the resource route group, but the general practice is for
     // the model name to be the parameter - and i think it's a good differentiation in the code while we convert the others.
     Route::patch('/hardware/{asset}', [Api\AssetsController::class, 'update'])->name('api.assets.update');
+    Route::put('/hardware/{asset}', [Api\AssetsController::class, 'update'])->name('api.assets.put-update');
 
     Route::resource('hardware',
         Api\AssetsController::class,


### PR DESCRIPTION
This addresses a regression where performing a PUT action to update an asset would result in a 405 method not allowed error.

This is not the ultimate fix and I largely hate this, but at least it fixes it for now.