### PR TITLE
Fixed dashboard box overflow

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -719,6 +719,14 @@ th.css-location > .th-inner::before {
     height:170px;
   }
 }
+@media screen and (max-width: 1494px) and (min-width: 1200px){
+  .dashboard{
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: center;
+    white-space: nowrap;
+  }
+}
 
 .ellipsis {
   overflow: hidden;

--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -715,25 +715,19 @@ th.css-location > .th-inner::before {
   }
 }
 @media screen and (max-width: 1318px) and (min-width: 1200px){
-  .box{
+  .admin.box{
     height:170px;
   }
 }
 @media screen and (max-width: 1494px) and (min-width: 1200px){
-  .dashboard{
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-align: center;
+  .dashboard.small-box{
     white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 188px;
+    display: block;
+    overflow: hidden;
   }
 }
-
-.ellipsis {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
 
 /** Form-stuff overrides for checkboxes and stuff **/
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -31,7 +31,7 @@
   <div class="col-lg-2 col-xs-6">
       <a href="{{ route('hardware.index') }}">
     <!-- small box -->
-    <div class="small-box bg-teal">
+    <div class="dashboard small-box bg-teal">
       <div class="inner">
         <h3>{{ number_format(\App\Models\Asset::AssetsForShow()->count()) }}</h3>
         <p>{{ strtolower(trans('general.assets')) }}</p>
@@ -49,7 +49,7 @@
   <div class="col-lg-2 col-xs-6">
      <a href="{{ route('licenses.index') }}">
     <!-- small box -->
-    <div class="small-box bg-maroon">
+    <div class="dashboard small-box bg-maroon">
       <div class="inner">
         <h3>{{ number_format($counts['license']) }}</h3>
         <p>{{ strtolower(trans('general.licenses')) }}</p>
@@ -68,7 +68,7 @@
   <div class="col-lg-2 col-xs-6">
     <!-- small box -->
       <a href="{{ route('accessories.index') }}">
-    <div class="small-box bg-orange">
+    <div class="dashboard small-box bg-orange">
       <div class="inner">
         <h3> {{ number_format($counts['accessory']) }}</h3>
         <p>{{ strtolower(trans('general.accessories')) }}</p>
@@ -87,7 +87,7 @@
     <!-- small box -->
 
       <a href="{{ route('consumables.index') }}">
-    <div class="small-box bg-purple">
+    <div class="dashboard small-box bg-purple">
       <div class="inner">
         <h3> {{ number_format($counts['consumable']) }}</h3>
         <p>{{ strtolower(trans('general.consumables')) }}</p>
@@ -104,7 +104,7 @@
   <div class="col-lg-2 col-xs-6">
     <a href="{{ route('components.index') }}">
    <!-- small box -->
-   <div class="small-box bg-yellow">
+   <div class="dashboard small-box bg-yellow">
      <div class="inner">
        <h3>{{ number_format($counts['component']) }}</h3>
        <p>{{ strtolower(trans('general.components')) }}</p>
@@ -122,7 +122,7 @@
  <div class="col-lg-2 col-xs-6">
     <a href="{{ route('users.index') }}">
    <!-- small box -->
-   <div class="small-box bg-light-blue">
+   <div class="dashboard small-box bg-light-blue">
      <div class="inner">
        <h3>{{ number_format($counts['user']) }}</h3>
        <p>{{ strtolower(trans('general.people')) }}</p>

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -57,7 +57,7 @@
     <div class="list clearfix">
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
               <a href="{{ route('settings.branding.index') }}" class="settings_button">
@@ -74,7 +74,7 @@
 
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
                 <a href="{{ route('settings.general.index') }}" class="settings_button">
@@ -91,7 +91,7 @@
 
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
                 <a href="{{ route('settings.security.index') }}" class="settings_button">
@@ -107,7 +107,7 @@
         </div>
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
                 <a href="{{ route('groups.index') }}" class="settings_button">
@@ -124,7 +124,7 @@
 
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
                 <a href="{{ route('settings.localization.index') }}" class="settings_button">
@@ -142,7 +142,7 @@
 
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
                 <a href="{{ route('settings.alerts.index') }}" class="settings_button">
@@ -158,7 +158,7 @@
         </div>
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
                 <a href="{{ route('settings.slack.index') }}" class="settings_button">
@@ -173,7 +173,7 @@
         </div>
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
                 <a href="{{ route('settings.asset_tags.index') }}" class="settings_button">
@@ -188,7 +188,7 @@
         </div>
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
                 <a href="{{ route('settings.barcodes.index') }}" class="settings_button">
@@ -203,7 +203,7 @@
         </div>
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
                 <a href="{{ route('settings.labels.index') }}" class="settings_button">
@@ -219,7 +219,7 @@
 
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
                 <a href="{{ route('settings.ldap.index') }}" class="settings_button">
@@ -234,7 +234,7 @@
         </div>
 
       <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-        <div class="box box-default">
+        <div class="admin box box-default">
           <div class="box-body text-center">
             <h5>
               <a href="{{ route('settings.google.index') }}" class="settings_button">
@@ -249,7 +249,7 @@
       </div>
 
       <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-        <div class="box box-default">
+        <div class="admin box box-default">
           <div class="box-body text-center">
             <h5>
               <a href="{{ route('settings.saml.index') }}" class="settings_button">
@@ -264,7 +264,7 @@
       </div>
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
                 <a href="{{ route('settings.backups.index') }}" class="settings_button">
@@ -280,7 +280,7 @@
 
 
       <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-        <div class="box box-default">
+        <div class="admin box box-default">
           <div class="box-body text-center">
             <h5>
               <a href="{{ route('settings.logins.index') }}" class="settings_button">
@@ -295,7 +295,7 @@
       </div>
 
         <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-          <div class="box box-default">
+          <div class="admin box box-default">
             <div class="box-body text-center">
               <h5>
               <a href="{{ route('settings.oauth.index') }}" class="settings_button">
@@ -311,7 +311,7 @@
 
         @if (config('app.debug')=== true)
           <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-            <div class="box box-default">
+            <div class="admin box box-default">
               <div class="box-body text-center">
                 <h5>
                   <a href="{{ route('settings.phpinfo.index') }}" class="settings_button">
@@ -329,7 +329,7 @@
 
 
     <div class="col-md-4 col-lg-3 col-sm-6 col-xl-1">
-      <div class="box box-danger">
+      <div class="admin box box-danger">
         <div class="box-body text-center">
           <h5>
             <a href="{{ route('settings.purge.index') }}" class="link-danger">


### PR DESCRIPTION
# Description
This creates a class of `dashboard` that is applied to all the box menu options on the dashboard that deals with text overflow.
Before:
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/15bef89c-3d89-4bfc-aa7c-8e0360df875d">

After:
<img width="1348" alt="image" src="https://github.com/user-attachments/assets/0207ee77-39cf-4dce-bdb1-7a0e2a9257a0">

Fixes #15197

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
