### PR TITLE
Updated `Company::getIdForCurrentUser()` to return null in certain scenarios

### DIFF
--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -26,11 +26,18 @@ class StoreAssetRequest extends ImageUploadRequest
 
     public function prepareForValidation(): void
     {
+        // Guard against users passing in an array for company_id instead of an integer.
+        // If the company_id is not an integer then we simply use what was
+        // provided to be caught by model level validation later.
+        $idForCurrentUser = is_int($this->company_id)
+            ? Company::getIdForCurrentUser($this->company_id)
+            : $this->company_id;
+
         $this->parseLastAuditDate();
 
         $this->merge([
             'asset_tag' => $this->asset_tag ?? Asset::autoincrement_asset(),
-            'company_id' => Company::getIdForCurrentUser($this->company_id),
+            'company_id' => $idForCurrentUser,
             'assigned_to' => $assigned_to ?? null,
         ]);
     }

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -29,6 +29,7 @@ class StoreAssetRequest extends ImageUploadRequest
         // Guard against users passing in an array for company_id instead of an integer.
         // If the company_id is not an integer then we simply use what was
         // provided to be caught by model level validation later.
+        // The use of is_numeric accounts for 1 and '1'.
         $idForCurrentUser = is_numeric($this->company_id)
             ? Company::getIdForCurrentUser($this->company_id)
             : $this->company_id;

--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -29,7 +29,7 @@ class StoreAssetRequest extends ImageUploadRequest
         // Guard against users passing in an array for company_id instead of an integer.
         // If the company_id is not an integer then we simply use what was
         // provided to be caught by model level validation later.
-        $idForCurrentUser = is_int($this->company_id)
+        $idForCurrentUser = is_numeric($this->company_id)
             ? Company::getIdForCurrentUser($this->company_id)
             : $this->company_id;
 

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -116,7 +116,7 @@ final class Company extends SnipeModel
                 if ($current_user->company_id != null) {
                     return $current_user->company_id;
                 } else {
-                    return static::getIdFromInput($unescaped_input);
+                    return null;
                 }
             }
         }

--- a/tests/Feature/Accessories/Ui/CreateAccessoryWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Accessories/Ui/CreateAccessoryWithFullMultipleCompanySupportTest.php
@@ -4,62 +4,14 @@ namespace Tests\Feature\Accessories\Ui;
 
 use App\Models\Accessory;
 use App\Models\Category;
