### PR TITLE
Accessories multimorph2 - multi-morph many-to-many relationships for accessories to users/locations

### DIFF
--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -255,8 +255,21 @@ class Accessory extends SnipeModel
      */
     public function checkouts()
     {
-        return $this->hasMany(\App\Models\AccessoryCheckout::class, 'accessory_id')
-            ->with('assignedTo');
+        return $this->morphToMany(Accessory::class, 'assignedAccessories', 'accessories_checkout', 'assigned_to', null,);
+    }
+
+    public function locationAssignments()
+    {
+        //I don't nkow that we'll want this, but this is a thing we can do - find the locations that have been assigned this accessory
+        return $this->morphedByMany(Location::class, 'accessory_assignment');
+
+    }
+
+    public function userAssignments()
+    {
+        //I don't nkow that we'll want this, but this is a thing we can do - find the locations that have been assigned this accessory
+        return $this->morphedByMany(User::class, 'accessory_assignment');
+
     }
 
     /**

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -255,20 +255,37 @@ class Accessory extends SnipeModel
      */
     public function checkouts()
     {
-        return $this->morphToMany(Accessory::class, 'assignedAccessories', 'accessories_checkout', 'assigned_to', null,);
+        // this is WEIRD - because we don't have a real concept in Laravel of a real polymorphic many-to-many
+        // relationship that will return all of the various things you've been checked-out-to, we have to re-introduce
+        // this interstitial class - this is the only place where you should need to access it, however. And the only
+        // way.
+        // If you're looking for just Users, or just accessories, use userAssignments or locationAssignments, respectively
+        return $this->hasMany(AccessoryCheckout::class);
     }
 
     public function locationAssignments()
     {
         //I don't nkow that we'll want this, but this is a thing we can do - find the locations that have been assigned this accessory
-        return $this->morphedByMany(Location::class, 'accessory_assignment');
+        return $this->morphedByMany(
+            Location::class,
+            'assigned', // weird, but we might need this to coerce the assigned_type
+            'accessories_checkout',
+            null, //'accessory_id', //CORRECT
+            'assigned_to', //CORRECT
+        );
 
     }
 
     public function userAssignments()
     {
-        //I don't nkow that we'll want this, but this is a thing we can do - find the locations that have been assigned this accessory
-        return $this->morphedByMany(User::class, 'accessory_assignment');
+        //I don't nkow that we'll want this, but this is a thing we can do - find the users that have been assigned this accessory
+        return $this->morphedByMany(
+            User::class,
+            'assigned', // weird, but we might need this to coerce the assigned_type
+            'accessories_checkout',
+            null, //'accessory_id', //CORRECT
+            'assigned_to', //CORRECT
+        );
 
     }
 
