### PR TITLE
Removed extra icon on settings button navigation item

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -647,7 +647,6 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                 <a href="#" id="settings">
                                     <x-icon type="settings" />
                                     <span>{{ trans('general.settings') }}</span>
-                                    <x-icon type="angle-left" class="fa-fw"/>
                                 </a>
 
                                 <ul class="treeview-menu">


### PR DESCRIPTION
# Description

I noticed the settings button had an extra icon under/over it and this PR removes it:

| Before | After |
|--------|--------|
| ![icon doubled up](https://github.com/user-attachments/assets/53ef16a9-fd4e-4549-8229-91ccf8dfd43e) | ![icon clean](https://github.com/user-attachments/assets/4e5f3bbb-6aff-4bbf-b2bd-52653a6eadd0) |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)