### PR TITLE
Refactor asset creation with API

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -598,7 +598,6 @@ class AssetsController extends Controller
         $asset->model()->associate(AssetModel::find((int) $request->get('model_id')));
 
         $asset->fill($request->validated());
-        $asset->company_id = Company::getIdForCurrentUser($request->validated()['company_id']);
         $asset->created_by    = auth()->id();
 
         /**

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -26,18 +26,11 @@ class StoreAssetRequest extends ImageUploadRequest
 
     public function prepareForValidation(): void
     {
-        // Guard against users passing in an array for company_id instead of an integer.
-        // If the company_id is not an integer then we simply use what was
-        // provided to be caught by model level validation later.
-        $idForCurrentUser = is_int($this->company_id)
-            ? Company::getIdForCurrentUser($this->company_id)
-            : $this->company_id;
-
         $this->parseLastAuditDate();
 
         $this->merge([
             'asset_tag' => $this->asset_tag ?? Asset::autoincrement_asset(),
-            'company_id' => $idForCurrentUser,
+            'company_id' => Company::getIdForCurrentUser($this->company_id),
             'assigned_to' => $assigned_to ?? null,
         ]);
     }


### PR DESCRIPTION
# Description

Commit fb4fe3004 restored the previous behaviour to check the company_id in case of FullMultipleCompanySupport. But after rereading the code and the laravel documentation, the check is already there where it belongs in AssetStoreRequest::prepareForValidation() The bug is the is_int-check of the request input in prepareForValidation(). Is is of type string even if it is a numeric value, so the call to getIdForCurrentUser() never happend. Fix this by removing the check and the now redundant call to getIdForCurrentUser(). Wrong values will get caught by the model-level validation rules.
