### PR TITLE
Importer model fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ Since the release of the JSON REST API, several third-party developers have been
 - [Snipe-IT plugin for Jira Service Desk](https://marketplace.atlassian.com/apps/1220964/snipe-it-for-jira)
 - [Python 3 CSV importer](https://github.com/gastamper/snipeit-csvimporter) - allows importing assets into Snipe-IT based on Item Name rather than Asset Tag.
 - [Snipe-IT Kubernetes Helm Chart](https://github.com/t3n/helm-charts/tree/master/snipeit) - For more information, [click here](https://hub.helm.sh/charts/t3n/snipeit).
-- [Snipe-IT Bulk Edit](https://github.com/bricelabelle/snipe-it-bulkedit) - Google Script files to use Google Sheets as a bulk checkout/checkin/edit tool for Snipe-it.
-- [MosyleSnipeSync](https://github.com/RodneyLeeBrands/MosyleSnipeSync) by [@Karpadiem](https://github.com/Karpadiem) - Python script to synchronize information between Mosyle and Snipe-IT
+- [Snipe-IT Bulk Edit](https://github.com/bricelabelle/snipe-it-bulkedit) - Google Script files to use Google Sheets as a bulk checkout/checkin/edit tool for Snipe-IT.
+- [MosyleSnipeSync](https://github.com/RodneyLeeBrands/MosyleSnipeSync) by [@Karpadiem](https://github.com/Karpadiem) - Python script to synchronize information between Mosyle and Snipe-IT.
 - [WWW::SnipeIT](https://github.com/SEDC/perl-www-snipeit) by [@SEDC](https://github.com/SEDC) - perl module for accessing the API
 - [UniFi to Snipe-IT](https://github.com/RodneyLeeBrands/UnifiSnipeSync) by [@karpadiem](https://github.com/karpadiem) - Python script that synchronizes UniFi devices with Snipe-IT.
 - [Kandji2Snipe](https://github.com/grokability/kandji2snipe) by [@briangoldstein](https://github.com/briangoldstein) - Python script that synchronizes Kandji with Snipe-IT.
-- [SnipeAgent](https://github.com/ReticentRobot/SnipeAgent) by [@ReticentRobot](https://github.com/ReticentRobot) - Windows agent for Snipe-IT
+- [SnipeAgent](https://github.com/ReticentRobot/SnipeAgent) by [@ReticentRobot](https://github.com/ReticentRobot) - Windows agent for Snipe-IT.
+- [Gate Pass Generator](https://github.com/cha7uraAE/snipe-it-gate-pass-system) by [@cha7uraAE](https://github.com/cha7uraAE) - A Streamlit application for generating gate passes based on hardware data from a Snipe-IT API.
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ Since the release of the JSON REST API, several third-party developers have been
 - [WWW::SnipeIT](https://github.com/SEDC/perl-www-snipeit) by [@SEDC](https://github.com/SEDC) - perl module for accessing the API
 - [UniFi to Snipe-IT](https://github.com/RodneyLeeBrands/UnifiSnipeSync) by [@karpadiem](https://github.com/karpadiem) - Python script that synchronizes UniFi devices with Snipe-IT.
 - [Kandji2Snipe](https://github.com/grokability/kandji2snipe) by [@briangoldstein](https://github.com/briangoldstein) - Python script that synchronizes Kandji with Snipe-IT.
-- [SnipeAgent](https://github.com/ReticentRobot/SnipeAgent) by @ReticentRobot - Windows agent for Snipe-IT
-- [UnifiSnipeSync](https://github.com/RodneyLeeBrands/UnifiSnipeSync) by [RodneyLeeBrands](https://github.com/RodneyLeeBrands) - Python script that synchronizes UniFi devices with Snipe-IT.
+- [SnipeAgent](https://github.com/ReticentRobot/SnipeAgent) by [@ReticentRobot](https://github.com/ReticentRobot) - Windows agent for Snipe-IT
 
 -----
 

--- a/app/Http/Traits/TwoColumnUniqueUndeletedTrait.php
+++ b/app/Http/Traits/TwoColumnUniqueUndeletedTrait.php
@@ -16,10 +16,12 @@ trait TwoColumnUniqueUndeletedTrait
         $column = $parameters[0];
         $value = $this->{$parameters[0]};
 
+        // This is an existing model we're updating so ignore the current ID ($this->getKey())
         if ($this->exists) {
             return 'two_column_unique_undeleted:'.$this->table.','.$this->getKey().','.$column.','.$value;
         }
 
+        // This is a new record, so we can ignore the current ID
         return 'two_column_unique_undeleted:'.$this->table.',0,'.$column.','.$value;
     }
 }

--- a/app/Http/Traits/TwoColumnUniqueUndeletedTrait.php
+++ b/app/Http/Traits/TwoColumnUniqueUndeletedTrait.php
@@ -11,7 +11,7 @@ trait TwoColumnUniqueUndeletedTrait
      * @param  string $field
      * @return string
      */
-    protected function prepareTwoColumnUniqueUndeletedRule($parameters, $field)
+    protected function prepareTwoColumnUniqueUndeletedRule($parameters)
     {
         $column = $parameters[0];
         $value = $this->{$parameters[0]};

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -71,8 +71,10 @@ class AssetImporter extends ItemImporter
         $asset = Asset::where(['asset_tag'=> (string) $asset_tag])->first();
         if ($asset) {
             if (! $this->updating) {
-                $this->log('A matching Asset '.$asset_tag.' already exists');
-                return;
+                $exists_error = 'A matching Asset '.$asset_tag.' already exists';
+                $this->log($exists_error);
+                $this->addErrorToBag($asset, 'asset_tag', $exists_error);
+                return $exists_error;
             }
 
             $this->log('Updating Asset');

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -71,7 +71,7 @@ class AssetImporter extends ItemImporter
         $asset = Asset::where(['asset_tag'=> (string) $asset_tag])->first();
         if ($asset) {
             if (! $this->updating) {
-                $exists_error = 'A matching Asset '.$asset_tag.' already exists';
+                $exists_error = trans('general.import_asset_tag_exists', ['asset_tag' => $asset_tag]);
                 $this->log($exists_error);
                 $this->addErrorToBag($asset, 'asset_tag', $exists_error);
                 return $exists_error;

--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -281,6 +281,13 @@ abstract class Importer
         }
     }
 
+    protected function addErrorToBag($item, $field,  $error_message)
+    {
+        if ($this->errorCallback) {
+            call_user_func($this->errorCallback, $item, $field, [$field => [$error_message]]);
+        }
+    }
+
     /**
      * Finds the user matching given data, or creates a new one if there is no match.
      * This is NOT used by the User Import, only for Asset/Accessory/etc where

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -262,7 +262,10 @@ class ItemImporter extends Importer
         $item['category_id'] = $this->createOrFetchCategory($asset_model_category);
 
         $asset_model->fill($item);
+        //$asset_model = AssetModel::firstOrNew($item);
         $item = null;
+
+
 
         if ($asset_model->save()) {
             $this->log('Asset Model '.$asset_model_name.' with model number '.$asset_modelNumber.' was created');

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -223,11 +223,6 @@ class ItemImporter extends Importer
         $editingModel = $this->updating;
         $asset_model = $asset_model->first();
 
-        $this->log('Name: '.$asset_model_name);
-        $this->log('Number: '.$asset_modelNumber);
-        $this->log('Category: '.$asset_model_category);
-        $this->log('Model Info: '.print_r($asset_model, true));
-
         if ($asset_model) {
 
             if (! $this->updating) {

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -221,7 +221,6 @@ class ItemImporter extends Importer
         }
 
         $editingModel = $this->updating;
-        $this->log('SQL: '.$asset_model->toSql());
         $asset_model = $asset_model->first();
 
         $this->log('Name: '.$asset_model_name);

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -196,55 +196,70 @@ class ItemImporter extends Importer
     {
         $condition = array();
         $asset_model_name = $this->findCsvMatch($row, 'asset_model');
+        $asset_model_category = $this->findCsvMatch($row, 'category');
         $asset_modelNumber = $this->findCsvMatch($row, 'model_number');
+
         // TODO: At the moment, this means  we can't update the model number if the model name stays the same.
         if (! $this->shouldUpdateField($asset_model_name)) {
             return;
         }
+
         if ((empty($asset_model_name)) && (! empty($asset_modelNumber))) {
             $asset_model_name = $asset_modelNumber;
         } elseif ((empty($asset_model_name)) && (empty($asset_modelNumber))) {
             $asset_model_name = 'Unknown';
         }
 
-        if ((!empty($asset_model_name)) && (empty($asset_modelNumber))) {
-            $condition[] = ['name', '=', $asset_model_name];
-        } elseif ((!empty($asset_model_name)) && (!empty($asset_modelNumber))) {
-            $condition[] = ['name', '=', $asset_model_name];
-            $condition[] = ['model_number', '=', $asset_modelNumber];
+        $asset_model = AssetModel::select('id');
+
+        if (!empty($asset_model_name)) {
+            $asset_model = $asset_model->where('name', '=', $asset_model_name);
+
+            if (!empty($asset_modelNumber)) {
+                $asset_model = $asset_model->where('model_number', '=', $asset_modelNumber);
+            }
         }
 
         $editingModel = $this->updating;
-        $asset_model = AssetModel::where($condition)->first();
+        $this->log('SQL: '.$asset_model->toSql());
+        $asset_model = $asset_model->first();
+
+        $this->log('Name: '.$asset_model_name);
+        $this->log('Number: '.$asset_modelNumber);
+        $this->log('Category: '.$asset_model_category);
+        $this->log('Model Info: '.print_r($asset_model, true));
 
         if ($asset_model) {
+
             if (! $this->updating) {
                 $this->log('A matching model already exists, returning it.');
-
                 return $asset_model->id;
             }
+
             $this->log('Matching Model found, updating it.');
             $item = $this->sanitizeItemForStoring($asset_model, $editingModel);
             $item['name'] = $asset_model_name;
             $item['notes'] = $this->findCsvMatch($row, 'model_notes');
 
-            if(!empty($asset_modelNumber)){
+            if (!empty($asset_modelNumber)){
                 $item['model_number'] = $asset_modelNumber;
             }
 
             $asset_model->update($item);
             $asset_model->save();
             $this->log('Asset Model Updated');
-
+            
             return $asset_model->id;
-        }
-        $this->log('No Matching Model, Creating a new one');
 
+        }
+
+        $this->log('No Matching Model, Creating a new one');
         $asset_model = new AssetModel();
         $item = $this->sanitizeItemForStoring($asset_model, $editingModel);
         $item['name'] = $asset_model_name;
         $item['model_number'] = $asset_modelNumber;
         $item['notes'] = $this->findCsvMatch($row, 'model_notes');
+        $item['category_id'] = $this->createOrFetchCategory($asset_model_category);
 
         $asset_model->fill($item);
         $item = null;
@@ -254,6 +269,7 @@ class ItemImporter extends Importer
 
             return $asset_model->id;
         }
+        $this->log('Asset Model Errors: '.$asset_model->getErrors());
         $this->logError($asset_model, 'Asset Model "'.$asset_model_name.'"');
 
         return null;

--- a/app/Livewire/Importer.php
+++ b/app/Livewire/Importer.php
@@ -374,6 +374,12 @@ class Importer extends Component
                     'model name',
                     'model',
                 ],
+            'eol_date' =>
+                [
+                    'eol',
+                    'eol date',
+                    'asset eol date',
+                ],
             'gravatar' =>
                 [
                     'gravatar',

--- a/app/Models/AssetModel.php
+++ b/app/Models/AssetModel.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Watson\Validating\ValidatingTrait;
 use \App\Presenters\AssetModelPresenter;
+use App\Http\Traits\TwoColumnUniqueUndeletedTrait;
 
 /**
  * Model for Asset Models. Asset Models contain higher level
@@ -21,21 +22,8 @@ class AssetModel extends SnipeModel
 {
     use HasFactory;
     use SoftDeletes;
-    protected $presenter = AssetModelPresenter::class;
     use Loggable, Requestable, Presentable;
-
-    protected $table = 'models';
-    protected $hidden = ['user_id', 'deleted_at'];
-
-    // Declare the rules for the model validation
-    protected $rules = [
-        'name'              => 'string|required|min:1|max:255|unique:models,name',
-        'model_number'      => 'string|max:255|nullable',
-        'min_amt'           => 'integer|min:0|nullable',
-        'category_id'       => 'required|integer|exists:categories,id',
-        'manufacturer_id'   => 'integer|exists:manufacturers,id|nullable',
-        'eol'               => 'integer:min:0|max:240|nullable',
-    ];
+    use TwoColumnUniqueUndeletedTrait;
 
     /**
      * Whether the model should inject its identifier to the unique
@@ -44,8 +32,26 @@ class AssetModel extends SnipeModel
      *
      * @var bool
      */
+
     protected $injectUniqueIdentifier = true;
     use ValidatingTrait;
+    protected $table = 'models';
+    protected $hidden = ['user_id', 'deleted_at'];
+    protected $presenter = AssetModelPresenter::class;
+
+    // Declare the rules for the model validation
+
+
+    protected $rules = [
+        'name'              => 'string|required|min:1|max:255|two_column_unique_undeleted:model_number',
+        'model_number'      => 'string|max:255|nullable|two_column_unique_undeleted:name',
+        'min_amt'           => 'integer|min:0|nullable',
+        'category_id'       => 'required|integer|exists:categories,id',
+        'manufacturer_id'   => 'integer|exists:manufacturers,id|nullable',
+        'eol'               => 'integer:min:0|max:240|nullable',
+    ];
+
+
 
     /**
      * The attributes that are mass assignable.
@@ -85,6 +91,9 @@ class AssetModel extends SnipeModel
         'category'     => ['name'],
         'manufacturer' => ['name'],
     ];
+
+
+
 
     /**
      * Establishes the model -> assets relationship

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -6,10 +6,7 @@ use App\Models\CustomField;
 use App\Models\Department;
 use App\Models\Setting;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Crypt;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Validator;
 
 /**
@@ -99,10 +96,11 @@ class ValidationServiceProvider extends ServiceProvider
         Validator::extend('two_column_unique_undeleted', function ($attribute, $value, $parameters, $validator) {
             if (count($parameters)) {
                 $count = DB::table($parameters[0])
-                         ->select('id')->where($attribute, '=', $value)
-                         ->whereNull('deleted_at')
-                         ->where('id', '!=', $parameters[1])
-                         ->where($parameters[2], $parameters[3])->count();
+                    ->select('id')->where($attribute, '=', $value)
+                    ->where('id', '!=', $parameters[1])
+                    ->where($parameters[2], $parameters[3])
+                    ->whereNull('deleted_at')
+                    ->count();
 
                 return $count < 1;
             }

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -88,18 +88,25 @@ class ValidationServiceProvider extends ServiceProvider
          *
          * $parameters[0] - the name of the first table we're looking at
          * $parameters[1] - the ID (this will be 0 on new creations)
-         * $parameters[2] - the name of the second table we're looking at
+         * $parameters[2] - the name of the second field we're looking at
          * $parameters[3] - the value that the request is passing for the second table we're
          *                  checking for uniqueness across
          *
          */
         Validator::extend('two_column_unique_undeleted', function ($attribute, $value, $parameters, $validator) {
+
             if (count($parameters)) {
+                
                 $count = DB::table($parameters[0])
-                    ->select('id')->where($attribute, '=', $value)
-                    ->where('id', '!=', $parameters[1])
-                    ->where($parameters[2], $parameters[3])
-                    ->whereNull('deleted_at')
+                    ->select('id')
+                    ->where($attribute, '=', $value)
+                    ->where('id', '!=', $parameters[1]);
+
+                if ($parameters[3]!='') {
+                    $count = $count->where($parameters[2], $parameters[3]);
+                }
+
+                $count = $count->whereNull('deleted_at')
                     ->count();
 
                 return $count < 1;

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -561,5 +561,6 @@ return [
     'remaining_var' => ':count Remaining',
     'assets_in_var' => 'Assets in :name :type',
     'label' => 'Label',
+    'import_asset_tag_exists' => 'An asset with the asset tag :asset_tag already exists and an update was not requested. No change was made.',
 
 ];

--- a/resources/views/livewire/importer.blade.php
+++ b/resources/views/livewire/importer.blade.php
@@ -33,6 +33,7 @@
                         <table class="table table-striped table-bordered" id="errors-table">
                             <thead>
                             <th>{{ trans('general.item') }}</th>
+                            <th>Field</th>
                             <th>{{ trans('general.error') }}</th>
                             </thead>
                             <tbody>
@@ -41,8 +42,8 @@
                                     @foreach($error_bag as $field => $error_list)
                                         <tr>
                                             <td><b>{{ $key }}</b></td>
+                                            <td><b>{{ $field }}</b></td>
                                             <td>
-                                                <b>{{ $field }}:</b>
                                                 <span>{{ implode(", ",$error_list) }}</span>
                                                 <br />
                                             </td>

--- a/tests/Feature/AssetModels/Api/CreateAssetModelsTest.php
+++ b/tests/Feature/AssetModels/Api/CreateAssetModelsTest.php
@@ -24,7 +24,7 @@ class CreateAssetModelsTest extends TestCase
         $response = $this->actingAsForApi(User::factory()->superuser()->create())
             ->postJson(route('api.models.store'), [
                 'name' => 'Test AssetModel',
-                'category_id' => Category::factory()->create()->id
+                'category_id' => Category::factory()->assetLaptopCategory()->create()->id
             ])
             ->assertOk()
             ->assertStatusMessageIs('success')
@@ -65,6 +65,7 @@ class CreateAssetModelsTest extends TestCase
             ->postJson(route('api.models.store'), [
                 'name' => 'Test Model',
                 'model_number' => '1234',
+                'category_id' => Category::factory()->assetLaptopCategory()->create()->id
             ])
             ->assertStatus(200)
             ->assertOk()
@@ -86,6 +87,7 @@ class CreateAssetModelsTest extends TestCase
         $this->actingAsForApi(User::factory()->superuser()->create())
             ->postJson(route('api.models.store'), [
                 'name' => 'Test Model',
+                'category_id' => Category::factory()->assetLaptopCategory()->create()->id
             ])
             ->assertStatus(200)
             ->assertOk()
@@ -93,7 +95,6 @@ class CreateAssetModelsTest extends TestCase
             ->assertJson([
                 'messages' => [
                     'name'    => ['The name must be unique across models and model number. '],
-                    'model_number'    => ['The model number must be unique across models and name. '],
                 ],
             ])
             ->json();

--- a/tests/Feature/AssetModels/Api/CreateAssetModelsTest.php
+++ b/tests/Feature/AssetModels/Api/CreateAssetModelsTest.php
@@ -53,8 +53,29 @@ class CreateAssetModelsTest extends TestCase
             ])
             ->json();
 
-        // dd($response);
         $this->assertFalse(AssetModel::where('name', 'Test AssetModel')->exists());
+
+    }
+
+    public function testUniquenessAcrossModelNameAndModelNumber()
+    {
+        AssetModel::factory()->create(['name' => 'Test Model', 'model_number'=>'1234']);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->postJson(route('api.models.store'), [
+                'name' => 'Test Model',
+                'model_number' => '1234',
+            ])
+            ->assertStatus(200)
+            ->assertOk()
+            ->assertStatusMessageIs('error')
+            ->assertJson([
+                'messages' => [
+                    'name'    => ['The name must be unique across models and model number. '],
+                    'model_number'    => ['The model number must be unique across models and name. '],
+                ],
+            ])
+            ->json();
 
     }
 

--- a/tests/Feature/AssetModels/Api/CreateAssetModelsTest.php
+++ b/tests/Feature/AssetModels/Api/CreateAssetModelsTest.php
@@ -79,4 +79,25 @@ class CreateAssetModelsTest extends TestCase
 
     }
 
+    public function testUniquenessAcrossModelNameAndModelNumberWithBlankModelNumber()
+    {
+        AssetModel::factory()->create(['name' => 'Test Model']);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->postJson(route('api.models.store'), [
+                'name' => 'Test Model',
+            ])
+            ->assertStatus(200)
+            ->assertOk()
+            ->assertStatusMessageIs('error')
+            ->assertJson([
+                'messages' => [
+                    'name'    => ['The name must be unique across models and model number. '],
+                    'model_number'    => ['The model number must be unique across models and name. '],
+                ],
+            ])
+            ->json();
+
+    }
+
 }

--- a/tests/Feature/AssetModels/Ui/CreateAssetModelsTest.php
+++ b/tests/Feature/AssetModels/Ui/CreateAssetModelsTest.php
@@ -51,4 +51,26 @@ class CreateAssetModelsTest extends TestCase
 
     }
 
+    public function testUniquenessAcrossModelNameAndModelNumber()
+    {
+
+        AssetModel::factory()->create(['name' => 'Test Model', 'model_number'=>'1234']);
+
+        $response = $this->actingAs(User::factory()->superuser()->create())
+            ->from(route('models.create'))
+            ->post(route('models.store'), [
+                'name' => 'Test Model',
+                'model_number' => '1234',
+                'category_id' => Category::factory()->create()->id
+            ])
+            ->assertStatus(302)
+            ->assertSessionHasErrors(['name','model_number'])
+            ->assertStatus(302)
+            ->assertRedirect(route('models.create'))
+            ->assertInvalid(['name','model_number']);
+
+        $this->followRedirects($response)->assertSee(trans('general.error'));
+
+    }
+
 }

--- a/tests/Feature/AssetModels/Ui/CreateAssetModelsTest.php
+++ b/tests/Feature/AssetModels/Ui/CreateAssetModelsTest.php
@@ -65,7 +65,27 @@ class CreateAssetModelsTest extends TestCase
             ])
             ->assertStatus(302)
             ->assertSessionHasErrors(['name','model_number'])
+            ->assertRedirect(route('models.create'))
+            ->assertInvalid(['name','model_number']);
+
+        $this->followRedirects($response)->assertSee(trans('general.error'));
+
+    }
+
+    public function testUniquenessAcrossModelNameAndModelNumberWithoutModelNumber()
+    {
+
+        AssetModel::factory()->create(['name' => 'Test Model', 'model_number'=> null]);
+
+        $response = $this->actingAs(User::factory()->superuser()->create())
+            ->from(route('models.create'))
+            ->post(route('models.store'), [
+                'name' => 'Test Model',
+                'model_number' => null,
+                'category_id' => Category::factory()->create()->id
+            ])
             ->assertStatus(302)
+            ->assertSessionHasErrors(['name','model_number'])
             ->assertRedirect(route('models.create'))
             ->assertInvalid(['name','model_number']);
 

--- a/tests/Feature/AssetModels/Ui/CreateAssetModelsTest.php
+++ b/tests/Feature/AssetModels/Ui/CreateAssetModelsTest.php
@@ -24,6 +24,7 @@ class CreateAssetModelsTest extends TestCase
         $this->assertFalse(AssetModel::where('name', 'Test Model')->exists());
 
         $this->actingAs(User::factory()->superuser()->create())
+            ->from(route('models.create'))
             ->post(route('models.store'), [
                 'name' => 'Test Model',
                 'category_id' => Category::factory()->create()->id
@@ -85,9 +86,9 @@ class CreateAssetModelsTest extends TestCase
                 'category_id' => Category::factory()->create()->id
             ])
             ->assertStatus(302)
-            ->assertSessionHasErrors(['name','model_number'])
+            ->assertSessionHasErrors(['name'])
             ->assertRedirect(route('models.create'))
-            ->assertInvalid(['name','model_number']);
+            ->assertInvalid(['name']);
 
         $this->followRedirects($response)->assertSee(trans('general.error'));
 


### PR DESCRIPTION
We had pulled the uniqueness constraint on models somewhere along the line, which made importing easier and less noisy, but also allowed duplicate names to be created via API and UI, which can cause confusion to the user. If yo have 4 "Macbook Pro 13", which is the "real" one?

This PR adds it back in, but allows for the same model name as long as the model_number is different. 

This also adds a nicer message if the asset tag already exists in the spreadsheet but the update button has not been checked.

If the update button is not checked, it will quietly update with the newer values, as it's always done.
