### PR TITLE
Improved indexes on manager_id for locations and users, including del…

### DIFF
--- a/database/migrations/2024_11_07_113631_improve_manager_indexes_on_users_and_locations.php
+++ b/database/migrations/2024_11_07_113631_improve_manager_indexes_on_users_and_locations.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->dropIndex(['manager_id']);
+            $table->index(['manager_id','deleted_at']);
+        });
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['manager_id']);
+            $table->index(['manager_id','deleted_at']);
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('locations', function (Blueprint $table) {
+            $table->dropIndex(['manager_id','deleted_at']);
+            $table->index(['manager_id']);
+        });
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['manager_id','deleted_at']);
+            $table->index(['manager_id']);
+        });
+    }
+};


### PR DESCRIPTION
I had added new indexes on `manager_id` yesterday for users and locations.

But interestingly enough, the `EXPLAIN` was showing that the MySQL query planner wasn't actually using it.

I was able to work out that this is because we didn't include the `deleted_at` attribute - MySQL figured it was easier to just scan the table and pick those up rather than walk through the index and then reach out to every individual record.

So this change just removes those indexes I had just added, replacing them with composite indexes across `manager_id` *and* `deleted_at`.