### PR TITLE
 Added #15312: Add checkin due in days setting

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -636,6 +636,7 @@ class SettingsController extends Controller
         $setting->alert_threshold = $request->input('alert_threshold');
         $setting->audit_interval = $request->input('audit_interval');
         $setting->audit_warning_days = $request->input('audit_warning_days');
+        $setting->due_checkin_days = $request->input('due_checkin_days');
         $setting->show_alerts_in_menu = $request->input('show_alerts_in_menu', '0');
 
         if ($setting->save()) {

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1315,7 +1315,7 @@ class Asset extends Depreciable
 
     public function scopeDueForCheckin($query, $settings)
     {
-        $interval = $settings->audit_warning_days ?? 0;
+        $interval = $settings->due_checkin_days ?? 0;
         $today = Carbon::now();
         $interval_date = $today->copy()->addDays($interval)->format('Y-m-d');
 

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -379,5 +379,7 @@ return [
     'default_avatar_help' => 'This image will be displayed as a profile if a user does not have a profile photo.',
     'restore_default_avatar' => 'Restore <a href=":default_avatar" data-toggle="lightbox" data-type="image">original system default avatar</a>',
     'restore_default_avatar_help' => '',
+    'due_checkin_days' => 'Due For Checkin Warning',
+    'due_checkin_days_help' => 'How many days before the expected checkin of an asset should it be listed in the "Due for checkin" page?',
 
 ];

--- a/resources/views/hardware/checkin-due.blade.php
+++ b/resources/views/hardware/checkin-due.blade.php
@@ -2,7 +2,7 @@
 
 {{-- Page title --}}
 @section('title')
-    {{ trans_choice('general.checkin_due_days', $settings->audit_warning_days, ['days' => $settings->audit_warning_days]) }}
+    {{ trans_choice('general.checkin_due_days', $settings->due_checkin_days, ['days' => $settings->due_checkin_days]) }}
 @stop
 
 {{-- Page content --}}

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -150,6 +150,25 @@
                             </div>
                         </div>
 
+                        <!-- Due for checkin days -->
+                        <div class="form-group {{ $errors->has('due_checkin_days') ? 'error' : '' }}">
+                            <div class="col-md-3">
+                                {{ Form::label('due_checkin_days', trans('admin/settings/general.due_checkin_days')) }}
+                            </div>
+                            <div class="input-group col-md-2">
+                                {{ Form::text('due_checkin_days', old('due_checkin_days', $setting->due_checkin_days), array('class' => 'form-control','placeholder' => '14', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
+                                <span class="input-group-addon">{{ trans('general.days') }}</span>
+
+
+
+
+                            </div>
+                            <div class="col-md-9 col-md-offset-3">
+                                {!! $errors->first('due_checkin_days', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                <p class="help-block">{{ trans('admin/settings/general.due_checkin_days_help') }}</p>
+                            </div>
+                        </div>
+
                     </div>
 
                 </div> <!--/.box-body-->


### PR DESCRIPTION
This PR implements a setting to specify the number of days before an asset appears on the due for check-in page. Currently, this uses the "audit warning days" setting, but a separate setting allows for different values for each field.

![image](https://github.com/user-attachments/assets/7f6a39f9-1f56-497c-8159-cde7456a2773)

Fixes #15312

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Different values have been assigned for both settings and both are saved correctly. The "Due for Checkin" page references the new setting.

**Test Configuration**:
* PHP version: 8.2.20
* MySQL version: Ver 15.1 Distrib 10.11.6-MariaDB
* Webserver version: Apache/2.4.59 (Debian)
* OS version: Debian GNU/Linux 12.6 (bookworm)

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
