### PR TITLE
Fixed Microsoft Teams notifications

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -31,6 +31,7 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
 use Exception;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Osama\LaravelTeamsNotification\TeamsNotification;
 
 class CheckoutableListener
@@ -94,7 +95,7 @@ class CheckoutableListener
 //                 Send Webhook notification
         try{
                 if ($this->shouldSendWebhookNotification()) {
-                    if (Setting::getSettings()->webhook_selected === 'microsoft') {
+                    if ($this->newMicrosoftTeamsWebhookEnabled()) {
                         $message = $this->getCheckoutNotification($event)->toMicrosoftTeams();
                         $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
                         $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
@@ -176,7 +177,7 @@ class CheckoutableListener
         // Send Webhook notification
         try {
             if ($this->shouldSendWebhookNotification()) {
-                    if (Setting::getSettings()->webhook_selected === 'microsoft') {
+                if ($this->newMicrosoftTeamsWebhookEnabled()) {
                         $message = $this->getCheckinNotification($event)->toMicrosoftTeams();
                         $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
                         $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
@@ -344,5 +345,10 @@ class CheckoutableListener
             return $event->checkoutable->license->checkin_email();
         }
         return (method_exists($event->checkoutable, 'checkin_email') && $event->checkoutable->checkin_email());
+    }
+
+    private function newMicrosoftTeamsWebhookEnabled(): bool
+    {
+        return Setting::getSettings()->webhook_selected === 'microsoft' && Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows');
     }
 }

--- a/app/Livewire/SlackSettingsForm.php
+++ b/app/Livewire/SlackSettingsForm.php
@@ -114,10 +114,9 @@ class SlackSettingsForm extends Component
             $this->webhook_channel = '#NA';
         }
     }
-    public function updatedwebhookEndpoint() {
-        $this->teams_webhook_deprecated = !Str::contains($this->webhook_endpoint, 'workflows');
-    }
-    public function updatedwebhookEndpoint() {
+
+    public function updatedwebhookEndpoint()
+    {
         $this->teams_webhook_deprecated = !Str::contains($this->webhook_endpoint, 'workflows');
     }
 

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -111,7 +111,8 @@ class CheckoutAssetNotification extends Notification
                     ->content($note);
             });
     }
-    public function toMicrosoftTeams() : array
+
+    public function toMicrosoftTeams()
     {
         $target = $this->target;
         $admin = $this->admin;


### PR DESCRIPTION
# Description

We currently have two ways to send webhooks to Microsoft Teams since one is being deprecated in the near future. This PR fixes a bug where we were accidentally not checking for which version should be used in the listener.

It also fixes a bug where the integrations page was not rendering.

Note: We don't have an old webhook to test with so we're going on prayers that the old version still works.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
