### PR TITLE
Fixes ##15236 - smaller email logo

### DIFF
--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -14,7 +14,7 @@
     @endif
 
     {{-- Show images in email!  --}}
-    @if (($snipeSettings->show_images_in_email=='1' ) && (($snipeSettings->brand == '3') || ($snipeSettings->brand == '2')))
+    @if (($snipeSettings->show_images_in_email=='1') && ($snipeSettings->email_logo!=''))
 
         {{-- $snipeSettings->brand = 1 = Text  --}}
         {{-- $snipeSettings->brand = 2 = Logo  --}}
@@ -22,32 +22,27 @@
         @if ($snipeSettings->brand == '3')
 
             @if ($snipeSettings->email_logo!='')
-            <img style="max-height: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->email_logo)) }}">
-            @elseif ($snipeSettings->logo!='')
-            <img style="max-height: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->logo)) }}">
+                <img style="max-height: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->email_logo)) }}">
             @endif
 
             <br><br>
             {{ $snipeSettings->site_name }}
             <br><br>
+
         {{-- else if branding type is just logo --}}
         @elseif ($snipeSettings->brand == '2')
             @if ($snipeSettings->email_logo!='')
-
-            <img style="max-width: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->email_logo)) }}">
-            @elseif ($snipeSettings->logo!='')
-            <img style="max-width: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->logo)) }}">
+                <img style="max-height: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->email_logo)) }}">
+            @else
+                {{ $snipeSettings->site_name }}
             @endif
         @endif
+
     @else
-        {{ $snipeSettings->site_name }}
+        {{ $snipeSettings->site_name ?? config('app.name') }}
     @endif
 
-{{-- Either the $snipeSettings variable isn't set or setup is not complete --}}
-@else
-{{ config('app.name') }}
 @endif
-
 @endcomponent
 @endslot
 

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -21,21 +21,14 @@
         {{-- $snipeSettings->brand = 3 = Logo + Text  --}}
         @if ($snipeSettings->brand == '3')
 
-            @if ($snipeSettings->email_logo!='')
-                <img style="max-height: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->email_logo)) }}">
-            @endif
-
+            <img style="max-height: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->email_logo)) }}">
             <br><br>
             {{ $snipeSettings->site_name }}
             <br><br>
 
         {{-- else if branding type is just logo --}}
         @elseif ($snipeSettings->brand == '2')
-            @if ($snipeSettings->email_logo!='')
-                <img style="max-height: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->email_logo)) }}">
-            @else
-                {{ $snipeSettings->site_name }}
-            @endif
+           <img style="max-height: 100px; vertical-align:middle;" src="{{ \Storage::disk('public')->url(e($snipeSettings->email_logo)) }}">
         @endif
 
     @else


### PR DESCRIPTION
This fixes #15236, where we were falling back to use the regular site logo if no email logo was uploaded, and also caps the max height instead of width.