### PR TITLE
Fix numeric sort 'ambiguous order clause' error

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -395,7 +395,7 @@ class AssetsController extends Controller
 
                     // This may not work for all databases, but it works for MySQL
                     if ($numeric_sort) {
-                        $assets->orderByRaw($sort_override . ' * 1 ' . $order);
+                        $assets->orderByRaw(DB::getTablePrefix() . 'assets.' . $sort_override . ' * 1 ' . $order);
                     } else {
                         $assets->orderBy($sort_override, $order);
                     }


### PR DESCRIPTION
With the new addition of the 'numeric sort' of custom fields, we introduced a bug in the `SortByRaw()` clause - were we needed to include the table alias of `assets` (which is `assets` since we have no alias). I also made sure to put in the DB prefix part in there so we should hopefully not mess those folks up either.