### PR TITLE
Added support for Docker secrets in Standard and alpine image.

### DIFF
--- a/docker/entrypoint_alpine.sh
+++ b/docker/entrypoint_alpine.sh
@@ -1,7 +1,48 @@
 #!/bin/sh
 
+# Cribbed from nextcloud docker official repo
+# https://github.com/nextcloud/docker/blob/master/docker-entrypoint.sh
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+    local varValue=$(env | grep -E "^${var}=" | sed -E -e "s/^${var}=//")
+    local fileVarValue=$(env | grep -E "^${fileVar}=" | sed -E -e "s/^${fileVar}=//")
+    if [ -n "${varValue}" ] && [ -n "${fileVarValue}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+    if [ -n "${varValue}" ]; then
+        export "$var"="${varValue}"
+    elif [ -n "${fileVarValue}" ]; then
+        export "$var"="$(cat "${fileVarValue}")"
+    elif [ -n "${def}" ]; then
+        export "$var"="$def"
+    fi
+    unset "$fileVar"
+}
+
+# Add docker secrets support for the variables below:
+file_env APP_KEY
+file_env DB_HOST
+file_env DB_PORT
+file_env DB_DATABASE
+file_env DB_USERNAME
+file_env DB_PASSWORD
+file_env REDIS_HOST
+file_env REDIS_PASSWORD
+file_env REDIS_PORT
+file_env MAIL_HOST
+file_env MAIL_PORT
+file_env MAIL_USERNAME
+file_env MAIL_PASSWORD
+
 # fix key if needed
-if [ -z "$APP_KEY" ]
+if [ -z "$APP_KEY" -a -z "$APP_KEY_FILE" ]
 then
   echo "Please re-run this container with an environment variable \$APP_KEY"
   echo "An example APP_KEY you could use is: "


### PR DESCRIPTION
# Description

#9313 #9331 added a new alpine-FPM image which also adds Docker secrets support. Docker secrets support was never backported to existing Standard and alpine Docker images.
This creates inconsistency.

Note: Additional, inconsistency in startup naming and location (`/startup.sh`, `/entrypoint.sh`, `/usr/local/bin/docker-snipeit-entrypoint`) between versions shall be addressed in another PR/commit. Startup script was renamed in #6606, but only for Standard image.

Fixes #10197 
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Reproduce the issue:
  - Create a test folder and create secrets file under secret folder
  - Clone this branch inside test folder
  - Create a base compose file:
```yaml
services:
  snipeit:
    container_name: snipeit
    image: snipe/snipe-it:v7.0.10
#    image: snipe/snipe-it:v7.0.10-alpine
    depends_on:
      snipeit-mysql:
        condition: service_healthy
        restart: true
    #volumes:
    # Mounting the new file for standard image
    #  - "./snipe-it/docker/startup.sh:/startup.sh"
    # Mounting the new file for alpine image
    #  - "./snipe-it/docker/entrypoint_alpine.sh:/entrypoint.sh"

    environment:
      - APP_KEY_FILE=/run/secrets/SNIPEIT_APP_KEY
      - DB_HOST=snipeit-mysql
      - DB_DATABASE_FILE=/run/secrets/SNIPEIT_DB_NAME
      - DB_USERNAME_FILE=/run/secrets/SNIPEIT_DB_USER
      - DB_PASSWORD_FILE=/run/secrets/SNIPEIT_DB_PASSWORD
    secrets:
      - SNIPEIT_APP_KEY
      - SNIPEIT_DB_NAME
      - SNIPEIT_DB_USER
      - SNIPEIT_DB_PASSWORD
    dns:
      - "127.0.0.11"
      - "8.8.8.8"
  snipeit-mysql:
    container_name: snipeit-mysql
    image: mariadb:11
    environment:
      - MYSQL_DATABASE_FILE=/run/secrets/SNIPEIT_DB_NAME
      - MYSQL_USER_FILE=/run/secrets/SNIPEIT_DB_USER
      - MYSQL_PASSWORD_FILE=/run/secrets/SNIPEIT_DB_PASSWORD
      - MYSQL_ROOT_PASSWORD_FILE=/run/secrets/SNIPEIT_DB_ROOT_PASSWORD
      - MARIADB_ROOT_PASSWORD_FILE=/run/secrets/SNIPEIT_DB_ROOT_PASSWORD
      - MARIADB_AUTO_UPGRADE=1
    healthcheck:
      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
      start_period: 10s
      interval: 10s
      timeout: 5s
      retries: 3
    secrets:
      - SNIPEIT_DB_NAME
      - SNIPEIT_DB_USER
      - SNIPEIT_DB_PASSWORD
      - SNIPEIT_DB_ROOT_PASSWORD
    restart: always
secrets:
  SNIPEIT_APP_KEY:
    file: './secrets/SNIPEIT_APP_KEY.txt'
  SNIPEIT_DB_NAME:
    file: './secrets/SNIPEIT_DB_NAME.txt'
  SNIPEIT_DB_USER:
    file: './secrets/SNIPEIT_DB_USER.txt'
  SNIPEIT_DB_PASSWORD:
    file: './secrets/SNIPEIT_DB_PASSWORD.txt'
  SNIPEIT_DB_ROOT_PASSWORD:
    file: './secrets/SNIPEIT_DB_ROOT_PASSWORD.txt'
```
  - `docker compose up` --> APP_KEY not defined
  - Repeat changing the alpine image
  
- [x] Test the new version
  - Uncomment the relevant volumes lines for each image version in `compose.yaml`
  - Re-run the tests, and it will work.

**Test Configuration**:
* PHP version: Docker image
* MySQL version 11
* Webserver version Docker Image
* OS version Docker images


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
