### PR TITLE
Fixed input field misalignments

### DIFF
--- a/resources/assets/less/app.less
+++ b/resources/assets/less/app.less
@@ -384,7 +384,7 @@ a.logo.no-hover a:hover {
   background-color: transparent;
 }
 
-.required {
+input:required, select:required {
   border-right: 6px solid orange;
 }
 

--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -156,10 +156,10 @@ a.accordion-header {
   height: 150px;
 }
 
-
 .select2-container {
   width: 100%;
 }
+
 .error input {
   color: #a94442;
   border: 2px solid #a94442 !important;
@@ -341,8 +341,11 @@ a.logo.no-hover a:hover {
 }
 
 
-.required {
-  border-right: 6px solid orange;
+input:required, select:required {
+  border-right: 4px solid orange;
+}
+select:required + .select2-container .select2-selection {
+  border-right: 4px solid orange;
 }
 
 body {


### PR DESCRIPTION
# Description
inputs were being resized to make room for the required class if required. By changing the `required` class to a pseudo class (`input:required`, `select:required`, etc) the required css highlights are applied inside of the input. 

BEFORE: 
Create Asset:
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/9562228c-0493-4f56-8560-a69d5c13bdb2">

Create Accessory:
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/36b8844c-77ff-4dd9-bb47-ac95bdba5884">

AFTER:
Create Asset:
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/6ac12bd4-d390-4ff2-98d3-fc0482b62b04">

Create Accessory:
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/fc4395c5-936c-47e6-aa3f-5e6586186f96">



Fixes #[sc-26893]

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
