### PR TITLE
Updated deprecated trigger for ms teams

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -175,8 +175,14 @@ class CheckoutableListener
         // Send Webhook notification
         try {
             if ($this->shouldSendWebhookNotification()) {
-                    Notification::route(Setting::getSettings()->webhook_selected, Setting::getSettings()->webhook_endpoint)
-                        ->notify($this->getCheckinNotification($event));
+                    if (Setting::getSettings()->webhook_selected === 'microsoft') {
+                        $message = $this->getCheckinNotification($event)->toMicrosoftTeams();
+                        $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
+                        $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
+                    } else {
+                        Notification::route(Setting::getSettings()->webhook_selected, Setting::getSettings()->webhook_endpoint)
+                            ->notify($this->getCheckinNotification($event, $acceptance));
+                    }
                 }
         } catch (ClientException $e) {
             Log::warning("Exception caught during checkin notification: " . $e->getMessage());

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -181,7 +181,7 @@ class CheckoutableListener
                         $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
                     } else {
                         Notification::route(Setting::getSettings()->webhook_selected, Setting::getSettings()->webhook_endpoint)
-                            ->notify($this->getCheckinNotification($event, $acceptance));
+                            ->notify($this->getCheckinNotification($event));
                     }
                 }
         } catch (ClientException $e) {

--- a/app/Livewire/SlackSettingsForm.php
+++ b/app/Livewire/SlackSettingsForm.php
@@ -113,6 +113,10 @@ class SlackSettingsForm extends Component
         if($this->webhook_selected == 'microsoft' || $this->webhook_selected == 'google'){
             $this->webhook_channel = '#NA';
         }
+
+    }
+    public function updatedwebhookEndpoint() {
+        $this->teams_webhook_deprecated = !Str::contains($this->webhook_endpoint, 'workflows');
     }
 
     private function isButtonDisabled() {


### PR DESCRIPTION
# Description

This adds an update check for the webhook endpoint. The deprecation check was based on what the endpoint was in the db and was not accounting for when it updated in the request.  which lead to an incorrect error message. 

Also the check in notification was missing..this adds it back.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
