### PR TITLE
Removed second icon in accessory file list

### DIFF
--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -194,7 +194,6 @@
                                         @foreach ($accessory->uploads as $file)
                                             <tr>
                                                 <td>
-                                                    <x-icon type="paperclip" class="fa-2x" />
                                                     <i class="{{ Helper::filetype_icon($file->filename) }} icon-med" aria-hidden="true"></i>
                                                     <span class="sr-only">{{ Helper::filetype_icon($file->filename) }}</span>
 


### PR DESCRIPTION
# Description

This PR fixes a visual bug in the accessory file uploads section where two icons were shown:
![Before there are two icons displayed](https://github.com/user-attachments/assets/b6ccbba1-1acf-4b9c-bdf8-0b0c476056ef)

Here is what it looks like with this PR:
![After there is only one icon](https://github.com/user-attachments/assets/14207732-dfa1-410d-9aeb-a1ddf4364a13)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
