### PR TITLE
Feature: Extend search capabilities to other assets attributes

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -483,7 +483,9 @@ class AssetsController extends Controller
 
         // If not a unique result, redirect to the index view
         if ($assets->count() != 1) {
-            return redirect()->route('hardware.index')->with('search', $tag);
+            return redirect()->route('hardware.index')
+                ->with('search', $tag)
+                ->with('warning', trans('admin/hardware/message.does_not_exist_var', [ 'asset_tag' => $tag ]));
         }
         $asset = $assets->first();
         $this->authorize('view', $asset);

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -478,9 +478,14 @@ class AssetsController extends Controller
         $tag = $tag ? $tag : $request->get('assetTag');
         $topsearch = ($request->get('topsearch') == 'true');
 
-        if (! $asset = Asset::where('asset_tag', '=', $tag)->first()) {
-            return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.does_not_exist'));
+        // Search for an exact and unique asset tag match
+        $assets = Asset::where('asset_tag', '=', $tag);
+
+        // If not a unique result, redirect to the index view
+        if ($assets->count() != 1) {
+            return redirect()->route('hardware.index')->with('search', $tag);
         }
+        $asset = $assets->first();
         $this->authorize('view', $asset);
 
         return redirect()->route('hardware.show', $asset->id)->with('topsearch', $topsearch);

--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -73,6 +73,7 @@
                 data-pagination="true"
                 data-id-table="assetsListingTable"
                 data-search="true"
+                data-search-text="{{ e(Session::get('search')) }}"
                 data-side-pagination="server"
                 data-show-columns="true"
                 data-show-export="true"


### PR DESCRIPTION
# Description

This pull request aims to address long-standing request from several users who need to search for assets with attributes other than the asset tag as mentioned in past discussions: #3216, #5812.

**Previous behavior:**
1. Lookup for the asset tag
2. If the asset tag exists, redirect to the asset page
3. Else redirect to the list of assets without search criteria and throw an error mentioning the asset doesn't exist

**Proposed behavior:**
1. Lookup for the asset tag
2. If the asset tag exists, redirect to the asset page
3. Else redirect to the list of assets having attributes matching the search string

_**Compatibility with barcode scanners hasn't been tested, but compatibility should likely be preserved.**_

Some points may need further discussion:
- Should the "does not exist" error message be kept?
- Should the search bar pleaceholder attribute be updated?

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

From the Dashboard, use the "Lookup by Asset Tag" search field and proceed to the following steps:
1. Search for an existing Asset Tag, you will be redirected to the asset page.
2. Search for an existing Asset Model, you will get the list of all assets of this model.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes