### PR TITLE
Removed duplicate JS and removed line break before user section

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -36,11 +36,7 @@
         @page {
             size: A4;
         }
-
-        #start_of_user_section {
-            break-before: page;
-        }
-
+        
         .print-logo {
             max-height: 40px;
         }
@@ -51,13 +47,6 @@
         }
     </style>
 
-    <script nonce="{{ csrf_token() }}">
-        window.snipeit = {
-            settings: {
-                "per_page": 50
-            }
-        };
-    </script>
 
 </head>
 <body>


### PR DESCRIPTION
This is a small fix for the "Print all assigned to selected users" that was recently introduced, which was causing a line break right after the logo. (Related to #15534)

### Before

<img width="1629" alt="Screenshot 2024-10-07 at 11 10 26 AM" src="https://github.com/user-attachments/assets/a5b0817d-be99-4f77-bc6a-299ea21c49fe">


### After

<img width="1629" alt="Screenshot 2024-10-07 at 11 09 06 AM" src="https://github.com/user-attachments/assets/9d45f735-62fa-4465-b2d6-2d0eba151651">