@@ -386,6 +403,7 @@ class Accessory extends SnipeModel
      */
     public function declinedCheckout(User $declinedBy, $signature)
     {
+        //FIXME - se shouldn't need to go with AccessoryCheckout
         if (is_null($accessory_checkout = AccessoryCheckout::userAssigned()->where('assigned_to', $declinedBy->id)->where('accessory_id', $this->id)->latest('created_at'))) {
             // Redirect to the accessory management page with error
             return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.does_not_exist'));

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -403,7 +403,9 @@ class Accessory extends SnipeModel
      */
     public function declinedCheckout(User $declinedBy, $signature)
     {
-        //FIXME - se shouldn't need to go with AccessoryCheckout
+        // TODO - we shouldn't need to go with AccessoryCheckout, we should be able to do:
+        // $a->userAssignments()->where("assigned_to",$declinedBy->id)->latest
+        // (Also TODO) - I hate 'latest()' here, it feels sloppy and prone to subtle errors
         if (is_null($accessory_checkout = AccessoryCheckout::userAssigned()->where('assigned_to', $declinedBy->id)->where('accessory_id', $this->id)->latest('created_at'))) {
             // Redirect to the accessory management page with error
             return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.does_not_exist'));

--- a/app/Models/AccessoryCheckout.php
+++ b/app/Models/AccessoryCheckout.php
@@ -68,7 +68,7 @@ class AccessoryCheckout extends Model
      * @since [v4.0]
      * @return string
      */
-    public function assignedType() //FIXME - we shouldn't need this.
+    public function assignedType() //TODO - we shouldn't need this.
     {
         return $this->assigned_type ? strtolower(class_basename($this->assigned_type)) : null;
     }
@@ -84,11 +84,13 @@ class AccessoryCheckout extends Model
      */
     public function checkedOutToUser(): bool
     {
-      return $this->assignedType() === Asset::USER;
+        // TODO - this shouldn't be necessary
+        return $this->assignedType() === Asset::USER;
     }
 
     public function scopeUserAssigned(Builder $query): void
     {
+        // TODO - not necessary; we have re
         $query->where('assigned_type', '=', User::class);
     }
 
@@ -101,6 +103,7 @@ class AccessoryCheckout extends Model
      */
     public function advancedTextSearch(Builder $query, array $terms)
     {
+        //TODO - is this used?
 
         $userQuery = User::where(function ($query) use ($terms) {
             foreach ($terms as $term) {

--- a/app/Models/AccessoryCheckout.php
+++ b/app/Models/AccessoryCheckout.php
@@ -33,7 +33,7 @@ class AccessoryCheckout extends Model
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
     public function accessory()
-    {
+    { // TODO - I kinda believe like this is belongsTo not hasOne?
         return $this->hasOne(\App\Models\Accessory::class, 'accessory_id');
     }
 
@@ -68,7 +68,7 @@ class AccessoryCheckout extends Model
      * @since [v4.0]
      * @return string
      */
-    public function assignedType()
+    public function assignedType() //FIXME - we shouldn't need this.
     {
         return $this->assigned_type ? strtolower(class_basename($this->assigned_type)) : null;
     }

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -253,6 +253,21 @@ class Location extends SnipeModel
         return $this->morphMany(\App\Models\Asset::class, 'assigned', 'assigned_type', 'assigned_to')->withTrashed();
     }
 
+    public function assignedAccessories()
+    {
+        return $this->morphToMany(
+            Accessory::class,
+            'accessory_assignment',
+            'accessories_checkout',
+            'assigned_to',
+            'assigned_type',
+            null,
+            null,
+            'accessory_assignment',
+            true
+        );
+    }
+
     public function setLdapOuAttribute($ldap_ou)
     {
         return $this->attributes['ldap_ou'] = empty($ldap_ou) ? null : $ldap_ou;

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -260,8 +260,8 @@ class Location extends SnipeModel
             Accessory::class,
             'assigned', //ok, closer?
             'accessories_checkout', //correct!
-            'assigned_to', //why does it want this null?
-        );
+            'assigned_to',
+        ); //FIXME - need pivots and stuff?
     }
 
     public function setLdapOuAttribute($ldap_ou)

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -255,13 +255,12 @@ class Location extends SnipeModel
 
     public function assignedAccessories()
     {
-        //NOTE - this method is CORRECT. Don't fuck with it.
         return $this->morphToMany(
             Accessory::class,
             'assigned', //ok, closer?
             'accessories_checkout', //correct!
             'assigned_to',
-        ); //FIXME - need pivots and stuff?
+        )->withTrashed(); // TODO - do we need pivot values here? If so, consider: "->withPivot('id', 'created_at', 'note')"
     }
 
     public function setLdapOuAttribute($ldap_ou)

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -255,16 +255,12 @@ class Location extends SnipeModel
 
     public function assignedAccessories()
     {
+        //NOTE - this method is CORRECT. Don't fuck with it.
         return $this->morphToMany(
             Accessory::class,
-            'accessory_assignment',
-            'accessories_checkout',
-            'assigned_to',
-            'assigned_type',
-            null,
-            null,
-            'accessory_assignment',
-            true
+            'assigned', //ok, closer?
+            'accessories_checkout', //correct!
+            'assigned_to', //why does it want this null?
         );
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -323,6 +323,17 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return $this->hasMany(\App\Models\AssetMaintenance::class, 'user_id')->withTrashed();
     }
 
+    public function assignedAccessories()
+    {
+        // This model is *ALSO CORRECT* - please don't fuck with _it_ either.
+        return $this->morphToMany(
+            Accessory::class,
+            'assigned',
+            'accessories_checkout',
+            'assigned_to',
+        );
+    }
+
     /**
      * Establishes the user -> accessories relationship
      *
@@ -330,7 +341,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      * @since [v2.0]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
-    public function accessories()
+    public function accessories() // FIXME - this is duplicated. And I think it might be wrong? And the name is confusing.
     {
         return $this->belongsToMany(\App\Models\Accessory::class, 'accessories_checkout', 'assigned_to', 'accessory_id')
             ->withPivot('id', 'created_at', 'note')->withTrashed()->orderBy('accessory_id');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -332,7 +332,6 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function accessories()
     {
-        // This model is *ALSO CORRECT* - please don't fuck with _it_ either.
         return $this->morphToMany(
             Accessory::class,
             'assigned',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -323,7 +323,14 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return $this->hasMany(\App\Models\AssetMaintenance::class, 'user_id')->withTrashed();
     }
 
-    public function assignedAccessories()
+    /**
+     * Establishes the user -> accessories relationship
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     * @since [v2.0]
+     * @author A. Gianotto <snipe@snipe.net>
+     */
+    public function accessories()
     {
         // This model is *ALSO CORRECT* - please don't fuck with _it_ either.
         return $this->morphToMany(
@@ -331,20 +338,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
             'assigned',
             'accessories_checkout',
             'assigned_to',
-        );
-    }
-
-    /**
-     * Establishes the user -> accessories relationship
-     *
-     * @author A. Gianotto <snipe@snipe.net>
-     * @since [v2.0]
-     * @return \Illuminate\Database\Eloquent\Relations\Relation
-     */
-    public function accessories() // FIXME - this is duplicated. And I think it might be wrong? And the name is confusing.
-    {
-        return $this->belongsToMany(\App\Models\Accessory::class, 'accessories_checkout', 'assigned_to', 'accessory_id')
-            ->withPivot('id', 'created_at', 'note')->withTrashed()->orderBy('accessory_id');
+        )->withPivot('id', 'created_at', 'note')->withTrashed()->orderBy('accessory_id');
     }
 
     /**


### PR DESCRIPTION
We have some good groundwork in-place for being able to checkout Accessories to both Locations and Users.

But @snipe was looking for the rest of that "connective tissue" to be in place so we can query which accessories are checked out to a User, which accessories are checked out to a Location. Also, from the Accessories side, we will need to be able to see which accessories are checked out to users, which to locations, and also being able to look at checked-out accessories in general, regardless of where they're checked-out-to.

This is the closest I've been able to come to getting something that makes sense here, but I suspect there's a bit more to go.

First off, this establishes the Laravel-standard "morphed-by-many" relationships:
 - From Users, we have the `accessories()` method which works how you expect.
 - From Locations, we have the `assignedAccessories()` method (naming is different to explain the difference between "assigned to this location" and "located at this location"). This also works how you expect.
 - From Accessories, we have two more methods:
 - - `locationAssignments()` - which gives which locations this accessory is checked out to
 - - `userAssignments()` - which gives which users this accessory is checked out to.

So that's all the standard stuff, the one weird one I put in was also to accessories, and is called `checkouts()` which gives you the 'interstitial class` results of `AccessoryCheckout` for the accessory in question. Those can be chased down and may include Users as well as Accessories.

If I have this right - and it's quite possible that I don't - that _last_ place _should_ be the only place where we need to refer to `AccessoryCheckout` at all - the rest of the relations all return users or locations or accessories as expected.

There are plenty of places in the code that still do refer to AccessoryCheckout and probably shouldn't need to - but I wanted to keep this PR small, and understandable, and not conflate different changes.

Most of my testing was with Tinker - making sure that accessories would properly show the appropriate users, locations, or checkouts. And then making sure that locations and users showed the right accessories that were assigned to them.

This _should_ give us the right tooling to re-introduce the "checkout accessory to location" feature, if I've done my job right.