### PR TITLE
Fixed #15717 - Added ability to checkout consumables in variable qty via API

### DIFF
--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -70,7 +70,7 @@ class ConsumableCheckoutController extends Controller
         $this->authorize('checkout', $consumable);
 
         // If the quantity is not present in the request or is not a positive integer, set it to 1
-        $quantity = $request->input('qty');
+        $quantity = $request->input('checkout_qty');
         if (!isset($quantity) || !ctype_digit((string)$quantity) || $quantity <= 0) {
             $quantity = 1;
         }
@@ -92,7 +92,7 @@ class ConsumableCheckoutController extends Controller
         // Update the consumable data
         $consumable->assigned_to = e($request->input('assigned_to'));
 
-        for($i = 0; $i < $quantity; $i++){
+        for ($i = 0; $i < $quantity; $i++){
         $consumable->users()->attach($consumable->id, [
             'consumable_id' => $consumable->id,
             'created_by' => $admin_user->id,
@@ -100,6 +100,8 @@ class ConsumableCheckoutController extends Controller
             'note' => $request->input('note'),
         ]);
         }
+
+        $consumable->checkout_qty = $quantity;
         event(new CheckoutableCheckedOut($consumable, $user, auth()->user(), $request->input('note')));
 
         $request->request->add(['checkout_to_type' => 'user']);

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -38,6 +38,7 @@ class CheckoutConsumableNotification extends Notification
         $this->note = $note;
         $this->target = $checkedOutTo;
         $this->acceptance = $acceptance;
+        $this->qty = $consumable->checkout_qty;
 
         $this->settings = Setting::getSettings();
     }
@@ -173,7 +174,6 @@ class CheckoutConsumableNotification extends Notification
      */
     public function toMail()
     {
-        Log::debug($this->item->getImageUrl());
         $eula = $this->item->getEula();
         $req_accept = $this->item->requireAcceptance();
 
@@ -188,6 +188,7 @@ class CheckoutConsumableNotification extends Notification
                 'eula'          => $eula,
                 'req_accept'    => $req_accept,
                 'accept_url'    => $accept_url,
+                'qty'           => $this->qty,
             ])
             ->subject(trans('mail.Confirm_consumable_delivery'));
     }

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -91,7 +91,7 @@
               <label for="qty" class="col-md-3 control-label">{{ trans('general.qty') }}</label>
               <div class="col-md-7 col-sm-12 required">
                   <div class="col-md-2" style="padding-left:0px">
-                    <input class="form-control" type="number" name="qty" id="qty" value="1" min="1" max="{{$consumable->numRemaining()}}" maxlength="999999"  />
+                    <input class="form-control" type="number" name="checkout_qty" id="checkout_qty" value="1" min="1" max="{{$consumable->numRemaining()}}" maxlength="999999"  />
                   </div>
               </div>
               {!! $errors->first('qty', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}

--- a/resources/views/notifications/markdown/checkout-consumable.blade.php
+++ b/resources/views/notifications/markdown/checkout-consumable.blade.php
@@ -11,6 +11,9 @@
 | **{{ trans('mail.checkout_date') }}** | {{ $checkout_date }} |
 @endif
 | **{{ trans('general.consumable') }}** | {{ $item->name }} |
+@if (isset($qty))
+| **{{ trans('general.qty') }}** | {{ $qty }} |
+@endif
 @if (isset($item->manufacturer))
 | **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
 @endif


### PR DESCRIPTION
This adds `checkout_qty` to the API as a field checkout more than one consumable at a time. Fixes #15717.