### PR TITLE
Possible fix for #15315 - decode as permissions as boolean 

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -703,7 +703,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
 
     public function decodePermissions()
     {
-        $permissions = json_decode($this->permissions, JSON_OBJECT_AS_ARRAY|JSON_NUMERIC_CHECK);
+        $permissions = json_decode($this->permissions, JSON_OBJECT_AS_ARRAY);
         foreach ($permissions as $permission => $value) {
             $permissions[$permission] = (int) $value;
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -703,7 +703,11 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
 
     public function decodePermissions()
     {
-        return json_decode($this->permissions, true);
+        $permissions = json_decode($this->permissions, JSON_OBJECT_AS_ARRAY|JSON_BIGINT_AS_STRING);
+        foreach ($permissions as $permission => $value) {
+            $permissions[$permission] = (int) $value;
+        }
+        return $permissions;
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -703,7 +703,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
 
     public function decodePermissions()
     {
-        $permissions = json_decode($this->permissions, JSON_OBJECT_AS_ARRAY|JSON_BIGINT_AS_STRING);
+        $permissions = json_decode($this->permissions, JSON_OBJECT_AS_ARRAY|JSON_NUMERIC_CHECK);
         foreach ($permissions as $permission => $value) {
             $permissions[$permission] = (int) $value;
         }


### PR DESCRIPTION
I'm not sure this is the right approach here, but if it is, I'm not 100% sure why we have to walk the loop. I feel like [JSON_NUMERIC_CHECK](https://www.php.net/manual/en/json.constants.php#constant.json-numeric-check) should have worked here and prevented us needing to walk the array, but it doesn't seem to work.

Possible fix for #15315 (tho we'll need to do this for groups too.