### PR TITLE
Fix: add missing admin/hardware/table.name key

### DIFF
--- a/resources/views/hardware/bulk-delete.blade.php
+++ b/resources/views/hardware/bulk-delete.blade.php
@@ -30,7 +30,7 @@
               <tr>
                 <td></td>
                 <td>{{ trans('admin/hardware/table.id') }}</td>
-                <td>{{ trans('admin/hardware/table.name') }}</td>
+                <td>{{ trans('general.asset_name') }}</td>
                 <td>{{ trans('admin/hardware/table.location')}}</td>
                 <td>{{ trans('admin/hardware/table.assigned_to') }}</td>
               </tr>


### PR DESCRIPTION
# Description

The translation key **admin/hardware/table.name** is missing. This key is only used in the **bulk delete** view.

This patch only adds it in the en-US locale file.

Before:
![image](https://github.com/user-attachments/assets/f97646a0-76a4-4786-b964-9898c288f4d7)

After:
![image](https://github.com/user-attachments/assets/d9d9b921-e68e-4aae-83dc-fff825e2b629)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
