### PR TITLE
Harden asset checkout validation

### DIFF
--- a/app/Http/Requests/AssetCheckoutRequest.php
+++ b/app/Http/Requests/AssetCheckoutRequest.php
@@ -24,9 +24,9 @@ class AssetCheckoutRequest extends Request
         $settings = \App\Models\Setting::getSettings();
 
         $rules = [
-            'assigned_user'         => 'required_without_all:assigned_asset,assigned_location',
-            'assigned_asset'        => 'required_without_all:assigned_user,assigned_location',
-            'assigned_location'     => 'required_without_all:assigned_user,assigned_asset',
+            'assigned_user' => 'numeric|nullable|required_without_all:assigned_asset,assigned_location',
+            'assigned_asset' => 'numeric|nullable|required_without_all:assigned_user,assigned_location',
+            'assigned_location' => 'numeric|nullable|required_without_all:assigned_user,assigned_asset',
             'status_id'             => 'exists:status_labels,id,deployable,1',
             'checkout_to_type'      => 'required|in:asset,location,user',
             'checkout_at' => [

--- a/tests/Feature/Checkouts/Ui/AssetCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/AssetCheckoutTest.php
@@ -177,16 +177,23 @@ class AssetCheckoutTest extends TestCase
         $asset = Asset::factory()->create();
         $admin = User::factory()->checkoutAssets()->create();
 
+        $defaultFieldsAlwaysIncludedInUIFormSubmission = [
+            'assigned_user' => null,
+            'assigned_asset' => null,
+            'assigned_location' => null,
+        ];
+
         $this->actingAs($admin)
-            ->post(route('hardware.checkout.store', $asset), [
+            ->post(route('hardware.checkout.store', $asset), array_merge($defaultFieldsAlwaysIncludedInUIFormSubmission, [
                 'checkout_to_type' => $type,
-                'assigned_' . $type => $target->id,
+                // overwrite the value from the default fields set above
+                'assigned_' . $type => (string) $target->id,
                 'name' => 'Changed Name',
-                'status_id' => $newStatus->id,
+                'status_id' => (string) $newStatus->id,
                 'checkout_at' => '2024-03-18',
                 'expected_checkin' => '2024-03-28',
                 'note' => 'An awesome note',
-            ]);
+            ]));
 
         $asset->refresh();
         $this->assertTrue($asset->assignedTo()->is($target));


### PR DESCRIPTION
# Description

This PR follows up the reverted #15892 and adds the `numeric` and `nullable` rules for `assigned_user`, `assigned_asset`, and `assigned_location`. 

The previous PR broke asset checkouts via the UI because the added rules didn't include `nullable` so validation failed since the UI includes the `assigned_user`, `assigned_asset`, and `assigned_location` fields in the submission. I amended the test to account for that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
