### PR TITLE
Added maxlengths to additional fields

### DIFF
--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -62,7 +62,7 @@ class Accessory extends SnipeModel
         'category_id'       => 'required|integer|exists:categories,id',
         'company_id'        => 'integer|nullable',
         'min_amt'           => 'integer|min:0|nullable',
-        'purchase_cost'     => 'numeric|nullable|gte:0',
+        'purchase_cost'     => 'numeric|nullable|gte:0|max:9999999999999',
         'purchase_date'     => 'date_format:Y-m-d|nullable',
     ];
 

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -112,7 +112,7 @@ class Asset extends Depreciable
         'rtd_location_id'   => ['nullable', 'exists:locations,id'],
         'purchase_date'     => ['nullable', 'date', 'date_format:Y-m-d'],
         'serial'            => ['nullable', 'unique_undeleted:assets,serial'],
-        'purchase_cost'     => ['nullable', 'numeric', 'gte:0'],
+        'purchase_cost'     => ['nullable', 'numeric', 'gte:0', 'max:9999999999999'],
         'supplier_id'       => ['nullable', 'exists:suppliers,id'],
         'asset_eol_date'    => ['nullable', 'date'],
         'eol_explicit'      => ['nullable', 'boolean'],

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -30,14 +30,14 @@ class Component extends SnipeModel
      * Category validation rules
      */
     public $rules = [
-        'name'           => 'required|min:3|max:255',
+        'name'           => 'required|min:3|max:191',
         'qty'            => 'required|integer|min:1',
         'category_id'    => 'required|integer|exists:categories,id',
         'supplier_id'    => 'nullable|integer|exists:suppliers,id',
         'company_id'     => 'integer|nullable|exists:companies,id',
         'min_amt'        => 'integer|min:0|nullable',
         'purchase_date'   => 'date_format:Y-m-d|nullable',
-        'purchase_cost'  => 'numeric|nullable|gte:0',
+        'purchase_cost'  => 'numeric|nullable|gte:0|max:9999999999999',
     ];
 
     /**

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -50,7 +50,7 @@ class Consumable extends SnipeModel
         'category_id' => 'required|integer',
         'company_id'  => 'integer|nullable',
         'min_amt'     => 'integer|min:0|max:99999|nullable',
-        'purchase_cost'   => 'numeric|nullable|gte:0',
+        'purchase_cost'   => 'numeric|nullable|gte:0|max:9999999999999',
         'purchase_date'   => 'date_format:Y-m-d|nullable',
     ];
 

--- a/resources/views/components/checkout.blade.php
+++ b/resources/views/components/checkout.blade.php
@@ -33,7 +33,7 @@
                 {{ trans('general.qty') }}
               </label>
               <div class="col-md-2 col-sm-5 col-xs-5">
-                <input class="form-control required col-md-12" type="text" name="assigned_qty" id="assigned_qty" value="{{ old('assigned_qty') ?? 1 }}" />
+                <input class="form-control required col-md-12" type="text" name="assigned_qty" id="assigned_qty" value="{{ old('assigned_qty') ?? 1 }}" maxlength="999999" />
               </div>
               @if ($errors->first('assigned_qty'))
                 <div class="col-md-9 col-md-offset-3">

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -91,7 +91,7 @@
               <label for="qty" class="col-md-3 control-label">{{ trans('general.qty') }}</label>
               <div class="col-md-7 col-sm-12 required">
                   <div class="col-md-2" style="padding-left:0px">
-                    <input class="form-control" type="number" name="qty" id="qty" value="1" min="1" max="{{$consumable->numRemaining()}}" />
+                    <input class="form-control" type="number" name="qty" id="qty" value="1" min="1" max="{{$consumable->numRemaining()}}" maxlength="999999"  />
                   </div>
               </div>
               {!! $errors->first('qty', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}

--- a/resources/views/licenses/edit.blade.php
+++ b/resources/views/licenses/edit.blade.php
@@ -20,7 +20,7 @@
 <!-- Seats -->
 <div class="form-group {{ $errors->has('seats') ? ' has-error' : '' }}">
     <label for="seats" class="col-md-3 control-label">{{ trans('admin/licenses/form.seats') }}</label>
-    <div class="col-md-7 col-sm-12 required">
+    <div class="col-md-7 col-sm-12">
         <div class="col-md-12" style="padding-left:0px">
             <input class="form-control" type="text" name="seats" id="seats" value="{{ old('seats', $item->seats) }}" minlength="1" required style="width: 97px;">
         </div>
@@ -112,7 +112,7 @@
 <div class="form-group {{ $errors->has('purchase_order') ? ' has-error' : '' }}">
     <label for="purchase_order" class="col-md-3 control-label">{{ trans('admin/licenses/form.purchase_order') }}</label>
     <div class="col-md-3">
-        <input class="form-control" type="text" name="purchase_order" id="purchase_order" value="{{ old('purchase_order', $item->purchase_order) }}" />
+        <input class="form-control" type="text" name="purchase_order" id="purchase_order" value="{{ old('purchase_order', $item->purchase_order) }}" maxlength="191" />
         {!! $errors->first('purchase_order', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/address.blade.php
+++ b/resources/views/partials/forms/edit/address.blade.php
@@ -15,17 +15,17 @@
 </div>
 
 <div class="form-group {{ $errors->has('city') ? ' has-error' : '' }}">
-    {{ Form::label('city', trans('general.city'), array('class' => 'col-md-3 control-label', 'maxlength'=>'191')) }}
+    {{ Form::label('city', trans('general.city'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-    {{Form::text('city', old('city', $item->city), array('class' => 'form-control', 'aria-label'=>'city')) }}
+    {{Form::text('city', old('city', $item->city), array('class' => 'form-control', 'aria-label'=>'city', 'maxlength'=>'191')) }}
         {!! $errors->first('city', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
 <div class="form-group {{ $errors->has('state') ? ' has-error' : '' }}">
-    {{ Form::label('state', trans('general.state'), array('class' => 'col-md-3 control-label', 'maxlength'=>'191')) }}
+    {{ Form::label('state', trans('general.state'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-    {{Form::text('state', old('state', $item->state), array('class' => 'form-control', 'aria-label'=>'state')) }}
+    {{Form::text('state', old('state', $item->state), array('class' => 'form-control', 'aria-label'=>'state', 'maxlength'=>'191')) }}
         {!! $errors->first('state', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
 
     </div>

--- a/resources/views/partials/forms/edit/email.blade.php
+++ b/resources/views/partials/forms/edit/email.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group {{ $errors->has('email') ? ' has-error' : '' }}">
     <label for="email" class="col-md-3 col-xs-12 control-label">{{ trans('admin/suppliers/table.email') }}</label>
     <div class="col-md-8 col-xs-12">
-        <input type="text" name="email" id="email" value="{{ old('email', ($item->email ?? $user->email)) }}" class="form-control" style="width:100%; display:flex;">
+        <input type="text" name="email" id="email" value="{{ old('email', ($item->email ?? $user->email)) }}" class="form-control"  maxlength="191" style="width:100%; display:flex;">
         {!! $errors->first('email', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/eol_date.blade.php
+++ b/resources/views/partials/forms/edit/eol_date.blade.php
@@ -3,7 +3,7 @@
     <label for="asset_eol_date" class="col-md-3 control-label">{{ trans('admin/hardware/form.eol_date') }}</label>
     <div class="input-group col-md-4">
         <div class="input-group date" data-provide="datepicker" data-date-clear-btn="true" data-date-format="yyyy-mm-dd"  data-autoclose="true">
-            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="asset_eol_date" id="asset_eol_date" readonly value="{{  old('asset_eol_date', optional($item->asset_eol_date)->format('Y-m-d') ?? $item->asset_eol_date ?? '')  }}"  style="background-color:inherit" />
+            <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="asset_eol_date" id="asset_eol_date" readonly value="{{  old('asset_eol_date', optional($item->asset_eol_date)->format('Y-m-d') ?? $item->asset_eol_date ?? '')  }}"  style="background-color:inherit"  maxlength="20" />
             <span class="input-group-addon"><x-icon type="calendar" /></span>
         </div>
         {!! $errors->first('asset_eol_date', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/partials/forms/edit/fax.blade.php
+++ b/resources/views/partials/forms/edit/fax.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group {{ $errors->has('fax') ? ' has-error' : '' }}">
     {{ Form::label('fax', trans('admin/suppliers/table.fax'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-        {{Form::text('fax', old('fax', $item->fax), array('class' => 'form-control')) }}
+        <input class="form-control" type="text" name="fax" aria-label="fax" id="fax" value="{{ old('fax', $item->fax) }}"  maxlength="34"  />
         {!! $errors->first('fax', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/name.blade.php
+++ b/resources/views/partials/forms/edit/name.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('name') ? ' has-error' : '' }}">
     <label for="name" class="col-md-3 control-label">{{ $translated_name }}</label>
     <div class="col-md-8 col-sm-12">
-        <input class="form-control" style="width:100%;" type="text" name="name" aria-label="name" id="name" value="{{ old('name', $item->name) }}"{!!  (Helper::checkIfRequired($item, 'name')) ? ' required' : '' !!} />
+        <input class="form-control" style="width:100%;" type="text" name="name" aria-label="name" id="name" value="{{ old('name', $item->name) }}"{!!  (Helper::checkIfRequired($item, 'name')) ? ' required' : '' !!} maxlength="191" />
         {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/order_number.blade.php
+++ b/resources/views/partials/forms/edit/order_number.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('order_number') ? ' has-error' : '' }}">
    <label for="order_number" class="col-md-3 control-label">{{ trans('general.order_number') }}</label>
    <div class="col-md-7 col-sm-12">
-       <input class="form-control" type="text" name="order_number" aria-label="order_number" id="order_number" value="{{ old('order_number', $item->order_number) }}" />
+       <input class="form-control" type="text" name="order_number" aria-label="order_number" id="order_number" value="{{ old('order_number', $item->order_number) }}"  maxlength="191"  />
        {!! $errors->first('order_number', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
    </div>
 </div>

--- a/resources/views/partials/forms/edit/phone.blade.php
+++ b/resources/views/partials/forms/edit/phone.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group {{ $errors->has('phone') ? ' has-error' : '' }}">
     {{ Form::label('phone', trans('admin/suppliers/table.phone'), array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
-    {{Form::text('phone', old('phone', $item->phone), array('class' => 'form-control', 'aria-label'=>'phone')) }}
+    {{Form::text('phone', old('phone', $item->phone), array('class' => 'form-control', 'aria-label'=>'phone', 'maxlength'=>'191')) }}
         {!! $errors->first('phone', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/purchase_cost.blade.php
+++ b/resources/views/partials/forms/edit/purchase_cost.blade.php
@@ -3,7 +3,7 @@
     <label for="purchase_cost" class="col-md-3 control-label">{{ trans('general.purchase_cost') }}</label>
     <div class="col-md-9">
         <div class="input-group col-md-4" style="padding-left: 0px;">
-            <input class="form-control" type="text" name="purchase_cost" aria-label="purchase_cost" id="purchase_cost" value="{{ old('purchase_cost', Helper::formatCurrencyOutput($item->purchase_cost)) }}" />
+            <input class="form-control" type="text" name="purchase_cost" aria-label="purchase_cost" id="purchase_cost" value="{{ old('purchase_cost', Helper::formatCurrencyOutput($item->purchase_cost)) }}" maxlength="24" />
             <span class="input-group-addon">
                 @if (isset($currency_type))
                     {{ $currency_type }}

--- a/resources/views/partials/forms/edit/serial.blade.php
+++ b/resources/views/partials/forms/edit/serial.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('serial') ? ' has-error' : '' }}">
     <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ trans('admin/hardware/form.serial') }} </label>
     <div class="col-md-7 col-sm-12">
-        <input class="form-control" type="text" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old((isset($old_val_name) ? $old_val_name : $fieldname), $item->serial) }}"{{  (Helper::checkIfRequired($item, 'serial')) ? ' required' : '' }} />
+        <input class="form-control" type="text" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old((isset($old_val_name) ? $old_val_name : $fieldname), $item->serial) }}"{{  (Helper::checkIfRequired($item, 'serial')) ? ' required' : '' }} maxlength="191" />
         {!! $errors->first('serial', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/username.blade.php
+++ b/resources/views/partials/forms/edit/username.blade.php
@@ -3,7 +3,12 @@
     $required = $required ?? '';
 @endphp
 <div class="form-group">
-    <div class="col-md-3 col-xs-12"><label for="modal-username">{{ trans('admin/users/table.username') }}:</label></div>
-    <div class="col-md-8 col-xs-12"><input type='text' name="username" id='modal-username' class="form-control"  {{ $required ? ' required' : ''}}></div>
+    <div class="col-md-3 col-xs-12">
+        <label for="modal-username">{{ trans('admin/users/table.username') }}:
+        </label>
+    </div>
+    <div class="col-md-8 col-xs-12">
+        <input type='text' name="username" id='modal-username' class="form-control" maxlength="191" {{ $required ? ' required' : ''}}>
+    </div>
 </div>
 <!-- partials/forms/edit/username.blade.php -->


### PR DESCRIPTION
This adds a few more `maxlength` restrictions on text fields and adds corresponding server side validation where feasible. (Note that when a field under validation is numeric, the `max` validates the value, not the length.