### PR TITLE
Fixed #11634 - Sort by numeric columns for numeric custom fields

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -372,7 +372,29 @@ class AssetsController extends Controller
                 $assets->OrderAssigned($order);
                 break;
             default:
-                $assets->orderBy($column_sort, $order);
+                $numeric_sort = false;
+
+                // Search through the custom fields array to see if we're sorting on a custom field
+                if (array_search($column_sort, $all_custom_fields->pluck('db_column')->toArray()) !== false) {
+
+                    // Check to see if this is a numeric field type
+                    foreach ($all_custom_fields as $field) {
+                        if (($field->db_column == $sort_override) && ($field->format == 'NUMERIC')) {
+                            $numeric_sort = true;
+                            break;
+                        }
+                    }
+
+                    // This may not work for all databases, but it works for MySQL
+                    if ($numeric_sort) {
+                        $assets->orderByRaw($sort_override . ' * 1 ' . $order);
+                    } else {
+                        $assets->orderBy($sort_override, $order);
+                    }
+
+                } else {
+                    $assets->orderBy($column_sort, $order);
+                }
                 break;
         }
 


### PR DESCRIPTION
This allows us to sort numerically on numeric custom fields. (Not 100% sure whether or not this could break on pgSQL, but seems to be okay on sqlite (though admittedly, we don't strongly test ordering currently.)

Fixes https://github.com/snipe/snipe-it/issues/15458 and #11634 