### PR TITLE
Fixed mail notification field `status label` not updating

### DIFF
--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -192,10 +192,9 @@ public function toGoogleChat()
      * @return \Illuminate\Notifications\Messages\MailMessage
      */
     public function toMail()
-    {
+    {   $this->item->load('assetstatus');
         $eula = method_exists($this->item, 'getEula') ? $this->item->getEula() : '';
         $req_accept = method_exists($this->item, 'requireAcceptance') ? $this->item->requireAcceptance() : 0;
-
         $fields = [];
 
         // Check if the item has custom fields associated with it


### PR DESCRIPTION
# Description

This refreshes the `assetstatus` relationship before sending mail notifications for checkout. Not sure why, but the new value was present everywhere except when it got to `toMail()` method. Giving it a refresh solved the issue.

Fixes #15515

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
