### PR TITLE
Adds checkin action on asset delete via View UI

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -780,9 +780,16 @@ class AssetsController extends Controller
         if ($asset = Asset::find($id)) {
             $this->authorize('delete', $asset);
 
-            DB::table('assets')
-                ->where('id', $asset->id)
-                ->update(['assigned_to' => null]);
+            if ($asset->assignedTo) {
+
+                $target = $asset->assignedTo;
+                $checkin_at = date('Y-m-d H:i:s');
+                $originalValues = $asset->getRawOriginal();
+                event(new CheckoutableCheckedIn($asset, $target, auth()->user(), 'Checkin on delete', $checkin_at, $originalValues));
+                DB::table('assets')
+                    ->where('id', $asset->id)
+                    ->update(['assigned_to' => null]);
+            }
 
             $asset->delete();
 

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -64,6 +64,7 @@ return [
     'checkout'  			=> 'Checkout',
     'checkouts_count'       => 'Checkouts',
     'checkins_count'        => 'Checkins',
+    'checkin_and_delete'  	=> 'Checkin and Delete',
     'user_requests_count'   => 'Requests',
     'city'  				=> 'City',
     'click_here'			=> 'Click here',

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -255,11 +255,16 @@
 
                                 @can('delete', $asset)
                                     <div class="col-md-12 hidden-print" style="padding-top: 30px; padding-bottom: 30px;">
+
                                         @if ($asset->deleted_at=='')
                                             <button class="btn btn-sm btn-block btn-danger btn-social delete-asset" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $asset->asset_tag]) }}" data-target="#dataConfirmModal">
 
                                                 <x-icon type="delete" />
-                                                {{ trans('general.delete') }}
+                                                @if ($asset->assignedTo)
+                                                    {{ trans('general.checkin_and_delete') }}
+                                                @else
+                                                    {{ trans('general.delete') }}
+                                                @endif
                                             </button>
                                             <span class="sr-only">{{ trans('general.delete') }}</span>
                                         @else


### PR DESCRIPTION
Previously, we would let you delete an asset that was checked out, and while we correctly logged the deletion, we didn't fire a checkin event. 

<img width="1477" alt="Screenshot 2024-10-01 at 2 28 02 PM" src="https://github.com/user-attachments/assets/c750d9ad-454e-4d96-b4ef-7911b395d920">
<img width="1479" alt="Screenshot 2024-10-01 at 2 28 13 PM" src="https://github.com/user-attachments/assets/df69d936-be10-4ec7-ab15-f55ffb9b7e68">
<img width="1477" alt="Screenshot 2024-10-01 at 2 28 39 PM" src="https://github.com/user-attachments/assets/a30a2596-8d69-49b0-8b66-a4bc6a2efb4a">