-use App\Models\Company;
-use App\Models\User;
-use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\ProvidesDataForFullMultipleCompanySupportTesting;
 use Tests\TestCase;
 
 class CreateAccessoryWithFullMultipleCompanySupportTest extends TestCase
 {
-    public static function userProvider(): Generator
-    {
-        yield "User in a company should result in user's company_id being used" => [
-            function () {
-                $jedi = Company::factory()->create();
-                $sith = Company::factory()->create();
-                $luke = User::factory()->for($jedi)->createAccessories()->create();
-
-                return [
-                    'actor' => $luke,
-                    'company_attempting_to_associate' => $sith,
-                    'assertions' => function ($accessory) use ($jedi) {
-                        self::assertEquals($jedi->id, $accessory->company_id);
-                    },
-                ];
-            }
-        ];
-
-        yield "User without a company should result in accessory's company_id being null" => [
-            function () {
-                $userInNoCompany = User::factory()->createAccessories()->create(['company_id' => null]);
-
-                return [
-                    'actor' => $userInNoCompany,
-                    'company_attempting_to_associate' => Company::factory()->create(),
-                    'assertions' => function ($accessory) {
-                        self::assertNull($accessory->company_id);
-                    },
-                ];
-            }
-        ];
-
-        yield "Super-User assigning across companies should result in accessory's company_id being set to what was provided" => [
-            function () {
-                $superUser = User::factory()->superuser()->create(['company_id' => null]);
-                $company = Company::factory()->create();
-
-                return [
-                    'actor' => $superUser,
-                    'company_attempting_to_associate' => $company,
-                    'assertions' => function ($accessory) use ($company) {
-                        self::assertEquals($accessory->company_id, $company->id);
-                    },
-                ];
-            }
-        ];
-    }
+    use ProvidesDataForFullMultipleCompanySupportTesting;
 
     #[Group('focus')]
     #[DataProvider('userProvider')]

--- a/tests/Feature/Accessories/Ui/CreateAccessoryWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Accessories/Ui/CreateAccessoryWithFullMultipleCompanySupportTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature\Accessories\Ui;
 use App\Models\Accessory;
 use App\Models\Category;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\ProvidesDataForFullMultipleCompanySupportTesting;
 use Tests\TestCase;
 
@@ -13,7 +12,6 @@ class CreateAccessoryWithFullMultipleCompanySupportTest extends TestCase
 {
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
-    #[Group('focus')]
     #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {

--- a/tests/Feature/Accessories/Ui/CreateAccessoryWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Accessories/Ui/CreateAccessoryWithFullMultipleCompanySupportTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Accessories\Ui;
+
+use App\Models\Accessory;
+use App\Models\Category;
+use App\Models\Company;
+use App\Models\User;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+class CreateAccessoryWithFullMultipleCompanySupportTest extends TestCase
+{
+    public static function userProvider(): Generator
+    {
+        yield "User in a company should result in user's company_id being used" => [
+            function () {
+                $jedi = Company::factory()->create();
+                $sith = Company::factory()->create();
+                $luke = User::factory()->for($jedi)->createAccessories()->create();
+
+                return [
+                    'actor' => $luke,
+                    'company_attempting_to_associate' => $sith,
+                    'assertions' => function ($accessory) use ($jedi) {
+                        self::assertEquals($jedi->id, $accessory->company_id);
+                    },
+                ];
+            }
+        ];
+
+        yield "User without a company should result in accessory's company_id being null" => [
+            function () {
+                $userInNoCompany = User::factory()->createAccessories()->create(['company_id' => null]);
+
+                return [
+                    'actor' => $userInNoCompany,
+                    'company_attempting_to_associate' => Company::factory()->create(),
+                    'assertions' => function ($accessory) {
+                        self::assertNull($accessory->company_id);
+                    },
+                ];
+            }
+        ];
+
+        yield "Super-User assigning across companies should result in accessory's company_id being set to what was provided" => [
+            function () {
+                $superUser = User::factory()->superuser()->create(['company_id' => null]);
+                $company = Company::factory()->create();
+
+                return [
+                    'actor' => $superUser,
+                    'company_attempting_to_associate' => $company,
+                    'assertions' => function ($accessory) use ($company) {
+                        self::assertEquals($accessory->company_id, $company->id);
+                    },
+                ];
+            }
+        ];
+    }
+
+    #[Group('focus')]
+    #[DataProvider('userProvider')]
+    public function testAdheresToFullMultipleCompaniesSupportScoping($data)
+    {
+        ['actor' => $actor, 'company_attempting_to_associate' => $company, 'assertions' => $assertions] = $data();
+
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $this->actingAs($actor)
+            ->post(route('accessories.store'), [
+                'redirect_option' => 'index',
+                'name' => 'My Cool Accessory',
+                'qty' => '1',
+                'category_id' => Category::factory()->create()->id,
+                'company_id' => $company->id,
+            ]);
+
+        $accessory = Accessory::withoutGlobalScopes()->where([
+            'name' => 'My Cool Accessory',
+        ])->sole();
+
+        $assertions($accessory);
+    }
+}

--- a/tests/Feature/Accessories/Ui/CreateAccessoryWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Accessories/Ui/CreateAccessoryWithFullMultipleCompanySupportTest.php
@@ -14,7 +14,7 @@ class CreateAccessoryWithFullMultipleCompanySupportTest extends TestCase
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
     #[Group('focus')]
-    #[DataProvider('userProvider')]
+    #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {
         ['actor' => $actor, 'company_attempting_to_associate' => $company, 'assertions' => $assertions] = $data();

--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -560,6 +560,9 @@ class StoreAssetTest extends TestCase
         $this->assertTrue($asset->assignedAssets()->find($response['payload']['id'])->is($apiAsset));
     }
 
+    /**
+     * @link https://app.shortcut.com/grokability/story/24475
+     */
     public function testCompanyIdNeedsToBeInteger()
     {
         $this->actingAsForApi(User::factory()->createAssets()->create())

--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -59,7 +59,7 @@ class StoreAssetTest extends TestCase
 
         yield "Super-User assigning across companies should result in asset's company_id being set to what was provided" => [
             function () {
-                $superUser = User::factory()->superuser()->create();
+                $superUser = User::factory()->superuser()->create(['company_id' => null]);
                 $company = Company::factory()->create();
 
                 return [

--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -12,7 +12,6 @@ use App\Models\Supplier;
 use App\Models\User;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Testing\Fluent\AssertableJson;
-use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
 class StoreAssetTest extends TestCase
@@ -564,7 +563,6 @@ class StoreAssetTest extends TestCase
     /**
      * @link https://app.shortcut.com/grokability/story/24475
      */
-    #[Group('focus')]
     public function testCompanyIdNeedsToBeInteger()
     {
         $this->actingAsForApi(User::factory()->createAssets()->create())

--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -10,10 +10,9 @@ use App\Models\Location;
 use App\Models\Statuslabel;
 use App\Models\Supplier;
 use App\Models\User;
-use Generator;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Testing\Fluent\AssertableJson;
-use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
 class StoreAssetTest extends TestCase
@@ -23,77 +22,6 @@ class StoreAssetTest extends TestCase
         $this->actingAsForApi(User::factory()->create())
             ->postJson(route('api.assets.store'))
             ->assertForbidden();
-    }
-
-    public static function userProvider(): Generator
-    {
-        yield "User in a company should result in user's company_id being used" => [
-            function () {
-                $jedi = Company::factory()->create();
-                $sith = Company::factory()->create();
-                $luke = User::factory()->for($jedi)->createAssets()->create();
-
-                return [
-                    'actor' => $luke,
-                    'company_attempting_to_associate' => $sith,
-                    'assertions' => function ($asset) use ($jedi) {
-                        self::assertEquals($jedi->id, $asset->company_id);
-                    },
-                ];
-            }
-        ];
-
-        yield "User without a company should result in asset's company_id being null" => [
-            function () {
-                $userInNoCompany = User::factory()->createAssets()->create(['company_id' => null]);
-
-                return [
-                    'actor' => $userInNoCompany,
-                    'company_attempting_to_associate' => Company::factory()->create(),
-                    'assertions' => function ($asset) {
-                        self::assertNull($asset->company_id);
-                    },
-                ];
-            }
-        ];
-
-        yield "Super-User assigning across companies should result in asset's company_id being set to what was provided" => [
-            function () {
-                $superUser = User::factory()->superuser()->create(['company_id' => null]);
-                $company = Company::factory()->create();
-
-                return [
-                    'actor' => $superUser,
-                    'company_attempting_to_associate' => $company,
-                    'assertions' => function ($asset) use ($company) {
-                        self::assertEquals($asset->company_id, $company->id);
-                    },
-                ];
-            }
-        ];
-    }
-
-    /**
-     * @link https://github.com/snipe/snipe-it/issues/15654
-     */
-    #[DataProvider('userProvider')]
-    public function testAdheresToFullMultipleCompaniesSupportScoping($data)
-    {
-        ['actor' => $actor, 'company_attempting_to_associate' => $company, 'assertions' => $assertions] = $data();
-
-        $this->settings->enableMultipleFullCompanySupport();
-
-        $response = $this->actingAsForApi($actor)
-            ->postJson(route('api.assets.store'), [
-                'asset_tag' => 'random_string',
-                'company_id' => $company->id,
-                'model_id' => AssetModel::factory()->create()->id,
-                'status_id' => Statuslabel::factory()->readyToDeploy()->create()->id,
-            ]);
-
-        $asset = Asset::withoutGlobalScopes()->findOrFail($response['payload']['id']);
-
-        $assertions($asset);
     }
 
     public function testAllAssetAttributesAreStored()
@@ -636,6 +564,7 @@ class StoreAssetTest extends TestCase
     /**
      * @link https://app.shortcut.com/grokability/story/24475
      */
+    #[Group('focus')]
     public function testCompanyIdNeedsToBeInteger()
     {
         $this->actingAsForApi(User::factory()->createAssets()->create())

--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -56,6 +56,21 @@ class StoreAssetTest extends TestCase
                 ];
             }
         ];
+
+        yield 'Super-User assigning across companies' => [
+            function () {
+                $superUser = User::factory()->superuser()->create();
+                $company = Company::factory()->create();
+
+                return [
+                    'actor' => $superUser,
+                    'company_attempting_to_associate' => $company,
+                    'assertions' => function ($asset) use ($company) {
+                        self::assertEquals($asset->company_id, $company->id);
+                    },
+                ];
+            }
+        ];
     }
 
     /**

--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -27,7 +27,7 @@ class StoreAssetTest extends TestCase
 
     public static function userProvider(): Generator
     {
-        yield 'User in a company' => [
+        yield "User in a company should result in user's company_id being used" => [
             function () {
                 $jedi = Company::factory()->create();
                 $sith = Company::factory()->create();
@@ -43,7 +43,7 @@ class StoreAssetTest extends TestCase
             }
         ];
 
-        yield 'User without a company' => [
+        yield "User without a company should result in asset's company_id being null" => [
             function () {
                 $userInNoCompany = User::factory()->createAssets()->create(['company_id' => null]);
 
@@ -57,7 +57,7 @@ class StoreAssetTest extends TestCase
             }
         ];
 
-        yield 'Super-User assigning across companies' => [
+        yield "Super-User assigning across companies should result in asset's company_id being set to what was provided" => [
             function () {
                 $superUser = User::factory()->superuser()->create();
                 $company = Company::factory()->create();

--- a/tests/Feature/Assets/Api/StoreAssetWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetWithFullMultipleCompanySupportTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\Assets\Api;
+
+use App\Models\Asset;
+use App\Models\AssetModel;
+use App\Models\Company;
+use App\Models\Statuslabel;
+use App\Models\User;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
+{
+    public static function userProvider(): Generator
+    {
+        yield "User in a company should result in user's company_id being used" => [
+            function () {
+                $jedi = Company::factory()->create();
+                $sith = Company::factory()->create();
+                $luke = User::factory()->for($jedi)->createAssets()->create();
+
+                return [
+                    'actor' => $luke,
+                    'company_attempting_to_associate' => $sith,
+                    'assertions' => function ($asset) use ($jedi) {
+                        self::assertEquals($jedi->id, $asset->company_id);
+                    },
+                ];
+            }
+        ];
+
+        yield "User without a company should result in asset's company_id being null" => [
+            function () {
+                $userInNoCompany = User::factory()->createAssets()->create(['company_id' => null]);
+
+                return [
+                    'actor' => $userInNoCompany,
+                    'company_attempting_to_associate' => Company::factory()->create(),
+                    'assertions' => function ($asset) {
+                        self::assertNull($asset->company_id);
+                    },
+                ];
+            }
+        ];
+
+        yield "Super-User assigning across companies should result in asset's company_id being set to what was provided" => [
+            function () {
+                $superUser = User::factory()->superuser()->create(['company_id' => null]);
+                $company = Company::factory()->create();
+
+                return [
+                    'actor' => $superUser,
+                    'company_attempting_to_associate' => $company,
+                    'assertions' => function ($asset) use ($company) {
+                        self::assertEquals($asset->company_id, $company->id);
+                    },
+                ];
+            }
+        ];
+    }
+
+    /**
+     * @link https://github.com/snipe/snipe-it/issues/15654
+     */
+    #[Group('focus')]
+    #[DataProvider('userProvider')]
+    public function testAdheresToFullMultipleCompaniesSupportScoping($data)
+    {
+        ['actor' => $actor, 'company_attempting_to_associate' => $company, 'assertions' => $assertions] = $data();
+
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $response = $this->actingAsForApi($actor)
+            ->postJson(route('api.assets.store'), [
+                'asset_tag' => 'random_string',
+                'company_id' => $company->id,
+                'model_id' => AssetModel::factory()->create()->id,
+                'status_id' => Statuslabel::factory()->readyToDeploy()->create()->id,
+            ]);
+
+        $asset = Asset::withoutGlobalScopes()->findOrFail($response['payload']['id']);
+
+        $assertions($asset);
+    }
+}

--- a/tests/Feature/Assets/Api/StoreAssetWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetWithFullMultipleCompanySupportTest.php
@@ -6,7 +6,6 @@ use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Statuslabel;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\ProvidesDataForFullMultipleCompanySupportTesting;
 use Tests\TestCase;
 
@@ -17,7 +16,6 @@ class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
     /**
      * @link https://github.com/snipe/snipe-it/issues/15654
      */
-    #[Group('focus')]
     #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {

--- a/tests/Feature/Assets/Api/StoreAssetWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetWithFullMultipleCompanySupportTest.php
@@ -4,63 +4,15 @@ namespace Tests\Feature\Assets\Api;
 
 use App\Models\Asset;
 use App\Models\AssetModel;
-use App\Models\Company;
 use App\Models\Statuslabel;
-use App\Models\User;
-use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use Tests\Support\ProvidesDataForFullMultipleCompanySupportTesting;
 use Tests\TestCase;
 
 class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
 {
-    public static function userProvider(): Generator
-    {
-        yield "User in a company should result in user's company_id being used" => [
-            function () {
-                $jedi = Company::factory()->create();
-                $sith = Company::factory()->create();
-                $luke = User::factory()->for($jedi)->createAssets()->create();
-
-                return [
-                    'actor' => $luke,
-                    'company_attempting_to_associate' => $sith,
-                    'assertions' => function ($asset) use ($jedi) {
-                        self::assertEquals($jedi->id, $asset->company_id);
-                    },
-                ];
-            }
-        ];
-
-        yield "User without a company should result in asset's company_id being null" => [
-            function () {
-                $userInNoCompany = User::factory()->createAssets()->create(['company_id' => null]);
-
-                return [
-                    'actor' => $userInNoCompany,
-                    'company_attempting_to_associate' => Company::factory()->create(),
-                    'assertions' => function ($asset) {
-                        self::assertNull($asset->company_id);
-                    },
-                ];
-            }
-        ];
-
-        yield "Super-User assigning across companies should result in asset's company_id being set to what was provided" => [
-            function () {
-                $superUser = User::factory()->superuser()->create(['company_id' => null]);
-                $company = Company::factory()->create();
-
-                return [
-                    'actor' => $superUser,
-                    'company_attempting_to_associate' => $company,
-                    'assertions' => function ($asset) use ($company) {
-                        self::assertEquals($asset->company_id, $company->id);
-                    },
-                ];
-            }
-        ];
-    }
+    use ProvidesDataForFullMultipleCompanySupportTesting;
 
     /**
      * @link https://github.com/snipe/snipe-it/issues/15654

--- a/tests/Feature/Assets/Api/StoreAssetWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetWithFullMultipleCompanySupportTest.php
@@ -18,7 +18,7 @@ class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
      * @link https://github.com/snipe/snipe-it/issues/15654
      */
     #[Group('focus')]
-    #[DataProvider('userProvider')]
+    #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {
         ['actor' => $actor, 'company_attempting_to_associate' => $company, 'assertions' => $assertions] = $data();

--- a/tests/Feature/Assets/Api/StoreAssetWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetWithFullMultipleCompanySupportTest.php
@@ -35,4 +35,24 @@ class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
 
         $assertions($asset);
     }
+
+    #[DataProvider('dataForFullMultipleCompanySupportTesting')]
+    public function testHandlesCompanyIdBeingString($data)
+    {
+        ['actor' => $actor, 'company_attempting_to_associate' => $company, 'assertions' => $assertions] = $data();
+
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $response = $this->actingAsForApi($actor)
+            ->postJson(route('api.assets.store'), [
+                'asset_tag' => 'random_string',
+                'company_id' => (string) $company->id,
+                'model_id' => AssetModel::factory()->create()->id,
+                'status_id' => Statuslabel::factory()->readyToDeploy()->create()->id,
+            ]);
+
+        $asset = Asset::withoutGlobalScopes()->findOrFail($response['payload']['id']);
+
+        $assertions($asset);
+    }
 }

