### PR TITLE
Bulk checkout to bulk actions for assets

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -575,22 +575,24 @@ class BulkAssetsController extends Controller
             }
 
             $errors = [];
-            DB::transaction(function () use ($target, $admin, $checkout_at, $expected_checkin, $errors, $asset_ids, $request) {
+            DB::transaction(function () use ($target, $admin, $checkout_at, $expected_checkin, &$errors, $asset_ids, $request) { //NOTE: $errors is passsed by reference!
                 foreach ($asset_ids as $asset_id) {
                     $asset = Asset::findOrFail($asset_id);
                     $this->authorize('checkout', $asset);
 
-                    $error = $asset->checkOut($target, $admin, $checkout_at, $expected_checkin, e($request->get('note')), $asset->name, null);
+                    $checkout_success = $asset->checkOut($target, $admin, $checkout_at, $expected_checkin, e($request->get('note')), $asset->name, null);
 
+                    //TODO - I think this logic is duplicated in the checkOut method?
                     if ($target->location_id != '') {
                         $asset->location_id = $target->location_id;
-                        $asset::withoutEvents(function () use ($asset) { // TODO - I don't know why this is being saved without events
+                        // TODO - I don't know why this is being saved without events
+                        $asset::withoutEvents(function () use ($asset) {
                             $asset->save();
                         });
                     }
 
-                    if ($error) {
-                        array_merge_recursive($errors, $asset->getErrors()->toArray());
+                    if (!$checkout_success) {
+                        $errors = array_merge_recursive($errors, $asset->getErrors()->toArray());
                     }
                 }
             });
@@ -600,7 +602,7 @@ class BulkAssetsController extends Controller
                 return redirect()->to('hardware')->with('success', trans_choice('admin/hardware/message.multi-checkout.success', $asset_ids));
             }
             // Redirect to the asset management page with error
-            return redirect()->route('hardware.bulkcheckout.show')->with('error', trans_choice('admin/hardware/message.multi-checkout.error', $asset_ids))->withErrors($errors);
+            return redirect()->route('hardware.bulkcheckout.show')->withInput()->with('error', trans_choice('admin/hardware/message.multi-checkout.error', $asset_ids))->withErrors($errors);
         } catch (ModelNotFoundException $e) {
             return redirect()->route('hardware.bulkcheckout.show')->with('error', $e->getErrors());
         }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Watson\Validating\ValidationException;
 use App\Events\CheckoutableCheckedOut;
 use App\Exceptions\CheckoutNotAllowed;
 use App\Helpers\Helper;
@@ -379,6 +380,9 @@ class Asset extends Depreciable
 
             return true;
         }
+        $validator = $this->makeValidator($this->getRules());
+
+        throw new ValidationException($validator, $this);
 
         return false;
     }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Watson\Validating\ValidationException;
 use App\Events\CheckoutableCheckedOut;
 use App\Exceptions\CheckoutNotAllowed;
 use App\Helpers\Helper;
@@ -380,9 +379,6 @@ class Asset extends Depreciable
 
             return true;
         }
-        $validator = $this->makeValidator($this->getRules());
-
-        throw new ValidationException($validator, $this);
 
         return false;
     }

--- a/resources/lang/en-US/admin/hardware/message.php
+++ b/resources/lang/en-US/admin/hardware/message.php
@@ -79,6 +79,11 @@ return [
         'no_assets_selected' => 'You must select at least one asset from the list',
     ],
 
