### PR TITLE
Fixes #15654 Fix asset creation with API and FullMultipleCompanySupport

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -598,6 +598,7 @@ class AssetsController extends Controller
         $asset->model()->associate(AssetModel::find((int) $request->get('model_id')));
 
         $asset->fill($request->validated());
+        $asset->company_id = Company::getIdForCurrentUser($request->validated()['company_id']);
         $asset->created_by    = auth()->id();
 
         /**


### PR DESCRIPTION
It is currently possible to create an asset with arbitrary company without being superuser and FullMultipleCompanySupport enabled. This bug goes back to 75ac7f80b9 which is part of version 6.3.0. Fix this by restoring the previous behaviour to check the company_id with getIdForCurrentUser().

Fixes #15654 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
