### PR TITLE
There were some weird constants I stripped out from the Asset model

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -77,10 +77,6 @@ class AssetCheckinController extends Controller
 
         $this->authorize('checkin', $asset);
 
-        if ($asset->assignedType() == Asset::USER) {
-            $user = $asset->assignedTo;
-        }
-
         $asset->expected_checkin = null;
         $asset->last_checkin = now();
         $asset->assignedTo()->disassociate($asset);

--- a/app/Models/AccessoryCheckout.php
+++ b/app/Models/AccessoryCheckout.php
@@ -84,7 +84,7 @@ class AccessoryCheckout extends Model
      */
     public function checkedOutToUser(): bool
     {
-      return $this->assignedType() === Asset::USER;
+        return $this->assignedType() === Asset::USER; //ARGH - delete me
     }
 
     public function scopeUserAssigned(Builder $query): void

--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -483,7 +483,7 @@ class StoreAssetTest extends TestCase
         $asset = Asset::find($response['payload']['id']);
 
         $this->assertTrue($asset->adminuser->is($user));
-        $this->assertTrue($asset->checkedOutToLocation());
+        $this->assertEquals($asset->assigned_type, Location::class);
         $this->assertTrue($asset->location->is($location));
     }
 
@@ -509,7 +509,7 @@ class StoreAssetTest extends TestCase
         $apiAsset = Asset::find($response['payload']['id']);
 
         $this->assertTrue($apiAsset->adminuser->is($user));
-        $this->assertTrue($apiAsset->checkedOutToAsset());
+        $this->assertEquals($apiAsset->assigned_type, Asset::class);
         // I think this makes sense, but open to a sanity check
         $this->assertTrue($asset->assignedAssets()->find($response['payload']['id'])->is($apiAsset));
     }


### PR DESCRIPTION
We have a chunk of weird constants and methods that we really didn't need to have in the Asset model. This PR pulls those out and just looks directly at `assigned_type` and compares to things like `User::class` et al.

I think this is easier to read and understand, and the additional abstractions were just confusing.

Tests pass, but that doesn't mean much. I'm happy to take a more deep pass through the code if we decide that this is even a direction we like.

Oh, and there were some code improvements I made to the `assetLoc` method that I think make it a bit cleaner to read.