### PR TITLE
Add new indexes to locations and users for faster manager lookups

### DIFF
--- a/database/migrations/2024_11_06_211457_add_manager_indexes_to_location_and_user.php
+++ b/database/migrations/2024_11_06_211457_add_manager_indexes_to_location_and_user.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->index('manager_id');
+        });
+        Schema::table('users', function (Blueprint $table) {
+            $table->index('manager_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->dropIndex(['manager_id']);
+        });
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['manager_id']);
+        });
+    }
+};


### PR DESCRIPTION
In many of our User lookups, we also return counts of "managed locations" and "managed users".

But unfortunately, we don't have indexes on `manager_id` for either of those, which can improve the performance of those subqueries.

This adds those two indexes