### PR TITLE
Fixed bug in component checkins via api

### DIFF
--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -317,14 +317,12 @@ class ComponentsController extends Controller
 
             $max_to_checkin = $component_assets->assigned_qty;
 
-            if ($max_to_checkin > 1) {
-                $validator = Validator::make($request->all(), [
-                    "checkin_qty" => "required|numeric|between:1,$max_to_checkin"
-                ]);
-    
-                if ($validator->fails()) {
-                    return response()->json(Helper::formatStandardApiResponse('error', null, 'Checkin quantity must be between 1 and '.$max_to_checkin));
-                }
+            $validator = Validator::make($request->all(), [
+                "checkin_qty" => "required|numeric|between:1,$max_to_checkin"
+            ]);
+
+            if ($validator->fails()) {
+                return response()->json(Helper::formatStandardApiResponse('error', null, 'Checkin quantity must be between 1 and ' . $max_to_checkin));
             }
 
             // Validation passed, so let's figure out what we have to do here.

--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -309,9 +309,7 @@ class ComponentsController extends Controller
     public function checkin(Request $request, $component_asset_id) : JsonResponse
     {
         if ($component_assets = DB::table('components_assets')->find($component_asset_id)) {
-
             if (is_null($component = Component::find($component_assets->component_id))) {
-
                 return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/components/message.not_found')));
             }
 
@@ -320,7 +318,6 @@ class ComponentsController extends Controller
             $max_to_checkin = $component_assets->assigned_qty;
 
             if ($max_to_checkin > 1) {
-                
                 $validator = Validator::make($request->all(), [
                     "checkin_qty" => "required|numeric|between:1,$max_to_checkin"
                 ]);
@@ -329,7 +326,6 @@ class ComponentsController extends Controller
                     return response()->json(Helper::formatStandardApiResponse('error', null, 'Checkin quantity must be between 1 and '.$max_to_checkin));
                 }
             }
-            
 
             // Validation passed, so let's figure out what we have to do here.
             $qty_remaining_in_checkout = ($component_assets->assigned_qty - (int)$request->input('checkin_qty', 1));
@@ -339,28 +335,23 @@ class ComponentsController extends Controller
             $component_assets->assigned_qty = $qty_remaining_in_checkout;
 
             Log::debug($component_asset_id.' - '.$qty_remaining_in_checkout.' remaining in record '.$component_assets->id);
-            
-            DB::table('components_assets')->where('id',
-                $component_asset_id)->update(['assigned_qty' => $qty_remaining_in_checkout]);
+
+            DB::table('components_assets')->where('id', $component_asset_id)->update(['assigned_qty' => $qty_remaining_in_checkout]);
 
             // If the checked-in qty is exactly the same as the assigned_qty,
             // we can simply delete the associated components_assets record
             if ($qty_remaining_in_checkout == 0) {
                 DB::table('components_assets')->where('id', '=', $component_asset_id)->delete();
             }
-            
 
             $asset = Asset::find($component_assets->asset_id);
 
             event(new CheckoutableCheckedIn($component, $asset, auth()->user(), $request->input('note'), Carbon::now()));
 
             return response()->json(Helper::formatStandardApiResponse('success', null,  trans('admin/components/message.checkin.success')));
-
         }
 
         return response()->json(Helper::formatStandardApiResponse('error', null, 'No matching checkouts for that component join record'));
-
-    
     }
 
 }

--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -340,7 +340,7 @@ class ComponentsController extends Controller
 
             // If the checked-in qty is exactly the same as the assigned_qty,
             // we can simply delete the associated components_assets record
