### PR TITLE
Added #15803: Category Field to Asset Related Mails

### DIFF
--- a/resources/views/mail/markdown/checkin-asset.blade.php
+++ b/resources/views/mail/markdown/checkin-asset.blade.php
@@ -16,6 +16,9 @@
 @if (($item->name!=$item->asset_tag))
 | **{{ trans('mail.asset_tag') }}** | {{ $item->asset_tag }} |
 @endif
+@if (isset($item->model->category))
+| **{{ trans('general.category') }}** | {{ $item->model->category->name }} |
+@endif
 @if (isset($item->manufacturer))
 | **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
 @endif

--- a/resources/views/mail/markdown/checkout-asset.blade.php
+++ b/resources/views/mail/markdown/checkout-asset.blade.php
@@ -16,6 +16,9 @@
 @if (($item->name!=$item->asset_tag))
 | **{{ trans('mail.asset_tag') }}** | {{ $item->asset_tag }} |
 @endif
+@if (isset($item->model->category))
+| **{{ trans('general.category') }}** | {{ $item->model->category->name }} |
+@endif
 @if (isset($item->manufacturer))
 | **{{ trans('general.manufacturer') }}** | {{ $item->manufacturer->name }} |
 @endif

--- a/resources/views/notifications/markdown/asset-acceptance.blade.php
+++ b/resources/views/notifications/markdown/asset-acceptance.blade.php
@@ -22,6 +22,9 @@
 @if ((isset($item_tag)) && ($item_tag!=''))
 | **{{ trans('mail.asset_tag') }}** | {{ $item_tag }} |
 @endif
+@if (isset($item->model->category))
+| **{{ trans('general.category') }}** | {{ $item->model->category->name }} |
+@endif
 @if ((isset($item_model)) && ($item_model!=''))
 | **{{ trans('mail.asset_name') }}** | {{ $item_model }} |
 @endif

--- a/resources/views/notifications/markdown/asset-requested.blade.php
+++ b/resources/views/notifications/markdown/asset-requested.blade.php
@@ -18,6 +18,9 @@
 @if ((isset($item->asset_tag)) && ($item->asset_tag!=''))
 | **{{ trans('mail.asset_tag') }}** | {{ $item->asset_tag }} |
 @endif
+@if (isset($item->model->category))
+| **{{ trans('general.category') }}** | {{ $item->model->category->name }} |
+@endif
 @if ((isset($item->name)) && ($item->name!=''))
 | **{{ trans('mail.asset_name') }}** | {{ $item->name }} |
 @endif


### PR DESCRIPTION
# Description

This pull request introduces the **Category** field to the emails generated for asset Check-in, Check-out, Acceptance, Decline and Requests. Previously, these emails included asset details like model and tag, but without the category, it was sometimes difficult to identify the type of asset. By including the category, the emails provide clearer and more actionable information.
 
### Key-Changes:
 
- Added the **Category** field to the templates of:
   - Check-in emails
   - Check-out emails
   - Asset acceptance/decline emails
   - Request confirmation emails
- Adjusted the email generation logic to pull and include the category from the database.

## Fixes #15803

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- **Unit Tests:** Verified that the new category field is correctly included in the email templates and rendered with valid data.
- **Manual Testing:**
    - Sent test emails for check-in, check-out, acceptance, delcine and requests.
    - Confirmed that the category is displayed properly for each type of email.

**Test Configuration**:
- **PHP version:** 8.1.2
- **MySQL version:** 8.0.33
- **Webserver version:** Apache 2.4.57
- **OS version:** Ubuntu 22.04

# Checklist:

- [X] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [X] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
