### PR TITLE
Fixed #15696: Removes the requirement for a user to have ldap_import set to 1 to be able to logon using ldap

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -179,7 +179,7 @@ class LoginController extends Controller
          }
 
          // Check if the user already exists in the database and was imported via LDAP
-         $user = User::where('username', '=', $request->input('username'))->whereNull('deleted_at')->where('ldap_import', '=', 1)->where('activated', '=', '1')->first(); // FIXME - if we get more than one we should fail. and we sure about this ldap_import thing?
+         $user = User::where('username', '=', $request->input('username'))->whereNull('deleted_at')->where('activated', '=', '1')->first(); // FIXME - if we get more than one we should fail.
          Log::debug("Local auth lookup complete");
 
          // The user does not exist in the database. Try to get them from LDAP.


### PR DESCRIPTION
# Description

Removes the requirement for a user to have ldap_import set to 1 to be able to logon using ldap

Fixes #15696

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Has been tested on our server 

**Test Configuration**:
* PHP version: 8.3
* MySQL version 10.11.8-MariaDB
* Webserver version 2.4.58
* OS version Ubuntu 24.04


# Checklist:

- [ X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
