### PR TITLE
Updated brianium/paratest to v7.4.8

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11792,16 +11792,16 @@
         },
         {
             "name": "brianium/paratest",
-            "version": "v7.3.1",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "551f46f52a93177d873f3be08a1649ae886b4a30"
+                "reference": "cf16fcbb9b8107a7df6b97e497fc91e819774d8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/551f46f52a93177d873f3be08a1649ae886b4a30",
-                "reference": "551f46f52a93177d873f3be08a1649ae886b4a30",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/cf16fcbb9b8107a7df6b97e497fc91e819774d8b",
+                "reference": "cf16fcbb9b8107a7df6b97e497fc91e819774d8b",
                 "shasum": ""
             },
             "require": {
@@ -11809,32 +11809,30 @@
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-simplexml": "*",
-                "fidry/cpu-core-counter": "^0.5.1 || ^1.0.0",
-                "jean85/pretty-package-versions": "^2.0.5",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-                "phpunit/php-code-coverage": "^10.1.7",
+                "fidry/cpu-core-counter": "^1.2.0",
+                "jean85/pretty-package-versions": "^2.0.6",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "phpunit/php-code-coverage": "^10.1.16",
                 "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-timer": "^6.0",
-                "phpunit/phpunit": "^10.4.2",
-                "sebastian/environment": "^6.0.1",
-                "symfony/console": "^6.3.4 || ^7.0.0",
-                "symfony/process": "^6.3.4 || ^7.0.0"
+                "phpunit/php-timer": "^6.0.0",
+                "phpunit/phpunit": "^10.5.36",
+                "sebastian/environment": "^6.1.0",
+                "symfony/console": "^6.4.7 || ^7.1.5",
+                "symfony/process": "^6.4.7 || ^7.1.5"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^12.0.0",
                 "ext-pcov": "*",
                 "ext-posix": "*",
-                "infection/infection": "^0.27.6",
-                "phpstan/phpstan": "^1.10.40",
-                "phpstan/phpstan-deprecation-rules": "^1.1.4",
-                "phpstan/phpstan-phpunit": "^1.3.15",
-                "phpstan/phpstan-strict-rules": "^1.5.2",
-                "squizlabs/php_codesniffer": "^3.7.2",
-                "symfony/filesystem": "^6.3.1 || ^7.0.0"
+                "phpstan/phpstan": "^1.12.6",
+                "phpstan/phpstan-deprecation-rules": "^1.2.1",
+                "phpstan/phpstan-phpunit": "^1.4.0",
+                "phpstan/phpstan-strict-rules": "^1.6.1",
+                "squizlabs/php_codesniffer": "^3.10.3",
+                "symfony/filesystem": "^6.4.3 || ^7.1.5"
             },
             "bin": [
                 "bin/paratest",
-                "bin/paratest.bat",
                 "bin/paratest_for_phpstorm"
             ],
             "type": "library",
@@ -11871,7 +11869,7 @@
             ],
             "support": {
                 "issues": "https://github.com/paratestphp/paratest/issues",
-                "source": "https://github.com/paratestphp/paratest/tree/v7.3.1"
+                "source": "https://github.com/paratestphp/paratest/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -11883,7 +11881,7 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2023-10-31T09:24:17+00:00"
+            "time": "2024-10-15T12:45:19+00:00"
         },
         {
             "name": "clue/ndjson-react",

--- a/database/.gitignore
+++ b/database/.gitignore
@@ -1,1 +1,2 @@
 *.sqlite
+*.sqlite_*


### PR DESCRIPTION
# Description

#15648 updated dependencies and caused tests to start failing in CI. This PR updates `brianium/paratest` from v7.3.1 to v7.4.8 and fixes the issue.

I also added the sqlite files that are created when running parallel tests and using the sqlite driver to gitignore:
![newly gitignored files](https://github.com/user-attachments/assets/57c72409-7c8c-481c-a811-db2a2ed70ca2)

--

The exceptions we are seeing in CI:

```
Fatal error: Uncaught Illuminate\Contracts\Container\BindingResolutionException: Target [Illuminate\Contracts\Debug\ExceptionHandler] is not instantiable. in /home/runner/work/snipe-it/snipe-it/vendor/laravel/framework/src/Illuminate/Container/Container.php:1126
Stack trace:
#0 /home/runner/work/snipe-it/snipe-it/vendor/laravel/framework/src/Illuminate/Container/Container.php(921): Illuminate\Container\Container->notInstantiable()
#1 /home/runner/work/snipe-it/snipe-it/vendor/laravel/framework/src/Illuminate/Container/Container.php(795): Illuminate\Container\Container->build()
#2 /home/runner/work/snipe-it/snipe-it/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(961): Illuminate\Container\Container->resolve()
#3 /home/runner/work/snipe-it/snipe-it/vendor/laravel/framework/src/Illuminate/Container/Container.php(731): Illuminate\Foundation\Application->resolve()
#4 /home/runner/work/snipe-it/snipe-it/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(946): Illuminate\Container\Container->make()
#5 /home/runner/work/snipe-it/snipe-it/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(288): Illuminate\Foundation\Application->make()
#6 /home/runner/work/snipe-it/snipe-it/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(207): Illuminate\Foundation\Bootstrap\HandleExceptions->getExceptionHandler()
#7 /home/runner/work/snipe-it/snipe-it/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(189): Illuminate\Foundation\Bootstrap\HandleExceptions->renderForConsole()
#8 /home/runner/work/snipe-it/snipe-it/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(2[55](https://github.com/snipe/snipe-it/actions/runs/11273029665/job/31349173173#step:11:56)): Illuminate\Foundation\Bootstrap\HandleExceptions->handleException()
#9 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->Illuminate\Foundation\Bootstrap\{closure}()
#10 {main}
  thrown in /home/runner/work/snipe-it/snipe-it/vendor/laravel/framework/src/Illuminate/Container/Container.php on line 1126
```

---
## Type of change

- [x] Dependencies