-            if ($qty_remaining_in_checkout == 0) {
+            if ($qty_remaining_in_checkout === 0) {
                 DB::table('components_assets')->where('id', '=', $component_asset_id)->delete();
             }
 

--- a/tests/Feature/Checkins/Api/ComponentCheckinTest.php
+++ b/tests/Feature/Checkins/Api/ComponentCheckinTest.php
@@ -52,7 +52,7 @@ class ComponentCheckinTest extends TestCase implements TestsFullMultipleCompanie
         $component = Component::factory()->checkedOutToAsset()->create();
 
         $pivot = $component->assets->first()->pivot;
-        $pivot->update(['assigned_qty' => 2]);
+        $pivot->update(['assigned_qty' => 1]);
 
         $this->actingAsForApi(User::factory()->checkinComponents()->create())
             ->postJson(route('api.components.checkin', $component->assets->first()->pivot->id), [

--- a/tests/Feature/Checkins/Api/ComponentCheckinTest.php
+++ b/tests/Feature/Checkins/Api/ComponentCheckinTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\Checkins\Api;
+
+use App\Events\CheckoutableCheckedIn;
+use App\Models\Asset;
+use App\Models\Company;
+use App\Models\Component;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Tests\Concerns\TestsFullMultipleCompaniesSupport;
+use Tests\Concerns\TestsPermissionsRequirement;
+use Tests\TestCase;
+
+class ComponentCheckinTest extends TestCase implements TestsFullMultipleCompaniesSupport, TestsPermissionsRequirement
+{
+    public function testRequiresPermission()
+    {
+        $component = Component::factory()->checkedOutToAsset()->create();
+
+        $this->actingAsForApi(User::factory()->create())
+            ->postJson(route('api.components.checkin', $component->assets->first()->pivot->id))
+            ->assertForbidden();
+    }
+
+    public function testHandlesNonExistentPivotId()
+    {
+        $this->actingAsForApi(User::factory()->checkinComponents()->create())
+            ->postJson(route('api.components.checkin', 1000), [
+                'checkin_qty' => 1,
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('error');
+    }
+
+    public function testHandlesNonExistentComponent()
+    {
+        $component = Component::factory()->checkedOutToAsset()->create();
+        $pivotId = $component->assets->first()->pivot->id;
+        $component->delete();
+
+        $this->actingAsForApi(User::factory()->checkinComponents()->create())
+            ->postJson(route('api.components.checkin', $pivotId), [
+                'checkin_qty' => 1,
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('error');
+    }
+
+    public function testCannotCheckinMoreThanCheckedOut()
+    {
+        $component = Component::factory()->checkedOutToAsset()->create();
+
+        $pivot = $component->assets->first()->pivot;
+        $pivot->update(['assigned_qty' => 2]);
+
+        $this->actingAsForApi(User::factory()->checkinComponents()->create())
+            ->postJson(route('api.components.checkin', $component->assets->first()->pivot->id), [
+                'checkin_qty' => 3,
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('error');
+    }
+
+    public function testCanCheckinComponent()
+    {
+        Event::fake([CheckoutableCheckedIn::class]);
+
+        $user = User::factory()->checkinComponents()->create();
+
+        $component = Component::factory()->checkedOutToAsset()->create();
+        $pivot = $component->assets->first()->pivot;
+        $pivot->update(['assigned_qty' => 3]);
+
+
+        $this->actingAsForApi($user)
+            ->postJson(route('api.components.checkin', $component->assets->first()->pivot->id), [
+                'checkin_qty' => 2,
+                'note' => 'my note',
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $this->assertEquals(1, $component->fresh()->assets->first()->pivot->assigned_qty);
+
+        Event::assertDispatched(function (CheckoutableCheckedIn $event) use ($user, $component) {
+            return $event->checkoutable->is($component)
+                && $event->checkedOutTo->is($component->assets->first())
+                && $event->checkedInBy->is($user)
+                && $event->note === 'my note';
+        });
+    }
+
+    public function testCheckingInEntireAssignedQuantityClearsThePivotRecordFromTheDatabase()
+    {
+        Event::fake([CheckoutableCheckedIn::class]);
+
+        $user = User::factory()->checkinComponents()->create();
+
+        $component = Component::factory()->checkedOutToAsset()->create();
+        $pivot = $component->assets->first()->pivot;
+        $pivot->update(['assigned_qty' => 3]);
+
+        $this->actingAsForApi($user)
+            ->postJson(route('api.components.checkin', $component->assets->first()->pivot->id), [
+                'checkin_qty' => 3,
+                'note' => 'my note',
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $this->assertEmpty($component->fresh()->assets);
+
+        Event::assertDispatched(function (CheckoutableCheckedIn $event) use ($user, $component) {
+            return $event->checkoutable->is($component)
+                && $event->checkedOutTo->is($component->assets->first())
+                && $event->checkedInBy->is($user)
+                && $event->note === 'my note';
+        });
+    }
+
+    public function testAdheresToFullMultipleCompaniesSupportScoping()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $componentInCompanyA = Component::factory()->for($companyA)->checkedOutToAsset()->create();
+        $userInCompanyB = User::factory()->for($companyB)->create();
+        $pivotId = $componentInCompanyA->assets->first()->pivot->id;
+
+        $this->actingAsForApi($userInCompanyB)
+            ->postJson(route('api.components.checkin', $pivotId), [
+                'checkin_qty' => 1,
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('error');
+    }
+
+    public function testCheckinIsLogged()
+    {
+        $user = User::factory()->checkinComponents()->create();
+
+        $component = Component::factory()->checkedOutToAsset()->create();
+        $pivot = $component->assets->first()->pivot;
+        $pivot->update(['assigned_qty' => 3]);
+
+        $this->actingAsForApi($user)
+            ->postJson(route('api.components.checkin', $component->assets->first()->pivot->id), [
+                'checkin_qty' => 3,
+                'note' => 'my note',
+            ]);
+
+        $this->assertDatabaseHas('action_logs', [
+            'created_by' => $user->id,
+            'action_type' => 'checkin from',
+            'target_id' => $component->assets->first()->id,
+            'target_type' => Asset::class,
+            'note' => 'my note',
+            'item_id' => $component->id,
+            'item_type' => Component::class,
+        ]);
+    }
+}


### PR DESCRIPTION
# Description

This PR fixes a bug in component checkins via the api where a user could check in a quantity higher than was checked out _if_ the checked out quantity was `1`.

It also includes tests around the endpoint.

## Type of change

- [x] Testing
