### PR TITLE
Fixed a couple migrate:rollback issues

### DIFF
--- a/database/migrations/2023_08_01_174150_change_webhook_settings_variable_type.php
+++ b/database/migrations/2023_08_01_174150_change_webhook_settings_variable_type.php
@@ -26,7 +26,7 @@ class ChangeWebhookSettingsVariableType extends Migration
     public function down()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->varchar('webhook_endpoint')->change();
+            $table->string('webhook_endpoint')->change();
         });
 
     }

--- a/database/migrations/2024_09_17_204302_change_user_id_to_created_by.php
+++ b/database/migrations/2024_09_17_204302_change_user_id_to_created_by.php
@@ -42,7 +42,7 @@ return new class extends Migration
         }
 
         foreach ($this->existing_table_list() as $table) {
-            if (Schema::hasColumn($table, 'user_id')) {
+            if (Schema::hasColumn($table, 'created_by')) {
                 Schema::table($table, function (Blueprint $table) {
                     $table->renameColumn('created_by', 'user_id');
                 });


### PR DESCRIPTION
# Description

This small PR fixes two issues in the `down` methods for migrations:
- `created_by` wasn't being reverted properly
- There was an attempt to use `varchar` when it should be `string`

I personally rarely use `migrate:rollback` but allowing it to complete successfully it is 👍🏾 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
