### PR TITLE
Check that the file exists before trying to download stored EULA

### DIFF
--- a/app/Http/Controllers/ActionlogController.php
+++ b/app/Http/Controllers/ActionlogController.php
@@ -37,10 +37,18 @@ class ActionlogController extends Controller
         }
     }
 
-    public function getStoredEula($filename) : Response | BinaryFileResponse
+    public function getStoredEula($filename) : Response | BinaryFileResponse | RedirectResponse
     {
         $this->authorize('view', \App\Models\Asset::class);
         $file = config('app.private_uploads').'/eula-pdfs/'.$filename;
-        return response()->download($file);
+
+        if (Storage::exists($file)) {
+            return response()->download($file);
+        }
+
+        return redirect()->back()->with('error',  trans('general.file_does_not_exist'));
+
+
+
     }
 }


### PR DESCRIPTION
This checks to make sure the file actually exists on the server before attempting to download it.