### PR TITLE
Fixed custom field defaults being prematurely updated

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -151,17 +151,17 @@ class AssetModelsController extends Controller
         $model->notes = $request->input('notes');
         $model->requestable = $request->input('requestable', '0');
 
-        $this->removeCustomFieldsDefaultValues($model);
-
         $model->fieldset_id = $request->input('fieldset_id');
 
-        if ($this->shouldAddDefaultValues($request->input())) {
-            if (!$this->assignCustomFieldsDefaultValues($model, $request->input('default_values'))){
-                return redirect()->back()->withInput()->with('error', trans('admin/custom_fields/message.fieldset_default_value.error'));
-            }
-        }
-
         if ($model->save()) {
+            $this->removeCustomFieldsDefaultValues($model);
+
+            if ($this->shouldAddDefaultValues($request->input())) {
+                if (!$this->assignCustomFieldsDefaultValues($model, $request->input('default_values'))) {
+                    return redirect()->back()->withInput()->with('error', trans('admin/custom_fields/message.fieldset_default_value.error'));
+                }
+            }
+
             if ($model->wasChanged('eol')) {
                     if ($model->eol > 0) {
                         $newEol = $model->eol; 

--- a/tests/Feature/AssetModels/Ui/UpdateAssetModelsTest.php
+++ b/tests/Feature/AssetModels/Ui/UpdateAssetModelsTest.php
@@ -14,11 +14,10 @@ class UpdateAssetModelsTest extends TestCase
     public function testPermissionRequiredToStoreAssetModel()
     {
         $this->actingAs(User::factory()->create())
-            ->post(route('models.store'), [
-                'name' => 'Test Model',
-                'category_id' => Category::factory()->create()->id
+            ->put(route('models.update', ['model' => AssetModel::factory()->create()]), [
+                'name' => 'Changed Name',
+                'category_id' => Category::factory()->create()->id,
             ])
-            ->assertStatus(403)
             ->assertForbidden();
     }
 

--- a/tests/Feature/AssetModels/Ui/UpdateAssetModelsTest.php
+++ b/tests/Feature/AssetModels/Ui/UpdateAssetModelsTest.php
@@ -90,13 +90,10 @@ class UpdateAssetModelsTest extends TestCase
                 ],
             ]);
 
-        $this->assertEquals(
-            2,
-            $assetModel->fresh()->defaultValues->filter(function (CustomField $field) {
-                return in_array($field->pivot->default_value, ['first default value', 'second default value']);
-            })->count(),
-            'Default field values were changed unexpectedly.'
-        );
+        $potentiallyChangedDefaultValues = $assetModel->defaultValues->pluck('pivot.default_value');
+        $this->assertCount(2, $potentiallyChangedDefaultValues);
+        $this->assertContains('first default value', $potentiallyChangedDefaultValues);
+        $this->assertContains('second default value', $potentiallyChangedDefaultValues);
     }
 
     public function test_default_values_can_be_updated()
@@ -129,7 +126,6 @@ class UpdateAssetModelsTest extends TestCase
             ]);
 
         $potentiallyChangedDefaultValues = $assetModel->defaultValues->pluck('pivot.default_value');
-
         $this->assertCount(2, $potentiallyChangedDefaultValues);
         $this->assertContains('first changed value', $potentiallyChangedDefaultValues);
         $this->assertContains('second changed value', $potentiallyChangedDefaultValues);

--- a/tests/Feature/AssetModels/Ui/UpdateAssetModelsTest.php
+++ b/tests/Feature/AssetModels/Ui/UpdateAssetModelsTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature\AssetModels\Ui;
 
 use App\Models\AssetModel;
 use App\Models\Category;
+use App\Models\CustomField;
+use App\Models\CustomFieldset;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -19,7 +21,7 @@ class UpdateAssetModelsTest extends TestCase
             ->assertStatus(403)
             ->assertForbidden();
     }
-    
+
     public function testUserCanEditAssetModels()
     {
         $category = Category::factory()->forAssets()->create();
@@ -62,4 +64,41 @@ class UpdateAssetModelsTest extends TestCase
 
     }
 
