### PR TITLE
Set image to null if model is deleted

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -202,6 +202,7 @@ class AssetModelsController extends Controller
         if ($model->image) {
             try {
                 Storage::disk('public')->delete('models/'.$model->image);
+                $model->update(['image' => null]);
             } catch (\Exception $e) {
                 Log::info($e);
             }


### PR DESCRIPTION
Previously, when a model is soft-deleted, we also delete the image from disk. This meant that the image would be gone, but in the deleted models page, it would still try to display a (now) missing image.

This updates the model's image field to null to prevent broken images.