### PR TITLE
WIP: "Orders" as a first-class object

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace App\Helpers;
+
+use App\Http\Requests\Request;
 use App\Models\Accessory;
 use App\Models\Asset;
 use App\Models\AssetModel;
@@ -9,6 +11,7 @@ use App\Models\Consumable;
 use App\Models\CustomField;
 use App\Models\CustomFieldset;
 use App\Models\Depreciation;
+use App\Models\Order;
 use App\Models\Setting;
 use App\Models\Statuslabel;
 use App\Models\License;

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\ImageUploadRequest;
 use App\Models\Actionlog;
 use App\Http\Requests\UploadFileRequest;
+use App\Models\Order;
 use Illuminate\Support\Facades\Log;
 use App\Models\Asset;
 use App\Models\AssetModel;
@@ -131,7 +132,7 @@ class AssetsController extends Controller
 
             $asset->company_id              = Company::getIdForCurrentUser($request->input('company_id'));
             $asset->model_id                = $request->input('model_id');
-            $asset->order_number            = $request->input('order_number');
+            $asset->order_id = Order::ensure($request, 'order_id');
             $asset->notes                   = $request->input('notes');
             $asset->created_by              = auth()->id();
             $asset->status_id               = request('status_id');
@@ -372,7 +373,7 @@ class AssetsController extends Controller
         $asset->name = $request->input('name');
         $asset->company_id = Company::getIdForCurrentUser($request->input('company_id'));
         $asset->model_id = $request->input('model_id');
-        $asset->order_number = $request->input('order_number');
+        $asset->order_id = Order::ensure($request, 'order_id');
 
         $asset_tags = $request->input('asset_tags');
         $asset->asset_tag = $request->input('asset_tags');

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\CheckInOutRequest;
 use App\Http\Controllers\Controller;
 use App\Models\Asset;
 use App\Models\AssetModel;
+use App\Models\Order;
 use App\Models\Statuslabel;
 use App\Models\Setting;
 use App\View\Label;
@@ -66,7 +67,7 @@ class BulkAssetsController extends Controller
             'last_checkout',
             'notes',
             'expected_checkin',
-            'order_number',
+            'order_id',
             'image',
             'assigned_to',
             'created_at',
@@ -233,7 +234,7 @@ class BulkAssetsController extends Controller
             || ($request->filled('expected_checkin'))
             || ($request->filled('purchase_cost'))
             || ($request->filled('supplier_id'))
-            || ($request->filled('order_number'))
+            || ($request->filled('order_id'))
             || ($request->filled('warranty_months'))
             || ($request->filled('rtd_location_id'))
             || ($request->filled('requestable'))
@@ -263,7 +264,7 @@ class BulkAssetsController extends Controller
                 $this->conditionallyAddItem('name')
                     ->conditionallyAddItem('purchase_date')
                     ->conditionallyAddItem('expected_checkin')
-                    ->conditionallyAddItem('order_number')
+//                    ->conditionallyAddItem('order_id')
                     ->conditionallyAddItem('requestable')
                     ->conditionallyAddItem('supplier_id')
                     ->conditionallyAddItem('warranty_months')
@@ -271,6 +272,10 @@ class BulkAssetsController extends Controller
                     foreach ($custom_field_columns as $key => $custom_field_column) {
                         $this->conditionallyAddItem($custom_field_column); 
                    }