+    public function test_default_values_remain_unchanged_after_validation_error_occurs()
+    {
+        $this->markIncompleteIfMySQL('Custom Field Tests do not work in MySQL');
+
+        $assetModel = AssetModel::factory()->create();
+
+        $customFieldset = CustomFieldset::factory()->create();
+
+        [$customFieldOne, $customFieldTwo] = CustomField::factory()->count(2)->create();
+
+        $customFieldset->fields()->attach($customFieldOne, ['order' => 1, 'required' => false]);
+        $customFieldset->fields()->attach($customFieldTwo, ['order' => 2, 'required' => false]);
+
+        $assetModel->fieldset()->associate($customFieldset);
+
+        $assetModel->defaultValues()->attach($customFieldOne, ['default_value' => 'first default value']);
+        $assetModel->defaultValues()->attach($customFieldTwo, ['default_value' => 'second default value']);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->put(route('models.update', ['model' => $assetModel]), [
+                // should trigger validation error without name, etc, and NOT remove or change default values
+                'add_default_values' => '1',
+                'fieldset_id' => $customFieldset->id,
+                'default_values' => [
+                    $customFieldOne->id => 'changed value',
+                    $customFieldTwo->id => 'changed value',
+                ],
+            ]);
+
+        $this->assertEquals(
+            2,
+            $assetModel->fresh()->defaultValues->filter(function (CustomField $field) {
+                return in_array($field->pivot->default_value, ['first default value', 'second default value']);
+            })->count(),
+            'Default field values were changed unexpectedly.'
+        );
+    }
 }

--- a/tests/Feature/AssetModels/Ui/UpdateAssetModelsTest.php
+++ b/tests/Feature/AssetModels/Ui/UpdateAssetModelsTest.php
@@ -68,9 +68,7 @@ class UpdateAssetModelsTest extends TestCase
         $this->markIncompleteIfMySQL('Custom Field Tests do not work in MySQL');
 
         $assetModel = AssetModel::factory()->create();
-
         $customFieldset = CustomFieldset::factory()->create();
-
         [$customFieldOne, $customFieldTwo] = CustomField::factory()->count(2)->create();
 
         $customFieldset->fields()->attach($customFieldOne, ['order' => 1, 'required' => false]);
@@ -87,8 +85,8 @@ class UpdateAssetModelsTest extends TestCase
                 'add_default_values' => '1',
                 'fieldset_id' => $customFieldset->id,
                 'default_values' => [
-                    $customFieldOne->id => 'changed value',
-                    $customFieldTwo->id => 'changed value',
+                    $customFieldOne->id => 'first changed value',
+                    $customFieldTwo->id => 'second changed value',
                 ],
             ]);
 
@@ -99,5 +97,41 @@ class UpdateAssetModelsTest extends TestCase
             })->count(),
             'Default field values were changed unexpectedly.'
         );
+    }
+
+    public function test_default_values_can_be_updated()
+    {
+        $this->markIncompleteIfMySQL('Custom Field Tests do not work in MySQL');
+
+        $assetModel = AssetModel::factory()->create();
+        $customFieldset = CustomFieldset::factory()->create();
+        [$customFieldOne, $customFieldTwo] = CustomField::factory()->count(2)->create();
+
+        $customFieldset->fields()->attach($customFieldOne, ['order' => 1, 'required' => false]);
+        $customFieldset->fields()->attach($customFieldTwo, ['order' => 2, 'required' => false]);
+
+        $assetModel->fieldset()->associate($customFieldset);
+
+        $assetModel->defaultValues()->attach($customFieldOne, ['default_value' => 'first default value']);
+        $assetModel->defaultValues()->attach($customFieldTwo, ['default_value' => 'second default value']);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->put(route('models.update', ['model' => $assetModel]), [
+                // should trigger validation error without name, etc, and NOT remove or change default values
+                'name' => 'Test Model Edited',
+                'category_id' => $assetModel->category_id,
+                'add_default_values' => '1',
+                'fieldset_id' => $customFieldset->id,
+                'default_values' => [
+                    $customFieldOne->id => 'first changed value',
+                    $customFieldTwo->id => 'second changed value',
+                ],
+            ]);
+
+        $potentiallyChangedDefaultValues = $assetModel->defaultValues->pluck('pivot.default_value');
+
+        $this->assertCount(2, $potentiallyChangedDefaultValues);
+        $this->assertContains('first changed value', $potentiallyChangedDefaultValues);
+        $this->assertContains('second changed value', $potentiallyChangedDefaultValues);
     }
 }


### PR DESCRIPTION
# Description


This PR fixes an issue where attempting to update an asset model but getting a validation error still updated custom field default values even though the user is redirected back to the form:

https://github.com/user-attachments/assets/c08aef60-0f56-45a8-a536-5e949851a7ee

> I manually disabled `required` for the name input to demonstrate the issue above.

The issue was we were updating the custom field value defaults before calling `$model->save()` and a failure at model level validation means the user would be redirected back but the defaults had already been updated.

We could probably update and utilize the `StoreAssetModelRequest` here but I found this as part of other work I'm doing and didn't want to get too distracted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)