### PR TITLE
Correctly save user’s city on bulk edit

### DIFF
--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -118,6 +118,7 @@ class BulkUsersController extends Controller
             ->conditionallyAddItem('activated')
             ->conditionallyAddItem('start_date')
             ->conditionallyAddItem('end_date')
+            ->conditionallyAddItem('city')
             ->conditionallyAddItem('autoassign_licenses');
 
 


### PR DESCRIPTION
This addresses #15464 - previously the system was not saving the city value on user bulk edit if a value was provided.