+
+                if ($request->filled('order_id')) {
+                    $this->update_array['order_id'] = Order::ensure($request, 'order_id');
+                }
 
                 if (!($asset->eol_explicit)) {
 					if ($request->filled('model_id')) {

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -10,6 +10,8 @@ use Carbon\Carbon;
 use Carbon\Exceptions\InvalidFormatException;
 use Illuminate\Support\Facades\Gate;
 use App\Rules\AssetCannotBeCheckedOutToNondeployableStatus;
+use Illuminate\Validation\Validator;
+
 
 class StoreAssetRequest extends ImageUploadRequest
 {
@@ -65,6 +67,15 @@ class StoreAssetRequest extends ImageUploadRequest
             ['status_id' => [new AssetCannotBeCheckedOutToNondeployableStatus()]],
             parent::rules(),
         );
+    }
+
+    public function after()
+    {
+        return [
+            function (Validator $validator) {
+                //do _something_ to create an 'order' if needed? FIXME
+            }
+        ];
     }
 
     private function parseLastAuditDate(): void

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -61,7 +61,7 @@ class AssetsTransformer
                 'name'=> e($asset->supplier->name),
             ] : null,
             'notes' => ($asset->notes) ? Helper::parseEscapedMarkedownInline($asset->notes) : null,
