### PR TITLE
Get us better debugging output for new Github Stale Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/stale@v9
         with:
           debug-only: true
-          operations-per-run: 100 # just while we're debugging
+          ascending: true
+          operations-per-run: 1000 # just while we're debugging
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 60
           days-before-close: 7


### PR DESCRIPTION
I've been working on re-activating a "Stalebot" functionality for our GH issues. But I haven't gotten any descent output yet. I suspect this is because our GH issues are all pretty lively - at least, the ones near the 'front'. So this increases the number of issues we look at, and also starts looking from the _beginning_ rather than the end - which, hopefully, should get us some useful debugging output we can use to dial in a configuration that works for us.