### PR TITLE
Fixed custom field checkboxes on asset edit page

### DIFF
--- a/app/Livewire/CustomFieldSetDefaultValuesForModel.php
+++ b/app/Livewire/CustomFieldSetDefaultValuesForModel.php
@@ -81,6 +81,12 @@ class CustomFieldSetDefaultValuesForModel extends Component
     {
         $this->fields->each(function ($field) {
             $this->selectedValues[$field->db_column] = $this->getSelectedValueForField($field);
+
+            // if the element is a checkbox and the value was just sent to null, make it
+            // an array since Livewire can't bind to non-array values for checkboxes.
+            if ($field->element === 'checkbox' && is_null($this->selectedValues[$field->db_column])) {
+                $this->selectedValues[$field->db_column] = [];
+            }
         });
     }
 


### PR DESCRIPTION
# Description

As noted in #15599, checkboxes for custom fields on the asset model page aren't working correctly:

![Checkboxes all get checked at once](https://github.com/user-attachments/assets/45e8e96d-d573-440b-8c32-1b1503de3020)

That's not good...

This PR fixes it:
![Checkboxes can be checked individually](https://github.com/user-attachments/assets/b716ce2e-eeba-4ad8-bcaf-fccd698b9c78)

Fixes #15599

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
