### PR TITLE
Fixed app settings view on mobile

### DIFF
--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -356,7 +356,8 @@
         <h2 class="box-title">{{ trans('admin/settings/general.system') }}</h2>
       </div>
       <div class="box-body">
-        <div class="container row row-striped" style="width:97%">
+        <div class="row" style="margin-right:4px;">
+        <div class="row row-new-striped">
 
           <!-- row -->
           <div class="row">
@@ -364,13 +365,13 @@
               <strong>{{ trans('admin/settings/general.snipe_version') }}:</strong>
             </div>
             <div class="col-md-4">
-            {{ config('version.app_version') }}  build {{ config('version.build_version') }} ({{ config('version.hash_version') }})
+              {{ config('version.app_version') }}  build {{ config('version.build_version') }} ({{ config('version.hash_version') }})
             </div>
 
             <div class="col-md-2">
               <strong>{{ trans('admin/settings/general.license') }}:</strong>
             </div>
-          <div class="col-md-4">
+            <div class="col-md-4">
               <a href="https://www.gnu.org/licenses/agpl-3.0.en.html" rel="noopener">AGPL3</a>
            </div>
           </div>
@@ -434,12 +435,15 @@
             <div class="col-md-2">
               <strong>{{ trans('admin/settings/general.bs_table_storage') }}:</strong>
             </div>
-            <div class="col-md-10">
+            <div class="col-md-4">
               {{ config('session.bs_table_storage') }}
             </div>
-
+            <div class="col-md-2">
+            </div>
+            <div class="col-md-4">
+            </div>
           </div>
-
+        </div>
         </div>
           </div>
           <!--/ row -->

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -357,21 +357,21 @@
       </div>
       <div class="box-body">
         <div class="row" style="margin-right:4px;">
-        <div class="row row-new-striped">
+        <div class="row row-new-striped" style="line-height: 23px;">
 
           <!-- row -->
           <div class="row">
-            <div class="col-md-2">
+            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
               <strong>{{ trans('admin/settings/general.snipe_version') }}:</strong>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
               {{ config('version.app_version') }}  build {{ config('version.build_version') }} ({{ config('version.hash_version') }})
             </div>
 
-            <div class="col-md-2">
+            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
               <strong>{{ trans('admin/settings/general.license') }}:</strong>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
               <a href="https://www.gnu.org/licenses/agpl-3.0.en.html" rel="noopener">AGPL3</a>
            </div>
           </div>
@@ -379,52 +379,52 @@
 
           <!-- row -->
           <div class="row">
-            <div class="col-md-2">
+            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
               <strong>{{ trans('admin/settings/general.php') }}:</strong>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
               {{ phpversion() }}
             </div>
 
-            <div class="col-md-2">
+            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
               <strong>{{ trans('admin/settings/general.laravel') }}:</strong>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
               {{ $snipeSettings->lar_ver() }}
             </div>
           </div>
 
           <!-- row -->
           <div class="row">
-              <div class="col-md-2">
+              <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
                 <strong>{{ trans('admin/settings/general.timezone') }}:</strong>
               </div>
-              <div class="col-md-4">
+              <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
                 {{ config('app.timezone') }}
               </div>
 
-              <div class="col-md-2">
+              <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
                 <strong>{{ trans('admin/settings/general.database_driver') }}:</strong>
               </div>
-              <div class="col-md-4">
+              <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
                 {{ config('database.default') }}
               </div>
           </div>
 
           <!-- row -->
           <div class="row">
-            <div class="col-md-2">
+            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
               <strong>{{ trans('admin/settings/general.mail_from') }}:</strong>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
               {{ config('mail.from.name') }}
               <code>&lt;{{ config('mail.from.address') }}&gt;</code>
             </div>
 
-            <div class="col-md-2">
+            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
               <strong>{{ trans('admin/settings/general.mail_reply_to') }}:</strong>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
               {{ config('mail.reply_to.name') }}
               <code>&lt;{{ config('mail.reply_to.address') }}&gt;</code>
             </div>
@@ -432,10 +432,10 @@
 
           <!-- row -->
           <div class="row">
-            <div class="col-md-2">
+            <div class="col-md-2" style="padding-top: 3px; padding-bottom: 3px;">
               <strong>{{ trans('admin/settings/general.bs_table_storage') }}:</strong>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-4" style="padding-top: 3px; padding-bottom: 3px;">
               {{ config('session.bs_table_storage') }}
             </div>
             <div class="col-md-2">


### PR DESCRIPTION
This fixes a layout issue on mobile when viewing the app configs in the settings index. It looked fine on full-size, but on `xs` screens, the "table" got out of whack. 

### Before
<img width="287" alt="Screenshot_2024-09-20_at_5_44_48 PM" src="https://github.com/user-attachments/assets/bec5c8a6-0782-49c4-8fa1-61b922ac5dc2">

### After
<img width="1388" alt="Screenshot 2024-09-24 at 10 54 38 AM" src="https://github.com/user-attachments/assets/a65721ac-6278-4699-b682-a36d67c03ae4">

<img width="563" alt="Screenshot 2024-09-24 at 11 09 37 AM" src="https://github.com/user-attachments/assets/c6ab9850-1bf0-44c6-905d-3ab17c27dc87">

