### PR TITLE
Fix multi create partial failure (fixes: [RB-18591])

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -112,10 +112,10 @@ class AssetsController extends Controller
 
         $settings = Setting::getSettings();
 
-        $successes = 0;
-        $failures = 0;
+        $successes = [];
+        $failures = [];
         $serials = $request->input('serials');
-        $last_succesful_asset = null;
+        $asset = null;
 
         for ($a = 1; $a <= count($asset_tags); $a++) {
             $asset = new Asset();
@@ -202,33 +202,32 @@ class AssetsController extends Controller
                     $asset->checkOut($target, auth()->user(), date('Y-m-d H:i:s'), $request->input('expected_checkin', null), 'Checked out on asset creation', $request->get('name'), $location);
                 }
 
-                $last_succesful_asset = $asset;
-                $successes++;
+                $successes[] = "<a href='" . route('hardware.show', ['hardware' => $asset->id]) . "' style='color: white;'>" . e($asset->asset_tag) . "</a>";
 
             } else {
-                $failures++;
+                $failures[] = join(",", $asset->getErrors()->all());
             }
         }
 
         session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => $request->get('checkout_to_type')]);
 
 
-        if ($successes > 0) {
-            if ($failures > 0) {
+        if ($successes) {
+            if ($failures) {
                 //some succeeded, some failed
-                return redirect()->to(Helper::getRedirectOption($request, $last_succesful_asset->id, 'Assets'))
-                    ->with('success-unescaped', trans_choice('admin/hardware/message.create.multi_success_linked', $successes, ['link' => route('hardware.show', ['hardware' => $last_succesful_asset->id]), 'id', 'tag' => e($last_succesful_asset->asset_tag)]))
-                    ->with('warning', trans_choice('admin/hardware/message.create.partial_failure', $failures));
+                return redirect()->to(Helper::getRedirectOption($request, $asset->id, 'Assets')) //FIXME - not tested
+                ->with('success-unescaped', trans_choice('admin/hardware/message.create.multi_success_linked', $successes, ['links' => join(", ", $successes)]))
+                    ->with('warning', trans_choice('admin/hardware/message.create.partial_failure', $failures, ['failures' => join("; ", $failures)]));
             } else {
-                if ($successes == 1) {
+                if (count($successes) == 1) {
                     //the most common case, keeping it so we don't have to make every use of that translation string be trans_choice'ed
                     //and re-translated
-                    return redirect()->to(Helper::getRedirectOption($request, $last_succesful_asset->id, 'Assets'))
-                        ->with('success-unescaped', trans('admin/hardware/message.create.success_linked', ['link' => route('hardware.show', ['hardware' => $last_succesful_asset->id]), 'id', 'tag' => e($last_succesful_asset->asset_tag)]));
+                    return redirect()->to(Helper::getRedirectOption($request, $asset->id, 'Assets'))
+                        ->with('success-unescaped', trans('admin/hardware/message.create.success_linked', ['link' => route('hardware.show', ['hardware' => $asset->id]), 'id', 'tag' => e($asset->asset_tag)]));
                 } else {
                     //multi-success
-                    return redirect()->to(Helper::getRedirectOption($request, $last_succesful_asset->id, 'Assets'))
-                        ->with('success-unescaped', trans_choice('admin/hardware/message.create.multi_success_linked', $successes, ['link' => route('hardware.show', ['hardware' => $last_succesful_asset->id]), 'id', 'tag' => e($last_succesful_asset->asset_tag)]));
+                    return redirect()->to(Helper::getRedirectOption($request, $asset->id, 'Assets'))
+                        ->with('success-unescaped', trans_choice('admin/hardware/message.create.multi_success_linked', $successes, ['links' => join(", ", $successes)]));
                 }
             }
 

--- a/resources/lang/en-US/admin/hardware/message.php
+++ b/resources/lang/en-US/admin/hardware/message.php
@@ -14,6 +14,9 @@ return [
         'error'   		=> 'Asset was not created, please try again. :(',
         'success' 		=> 'Asset created successfully. :)',
         'success_linked' => 'Asset with tag :tag was created successfully. <strong><a href=":link" style="color: white;">Click here to view</a></strong>.',
+        'multi_success_linked' => 'Asset with tag :tag was created successfully. <strong><a href=":link" style="color: white;">Click here to view</a></strong>.|:count assets were created succesfully. The last one was :tag. <strong><a href=":link" style="color: white;">Click here to view</a></strong>.',
+        'partial_success_linked' => 'Asset with tag :tag was created successfully. <strong><a href=":link" style="color: white;">Click here to view</a></strong>.',
+        'partial_failure' => 'An asset was unable to be created.|:count assets were unable to be created.'
     ],
 
     'update' => [

--- a/resources/lang/en-US/admin/hardware/message.php
+++ b/resources/lang/en-US/admin/hardware/message.php
@@ -14,9 +14,8 @@ return [
         'error'   		=> 'Asset was not created, please try again. :(',
         'success' 		=> 'Asset created successfully. :)',
         'success_linked' => 'Asset with tag :tag was created successfully. <strong><a href=":link" style="color: white;">Click here to view</a></strong>.',
-        'multi_success_linked' => 'Asset with tag :tag was created successfully. <strong><a href=":link" style="color: white;">Click here to view</a></strong>.|:count assets were created succesfully. The last one was :tag. <strong><a href=":link" style="color: white;">Click here to view</a></strong>.',
-        'partial_success_linked' => 'Asset with tag :tag was created successfully. <strong><a href=":link" style="color: white;">Click here to view</a></strong>.',
-        'partial_failure' => 'An asset was unable to be created.|:count assets were unable to be created.'
+        'multi_success_linked' => 'Asset with tag :links was created successfully.|:count assets were created succesfully. :links.',
+        'partial_failure' => 'An asset was unable to be created. Reason: :failures|:count assets were unable to be created. Reasons: :failures',
     ],
 
     'update' => [


### PR DESCRIPTION
When you are creating multiple assets, you can trigger a 500 if your first asset creates successfully, but the _last_ does not.

This also fixes a Rollbar that keeps showing up and annoying us.

I opted to _keep_ the existing singleton-translation `admin/hardware/message.create.success_linked` even though it's mostly subsumed into the new `trans_choice()` option `admin/hardware/message.create.multi_success_linked`. The reason is that a) I didn't want to have to make it so that everywhere we might've used the previous translation, we would have to instead switch it over to `trans_choice()`. And, possibly more important, I didn't want that string to have to be re-translated when it's already been pretty heavily translated.

The error output starts to not look so nice when there are multiple errors on multiple assets, but I'm happy to workshop better ways of displaying that. But this is better than what we do now, which is 500. And we do at least show an error message.

Here are some screenshots (and, again, this is all negotiable. If we really think it's best to add full customized template into the notification blade, I'm OK with that).

Success adding a single Asset:
<img width="1413" alt="Screenshot 2024-09-24 at 5 15 34 PM" src="https://github.com/user-attachments/assets/12be0a83-b7d2-41fa-8b4e-7bab3af93d86">

Success adding multiple assets:
<img width="1408" alt="Screenshot 2024-09-24 at 5 15 06 PM" src="https://github.com/user-attachments/assets/d464881c-d156-4aa3-b7e9-c52b9005d40f">

One success, one failure (multiple causes for the failure):
<img width="747" alt="Screenshot 2024-09-24 at 5 14 28 PM" src="https://github.com/user-attachments/assets/d592c7aa-cad5-4cfc-88ee-4088587d6acd">
:
2 successes, 2 failures (multiple causes for the failures):
<img width="1400" alt="Screenshot 2024-09-24 at 5 14 36 PM" src="https://github.com/user-attachments/assets/85a0c9e1-37da-4612-a96a-41ab3e362593">

*_EDIT_* - a good way to trigger this error is either to duplicate asset tags, or have serial number uniqueness enforced and duplicating those - just FYI.

