### PR TITLE
replace the via() channel for MS Teams (deprecated)

### DIFF
--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -70,7 +70,7 @@ class CheckoutAssetNotification extends Notification
 
         if (Setting::getSettings()->webhook_selected === 'microsoft' && Setting::getSettings()->webhook_endpoint) {
 
-            $notifyBy[] = TeamsNotification::class;
+            $notifyBy[] = MicrosoftTeamsChannel::class;
         }
 
 


### PR DESCRIPTION
# Description

This reverts the via method back to MicrosoftTeamsChannel.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)



