### PR TITLE
Fixed #15301 - Added optional status to quickscan checkin

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -928,7 +928,7 @@ class AssetsController extends Controller
             }
         }
 
-        if ($request->has('status_id')) {
+        if ($request->filled('status_id')) {
             $asset->status_id = $request->input('status_id');
         }
         
@@ -978,7 +978,7 @@ class AssetsController extends Controller
     public function checkinByTag(Request $request, $tag = null) : JsonResponse
     {
         $this->authorize('checkin', Asset::class);
-        if(null == $tag && null !== ($request->input('asset_tag'))) {
+        if (null == $tag && null !== ($request->input('asset_tag'))) {
             $tag = $request->input('asset_tag');
         }
         $asset = Asset::where('asset_tag', $tag)->first();

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -837,14 +837,14 @@ class AssetsController extends Controller
         $this->authorize('audit', Asset::class);
         $dt = Carbon::now()->addMonths(12)->toDateString();
 
-        return view('hardware/quickscan')->with('next_audit_date', $dt);
+        return view('hardware/quickscan')->with('statusLabel_list', Helper::statusLabelList())->with('next_audit_date', $dt);
     }
 
     public function quickScanCheckin()
     {
         $this->authorize('checkin', Asset::class);
 
-        return view('hardware/quickscan-checkin');
+        return view('hardware/quickscan-checkin')->with('statusLabel_list', Helper::statusLabelList());
     }
 
     public function audit($id)

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -837,7 +837,7 @@ class AssetsController extends Controller
         $this->authorize('audit', Asset::class);
         $dt = Carbon::now()->addMonths(12)->toDateString();
 
-        return view('hardware/quickscan')->with('statusLabel_list', Helper::statusLabelList())->with('next_audit_date', $dt);
+        return view('hardware/quickscan')->with('next_audit_date', $dt);
     }
 
     public function quickScanCheckin()

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -279,6 +279,7 @@ return [
     'site_name'				=> 'Site Name',
     'state'  				=> 'State',
     'status_labels'			=> 'Status Labels',
+    'status_label'			=> 'Status Label',
     'status'    			=> 'Status',
     'accept_eula'           => 'Acceptance Agreement',
     'supplier'              => 'Supplier',

--- a/resources/views/hardware/quickscan-checkin.blade.php
+++ b/resources/views/hardware/quickscan-checkin.blade.php
@@ -33,14 +33,25 @@
                     <div class="form-group {{ $errors->has('asset_tag') ? 'error' : '' }}">
                         {{ Form::label('asset_tag', trans('general.asset_tag'), array('class' => 'col-md-3 control-label', 'id' => 'checkin_tag')) }}
                         <div class="col-md-9">
-                            <div class="input-group date col-md-5" data-date-format="yyyy-mm-dd">
-                                <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ old('asset_tag') }}">
+                            <div class="input-group date col-md-11" data-date-format="yyyy-mm-dd">
+                                <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ old('asset_tag') }}" required>
 
                             </div>
                             {!! $errors->first('asset_tag', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                         </div>
                     </div>
-    
+
+                    <!-- Status -->
+                    <div class="form-group {{ $errors->has('status_id') ? 'error' : '' }}">
+                        <label for="status_id" class="col-md-3 control-label">
+                            {{ trans('admin/hardware/form.status') }}
+                        </label>
+                        <div class="col-md-7">
+                            {{ Form::select('status_id', $statusLabel_list, '', array('class'=>'select2', 'style'=>'width:100%','', 'aria-label'=>'status_id')) }}
+                            {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                        </div>
+                    </div>
+
                     <!-- Locations -->
                     @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'location_id'])
 

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -31,7 +31,7 @@
                         <div class="form-group {{ $errors->has('asset_tag') ? 'error' : '' }}">
                             {{ Form::label('asset_tag', trans('general.asset_tag'), array('class' => 'col-md-3 control-label', 'id' => 'audit_tag')) }}
                             <div class="col-md-9">
-                                <div class="input-group date col-md-5" data-date-format="yyyy-mm-dd">
+                                <div class="input-group date col-md-11 required" data-date-format="yyyy-mm-dd">
                                     <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ old('asset_tag') }}">
 
                                 </div>
@@ -49,10 +49,13 @@
                         <div class="form-group">
                             <div class="col-sm-offset-3 col-md-9">
                                 <label class="form-control">
-                                    <input type="checkbox" value="1" name="update_location" {{ old('update_location') == '1' ? ' checked="checked"' : '' }}> {{ trans('admin/hardware/form.asset_location') }}
+                                    <input type="checkbox" value="1" name="update_location" {{ old('update_location') == '1' ? ' checked="checked"' : '' }}>
+                                    <span>{{ trans('admin/hardware/form.asset_location') }}
+                                    <a href="#" class="text-dark-gray" tabindex="0" role="button" data-toggle="popover" data-trigger="focus" title="<i class='far fa-life-ring'></i> {{ trans('general.more_info') }}" data-html="true" data-content="{{ trans('general.quickscan_bulk_help') }}"><i class="far fa-life-ring"></i></a></span>
+
                                 </label>
 
-                                <a href="#" class="text-dark-gray" tabindex="0" role="button" data-toggle="popover" data-trigger="focus" title="<i class='far fa-life-ring'></i>"{{ trans('general.more_info') }} data-html="true" data-content="{{ trans('general.quickscan_bulk_help') }}"><i class="far fa-life-ring"></i></a>
+
 
                             </div>
                         </div>


### PR DESCRIPTION
This allows an optional status label field to be used for the quick scan checkin. 

<img width="1506" alt="Screenshot 2024-08-15 at 10 21 04 AM" src="https://github.com/user-attachments/assets/e31ab9b5-7648-4c3c-88f6-033c1b07f06c">
<img width="1512" alt="Screenshot 2024-08-15 at 10 21 11 AM" src="https://github.com/user-attachments/assets/9b0e23fd-fdad-4e38-a3ae-e08173b2e292">
<img width="1506" alt="Screenshot 2024-08-15 at 10 21 32 AM" src="https://github.com/user-attachments/assets/bf383548-5a5c-44fd-9fba-0701b12d3f8f">
<img width="1509" alt="Screenshot 2024-08-15 at 10 21 40 AM" src="https://github.com/user-attachments/assets/114ea9a5-d224-4e23-8ed0-f046f948cf59">

Fixes #15301