### PR TITLE
replace env with config variable for from address

### DIFF
--- a/.env.testing.example
+++ b/.env.testing.example
@@ -17,3 +17,5 @@ DB_PORT=3306
 DB_DATABASE=null
 DB_USERNAME=null
 DB_PASSWORD=null
+
+MAIL_FROM_ADDR=you@example.com

--- a/app/Mail/CheckinAccessoryMail.php
+++ b/app/Mail/CheckinAccessoryMail.php
@@ -34,7 +34,7 @@ class CheckinAccessoryMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
+        $from = new Address(config('mail.from.address'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckinAccessoryMail.php
+++ b/app/Mail/CheckinAccessoryMail.php
@@ -34,7 +34,7 @@ class CheckinAccessoryMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(env('MAIL_FROM_ADDR','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address','service@snipe-it.io'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckinAccessoryMail.php
+++ b/app/Mail/CheckinAccessoryMail.php
@@ -34,7 +34,7 @@ class CheckinAccessoryMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckinAssetMail.php
+++ b/app/Mail/CheckinAssetMail.php
@@ -43,7 +43,7 @@ class CheckinAssetMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckinAssetMail.php
+++ b/app/Mail/CheckinAssetMail.php
@@ -43,7 +43,7 @@ class CheckinAssetMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(env('MAIL_FROM_ADDR','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address','service@snipe-it.io'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckinAssetMail.php
+++ b/app/Mail/CheckinAssetMail.php
@@ -43,7 +43,7 @@ class CheckinAssetMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
+        $from = new Address(config('mail.from.address'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckinLicenseMail.php
+++ b/app/Mail/CheckinLicenseMail.php
@@ -34,7 +34,7 @@ class CheckinLicenseMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(env('MAIL_FROM_ADDR','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address','service@snipe-it.io'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckinLicenseMail.php
+++ b/app/Mail/CheckinLicenseMail.php
@@ -34,7 +34,7 @@ class CheckinLicenseMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckinLicenseMail.php
+++ b/app/Mail/CheckinLicenseMail.php
@@ -34,7 +34,7 @@ class CheckinLicenseMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
+        $from = new Address(config('mail.from.address'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutAccessoryMail.php
+++ b/app/Mail/CheckoutAccessoryMail.php
@@ -37,7 +37,7 @@ class CheckoutAccessoryMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(env('MAIL_FROM_ADDR','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address','service@snipe-it.io'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutAccessoryMail.php
+++ b/app/Mail/CheckoutAccessoryMail.php
@@ -37,7 +37,7 @@ class CheckoutAccessoryMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutAccessoryMail.php
+++ b/app/Mail/CheckoutAccessoryMail.php
@@ -37,7 +37,7 @@ class CheckoutAccessoryMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
+        $from = new Address(config('mail.from.address'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -52,7 +52,7 @@ class CheckoutAssetMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address', 'service@snipe-it.io'));
+        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -52,7 +52,7 @@ class CheckoutAssetMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
+        $from = new Address(config('mail.from.address'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -52,7 +52,7 @@ class CheckoutAssetMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(env('MAIL_FROM_ADDR', 'service@snipe-it.io'));
+        $from = new Address(config('mail.from.address', 'service@snipe-it.io'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutConsumableMail.php
+++ b/app/Mail/CheckoutConsumableMail.php
@@ -38,7 +38,7 @@ class CheckoutConsumableMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
+        $from = new Address(config('mail.from.address'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutConsumableMail.php
+++ b/app/Mail/CheckoutConsumableMail.php
@@ -38,7 +38,7 @@ class CheckoutConsumableMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(env('MAIL_FROM_ADDR','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address','service@snipe-it.io'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutConsumableMail.php
+++ b/app/Mail/CheckoutConsumableMail.php
@@ -38,7 +38,7 @@ class CheckoutConsumableMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutLicenseMail.php
+++ b/app/Mail/CheckoutLicenseMail.php
@@ -36,7 +36,7 @@ class CheckoutLicenseMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutLicenseMail.php
+++ b/app/Mail/CheckoutLicenseMail.php
@@ -36,7 +36,7 @@ class CheckoutLicenseMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(env('MAIL_FROM_ADDR','service@snipe-it.io'));
+        $from = new Address(config('mail.from.address','service@snipe-it.io'));
 
         return new Envelope(
             from: $from,

--- a/app/Mail/CheckoutLicenseMail.php
+++ b/app/Mail/CheckoutLicenseMail.php
@@ -36,7 +36,7 @@ class CheckoutLicenseMail extends Mailable
      */
     public function envelope(): Envelope
     {
-        $from = new Address(config('mail.from.address'),config('MAIL_ENV_FROM_ADDR'));
+        $from = new Address(config('mail.from.address'));
 
         return new Envelope(
             from: $from,

--- a/config/mail.php
+++ b/config/mail.php
@@ -237,7 +237,7 @@ return [
     */
 
     'from' => [
-        'address' => env('MAIL_FROM_ADDR', null),
+        'address' => env('MAIL_FROM_ADDR', env('MAIL_ENV_FROM_ADDR')),
         'name' => env('MAIL_FROM_NAME', null),
     ],
 

--- a/config/mail.php
+++ b/config/mail.php
@@ -237,7 +237,7 @@ return [
     */
 
     'from' => [
-        'address' => env('MAIL_FROM_ADDR', env('MAIL_ENV_FROM_ADDR')),
+        'address' => env('MAIL_FROM_ADDR', null),
         'name' => env('MAIL_FROM_NAME', null),
     ],
 


### PR DESCRIPTION
# Description
This replaces the env variable being used in the from field for mail notifications with the config variable `mail.from.address`

Fixes #15813

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
