### PR TITLE
Custom Field Existence Validation Issue

### DIFF
--- a/app/Http/Requests/Traits/MayContainCustomFields.php
+++ b/app/Http/Requests/Traits/MayContainCustomFields.php
@@ -23,7 +23,7 @@ trait MayContainCustomFields
                 return str_starts_with($attributes, '_snipeit_');
             });
             // if there are custom fields, find the one's that don't exist on the model's fieldset and add an error to the validator's error bag
-            if (count($request_fields) > 0) {
+            if (count($request_fields) > 0 && $validator->errors()->isEmpty()) {
                 $request_fields->diff($asset_model?->fieldset?->fields?->pluck('db_column'))
                         ->each(function ($request_field_name) use ($request_fields, $validator) {
                             if (CustomField::where('db_column', $request_field_name)->exists()) {


### PR DESCRIPTION
# Description
Very strange bug, and I'm not sure @marcusmoore or I really understand it, but added an extra check to determine that the initial validation passes before performing the validation provided by this trait. 🤷‍♂️ Pretty annoyed about it, but hopefully this fixes the issue once and for all. 

- [x] Bug fix (non-breaking change which fixes an issue)

