### PR TITLE
Fixed priority for category eula vs default eula

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -950,11 +950,12 @@ class Asset extends Depreciable
     {
 
         if (($this->model) && ($this->model->category)) {
-            if ($this->model->category->eula_text) {
+            if (($this->model->category->eula_text) && ($this->model->category->use_default_eula === 0)) {
                 return Helper::parseEscapedMarkedown($this->model->category->eula_text);
-            } elseif ($this->model->category->use_default_eula == '1') {
+            } elseif ($this->model->category->use_default_eula === 1) {
                 return Helper::parseEscapedMarkedown(Setting::getSettings()->default_eula_text);
             } else {
+
                 return false;
             }
         }

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -158,8 +158,8 @@ class Label implements View
                                 // The end result of this will be in this format:
                                 // {labelOne} {valueOne} | {labelTwo} {valueTwo} | {labelThree} {valueThree}
                                 $previous['value'] = trim(implode(' | ', [
-                                    implode(' ', [$previous['label'], $previous['value']]),
-                                    implode(' ', [$current['label'], $current['value']]),
+                                    implode(' ', [$previous['label'], str_replace(['{', '}'], '', $previous['value'])]),
+                                    implode(' ', [$current['label'], str_replace(['{', '}'], '', $current['value'])]),
                                 ]));
 
                                 // We'll set the label to an empty string since we

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -158,8 +158,8 @@ class Label implements View
                                 // The end result of this will be in this format:
                                 // {labelOne} {valueOne} | {labelTwo} {valueTwo} | {labelThree} {valueThree}
                                 $previous['value'] = trim(implode(' | ', [
-                                    implode(' ', [$previous['label'], str_replace(['{', '}'], '', $previous['value'])]),
-                                    implode(' ', [$current['label'], str_replace(['{', '}'], '', $current['value'])]),
+                                    implode(' ', [$previous['label'], $previous['value']]),
+                                    implode(' ', [$current['label'], $current['value']]),
                                 ]));
 
                                 // We'll set the label to an empty string since we

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -121,6 +121,10 @@ class Settings
             'ldap_basedn' => 'CN=Users,DC=ad,DC=example,Dc=com'
         ]);
     }
+    public function setEula($text = 'Default EULA text')
+    {
+        return $this->update(['default_eula_text' => $text]);
+    }
 
     /**
      * @param array $attributes Attributes to modify in the application's settings.


### PR DESCRIPTION
# Description

This adds a check to see if the `use_default_eula` is enabled while the category `eula_text` is populated. properly selecting the eula intended to be used now.

Fixes #[sc-26637]

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
