### PR TITLE
Added asset tag to info with quick copy

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -384,7 +384,20 @@
                                             </div>
                                         </div>
                                     @endif
+                                        @if ($asset->asset_tag)
+                                            <div class="row">
+                                                <div class="col-md-3">
+                                                    <strong>{{ trans('admin/hardware/form.tag') }}</strong>
+                                                </div>
+                                                <div class="col-md-9">
+                                                    <span class="js-copy">{{ $asset->asset_tag  }}</span>
 
+                                                    <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
+                                                        <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
+                                                    </i>
+                                                </div>
+                                            </div>
+                                        @endif
                                     @if ($asset->serial)
                                         <div class="row">
                                             <div class="col-md-3">


### PR DESCRIPTION
# Description

This adds the Asset tag to the asset info page with a copy button for quick access.
<img width="757" alt="image" src="https://github.com/user-attachments/assets/5a61abe3-31a8-41a2-bce1-27d85e7a31b4">


Fixes #15205

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
