### PR TITLE
An attempt to make checkout accessories a multimorph relationship

### DIFF
--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -255,8 +255,21 @@ class Accessory extends SnipeModel
      */
     public function checkouts()
     {
-        return $this->hasMany(\App\Models\AccessoryCheckout::class, 'accessory_id')
-            ->with('assignedTo');
+        return $this->morphToMany(Accessory::class, 'assignedAccessories', 'accessories_checkout', 'assigned_to', null,);
+    }
+
+    public function locationAssignments()
+    {
+        //I don't nkow that we'll want this, but this is a thing we can do - find the locations that have been assigned this accessory
+        return $this->morphedByMany(Location::class, 'accessory_assignment');
+
+    }
+
+    public function userAssignments()
+    {
+        //I don't nkow that we'll want this, but this is a thing we can do - find the locations that have been assigned this accessory
+        return $this->morphedByMany(User::class, 'accessory_assignment');
+
     }
 
     /**

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -253,6 +253,21 @@ class Location extends SnipeModel
         return $this->morphMany(\App\Models\Asset::class, 'assigned', 'assigned_type', 'assigned_to')->withTrashed();
     }
 
+    public function assignedAccessories()
+    {
+        return $this->morphToMany(
+            Accessory::class,
+            'accessory_assignment',
+            'accessories_checkout',
+            'assigned_to',
+            'assigned_type',
+            null,
+            null,
+            'accessory_assignment',
+            true
+        );
+    }
+
     public function setLdapOuAttribute($ldap_ou)
     {
         return $this->attributes['ldap_ou'] = empty($ldap_ou) ? null : $ldap_ou;


### PR DESCRIPTION
This ill-fated attempt was a try to get the accessories->users and accessories->locations relationships working correctly, using a MorphToMany/MorphedByMany relationship. It did not go well.

I got stuck on several different points. The biggest one was the `assignedAccessories` method in the Location object. I couldn't find options to be able to specify the name of the 'type' field so I just kept getting database errors. Of course, we could probably find a way to 'normalize' the `_type` field name so it doesn't require overriding, but even doing that will probably result in problems.

From the Accessories model, the problems I ran into there were that I can't just seem to get a list of 'all checkouts of this accessory' - I would _expect_ to get a list of things, some of which that are Users, and some of which that are Locations.

But it really seems like Laravel just wants to give you only one type of 'thing' - so I have to have two separate methods to list all checkouts - one to list all user-checkouts of an accessory, and one to list all location-checkouts of an accessory. I've read some stuff online about people "stitching together" the results of those calls into a new collection, but that seems awfully gross to me.