### PR TITLE
Fixes margin for the sidebar menus while using rtl languages

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -426,7 +426,11 @@ dir="{{ Helper::determineLanguageDirection() }}">
                 <!-- sidebar: style can be found in sidebar.less -->
                 <section class="sidebar">
                     <!-- sidebar menu: : style can be found in sidebar.less -->
-                    <ul class="sidebar-menu" data-widget="tree">
+                    @if(\App\Helpers\Helper::determineLanguageDirection() === 'rtl')
+                        <ul class="sidebar-menu" data-widget="tree" style="margin-right:12px;">
+                    @else
+                        <ul class="sidebar-menu" data-widget="tree">
+                    @endif
                         @can('admin')
                             <li {!! (\Request::route()->getName()=='home' ? ' class="active"' : '') !!} class="firstnav">
                                 <a href="{{ route('home') }}">

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -426,11 +426,7 @@ dir="{{ Helper::determineLanguageDirection() }}">
                 <!-- sidebar: style can be found in sidebar.less -->
                 <section class="sidebar">
                     <!-- sidebar menu: : style can be found in sidebar.less -->
-                    @if(\App\Helpers\Helper::determineLanguageDirection() === 'rtl')
-                        <ul class="sidebar-menu" data-widget="tree" style="margin-right:12px;">
-                    @else
-                        <ul class="sidebar-menu" data-widget="tree">
-                    @endif
+                    <ul class="sidebar-menu" data-widget="tree" style="margin-right: {{ \App\Helpers\Helper::determineLanguageDirection() === 'rtl' ? '12px' : '0px' }};">
                         @can('admin')
                             <li {!! (\Request::route()->getName()=='home' ? ' class="active"' : '') !!} class="firstnav">
                                 <a href="{{ route('home') }}">

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -426,7 +426,7 @@ dir="{{ Helper::determineLanguageDirection() }}">
                 <!-- sidebar: style can be found in sidebar.less -->
                 <section class="sidebar">
                     <!-- sidebar menu: : style can be found in sidebar.less -->
-                    <ul class="sidebar-menu" data-widget="tree" style="margin-right: {{ \App\Helpers\Helper::determineLanguageDirection() === 'rtl' ? '12px' : '0px' }};">
+                    <ul class="sidebar-menu" data-widget="tree" {{ \App\Helpers\Helper::determineLanguageDirection() == 'rtl' ? 'style="margin-right:12px' : '' }}>
                         @can('admin')
                             <li {!! (\Request::route()->getName()=='home' ? ' class="active"' : '') !!} class="firstnav">
                                 <a href="{{ route('home') }}">


### PR DESCRIPTION
# Description

This makes the icons of the sidebar menu centered again while using Right to Left languages.

<img width="989" alt="image" src="https://github.com/user-attachments/assets/95be015f-b1b2-45a1-a402-330d3d7d0c5b">


Fixes #[sc-26688]

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
