### PR TITLE
Fixed #15651 - admin user now displaying on maintenances page

### DIFF
--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -66,7 +66,7 @@ class AssetMaintenancesTransformer
             'completion_date'     => Helper::getFormattedDateObject($assetmaintenance->completion_date, 'date'),
             'user_id'    => ($assetmaintenance->adminuser) ? [
                 'id' => $assetmaintenance->adminuser->id,
-                'name'=> e($assetmaintenance->admin->getFullNameAttribute())
+                'name'=> e($assetmaintenance->adminuser->present()->fullName())
             ] : null, // legacy to not change the shape of the API
             'created_by' => ($assetmaintenance->adminuser) ? [
                 'id' => (int) $assetmaintenance->adminuser->id,

--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -176,7 +176,7 @@ class AssetMaintenance extends Model implements ICompanyableChild
      */
     public function adminuser()
     {
-        return $this->belongsTo(\App\Models\User::class, 'user_id')
+        return $this->belongsTo(\App\Models\User::class, 'created_by')
             ->withTrashed();
     }
 

--- a/app/Presenters/AssetMaintenancesPresenter.php
+++ b/app/Presenters/AssetMaintenancesPresenter.php
@@ -117,12 +117,6 @@ class AssetMaintenancesPresenter extends Presenter
                 'title' => trans('admin/asset_maintenances/form.cost'),
                 'class' => 'text-right',
             ], [
-                'field' => 'user_id',
-                'searchable' => true,
-                'sortable' => true,
-                'title' => trans('general.admin'),
-                'formatter' => 'usersLinkObjFormatter',
-            ], [
                 'field' => 'created_by',
                 'searchable' => false,
                 'sortable' => true,


### PR DESCRIPTION
This fixes #15651, where the admin user who created the maintenance was not displaying on the maintenances page.