--- a/tests/Feature/Assets/Ui/StoreAssetWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Assets/Ui/StoreAssetWithFullMultipleCompanySupportTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature\Assets\Ui;
+
+use App\Models\Asset;
+use App\Models\AssetModel;
+use App\Models\Company;
+use App\Models\Statuslabel;
+use App\Models\User;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
+{
+    public static function userProvider(): Generator
+    {
+        yield "User in a company should result in user's company_id being used" => [
+            function () {
+                $jedi = Company::factory()->create();
+                $sith = Company::factory()->create();
+                $luke = User::factory()->for($jedi)->createAssets()->create();
+
+                return [
+                    'actor' => $luke,
+                    'company_attempting_to_associate' => $sith,
+                    'assertions' => function ($asset) use ($jedi) {
+                        self::assertEquals($jedi->id, $asset->company_id);
+                    },
+                ];
+            }
+        ];
+
+        yield "User without a company should result in asset's company_id being null" => [
+            function () {
+                $userInNoCompany = User::factory()->createAssets()->create(['company_id' => null]);
+
+                return [
+                    'actor' => $userInNoCompany,
+                    'company_attempting_to_associate' => Company::factory()->create(),
+                    'assertions' => function ($asset) {
+                        self::assertNull($asset->company_id);
+                    },
+                ];
+            }
+        ];
+
+        yield "Super-User assigning across companies should result in asset's company_id being set to what was provided" => [
+            function () {
+                $superUser = User::factory()->superuser()->create(['company_id' => null]);
+                $company = Company::factory()->create();
+
+                return [
+                    'actor' => $superUser,
+                    'company_attempting_to_associate' => $company,
+                    'assertions' => function ($asset) use ($company) {
+                        self::assertEquals($asset->company_id, $company->id);
+                    },
+                ];
+            }
+        ];
+    }
+
+    #[Group('focus')]
+    #[DataProvider('userProvider')]
+    public function testAdheresToFullMultipleCompaniesSupportScoping($data)
+    {
+        ['actor' => $actor, 'company_attempting_to_associate' => $company, 'assertions' => $assertions] = $data();
+
+        $this->settings->enableMultipleFullCompanySupport();
+
+        $this->actingAs($actor)
+            ->post(route('hardware.store'), [
+                'asset_tags' => ['1' => '1234'],
+                'model_id' => AssetModel::factory()->create()->id,
+                'status_id' => Statuslabel::factory()->create()->id,
+                'company_id' => $company->id,
+            ]);
+
+        $asset = Asset::where('asset_tag', '1234')->sole();
+
+        $assertions($asset);
+    }
+}

