### PR TITLE
Fixes the `acceptance-reminder` command

### DIFF
--- a/app/Console/Commands/SendAcceptanceReminder.php
+++ b/app/Console/Commands/SendAcceptanceReminder.php
@@ -47,9 +47,10 @@ class SendAcceptanceReminder extends Command
     {
         $pending = CheckoutAcceptance::pending()->where('checkoutable_type', 'App\Models\Asset')
                                                 ->whereHas('checkoutable', function($query) {
-                                                    $query->where('archived', 0);
+                                                    $query->where('accepted_at', null)
+                                                          ->where('declined_at', null);
                                                 })
-                                                ->with(['assignedTo', 'checkoutable.assignedTo', 'checkoutable.model', 'checkoutable.adminuser'])
+                                                ->with(['assignedTo', 'checkoutable.assignedTo', 'checkoutable.model', 'checkoutable.admin'])
                                                 ->get();
 
         $count = 0;


### PR DESCRIPTION
# Description
 Fixed the `acceptance-reminder` command.  it was looking for the wrong columns. Now it looks to make sure the `accepted_at` and `declined_at` are both null before sending a reminder.

Fixes #15370 

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
