### PR TITLE
Fixed double webhook notifications // Separated email and webhook notifications.

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -50,7 +50,7 @@ class CheckoutableListener
             foreach ($notifiables as $notifiable) {
                 if ($notifiable instanceof User && $notifiable->email != '') {
                     if (! $event->checkedOutTo->locale){
-                        Notification::locale(Setting::getSettings()->locale)->send($notifiables, $this->getCheckoutNotification($event, $acceptance));
+                        Notification::locale(Setting::getSettings()->locale)->send($notifiable, $this->getCheckoutNotification($event, $acceptance));
                     }
                     else {
                         Notification::send($notifiable, $this->getCheckoutNotification($event, $acceptance));
@@ -63,7 +63,7 @@ class CheckoutableListener
                 // Slack doesn't include the URL in its messaging format, so this is needed to hit the endpoint
                 if (Setting::getSettings()->webhook_selected === 'slack' || Setting::getSettings()->webhook_selected === 'general') {
                     Notification::route('slack', Setting::getSettings()->webhook_endpoint)
-                        ->notify($this->getCheckoutNotification($event));
+                        ->notify($this->getCheckoutNotification($event, $acceptance));
                 } else {
                     Notification::route(Setting::getSettings()->webhook_selected, Setting::getSettings()->webhook_endpoint)
                         ->notify($this->getCheckoutNotification($event, $acceptance));
@@ -102,17 +102,17 @@ class CheckoutableListener
                 }
             }
         }
-        $acceptance = $this->getCheckoutAcceptance($event);
+
         $notifiables = $this->getNotifiables($event);
         // Send email notifications
         try {
             foreach ($notifiables as $notifiable) {
                 if ($notifiable instanceof User && $notifiable->email != '') {
                     if (! $event->checkedOutTo->locale){
-                        Notification::locale(Setting::getSettings()->locale)->send($notifiables, $this->getCheckoutNotification($event, $acceptance));
+                        Notification::locale(Setting::getSettings()->locale)->send($notifiable, $this->getCheckoutNotification($event, $acceptance));
                     }
                     else {
-                        Notification::send($notifiable, $this->getCheckinNotification($event, $acceptance));
+                        Notification::send($notifiable, $this->getCheckinNotification($event));
                     }
                 }
             }
@@ -124,7 +124,7 @@ class CheckoutableListener
                         ->notify($this->getCheckinNotification($event));
                 } else {
                     Notification::route(Setting::getSettings()->webhook_selected, Setting::getSettings()->webhook_endpoint)
-                        ->notify($this->getCheckinNotification($event, $acceptance));
+                        ->notify($this->getCheckinNotification($event));
                 }
             }
 

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -11,6 +11,7 @@ use App\Models\Consumable;
 use App\Models\LicenseSeat;
 use App\Models\Recipients\AdminRecipient;
 use App\Models\Setting;
+use App\Models\User;
 use App\Notifications\CheckinAccessoryNotification;
 use App\Notifications\CheckinAssetNotification;
 use App\Notifications\CheckinLicenseSeatNotification;


### PR DESCRIPTION
# Description
Seperated the notification call in the checkoutable listener to exclude `$notifiables` from webhook notifications. With the way things were, if you had more than one email to notify it would send an additional webhook notification. 
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/9a2a298e-896e-42fc-abaa-80f5c300fd66">

This removes that bug.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
