### PR TITLE
Fixes print assigned in profile

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -194,14 +194,14 @@ class ProfileController extends Controller
      */
     public function printInventory() : View
     {
-        $show_user = auth()->user();
+        $show_users = User::where('id',auth()->user()->id)->get();
 
         return view('users/print')
-            ->with('assets', auth()->user()->assets)
-            ->with('licenses', $show_user->licenses()->get())
-            ->with('accessories', $show_user->accessories()->get())
-            ->with('consumables', $show_user->consumables()->get())
-            ->with('show_user', $show_user)
+            ->with('assets', auth()->user()->assets())
+            ->with('licenses', auth()->user()->licenses()->get())
+            ->with('accessories', auth()->user()->accessories()->get())
+            ->with('consumables', auth()->user()->consumables()->get())
+            ->with('users', $show_users)
             ->with('settings', Setting::getSettings());
     }
 
@@ -222,7 +222,12 @@ class ProfileController extends Controller
             return redirect()->back()->with('error', trans('admin/users/message.user_has_no_email'));
         }
 
-        $user->notify((new CurrentInventory($user)));
+        try {
+            $user->notify((new CurrentInventory($user)));
+        } catch (\Exception $e) {
+            \Log::error($e);
+        }
+
         return redirect()->back()->with('success', trans('admin/users/general.user_notified'));
     }
 }

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -103,20 +103,23 @@
                 </div>
                 @can('self.profile')
                   <div class="col-md-12">
-                    <a href="{{ route('profile') }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print">
+                    <a href="{{ route('profile') }}" style="width: 100%;" class="btn btn-sm btn-warning btn-social btn-block hidden-print">
+                      <x-icon type="edit" />
                       {{ trans('general.editprofile') }}
                     </a>
                   </div>
                 @endcan
                 <div class="col-md-12" style="padding-top: 5px;">
-                  <a href="{{ route('account.password.index') }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print" target="_blank" rel="noopener">
+                  <a href="{{ route('account.password.index') }}" style="width: 100%;" class="btn btn-sm btn-primary btn-social btn-block hidden-print" target="_blank" rel="noopener">
+                    <x-icon type="password" class="fa-fw" />
                     {{ trans('general.changepassword') }}
                   </a>
                 </div>
 
                 @can('self.api')
                 <div class="col-md-12" style="padding-top: 5px;">
-                  <a href="{{ route('user.api') }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print" target="_blank" rel="noopener">
+                  <a href="{{ route('user.api') }}" style="width: 100%;" class="btn btn-sm btn-primary btn-social btn-block hidden-print" target="_blank" rel="noopener">
+                    <x-icon type="api-key" class="fa-fw" />
                     {{ trans('general.manage_api_keys') }}
                   </a>
                 </div>
@@ -124,7 +127,8 @@
 
 
                   <div class="col-md-12" style="padding-top: 5px;">
-                    <a href="{{ route('profile.print') }}" style="width: 100%;" class="btn btn-sm btn-primary hidden-print" target="_blank" rel="noopener">
+                    <a href="{{ route('profile.print') }}" style="width: 100%;" class="btn btn-sm btn-primary btn-social btn-block hidden-print" target="_blank" rel="noopener">
+                      <x-icon type="print" class="fa-fw" />
                       {{ trans('admin/users/general.print_assigned') }}
                     </a>
                   </div>
@@ -134,10 +138,15 @@
                     @if (!empty($user->email))
                       <form action="{{ route('profile.email_assets') }}" method="POST">
                         {{ csrf_field() }}
-                        <button style="width: 100%;" class="btn btn-sm btn-primary hidden-print" rel="noopener">{{ trans('admin/users/general.email_assigned') }}</button>
+                        <button style="width: 100%;" class="btn btn-sm btn-primary btn-social btn-block hidden-print" rel="noopener">
+                          <x-icon type="email" class="fa-fw" />
+                          {{ trans('admin/users/general.email_assigned') }}
+                        </button>
                       </form>
                     @else
-                      <button style="width: 100%;" class="btn btn-sm btn-primary hidden-print" rel="noopener" disabled title="{{ trans('admin/users/message.user_has_no_email') }}">{{ trans('admin/users/general.email_assigned') }}</button>
+                      <button style="width: 100%;" class="btn btn-sm btn-primary hidden-print" rel="noopener" disabled title="{{ trans('admin/users/message.user_has_no_email') }}">
+                        {{ trans('admin/users/general.email_assigned') }}
+                      </button>
                     @endif
                   </div>
 

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -2,7 +2,7 @@
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    @if (count($users) === 1)
+    @if ((isset($users) && count($users) === 1))
         <title>{{ trans('general.assigned_to', ['name' => $users[0]->present()->fullName()]) }} - {{ date('Y-m-d H:i', time()) }}</title>
     @else
         <title>{{ trans('admin/users/general.print_assigned') }} - {{ date('Y-m-d H:i', time()) }}</title>


### PR DESCRIPTION
This addresses a regression created in #15534 where printing multiple users was possible, but if a user tried to print their own assets, it would 500 since we were not returning a collection. 

I also took the opportunity to update the buttons to reflect the newer style (left aligned, with an icon.)

### Before
<img width="1512" alt="Screenshot 2024-10-03 at 4 21 48 PM" src="https://github.com/user-attachments/assets/749c46d7-be22-4ea4-90ab-873614a9a1bb">

### After

<img width="1512" alt="Screenshot 2024-10-03 at 4 22 30 PM" src="https://github.com/user-attachments/assets/b11cb96d-d60c-4c06-99fe-67f8ee9a2c1d">