### PR TITLE
Always call resizeCanvas

### DIFF
--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -111,21 +111,20 @@
             signaturePad;
 
         // Adjust canvas coordinate space taking into account pixel ratio,
-        // to make it look crisp on mobile devices.
-        // This also causes canvas to be cleared.
-        if (window.matchMedia("(min-width: 768px)").matches) {
-            function resizeCanvas() {
-                // When zoomed out to less than 100%, for some very strange reason,
-                // some browsers report devicePixelRatio as less than 1
-                // and only part of the canvas is cleared then.
-                var ratio = Math.max(window.devicePixelRatio || 1, 1);
-                canvas.width = canvas.offsetWidth * ratio;
-                canvas.height = canvas.offsetHeight * ratio;
-                canvas.getContext("2d").scale(ratio, ratio);
-            }
-            window.onresize = resizeCanvas;
-            resizeCanvas();
+        // to make it look crisp on smaller screens.
+        // https://github.com/szimek/signature_pad#handling-high-dpi-screens
+        // (This also causes canvas to be cleared.)
+        function resizeCanvas() {
+            // When zoomed out to less than 100%, for some very strange reason,
+            // some browsers report devicePixelRatio as less than 1
+            // and only part of the canvas is cleared then.
+            var ratio = Math.max(window.devicePixelRatio || 1, 1);
+            canvas.width = canvas.offsetWidth * ratio;
+            canvas.height = canvas.offsetHeight * ratio;
+            canvas.getContext("2d").scale(ratio, ratio);
         }
+        window.onresize = resizeCanvas;
+        resizeCanvas();
 
         signaturePad = new SignaturePad(canvas);
 

--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -110,23 +110,27 @@
             canvas = wrapper.querySelector("canvas"),
             signaturePad;
 
+        signaturePad = new SignaturePad(canvas);
+
         // Adjust canvas coordinate space taking into account pixel ratio,
         // to make it look crisp on smaller screens.
         // https://github.com/szimek/signature_pad#handling-high-dpi-screens
         // (This also causes canvas to be cleared.)
         function resizeCanvas() {
+            console.log('resizeCanvas');
             // When zoomed out to less than 100%, for some very strange reason,
             // some browsers report devicePixelRatio as less than 1
             // and only part of the canvas is cleared then.
-            var ratio = Math.max(window.devicePixelRatio || 1, 1);
+            let devicePixelRatio = window.devicePixelRatio;
+            console.log({devicePixelRatio})
+            var ratio = Math.max(devicePixelRatio || 1, 1);
             canvas.width = canvas.offsetWidth * ratio;
             canvas.height = canvas.offsetHeight * ratio;
             canvas.getContext("2d").scale(ratio, ratio);
+            signaturePad.clear(); // otherwise isEmpty() might return incorrect value
         }
         window.onresize = resizeCanvas;
         resizeCanvas();
-
-        signaturePad = new SignaturePad(canvas);
 
         $('#clear_button').on("click", function (event) {
             signaturePad.clear();

--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -117,13 +117,10 @@
         // https://github.com/szimek/signature_pad#handling-high-dpi-screens
         // (This also causes canvas to be cleared.)
         function resizeCanvas() {
-            console.log('resizeCanvas');
             // When zoomed out to less than 100%, for some very strange reason,
             // some browsers report devicePixelRatio as less than 1
             // and only part of the canvas is cleared then.
-            let devicePixelRatio = window.devicePixelRatio;
-            console.log({devicePixelRatio})
-            var ratio = Math.max(devicePixelRatio || 1, 1);
+            var ratio = Math.max(window.devicePixelRatio || 1, 1);
             canvas.width = canvas.offsetWidth * ratio;
             canvas.height = canvas.offsetHeight * ratio;
             canvas.getContext("2d").scale(ratio, ratio);


### PR DESCRIPTION
# Description

This PR partially addresses an issue (#15530) with the signature pad on small screens.

Currently, rendering the signature pad on very small screens (less than 470px it seems like) has two issues:
- The lines are blurry
- The lines progressively appear further to the right of the cursor location the further right the line is drawn:
![Current issue](https://github.com/user-attachments/assets/3f815753-e1a0-4fbe-b4f3-6e4559e4f17d)


With this PR the lines are drawn accurately and more clear:
![CleanShot 2024-11-21 at 14 39 44](https://github.com/user-attachments/assets/fafcd750-71d0-47dc-b537-2c8e89ca5bd2)

This is achieved by _always_ calling the function that handles [high DPI screens](https://github.com/szimek/signature_pad#handling-high-dpi-screens) and also re-calling it when the screen is re-sized.

_But_, two things I've noticed is that manually re-sizing the window from large to small or opening/closing the sidebar still exhibit the previous behavior. I'm opening this PR as-is since I think the major problem is solved and I couldn't find an easy solution for the last two issues.

---

The diff for this looks worse than it is. Showing No Whitespace makes it a lot clearer since I removed an `if` block and de-indented a chunk of code.

---

This builds on the work in #14577

Fixes #15530

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
