### PR TITLE
Fixed component check in test

### DIFF
--- a/tests/Feature/Checkins/Ui/ComponentCheckinTest.php
+++ b/tests/Feature/Checkins/Ui/ComponentCheckinTest.php
@@ -4,27 +4,35 @@ namespace Tests\Feature\Checkins\Ui;
 
 use App\Models\Component;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class ComponentCheckinTest extends TestCase
 {
     public function testCheckingInComponentRequiresCorrectPermission()
     {
+        $component = Component::factory()->checkedOutToAsset()->create();
+
+        $componentAsset = DB::table('components_assets')->where('component_id', $component->id)->first();
+
         $this->actingAs(User::factory()->create())
             ->post(route('components.checkin.store', [
-                'componentID' => Component::factory()->checkedOutToAsset()->create()->id,
+                'componentID' => $componentAsset->id,
             ]))
             ->assertForbidden();
     }
-
 
     public function testComponentCheckinPagePostIsRedirectedIfRedirectSelectionIsIndex()
     {
         $component = Component::factory()->checkedOutToAsset()->create();
 
+        $componentAsset = DB::table('components_assets')->where('component_id', $component->id)->first();
+
         $this->actingAs(User::factory()->admin()->create())
             ->from(route('components.index'))
-            ->post(route('components.checkin.store', $component), [
+            ->post(route('components.checkin.store', [
+                'componentID' => $componentAsset->id,
+            ]), [
                 'redirect_option' => 'index',
                 'checkin_qty' => 1,
             ])
@@ -36,9 +44,13 @@ class ComponentCheckinTest extends TestCase
     {
         $component = Component::factory()->checkedOutToAsset()->create();
 
+        $componentAsset = DB::table('components_assets')->where('component_id', $component->id)->first();
+
         $this->actingAs(User::factory()->admin()->create())
             ->from(route('components.index'))
-            ->post(route('components.checkin.store', $component), [
+            ->post(route('components.checkin.store', [
+                'componentID' => $componentAsset->id,
+            ]), [
                 'redirect_option' => 'item',
                 'checkin_qty' => 1,
             ])
@@ -46,6 +58,4 @@ class ComponentCheckinTest extends TestCase
             ->assertSessionHasNoErrors()
             ->assertRedirect(route('components.show', ['component' => $component->id]));
     }
-
-
 }


### PR DESCRIPTION
# Description

This PR follows up on #15172 and gets our tests back to green.

A few test cases were incorrectly referencing a component ID when the controller actually expects the id from the `components_assets` table. 

Some details: It was a little tricky to track down because the tests would only fail when MySQL was used _and_ multiple components were created during the test run. The reason is that sqlite re-uses IDs so the id used in the test, `1`,  would work since there existed a row with an id of `1` in `components` and `components_assets` tables. But MySQL keeps on incrementing when rows are deleted and since other tests created components, the result would be (something like) `8` being passed as the id in the route (because other tests had created 7 components previously) and a row with the id of `8` did not exist in the `components_assets` table.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)