--- a/tests/Feature/Assets/Ui/StoreAssetWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Assets/Ui/StoreAssetWithFullMultipleCompanySupportTest.php
@@ -6,7 +6,6 @@ use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Statuslabel;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\ProvidesDataForFullMultipleCompanySupportTesting;
 use Tests\TestCase;
 
@@ -14,7 +13,6 @@ class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
 {
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
-    #[Group('focus')]
     #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {

--- a/tests/Feature/Assets/Ui/StoreAssetWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Assets/Ui/StoreAssetWithFullMultipleCompanySupportTest.php
@@ -15,7 +15,7 @@ class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
     #[Group('focus')]
-    #[DataProvider('userProvider')]
+    #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {
         ['actor' => $actor, 'company_attempting_to_associate' => $company, 'assertions' => $assertions] = $data();

--- a/tests/Feature/Components/Ui/StoreComponentWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Components/Ui/StoreComponentWithFullMultipleCompanySupportTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature\Components\Ui;
 use App\Models\Category;
 use App\Models\Component;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\ProvidesDataForFullMultipleCompanySupportTesting;
 use Tests\TestCase;
 
@@ -13,7 +12,6 @@ class StoreComponentWithFullMultipleCompanySupportTest extends TestCase
 {
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
-    #[Group('focus')]
     #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {

--- a/tests/Feature/Components/Ui/StoreComponentWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Components/Ui/StoreComponentWithFullMultipleCompanySupportTest.php
@@ -1,16 +1,15 @@
 <?php
 
-namespace Tests\Feature\Assets\Ui;
+namespace Tests\Feature\Components\Ui;
 
-use App\Models\Asset;
-use App\Models\AssetModel;
-use App\Models\Statuslabel;
+use App\Models\Category;
+use App\Models\Component;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\ProvidesDataForFullMultipleCompanySupportTesting;
 use Tests\TestCase;
 
-class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
+class StoreComponentWithFullMultipleCompanySupportTest extends TestCase
 {
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
@@ -23,15 +22,15 @@ class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
         $this->settings->enableMultipleFullCompanySupport();
 
         $this->actingAs($actor)
-            ->post(route('hardware.store'), [
-                'asset_tags' => ['1' => '1234'],
-                'model_id' => AssetModel::factory()->create()->id,
-                'status_id' => Statuslabel::factory()->create()->id,
+            ->post(route('components.store'), [
+                'name' => 'My Cool Component',
+                'qty' => '1',
+                'category_id' => Category::factory()->create()->id,
                 'company_id' => $company->id,
             ]);
 
-        $asset = Asset::where('asset_tag', '1234')->sole();
+        $component = Component::where('name', 'My Cool Component')->sole();
 
-        $assertions($asset);
+        $assertions($component);
     }
 }

--- a/tests/Feature/Components/Ui/StoreComponentWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Components/Ui/StoreComponentWithFullMultipleCompanySupportTest.php
@@ -14,7 +14,7 @@ class StoreComponentWithFullMultipleCompanySupportTest extends TestCase
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
     #[Group('focus')]
-    #[DataProvider('userProvider')]
+    #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {
         ['actor' => $actor, 'company_attempting_to_associate' => $company, 'assertions' => $assertions] = $data();

--- a/tests/Feature/Consumables/Ui/StoreConsumableWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Consumables/Ui/StoreConsumableWithFullMultipleCompanySupportTest.php
@@ -14,7 +14,7 @@ class StoreConsumableWithFullMultipleCompanySupportTest extends TestCase
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
     #[Group('focus')]
-    #[DataProvider('userProvider')]
+    #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {
         ['actor' => $actor, 'company_attempting_to_associate' => $company, 'assertions' => $assertions] = $data();

--- a/tests/Feature/Consumables/Ui/StoreConsumableWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Consumables/Ui/StoreConsumableWithFullMultipleCompanySupportTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature\Consumables\Ui;
 use App\Models\Category;
 use App\Models\Consumable;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\ProvidesDataForFullMultipleCompanySupportTesting;
 use Tests\TestCase;
 
@@ -13,7 +12,6 @@ class StoreConsumableWithFullMultipleCompanySupportTest extends TestCase
 {
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
-    #[Group('focus')]
     #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {

--- a/tests/Feature/Consumables/Ui/StoreConsumableWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Consumables/Ui/StoreConsumableWithFullMultipleCompanySupportTest.php
@@ -1,16 +1,15 @@
 <?php
 
-namespace Tests\Feature\Assets\Ui;
+namespace Tests\Feature\Consumables\Ui;
 
-use App\Models\Asset;
-use App\Models\AssetModel;
-use App\Models\Statuslabel;
+use App\Models\Category;
+use App\Models\Consumable;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\ProvidesDataForFullMultipleCompanySupportTesting;
 use Tests\TestCase;
 
-class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
+class StoreConsumableWithFullMultipleCompanySupportTest extends TestCase
 {
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
@@ -23,15 +22,14 @@ class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
         $this->settings->enableMultipleFullCompanySupport();
 
         $this->actingAs($actor)
-            ->post(route('hardware.store'), [
-                'asset_tags' => ['1' => '1234'],
-                'model_id' => AssetModel::factory()->create()->id,
-                'status_id' => Statuslabel::factory()->create()->id,
+            ->post(route('consumables.store'), [
+                'name' => 'My Cool Consumable',
+                'category_id' => Category::factory()->forConsumables()->create()->id,
                 'company_id' => $company->id,
             ]);
 
-        $asset = Asset::where('asset_tag', '1234')->sole();
+        $consumable = Consumable::where('name', 'My Cool Consumable')->sole();
 
-        $assertions($asset);
+        $assertions($consumable);
     }
 }

--- a/tests/Feature/Licenses/Ui/StoreLicenseWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Licenses/Ui/StoreLicenseWithFullMultipleCompanySupportTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature\Licenses\Ui;
 use App\Models\Category;
 use App\Models\License;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\ProvidesDataForFullMultipleCompanySupportTesting;
 use Tests\TestCase;
 
@@ -13,7 +12,6 @@ class StoreLicenseWithFullMultipleCompanySupportTest extends TestCase
 {
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
-    #[Group('focus')]
     #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {

--- a/tests/Feature/Licenses/Ui/StoreLicenseWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Licenses/Ui/StoreLicenseWithFullMultipleCompanySupportTest.php
@@ -1,16 +1,15 @@
 <?php
 
-namespace Tests\Feature\Assets\Ui;
+namespace Tests\Feature\Licenses\Ui;
 
-use App\Models\Asset;
-use App\Models\AssetModel;
-use App\Models\Statuslabel;
+use App\Models\Category;
+use App\Models\License;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Tests\Support\ProvidesDataForFullMultipleCompanySupportTesting;
 use Tests\TestCase;
 
-class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
+class StoreLicenseWithFullMultipleCompanySupportTest extends TestCase
 {
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
@@ -23,15 +22,15 @@ class StoreAssetWithFullMultipleCompanySupportTest extends TestCase
         $this->settings->enableMultipleFullCompanySupport();
 
         $this->actingAs($actor)
-            ->post(route('hardware.store'), [
-                'asset_tags' => ['1' => '1234'],
-                'model_id' => AssetModel::factory()->create()->id,
-                'status_id' => Statuslabel::factory()->create()->id,
+            ->post(route('licenses.store'), [
+                'name' => 'My Cool License',
+                'seats' => '1',
+                'category_id' => Category::factory()->forLicenses()->create()->id,
                 'company_id' => $company->id,
             ]);
 
-        $asset = Asset::where('asset_tag', '1234')->sole();
+        $license = License::where('name', 'My Cool License')->sole();
 
-        $assertions($asset);
+        $assertions($license);
     }
 }

--- a/tests/Feature/Licenses/Ui/StoreLicenseWithFullMultipleCompanySupportTest.php
+++ b/tests/Feature/Licenses/Ui/StoreLicenseWithFullMultipleCompanySupportTest.php
@@ -14,7 +14,7 @@ class StoreLicenseWithFullMultipleCompanySupportTest extends TestCase
     use ProvidesDataForFullMultipleCompanySupportTesting;
 
     #[Group('focus')]
-    #[DataProvider('userProvider')]
+    #[DataProvider('dataForFullMultipleCompanySupportTesting')]
     public function testAdheresToFullMultipleCompaniesSupportScoping($data)
     {
         ['actor' => $actor, 'company_attempting_to_associate' => $company, 'assertions' => $assertions] = $data();

--- a/tests/Support/ProvidesDataForFullMultipleCompanySupportTesting.php
+++ b/tests/Support/ProvidesDataForFullMultipleCompanySupportTesting.php
@@ -8,7 +8,7 @@ use Generator;
 
 trait ProvidesDataForFullMultipleCompanySupportTesting
 {
-    public static function userProvider(): Generator
+    public static function dataForFullMultipleCompanySupportTesting(): Generator
     {
         yield "User in a company should result in user's company_id being used" => [
             function () {

--- a/tests/Support/ProvidesDataForFullMultipleCompanySupportTesting.php
+++ b/tests/Support/ProvidesDataForFullMultipleCompanySupportTesting.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Support;
+
+use App\Models\Company;
+use App\Models\User;
+use Generator;
+
+trait ProvidesDataForFullMultipleCompanySupportTesting
+{
+    public static function userProvider(): Generator
+    {
+        yield "User in a company should result in user's company_id being used" => [
+            function () {
+                $jedi = Company::factory()->create();
+                $sith = Company::factory()->create();
+                $luke = User::factory()->for($jedi)
+                    ->createAccessories()
+                    ->createAssets()
+                    ->createComponents()
+                    ->createConsumables()
+                    ->createLicenses()
+                    ->create();
+
+                return [
+                    'actor' => $luke,
+                    'company_attempting_to_associate' => $sith,
+                    'assertions' => function ($model) use ($jedi) {
+                        self::assertEquals($jedi->id, $model->company_id);
+                    },
+                ];
+            }
+        ];
+
+        yield "User without a company should result in company_id being null" => [
+            function () {
+                $userInNoCompany = User::factory()
+                    ->createAccessories()
+                    ->createAssets()
+                    ->createComponents()
+                    ->createConsumables()
+                    ->createLicenses()
+                    ->create(['company_id' => null]);
+
+                return [
+                    'actor' => $userInNoCompany,
+                    'company_attempting_to_associate' => Company::factory()->create(),
+                    'assertions' => function ($model) {
+                        self::assertNull($model->company_id);
+                    },
+                ];
+            }
+        ];
+
+        yield "Super-User assigning across companies should result in company_id being set to what was provided" => [
+            function () {
+                $superUser = User::factory()->superuser()->create(['company_id' => null]);
+                $company = Company::factory()->create();
+
+                return [
+                    'actor' => $superUser,
+                    'company_attempting_to_associate' => $company,
+                    'assertions' => function ($model) use ($company) {
+                        self::assertEquals($model->company_id, $company->id);
+                    },
+                ];
+            }
+        ];
+    }
+}

--- a/tests/Unit/Models/Company/GetIdForCurrentUserTest.php
+++ b/tests/Unit/Models/Company/GetIdForCurrentUserTest.php
@@ -4,10 +4,8 @@ namespace Tests\Unit\Models\Company;
 
 use App\Models\Company;
 use App\Models\User;
-use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
-#[Group('focus')]
 class GetIdForCurrentUserTest extends TestCase
 {
     public function testReturnsProvidedValueWhenFullCompanySupportDisabled()

--- a/tests/Unit/Models/Company/GetIdForCurrentUserTest.php
+++ b/tests/Unit/Models/Company/GetIdForCurrentUserTest.php
@@ -4,8 +4,10 @@ namespace Tests\Unit\Models\Company;
 
 use App\Models\Company;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
+#[Group('focus')]
 class GetIdForCurrentUserTest extends TestCase
 {
     public function testReturnsProvidedValueWhenFullCompanySupportDisabled()
@@ -32,11 +34,11 @@ class GetIdForCurrentUserTest extends TestCase
         $this->assertEquals(2000, Company::getIdForCurrentUser(1000));
     }
 
-    public function testReturnsProvidedValueForNonSuperUserWithoutCompanyIdWhenFullCompanySupportEnabled()
+    public function testReturnsNullForNonSuperUserWithoutCompanyIdWhenFullCompanySupportEnabled()
     {
         $this->settings->enableMultipleFullCompanySupport();
 
         $this->actingAs(User::factory()->create(['company_id' => null]));
-        $this->assertEquals(1000, Company::getIdForCurrentUser(1000));
+        $this->assertNull(Company::getIdForCurrentUser(1000));
     }
 }


### PR DESCRIPTION
# Description

This PR fixes a bug in the `Company::getIdForCurrentUser()` method when full multiple company support was enabled, the acting user was _not_ a super user and didn't have a `company_id` set the provided input was returned instead of `null` like expected.

This follows up the fix in #15660 by re-adding the code that was removed in the form request  and handling it in the bug in the `Company::getIdForCurrentUser()` method mentioned above.

This PR is mostly test code testing some, but not all, of the places the method is being used.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
