### PR TITLE
Improved layout: Set layout push/pull breakpoints to medium for alignment with columns

### DIFF
--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -91,7 +91,7 @@
 
 
               <!-- Start button column -->
-              <div class="col-md-3 col-xs-12 col-sm-push-9">
+              <div class="col-md-3 col-xs-12 col-md-push-9">
 
 
 
@@ -146,7 +146,7 @@
 
               <!-- End button column -->
 
-              <div class="col-md-9 col-xs-12 col-sm-pull-3">
+              <div class="col-md-9 col-xs-12 col-md-pull-3">
 
                 <div class="row-new-striped">
 

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -85,7 +85,7 @@
             <div class="row">
 
               <!-- Start button column -->
-              <div class="col-md-3 col-xs-12 col-sm-push-9">
+              <div class="col-md-3 col-xs-12 col-md-push-9">
 
                 @if ($consumable->image!='')
                   <div class="col-md-12 text-center" style="padding-bottom: 20px;">
@@ -151,7 +151,7 @@
 
               <!-- End button column -->
 
-              <div class="col-md-9 col-xs-12 col-sm-pull-3">
+              <div class="col-md-9 col-xs-12 col-md-pull-3">
 
                 <div class="row-new-striped" style="margin: 0px;">
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -162,7 +162,7 @@
                             @endif
                         <div class="info-stack-container">
                             <!-- Start button column -->
-                            <div class="col-md-3 col-xs-12 col-sm-push-9 info-stack">
+                            <div class="col-md-3 col-xs-12 col-md-push-9 info-stack">
 
                                 <div class="col-md-12 text-center">
                                     @if (($asset->image) || (($asset->model) && ($asset->model->image!='')))
@@ -365,7 +365,7 @@
 
                             <!-- End button column -->
 
-                            <div class="col-md-9 col-xs-12 col-sm-pull-3 info-stack">
+                            <div class="col-md-9 col-xs-12 col-md-pull-3 info-stack">
 
                                 <div class="row-new-striped">
 

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -161,7 +161,7 @@
             @endif
         <div class="info-stack-container">
             <!-- Start button column -->
-            <div class="col-md-3 col-xs-12 col-sm-push-9 info-stack">
+            <div class="col-md-3 col-xs-12 col-md-push-9 info-stack">
 
               
 
@@ -304,7 +304,7 @@
  
             <!-- End button column -->
           
-            <div class="col-md-9 col-xs-12 col-sm-pull-3 info-stack">
+            <div class="col-md-9 col-xs-12 col-md-pull-3 info-stack">
 
                <div class="row-new-striped">
                 


### PR DESCRIPTION
# Description

The new asset/consumable/user layout introduced in 95a0f3dbe5d307fe and a few related commits splits the view into two blocks. On breakpoints XS and SM they're full-width 12-cell containers, while on MD, LG, XL they are 3-cell wide for the button column and 9-cell wide for the details table. Then, extra Bootstrap classes are used to push/pull them so that the button column is on the right.

The push/pull classes were used with the SM breakpoint, while content was still 12-cell wide. This results in the SM breakpoint layout being broken - this commit makes these use the MD breakpoint instead.

[output.webm](https://github.com/user-attachments/assets/1d9c48e4-e72d-4600-8d72-9fbda0761529)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Manually checked the CSS change on each affected page. This was changed live on our instance to unblock some people running the desktop layout on their phones.


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
