### PR TITLE
Indicate requiredness on status select on bulk user checkin+delete

### DIFF
--- a/resources/views/users/confirm-bulk-delete.blade.php
+++ b/resources/views/users/confirm-bulk-delete.blade.php
@@ -109,7 +109,7 @@
 
                   <tr>
                     <td colspan="8">
-                      {{ Form::select('status_id', $statuslabel_list , old('status_id'), array('class'=>'select2', 'style'=>'width:250px')) }}
+                      {{ Form::select('status_id', $statuslabel_list , old('status_id'), array('class'=>'select2', 'style'=>'width:250px', 'required' => true)) }}
                       <label>{{ trans('admin/users/general.update_user_assets_status') }}</label>
                     </td>
                   </tr>


### PR DESCRIPTION
This just adds the `required` selector to the status ID dropdown on bulk user checkin and delete to better indicate that the field is required. (It was a little confusing, since the submit button is unclickable until you select a status.)