### PR TITLE
Improve import performance

### DIFF
--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Illuminate\Support\Facades\Log;
+use Symfony\Component\Console\Helper\ProgressIndicator;
 
 ini_set('max_execution_time', env('IMPORT_TIME_LIMIT', 600)); //600 seconds = 10 minutes
 ini_set('memory_limit', env('IMPORT_MEMORY_LIMIT', '500M'));
@@ -30,6 +31,11 @@ class ObjectImportCommand extends Command
     protected $description = 'Import Items from CSV';
 
     /**
+     * The progress indicator instance.
+     */
+    protected ProgressIndicator $progressIndicator;
+
+    /**
      * Create a new command instance.
      *
      * @return void
@@ -39,8 +45,6 @@ class ObjectImportCommand extends Command
         parent::__construct();
     }
 
-    private $bar;
-
     /**
      * Execute the console command.
      *
@@ -48,6 +52,8 @@ class ObjectImportCommand extends Command
      */
     public function handle()
     {
+        $this->progressIndicator = new ProgressIndicator($this->output);
+
         $filename = $this->argument('filename');
         $class = title_case($this->option('item-type'));
         $classString = "App\\Importer\\{$class}Importer";
@@ -61,45 +67,24 @@ class ObjectImportCommand extends Command
         // This $logFile/useFiles() bit is currently broken, so commenting it out for now
         // $logFile = $this->option('logfile');
         // Log::useFiles($logFile);
-        $this->comment('======= Importing Items from '.$filename.' =========');
+        $this->progressIndicator->start('======= Importing Items from '.$filename.' =========');
+
         $importer->import();
 
-        $this->bar = null;
-
-        if (! empty($this->errors)) {
-            $this->comment('The following Errors were encountered.');
-            foreach ($this->errors as $asset => $error) {
-                $this->comment('Error: Item: '.$asset.' failed validation: '.json_encode($error));
-            }
-        } else {
-            $this->comment('All Items imported successfully!');
-        }
-        $this->comment('');
+        $this->progressIndicator->finish('Import finished.');
     }
 
-    public function errorCallback($item, $field, $errorString)
+    public function errorCallback($item, $field, $error)
     {
-        $this->errors[$item->name][$field] = $errorString;
+        $this->output->write("\x0D\x1B[2K");
+
+        $this->warn('Error: Item: '.$item->name.' failed validation: '.json_encode($error));
     }
 
-    public function progress($count)
+    public function progress($importedItemsCount)
     {
-        if (! $this->bar) {
-            $this->bar = $this->output->createProgressBar($count);
-        }
-        static $index = 0;
-        $index++;
-        if ($index < $count) {
-            $this->bar->advance();
-        } else {
-            $this->bar->finish();
-        }
+        $this->progressIndicator->advance();
     }
-
-    // Tracks the current item for error messages
-    private $updating;
-    // An array of errors encountered while parsing
-    private $errors;
 
     /**
      * Log a message to file, configurable by the --log-file parameter.


### PR DESCRIPTION
# Description

This PR introduces improvements to the importer, which previously stored imported data in memory, potentially consuming excessive resources for larger files. This update leverages the League/Csv package memory efficient technique. This PR also reduces the overhead of performing two iterations. The only caveat is the use of a progress indicator when using the import command instead of a progress bar, which, in my opinion, is more appropriate for long-running commands and tasks that cannot be easily quantified.

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
