### PR TITLE
Docker Env: Change trusted proxies to RFC1918

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -97,7 +97,7 @@ API_TOKEN_EXPIRATION_YEARS=40
 # --------------------------------------------
 # OPTIONAL: SECURITY HEADER SETTINGS
 # --------------------------------------------
-APP_TRUSTED_PROXIES=192.168.1.1,10.0.0.1,172.0.0.0/8
+APP_TRUSTED_PROXIES=192.168.1.1,10.0.0.1,172.16.0.0/12
 ALLOW_IFRAMING=false
 REFERRER_POLICY=same-origin
 ENABLE_CSP=false


### PR DESCRIPTION
# Description

Updated `APP_TRUSTED_PROXIES` in `.env.docker`, changing `172.0.0.0/8` to `172.16.0.0/12` to conform with RFC1918 (Address Allocation for Private Internets), the current default is trusting public IPs for reverse proxying.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Verified that addresses outside `172.16/12` but still inside `172/8`  are not trusted proxies. 

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
