### PR TITLE
Allow user to specify null for calculation or explicit on bulk edit

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -321,7 +321,11 @@ class BulkAssetsController extends Controller
 
                 if ($request->input('null_asset_eol_date')=='1') {
                     $this->update_array['asset_eol_date'] = null;
-                    $this->update_array['eol_explicit'] = 1;
+
+                    // If they are nulling the EOL date to allow it to calculate, set eol explicit to 0
+                    if ($request->input('calc_eol')=='1') {
+                        $this->update_array['eol_explicit'] = 0;
+                    }
                 }
 
 

--- a/resources/lang/en-US/admin/hardware/form.php
+++ b/resources/lang/en-US/admin/hardware/form.php
@@ -59,5 +59,6 @@ return [
     'asset_deployable' => 'That status is deployable. This asset can be checked out.',
     'processing_spinner' => 'Processing... (This might take a bit of time on large files)',
     'optional_infos'  => 'Optional Information',
-    'order_details'   => 'Order Related Information'
+    'order_details'   => 'Order Related Information',
+    'calc_eol'    => 'If nulling the EOL date, use automatic EOL calculation based on the purchase date and EOL rate.',
 ];

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -91,7 +91,7 @@
               </div>
           </div>
 
-          <!-- Purchase Date -->
+          <!-- EOL Date -->
           <div class="form-group {{ $errors->has('asset_eol_date') ? ' has-error' : '' }}">
             <label for="eol_date" class="col-md-3 control-label">{{ trans('admin/hardware/form.eol_date') }}</label>
             <div class="col-md-4">
@@ -105,6 +105,15 @@
               <label class="form-control">
                 {{ Form::checkbox('null_asset_eol_date', '1', false) }}
                 {{ trans_choice('general.set_to_null', count($assets),['selection_count' => count($assets)]) }}
+              </label>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div class="col-md-9 col-md-offset-3">
+              <label class="form-control">
+                {{ Form::checkbox('calc_eol', '1', false) }}
+                {{ trans('admin/hardware/form.calc_eol') }}
               </label>
             </div>
           </div>


### PR DESCRIPTION
This allows the user to specify whether they want a nulled EOL date to be specifically NULL or if they want the auto-calculation to be used.