-            'order_number' => ($asset->order_number) ? e($asset->order_number) : null,
+            'order_number' => ($asset->order) ? e($asset->order->order_number) : null, //FIXME
             'company' => ($asset->company) ? [
                 'id' => (int) $asset->company->id,
                 'name'=> e($asset->company->name),

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -38,7 +38,7 @@ class Accessory extends SnipeModel
      * 
      * @var array
      */
-    protected $searchableAttributes = ['name', 'model_number', 'order_number', 'purchase_date', 'notes'];
+    protected $searchableAttributes = ['name', 'model_number', 'purchase_date', 'notes'];
 
     /**
      * The relations and their attributes that should be included when searching the model.
@@ -51,6 +51,7 @@ class Accessory extends SnipeModel
         'manufacturer' => ['name'],
         'supplier'     => ['name'],
         'location'     => ['name'],
+        'order' => ['order_number']
     ];
 
     /**
@@ -129,6 +130,11 @@ class Accessory extends SnipeModel
     public function supplier()
     {
         return $this->belongsTo(\App\Models\Supplier::class, 'supplier_id');
+    }
+
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
     }
 
 

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -64,7 +64,8 @@ class Component extends SnipeModel
         'purchase_cost',
         'purchase_date',
         'min_amt',
-        'order_number',
+//        'order_number',
+        'order_id',
         'qty',
         'serial',
         'notes',
@@ -77,7 +78,7 @@ class Component extends SnipeModel
      *
      * @var array
      */
-    protected $searchableAttributes = ['name', 'order_number', 'serial', 'purchase_cost', 'purchase_date', 'notes'];
+    protected $searchableAttributes = ['name', 'serial', 'purchase_cost', 'purchase_date', 'notes'];
 
     /**
      * The relations and their attributes that should be included when searching the model.
@@ -89,6 +90,7 @@ class Component extends SnipeModel
         'company'      => ['name'],
         'location'     => ['name'],
         'supplier'     => ['name'],
+        'order' => ['order_number']
     ];
 
 
@@ -181,6 +183,11 @@ class Component extends SnipeModel
     public function supplier()
     {
         return $this->belongsTo(\App\Models\Supplier::class, 'supplier_id');
+    }
+
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
     }
 
     /**

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -76,7 +76,8 @@ class Consumable extends SnipeModel
         'location_id',
         'manufacturer_id',
         'name',
-        'order_number',
+//        'order_number',
+        'order_id',
         'model_number',
         'purchase_cost',
         'purchase_date',
@@ -93,7 +94,7 @@ class Consumable extends SnipeModel
      *
      * @var array
      */
-    protected $searchableAttributes = ['name', 'order_number', 'purchase_cost', 'purchase_date', 'item_no', 'model_number', 'notes'];
+    protected $searchableAttributes = ['name', 'purchase_cost', 'purchase_date', 'item_no', 'model_number', 'notes'];
 
     /**
      * The relations and their attributes that should be included when searching the model.
@@ -106,6 +107,7 @@ class Consumable extends SnipeModel
         'location'     => ['name'],
         'manufacturer' => ['name'],
         'supplier'     => ['name'],
+        'order' => ['order_number']
     ];
 
 
@@ -271,6 +273,10 @@ class Consumable extends SnipeModel
         return $this->belongsTo(Supplier::class, 'supplier_id');
     }
 
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
+    }
 
     /**
      * Determine whether to send a checkin/checkout email based on

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -72,7 +72,8 @@ class License extends Depreciable
         'category_id',
         'name',
         'notes',
-        'order_number',
+//        'order_number',
+        'order_id',
         'purchase_cost',
         'purchase_date',
         'purchase_order',
@@ -96,7 +97,7 @@ class License extends Depreciable
         'name',
         'serial',
         'notes',
-        'order_number',
+//        'order_number',
         'purchase_order',
         'purchase_cost',
         'purchase_date',
@@ -113,6 +114,7 @@ class License extends Depreciable
         'company'      => ['name'],
         'category'     => ['name'],
         'depreciation' => ['name'],
+        'order' => ['order_number']
     ];
     protected $appends = ['free_seat_count'];
 
@@ -327,6 +329,12 @@ class License extends Depreciable
     {
         return $this->belongsTo(\App\Models\Manufacturer::class, 'manufacturer_id');
     }
+
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
+    }
+
 
     /**
      * Determine whether the user should be emailed on checkin/checkout

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+//use App\Http\Requests\Request;
+use Illuminate\Http\Request; //FIXME - which request to use?!?!!?
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['order_number'];
+
+    //TODO - should this go in a formrequest or something?
+    //TODO - I feel slightly oogie having a *model* that's looking at a *request* ...
+    public static function ensure(Request $request, $input_name): ?int
+    {
+        if($request->input($input_name) == '') {
+            return null;
+        }
+        if($request->input($input_name) && $request->input($input_name) != -1) {
+            return $request->input($input_name);
+        }
+        return Order::firstOrCreate(['order_number' => $request->input($input_name."_new_order")])->id;
+    }
+
+
+    function assets() {
+        return $this->hasMany(Asset::class);
+    }
+
+    function components() {
+        return $this->hasMany(Component::class);
+    }
+
+    function licenses() {
+        return $this->hasMany(License::class);
+    }
+
+    function  accessories() {
+        return $this->hasMany(Accessory::class);
+    }
+
+    function consumables() {
+        return $this->hasMany(Consumable::class);
+    }
+}

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -6,6 +6,7 @@ use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\CustomField;
 use App\Models\Location;
+use App\Models\Order;
 use App\Models\Statuslabel;
 use App\Models\Supplier;
 use App\Models\User;
@@ -41,7 +42,7 @@ class AssetFactory extends Factory
             'notes'   => 'Created by DB seeder',
             'purchase_date' => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get())->format('Y-m-d'),
             'purchase_cost' => $this->faker->randomFloat(2, '299.99', '2999.99'),
-            'order_number' => (string) $this->faker->numberBetween(1000000, 50000000),
+            'order_id' => Order::factory(),
             'supplier_id' => Supplier::factory(),
             'requestable' => $this->faker->boolean(),
             'assigned_to' => null,

--- a/database/factories/ComponentFactory.php
+++ b/database/factories/ComponentFactory.php
@@ -9,6 +9,7 @@ use App\Models\Company;
 use App\Models\Component;
 use App\Models\Consumable;
 use App\Models\Location;
+use App\Models\Order;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -36,7 +37,7 @@ class ComponentFactory extends Factory
             'location_id' => Location::factory(),
             'serial'   => $this->faker->uuid(),
             'qty' => $this->faker->numberBetween(3, 10),
-            'order_number' => $this->faker->numberBetween(1000000, 50000000),
+            'order_id' => Order::factory(),
             'purchase_date' => $this->faker->dateTime()->format('Y-m-d'),
             'purchase_cost' => $this->faker->randomFloat(2),
             'min_amt' => $this->faker->numberBetween($min = 1, $max = 2),

--- a/database/factories/ConsumableFactory.php
+++ b/database/factories/ConsumableFactory.php
@@ -6,6 +6,7 @@ use App\Models\Category;
 use App\Models\Company;
 use App\Models\Consumable;
 use App\Models\Manufacturer;
+use App\Models\Order;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -32,7 +33,7 @@ class ConsumableFactory extends Factory
             'category_id' => Category::factory(),
             'created_by' => User::factory()->superuser(),
             'item_no' => $this->faker->numberBetween(1000000, 50000000),
-            'order_number' => $this->faker->numberBetween(1000000, 50000000),
+            'order_id' => Order::factory(),
             'purchase_date' => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get())->format('Y-m-d'),
             'purchase_cost' => $this->faker->randomFloat(2, 1, 50),
             'qty' => $this->faker->numberBetween(5, 10),

--- a/database/factories/LicenseFactory.php
+++ b/database/factories/LicenseFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 use App\Models\Category;
 use App\Models\License;
 use App\Models\Manufacturer;
+use App\Models\Order;
 use App\Models\Supplier;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -32,7 +33,7 @@ class LicenseFactory extends Factory
             'notes'   => 'Created by DB seeder',
             'seats' => $this->faker->numberBetween(1, 10),
             'purchase_date' => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get())->format('Y-m-d'),
-            'order_number' => $this->faker->numberBetween(1000000, 50000000),
+            'order_id' => Order::factory(),
             'expiration_date' => $this->faker->dateTimeBetween('now', '+3 years', date_default_timezone_get())->format('Y-m-d H:i:s'),
             'reassignable' => $this->faker->boolean(),
             'termination_date' => $this->faker->dateTimeBetween('-1 years', 'now', date_default_timezone_get())->format('Y-m-d H:i:s'),

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Order>
+ */
+class OrderFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'order_number' =>(string) $this->faker->numberBetween(1000000, 50000000)
+        ];
+    }
+}

