### PR TITLE
Patch for whitespace causing HTTP 500 errors.

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -932,7 +932,7 @@ case $setupmail in
 
     echo -n "  From name:"
     read -r mailfromname
-    sed -i "s|^\\(MAIL_FROM_NAME=\\).*|\\1$mailfromname|" "$APP_PATH/.env"
+    sed -i  "s|^\\(MAIL_FROM_NAME=\\).*|\\1\\'$mailfromname\\'|" "$APP_PATH/.env"
 
     echo -n "  Reply to address:"
     read -r mailreplytoaddr
@@ -940,7 +940,7 @@ case $setupmail in
 
     echo -n "  Reply to name:"
     read -r mailreplytoname
-    sed -i "s|^\\(MAIL_REPLYTO_NAME=\\).*|\\1$mailreplytoname|" "$APP_PATH/.env"
+    sed -i "s|^\\(MAIL_REPLYTO_NAME=\\).*|\\1\\'$mailreplytoname\\'|" "$APP_PATH/.env"
     setupmail="yes"
     ;;
   [nN] | [n|N][O|o] )


### PR DESCRIPTION
Description
Patch that adds qoutes around MAIL_FROM_NAME and MAIL_REPLYTO_NAME as current script will generate a .env file which causes an 500 error preventing the site from loading.

Log File: /var/log/apache2/error.log:
The environment file is invalid!
Failed to parse dotenv file. Encountered unexpected whitespace at [Asset Management System].

Fixes # (issue)
See above

Type of change
Please delete options that are not relevant.

[X ] Bug fix (non-breaking change which fixes an issue)
How Has This Been Tested?
Tested in local enviroment with mail being sent to a external email server running postfix.