### PR TITLE
"Accessory checkout" version of checkout accessories to locations

### DIFF
--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -255,8 +255,7 @@ class Accessory extends SnipeModel
      */
     public function checkouts()
     {
-        return $this->hasMany(\App\Models\AccessoryCheckout::class, 'accessory_id')
-            ->with('assignedTo');
+        return $this->hasMany(\App\Models\AccessoryCheckout::class, 'accessory_id'); // TODO - is that right, is that what I want?
     }
 
     /**

--- a/app/Models/AccessoryCheckout.php
+++ b/app/Models/AccessoryCheckout.php
@@ -45,7 +45,7 @@ class AccessoryCheckout extends Model
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
     public function user()
-    {
+    { // This needs fixing
         return $this->hasOne(\App\Models\User::class, 'user_id');
     }
 
@@ -58,7 +58,7 @@ class AccessoryCheckout extends Model
      */
     public function assignedTo()
     {
-        return $this->morphTo('assigned', 'assigned_type', 'assigned_to')->withTrashed();
+        return $this->morphTo('assigned' /* this? */, 'assigned_type', 'assigned_to')->withTrashed();
     }
 
     /**

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -249,8 +249,13 @@ class Location extends SnipeModel
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
     public function assignedAssets()
-    {
+    { //the morph relationship is weird here?
         return $this->morphMany(\App\Models\Asset::class, 'assigned', 'assigned_type', 'assigned_to')->withTrashed();
+    }
+
+    public function assignedAccessories()
+    {
+        return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to');
     }
 
     public function setLdapOuAttribute($ldap_ou)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -331,6 +331,13 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function accessories()
     {
+        /*******************************
+         *
+         * so 'assignedTo' as the name returns 'unknown column accessories_checkout.assignedTo_type'
+         * 'assigned' returns 'unknown column accessories_checkout.assigned_id'
+         */
+        return $this->morphMany(AccessoryCheckout::class, 'assigned', 'assigned_type', 'assigned_to');
+        //no, wrong. I mean, it's skipping the polymorphic-ness
         return $this->belongsToMany(\App\Models\Accessory::class, 'accessories_checkout', 'assigned_to', 'accessory_id')
             ->withPivot('id', 'created_at', 'note')->withTrashed()->orderBy('accessory_id');
     }


### PR DESCRIPTION
For being able to 'checkout to location' as well as 'checkout to user' for Accessories, a lot of the fundamentals of how those relationships work needs to change. This is one attempt at getting those relationships to sort-of work right.

At this point, I can go into Tinker and, from an Accessory, look at AccessoryCheckouts which can point to users or locations. As well as going the other directions.

The extra level of indirection is a little awkward when running through the relationships, which is why I figured MorphedByMany approach might be better - but, in fact, it's so much worse :(

This is by no means complete, but at least the basic relationships seem to work at the model level.