### PR TITLE
Added test to ensure icon component does not end in newline

### DIFF
--- a/tests/Unit/BladeComponents/IconComponentTest.php
+++ b/tests/Unit/BladeComponents/IconComponentTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit\BladeComponents;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class IconComponentTest extends TestCase
+{
+    public function testIconComponentDoesNotEndInNewline()
+    {
+        $renderedTemplateString = View::make('blade.icon', ['type' => 'checkout'])->render();
+
+        $this->assertFalse(
+            Str::endsWith($renderedTemplateString, PHP_EOL),
+            'Newline found at end of icon component. Bootstrap tables will not render if there is a newline at the end of the file.'
+        );
+    }
+}


### PR DESCRIPTION
# Description

This tiny PR simply adds a test to ensure the icon blade component does not have a newline at the end of it since that breaks the loaders for bootstrap table.

It's a minor test but can be annoying to debug if a newline accidentally gets added.

## Type of change

- [x] Testing
