### PR TITLE
Prevent passing an array as login

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -508,8 +508,8 @@ class LoginController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
-            'username' => 'required',
-            'password' => 'required',
+            'username' => 'required|not_array',
+            'password' => 'required|not_array',
         ]);
     }
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -57,16 +57,22 @@
                                     <fieldset>
 
                                         <div class="form-group{{ $errors->has('username') ? ' has-error' : '' }}">
-                                            <label for="username"><i class="fas fa-user" aria-hidden="true"></i> {{ trans('admin/users/table.username')  }}</label>
+                                            <label for="username">
+                                                <i class="fas fa-user" aria-hidden="true"></i>
+                                                {{ trans('admin/users/table.username')  }}
+                                            </label>
                                             <input class="form-control" placeholder="{{ trans('admin/users/table.username')  }}" name="username" type="text" id="username" autocomplete="{{ (config('auth.login_autocomplete') === true) ? 'on' : 'off'  }}" autofocus>
                                             {!! $errors->first('username', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                         </div>
                                         <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                                            <label for="password"><i class="fa fa-key" aria-hidden="true"></i> {{ trans('admin/users/table.password')  }}</label>
+                                            <label for="password">
+                                                <i class="fa fa-key" aria-hidden="true"></i>
+                                                {{ trans('admin/users/table.password')  }}
+                                            </label>
                                             <input class="form-control" placeholder="{{ trans('admin/users/table.password')  }}" name="password" type="password" id="password" autocomplete="{{ (config('auth.login_autocomplete') === true) ? 'on' : 'off'  }}">
                                             {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                                         </div>
-                                        <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
+                                        <div class="form-group">
                                             <label class="form-control">
                                                 <input name="remember" type="checkbox" value="1"> {{ trans('auth/general.remember_me')  }}
                                             </label>


### PR DESCRIPTION
Someone was faffing around on the demo, injecting additional username fields, causing a 500. While they were clearly trying (unsuccessfully) to test for exploits, it was lighting up our rollbar and was annoying. This solves that.