### PR TITLE
Feature: allow user to permanently dismiss the "Asset not found" message

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -19,6 +19,7 @@ use App\Models\Statuslabel;
 use App\Models\User;
 use App\View\Label;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Http\Request;
@@ -510,12 +511,14 @@ class AssetsController extends Controller
 
         // Search for an exact and unique asset tag match
         $assets = Asset::where('asset_tag', '=', $tag);
+        $user = auth()->user();
 
         // If not a unique result, redirect to the index view
         if ($assets->count() != 1) {
             return redirect()->route('hardware.index')
                 ->with('search', $tag)
-                ->with('search_warning', trans('admin/hardware/message.does_not_exist_var', [ 'asset_tag' => $tag ]));
+                ->with('search_warning', trans('admin/hardware/message.does_not_exist_var', [ 'asset_tag' => $tag ]))
+                ->with('hide_lookup_alert', $user->hide_lookup_alert);
         }
         $asset = $assets->first();
         $this->authorize('view', $asset);

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -515,7 +515,7 @@ class AssetsController extends Controller
         if ($assets->count() != 1) {
             return redirect()->route('hardware.index')
                 ->with('search', $tag)
-                ->with('warning', trans('admin/hardware/message.does_not_exist_var', [ 'asset_tag' => $tag ]));
+                ->with('search_warning', trans('admin/hardware/message.does_not_exist_var', [ 'asset_tag' => $tag ]));
         }
         $asset = $assets->first();
         $this->authorize('view', $asset);

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -51,6 +51,7 @@ class ProfileController extends Controller
         $user->phone = $request->input('phone');
         $user->enable_sounds = $request->input('enable_sounds', false);
         $user->enable_confetti = $request->input('enable_confetti', false);
+        $user->hide_lookup_alert = $request->input('hide_lookup_alert', false);
 
         if (! config('app.lock_passwords')) {
             $user->locale = $request->input('locale', 'en-US');

--- a/database/migrations/2024_11_25_171321_add_hide_lookup_alert_to_profile.php
+++ b/database/migrations/2024_11_25_171321_add_hide_lookup_alert_to_profile.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('hide_lookup_alert')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('Hide_lookup_alert');
+        });
+    }
+};

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -534,6 +534,16 @@ $(function () {
 
     });
 
