### PR TITLE
Added reporting-only access for selectlists

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -230,7 +230,8 @@ class AuthServiceProvider extends ServiceProvider
                 || $user->can('update', Accessory::class)
                 || $user->can('create', Accessory::class)   
                 || $user->can('update', User::class)
-                || $user->can('create', User::class);  
+                || $user->can('create', User::class)
+                || ($user->hasAccess('reports.view'));
         });
 
 


### PR DESCRIPTION
While this is an unusual case, this PR adds the ability for users with *only* report-view capabilities to see select lists. Previously, if a user only had report-view and no ability to edit/create anything else, the select lists in the custom report would not load properly. 