### PR TITLE
Fix ${var} deprecation warning in License model

### DIFF
--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -184,7 +184,7 @@ class License extends Depreciable
             $logAction->item_type = self::class;
             $logAction->item_id = $license->id;
             $logAction->created_by = auth()->id() ?: 1; // We don't have an id while running the importer from CLI.
-            $logAction->note = "deleted ${change} seats";
+            $logAction->note = "deleted {$change} seats";
             $logAction->target_id = null;
             $logAction->logaction('delete seats');
 
@@ -216,7 +216,7 @@ class License extends Depreciable
             $logAction->item_type = self::class;
             $logAction->item_id = $license->id;
             $logAction->created_by = auth()->id() ?: 1; // Importer.
-            $logAction->note = "added ${change} seats";
+            $logAction->note = "added {$change} seats";
             $logAction->target_id = null;
             $logAction->logaction('add seats');
         }


### PR DESCRIPTION
# Description

When upgrading to php8.3 i started getting deprecation warning about using ${var} instead of {$var} in 2 places in License.php

```
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/snipe-it/app/Models/License.php on line 187
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/snipe-it/app/Models/License.php on line 219
```

This simple fix switches the offending statements to {$var} syntax. It works on php8.1 and no removed the errors on 8.3

