### PR TITLE
Fixed login success message not being displayed

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Http\RedirectResponse;
 use \Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Session;
 
 
 /**
@@ -44,6 +45,8 @@ class DashboardController extends Controller
 
             return view('dashboard')->with('asset_stats', $asset_stats)->with('counts', $counts);
         } else {
+            Session::reflash();
+
             // Redirect to the profile page
             return redirect()->intended('account/view-assets');
         }


### PR DESCRIPTION
# Description

This PR fixes a small bug where the "Success: You have successfully logged in." message was not shown for non-admin users after login.

Before:
![message is not displayed on landing page](https://github.com/user-attachments/assets/3eacdac9-f7fe-4098-8010-3bfe7e0a3c1d)

After:
![message is displayed on landing page](https://github.com/user-attachments/assets/a5b0d7c0-44e5-4c0d-9216-b104b48d7c85)

Fixes [sc-26730]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
