### PR TITLE
Fixed #15190 - Improvements to upgrade.php script to improve Windows experience

### DIFF
--- a/upgrade.php
+++ b/upgrade.php
@@ -1,9 +1,14 @@
 <?php
 (PHP_SAPI !== 'cli' || isset($_SERVER['HTTP_USER_AGENT'])) && die('Access denied.');
 
-// We define this because we can't reliable use file_get_contents because some
+// We define this because we can't reliably use file_get_contents because some
 // machines don't allow URL access via allow_url_fopen being set to off
 function url_get_contents ($Url) {
+    $results = file_get_contents($Url);
+    if ($results) {
+        return $results;
+    }
+    print("file_get_contents() failed, trying curl instead.\n");
     if (!function_exists('curl_init')){
         die("cURL is not installed!\nThis is required for Snipe-IT as well as the upgrade script, so you will need to fix this before continuing.\nAborting upgrade...\n");
     }
@@ -13,11 +18,18 @@ function url_get_contents ($Url) {
     // If we're on windows, make sure we can load intermediate certificates in
     // weird corporate environments.
     // See:  https://github.com/curl/curl/commit/2d6333101a71129a6a802eb93f84a5ac89e34479
-    if (PHP_OS == "WINNT"){
+    // this will _probably_ only work if your libcurl has been linked to Schannel, the native Windows SSL implementation
+    if (PHP_OS == "WINNT" && defined("CURLOPT_SSL_OPTIONS") && defined("CURLSSLOPT_NATIVE_CA")) {
         curl_setopt($ch, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
     }
     $output = curl_exec($ch);
     curl_close($ch);
+    if ($output === false) {
+        print("Error retrieving PHP requirements!\n");
+        print("Error was: " . curl_error($ch) . "\n");
+        print("Try enabling allow_url_fopen in php.ini, or fixing your curl/OpenSSL setup, or try rerunning with --skip-php-compatibility-checks");
+        return '{}';
+    }
     return $output;
 }
 
@@ -72,7 +84,7 @@ if (! $upgrade_requirements) {
         echo "\nERROR: Failed to retrieve remote requirements from $remote_requirements_file\n\n";
         if ($branch_override){
             echo "NOTE: You passed a custom branch: $branch\n";
-            echo "   If the above URL doesn't work, that may be why. Please check you branch spelling/extistance\n\n";
+            echo "   If the above URL doesn't work, that may be why. Please check you branch spelling/existence\n\n";
         }
 
         if (json_last_error()) {
@@ -149,7 +161,11 @@ foreach ($env as $line_num => $line) {
 
     if ((strlen($line) > 1) && (strpos($line, "#") !== 0)) {
 
-        list ($env_key, $env_value) = $env_line = explode('=', $line);
+        $env_line = explode('=', $line, 2);
+        if (count($env_line) != 2) {
+            continue;
+        }
+        list ($env_key, $env_value) = $env_line;
 
         // The array starts at 0
         $show_line_num = $line_num+1;


### PR DESCRIPTION
This is not a *complete* fix for all of the problems listed in that issue, but it should handle several of the use-cases.

1. When fetching the version requirements JSON blob, we now try to use `file_get_contents()` first, which can provide a better experience on Windows. But if `allow_url_fopen` is disabled, we fall back to using `curl`. This `curl` command might not work in Windows environments unless a CA bundle has been installed, typically this is done by installing OpenSSL.
2. We check to see if the appropriate constants are defined before we try to set those options in curl. Only some versions of `curl` on Windows, for some versions of PHP, will have these constants pre-defined.
3. We try to return valid, minimal JSON (`{}`) if all of the version requirements JSON-fetching fails, so the JSON parsing will still work - especially useful if you're using `--skip-php-compatibility-checks`.
4. Some spurious output might have occurred when parsing the `.env` file; this fixes that.

We discussed the possibility of moving the backup part *after* the composer install part, but that's not going to make a difference - we *also* run `php artisan down` which would **also** fail if the current install is not properly `composer install`'ed. So I left it as-is. I'm OK with the idea of either making these failures less 'hard' or possibly introducing new command-line options to better handle a semi-donked Snipe-IT install. But I suspect we should do that in a separate PR.