### PR TITLE
FIXED: Bulk Delete page not showing full information

### DIFF
--- a/resources/views/hardware/bulk-delete.blade.php
+++ b/resources/views/hardware/bulk-delete.blade.php
@@ -42,10 +42,10 @@
                 <td>{{ $asset->id }}</td>
                 <td>{{ $asset->present()->name() }}</td>
                 <td>
-                  @if ($asset->location)
-                  {{ $asset->location->name }}
-                  @elseif($asset->rtd_location)
-                  {{ $asset->defaultLoc->name }}
+                  @if ($asset->location || $asset->location_id)
+                  {{ $asset->location->present()->name() }}
+                  @elseif($asset->rtd_location || $asset->rtd_location_id)
+                  {{ $asset->defaultLoc->present()->name() }}
                   @endif
                 </td>
                 <td>

--- a/resources/views/hardware/bulk-delete.blade.php
+++ b/resources/views/hardware/bulk-delete.blade.php
@@ -42,15 +42,15 @@
                 <td>{{ $asset->id }}</td>
                 <td>{{ $asset->present()->name() }}</td>
                 <td>
-                  @if ($asset->location)
+                  @if ($asset->location_id)
                   {{ $asset->location->name }}
+                  @elseif($asset->rtd_location_id)
+                  {{ $asset->defaultLoc->name }}
                   @endif
                 </td>
                 <td>
-
-                  {{ $asset->assigned_to }}
-                  @if ($asset->assignedTo)
-                  {{ $asset->assignedTo->present()->name()}}
+                  @if ($asset->assigned_to)
+                    {{ $asset->assigned->present()->name() }}
                   @endif
                 </td>
               </tr>

--- a/resources/views/hardware/bulk-delete.blade.php
+++ b/resources/views/hardware/bulk-delete.blade.php
@@ -42,9 +42,9 @@
                 <td>{{ $asset->id }}</td>
                 <td>{{ $asset->present()->name() }}</td>
                 <td>
-                  @if ($asset->location || $asset->location_id)
+                  @if ($asset->location)
                   {{ $asset->location->present()->name() }}
-                  @elseif($asset->rtd_location || $asset->rtd_location_id)
+                  @elseif($asset->rtd_location)
                   {{ $asset->defaultLoc->present()->name() }}
                   @endif
                 </td>

--- a/resources/views/hardware/bulk-delete.blade.php
+++ b/resources/views/hardware/bulk-delete.blade.php
@@ -42,9 +42,9 @@
                 <td>{{ $asset->id }}</td>
                 <td>{{ $asset->present()->name() }}</td>
                 <td>
-                  @if ($asset->location_id)
+                  @if ($asset->location)
                   {{ $asset->location->name }}
-                  @elseif($asset->rtd_location_id)
+                  @elseif($asset->rtd_location)
                   {{ $asset->defaultLoc->name }}
                   @endif
                 </td>


### PR DESCRIPTION
# Description
The Bulk Delete page had missing information:
1) showed user id instead of the person's name
2) showed incomplete information for a user's asset in they did not have a location set

Before:
<img width="1493" alt="Screenshot 2024-10-30 at 7 29 51 PM" src="https://github.com/user-attachments/assets/083dcbfd-776b-40fc-a4cf-2ed0d6586eb6">

After:
<img width="1483" alt="Screenshot 2024-10-30 at 7 29 29 PM" src="https://github.com/user-attachments/assets/b953f0bb-c1fc-44ee-a431-f986abe3c43d">

The location will be listed to match the location of the asset as it appears on the Assets index page.

Fixes # [26944](https://app.shortcut.com/grokability/story/26944/bulk-delete-assets-does-not-show-assigned-to)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
manual tests and test suite 

* PHP version: 8.1
* OS version: Sonoma 14.6


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
