### PR TITLE
Fixed #15901 - re-added required indicator on text and select custom fields

### DIFF
--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -2,20 +2,22 @@
   @foreach($model->fieldset->fields AS $field)
     <div class="form-group{{ $errors->has($field->db_column_name()) ? ' has-error' : '' }}">
       <label for="{{ $field->db_column_name() }}" class="col-md-3 control-label">{{ $field->name }} </label>
-      <div class="col-md-7 col-sm-12{{ ($field->pivot->required=='1') ? ' required' : '' }}">
+      <div class="col-md-7 col-sm-12">
 
 
           @if ($field->element!='text')
-              <!-- Listbox -->
+
               @if ($field->element=='listbox')
+                  <!-- Listbox -->
                    {{ Form::select($field->db_column_name(), $field->formatFieldValuesAsArray(),
-                  old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))), ['class'=>'format select2 form-control']) }}
+                  old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))), ['class' => 'format select2 form-control',  ($field->pivot->required=='1' ? ' required' : '') ]) }}
 
               @elseif ($field->element=='textarea')
-                  <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>
+                  <!-- Textarea -->
+                  <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}"{{ ($field->pivot->required=='1') ? ' required' : '' }}>{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>
 
               @elseif ($field->element=='checkbox')
-                    <!-- Checkboxes -->
+                  <!-- Checkbox -->
                   @foreach ($field->formatFieldValuesAsArray() as $key => $value)
                       <div>
                           <label class="form-control">
@@ -26,27 +28,25 @@
                   @endforeach
 
               @elseif ($field->element=='radio')
-              @foreach ($field->formatFieldValuesAsArray() as $value)
-
-              <div>
-                  <label class="form-control">
-                      <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($value, explode(', ', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
-                      {{ $value }}
-                  </label>
-              </div>
-          @endforeach
-
+                  <!-- Radio -->
+                  @foreach ($field->formatFieldValuesAsArray() as $value)
+                      <div>
+                          <label class="form-control">
+                              <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($value, explode(', ', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
+                              {{ $value }}
+                          </label>
+                      </div>
+                  @endforeach
               @endif
 
 
           @else
             <!-- Date field -->
-
                 @if ($field->format=='DATE')
 
                         <div class="input-group col-md-5" style="padding-left: 0px;">
                             <div class="input-group date" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-autoclose="true" data-date-clear-btn="true">
-                                <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="{{ $field->db_column_name() }}" id="{{ $field->db_column_name() }}" readonly value="{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}"  style="background-color:inherit">
+                                <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="{{ $field->db_column_name() }}" id="{{ $field->db_column_name() }}" readonly value="{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}"  style="background-color:inherit"{{ ($field->pivot->required=='1') ? ' required' : '' }}>
                                 <span class="input-group-addon"><x-icon type="calendar" /></span>
                             </div>
                         </div>
@@ -54,7 +54,7 @@
 
                 @else
                     @if (($field->field_encrypted=='0') || (Gate::allows('assets.view.encrypted_custom_fields')))
-                    <input type="text" value="{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}" id="{{ $field->db_column_name() }}" class="form-control" name="{{ $field->db_column_name() }}" placeholder="Enter {{ strtolower($field->format) }} text">
+                    <input type="text" value="{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}" id="{{ $field->db_column_name() }}" class="form-control" name="{{ $field->db_column_name() }}" placeholder="Enter {{ strtolower($field->format) }} text"{{ ($field->pivot->required=='1') ? ' required' : '' }}>
                         @else
                             <input type="text" value="{{ strtoupper(trans('admin/custom_fields/general.encrypted')) }}" class="form-control disabled" disabled>
                     @endif


### PR DESCRIPTION
This should fix a regression introduced in https://github.com/snipe/snipe-it/pull/15552 that was partially fixed in #15573.

Basically, in PR #15552, we changed the CSS to use the CSS selector instead of the CSS class for the HTML form element, however this caused inconsistencies since we were not using the required selector on every form field. I thought we had gotten them all in the PR #15573 but it looks like we missed a few. 

### On Edit, Before Submitting

<img width="736" alt="Screenshot 2024-12-02 at 3 49 44 PM" src="https://github.com/user-attachments/assets/ca780cb2-f00a-40ed-9599-96a302cdf81c">

### On Edit, After Submitting

<img width="736" alt="Screenshot 2024-12-02 at 3 49 32 PM" src="https://github.com/user-attachments/assets/01b0dee7-694c-4912-81a8-b951581a7f3b">

We still don't seem to be handling required checkboxes and radios correctly on the display, but I'll open a Shortcut for that.

Should fix #15901