### PR TITLE
Fixed notifications for licenses and asset to asset checkoutables

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -61,24 +61,12 @@ class CheckoutableListener
             $adminCcEmailsArray = array_map('trim', explode(',', $adminCcEmail));
         }
         $ccEmails = array_filter($adminCcEmailsArray);
-
         $mailable = $this->getCheckoutMailType($event, $acceptance);
-
-        if($event->checkedOutTo instanceof Asset){
-            $event->checkedOutTo->load('assignedTo');
-            $notifiable = $event->checkedOutTo->assignedto?->email ?? '';
-        }
-        else if($event->checkedOutTo instanceof Location) {
-            $notifiable = $event->checkedOutTo->manager?->email ?? '';
-        }
-        else{
-            $notifiable = $event->checkedOutTo->email;
-        }
+        $notifiable = $this->getNotifiables($event);
 
         if  (!$event->checkedOutTo->locale){
             $mailable->locale($event->checkedOutTo->locale);
         }
-
         // Send email notifications
         try {
             /**
@@ -156,18 +144,8 @@ class CheckoutableListener
         }
         $ccEmails = array_filter($adminCcEmailsArray);
         $mailable =  $this->getCheckinMailType($event);
+        $notifiable = $this->getNotifiables($event);
 
-
-        if($event->checkedOutTo instanceof Asset){
-            $event->checkedOutTo->load('assignedTo');
-            $notifiable = $event->checkedOutTo->assignedto?->email ?? '';
-        }
-        else if($event->checkedOutTo instanceof Location) {
-            $notifiable = $event->checkedOutTo->manager?->email ?? '';
-        }
-        else{
-            $notifiable = $event->checkedOutTo->email;
-        }
         if  (!$event->checkedOutTo->locale){
             $mailable->locale($event->checkedOutTo->locale);
         }
@@ -310,6 +288,19 @@ class CheckoutableListener
 
         return new $mailable($event->checkoutable, $event->checkedOutTo, $event->checkedInBy, $event->note);
 
+    }
+    private function getNotifiables($event){
+
+        if($event->checkedOutTo instanceof Asset){
+            $event->checkedOutTo->load('assignedTo');
+            return $event->checkedOutTo->assignedto?->email ?? '';
+        }
+        else if($event->checkedOutTo instanceof Location) {
+            return $event->checkedOutTo->manager?->email ?? '';
+        }
+        else{
+            return $event->checkedOutTo->email;
+        }
     }
 
     /**

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -16,6 +16,7 @@ use App\Models\CheckoutAcceptance;
 use App\Models\Component;
 use App\Models\Consumable;
 use App\Models\LicenseSeat;
+use App\Models\Location;
 use App\Models\Setting;
 use App\Models\User;
 use App\Notifications\CheckinAccessoryNotification;
@@ -60,14 +61,26 @@ class CheckoutableListener
             $adminCcEmailsArray = array_map('trim', explode(',', $adminCcEmail));
         }
         $ccEmails = array_filter($adminCcEmailsArray);
-        $notifiable = $event->checkedOutTo;
+
         $mailable = $this->getCheckoutMailType($event, $acceptance);
+
+        if($event->checkedOutTo instanceof Asset){
+            $event->checkedOutTo->load('assignedTo');
+            $notifiable = $event->checkedOutTo->assignedto?->email ?? '';
+        }
+        else if($event->checkedOutTo instanceof Location) {
+            $notifiable = $event->checkedOutTo->manager?->email ?? '';
+        }
+        else{
+            $notifiable = $event->checkedOutTo->email;
+        }
+
+        if  (!$event->checkedOutTo->locale){
+            $mailable->locale($event->checkedOutTo->locale);
+        }
+
         // Send email notifications
         try {
-                if  (!$event->checkedOutTo->locale){
-                    $mailable->locale($event->checkedOutTo->locale);
-                }
-
             /**
              * Send an email if any of the following conditions are met:
              * 1. The asset requires acceptance
@@ -77,15 +90,20 @@ class CheckoutableListener
 
                 if ($event->checkoutable->requireAcceptance() || $event->checkoutable->getEula() ||
                     (method_exists($event->checkoutable, 'checkin_email') && $event->checkoutable->checkin_email())) {
-                    if (!empty($notifiable->email)) {
+                    if (!empty($notifiable)) {
                         Mail::to($notifiable)->cc($ccEmails)->send($mailable);
-                    } else {
+                    } elseif (!empty($ccEmails)) {
                         Mail::cc($ccEmails)->send($mailable);
                     }
-                Log::info('Sending email, Locale: ' . ($event->checkedOutTo->locale ?? 'default'));
-            }
-
+                    Log::info('Sending email, Locale: ' . ($event->checkedOutTo->locale ?? 'default'));
+                }
+        } catch (ClientException $e) {
+            Log::debug("Exception caught during checkout email: " . $e->getMessage());
+        } catch (Exception $e) {
+            Log::debug("Exception caught during checkout email: " . $e->getMessage());
+        }
 //                 Send Webhook notification
+        try{
                 if ($this->shouldSendWebhookNotification()) {
                     if (Setting::getSettings()->webhook_selected === 'microsoft') {
                         $message = $this->getCheckoutNotification($event)->toMicrosoftTeams();
@@ -137,38 +155,53 @@ class CheckoutableListener
             $adminCcEmailsArray = array_map('trim', explode(',', $adminCcEmail));
         }
         $ccEmails = array_filter($adminCcEmailsArray);
-        $notifiable = $event->checkedOutTo;
         $mailable =  $this->getCheckinMailType($event);
 
+
+        if($event->checkedOutTo instanceof Asset){
+            $event->checkedOutTo->load('assignedTo');
+            $notifiable = $event->checkedOutTo->assignedto?->email ?? '';
+        }
+        else if($event->checkedOutTo instanceof Location) {
+            $notifiable = $event->checkedOutTo->manager?->email ?? '';
+        }
+        else{
+            $notifiable = $event->checkedOutTo->email;
+        }
+        if  (!$event->checkedOutTo->locale){
+            $mailable->locale($event->checkedOutTo->locale);
+        }
         // Send email notifications
         try {
-            if  (!$event->checkedOutTo->locale){
-                $mailable->locale($event->checkedOutTo->locale);
-            }
             /**
              * Send an email if any of the following conditions are met:
              * 1. The asset requires acceptance
              * 2. The item has a EULA
              * 3. The item should send an email at check-in/check-out
              */
-
                 if ($event->checkoutable->requireAcceptance() || $event->checkoutable->getEula() ||
                     (method_exists($event->checkoutable, 'checkin_email') && $event->checkoutable->checkin_email())) {
-                    if (!empty($notifiable->email)) {
+                    if (!empty($notifiable)) {
                         Mail::to($notifiable)->cc($ccEmails)->send($mailable);
-                    } else {
+                    } elseif (!empty($ccEmails)){
                         Mail::cc($ccEmails)->send($mailable);
                     }
                     Log::info('Sending email, Locale: ' . $event->checkedOutTo->locale);
                 }
+        } catch (ClientException $e) {
+            Log::debug("Exception caught during checkin email: " . $e->getMessage());
+        } catch (Exception $e) {
+            Log::debug("Exception caught during checkin email: " . $e->getMessage());
+        }
 
-            // Send Webhook notification
+        // Send Webhook notification
+        try {
             if ($this->shouldSendWebhookNotification()) {
                     Notification::route(Setting::getSettings()->webhook_selected, Setting::getSettings()->webhook_endpoint)
                         ->notify($this->getCheckinNotification($event));
                 }
         } catch (ClientException $e) {
-            Log::warning("Exception caught during checkout notification: " . $e->getMessage());
+            Log::warning("Exception caught during checkin notification: " . $e->getMessage());
         } catch (Exception $e) {
             Log::warning("Exception caught during checkin notification: " . $e->getMessage());
         }

--- a/app/Mail/CheckinLicenseMail.php
+++ b/app/Mail/CheckinLicenseMail.php
@@ -23,7 +23,7 @@ class CheckinLicenseMail extends Mailable
     public function __construct(LicenseSeat $licenseSeat, $checkedOutTo, User $checkedInBy, $note)
     {
         $this->target = $checkedOutTo;
-        $this->item = $licenseSeat->license;
+        $this->item = $licenseSeat;
         $this->admin = $checkedInBy;
         $this->note = $note;
         $this->settings = Setting::getSettings();
@@ -50,7 +50,8 @@ class CheckinLicenseMail extends Mailable
         return new Content(
             markdown: 'mail.markdown.checkin-license',
             with:   [
-                'item'          => $this->item,
+                'license_seat'  => $this->item,
+                'license'       => $this->item->license,
                 'admin'         => $this->admin,
                 'note'          => $this->note,
                 'target'        => $this->target,

--- a/app/Mail/CheckoutLicenseMail.php
+++ b/app/Mail/CheckoutLicenseMail.php
@@ -22,7 +22,7 @@ class CheckoutLicenseMail extends Mailable
      */
     public function __construct(LicenseSeat $licenseSeat, $checkedOutTo, User $checkedOutBy, $acceptance, $note)
     {
-        $this->item = $licenseSeat->license;
+        $this->item = $licenseSeat;
         $this->admin = $checkedOutBy;
         $this->note = $note;
         $this->target = $checkedOutTo;
@@ -53,11 +53,11 @@ class CheckoutLicenseMail extends Mailable
         $req_accept = method_exists($this->item, 'requireAcceptance') ? $this->item->requireAcceptance() : 0;
 
         $accept_url = is_null($this->acceptance) ? null : route('account.accept.item', $this->acceptance);
-
         return new Content(
             markdown: 'mail.markdown.checkout-license',
             with:   [
-                'item'          => $this->item,
+                'license_seat'  => $this->item,
+                'license'       => $this->item->license,
                 'admin'         => $this->admin,
                 'note'          => $this->note,
                 'target'        => $this->target,

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -7,6 +7,7 @@ use App\Models\Asset;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Channels\SlackWebhookChannel;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -62,7 +63,7 @@ class CheckinAssetNotification extends Notification
         }
         if (Setting::getSettings()->webhook_selected == 'slack' || Setting::getSettings()->webhook_selected == 'general' ) {
             Log::debug('use webhook');
-            $notifyBy[] = 'slack';
+            $notifyBy[] = SlackWebhookChannel::class;
         }
 
         return $notifyBy;

--- a/resources/views/mail/markdown/checkin-license.blade.php
+++ b/resources/views/mail/markdown/checkin-license.blade.php
@@ -6,15 +6,15 @@
 @component('mail::table')
 |        |          |
 | ------------- | ------------- |
-| **{{ trans('mail.asset_name') }}** | {{ $item->name }} |
-@if (isset($item->manufacturer))
-| **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
+| **{{ trans('mail.asset_name') }}** | {{ $license->name }} |
+@if (isset($license->manufacturer))
+| **{{ trans('general.manufacturer') }}** | {{ $license->manufacturer->name }} |
 @endif
-@if ($target->can('update', $item))
-| **Key** | {{ $item->serial }} |
+@if (($target instanceof \App\Models\User && $target->can('view', $license)) ||($target instanceof \App\Models\Asset && $license_seat->user->can('view', $license)))
+| **Key** | {{ $license->serial }} |
 @endif
 @if (isset($item->category))
-| **{{ trans('general.category') }}** | {{ $item->category->name }} |
+| **{{ trans('general.category') }}** | {{ $license->category->name }} |
 @endif
 @if ($admin)
 | **{{ trans('general.administrator') }}** | {{ $admin->present()->fullName() }} |

--- a/resources/views/mail/markdown/checkout-license.blade.php
+++ b/resources/views/mail/markdown/checkout-license.blade.php
@@ -9,15 +9,15 @@
 @if (isset($checkout_date))
 | **{{ trans('mail.checkout_date') }}** | {{ $checkout_date }} |
 @endif
-| **{{ trans('general.license') }}** | {{ $item->name }} |
-@if (isset($item->manufacturer))
-| **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
+| **{{ trans('general.license') }}** | {{ $license->name}} |
+@if (isset($license->manufacturer))
+| **{{ trans('general.manufacturer') }}** | {{ $license->manufacturer->name }} |
 @endif
-@if (isset($item->category))
-| **{{ trans('general.category') }}** | {{ $item->category->name }} |
+@if (isset($license->category))
+| **{{ trans('general.category') }}** | {{ $license->category->name }} |
 @endif
-@if ($target->can('view', $item))
-| **Key** | {{ $item->serial }} |
+@if (($target instanceof \App\Models\User && $target->can('view', $license)) || ($target instanceof \App\Models\Asset && $license_seat->user->can('view', $license)))
+| **Key** | {{ $license->serial }} |
 @endif
 @if ($note)
 | **{{ trans('mail.additional_notes') }}** | {{ $note }} |

--- a/tests/Feature/Notifications/Webhooks/SlackNotificationsUponCheckinTest.php
+++ b/tests/Feature/Notifications/Webhooks/SlackNotificationsUponCheckinTest.php
@@ -31,8 +31,8 @@ class SlackNotificationsUponCheckinTest extends TestCase
     public static function assetCheckInTargets(): array
     {
         return [
-            'Asset checked out to user' => [fn() => User::factory()->create()],
-            'Asset checked out to asset' => [fn() => Asset::factory()->laptopMbp()->create()],
+//            'Asset checked out to user' => [fn() => User::factory()->create()],
+//            'Asset checked out to asset' => [fn() => Asset::factory()->laptopMbp()->create()],
             'Asset checked out to location' => [fn() => Location::factory()->create()],
         ];
     }

--- a/tests/Feature/Notifications/Webhooks/SlackNotificationsUponCheckinTest.php
+++ b/tests/Feature/Notifications/Webhooks/SlackNotificationsUponCheckinTest.php
@@ -31,8 +31,8 @@ class SlackNotificationsUponCheckinTest extends TestCase
     public static function assetCheckInTargets(): array
     {
         return [
-//            'Asset checked out to user' => [fn() => User::factory()->create()],
-//            'Asset checked out to asset' => [fn() => Asset::factory()->laptopMbp()->create()],
+            'Asset checked out to user' => [fn() => User::factory()->create()],
+            'Asset checked out to asset' => [fn() => Asset::factory()->laptopMbp()->create()],
             'Asset checked out to location' => [fn() => Location::factory()->create()],
         ];
     }


### PR DESCRIPTION
# Description

Fixed notifications firing when a license is checked out, if the target is an asset finding the assignedto is important on the markdown. correctly grabs the email of managers of locations, owners of assets that assets are being assigned to.

Adds try/catches around mail. if mail breaks notifications will still be sent. Also adds a conditional around `Ccemails` if sending to `Ccemails` is the only thing Mail is trying to send to.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
