### PR TITLE
Revert "Hardened asset checkout validation by requiring integer"

### DIFF
--- a/app/Http/Requests/AssetCheckoutRequest.php
+++ b/app/Http/Requests/AssetCheckoutRequest.php
@@ -24,9 +24,9 @@ class AssetCheckoutRequest extends Request
         $settings = \App\Models\Setting::getSettings();
 
         $rules = [
-            'assigned_user'         => 'integer|required_without_all:assigned_asset,assigned_location',
-            'assigned_asset'        => 'integer|required_without_all:assigned_user,assigned_location',
-            'assigned_location'     => 'integer|required_without_all:assigned_user,assigned_asset',
+            'assigned_user'         => 'required_without_all:assigned_asset,assigned_location',
+            'assigned_asset'        => 'required_without_all:assigned_user,assigned_location',
+            'assigned_location'     => 'required_without_all:assigned_user,assigned_asset',
             'status_id'             => 'exists:status_labels,id,deployable,1',
             'checkout_to_type'      => 'required|in:asset,location,user',
             'checkout_at' => [


### PR DESCRIPTION
This PR breaks asset checkouts via the UI and we should revert it. (sorry)

Reverts snipe/snipe-it#15892

---

Follow up: #15912