### PR TITLE
Fixed Status Labels Error Message

### DIFF
--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -95,7 +95,8 @@ class StatuslabelsController extends Controller
         $request->except('deployable', 'pending', 'archived');
 
         if (! $request->filled('type')) {
-            return response()->json(Helper::formatStandardApiResponse('error', null, ['type' => ['Status label type is required.']]), 500);
+
+            return response()->json(Helper::formatStandardApiResponse('error', null, ['type' => ['Status label type is required.']]));
         }
 
         $statuslabel = new Statuslabel;


### PR DESCRIPTION
# Description
Error message handler for status labels had an extra parameter in it. It was returning `Server Error: [object Object]`. This fixes that.

Before:
<img width="657" alt="image" src="https://github.com/user-attachments/assets/327b1876-b93f-478e-812b-8efa700fcdb8">

After:
<img width="657" alt="image" src="https://github.com/user-attachments/assets/dce8fa89-7a4c-4b32-9d82-0b223b5e6e5a">


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
