### PR TITLE
FIXED: Badge counter showing deleted assets on User page

### DIFF
--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -31,7 +31,7 @@
             <x-icon type="assets" class="fa-2x" />
             </span>
             <span class="hidden-xs hidden-sm">{{ trans('general.assets') }}
-              {!! ($user->assets()->AssetsForShow()->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($user->assets()->AssetsForShow()->count()).'</badge>' : '' !!}
+              {!! ($user->assets()->AssetsForShow()->count() > 0 ) ? '<badge class="badge badge-secondary">'.number_format($user->assets()->AssetsForShow()->withoutTrashed()->count()).'</badge>' : '' !!}
             </span>
           </a>
         </li>


### PR DESCRIPTION
# Description
Users who had deleted items that were still assigned to a user, were having those assets counted in the badge counter on the user view page. This fixes that bug.
<img width="400" alt="Screenshot 2024-10-08 at 4 41 37 PM" src="https://github.com/user-attachments/assets/f27dbe35-aec8-48a2-a690-c392d56ec50d">
<img width="389" alt="Screenshot 2024-10-08 at 4 41 55 PM" src="https://github.com/user-attachments/assets/ece97283-03b4-467e-a17f-dc97c5993c45">


Fixes #15289

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested locally by force deleting an asset in TablePlus, and then checking the badge count.
Tests also run via test suite

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
