### PR TITLE
Removed sortablity for current value column in depreciations report

### DIFF
--- a/app/Presenters/DepreciationReportPresenter.php
+++ b/app/Presenters/DepreciationReportPresenter.php
@@ -140,7 +140,7 @@ class DepreciationReportPresenter extends Presenter
             ], [
                 "field" => "book_value",
                 "searchable" => true,
-                "sortable" => true,
+                "sortable" => false,
                 "visible" => true,
                 "title" => trans('admin/hardware/table.book_value'),
                 "footerFormatter" => 'sumFormatter',


### PR DESCRIPTION
# Description

Removing the ability to sort by Current Value in the depreciation reports. They currently are updated through the presenter so, sorting them currently is not accurate. We are discussing how we can better handle this for the future.

Fixes #[sc-26924]

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