+    'multi-checkout' => [
+        'error'   => 'Asset was not checked out, please try again|Assets were not checked out, please try again',
+        'success' => 'Asset checked out successfully.|Assets checked out successfully.',
+    ],
+
     'checkin' => [
         'error'   		=> 'Asset was not checked in, please try again',
         'success' 		=> 'Asset checked in successfully.',

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -115,5 +115,12 @@
 
 @section('moar_scripts')
 @include('partials/assets-assigned')
+<script nonce="{{ csrf_token() }}">
+    $(function () {
+        //if there's already a user selected, make sure their checked-out assets show up
+        // (if there isn't one, it won't do anything)
+        $('#assigned_user').change();
+    });
+</script>
 
 @stop

--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -16,17 +16,20 @@
     </label>
     <select name="bulk_actions" class="form-control select2" aria-label="bulk_actions" style="min-width: 350px;">
         @if((isset($status)) && ($status == 'Deleted'))
-        @can('delete', \App\Models\Asset::class)
-            <option value="restore">{{trans('button.restore')}}</option> 
-        @endcan
+            @can('delete', \App\Models\Asset::class)
+                <option value="restore">{{trans('button.restore')}}</option>
+            @endcan
         @else
-        @can('update', \App\Models\Asset::class)
-            <option value="edit">{{ trans('button.edit') }}</option>
-        @endcan
-        @can('delete', \App\Models\Asset::class)
-            <option value="delete">{{ trans('button.delete') }}</option>
-        @endcan
-        <option value="labels" {{$snipeSettings->shortcuts_enabled == 1 ? "accesskey=l" : ''}}>{{ trans_choice('button.generate_labels', 2) }}</option>
+            @can('update', \App\Models\Asset::class)
+                <option value="edit">{{ trans('button.edit') }}</option>
+            @endcan
+            @can('checkout', \App\Models\Asset::class)
+                <option value="checkout">{{ trans('general.bulk_checkout') }}</option>
+            @endcan
+            @can('delete', \App\Models\Asset::class)
+                <option value="delete">{{ trans('button.delete') }}</option>
+            @endcan
+            <option value="labels" {{$snipeSettings->shortcuts_enabled == 1 ? "accesskey=l" : ''}}>{{ trans_choice('button.generate_labels', 2) }}</option>
         @endif
     </select>
 


### PR DESCRIPTION
While fixing up some of the Javascript for the Bulk Checkout issues that we had, I thought it might be nice if you could also access the bulk checkout functionality from the same drop-down selector you get when looking at a list of assets.

We also weren't handling errors quite right during bulk checkout - it looks like we needed to pass the `$errors` array by reference in the `use(....)` statement in the anonymous function. And we weren't looking at the return value from `$asset->checkOut()` the right way.

While I was there I did notice a thing where we were unsetting the event dispatcher on an asset - I did that in a closure instead so we know that the event dispatcher is only unset for this *one* `save()` call, nothing else.

I added some new translation strings that work with `trans_choice()` to provide optional plurals in the success or failure messages.

And I made sure that, if you ran into an error during checkout, the display reloads with all of your old data correctly.

As a side note, there was some weird indenting in the blade which I fixed - so make sure to 'hide whitespace changes'.

I tried to test multiple checkouts to Users, Locations, and Assets, some causing errors, and some succeeding. I don't like the error output that much, as it doesn't point out the problem (in my case, a required custom field that was added after-the-fact - none of the assets will save cleanly, and a `checkout()` involves a `save()`). But having some output showing an error is better than having it act like it succeeded when it didn't, I figure.

The obligatory screenshots!

<img width="1091" alt="Screenshot 2024-10-16 at 11 23 21 PM" src="https://github.com/user-attachments/assets/f7659bbf-a04d-4a0a-8a0c-edfb586417d7">
<img width="471" alt="Screenshot 2024-10-16 at 11 23 27 PM" src="https://github.com/user-attachments/assets/0bf3d736-14e9-4478-abad-671437c3c41e">
<img width="647" alt="Screenshot 2024-10-16 at 11 23 37 PM" src="https://github.com/user-attachments/assets/49a5422c-e061-47a9-820f-5a3a71fe6b67">
<img width="1109" alt="Screenshot 2024-10-16 at 11 24 06 PM" src="https://github.com/user-attachments/assets/691915dc-3637-4d4f-a290-2982626851f7">