--- a/database/migrations/2024_09_30_133307_create_orders_table.php
+++ b/database/migrations/2024_09_30_133307_create_orders_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('orders', function (Blueprint $table) {
+            $table->id();
+            $table->string('order_number')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('orders');
+    }
+};

--- a/database/migrations/2024_09_30_133758_change_order_numbers_to_ids.php
+++ b/database/migrations/2024_09_30_133758_change_order_numbers_to_ids.php
@@ -19,9 +19,8 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $order_hash = [];
         foreach(self::$tables as $table_name) {
-            Schema::table($table_name, function (Blueprint $table) use ($table_name,$order_hash) {
+            Schema::table($table_name, function (Blueprint $table) use ($table_name) {
                 //
                 $table->integer('order_id')->nullable()->default(null)->after('order_number');
                 $table->renameColumn('order_number', 'deprecated_order_number');

--- a/database/migrations/2024_09_30_133758_change_order_numbers_to_ids.php
+++ b/database/migrations/2024_09_30_133758_change_order_numbers_to_ids.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    static $tables = [
+        'assets',
+        'components',
+        'licenses',
+        'accessories',
+        'consumables'
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $order_hash = [];
+        foreach(self::$tables as $table_name) {
+            Schema::table($table_name, function (Blueprint $table) use ($table_name,$order_hash) {
+                //
+                $table->integer('order_id')->nullable()->default(null)->after('order_number');
+                $table->renameColumn('order_number', 'deprecated_order_number');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        foreach(self::$tables as $table_name) {
+            Schema::table($table_name, function (Blueprint $table) {
+                //
+                $table->dropColumn('order_id');
+                $table->renameColumn('deprecated_order_number','order_number');
+            });
+        }
+    }
+};

--- a/database/migrations/2024_09_30_154450_migrate_order_numbers.php
+++ b/database/migrations/2024_09_30_154450_migrate_order_numbers.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\Order;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    static $tables = [
+        'assets',
+        'components',
+        'licenses',
+        'accessories',
+        'consumables'
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $order_hash = [];
+        foreach (self::$tables as $table_name) {
+            DB::table($table_name)->select(['id', 'deprecated_order_number'])->whereNotNull('deprecated_order_number')->orderBy('id')->chunk(100, function (Collection $order_numbers) use ($order_hash, $table_name) {
+                foreach ($order_numbers as $order) {
+                    if (!array_key_exists($order->deprecated_order_number, $order_hash)) {
+                        $order_record = Order::create(['order_number' => $order->deprecated_order_number]);
+                        $order_hash[$order->deprecated_order_number] = $order_record->id;
+                    }
+                    DB::table($table_name)->where('id', $order->id)->update(['order_id' => $order_hash[$order->deprecated_order_number]]);
+                }
+            });
+
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -597,3 +597,22 @@ document.addEventListener('livewire:init', () => {
         });
     });
 });
+
+/**
+ * JS Helper for Select2 drop-down lists that handle orders.
+ *
+ * This populates the 'order_id' with -1, which is a 'sentinel' which should let us know that this is going to be
+ * a new order. It also populates a hidden field with the new order number so the back-end can create it if/when the
+ * form is submitted.
+ */
+$('.order-select').select2({
+    createTag: function (params) {
+        var order_number = $.trim(params.term)
+        var prefix = this.$element.data('create-new');
+        $('#' + this.$element[0].name + "_new_order").val(order_number)
+        return {
+            id: -1,
+            text: prefix + order_number
+        };
+    }
+})

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -266,6 +266,8 @@ return [
     'select_statuslabel'	=> 'Select Status',
     'select_company'    	=> 'Select Company',
     'select_asset'    		=> 'Select Asset',
+    'select_order' => 'Select or Create New Order',
+    'select_create_new_order' => 'New Order: ',
     'settings'				=> 'Settings',
     'show_deleted'  		=> 'Show Deleted',
     'show_current'  		=> 'Show Current',

--- a/resources/views/blade/order_number.blade.php
+++ b/resources/views/blade/order_number.blade.php
@@ -1,0 +1,30 @@
+@props(['value' => '','name' => 'order_id','div_class' => ''])
+<div class="form-group {{ $errors->has($name) ? ' has-error' : '' }}">
+    <label for="order_number" class="col-md-3 control-label">{{ trans('general.order_number') }}</label>
+    <div class="{{ $div_class }}">
+        <select name="{{ $name }}"
+                {{ $attributes->merge(['class' => 'select2 order-select']) }} aria-label="{{ $name }}"
+                id="{{ $name }}"
+                data-allow-clear="true" data-placeholder="{{ trans('general.select_order') }}" data-tags="true"
+                data-create-new="{{ trans('general.select_create_new_order') }}"
+                style="width:100%">
+            <option>{{-- Required to make an 'unselectable' first thing --}}</option>
+            @foreach(App\Models\Order::orderBy('order_number')->get() as $order)
+                <option value="{{ $order->id }}"
+                        {{ $order->id == $value ? " selected='selected'": "" }} role="option">{{ $order->order_number }}</option>
+            @endforeach
+        </select>
+        <input type="hidden" name="{{ $name }}_new_order" id="{{ $name }}_new_order" value=""/>
+        {!! $errors->first($name, '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+    </div>
+</div>
+{{-- Alison wants to add 'data-tags="true"' to inline-create an order... --}}
+{{--
+   <div class="col-md-7 col-sm-12">
+       <input class="form-control" type="text" name="order_number" aria-label="order_number" id="order_number" value="{{ old('order_number', $item->order_number) }}" />
+       {!! $errors->first('order_number', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+   </div>
+
+
+
+--}}

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -148,15 +148,7 @@
           @include ('partials.forms.edit.company-select', ['translated_name' => trans('general.company'), 'fieldname' => 'company_id'])
 
           <!-- Order Number -->
-          <div class="form-group {{ $errors->has('order_number') ? ' has-error' : '' }}">
-            <label for="order_number" class="col-md-3 control-label">
-              {{ trans('admin/hardware/form.order') }}
-            </label>
-            <div class="col-md-7">
-              <input class="form-control" type="text" maxlength="200" name="order_number" id="order_number" value="{{ old('order_number') }}" />
-              {!! $errors->first('order_number', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-            </div>
-          </div>
+          <x-order_number div_class="col-md-7"/>
 
           <!-- Warranty -->
           <div class="form-group {{ $errors->has('warranty_months') ? ' has-error' : '' }}">

--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -160,7 +160,9 @@
 
         <div id='order_details' class="col-md-12" style="display:none">
             <br>
-            @include ('partials.forms.edit.order_number')
+            {{--            @include ('partials.forms.edit.order_number')--}}
+            <x-order_number :value="$item->order_id"
+                            div_class="col-md-7 col-sm-12"/> {{-- div_class was: 'col-md-7 col-sm-12' --}}
             @include ('partials.forms.edit.purchase_date')
             @include ('partials.forms.edit.eol_date')
             @include ('partials.forms.edit.supplier-select', ['translated_name' => trans('general.supplier'), 'fieldname' => 'supplier_id'])

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -804,7 +804,7 @@
                                             </div>
                                         </div>
                                     @endif
-                                    @if ($asset->order_number)
+                                        @if ($asset->order)
                                         <div class="row">
                                             <div class="col-md-3">
                                                 <strong>
@@ -812,7 +812,8 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-9">
-                                                <a href="{{ route('hardware.index', ['order_number' => $asset->order_number]) }}">{{ $asset->order_number }}</a>
+                                                {{-- FIXME - we should probably route to the *ORDER* itself? --}}
+                                                <a href="{{ route('hardware.index', ['order_id' => $asset->order->id]) }}">{{ $asset->order->order_number }}</a>
                                             </div>
                                         </div>
                                     @endif

--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -45,7 +45,7 @@ class StoreAssetTest extends TestCase
                 'model_id' => $model->id,
                 'name' => 'A New Asset',
                 'notes' => 'Some notes',
-                'order_number' => '5678',
+                'order_number' => '5678', //yes, this *is* order_number
                 'purchase_cost' => '123.45',
                 'purchase_date' => '2023-09-02',
                 'requestable' => true,
@@ -72,7 +72,7 @@ class StoreAssetTest extends TestCase
         $this->assertTrue($asset->model->is($model));
         $this->assertEquals('A New Asset', $asset->name);
         $this->assertEquals('Some notes', $asset->notes);
-        $this->assertEquals('5678', $asset->order_number);
+        $this->assertEquals('5678', $asset->order->order_number);
         $this->assertEquals('123.45', $asset->purchase_cost);
         $this->assertTrue($asset->purchase_date->is('2023-09-02'));
         $this->assertEquals('1', $asset->requestable);

--- a/tests/Feature/Assets/Api/UpdateAssetTest.php
+++ b/tests/Feature/Assets/Api/UpdateAssetTest.php
@@ -90,7 +90,7 @@ class UpdateAssetTest extends TestCase
         $this->assertTrue($updatedAsset->model->is($model));
         $this->assertEquals('A New Asset', $updatedAsset->name);
         $this->assertEquals('Some notes', $updatedAsset->notes);
-        $this->assertEquals('5678', $updatedAsset->order_number);
+        $this->assertEquals('5678', $updatedAsset->order->order_number);
         $this->assertEquals('123.45', $updatedAsset->purchase_cost);
         $this->assertTrue($updatedAsset->purchase_date->is('2023-09-02'));
         $this->assertEquals('1', $updatedAsset->requestable);

--- a/tests/Feature/Assets/Ui/BulkEditAssetsTest.php
+++ b/tests/Feature/Assets/Ui/BulkEditAssetsTest.php
@@ -6,6 +6,7 @@ use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Company;
 use App\Models\CustomField;
+use App\Models\Order;
 use App\Models\Statuslabel;
 use App\Models\Supplier;
 use App\Models\User;
@@ -66,7 +67,7 @@ class BulkEditAssetsTest extends TestCase
             'purchase_cost'    => 1234.90,
             'supplier_id'      => $supplier1->id,
             'company_id'       => $company1->id,
-            'order_number'     => '123456',
+            'order_id' => Order::factory()->create(['order_number' => '123456']),
             'warranty_months'  => 24,
             'next_audit_date'  => '2024-06-01',
             'requestable'      => false
@@ -86,7 +87,7 @@ class BulkEditAssetsTest extends TestCase
             'purchase_cost'    => 5678.92,
             'supplier_id'      => $supplier2->id,
             'company_id'       => $company2->id,
-            'order_number'     => '7890',
+            'order_id' => Order::factory()->create(['order_number' => '7890'])->id,
             'warranty_months'  => 36,
             'next_audit_date'  => '2025-01-01',
             'requestable'      => true
@@ -104,7 +105,7 @@ class BulkEditAssetsTest extends TestCase
             $this->assertEquals(5678.92, $asset->purchase_cost);
             $this->assertEquals($supplier2->id, $asset->supplier_id);
             $this->assertEquals($company2->id, $asset->company_id);
-            $this->assertEquals(7890, $asset->order_number);
+            $this->assertEquals(7890, $asset->order->order_number);
             $this->assertEquals(36, $asset->warranty_months);
             $this->assertEquals('2025-01-01', $asset->next_audit_date);
             // shouldn't requestable be cast as a boolean??? it's not.
@@ -134,7 +135,7 @@ class BulkEditAssetsTest extends TestCase
             'purchase_cost'    => 1234.90,
             'supplier_id'      => $supplier1->id,
             'company_id'       => $company1->id,
-            'order_number'     => '123456',
+            'order_id' => Order::factory()->create(['order_number' => '123456']),
             'warranty_months'  => 24,
             'next_audit_date'  => '2024-06-01',
             'requestable'      => false


### PR DESCRIPTION
This is the _start_ for beginning to make Orders into a first-class object - that can be used across any of the other objects we have that had an `order_number`. Now they all have `order_id` and there's a new `orders` table that has, for now, just `order_number`. I also included a migration that populates the `orders` table and the various `order_id` values to point back to it.

This should (hopefully) give us the ability to flesh out this ordering system in order to better support re-ordering accessories, components, assets, etc. But, first, we need a table, rather than just a simple `order_number`.

I opted to keep the API the _same_ - so it still takes `order_number` as a field name, and will automatically create orders as needed.

I have all of Assets handled at this point, but I need to continue to go through the rest of accessories, components, licenses, etc to get them all working as well. I've only handled their Models so far.

For some bizarre reason, I *cannot* get the tests to pass on sqlite, at all - it comes up with a ton of failures. I have no idea what's going on there.

# Screenshots

## Show Asset:

(Note the URL preview points to the `order_id`, rather than the order number. I'm not committed to doing that yet - I may keep it with `order_number` for a little bit and handle that on the next pass).

<img width="1767" alt="Screenshot 2024-10-01 at 3 58 19 PM" src="https://github.com/user-attachments/assets/2fdca05f-d779-40d4-990d-eb062209d234">

## Edit Asset (with an existing order attached):

<img width="822" alt="Screenshot 2024-10-01 at 4 02 54 PM" src="https://github.com/user-attachments/assets/dcd0e39f-fe72-404f-91c8-2188eed0d20e">

## Edit Asset (with the order unassociated):

<img width="813" alt="Screenshot 2024-10-01 at 4 03 05 PM" src="https://github.com/user-attachments/assets/66e88ecf-4965-4c2e-810c-2a570f6381de">

## Edit Asset (creating a new order):

<img width="864" alt="Screenshot 2024-10-01 at 4 03 16 PM" src="https://github.com/user-attachments/assets/c7312ca6-4bb3-4a22-802e-8a78c8404d5a">

## Bulk Edit:

<img width="913" alt="Screenshot 2024-10-01 at 7 09 53 PM" src="https://github.com/user-attachments/assets/87b84c70-a101-4f96-8728-1c9abe010e7c">
