### PR TITLE
Hardened asset checkout validation by requiring integer

### DIFF
--- a/app/Http/Requests/AssetCheckoutRequest.php
+++ b/app/Http/Requests/AssetCheckoutRequest.php
@@ -22,9 +22,9 @@ class AssetCheckoutRequest extends Request
     public function rules()
     {
         $rules = [
-            'assigned_user'         => 'required_without_all:assigned_asset,assigned_location',
-            'assigned_asset'        => 'required_without_all:assigned_user,assigned_location',
-            'assigned_location'     => 'required_without_all:assigned_user,assigned_asset',
+            'assigned_user'         => 'integer|required_without_all:assigned_asset,assigned_location',
+            'assigned_asset'        => 'integer|required_without_all:assigned_user,assigned_location',
+            'assigned_location'     => 'integer|required_without_all:assigned_user,assigned_asset',
             'status_id'             => 'exists:status_labels,id,deployable,1',
             'checkout_to_type'      => 'required|in:asset,location,user',
             'checkout_at' => [


### PR DESCRIPTION
# Description

This PR adds `integer` to the rules for `assigned_user`, `assigned_asset`, and `assigned_location` when checking out an asset via the api. This is to avoid passing in an array or something else unexpected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
