### PR TITLE
WIP - fixed #15439 - check db on healthcheck

### DIFF
--- a/app/Http/Controllers/HealthController.php
+++ b/app/Http/Controllers/HealthController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Support\Facades\DB;
 
 /**
  * This controller provide the health route  for
@@ -20,8 +21,19 @@ class HealthController extends BaseController
      */
     public function get()
     {
-        return response()->json([
-            'status' => 'ok',
-        ]);
+        try {
+            DB::select('select 2 + 2');
+            return response()->json([
+                'status' => 'ok',
+            ], 200);
+
+        } catch (\PDOException $e) {
+            return response()->json([
+                'status' => 'database error: '.$e->getMessage(),
+            ], 500);
+        }
+
+
+
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,7 +19,6 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance::class,
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-        \App\Http\Middleware\CheckForSetup::class,
         \App\Http\Middleware\CheckForDebug::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrimStrings::class,
@@ -39,6 +38,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
+            \App\Http\Middleware\CheckForSetup::class,
             \App\Http\Middleware\CheckLocale::class,
             \App\Http\Middleware\CheckUserIsActivated::class,
             \App\Http\Middleware\CheckForTwoFactor::class,
@@ -46,12 +46,18 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\AssetCountForSidebar::class,
             \Illuminate\Session\Middleware\AuthenticateSession::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+
         ],
 
         'api' => [
             'auth:api',
+            \App\Http\Middleware\CheckForSetup::class,
             \App\Http\Middleware\CheckLocale::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+
+        'health' => [
+
         ],
     ];
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -37,8 +37,8 @@ class Kernel extends HttpKernel
         'web' => [
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-            \App\Http\Middleware\VerifyCsrfToken::class,
             \App\Http\Middleware\CheckForSetup::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
             \App\Http\Middleware\CheckLocale::class,
             \App\Http\Middleware\CheckUserIsActivated::class,
             \App\Http\Middleware\CheckForTwoFactor::class,
@@ -46,18 +46,12 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\AssetCountForSidebar::class,
             \Illuminate\Session\Middleware\AuthenticateSession::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
-
         ],
 
         'api' => [
             'auth:api',
-            \App\Http\Middleware\CheckForSetup::class,
             \App\Http\Middleware\CheckLocale::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
-        ],
-
-        'health' => [
-
         ],
     ];
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -536,13 +536,16 @@ Route::group(['middleware' => 'web'], function () {
     )->name('logout.post');
 });
 
+
+// Use the
+Route::group(['middleware' => 'health'], function () {
+    Route::get(
+        '/health',
+        [HealthController::class, 'get']
+    )->name('health');
+});
+
 //Auth::routes();
-
-Route::get(
-    '/health', 
-    [HealthController::class, 'get']
-)->name('health');
-
 Route::middleware(['auth'])->get(
     '/',
     [DashboardController::class, 'index']

--- a/routes/web.php
+++ b/routes/web.php
@@ -538,7 +538,7 @@ Route::group(['middleware' => 'web'], function () {
 
 
 // Use the
-Route::group(['middleware' => 'health'], function () {
+Route::group(['middleware' => 'guest'], function () {
     Route::get(
         '/health',
         [HealthController::class, 'get']


### PR DESCRIPTION
Not sure this is the right way to approach this, but it's a stab at it anyway. User is saying that the health check should check for database connection as well. I know we kept the health check out of the web middleware specifically so it didn't try to create a buttload of session files, but there might be a clearer approach, perhaps it's own middleware instead of `  \App\Http\Middleware\CheckForSetup::class`.

Tests are failing on index pages with a 401 though, even though it seems to work locally with Postman (which implies to me that the tests might wrong.)

```
  FAILED  Tests\Feature\AssetModels\Api\IndexAssetModelsTest > viewing asset model index requires authentication
  Expected response status code [201, 301, 302, 303, 307, 308] but received 401.
Failed asserting that false is true.

  at tests/Feature/AssetModels/Api/IndexAssetModelsTest.php:15
     11▕ class IndexAssetModelsTest extends TestCase
     12▕ {
     13▕     public function testViewingAssetModelIndexRequiresAuthentication()
     14▕     {
  ➜  15▕         $this->getJson(route('api.models.index'))->assertRedirect();
     16▕     }
     17▕
     18▕     public function testViewingAssetModelIndexRequiresPermission()
     19▕     {

  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   FAILED  Tests\Feature\Departments\Api\DepartmentsIndexTest > viewing department index requires authentication
  Expected response status code [201, 301, 302, 303, 307, 308] but received 401.
Failed asserting that false is true.

  at tests/Feature/Departments/Api/DepartmentsIndexTest.php:15
     11▕ class DepartmentsIndexTest extends TestCase
     12▕ {
     13▕     public function testViewingDepartmentIndexRequiresAuthentication()
     14▕     {
  ➜  15▕         $this->getJson(route('api.departments.index'))->assertRedirect();
     16▕     }
     17▕
     18▕     public function testViewingDepartmentIndexRequiresPermission()
     19▕     {

  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   FAILED  Tests\Feature\Locations\Api\IndexLocationsTest > viewing location index requires authentication
  Expected response status code [201, 301, 302, 303, 307, 308] but received 401.
Failed asserting that false is true.

  at tests/Feature/Locations/Api/IndexLocationsTest.php:15
     11▕ class IndexLocationsTest extends TestCase
     12▕ {
     13▕     public function testViewingLocationIndexRequiresAuthentication()
     14▕     {
  ➜  15▕         $this->getJson(route('api.locations.index'))->assertRedirect();
     16▕     }
     17▕
     18▕     public function testViewingLocationIndexRequiresPermission()
     19▕     {


  Tests:    3 failed, 10 incomplete, 580 passed (2233 assertions)
``` 

Potential (WIP) fix for #15439.