### PR TITLE
Fixed general webhook option notifications not firing

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -100,7 +100,7 @@ class CheckoutableListener
                         $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
                         $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
                     } else {
-                        Notification::route(Setting::getSettings()->webhook_selected, Setting::getSettings()->webhook_endpoint)
+                        Notification::route($this->webhookSelected(), Setting::getSettings()->webhook_endpoint)
                             ->notify($this->getCheckoutNotification($event, $acceptance));
                     }
                 }
@@ -182,7 +182,7 @@ class CheckoutableListener
                         $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
                         $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
                     } else {
-                        Notification::route(Setting::getSettings()->webhook_selected, Setting::getSettings()->webhook_endpoint)
+                        Notification::route($this->webhookSelected(), Setting::getSettings()->webhook_endpoint)
                             ->notify($this->getCheckinNotification($event));
                     }
                 }
@@ -309,6 +309,13 @@ class CheckoutableListener
         else{
             return $event->checkedOutTo?->email ?? '';
         }
+    }
+    private function webhookSelected(){
+        if(Setting::getSettings()->webhook_selected === 'slack' || Setting::getSettings()->webhook_selected === 'general'){
+            return 'slack';
+        }
+
+        return Setting::getSettings()->webhook_selected;
     }
 
     /**


### PR DESCRIPTION
# Description

This fixes an issue with the general webhook not firing. If the general webhook is selected, it uses the slack notification files. The `SlackWebhookChannel` class was looking for `slack` when we were passing in `general`. 

Since we changed how notifications are triggered, a method has been added that if the general webhook is selected we will return `slack` in the listener's notification route instead of passing `general` instead of waiting for it to trigger later on in the stack. (if that makes sense)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
