### PR TITLE
Use the null-safe property accessor for new-user creation

### DIFF
--- a/app/Http/Requests/SaveUserRequest.php
+++ b/app/Http/Requests/SaveUserRequest.php
@@ -37,7 +37,7 @@ class SaveUserRequest extends FormRequest
             'company_id' => [
                 // determines if the user is being moved between companies and checks to see if they have any items assigned
                 function ($attribute, $value, $fail) {
-                    if (($this->has('company_id')) && ($this->user->allAssignedCount() > 0) && (Setting::getSettings()->full_multiple_companies_support)) {
+                    if (($this->has('company_id')) && ($this->user?->allAssignedCount() > 0) && (Setting::getSettings()->full_multiple_companies_support)) {
                         $fail(trans('admin/users/message.error.multi_company_items_assigned'));
                     }
                 }


### PR DESCRIPTION
What it says on the tin!

Corrects a defect created in #15284