### PR TITLE
Mobile view fix

### DIFF
--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -876,8 +876,10 @@ th.css-component > .th-inner::before
 }
 @media screen and (max-width: 992px){
   .info-stack-container {
-    display: flex;
     flex-direction: column;
+  }
+  .row-new-striped div {
+    width:100%;
   }
   .col-md-3.col-xs-12.col-sm-push-9.info-stack{
     left:auto;

--- a/resources/assets/less/overrides.less
+++ b/resources/assets/less/overrides.less
@@ -878,9 +878,6 @@ th.css-component > .th-inner::before
   .info-stack-container {
     flex-direction: column;
   }
-  .row-new-striped div {
-    width:100%;
-  }
   .col-md-3.col-xs-12.col-sm-push-9.info-stack{
     left:auto;
     order:1;
@@ -894,6 +891,12 @@ th.css-component > .th-inner::before
     float:none;
   }
 }
+@media screen and (max-width: 992px){
+  .row-new-striped div{
+    width:100%;
+  }
+}
+
 @media screen and (max-width: 1318px) and (min-width: 1200px){
   .admin.box{
     height:170px;

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -309,10 +309,10 @@
                   <div class="row">
                     <!-- name -->
     
-                      <div class="col-md-3 col-sm-2">
+                      <div class="col-md-3">
                         {{ trans('admin/users/table.name') }}
                       </div>
-                      <div class="col-md-9 col-sm-2">
+                      <div class="col-md-9">
                         {{ $user->present()->fullName() }}
                       </div>
 
@@ -751,7 +751,7 @@
                            {{Helper::formatCurrencyOutput($user->getUserTotalCost()->total_user_cost)}}
 
                            <a id="optional_info" class="text-primary">
-                               <x-icon type="caret-right" id="optional_info_icon" /></i>
+                               <x-icon type="caret-right" id="optional_info_icon" />
                                <strong>{{ trans('admin/hardware/form.optional_infos') }}</strong>
                            </a>
                        </div>


### PR DESCRIPTION
# Description
This fixes the mobile view for assets and users being too narrow and the table not stretching the full width.

Before:
<img width="476" alt="image" src="https://github.com/user-attachments/assets/b405597b-8b8d-409a-85e0-60e05396e1a0">
After:
<img width="476" alt="image" src="https://github.com/user-attachments/assets/17827119-e341-436b-acac-8d1c1514597d">

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
