### PR TITLE
Fixed check for outside assets on user update validation

### DIFF
--- a/app/Rules/UserCannotSwitchCompaniesIfItemsAssigned.php
+++ b/app/Rules/UserCannotSwitchCompaniesIfItemsAssigned.php
@@ -16,8 +16,14 @@ class UserCannotSwitchCompaniesIfItemsAssigned implements ValidationRule
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $user = User::find(request()->route('user')->id);
-        if (($value) && ($user->allAssignedCount() > 0) && (Setting::getSettings()->full_multiple_companies_support)) {
-            $fail(trans('admin/users/message.error.multi_company_items_assigned'));
+
+        if (($value) && ($user->allAssignedCount() > 0) && (Setting::getSettings()->full_multiple_companies_support=='1')) {
+
+            // Check for assets with a different company_id than the selected company_id
+            $user_assets = $user->assets()->where('assets.company_id', '!=', $value)->count();
+            if ($user_assets > 0) {
+                $fail(trans('admin/users/message.error.multi_company_items_assigned'));
+            }
         }
     }
 }

--- a/resources/lang/en-US/admin/users/message.php
+++ b/resources/lang/en-US/admin/users/message.php
@@ -53,7 +53,7 @@ return array(
         'ldap_could_not_search' => 'Could not search the LDAP server. Please check your LDAP server configuration in the LDAP config file. <br>Error from LDAP Server:',
         'ldap_could_not_get_entries' => 'Could not get entries from the LDAP server. Please check your LDAP server configuration in the LDAP config file. <br>Error from LDAP Server:',
         'password_ldap' => 'The password for this account is managed by LDAP/Active Directory. Please contact your IT department to change your password. ',
-        'multi_company_items_assigned' => 'This user has items assigned, please check them in before moving companies.'
+        'multi_company_items_assigned' => 'This user has items assigned that belong to a different company. Please check them in or edit their company.'
     ),
 
     'deletefile' => array(

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -330,7 +330,13 @@
                         {{ trans('general.company') }}
                       </div>
                       <div class="col-md-9">
-                        {{ $user->company->name }}
+                          @can('view', 'App\Models\Company')
+                            <a href="{{ route('companies.show', $user->company->id) }}">
+                                {{ $user->company->name }}
+                            </a>
+                              @else
+                              {{ $user->company->name }}
+                            @endcan
                       </div>
 
                     </div>

--- a/tests/Feature/Users/Ui/UpdateUserTest.php
+++ b/tests/Feature/Users/Ui/UpdateUserTest.php
@@ -82,7 +82,7 @@ class UpdateUserTest extends TestCase
         $this->assertEquals(1, $admin->refresh()->activated);
     }
 
-    public function testMultiCompanyUserCannotBeMovedIfHasAsset()
+    public function testMultiCompanyUserCannotBeMovedIfHasAssetInDifferentCompany()
     {
         $this->settings->enableMultipleFullCompanySupport();
 
@@ -94,7 +94,9 @@ class UpdateUserTest extends TestCase
         ]);
         $superUser = User::factory()->superuser()->create();
 
-        $asset = Asset::factory()->create();
+        $asset = Asset::factory()->create([
+            'company_id' => $companyA->id,
+        ]);
 
         // no assets assigned, therefore success
         $this->actingAs($superUser)->put(route('users.update', $user), [
@@ -115,5 +117,41 @@ class UpdateUserTest extends TestCase
         ]);
 
         $this->followRedirects($response)->assertSee('error');
+    }
+
+    public function testMultiCompanyUserCanBeUpdatedIfHasAssetInSameCompany()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $companyA = Company::factory()->create();
+
+        $user = User::factory()->create([
+            'company_id' => $companyA->id,
+        ]);
+        $superUser = User::factory()->superuser()->create();
+
+        $asset = Asset::factory()->create([
+            'company_id' => $companyA->id,
+        ]);
+
+        // no assets assigned, therefore success
+        $this->actingAs($superUser)->put(route('users.update', $user), [
+            'first_name'      => 'test',
+            'username'        => 'test',
+            'company_id'      => $companyA->id,
+            'redirect_option' => 'index'
+        ])->assertRedirect(route('users.index'));
+
+        $asset->checkOut($user, $superUser);
+
+        // asset assigned, therefore error
+        $response = $this->actingAs($superUser)->patchJson(route('users.update', $user), [
+            'first_name'      => 'test',
+            'username'        => 'test',
+            'company_id'      => $companyA->id,
+            'redirect_option' => 'index'
+        ]);
+
+        $this->followRedirects($response)->assertSee('success');
     }
 }


### PR DESCRIPTION
This clarifies the validation on user editing to only throw a failure if the user has asset that belong to a different company ID. (It was previously incorrectly throwing a validation error if the user had any assets assigned, regardless of the company the assets belong to.)