### PR TITLE
Fixed Unaccepted Assets Reports Resend acceptance reminder email function

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1154,14 +1154,14 @@ class ReportsController extends Controller
         }
 
         // Only send notification if assigned
-        if ($assetItem->assignedTo->email) {
+        if ($assetItem->assignedTo?->email) {
                 Mail::to($assetItem->assignedTo->email)->send((new CheckoutAssetMail($assetItem, $assetItem->assignedTo, $logItem->user, $logItem->note, $acceptance))->locale($assetItem->assignedTo?->locale));
 
             } else {
                 Mail::to($assetItem->assignedTo->email)->send((new CheckoutAssetMail($assetItem, $assetItem->assignedTo, $logItem->user, $logItem->note, $acceptance)));
             }
 
-        if ($assetItem->assignedTo->email == ''){
+        if ($assetItem->assignedTo?->email == ''){
             return redirect()->route('reports/unaccepted_assets')->with('error', trans('general.no_email'));
         }
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1152,13 +1152,14 @@ class ReportsController extends Controller
             }
             $logItem = $logItem_res[0];
         }
-
+        $email = $assetItem->assignedTo?->email;
+        $locale = $assetItem->assignedTo?->locale;
         // Only send notification if assigned
-        if ($assetItem->assignedTo?->email) {
-                Mail::to($assetItem->assignedTo->email)->send((new CheckoutAssetMail($assetItem, $assetItem->assignedTo, $logItem->user, $logItem->note, $acceptance))->locale($assetItem->assignedTo?->locale));
+        if ($locale && $email) {
+                Mail::to($email)->send((new CheckoutAssetMail($assetItem, $assetItem->assignedTo, $logItem->user, $logItem->note, $acceptance))->locale($locale));
 
-            } else {
-                Mail::to($assetItem->assignedTo->email)->send((new CheckoutAssetMail($assetItem, $assetItem->assignedTo, $logItem->user, $logItem->note, $acceptance)));
+            } elseif ($email) {
+                Mail::to($email)->send((new CheckoutAssetMail($assetItem, $assetItem->assignedTo, $logItem->user, $logItem->note, $acceptance)));
             }
 
         if ($assetItem->assignedTo?->email == ''){

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1162,7 +1162,7 @@ class ReportsController extends Controller
                 Mail::to($email)->send((new CheckoutAssetMail($assetItem, $assetItem->assignedTo, $logItem->user, $logItem->note, $acceptance)));
             }
 
-        if ($assetItem->assignedTo?->email == ''){
+        if ($email == ''){
             return redirect()->route('reports/unaccepted_assets')->with('error', trans('general.no_email'));
         }
 


### PR DESCRIPTION
# Description
This fixes the Resend acceptance reminder on the Unaccepted Assets Report.

Fixes #15887

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
