### PR TITLE
Fixing #15064 - to not fail ldap sync on single data issue with ldap …

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -320,22 +320,29 @@ class LdapSync extends Command
                                 ]
                             ];
                         }
-
+                        
+                        $add_manager_to_cache = true;
                         if ($ldap_manager["count"] > 0) {
+                            try {
+                                // Get the Manager's username
+                                // PHP LDAP returns every LDAP attribute as an array, and 90% of the time it's an array of just one item. But, hey, it's an array.
+                                $ldapManagerUsername = $ldap_manager[0][$ldap_map["username"]][0];
 
-                            // Get the Manager's username
-                            // PHP LDAP returns every LDAP attribute as an array, and 90% of the time it's an array of just one item. But, hey, it's an array.
-                            $ldapManagerUsername = $ldap_manager[0][$ldap_map["username"]][0];
+                                // Get User from Manager username.
+                                $ldap_manager = User::where('username', $ldapManagerUsername)->first();
 
-                            // Get User from Manager username.
-                            $ldap_manager = User::where('username', $ldapManagerUsername)->first();
-
-                            if ($ldap_manager && isset($ldap_manager->id)) {
-                                // Link user to manager id.
-                                $user->manager_id = $ldap_manager->id;
+                                if ($ldap_manager && isset($ldap_manager->id)) {
+                                    // Link user to manager id.
+                                    $user->manager_id = $ldap_manager->id;
+                                }
+                            } catch (\Exception $e) {
+                                $add_manager_to_cache = false;
+                                \Log::warning('Handling ldap manager ' . $item['manager'] . ' caused an exception: ' . $e->getMessage() . '. Continuing synchronization.');
                             }
                         }
-                        $manager_cache[$item['manager']] = $ldap_manager && isset($ldap_manager->id)  ? $ldap_manager->id : null; // Store results in cache, even if 'failed'
+                        if ($add_manager_to_cache) {
+                            $manager_cache[$item['manager']] = $ldap_manager && isset($ldap_manager->id)  ? $ldap_manager->id : null; // Store results in cache, even if 'failed'
+                        }
 
                     }
                 }


### PR DESCRIPTION
# Description

Change answers issue described in #15064 and the goal is to not fail whole ldap synchronization because of single invalid manager entry.


Fixes #15064

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Changes were tested with SnipeIT instance that encountered described issue. After introducing change the sync process finishes even if there were some issues with individual entries.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* SnipeIT version: v6.1.1-pre - build 10653 (master)
* PHP version: 7.x
* MySQL version: n/a
* Webserver version: n/a
* OS version: n/a


# Checklist:

- [ x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
