### PR TITLE
Fixes #15701 - load avif files properly in lightbox

### DIFF
--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -179,7 +179,8 @@
       @if ($accessory->image!='')
           <div class="row">
               <div class="col-md-12 text-center" style="padding-bottom: 15px;">
-                  <a href="{{ Storage::disk('public')->url('accessories/'.e($accessory->image)) }}" data-toggle="lightbox"><img src="{{ Storage::disk('public')->url('accessories/'.e($accessory->image)) }}" class="img-responsive img-thumbnail" alt="{{ $accessory->name }}"></a>
+                  <a href="{{ Storage::disk('public')->url('accessories/'.e($accessory->image)) }}" data-toggle="lightbox" data-type="image">
+                      <img src="{{ Storage::disk('public')->url('accessories/'.e($accessory->image)) }}" class="img-responsive img-thumbnail" alt="{{ $accessory->name }}"></a>
               </div>
           </div>
       @endif

--- a/resources/views/components/view.blade.php
+++ b/resources/views/components/view.blade.php
@@ -161,7 +161,7 @@
   <div class="col-md-3">
     @if ($component->image!='')
       <div class="col-md-12 text-center" style="padding-bottom: 15px;">
-        <a href="{{ Storage::disk('public')->url('components/'.e($component->image)) }}" data-toggle="lightbox">
+        <a href="{{ Storage::disk('public')->url('components/'.e($component->image)) }}" data-toggle="lightbox" data-type="image">
           <img src="{{ Storage::disk('public')->url('components/'.e($component->image)) }}" class="img-responsive img-thumbnail" alt="{{ $component->name }}"></a>
       </div>
 

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -89,7 +89,7 @@
 
                 @if ($consumable->image!='')
                   <div class="col-md-12 text-center" style="padding-bottom: 20px;">
-                    <a href="{{ Storage::disk('public')->url('consumables/'.e($consumable->image)) }}" data-toggle="lightbox">
+                    <a href="{{ Storage::disk('public')->url('consumables/'.e($consumable->image)) }}" data-toggle="lightbox" data-type="image">
                       <img src="{{ Storage::disk('public')->url('consumables/'.e($consumable->image)) }}" class="img-responsive img-thumbnail" alt="{{ $consumable->name }}"></a>
                   </div>
                 @endif

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -168,7 +168,7 @@
                                 <div class="col-md-12 text-center">
                                     @if (($asset->image) || (($asset->model) && ($asset->model->image!='')))
                                         <div class="text-center col-md-12" style="padding-bottom: 15px;">
-                                            <a href="{{ ($asset->getImageUrl()) ? $asset->getImageUrl() : null }}" data-toggle="lightbox">
+                                            <a href="{{ ($asset->getImageUrl()) ? $asset->getImageUrl() : null }}" data-toggle="lightbox" data-type="image">
                                                 <img src="{{ ($asset->getImageUrl()) ? $asset->getImageUrl() : null }}" class="assetimg img-responsive" alt="{{ $asset->getDisplayNameAttribute() }}">
                                             </a>
                                         </div>
@@ -180,7 +180,7 @@
 
                                 @if ($asset->deleted_at=='')
                                     @can('update', $asset)
-                                        <div class="col-md-12 hidden-print" style="padding-top: 5px;">
+                                        <div class="col-md-12 hidden-print" style="padding-top: 5px;">s
                                             <a href="{{ route('hardware.edit', $asset->id) }}" class="btn btn-sm btn-warning btn-social btn-block hidden-print">
                                                 <x-icon type="edit" />
                                                 {{ trans('admin/hardware/general.edit') }}

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -180,7 +180,7 @@
 
                                 @if ($asset->deleted_at=='')
                                     @can('update', $asset)
-                                        <div class="col-md-12 hidden-print" style="padding-top: 5px;">s
+                                        <div class="col-md-12 hidden-print" style="padding-top: 5px;">
                                             <a href="{{ route('hardware.edit', $asset->id) }}" class="btn btn-sm btn-warning btn-social btn-block hidden-print">
                                                 <x-icon type="edit" />
                                                 {{ trans('admin/hardware/general.edit') }}


### PR DESCRIPTION
This strictly sets the file type to `image`, loading non-standard (avif, probably webp) files to load in the lightbox onclick the same way regular jpegs, pngs, etc do.