### PR TITLE
Removes asset tag if 2D code is not present

### DIFF
--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
@@ -49,13 +49,6 @@ class LabelWriter_1933081 extends LabelWriter
             );
             $currentX += $barcodeSize + self::BARCODE_MARGIN;
             $usableWidth -= $barcodeSize + self::BARCODE_MARGIN;
-        } else {
-            static::writeText(
-                $pdf, $record->get('tag'),
-                $pa->x1, $pa->y2 - self::TAG_SIZE,
-                'freesans', 'b', self::TAG_SIZE, 'R',
-                $usableWidth, self::TAG_SIZE, true, 0
-            );
         }
 
         if ($record->has('title')) {

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_1933081.php
@@ -49,6 +49,13 @@ class LabelWriter_1933081 extends LabelWriter
             );
             $currentX += $barcodeSize + self::BARCODE_MARGIN;
             $usableWidth -= $barcodeSize + self::BARCODE_MARGIN;
+        } else {
+            static::writeText(
+                $pdf, $record->get('tag'),
+                $pa->x1, $pa->y2 - self::TAG_SIZE,
+                'freesans', 'b', self::TAG_SIZE, 'R',
+                $usableWidth, self::TAG_SIZE, true, 0
+            );
         }
 
         if ($record->has('title')) {

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_2112283.php
@@ -49,13 +49,6 @@ class LabelWriter_2112283 extends LabelWriter
             );
             $currentX += $barcodeSize + self::BARCODE_MARGIN;
             $usableWidth -= $barcodeSize + self::BARCODE_MARGIN;
-        } else {
-            static::writeText(
-                $pdf, $record->get('tag'),
-                $pa->x1, $pa->y2 - self::TAG_SIZE,
-                'freesans', 'b', self::TAG_SIZE, 'R',
-                $usableWidth, self::TAG_SIZE, true, 0
-            );
         }
 
         if ($record->has('title')) {

--- a/app/Models/Labels/Tapes/Dymo/LabelWriter_30252.php
+++ b/app/Models/Labels/Tapes/Dymo/LabelWriter_30252.php
@@ -50,13 +50,6 @@ class LabelWriter_30252 extends LabelWriter
             );
             $currentX += $barcodeSize + self::BARCODE_MARGIN;
             $usableWidth -= $barcodeSize + self::BARCODE_MARGIN;
-        } else {
-            static::writeText(
-                $pdf, $record->get('tag'),
-                $pa->x1, $pa->y2 - self::TAG_SIZE,
-                'freemono', 'b', self::TAG_SIZE, 'R',
-                $usableWidth, self::TAG_SIZE, true, 0
-            );
         }
 
         if ($record->has('title')) {


### PR DESCRIPTION
# Description

The asset tag comes free when a QR code is used. 
<img width="338" alt="image" src="https://github.com/user-attachments/assets/30a2152a-e0cc-4e62-98a2-2035f9e1bc4d">

But if the QR code is not present the asset tag would be placed in an awkward place.
<img width="338" alt="image" src="https://github.com/user-attachments/assets/556dbe11-73fe-4453-8fdd-a7520f5a308c">

If a QR code is not being used the asset tag will have to be in a field space now:
<img width="338" alt="image" src="https://github.com/user-attachments/assets/b5643c6f-59b6-468a-8c35-b9a26adff250">

These changes are applied to the following labels:
LabelWriter_1933081 
LabelWriter_2112283 
LabelWriter_30252

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
