### PR TITLE
Fixed dark background to fieldsets and right border

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -47,7 +47,7 @@
   padding: 10px;
   background: #f4f4f4;
   margin-bottom: 3px;
-  border-left: 2px solid #e6e7e8;
+  border-inline: 2px solid #e6e7e8;
   color: #444;
   cursor: move;
 }

--- a/resources/assets/less/skins/skin-black-dark.less
+++ b/resources/assets/less/skins/skin-black-dark.less
@@ -112,8 +112,10 @@ a {
   color: #fff;
 }
 
-
-
+#sort tr.cansort{
+  background-color:var(--back-main);
+  color:var(--text-main);
+}
 
 :root {
   --background: #222;

--- a/resources/assets/less/skins/skin-blue-dark.less
+++ b/resources/assets/less/skins/skin-blue-dark.less
@@ -107,6 +107,10 @@ a {
 .text-primary {
   color: #fff;
 }
+#sort tr.cansort{
+  background-color:var(--back-main);
+  color:var(--text-main);
+}
 
 
 

--- a/resources/assets/less/skins/skin-green-dark.less
+++ b/resources/assets/less/skins/skin-green-dark.less
@@ -107,6 +107,10 @@ a {
   color: #fff;
 }
 
+#sort tr.cansort{
+  background-color:var(--back-main);
+  color:var(--text-main);
+}
 
 
 

--- a/resources/assets/less/skins/skin-orange-dark.less
+++ b/resources/assets/less/skins/skin-orange-dark.less
@@ -98,6 +98,11 @@ li.dropdown-item-marker {
   color: #fff;
 }
 
+#sort tr.cansort{
+  background-color:var(--back-main);
+  color:var(--text-main);
+}
+
 :root {
   --background: #222;
   --back-main: #333;

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -108,8 +108,10 @@ a {
   color: #fff;
 }
 
-
-
+#sort tr.cansort{
+  background-color:var(--back-main);
+  color:var(--text-main);
+}
 
 :root {
   --background: #222;

--- a/resources/assets/less/skins/skin-red-dark.less
+++ b/resources/assets/less/skins/skin-red-dark.less
@@ -107,8 +107,10 @@ a {
   color: #fff;
 }
 
-
-
+#sort tr.cansort{
+  background-color:var(--back-main);
+  color:var(--text-main);
+}
 
 :root {
   --background: #222;

--- a/resources/assets/less/skins/skin-yellow-dark.less
+++ b/resources/assets/less/skins/skin-yellow-dark.less
@@ -104,8 +104,10 @@ a {
   color: #fff;
 }
 
-
-
+#sort tr.cansort{
+  background-color:var(--back-main);
+  color:var(--text-main);
+}
 
 :root {
   --background: #222;


### PR DESCRIPTION
# Description

Fixes the fieldset table background color and right border.

Before:
![image](https://github.com/user-attachments/assets/25245d16-1770-4a53-b803-e7d3300b83a4)

After:
<img width="1673" alt="image" src="https://github.com/user-attachments/assets/3e6b9c9a-fbec-43b3-9326-98559a0d8d03">

These changes are applied to all dark themes.

Fixes #[sc-27326]

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
