### PR TITLE
Fixed: [sc-26355] Attempt to de-escalate SAML login and logout errors

### DIFF
--- a/app/Services/Saml.php
+++ b/app/Services/Saml.php
@@ -337,12 +337,12 @@ class Saml
     /**
      * Get a setting.
      *
-     * @author Johnson Yi <jyi.dev@outlook.com>
-     *
      * @param string|array|int $key
      * @param mixed $default
      *
-     * @return void
+     * @return mixed
+     *@author Johnson Yi <jyi.dev@outlook.com>
+     *
      */
     public function getSetting($key, $default = null)
     {

--- a/app/Services/Saml.php
+++ b/app/Services/Saml.php
@@ -341,7 +341,7 @@ class Saml
      * @param mixed $default
      *
      * @return mixed
-     *@author Johnson Yi <jyi.dev@outlook.com>
+     * @author Johnson Yi <jyi.dev@outlook.com>
      *
      */
     public function getSetting($key, $default = null)


### PR DESCRIPTION
The SAML login and logout process are both pretty solid, but they do occasionally throw errors when there's some kind of misconfiguration. This ends up resulting in error 500 pages being returned to the user rather than a 4xx. Additionally, it adds a lot of 'noise' to our internal Rollbar tooling, and those errors aren't ones that we, ourselves can fix - only the customer can.

This change wraps the login and logout methods within a try/catch, and dumps a warning in the Laravel log (rather than an 'error').

Additionally, one of the SAML methods had an incorrect signature in its docblock that was making PHPStorm slightly annoyed, so I fixed that while I was there.

I was able to test the 'happy path' here and do a SAML login and logout on my local which worked OK.