### PR TITLE
[Fixes fd-43940] Improve multi-asset create when using numeric prefixes to asset_tags

### DIFF
--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -301,7 +301,7 @@
 
             e.preventDefault();
 
-            var auto_tag        = $("#asset_tag").val().replace(/[^\d]/g, '');
+            var auto_tag = $("#asset_tag").val().replace(/^{{ preg_quote(App\Models\Setting::getSettings()->auto_increment_prefix) }}/g, '');
             var box_html        = '';
 			const zeroPad 		= (num, places) => String(num).padStart(places, '0');
 


### PR DESCRIPTION
If you have an asset_tag prefix that's numeric, the multiple-asset create feature did not correctly strip and replace the prefix for the newly-created assets after the first one. This fixes that.

I made sure to test with numeric prefixes, as well as no prefix at all, and it seems to work in all scenarios.