### PR TITLE
Fixed variable name to correctly log created_by and date for bulk user delete/checkin

### DIFF
--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -323,7 +323,7 @@ class BulkUsersController extends Controller
             $logAction->item_type = $itemType;
             $logAction->target_id = $item->assigned_to;
             $logAction->target_type = User::class;
-            $logAction->created_at = auth()->id();
+            $logAction->created_by = auth()->id();
             $logAction->note = 'Bulk checkin items';
             $logAction->logaction('checkin from');
         }


### PR DESCRIPTION
We were using the wrong variable name for `created_by` which was therefore 1) not correctly logging the acting user, and also bonking the date on the asset checkin log.