### PR TITLE
Linked accessory files in activity report

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -141,6 +141,8 @@ class ActionlogsTransformer
                 if ($actionlog->item) {
                     if ($actionlog->itemType() == 'asset') {
                         $file_url = route('show/assetfile', ['assetId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
+                    } elseif ($actionlog->itemType() == 'accessory') {
+                        $file_url = route('show.accessoryfile', ['accessoryId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
                     } elseif ($actionlog->itemType() == 'license') {
                         $file_url = route('show.licensefile', ['licenseId' => $actionlog->item->id, 'fileId' => $actionlog->id]);
                     } elseif ($actionlog->itemType() == 'user') {


### PR DESCRIPTION
# Description

This PR fixes a bug where files uploaded for accessories were not linked in activity reports.

Before:
![Filename not shown for accessory](https://github.com/user-attachments/assets/81af92ae-27ba-46fe-b672-573d615022ab)

After:
![Filename shown for accessory](https://github.com/user-attachments/assets/7da49110-eeb4-4d5d-80fd-91f5249f0526)


Fixes [sc-27188]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
