### PR TITLE
Implemented artisan test case

### DIFF
--- a/tests/Feature/Console/FixupAssignedToAssignedTypeTest.php
+++ b/tests/Feature/Console/FixupAssignedToAssignedTypeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Console;
 
 use App\Models\Asset;
 use App\Models\User;

--- a/tests/Feature/Console/FixupAssignedToAssignedTypeTest.php
+++ b/tests/Feature/Console/FixupAssignedToAssignedTypeTest.php
@@ -10,7 +10,6 @@ class FixupAssignedToAssignedTypeTest extends TestCase
 {
     public function testEmptyAssignedType()
     {
-        $this->markTestIncomplete();
         $asset = Asset::factory()->create();
         $user = User::factory()->create();
         $admin = User::factory()->admin()->create();
@@ -18,15 +17,10 @@ class FixupAssignedToAssignedTypeTest extends TestCase
         $asset->checkOut($user, $admin);
         $asset->assigned_type=null; //blank out the assigned type
         $asset->save();
-        print "Okay we set everything up~!!!\n";
 
-        $output = $this->artisan('snipeit:assigned-to-fixup --debug')->assertExitCode(0);
-        print "artisan ran!\n";
-        dump($output);
-        $asset = Asset::find($asset->id);
-        print "\n we refreshed the asset?";
-        dump($asset);
-        $this->assertEquals(User::class, $asset->assigned_type);
+        $this->artisan('snipeit:assigned-to-fixup --debug')->assertExitCode(0);
+
+        $this->assertEquals(User::class, $asset->fresh()->assigned_type);
     }
 
     public function testInvalidAssignedTo()
@@ -37,21 +31,15 @@ class FixupAssignedToAssignedTypeTest extends TestCase
         $admin = User::factory()->admin()->create();
 
         $asset->checkOut($user, $admin);
-//        $asset->checkIn($user, $admin); //no such method btw
         $asset->assigned_type=null;
         $asset->assigned_to=null;
         $asset->saveOrFail(); //*should* generate a 'checkin'?
 
         $asset->assigned_to=$user->id; //incorrectly mark asset as partially checked-out
         $asset->saveOrFail();
-        print "Okay we set everything up for test TWO~!!!\n";
 
-        $output = $this->artisan('snipeit:assigned-to-fixup --debug')->assertExitCode(0);
-        print "artisan ran TWO!\n";
-        dump($output);
-        $asset = Asset::find($asset->id);
-        print "\n we refreshed the asset?";
-        dump($asset);
-        $this->assertNull($asset->assigned_to);
+        $this->artisan('snipeit:assigned-to-fixup --debug')->assertExitCode(0);
+
+        $this->assertNull($asset->fresh()->assigned_to);
     }
 }


### PR DESCRIPTION
# Description

This PR implements an incomplete test from #15266. The problem was we were assigning `$this->artisan` to a variable...

>The problem is that when we assign $this->artisan to a variable, the command is not actually run until the test method finishes. Because of this, any assertions we make about what the command should have done are going to fail. The command hasn't run yet!
- [Mastering Laravel](https://masteringlaravel.io/daily/2024-02-09-watch-out-for-this-when-testing-artisan-commands).

Heads up @uberbrady, I cleaned up the second test case but it looks like it was actually failing. It looks like this `return` is preventing the behavior the test expects:

https://github.com/snipe/snipe-it/blob/1706ddd5118054f166964947fe57f0d4864e7c16/app/Console/Commands/FixupAssignedToWithoutAssignedType.php#L57

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
