### PR TITLE
FIXED: Login button can disappear under some circumstances

### DIFF
--- a/resources/views/layouts/basic.blade.php
+++ b/resources/views/layouts/basic.blade.php
@@ -32,13 +32,6 @@
         .skin-blue .sidebar-menu > li:hover > a, .skin-blue .sidebar-menu > li.active > a {
         border-left-color: {{ $snipeSettings->header_color }};
         }
-
-        .btn-primary {
-        background-color: {{ $snipeSettings->header_color }};
-        border-color: {{ $snipeSettings->header_color }};
-        }
-
-
         </style>
     @endif
 


### PR DESCRIPTION
# Description
The login button can disappear when the header color in Admin>Branding is set to white (#FFFFFF) since the button is set on a white background.
It appears on hover, and is still usable.
Some styling has been removed and the button will no longer take on the header color and thus will always be visible.

before
<img width="514" alt="Screenshot 2024-10-24 at 5 20 43 PM" src="https://github.com/user-attachments/assets/63eb6e7c-d788-4a66-adcd-b909de0450ab">
current button
<img width="588" alt="Screenshot 2024-10-24 at 5 20 47 PM" src="https://github.com/user-attachments/assets/3ec3cfa1-74d0-485f-b799-af0aad1e7d13">


Fixes # ([26974](https://app.shortcut.com/grokability/story/26974/login-button-assumes-the-color-of-the-custom-header-color))

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
visual test and test suite

**Test Configuration**:
* PHP version: 8.1
* OS version: Sonoma 14.6


# Checklist:
- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
