### PR TITLE
Fixed icon not rotated and simplified component

### DIFF
--- a/resources/views/blade/icon.blade.php
+++ b/resources/views/blade/icon.blade.php
@@ -2,6 +2,5 @@
 
 @props([
     'type' => '',
-    'id' => false,
 ])
 <i {{ $attributes->merge(['class' => Icon::icon($type)]) }} aria-hidden="true"></i>

--- a/resources/views/blade/icon.blade.php
+++ b/resources/views/blade/icon.blade.php
@@ -2,9 +2,6 @@
 
 @props([
     'type' => '',
-    'class' => false,
-    'style' => false,
     'id' => false,
-    'title' => false,
 ])
-<i {{ $attributes->merge(['class' => Icon::icon($type).' '.$class]) }} {{ isset($style) ? $attributes->merge(['style' => $style]): '' }}  {{ isset($title) ? $attributes->merge(['title' => $title]): '' }}  aria-hidden="true"></i>
+<i {{ $attributes->merge(['class' => Icon::icon($type)]) }} aria-hidden="true"></i>


### PR DESCRIPTION
# Description

This PR builds on #15327 and simplifies the icon component by relying on the [behavior of rendering](https://laravel.com/docs/10.x/blade#component-attributes) `{{ $attributes }}` within a component. This allows any native html attributes to be rendered on the component by passing them in (`<x-icon something="here"`) and utilizing the `{{ $attributes }}` that is already rendered in the component.

The removal of `id` from the `props` is especially helpful since it allows it to be rendered when `$attributes` is used within the component and fixes an issue where a couple icons weren't rotating any more since `id` was no longer being added:

| Before | After |
|--------|--------|
| ![Icon not rotating](https://github.com/user-attachments/assets/9177960e-23f6-465a-8599-9cc71c0af6e6) | ![Icon rotates](https://github.com/user-attachments/assets/c0a98b2b-75bb-4e95-9add-f30c32125fb4) |

In other words, by including `id` in `props` we would have had to manually write `{{ $id }}` within the component's `i` tag to get it to render.

Another potential (minor) change would be to _not_ set a default value for `title` in `props` since it should always be passed in but I'll skip that in this PR to avoid re-testing all views.

## Type of change

- [x] Bug fix (ish)