### PR TITLE
Fix - warn user on changing status to undeployable when editing

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -331,14 +331,14 @@ class AssetsController extends Controller
         $asset->expected_checkin = $request->input('expected_checkin', null);
 
         // If the box isn't checked, it's not in the request at all.
-        $asset->requestable = $request->filled('requestable');
+        $asset->requestable = $request->filled('requestable', 0);
         $asset->rtd_location_id = $request->input('rtd_location_id', null);
         $asset->byod = $request->input('byod', 0);
 
-        $status = Statuslabel::find($asset->status_id);
+        $status = Statuslabel::find($request->input('status_id'));
 
         // This is a non-deployable status label - we should check the asset back in.
-        if (($status && $status->getStatuslabelType() != 'deployable') && (is_null($target = $asset->assignedTo))) {
+        if (($status && $status->getStatuslabelType() != 'deployable') && ($target = $asset->assignedTo)) {
 
             $originalValues = $asset->getRawOriginal();
             $asset->assigned_to = null;

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -343,6 +343,7 @@ class AssetsController extends Controller
             $originalValues = $asset->getRawOriginal();
             $asset->assigned_to = null;
             $asset->assigned_type = null;
+            $asset->accepted = null;
 
             event(new CheckoutableCheckedIn($asset, $target, auth()->user(), 'Checkin on asset update', date('Y-m-d H:i:s'), $originalValues));
         }

--- a/resources/lang/en-US/admin/hardware/form.php
+++ b/resources/lang/en-US/admin/hardware/form.php
@@ -55,6 +55,7 @@ return [
     'asset_location_update_default' => 'Update only default location',
     'asset_location_update_actual' => 'Update only actual location',
     'asset_not_deployable' => 'That asset status is not deployable. This asset cannot be checked out.',
+    'asset_not_deployable_checkin' => 'That asset status is not deployable. Using this status label will checkin the asset.',
     'asset_deployable' => 'That status is deployable. This asset can be checked out.',
     'processing_spinner' => 'Processing... (This might take a bit of time on large files)',
     'optional_infos'  => 'Optional Information',

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -263,7 +263,7 @@
                         $("#assignto_selector").hide();
                         $("#selected_status_status").removeClass('text-success');
                         $("#selected_status_status").addClass('text-danger');
-                        $("#selected_status_status").html('<x-icon type="warning" /> {{ trans('admin/hardware/form.asset_not_deployable')}} ');
+                        $("#selected_status_status").html('<x-icon type="warning" /> {{ (($item->assignedTo) && ($item->deleted_at == '')) ? trans('admin/hardware/form.asset_not_deployable_checkin') : trans('admin/hardware/form.asset_not_deployable')  }} ');
                     }
                 }
             });

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -263,7 +263,7 @@
                         $("#assignto_selector").hide();
                         $("#selected_status_status").removeClass('text-success');
                         $("#selected_status_status").addClass('text-danger');
-                        $("#selected_status_status").html('<x-icon type="warning" /> {{ (($item->assignedTo) && ($item->deleted_at == '')) ? trans('admin/hardware/form.asset_not_deployable_checkin') : trans('admin/hardware/form.asset_not_deployable')  }} ');
+                        $("#selected_status_status").html('<x-icon type="warning" /> {{ (($item->assigned_to!='') && ($item->assigned_type!='') && ($item->deleted_at == '')) ? trans('admin/hardware/form.asset_not_deployable_checkin') : trans('admin/hardware/form.asset_not_deployable')  }} ');
                     }
                 }
             });

--- a/tests/Feature/Assets/Ui/EditAssetTest.php
+++ b/tests/Feature/Assets/Ui/EditAssetTest.php
@@ -81,16 +81,19 @@ class EditAssetTest extends TestCase
         $currentTimestamp = now();
 
         $this->actingAs(User::factory()->viewAssets()->editAssets()->create())
-            ->from(route('hardware.edit', $asset))
-            ->patch(route('hardware.update', $asset), [
+            ->from(route('hardware.edit', $asset->id))
+            ->put(route('hardware.update', $asset->id), [
                     'status_id' => $achived_status->id,
                     'model_id' => $asset->model_id,
-                    'asset_tag' => $asset->asset_tag,
+                    'asset_tags' => $asset->asset_tag,
                 ],
             )
             ->assertStatus(302);
+            //->assertRedirect(route('hardware.show', ['hardware' => $asset->id]));;
 
-        $asset->refresh();
+        // $asset->refresh();
+        $asset = Asset::find($asset->id);
+        $this->assertNull($asset->assigned_to);
         $this->assertNull($asset->assigned_type);
         $this->assertEquals($achived_status->id, $asset->status_id);
 


### PR DESCRIPTION
A customer in the helpdesk and a few users in MacAdmins pointed out that we were not logging the checkin (or even the status change) if an asset is checked out and an admin changes the status to an undeployable status type. In the code, we were silently checking it in but we were NOT triggering a checkin event, and the edit didn't even show up in the history log:

### Before

https://github.com/user-attachments/assets/7e1eda60-67e2-49fd-9f57-2dc6dd1fd94d

### After

https://github.com/user-attachments/assets/cda22fe2-bb3e-4800-945e-c89720f1150e

Big thanks for Dan Christovic and Guy for pointing out this bug.