### PR TITLE
Added TrimStrings middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\CheckForSetup::class,
         \App\Http\Middleware\CheckForDebug::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\TrimStrings::class,
         \App\Http\Middleware\SecurityHeaders::class,
         \App\Http\Middleware\PreventBackHistory::class,
         \Illuminate\Http\Middleware\HandleCors::class,


### PR DESCRIPTION
This properly invokes the TrimStrings middleware so that extra spaces around submitted data will be removed before being saved.