### PR TITLE
Included MAIL_FROM_ADDR in phpunit configuration

### DIFF
--- a/.env.testing.example
+++ b/.env.testing.example
@@ -17,5 +17,3 @@ DB_PORT=3306
 DB_DATABASE=null
 DB_USERNAME=null
 DB_PASSWORD=null
-
-MAIL_FROM_ADDR=you@example.com

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,6 +21,7 @@
     <env name="APP_ENV" value="testing"/>
     <env name="BCRYPT_ROUNDS" value="4"/>
     <env name="CACHE_DRIVER" value="array"/>
+    <env name="MAIL_FROM_ADDR" value="app@example.com"/>
     <env name="MAIL_MAILER" value="array"/>
     <env name="QUEUE_DRIVER" value="sync"/>
     <env name="SESSION_DRIVER" value="array"/>


### PR DESCRIPTION
# Description

In #15839 I asked @Godmartinz to add `MAIL_FROM_ADDR` to `.env.testing` in order to get tests back to green. This worked but I really should have suggested adding it to `phpunit.xml` so future devs wouldn't have to notice the addition of the variable to `.env.testing.example` and add it locally themselves. 

This PR does handles this better by included it in `phpunit.xml`.

## Type of change

- [x] Chore?
