### PR TITLE
Fixed #15504 - allow nulling/not changing locale in user bulk edit

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -206,6 +206,10 @@ class UsersController extends Controller
             $users->where('autoassign_licenses', '=', $request->input('autoassign_licenses'));
         }
 
+        if ($request->filled('locale')) {
+            $users = $users->where('users.locale', '=', $request->input('locale'));
+        }
+
 
         if (($request->filled('deleted')) && ($request->input('deleted') == 'true')) {
             $users = $users->onlyTrashed();
@@ -276,6 +280,7 @@ class UsersController extends Controller
                         'end_date',
                         'autoassign_licenses',
                         'website',
+                        'locale',
                     ];
 
                 $sort = in_array($request->input('sort'), $allowed_columns) ? $request->input('sort') : 'first_name';

--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -157,6 +157,10 @@ class BulkUsersController extends Controller
             $this->update_array['end_date'] = null;
         }
 
+        if ($request->input('null_locale')=='1') {
+            $this->update_array['locale'] = null;
+        }
+
         if (! $manager_conflict) {
             $this->conditionallyAddItem('manager_id');
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -122,6 +122,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         'jobtitle',
         'employee_num',
         'website',
+        'locale',
     ];
 
     /**

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -189,6 +189,14 @@ class UserPresenter extends Presenter
                 'visible' => false,
             ],
             [
+                'field' => 'locale',
+                'searchable' => true,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('general.language'),
+                'visible' => false,
+            ],
+            [
                 'field' => 'department',
                 'searchable' => true,
                 'sortable' => true,

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -90,12 +90,21 @@
                         </div>
 
 
-                        <!-- language -->
+                        <!-- Language -->
                         <div class="form-group {{ $errors->has('locale') ? 'has-error' : '' }}">
                             <label class="col-md-3 control-label" for="locale">{{ trans('general.language') }}</label>
                             <div class="col-md-8">
-                                {!! Form::locales('locale', old('locale', $user->locale), 'select2') !!}
+                                {!! Form::locales('locale', old('locale', ''), 'select2') !!}
                                 {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <div class=" col-md-9 col-md-offset-3">
+                                <label class="form-control">
+                                    {{ Form::checkbox('null_locale', '1', false) }}
+                                    {{ trans_choice('general.set_users_field_to_null', count($users), ['field' => trans('general.language'), 'user_count' => count($users)]) }}
+                                </label>
                             </div>
                         </div>
 


### PR DESCRIPTION
This fixed #15504, where when an admin was bulk editing a group of users, the locale setting defaulted to the logged in admin's locale. This change makes it so that we do not update the language on save unless something was specifically chosen, and also grants the ability to null out all selected users' locale.

This also adds locale to the list view and makes it sortable and searchable.