+    // Search warning message: lookup in localStorage if the banner was dismissed
+    $(function() {
+        const showSearchWarning = localStorage.getItem("search-warning-dismissed") === null;
+        $(".search-warning").toggleClass("hidden",!showSearchWarning);
+        $(".search-warning-dismiss").on("click",function() {
+            localStorage.setItem("search-warning-dismissed","true");
+            $(this).closest(".search-warning").addClass("hidden");
+        });
+    })
+
 });
 
 function htmlEntities(str) {

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -533,17 +533,6 @@ $(function () {
 
 
     });
-
-    // Search warning message: lookup in localStorage if the banner was dismissed
-    $(function() {
-        const showSearchWarning = localStorage.getItem("search-warning-dismissed") === null;
-        $(".search-warning").toggleClass("hidden",!showSearchWarning);
-        $(".search-warning-dismiss").on("click",function() {
-            localStorage.setItem("search-warning-dismissed","true");
-            $(this).closest(".search-warning").addClass("hidden");
-        });
-    })
-
 });
 
 function htmlEntities(str) {

--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -1109,3 +1109,19 @@ input[type="radio"]:checked::before {
   filter: brightness(70%);
   font-size: 70%;
 }
+
+.search-warning-separator {
+  float: right;
+  height: 21px;
+  border-right: solid;
+  border-width: 1px;
+  margin-right: 10px;
+  opacity: 0.2;
+  color: #000;
+}
+
+.search-warning-dismiss {
+  font-weight: bold;
+  color: #fff;
+  opacity: 0.8;
+}

--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -1110,18 +1110,14 @@ input[type="radio"]:checked::before {
   font-size: 70%;
 }
 
-.search-warning-separator {
+.search-warning-menu {
   float: right;
-  height: 21px;
-  border-right: solid;
-  border-width: 1px;
   margin-right: 10px;
-  opacity: 0.2;
-  color: #000;
+  background-color: #f39c12;
 }
 
 .search-warning-dismiss {
   font-weight: bold;
   color: #fff;
-  opacity: 0.8;
+  text-align: center;
 }

--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -1113,11 +1113,14 @@ input[type="radio"]:checked::before {
 .search-warning-menu {
   float: right;
   margin-right: 10px;
-  background-color: #f39c12;
 }
 
 .search-warning-dismiss {
   font-weight: bold;
   color: #fff;
   text-align: center;
+}
+
+.search-warning-dismiss > a:visited {
+  color: #fff !important;
 }

--- a/resources/lang/en-US/account/general.php
+++ b/resources/lang/en-US/account/general.php
@@ -14,4 +14,5 @@ return array(
     'no_tokens' => 'You have not created any personal access tokens.',
     'enable_sounds' => 'Enable sound effects',
     'enable_confetti' => 'Enable confetti effects',
+    'hide_lookup_alert' => 'Hide alert message if lookup search fails',
 );

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -398,6 +398,7 @@ return [
     'notification_bulk_error_hint' => 'The following fields had validation errors and were not edited:',
     'notification_success'  => 'Success',
     'notification_warning'   => 'Warning',
+    'notification_search_warning' => 'Dismiss permanently',
     'notification_info'      => 'Info',
     'asset_information'     => 'Asset Information',
     'model_name'            => 'Model Name',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -398,7 +398,7 @@ return [
     'notification_bulk_error_hint' => 'The following fields had validation errors and were not edited:',
     'notification_success'  => 'Success',
     'notification_warning'   => 'Warning',
-    'notification_search_warning' => 'Dismiss permanently',
+    'notification_hide_search_warning' => 'Hide permanently',
     'notification_info'      => 'Info',
     'asset_information'     => 'Asset Information',
     'model_name'            => 'Model Name',

--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -107,6 +107,15 @@
           </div>
         </div>
 
+        <div class="form-group">
+          <div class="col-md-9 col-md-offset-3">
+            <label class="form-control">
+              <input type="checkbox" name="hide_lookup_alert" value="1" {{ old('hide_lookup_alert', $user->hide_lookup_alert) ? 'checked' : '' }}>
+              {{ trans('account/general.hide_lookup_alert') }}
+            </label>
+          </div>
+        </div>
+
         <!-- Gravatar Email -->
         <div class="form-group {{ $errors->has('gravatar') ? ' has-error' : '' }}">
           <label for="gravatar" class="col-md-3 control-label">{{ trans('general.gravatar_email') }}

--- a/resources/views/notifications.blade.php
+++ b/resources/views/notifications.blade.php
@@ -170,3 +170,19 @@
     </div>
 </div>
 @endif
+
+
+@if ($message = session()->get('search_warning'))
+<div class="col-md-12">
+    <div class="alert alert-warning search-warning fade in hidden">
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
+        <strong>{{ trans('general.notification_warning') }}: </strong>
+        {{ $message }}
+        <div class="search-warning-separator"></div>
+        <div class="pull-right btn btn-xs search-warning-dismiss">
+            {{ trans('general.notification_search_warning') }}
+        </div>
+    </div>
+</div>
+@endif

--- a/resources/views/notifications.blade.php
+++ b/resources/views/notifications.blade.php
@@ -179,9 +179,17 @@
         <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
         <strong>{{ trans('general.notification_warning') }}: </strong>
         {{ $message }}
-        <div class="search-warning-separator"></div>
-        <div class="pull-right btn btn-xs search-warning-dismiss">
-            {{ trans('general.notification_search_warning') }}
+        <div class="btn-group dropleft search-warning-menu">
+            <button class="btn btn-default dropdown-toggle close" data-toggle="dropdown" aria-expanded="false">
+                <i class="fa-solid fa-ellipsis-vertical"></i>
+            </button>
+            <ul class="dropdown-menu alert-warning pull-right">
+                <li class="text-center">
+                    <div class="btn btn-xs search-warning-dismiss">
+                        {{ trans('general.notification_search_warning') }}
+                    </div>
+                </li>
+            </ul>
         </div>
     </div>
 </div>

--- a/resources/views/notifications.blade.php
+++ b/resources/views/notifications.blade.php
@@ -173,8 +173,9 @@
 
 
 @if ($message = session()->get('search_warning'))
+@if (!session()->get('hide_lookup_alert'))
 <div class="col-md-12">
-    <div class="alert alert-warning search-warning fade in hidden">
+    <div class="alert alert-warning search-warning fade in">
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         <i class="fas fa-exclamation-triangle faa-pulse animated"></i>
         <strong>{{ trans('general.notification_warning') }}: </strong>
@@ -183,14 +184,13 @@
             <button class="btn btn-default dropdown-toggle close" data-toggle="dropdown" aria-expanded="false">
                 <i class="fa-solid fa-ellipsis-vertical"></i>
             </button>
-            <ul class="dropdown-menu alert-warning pull-right">
-                <li class="text-center">
-                    <div class="btn btn-xs search-warning-dismiss">
-                        {{ trans('general.notification_search_warning') }}
-                    </div>
-                </li>
+            <ul class="dropdown-menu alert-warning pull-right search-warning-dismiss">
+                <a class="btn btn-xs" href="/account/profile">
+                    {{ trans('general.notification_hide_search_warning') }}
+                </a>
             </ul>
         </div>
     </div>
 </div>
+@endif
 @endif


### PR DESCRIPTION
# Description

Every time a user performs a search for a value that is not an asset tag, a warning message will show up mentioning the assset wasn't found. If such use of the search field is intentional, it would be good to allow the user to permanently dismiss the warning message.

**Note:** for the search feature, refer to PR #15217.

**What changes**
This PR gives the possibility to permanently dismiss the warning message shown when an asset tag doesn't exist.

**Current proposition:**
![image](https://github.com/user-attachments/assets/ff01297e-5915-425a-875f-d9b5df4468d9)

**Remaining tasks**
- Improve the design: any suggestion is welcome.
- Is it ok to store the user choice in the localStorage? Or better in a cookie? Or in database (...)?

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Search for a random string in the "Lookup for Asset Tag" search box
2. Confirm the warning message shows up
3. Click on "Dismiss permanently"
4. Perform another search in the "Lookup for Asset Tag" search box
5. The warning message should not show up anymore

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
