### PR TITLE
Improved speed of sqlite tests in GitHub Actions

### DIFF
--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -43,6 +43,9 @@ jobs:
           cp -v .env.testing.example .env
           cp -v .env.testing.example .env.testing
 
+      - name: Create database file
+        run: touch database/database.sqlite
+
       - name: Install Dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
 
@@ -57,5 +60,5 @@ jobs:
 
       - name: Execute tests (Unit and Feature tests) via PHPUnit
         env:
-          DB_CONNECTION: sqlite_testing
+          DB_CONNECTION: sqlite
         run: php artisan test


### PR DESCRIPTION
# Description

Running sqlite tests in Github Actions is starting to take a while (8 minutes in a [recent PR](https://github.com/snipe/snipe-it/pull/15851)). This PR switches from running them in-memory to using a file on disk and improves the run time (8 minutes -> 1 minute)

## Type of change

- [x] Testing