### PR TITLE
Catch Exceptions on Checkout Notification

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -237,7 +237,11 @@ class AcceptanceController extends Controller
             }
 
             $acceptance->accept($sig_filename, $item->getEula(), $pdf_filename, $request->input('note'));
-            $acceptance->notify(new AcceptanceAssetAcceptedNotification($data));
+            try {
+                $acceptance->notify(new AcceptanceAssetAcceptedNotification($data));
+            } catch (\Exception $e) {
+                Log::error($e);
+            }
             event(new CheckoutAccepted($acceptance));
 
             $return_msg = trans('admin/users/message.accepted');


### PR DESCRIPTION
# Description
Wrapped the notification in a simple try/catch to resolve #15253 - just putting the error in to logs right now, but we could return a different message, just not sure what kind of wording we'd want, and would have to change the order in which the `CheckoutAccepted` event is fired as well. Happy to do that, but not sure if it's needed/wanted and what kind of wording we'd want. 

Fixes #15253

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
