### PR TITLE
Fixed `)` being added to expected asset checkin report email header

### DIFF
--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -14,7 +14,7 @@
     @endif
 
     {{-- Show images in email!  --}}
-    @if (($snipeSettings->show_images_in_email=='1') && ($snipeSettings->email_logo!='') && $snipeSettings->brand != '1'))
+    @if (($snipeSettings->show_images_in_email=='1') && ($snipeSettings->email_logo!='') && ($snipeSettings->brand != '1'))
 
         {{-- $snipeSettings->brand = 1 = Text  --}}
         {{-- $snipeSettings->brand = 2 = Logo  --}}


### PR DESCRIPTION
# Description

This PR fixes an issue where an extra `(` was being added to the header of the expected asset checkin report email when Logo+Text was set for the branding option.

Before:
![parentheses added to header](https://github.com/user-attachments/assets/06fe5e6d-5b5f-4b41-94e3-91199e5c6d52)

After:
![parentheses removed](https://github.com/user-attachments/assets/265aeba1-68fd-44cb-8bd0-2b64c7cb0df7)

Fixes #15335

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
