### PR TITLE
Corrected route name for delete action on filestable on assets

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1365,7 +1365,7 @@
                                 <x-filestable
                                         filepath="private_uploads/assets/"
                                         showfile_routename="show/assetfile"
-                                        deletefile_routename="delete/modelfile"
+                                        deletefile_routename="delete/assetfile"
                                         :object="$asset" />
                             </div> <!-- /.col-md-12 -->
                         </div> <!-- /.row -->
@@ -1379,7 +1379,7 @@
                                 <x-filestable
                                         filepath="private_uploads/assetmodels/"
                                         showfile_routename="show/modelfile"
-                                        deletefile_routename="userfile.destroy"
+                                        deletefile_routename="modelfile.destroy"
                                         :object="$asset->model" />
 
                             </div> <!-- /.col-md-12 -->

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1379,7 +1379,7 @@
                                 <x-filestable
                                         filepath="private_uploads/assetmodels/"
                                         showfile_routename="show/modelfile"
-                                        deletefile_routename="modelfile.destroy"
+                                        deletefile_routename="delete/modelfile"
                                         :object="$asset->model" />
 
                             </div> <!-- /.col-md-12 -->


### PR DESCRIPTION
This fixes a bug when trying to delete an uploaded asset file where it would say that the asset does not exist and the file would not be deleted.