### PR TITLE
Fixes Vague Error Messages In Setting Asset Model Default Values

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -487,7 +487,6 @@ class AssetModelsController extends Controller
 
         if($validator->fails()){
             $this->validatorErrors = $validator->errors();
-            dump($this->validatorErrors);
             return false;
         }
 

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -161,7 +161,7 @@ class AssetModelsController extends Controller
             if ($this->shouldAddDefaultValues($request->input())) {
                 if (!$this->assignCustomFieldsDefaultValues($model, $request->input('default_values'))) {
                     //return redirect()->back()->withInput()->with('error', trans('admin/custom_fields/message.fieldset_default_value.error'));
-                    return redirect()->back()->withErrors($this->validatorErrors);
+                    return redirect()->back()->withInput()->withErrors($this->validatorErrors);
                 }
             }
 
@@ -487,7 +487,8 @@ class AssetModelsController extends Controller
         $validator = Validator::make($data, $rules);
 
         if($validator->fails()){
-            $this->validatorErrors = $validator->messages();
+            $this->validatorErrors = $validator->errors();
+            dump($this->validatorErrors);
             return false;
         }
 

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -483,7 +483,12 @@ class AssetModelsController extends Controller
             $rules[$field] = $validation;
         }
 
-        $validator = Validator::make($data, $rules);
+        $attributes = [];
+        foreach ($model->fieldset->fields as $field) {
+            $attributes[$field->db_column] = trim(preg_replace('/_+|snipeit|\d+/', ' ', $field->db_column));
+        }
+
+        $validator = Validator::make($data, $rules)->setAttributeNames($attributes);
 
         if($validator->fails()){
             $this->validatorErrors = $validator->errors();

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
 use \Illuminate\Contracts\View\View;
 use \Illuminate\Http\RedirectResponse;
+use Illuminate\Support\MessageBag;
 
 
 /**
@@ -29,6 +30,7 @@ use \Illuminate\Http\RedirectResponse;
  */
 class AssetModelsController extends Controller
 {
+    protected MessageBag $validatorErrors;
     /**
      * Returns a view that invokes the ajax tables which actually contains
      * the content for the accessories listing, which is generated in getDatatable.
@@ -158,7 +160,8 @@ class AssetModelsController extends Controller
 
             if ($this->shouldAddDefaultValues($request->input())) {
                 if (!$this->assignCustomFieldsDefaultValues($model, $request->input('default_values'))) {
-                    return redirect()->back()->withInput()->with('error', trans('admin/custom_fields/message.fieldset_default_value.error'));
+                    //return redirect()->back()->withInput()->with('error', trans('admin/custom_fields/message.fieldset_default_value.error'));
+                    return redirect()->back()->withErrors($this->validatorErrors);
                 }
             }
 
@@ -484,6 +487,7 @@ class AssetModelsController extends Controller
         $validator = Validator::make($data, $rules);
 
         if($validator->fails()){
+            $this->validatorErrors = $validator->messages();
             return false;
         }
 

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -160,7 +160,6 @@ class AssetModelsController extends Controller
 
             if ($this->shouldAddDefaultValues($request->input())) {
                 if (!$this->assignCustomFieldsDefaultValues($model, $request->input('default_values'))) {
-                    //return redirect()->back()->withInput()->with('error', trans('admin/custom_fields/message.fieldset_default_value.error'));
                     return redirect()->back()->withInput()->withErrors($this->validatorErrors);
                 }
             }

--- a/app/Livewire/CustomFieldSetDefaultValuesForModel.php
+++ b/app/Livewire/CustomFieldSetDefaultValuesForModel.php
@@ -24,7 +24,15 @@ class CustomFieldSetDefaultValuesForModel extends Component
         $this->fieldset_id = $this->model?->fieldset_id;
         $this->add_default_values = ($this->model?->defaultValues->count() > 0);
 
+
         $this->initializeSelectedValuesArray();
+        if (session()->has('errors')) {
+            $errors = session('errors')->keys();
+            $selectedValuesKeys = array_keys($this->selectedValues);
+            if (count(array_intersect($selectedValuesKeys, $errors)) > 0) {
+                $this->add_default_values = true;
+            };
+        }
         $this->populatedSelectedValuesArray();
     }
 

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -127,7 +127,7 @@
                                         <?php
                                         $errormessage = $errors->first($field->db_column_name());
                                         if ($errormessage) {
-                                            $errormessage = preg_replace('/ snipeit /', '', $errormessage);
+                                            $errormessage = preg_replace('/snipeit|\d+/', '', $errormessage);
                                             print('<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> '.$errormessage.'</span>');
                                         }
                                         ?>

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -1,4 +1,5 @@
 <span>
+    @dump($errors)
     <div class="form-group{{ $errors->has('custom_fieldset') ? ' has-error' : '' }}">
         <label for="custom_fieldset" class="col-md-3 control-label">
             {{ trans('admin/models/general.fieldset') }}
@@ -17,11 +18,10 @@
         </div>
     </div>
 
-    @if ($add_default_values)
+    @if ($add_default_values || $errors->count() > 0)
             @if ($this->fields)
 
                 @foreach ($this->fields as $field)
-                @dump($errors)
                 @if($errors->has($field->db_column_name()))
                     "poop"
                 @endif

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -127,7 +127,6 @@
                                         <?php
                                         $errormessage = $errors->first($field->db_column_name());
                                         if ($errormessage) {
-                                            $errormessage = preg_replace('/snipeit|\d+/', '', $errormessage);
                                             print('<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> '.$errormessage.'</span>');
                                         }
                                         ?>

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -11,6 +11,7 @@
         <div class="col-md-3">
             @if ($fieldset_id)
                 <label class="form-control">
+
                     {{ Form::checkbox('add_default_values', 1, old('add_default_values', $add_default_values), ['data-livewire-component' => $this->getId(), 'id' => 'add_default_values', 'wire:model.live' => 'add_default_values', 'disabled' => $this->fields->isEmpty()]) }}
                     {{ trans('admin/models/general.add_default_values') }}
                 </label>
@@ -18,8 +19,9 @@
         </div>
     </div>
 
-    @if ($add_default_values || $errors->count() > 0)
-            @if ($this->fields)
+    @if ($add_default_values)
+
+        @if ($this->fields)
 
                 @foreach ($this->fields as $field)
                 @if($errors->has($field->db_column_name()))

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -1,5 +1,4 @@
 <span>
-    @dump($errors)
     <div class="form-group{{ $errors->has('custom_fieldset') ? ' has-error' : '' }}">
         <label for="custom_fieldset" class="col-md-3 control-label">
             {{ trans('admin/models/general.fieldset') }}
@@ -24,12 +23,9 @@
         @if ($this->fields)
 
                 @foreach ($this->fields as $field)
-                @if($errors->has($field->db_column_name()))
-                    "poop"
-                @endif
                     <div class="form-group" wire:key="field-{{ $field->id }}">
 
-                        <label class="col-md-3 control-label{{ $errors->has($field->name) ? ' has-error' : '' }}">{{ $field->name }}</label>
+                        <label class="col-md-3 control-label{{ $errors->has($field->db_column_name()) ? ' has-error' : '' }}">{{ $field->name }}</label>
 
                         <div class="col-md-7">
 
@@ -128,10 +124,17 @@
                                         Unknown field element: {{ $field->element }}
                                     </span>
                                 @endif
+                                        <?php
+                                        $errormessage = $errors->first($field->db_column_name());
+                                        if ($errormessage) {
+                                            $errormessage = preg_replace('/ snipeit /', '', $errormessage);
+                                            print('<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> '.$errormessage.'</span>');
+                                        }
+                                        ?>
                         </div>
                     </div>
 
-                @endforeach
+            @endforeach
 
             @endif
 

--- a/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
+++ b/resources/views/livewire/custom-field-set-default-values-for-model.blade.php
@@ -1,5 +1,4 @@
 <span>
-
     <div class="form-group{{ $errors->has('custom_fieldset') ? ' has-error' : '' }}">
         <label for="custom_fieldset" class="col-md-3 control-label">
             {{ trans('admin/models/general.fieldset') }}
@@ -22,6 +21,10 @@
             @if ($this->fields)
 
                 @foreach ($this->fields as $field)
+                @dump($errors)
+                @if($errors->has($field->db_column_name()))
+                    "poop"
+                @endif
                     <div class="form-group" wire:key="field-{{ $field->id }}">
 
                         <label class="col-md-3 control-label{{ $errors->has($field->name) ? ' has-error' : '' }}">{{ $field->name }}</label>

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -66,13 +66,13 @@
               <p class="help-block">{{ $field->help_text }}</p>
               @endif
 
-          <?php
-          $errormessage=$errors->first($field->db_column_name());
-          if ($errormessage) {
-              $errormessage=preg_replace('/ snipeit /', '', $errormessage);
-              print('<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> '.$errormessage.'</span>');
-          }
-            ?>
+                  <?php
+                  $errormessage = $errors->first($field->db_column_name());
+                  if ($errormessage) {
+                      $errormessage = preg_replace('/ snipeit /', '', $errormessage);
+                      print('<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> '.$errormessage.'</span>');
+                  }
+                  ?>
       </div>
 
         @if ($field->field_encrypted)

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -36,7 +36,7 @@
 
 <!-- Custom Fieldset -->
 <!-- If $item->id is null we are cloning the model and we need the $model_id variable -->
-@livewire('custom-field-set-default-values-for-model', ["model_id" => $item->id ?? $model_id ?? null, "errors" => $errors])
+@livewire('custom-field-set-default-values-for-model', ["model_id" => $item->id ?? $model_id ?? null])
 
 @include ('partials.forms.edit.notes')
 @include ('partials.forms.edit.requestable', ['requestable_text' => trans('admin/models/general.requestable')])

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -36,7 +36,7 @@
 
 <!-- Custom Fieldset -->
 <!-- If $item->id is null we are cloning the model and we need the $model_id variable -->
-@livewire('custom-field-set-default-values-for-model',["model_id" => $item->id ?? $model_id ?? null  ])
+@livewire('custom-field-set-default-values-for-model', ["model_id" => $item->id ?? $model_id ?? null, "errors" => $errors])
 
 @include ('partials.forms.edit.notes')
 @include ('partials.forms.edit.requestable', ['requestable_text' => trans('admin/models/general.requestable')])


### PR DESCRIPTION
# Description
Fixes an issue when setting default values for custom fields on a model would error, but not show the field that errored or keep the custom fields shown.  

<img width="2562" alt="image" src="https://github.com/user-attachments/assets/c52e79c3-1499-4b38-b8e1-ef5d46e0ee28">


Fixes #SC-25921

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* PHP version: 8.2
* MySQL version 8.1
