### PR TITLE
Fixes consumables' checkout 500 error and memory exhaustion

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
     "repository": "https://github.com/snipe/snipe-it",
     "logo": "https://pbs.twimg.com/profile_images/976748875733020672/K-HnZCCK_400x400.jpg",
     "success_url": "/setup",
-    "": {
+    "env": {
       "APP_ENV": {
         "description": "Laravel environment mode. Unless developing the application, this should be production.",
         "value": "production"

--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
     "repository": "https://github.com/snipe/snipe-it",
     "logo": "https://pbs.twimg.com/profile_images/976748875733020672/K-HnZCCK_400x400.jpg",
     "success_url": "/setup",
-    "env": {
+    "": {
       "APP_ENV": {
         "description": "Laravel environment mode. Unless developing the application, this should be production.",
         "value": "production"

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use Illuminate\Http\Request;
 use \Illuminate\Contracts\View\View;
 use \Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
 
 class ConsumableCheckoutController extends Controller
 {
@@ -63,8 +64,9 @@ class ConsumableCheckoutController extends Controller
      */
     public function store(Request $request, $consumableId)
     {
-        if (is_null($consumable = Consumable::with('users')->find($consumableId))) {
-            return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.not_found'));
+        if (is_null($consumable = Consumable::find($consumableId))) {
+            return redirect()->route('consumables.index')
+                ->with('error', trans('admin/consumables/message.not_found'));
         }
 
         $this->authorize('checkout', $consumable);
@@ -74,10 +76,16 @@ class ConsumableCheckoutController extends Controller
         if (!isset($quantity) || !ctype_digit((string)$quantity) || $quantity <= 0) {
             $quantity = 1;
         }
+        // attaching large amounts of checkouts can exhaust memory.
+        if($quantity > 10000){
+            return redirect()->back()
+                ->with('error', trans('admin/consumables/message.checkout.large_quantity_error', ['requested' => $quantity, 'remaining' => $consumable->numRemaining() ]));
+        }
 
         // Make sure there is at least one available to checkout
-        if ($consumable->numRemaining() <= 0 || $quantity > $consumable->numRemaining()) {
-            return redirect()->route('consumables.index')->with('error', trans('admin/consumables/message.checkout.unavailable', ['requested' => $quantity, 'remaining' => $consumable->numRemaining() ]));
+        if ($consumable->numRemaining() <= 0 || $quantity > $consumable->numRemaining() ){
+            return redirect()->route('consumables.index')
+                ->with('error', trans('admin/consumables/message.checkout.unavailable', ['requested' => $quantity, 'remaining' => $consumable->numRemaining() ]));
         }
 
         $admin_user = auth()->user();
@@ -86,26 +94,35 @@ class ConsumableCheckoutController extends Controller
         // Check if the user exists
         if (is_null($user = User::find($assigned_to))) {
             // Redirect to the consumable management page with error
-            return redirect()->route('consumables.checkout.show', $consumable)->with('error', trans('admin/consumables/message.checkout.user_does_not_exist'))->withInput();
+            return redirect()->route('consumables.checkout.show', $consumable)
+                ->with('error', trans('admin/consumables/message.checkout.user_does_not_exist'))
+                ->withInput();
+        }
+        $now = now();
+
+        try {
+            $data = [
+                'consumable_id' => $consumable->id,
+                'created_by' => $admin_user->id,
+                'assigned_to' => $assigned_to,
+                'note' => $request->input('note') ?: null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+
+            // Update the consumable data
+            $attachData = array_fill(0,$quantity, $data);
+
+            DB::transaction(function () use ($consumable, $attachData, $user, $request) {
+                $consumable->users()->attach($attachData);
+                event(new CheckoutableCheckedOut($consumable, $user, auth()->user(), $request->input('note')));
+            });
+        }catch(\Exception $e){
+           report ($e);
+           return redirect()->back()->with('error', trans('admin/consumables/message.checkout.checkout_error'));
         }
 
-        // Update the consumable data
-        $consumable->assigned_to = e($request->input('assigned_to'));
-
-        for ($i = 0; $i < $quantity; $i++){
-        $consumable->users()->attach($consumable->id, [
-            'consumable_id' => $consumable->id,
-            'created_by' => $admin_user->id,
-            'assigned_to' => e($request->input('assigned_to')),
-            'note' => $request->input('note'),
-        ]);
-        }
-
-        $consumable->checkout_qty = $quantity;
-        event(new CheckoutableCheckedOut($consumable, $user, auth()->user(), $request->input('note')));
-
-        $request->request->add(['checkout_to_type' => 'user']);
-        $request->request->add(['assigned_user' => $user->id]);
+        $request->request->add(['checkout_to_type' => 'user', 'assigned_user' => $user->id]);
 
         session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => $request->get('checkout_to_type')]);
 

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -79,7 +79,7 @@ class ConsumableCheckoutController extends Controller
         // attaching large amounts of checkouts can exhaust memory.
         if($quantity > 10000){
             return redirect()->back()
-                ->with('error', trans('admin/consumables/message.checkout.large_quantity_error', ['requested' => $quantity, 'remaining' => $consumable->numRemaining() ]));
+                ->with('error', trans('admin/consumables/message.checkout.large_quantity_error', ['max_amount' => 10000]));
         }
 
         // Make sure there is at least one available to checkout

--- a/resources/lang/en-US/admin/consumables/message.php
+++ b/resources/lang/en-US/admin/consumables/message.php
@@ -28,7 +28,7 @@ return array(
         'user_does_not_exist' => 'That user is invalid. Please try again.',
          'unavailable'      => 'There are not enough consumables for this checkout. Please check the quantity left. ',
          'checkout_error' => 'Something went wrong with your Checkout',
-         'large_quantity_error' => '10,000 is the max quantity per checkout.',
+         'large_quantity_error' => ':max_amount is the max quantity per checkout.',
     ),
 
     'checkin' => array(

--- a/resources/lang/en-US/admin/consumables/message.php
+++ b/resources/lang/en-US/admin/consumables/message.php
@@ -5,6 +5,7 @@ return array(
     'invalid_category_type' => 'The category must be a consumable category.',
     'does_not_exist' => 'Consumable does not exist.',
 
+
     'create' => array(
         'error'   => 'Consumable was not created, please try again.',
         'success' => 'Consumable created successfully.'
@@ -26,6 +27,8 @@ return array(
         'success' 		=> 'Consumable checked out successfully.',
         'user_does_not_exist' => 'That user is invalid. Please try again.',
          'unavailable'      => 'There are not enough consumables for this checkout. Please check the quantity left. ',
+         'checkout_error' => 'Something went wrong with your Checkout',
+         'large_quantity_error' => '10,000 is the max quantity per checkout.',
     ),
 
     'checkin' => array(


### PR DESCRIPTION
# Description

This fixes the 500 error upon consumable checkout and adds try/catch around the array creation and db transaction. 
Speaking of a DB transaction, this refactors the store method by cutting back on querying the users table too many times and utilizes a DB transaction.
This also caps the checkout quantity to 10 thousand. Performance gets shotty above that and can error sometimes. 
<img width="1953" alt="image" src="https://github.com/user-attachments/assets/aba74fe8-2708-4684-974b-54f3b50ff64b">

If an error occurs or memory exhaustion it will no longer 500 but return an error message:
<img width="1953" alt="image" src="https://github.com/user-attachments/assets/5b0e3e66-62f2-4b48-840c-ff5b2ff55317">


Fixes #[sc-27379]

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
