### PR TITLE
Changed `action_date` to `created_at` in activity report

### DIFF
--- a/app/Http/Controllers/Api/ReportsController.php
+++ b/app/Http/Controllers/Api/ReportsController.php
@@ -75,6 +75,7 @@ class ReportsController extends Controller
             'remote_ip',
             'user_agent',
             'action_source',
+            'action_date',
         ];
 
 

--- a/resources/views/reports/activity.blade.php
+++ b/resources/views/reports/activity.blade.php
@@ -52,7 +52,7 @@
                             <th data-field="icon" style="width: 40px;" class="hidden-xs" data-formatter="iconFormatter">
                                 {{ trans('admin/hardware/table.icon') }}
                             </th>
-                            <th class="col-sm-3" data-searchable="false" data-sortable="true" data-field="action_date" data-formatter="dateDisplayFormatter">
+                            <th class="col-sm-3" data-searchable="false" data-sortable="true" data-field="created_at" data-formatter="dateDisplayFormatter">
                                 {{ trans('general.date') }}
                             </th>
                             <th class="col-sm-2" data-searchable="true" data-sortable="true" data-field="created_by" data-formatter="usersLinkObjFormatter">


### PR DESCRIPTION
The value of action_date is not always present, since it's largely used to back-date or forward-date actions without compromising the date the actual thing happened. This just fixes the sorting on the activity report. 