### PR TITLE
Catch Errors Around Request Notifications

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -240,7 +240,7 @@ class AcceptanceController extends Controller
             try {
                 $acceptance->notify(new AcceptanceAssetAcceptedNotification($data));
             } catch (\Exception $e) {
-                Log::error($e);
+                Log::warning($e);
             }
             event(new CheckoutAccepted($acceptance));
 

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -183,7 +183,7 @@ class ViewAssetsController extends Controller
             try {
                 $settings->notify(new RequestAssetCancelation($data));
             } catch (\Exception $e) {
-                Log::error($e);
+                Log::warning($e);
             }
             return redirect()->route('requestable-assets')
                 ->with('success')->with('success', trans('admin/hardware/message.requests.canceled'));
@@ -195,7 +195,7 @@ class ViewAssetsController extends Controller
         try {
             $settings->notify(new RequestAssetNotification($data));
         } catch (\Exception $e) {
-            Log::error($e);
+            Log::warning($e);
         }
 
         return redirect()->route('requestable-assets')->with('success')->with('success', trans('admin/hardware/message.requests.success'));

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -13,6 +13,7 @@ use App\Notifications\RequestAssetNotification;
 use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
 use \Illuminate\Contracts\View\View;
+use Log;
 
 /**
  * This controller handles all actions related to the ability for users
@@ -179,8 +180,11 @@ class ViewAssetsController extends Controller
             $asset->decrement('requests_counter', 1);
 
             $logaction->logaction('request canceled');
-            $settings->notify(new RequestAssetCancelation($data));
-
+            try {
+                $settings->notify(new RequestAssetCancelation($data));
+            } catch (\Exception $e) {
+                Log::error($e);
+            }
             return redirect()->route('requestable-assets')
                 ->with('success')->with('success', trans('admin/hardware/message.requests.canceled'));
         }
@@ -188,7 +192,11 @@ class ViewAssetsController extends Controller
         $logaction->logaction('requested');
         $asset->request();
         $asset->increment('requests_counter', 1);
-        $settings->notify(new RequestAssetNotification($data));
+        try {
+            $settings->notify(new RequestAssetNotification($data));
+        } catch (\Exception $e) {
+            Log::error($e);
+        }
 
         return redirect()->route('requestable-assets')->with('success')->with('success', trans('admin/hardware/message.requests.success'));
     }


### PR DESCRIPTION
# Description
Happened to notice a couple more uncaught mail authentication errors while requesting assets - just wrapped them in try/catches with logging. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
