### PR TITLE
Added `Model::reguard()` to importer

### DIFF
--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -164,6 +164,7 @@ abstract class Importer
 
                 $this->log('------------- Action Summary ----------------');
             }
+            Model::reguard();
         });
     }
 


### PR DESCRIPTION
# Description

This PR adds `Model::reguard()` to match the `Model::unguard()` a [few lines above it](https://github.com/snipe/snipe-it/blob/4363e8b34c2b94d94543a6988fd026449a01e04a/app/Importer/Importer.php#L157) in the importer.

This should fix the broken tests in #15579 that are unrelated to the focus of that PR.


## Type of change

- [x] Bug fix (kinda?)
