### PR TITLE
Disallowed checking out components to different companies and fixed number remaining counts

### DIFF
--- a/app/Http/Controllers/Components/ComponentCheckoutController.php
+++ b/app/Http/Controllers/Components/ComponentCheckoutController.php
@@ -8,6 +8,7 @@ use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Models\Asset;
 use App\Models\Component;
+use App\Models\Setting;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Input;
@@ -96,6 +97,10 @@ class ComponentCheckoutController extends Controller
 
         // Check if the asset exists
         $asset = Asset::find($request->input('asset_id'));
+
+        if ((Setting::getSettings()->full_multiple_companies_support) && $component->company_id !== $asset->company_id) {
+            return redirect()->route('components.checkout.show', $componentId)->with('error', trans('general.error_user_company'));
+        }
 
         // Update the component data
         $component->asset_id = $request->input('asset_id');

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -205,7 +205,11 @@ class Component extends SnipeModel
     public function numCheckedOut()
     {
         $checkedout = 0;
-        foreach ($this->assets as $checkout) {
+
+        // In case there are elements checked out to assets that belong to a different company
+        // than this asset and full multiple company support is on we'll remove the global scope,
+        // so they are included in the count.
+        foreach ($this->assets()->withoutGlobalScope(new CompanyableScope)->get() as $checkout) {
             $checkedout += $checkout->pivot->assigned_qty;
         }
 

--- a/tests/Feature/Checkouts/Ui/ComponentsCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/ComponentsCheckoutTest.php
@@ -21,7 +21,7 @@ class ComponentsCheckoutTest extends TestCase
             ->assertForbidden();
     }
 
-    public function testCannotCheckoutAcrossCompaniesWhenFullCompanySupportEnabled()
+    public function test_cannot_checkout_across_companies_when_full_company_support_enabled()
     {
         Event::fake([CheckoutableCheckedOut::class]);
 
@@ -36,9 +36,6 @@ class ComponentsCheckoutTest extends TestCase
             ->post(route('components.checkout.store', $component), [
                 'asset_id' => $asset->id,
                 'assigned_qty' => '1',
-                // @todo:
-                'note' => null,
-                // @todo:
                 'redirect_option' => 'index',
             ]);
 

--- a/tests/Feature/Checkouts/Ui/ComponentsCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/ComponentsCheckoutTest.php
@@ -1,10 +1,13 @@
 <?php
 
-namespace Tests\Feature\Checkins\Ui;
+namespace Tests\Feature\Checkouts\Ui;
 
+use App\Events\CheckoutableCheckedOut;
 use App\Models\Asset;
+use App\Models\Company;
 use App\Models\Component;
 use App\Models\User;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 class ComponentsCheckoutTest extends TestCase
@@ -16,6 +19,30 @@ class ComponentsCheckoutTest extends TestCase
                 'componentID' => Component::factory()->checkedOutToAsset()->create()->id,
             ]))
             ->assertForbidden();
+    }
+
+    public function testCannotCheckoutAcrossCompaniesWhenFullCompanySupportEnabled()
+    {
+        Event::fake([CheckoutableCheckedOut::class]);
+
+        $this->settings->enableMultipleFullCompanySupport();
+
+        [$assetCompany, $componentCompany] = Company::factory()->count(2)->create();
+
+        $asset = Asset::factory()->for($assetCompany)->create();
+        $component = Component::factory()->for($componentCompany)->create();
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('components.checkout.store', $component), [
+                'asset_id' => $asset->id,
+                'assigned_qty' => '1',
+                // @todo:
+                'note' => null,
+                // @todo:
+                'redirect_option' => 'index',
+            ]);
+
+        Event::assertNotDispatched(CheckoutableCheckedOut::class);
     }
 
     public function testComponentCheckoutPagePostIsRedirectedIfRedirectSelectionIsIndex()
@@ -63,6 +90,4 @@ class ComponentsCheckoutTest extends TestCase
             ->assertStatus(302)
             ->assertRedirect(route('hardware.show', ['hardware' => $asset]));
     }
-
-
 }

--- a/tests/Unit/ComponentTest.php
+++ b/tests/Unit/ComponentTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Tests\Unit;
 
+use App\Models\Asset;
 use App\Models\Category;
 use App\Models\Company;
 use App\Models\Component;
 use App\Models\Location;
+use App\Models\User;
 use Tests\TestCase;
 
 class ComponentTest extends TestCase
