### PR TITLE
Fixed duplicate entries preventing LDAP sync from continuing

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -424,8 +424,12 @@ class LdapSync extends Command
                 $item['note'] = $item['createorupdate'];
                 $item['status'] = 'success';
                 if ($item['createorupdate'] === 'created' && $ldap_default_group) {
-                    $user->groups()->attach($ldap_default_group);
+                 // Check if the relationship already exists
+                if (!$user->groups()->where('group_id', $ldap_default_group)->exists()) {
+                $user->groups()->attach($ldap_default_group);
+                    }
                 }
+                
                 //updates assets location based on user's location
                 Asset::where('assigned_to', '=', $user->id)->update(['location_id' => $user->location_id]);
 


### PR DESCRIPTION
My first pull request. Hope I'm doing this correctly. 

Fix for duplicate entries preventing the sync from continuing. 

  SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '13178-6' for key 'PRIMARY' (Connection: mysql, SQL: insert into users_groups (group_id, user_id) values (6, 13178))

# Description

Was getting a duplicate error which would prevent the sync from completing.

The command I'm using is 

`LDAP_BASE_DN=OU="_Student Accounts,OU=_District-Delegated,DC=xxx,DC=xxx,DC=xxx,DC=xxx" php artisan snipeit:ldap-sync --verbose`

The output:



 

> Illuminate\Database\UniqueConstraintViolationException
> 
>   SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '13178-6' for key 'PRIMARY' (Connection: mysql, SQL: insert into users_groups (group_id, user_id) values (6, 13178))
> 
>   at vendor/laravel/framework/src/Illuminate/Database/Connection.php:824
>     820▕         // message to include the bindings with SQL, which will make this exception a
>     821▕         // lot more helpful to the developer instead of just the database's errors.
>     822▕         catch (Exception $e) {
>     823▕             if ($this->isUniqueConstraintError($e)) {
>   ➜ 824▕                 throw new UniqueConstraintViolationException(
>     825▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
>     826▕                 );
>     827▕             }
> 828▕
> 
>   1   vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:45
>       PDOException::("SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '13178-6' for key 'PRIMARY'")
> 
>   2   vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:45
>       PDOStatement::execute()
> 
>   3   vendor/laravel/framework/src/Illuminate/Database/Connection.php:816
>       Illuminate\Database\MySqlConnection::Illuminate\Database\{closure}()
> 
>   4   vendor/laravel/framework/src/Illuminate/Database/Connection.php:783
>       Illuminate\Database\Connection::runQueryCallback()
> 
>   5   vendor/laravel/framework/src/Illuminate/Database/MySqlConnection.php:50
>       Illuminate\Database\Connection::run()
> 
>   6   vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:3500
>       Illuminate\Database\MySqlConnection::insert()
> 
>   7   vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php:277
>       Illuminate\Database\Query\Builder::insert()
> 
>   8   app/Console/Commands/LdapSync.php:427
>       Illuminate\Database\Eloquent\Relations\BelongsToMany::attach()
> 
>   9   vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:36
>       App\Console\Commands\LdapSync::handle()
> 
>   10  vendor/laravel/framework/src/Illuminate/Container/Util.php:41
>       Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
> 
>   11  vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:93
>       Illuminate\Container\Util::unwrapIfClosure()
> 
>   12  vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:37
>       Illuminate\Container\BoundMethod::callBoundMethod()
> 
>   13  vendor/laravel/framework/src/Illuminate/Container/Container.php:662
>       Illuminate\Container\BoundMethod::call()
> 
>   14  vendor/laravel/framework/src/Illuminate/Console/Command.php:211
>       Illuminate\Container\Container::call()
> 
>   15  vendor/symfony/console/Command/Command.php:326
>       Illuminate\Console\Command::execute()
> 
>   16  vendor/laravel/framework/src/Illuminate/Console/Command.php:181
>       Symfony\Component\Console\Command\Command::run()
> 
>   17  vendor/symfony/console/Application.php:1096
>       Illuminate\Console\Command::run()
> 
>   18  vendor/symfony/console/Application.php:324
>       Symfony\Component\Console\Application::doRunCommand()
> 
>   19  vendor/symfony/console/Application.php:175
>       Symfony\Component\Console\Application::doRun()
> 
>   20  vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:201
>       Symfony\Component\Console\Application::run()
> 
>   21  artisan:35
>       Illuminate\Foundation\Console\Kernel::handle()


Fixes # (issue)

## Type of change

Please delete options that are not relevant.



# How Has This Been Tested?

- [ ] Test A - Added to my own local code and was able to successfully run a full ldap sync. Before it would stop with an error and and users after that wouldn't be synced over. 

**Test Configuration**:
* PHP version:  8.1.2-1
* MySQL version:  10.6.18-MariaDB-0ubuntu0.22.04.1
* Webserver version
* OS version: Ubuntu 22.04

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
