### PR TITLE
Added the display of logs when tests fail in GitHub Actions

### DIFF
--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -77,3 +77,7 @@ jobs:
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root
         run: php artisan test
+
+      - name: Test failure
+        if: ${{ failure() }}
+        run: docker exec "$PROJECT_NAME-php-fpm" cat storage/logs/laravel.log

--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -75,3 +75,7 @@ jobs:
           DB_USERNAME: snipeit
           DB_PASSWORD: password
         run: php artisan test
+
+      - name: Test failure
+        if: ${{ failure() }}
+        run: docker exec "$PROJECT_NAME-php-fpm" cat storage/logs/laravel.log

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -59,3 +59,7 @@ jobs:
         env:
           DB_CONNECTION: sqlite_testing
         run: php artisan test
+
+      - name: Test failure
+        if: ${{ failure() }}
+        run: docker exec "$PROJECT_NAME-php-fpm" cat storage/logs/laravel.log


### PR DESCRIPTION
# Description

Copy/Pasted from Joel over at [Mastering Laravel](https://masteringlaravel.io/daily/2024-10-28-make-it-easier-to-debug-github-actions), this PR adds a step to our tests in GitHub Actions so the application log is displayed when tests fail.

## Type of change

- [x] Chore
