### PR TITLE
Adds a ternary for blank emails for mail notifications

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -307,7 +307,7 @@ class CheckoutableListener
             return $event->checkedOutTo->manager?->email ?? '';
         }
         else{
-            return $event->checkedOutTo->email;
+            return $event->checkedOutTo?->email ?? '';
         }
     }
 


### PR DESCRIPTION
# Description

This adds a ternary operator on the `checkedOutTo` email check. removing the warning error of `ErrorException: Attempt to read property "email" on null`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

