### PR TITLE
Partial revert for checkout accessories to non user

### DIFF
--- a/app/Http/Controllers/CheckInOutRequest.php
+++ b/app/Http/Controllers/CheckInOutRequest.php
@@ -20,7 +20,7 @@ trait CheckInOutRequest
                 return Location::findOrFail(request('assigned_location'));
             case 'asset':
                 return Asset::findOrFail(request('assigned_asset'));
-            case 'user':
+            default:
                 return User::findOrFail(request('assigned_user'));
         }
 

--- a/resources/views/accessories/checkout.blade.php
+++ b/resources/views/accessories/checkout.blade.php
@@ -66,14 +66,8 @@
              </div>
           <!-- User -->
 
-          @include ('partials.forms.checkout-selector', ['user_select' => 'true','asset_select' => 'true', 'location_select' => 'true'])
-
           @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.select_user'), 'fieldname' => 'assigned_user', 'required'=> 'true'])
 
-          <!-- We have to pass unselect here so that we don't default to the asset that's being checked out. We want that asset to be pre-selected everywhere else. -->
-          @include ('partials.forms.edit.asset-select', ['translated_name' => trans('general.asset'), 'fieldname' => 'assigned_asset', 'unselect' => 'true', 'style' => 'display:none;', 'required'=>'true'])
-
-          @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'assigned_location', 'style' => 'display:none;', 'required'=>'true'])
 
              <!-- Checkout QTY -->
              <div class="form-group {{ $errors->has('checkout_qty') ? 'error' : '' }} ">


### PR DESCRIPTION
This removes the location and asset selector introduced in https://github.com/snipe/snipe-it/pull/15185, since the other end of that (where you can see the accessories that are checked out to the location/asset on the location/asset's page, which would make for a very confusing user experience.

I have a WIP to fix that [here](https://github.com/snipe/snipe-it/pull/15235), but this at least reverts the front end of it so we don't confuse users and aren't holding up `develop`.