### PR TITLE
Added UI tests for creating accessories

### DIFF
--- a/tests/Feature/Accessories/Ui/AccessoriesIndexTest.php
+++ b/tests/Feature/Accessories/Ui/AccessoriesIndexTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature\Accessories\Ui;
+
+use App\Models\User;
+use Tests\TestCase;
+
+class AccessoriesIndexTest extends TestCase
+{
+    public function testPermissionRequiredToViewAccessoryList()
+    {
+        $this->actingAs(User::factory()->create())
+            ->get(route('accessories.index'))
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Accessories/Ui/CreateAccessoriesTest.php
+++ b/tests/Feature/Accessories/Ui/CreateAccessoriesTest.php
@@ -56,10 +56,12 @@ class CreateAccessoriesTest extends TestCase
             'notes' => 'Some notes here',
         ];
 
-        $this->actingAs(User::factory()->createAccessories()->create())
+        $user = User::factory()->createAccessories()->create();
+
+        $this->actingAs($user)
             ->post(route('accessories.store'), array_merge($data, ['redirect_option' => 'index']))
             ->assertRedirect(route('accessories.index'));
 
-        $this->assertDatabaseHas('accessories', $data);
+        $this->assertDatabaseHas('accessories', array_merge($data, ['user_id' => $user->id]));
     }
 }

--- a/tests/Feature/Accessories/Ui/CreateAccessoriesTest.php
+++ b/tests/Feature/Accessories/Ui/CreateAccessoriesTest.php
@@ -27,6 +27,13 @@ class CreateAccessoriesTest extends TestCase
             ->assertViewIs('accessories.edit');
     }
 
+    public function testRequiresPermissionToCreateAccessory()
+    {
+        $this->actingAs(User::factory()->create())
+            ->post(route('accessories.store'))
+            ->assertForbidden();
+    }
+
     public function testValidDataRequiredToCreateAccessory()
     {
         $this->actingAs(User::factory()->createAccessories()->create())

--- a/tests/Feature/Accessories/Ui/CreateAccessoriesTest.php
+++ b/tests/Feature/Accessories/Ui/CreateAccessoriesTest.php
@@ -29,7 +29,15 @@ class CreateAccessoriesTest extends TestCase
 
     public function testValidDataRequiredToCreateAccessory()
     {
-        $this->markTestIncomplete();
+        $this->actingAs(User::factory()->createAccessories()->create())
+            ->post(route('accessories.store'), [
+                //
+            ])
+            ->assertSessionHasErrors([
+                'name',
+                'qty',
+                'category_id',
+            ]);
     }
 
     public function testCanCreateAccessory()

--- a/tests/Feature/Accessories/Ui/CreateAccessoriesTest.php
+++ b/tests/Feature/Accessories/Ui/CreateAccessoriesTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Accessories\Ui;
+
+use App\Models\Category;
+use App\Models\Company;
+use App\Models\Location;
+use App\Models\Manufacturer;
+use App\Models\Supplier;
+use App\Models\User;
+use Tests\TestCase;
+
+class CreateAccessoriesTest extends TestCase
+{
+    public function testRequiresPermissionToViewCreateAccessoryPage()
+    {
+        $this->actingAs(User::factory()->create())
+            ->get(route('accessories.create'))
+            ->assertForbidden();
+    }
+
+    public function testCreateAccessoryPageRenders()
+    {
+        $this->actingAs(User::factory()->createAccessories()->create())
+            ->get(route('accessories.create'))
+            ->assertOk()
+            ->assertViewIs('accessories.edit');
+    }
+
+    public function testValidDataRequiredToCreateAccessory()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testCanCreateAccessory()
+    {
+        $category = Category::factory()->create();
+        $company = Company::factory()->create();
+        $location = Location::factory()->create();
+        $manufacturer = Manufacturer::factory()->create();
+        $supplier = Supplier::factory()->create();
+
+        $data = [
+            'company_id' => $company->id,
+            'name' => 'My Accessory Name',
+            'category_id' => $category->id,
+            'supplier_id' => $supplier->id,
+            'manufacturer_id' => $manufacturer->id,
+            'location_id' => $location->id,
+            'model_number' => '12345',
+            'order_number' => '9876',
+            'purchase_date' => '2024-09-04',
+            'purchase_cost' => '99.98',
+            'qty' => '3',
+            'min_amt' => '1',
+            'notes' => 'Some notes here',
+        ];
+
+        $this->actingAs(User::factory()->createAccessories()->create())
+            ->post(route('accessories.store'), array_merge($data, ['redirect_option' => 'index']))
+            ->assertRedirect(route('accessories.index'));
+
+        $this->assertDatabaseHas('accessories', $data);
+    }
+}

--- a/tests/Feature/Accessories/Ui/CreateAccessoriesTest.php
+++ b/tests/Feature/Accessories/Ui/CreateAccessoriesTest.php
@@ -41,19 +41,19 @@ class CreateAccessoriesTest extends TestCase
         $supplier = Supplier::factory()->create();
 
         $data = [
-            'company_id' => $company->id,
-            'name' => 'My Accessory Name',
             'category_id' => $category->id,
-            'supplier_id' => $supplier->id,
-            'manufacturer_id' => $manufacturer->id,
+            'company_id' => $company->id,
             'location_id' => $location->id,
-            'model_number' => '12345',
-            'order_number' => '9876',
-            'purchase_date' => '2024-09-04',
-            'purchase_cost' => '99.98',
-            'qty' => '3',
+            'manufacturer_id' => $manufacturer->id,
             'min_amt' => '1',
+            'model_number' => '12345',
+            'name' => 'My Accessory Name',
             'notes' => 'Some notes here',
+            'order_number' => '9876',
+            'purchase_cost' => '99.98',
+            'purchase_date' => '2024-09-04',
+            'qty' => '3',
+            'supplier_id' => $supplier->id,
         ];
 
         $user = User::factory()->createAccessories()->create();


### PR DESCRIPTION
# Description

This PR adds some simple UI tests for the checking permissions on the accessory index and accessory create pages, along with validation and assertions that accessories can be created via the UI.

## Type of change

- [x] Testing