### PR TITLE
Fixed Issue with Acceptances Being Created

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -137,7 +137,11 @@ class CheckoutableListener
      */
     private function getCheckoutAcceptance($event)
     {
-        if (! $event->checkoutable->requireAcceptance()) {
+        $checkedOutToType = get_class($event->checkedOutTo);
+        if ($checkedOutToType != "App\Models\User") {
+            return null;
+        }
+        if (!$event->checkoutable->requireAcceptance()) {
             return null;
         }
 


### PR DESCRIPTION
# Description
Acceptances were being created for acceptable assets being checked out to Locations or other Assets - leading to some reports of users declining acceptance of things that were not assigned to them, but to a Location or an Asset. This just adds a simple conditional to prevent that for now.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
