### PR TITLE
Only show EULA when available on print users page

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -373,8 +373,11 @@
         </table>
     @endif
 
+    @php
+        if (!empty($eulas)) $eulas = array_unique($eulas);
+    @endphp
     {{-- This may have been render at the top of the page if we're rendering more than one user... --}}
-    @if (count($users) === 1)
+    @if (count($users) === 1 && !empty($eulas))
         <p></p>
         <div class="pull-right">
             <button class="btn btn-default hidden-print" type="button" data-toggle="collapse" data-target=".eula-row" aria-expanded="false" aria-controls="eula-row" title="EULAs">
@@ -384,19 +387,16 @@
     @endif
 
     <table style="margin-top: 80px;">
+        @if (!empty($eulas))
         <tr class="collapse eula-row">
             <td style="padding-right: 10px; vertical-align: top; font-weight: bold;">EULA</td>
             <td style="padding-right: 10px; vertical-align: top; padding-bottom: 80px;" colspan="3">
-                @php
-                    if (!empty($eulas)) $eulas = array_unique($eulas);
-                @endphp
-                @if (!empty($eulas))
-                    @foreach ($eulas as $key => $eula)
-                        {!! $eula !!}
-                    @endforeach
-                @endif
+                @foreach ($eulas as $key => $eula)
+                    {!! $eula !!}
+                @endforeach
             </td>
         </tr>
+        @endif
         <tr>
             <td style="padding-right: 10px; vertical-align: top; font-weight: bold;">{{ trans('general.signed_off_by') }}:</td>
             <td style="padding-right: 10px; vertical-align: top;">______________________________________</td>


### PR DESCRIPTION
# Description

This PR updates how the print user(s) view displays EULAs.

---

Existing behavior for users with EULAs to display is preserved:
![existing behavior](https://github.com/user-attachments/assets/24868d3b-34b4-44bf-ba14-cc5dd80ecbd8)

---

When printing a single user that does not have EULAS to display the button is not shown:
![button not shown](https://github.com/user-attachments/assets/3e66c370-5ee4-4f56-95d4-8cdfa8927b33)

---

When bulk printing the button will show the EULA section for users that have EULAs but skip displaying the "EULA" label for users that do not:
![bulk print](https://github.com/user-attachments/assets/e21ad445-ec45-4251-8b5a-118152225de2)


---

Fixes [sc-27028]

## Type of change

- [x] Bug fix (ish)
