### PR TITLE
Fix bulk checkout to users, assets, and locations

### DIFF
--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -34,6 +34,8 @@
            'required' => true,
            'asset_status_type' => 'RTD',
            'select_id' => 'assigned_assets_select',
+           'asset_selector_div_id' => 'assets_to_checkout_div',
+           'asset_ids' => old('selected_assets')
          ])
 
 
@@ -42,7 +44,7 @@
           @include ('partials.forms.checkout-selector', ['user_select' => 'true','asset_select' => 'true', 'location_select' => 'true'])
 
           @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.user'), 'fieldname' => 'assigned_user'])
-          @include ('partials.forms.edit.asset-select', ['translated_name' => trans('general.asset'), 'fieldname' => 'assigned_asset', 'unselect' => 'true', 'style' => 'display:none;'])
+            @include ('partials.forms.edit.asset-select', ['translated_name' => trans('general.asset'), 'asset_selector_div_id' => 'assigned_asset', 'fieldname' => 'assigned_asset', 'unselect' => 'true', 'style' => 'display:none;'])
           @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'assigned_location', 'style' => 'display:none;'])
 
           <!-- Checkout/Checkin Date -->

--- a/resources/views/partials/forms/edit/asset-select.blade.php
+++ b/resources/views/partials/forms/edit/asset-select.blade.php
@@ -1,5 +1,6 @@
 <!-- Asset -->
-<div id="assigned_asset" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
+<div id="{{ $asset_selector_div_id ?? "assigned_asset" }}"
+     class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
     {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
     <div class="col-md-7">
         <select class="js-data-ajax select2" data-endpoint="hardware" data-placeholder="{{ trans('general.select_asset') }}" aria-label="{{ $fieldname }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_asset_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}{!! (!empty($asset_status_type)) ? ' data-asset-status-type="' . $asset_status_type . '"' : '' !!}{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}>
@@ -11,6 +12,15 @@
             @else
                 @if(!isset($multiple))
                     <option value=""  role="option">{{ trans('general.select_asset') }}</option>
+                @else
+                    @if(isset($asset_ids))
+                        @foreach($asset_ids as $asset_id)
+                            <option value="{{ $asset_id }}" selected="selected" role="option" aria-selected="true"
+                                    role="option">
+                                {{ (\App\Models\Asset::find($asset_id)) ? \App\Models\Asset::find($asset_id)->present()->fullName : '' }}
+                            </option>
+                        @endforeach
+                    @endif
                 @endif
             @endif
         </select>


### PR DESCRIPTION
This fixes bulk checkout, I think?

I was able to checkout two assets each to a user, a location, and another asset.

One complication here is that I have some of these changes tied up with some other changes that I'm working on. But bulk edit is broken now, and we need to fix it, so I've tried to carve this piece off from that.

We'll probably want to do a quick smoke test to make sure these changes aren't secretly relying on some other changes that I have in my tree.