@@ -40,5 +42,59 @@ class ComponentTest extends TestCase
                 )->id]);
         $this->assertInstanceOf(Category::class, $component->category);
         $this->assertEquals('component', $component->category->category_type);
+    }
+
+    public function test_num_checked_out_takes_does_not_scope_by_company()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $componentForCompanyA = Component::factory()->for($companyA)->create(['qty' => 5]);
+        $assetForCompanyB = Asset::factory()->for($companyB)->create();
+
+        // Ideally, we shouldn't have a component attached to an
+        // asset from a different company but alas...
+        $componentForCompanyA->assets()->attach($componentForCompanyA->id, [
+            'component_id' => $componentForCompanyA->id,
+            'assigned_qty' => 4,
+            'asset_id' => $assetForCompanyB->id,
+        ]);
+
+        $this->actingAs(User::factory()->superuser()->create());
+        $this->assertEquals(4, $componentForCompanyA->fresh()->numCheckedOut());
+
+        $this->actingAs(User::factory()->admin()->create());
+        $this->assertEquals(4, $componentForCompanyA->fresh()->numCheckedOut());
+
+        $this->actingAs(User::factory()->for($companyA)->create());
+        $this->assertEquals(4, $componentForCompanyA->fresh()->numCheckedOut());
+    }
+
+    public function test_num_remaining_takes_company_scoping_into_account()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $componentForCompanyA = Component::factory()->for($companyA)->create(['qty' => 5]);
+        $assetForCompanyB = Asset::factory()->for($companyB)->create();
+
+        // Ideally, we shouldn't have a component attached to an
+        // asset from a different company but alas...
+        $componentForCompanyA->assets()->attach($componentForCompanyA->id, [
+            'component_id' => $componentForCompanyA->id,
+            'assigned_qty' => 4,
+            'asset_id' => $assetForCompanyB->id,
+        ]);
+
+        $this->actingAs(User::factory()->superuser()->create());
+        $this->assertEquals(1, $componentForCompanyA->fresh()->numRemaining());
+
+        $this->actingAs(User::factory()->admin()->create());
+        $this->assertEquals(1, $componentForCompanyA->fresh()->numRemaining());
+
+        $this->actingAs(User::factory()->for($companyA)->create());
+        $this->assertEquals(1, $componentForCompanyA->fresh()->numRemaining());
     }
 }


### PR DESCRIPTION
# Description

This PR fixes two issues when full multiple company support was enabled:
- Components were able to be checked out to assets belonging to different companies than the company the component belonged to.
- The "number remaining" (in the table and on the individual page) would show an inaccurate count for non-admins in the cases where components were checked out to assets belonging to a company different than the user's.

---

The scenario in pictures...

Two companies with the ids of 9 and 10:
![companies in the database](https://github.com/user-attachments/assets/173782eb-f6cc-409a-b2f5-fdbf5ef19c4e)

Two components, one for each company:
![components in the database](https://github.com/user-attachments/assets/97b9812b-5ab6-4651-8e44-6988b2b8441f)

Three assets assigned to three companies, including one that is not associated with a component above:
![assets in the database](https://github.com/user-attachments/assets/f05603a7-0d05-4c37-9cec-a88246af9c7c)

The `component_assets` table that shows components assigned to assets.
![db table](https://github.com/user-attachments/assets/306c490b-98ae-4a29-8711-f5fc2af909c4)
> Only id:9 should be valid since only asset:2 is part of company:9 (Company A in text)

---

Acting as a super admin I can accurately see the remaining counts before and after this PR:
![super admin viewing table](https://github.com/user-attachments/assets/a2d7d5d9-7cde-49ce-9614-ba6c96848286)

But as an admin for Company A (id:9) I see there are 4 remaining (should be 2):
![company a user viewing table](https://github.com/user-attachments/assets/a297513b-f865-47ff-8047-8e6ac43ded5f)

After this PR the user sees the correct amount:
![after](https://github.com/user-attachments/assets/a918a1ee-b8d1-4a04-94e0-5385a8d9f763)


---

In addition, we can no longer check out a component to an asset that is not part of the same company when FMCS is enabled:
![attempted checkout](https://github.com/user-attachments/assets/56fbffda-fad4-4dc3-b867-032c4c94948b)


---

Should address the issues mentioned in #15212.

Fixes #15212

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)