### PR TITLE
Added Checkout ID column to user accessory table

### DIFF
--- a/resources/lang/en-US/admin/accessories/table.php
+++ b/resources/lang/en-US/admin/accessories/table.php
@@ -1,7 +1,6 @@
 <?php
 
 return array(
-    'accessory_checkout_id'     => 'Checkout ID',
 	'dl_csv'      				=> 'Download CSV',
 	'eula_text'      			=> 'EULA',
     'id'      					=> 'ID',

--- a/resources/lang/en-US/admin/accessories/table.php
+++ b/resources/lang/en-US/admin/accessories/table.php
@@ -1,11 +1,10 @@
 <?php
 
 return array(
+    'accessory_checkout_id'     => 'Checkout ID',
 	'dl_csv'      				=> 'Download CSV',
 	'eula_text'      			=> 'EULA',
     'id'      					=> 'ID',
     'require_acceptance'      	=> 'Acceptance',
     'title'      				=> 'Accessory Name',
-
-
 );

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -896,7 +896,7 @@
                     }'>
               <thead>
                 <tr>
-                    <th class="col-md-1">{{ trans('admin/accessories/table.accessory_checkout_id') }}</th>
+                    <th class="col-md-1">{{ trans('general.id') }}</th>
                     <th class="col-md-4">{{ trans('general.name') }}</th>
                     <th class-="col-md-5" data-fieldname="note">{{ trans('general.notes') }}</th>
                     <th class="col-md-1" data-footer-formatter="sumFormatter" data-fieldname="purchase_cost">{{ trans('general.purchase_cost') }}</th>

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -896,7 +896,8 @@
                     }'>
               <thead>
                 <tr>
-                    <th class="col-md-5">{{ trans('general.name') }}</th>
+                    <th class="col-md-1">{{ trans('admin/accessories/table.accessory_checkout_id') }}</th>
+                    <th class="col-md-4">{{ trans('general.name') }}</th>
                     <th class-="col-md-5" data-fieldname="note">{{ trans('general.notes') }}</th>
                     <th class="col-md-1" data-footer-formatter="sumFormatter" data-fieldname="purchase_cost">{{ trans('general.purchase_cost') }}</th>
                     <th class="col-md-1 hidden-print">{{ trans('general.action') }}</th>
@@ -905,7 +906,8 @@
               <tbody>
                   @foreach ($user->accessories as $accessory)
                   <tr>
-                    <td>{!!$accessory->present()->nameUrl()!!}</td>
+                      <td>{{ $accessory->pivot->id }}</td>
+                      <td>{!!$accessory->present()->nameUrl()!!}</td>
                       <td>{!! $accessory->pivot->note !!}</td>
                       <td>
                       {!! Helper::formatCurrencyOutput($accessory->purchase_cost) !!}


### PR DESCRIPTION
# Description

This PR adds a `Checkout ID` column to the user's accessories table:
![user accessory table with Checkout ID listed](https://github.com/user-attachments/assets/12587866-7d95-46b7-b176-21410c03312e)

This gives a visual indication of what ID needs to be sent to the check in accessory api [endpoint](https://snipe-it.readme.io/reference/accessories-checkin).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
