### PR TITLE
Fixed #15205 - adds copy to asset tag

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -316,6 +316,21 @@
 
                                 <div class="row-new-striped">
 
+                                    @if ($asset->asset_tag)
+                                        <div class="row">
+                                            <div class="col-md-3">
+                                                <strong>{{ trans('admin/hardware/form.tag') }}</strong>
+                                            </div>
+                                            <div class="col-md-9">
+                                                <span class="js-copy">{{ $asset->asset_tag  }}</span>
+
+                                                <i class="fa-regular fa-clipboard js-copy-link" data-clipboard-target=".js-copy" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
+                                                    <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
+                                                </i>
+                                            </div>
+                                        </div>
+                                    @endif
+
 
                                     @if ($asset->deleted_at!='')
                                         <div class="row">


### PR DESCRIPTION
This adds a copy-to-clipboard link on the asset detail page.