### PR TITLE
Fixed #15248 Removed pound symbol from order number on asset view

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -731,7 +731,7 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-9">
-                                                <a href="{{ route('hardware.index', ['order_number' => $asset->order_number]) }}">#{{ $asset->order_number }}</a>
+                                                <a href="{{ route('hardware.index', ['order_number' => $asset->order_number]) }}">{{ $asset->order_number }}</a>
                                             </div>
                                         </div>
                                     @endif


### PR DESCRIPTION
Removed the `#` symbol from the order number in the asset view. I have no idea why this would matter and why anyone would care, but apparently one person does. (I personally chose to add the `#` because it looks better, but WTF do I know, I guess.)

"Fixed" #15248