### PR TITLE
Fixed #15374: load TrustProxies middleware in Kernel.php

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,6 +14,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
+        \App\Http\Middleware\TrustProxies::class,
         \App\Http\Middleware\NoSessionStore::class,
         \Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance::class,
         \Illuminate\Session\Middleware\StartSession::class,


### PR DESCRIPTION
# Description

Loads the (already implemented) TrustProxies middleware.

Fixes a whole sleuth of issues pertaining to reverse proxies. People complaining about it have been pointed towards correctly configuring their trusted proxies; however it turns out even if they did, Snipe-IT failed to load the middleware responsible for taking them into account.

No additional dependencies required.

Before:

![image](https://github.com/user-attachments/assets/dd6c68b3-024a-4223-8d98-099119e48da4)

After:

![image](https://github.com/user-attachments/assets/499821ff-8e0c-474d-8175-73c488a3a811)

Fixes #15374

**Might** also fix (non-exhaustive list):
- #15346
- #15332
- #14699
- #13653
- #11898
- #10779
- #9179

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Relevant details: run the `snipe/snipe-it` Docker image on a machine, exposing port 80 of the container as port 8080 of the host (127.0.0.1 only if you prefer). Slap a reverse proxy in front of it. Make sure you set all the relevant headers for proxy stuff. If you're using nginx; that would be:

```
		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
		proxy_set_header X-Forwarded-Host $host;
		proxy_set_header X-Forwarded-Proto $scheme;
``` 

On the Snipe-IT config side, make sure you set `APP_URL` to whatever you'd use to reach your reverse proxy.  And set `APP_TRUSTED_PROXIES=172.17.0.1`. This is the IP address of the docker host from the perspective of the docker container, **on linux**. On other platforms, set it to whatever is appropriate. If you're not sure, `0.0.0.0/0` or `*` should probably work, but I haven't tested it because I do not use such platforms.

- [ ] Test A

Open the correct app url that connects you to the reverse proxy (that proxies your request to the snipe-it container). See a big red error, because snipe-it thinks its hostname is `localhost:8080` even though you told it to expect something else.

- [ ] Test B

Apply the patch, change nothing else. Live in a sea of blissful green checkmarks.

**Test Configuration**:
* PHP version: whatever is in `snipe/snipe-it`
* MySQL version: not relevant
* Webserver version: whatever is in `snipe/snipe-it`
* OS version: Ubuntu 22.04

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
