### PR TITLE
Fixed Mobile misalignment of info on Assets and Users view pages

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -851,6 +851,24 @@ th.css-component > .th-inner::before
     margin-top:50px
   }
 }
+@media screen and (max-width: 992px){
+  .info-stack-container {
+    display: flex;
+    flex-direction: column;
+  }
+  .col-md-3.col-xs-12.col-sm-push-9.info-stack{
+    left:auto;
+    order:2;
+  }
+  .col-md-9.col-xs-12.col-sm-pull-3.info-stack{
+    right:auto;
+    order:1;
+  }
+  .info-stack-container > .col-md-9.col-xs-12.col-sm-pull-3.info-stack > .row-new-striped > .row > .col-sm-2{
+    width:auto;
+    float:none;
+  }
+}
 @media screen and (max-width: 1318px) and (min-width: 1200px){
   .admin.box{
     height:170px;

--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -858,11 +858,11 @@ th.css-component > .th-inner::before
   }
   .col-md-3.col-xs-12.col-sm-push-9.info-stack{
     left:auto;
-    order:2;
+    order:1;
   }
   .col-md-9.col-xs-12.col-sm-pull-3.info-stack{
     right:auto;
-    order:1;
+    order:2;
   }
   .info-stack-container > .col-md-9.col-xs-12.col-sm-pull-3.info-stack > .row-new-striped > .row > .col-sm-2{
     width:auto;

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -160,9 +160,9 @@
                                     </div>
                                 </div>
                             @endif
-
+                        <div class="info-stack-container">
                             <!-- Start button column -->
-                            <div class="col-md-3 col-xs-12 col-sm-push-9">
+                            <div class="col-md-3 col-xs-12 col-sm-push-9 info-stack">
 
                                 <div class="col-md-12 text-center">
                                     @if (($asset->image) || (($asset->model) && ($asset->model->image!='')))
@@ -334,7 +334,7 @@
 
                             <!-- End button column -->
 
-                            <div class="col-md-9 col-xs-12 col-sm-pull-3">
+                            <div class="col-md-9 col-xs-12 col-sm-pull-3 info-stack">
 
                                 <div class="row-new-striped">
 
@@ -1078,6 +1078,7 @@
                                     
                                 </div> <!--/end striped container-->
                             </div> <!-- end col-md-9 -->
+                        </div><!-- end info-stack-container -->
                         </div> <!--/.row-->
                     </div><!-- /.tab-pane -->
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -159,9 +159,9 @@
                 </div>
               </div>
             @endif
-
+        <div class="info-stack-container">
             <!-- Start button column -->
-            <div class="col-md-3 col-xs-12 col-sm-push-9">
+            <div class="col-md-3 col-xs-12 col-sm-push-9 info-stack">
 
               
 
@@ -306,7 +306,7 @@
  
             <!-- End button column -->
           
-            <div class="col-md-9 col-xs-12 col-sm-pull-3">
+            <div class="col-md-9 col-xs-12 col-sm-pull-3 info-stack">
 
                <div class="row-new-striped">
                 
@@ -765,6 +765,7 @@
                    @endif
                   </div> <!--/end striped container-->
                 </div> <!-- end col-md-9 -->
+             </div><!-- end info-stack-container-->
           </div> <!--/.row-->
         </div><!-- /.tab-pane -->
 


### PR DESCRIPTION
# Description

This corrects the misalignment of the info on the users' and assets' view pages. These changes now position both divs into a column and display the table info first. The push and pull classes were oddly the culprit here on smaller screens. Since there is only room for 1 column they were pushing/pulling the divs 25% and 75% respectively from center.
I've introduced an `info-stack-container` class as well as an `info-stack` for the children divs applying an order now.

Before:
![image](https://github.com/user-attachments/assets/c344c64e-fd52-4606-9e7f-7295538f0042)

After:
Assets:
<img width="810" alt="image" src="https://github.com/user-attachments/assets/cf909e9a-4e1c-41d4-bf3b-9c2856285cdb">
Users:
<img width="810" alt="image" src="https://github.com/user-attachments/assets/bf1d9d7a-72a5-4a1a-b9cc-71d04092d8ca">

Fixes #[SC-26615]

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
