### PR TITLE
Added coverage commands for Herd users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ storage/private_uploads/users/*
 tests/_data/scenarios
 tests/_output/*
 tests/_support/_generated/*
+tests/coverage/*
 /npm-debug.log
 /storage/oauth-private.key
 /storage/oauth-public.key

--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,9 @@
     ],
     "post-create-project-cmd": [
       "php artisan key:generate"
-    ]
+    ],
+    "coverage:herd:clover": "herd coverage vendor/bin/phpunit --coverage-clover tests/coverage/clover.xml",
+    "coverage:herd:html": "herd coverage vendor/bin/phpunit --coverage-html tests/coverage/html"
   },
   "config": {
     "preferred-install": "dist",


### PR DESCRIPTION
# Description

This PR adds composer commands so Herd users can easily generate code coverage reports in clover or html format:
```
coverage:herd:clover
coverage:herd:html
```

Here is what they are aliases for:
```
herd coverage vendor/bin/phpunit --coverage-clover tests/coverage/clover.xml
herd coverage vendor/bin/phpunit --coverage-html tests/coverage/html
```

The reports are dumped to the `tests/coverage/` directory after generating.

The html format is human-readable and the clover format can be imported to PHPStorm (and other IDEs) for direct referencing in the IDE.

---

This is really just so I don't have to remember the longer commands that are aliased and I won't be mad if this isn't accepted (I can throw them into my bash aliases)...

## Type of change

- [x] Chore