### PR TITLE
Fixes #15548 - unify audit api endpoints

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -161,36 +161,28 @@ class AssetsController extends Controller
         switch ($action) {
             // Audit (singular) is left over from earlier legacy APIs
             case 'audits' :
-                \Log::error('audit/audits');
                 switch ($upcoming_status) {
                     case 'due':
-                        \Log::error('due');
                         $assets->DueForAudit($settings);
                         break;
                     case 'overdue':
-                        \Log::error('overdue');
                         $assets->OverdueForAudit();
                         break;
                     case 'due-or-overdue':
-                        \Log::error('due-or-overdue');
                         $assets->DueOrOverdueForAudit($settings);
                         break;
                 }
                 break;
 
             case 'checkins':
-                \Log::error('checkins');
                 switch ($upcoming_status) {
                     case 'due':
-                        \Log::error('due');
                         $assets->DueForCheckin($settings);
                         break;
                     case 'overdue':
-                        \Log::error('overdue');
                         $assets->OverdueForCheckin();
                         break;
                     case 'due-or-overdue':
-                        \Log::error('due-or-overdue');
                         $assets->DueOrOverdueForCheckin($settings);
                         break;
                 }

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -56,6 +56,11 @@ class AssetsController extends Controller
     public function index(Request $request, $action = null, $upcoming_status = null) : JsonResponse | array
     {
 
+
+        // This handles the legacy audit endpoints :(
+        if ($action == 'audit') {
+            $action = 'audits';
+        }
         $filter_non_deprecable_assets = false;
 
         /**
@@ -155,30 +160,37 @@ class AssetsController extends Controller
          */
         switch ($action) {
             // Audit (singular) is left over from earlier legacy APIs
-            case ('audit' || 'audits'):
-
+            case 'audits' :
+                \Log::error('audit/audits');
                 switch ($upcoming_status) {
                     case 'due':
+                        \Log::error('due');
                         $assets->DueForAudit($settings);
                         break;
                     case 'overdue':
+                        \Log::error('overdue');
                         $assets->OverdueForAudit();
                         break;
                     case 'due-or-overdue':
+                        \Log::error('due-or-overdue');
                         $assets->DueOrOverdueForAudit($settings);
                         break;
                 }
                 break;
 
             case 'checkins':
+                \Log::error('checkins');
                 switch ($upcoming_status) {
                     case 'due':
+                        \Log::error('due');
                         $assets->DueForCheckin($settings);
                         break;
                     case 'overdue':
+                        \Log::error('overdue');
                         $assets->OverdueForCheckin();
                         break;
                     case 'due-or-overdue':
+                        \Log::error('due-or-overdue');
                         $assets->DueOrOverdueForCheckin($settings);
                         break;
                 }

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -154,7 +154,8 @@ class AssetsController extends Controller
          * Handle due and overdue audits and checkin dates
          */
         switch ($action) {
-            case 'audits':
+            // Audit (singular) is left over from earlier legacy APIs
+            case ('audit' || 'audits'):
 
                 switch ($upcoming_status) {
                     case 'due':

--- a/routes/api.php
+++ b/routes/api.php
@@ -495,13 +495,6 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
         )->name('api.assets.show.byserial')
         ->where('any', '.*');
 
-        // LEGACY URL - Get assets that are due or overdue for audit
-        Route::get('audit/{status}',
-        [
-            Api\AssetsController::class, 
-            'index'
-        ]
-        )->name('api.asset.to-audit');
 
 
 
@@ -512,7 +505,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
                   'index'
               ]
         )->name('api.assets.list-upcoming')
-        ->where(['action' => 'audits|checkins', 'upcoming_status' => 'due|overdue|due-or-overdue']);
+        ->where(['action' => 'audit|audits|checkins', 'upcoming_status' => 'due|overdue|due-or-overdue']);
 
 
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -498,7 +498,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
 
 
 
-        // This gets the "due or overdue" API endpoints for audits and checkins
+        // This gets the "due or overdue" API endpoints for audit/audits and checkins
         Route::get('{action}/{upcoming_status}',
               [
                   Api\AssetsController::class,


### PR DESCRIPTION
This removes some older code paths (since we changed the name of the urls slightly with a nicer version but still supported both). Now you can use `/v1/hardware/audit/overdue` or `/v1/hardware/audits/overdue` as the endpoint.

I don't love hanging on to legacy code, but this is necessary unless we want to do a full point release.

Should fix #15548.