### PR TITLE
Removed the `table-responsive` div from several index blades

### DIFF
--- a/resources/views/accessories/index.blade.php
+++ b/resources/views/accessories/index.blade.php
@@ -20,7 +20,6 @@
 
     <div class="box box-default">
       <div class="box-body">
-        <div class="table-responsive">
 
             <table
                 data-columns="{{ \App\Presenters\AccessoryPresenter::dataTableLayout() }}"
@@ -43,7 +42,6 @@
                     "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                     }'>
           </table>
-        </div>
       </div>
     </div>
   </div>

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -19,8 +19,6 @@
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-body">
-        <div class="table-responsive">
-
         <table
             data-columns="{{ \App\Presenters\CategoryPresenter::dataTableLayout() }}"
             data-cookie-id-table="categoryTable"
@@ -41,7 +39,6 @@
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
               }'>
           </table>
-        </div>
       </div><!-- /.box-body -->
     </div><!-- /.box -->
   </div>

--- a/resources/views/companies/index.blade.php
+++ b/resources/views/companies/index.blade.php
@@ -16,8 +16,6 @@
     <div class="col-md-9">
       <div class="box box-default">
         <div class="box-body">
-          <div class="table-responsive">
-
             <table
               data-columns="{{ \App\Presenters\CompanyPresenter::dataTableLayout() }}"
               data-cookie-id-table="companiesTable"
@@ -37,9 +35,7 @@
                         "fileName": "export-companies-{{ date('Y-m-d') }}",
                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                         }'>
-
             </table>
-          </div>
         </div>
       </div>
     </div>

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -125,7 +125,6 @@
       </div><!-- /.box-header -->
       <div class="box-body">
 
-        <div class="table-responsive">
         <table
                 data-cookie-id-table="customFieldsTable"
                 data-id-table="customFieldsTable"
@@ -222,7 +221,6 @@
             @endforeach
           </tbody>
         </table>
-        </div>
       </div><!-- /.box-body -->
     </div><!-- /.box -->
   </div> <!-- /.col-md-9-->

--- a/resources/views/departments/index.blade.php
+++ b/resources/views/departments/index.blade.php
@@ -16,8 +16,6 @@
         <div class="col-md-12">
             <div class="box box-default">
                 <div class="box-body">
-                    <div class="table-responsive">
-
                         <table
                                 data-cookie-id-table="departmentsTable"
                                 data-pagination="true"
@@ -50,7 +48,6 @@
                             </tr>
                             </thead>
                         </table>
-                    </div>
                 </div>
             </div>
         </div>

--- a/resources/views/depreciations/index.blade.php
+++ b/resources/views/depreciations/index.blade.php
@@ -19,8 +19,6 @@
   <div class="col-md-9">
     <div class="box box-default">
       <div class="box-body">
-        <div class="table-responsive">
-
           <table
                   data-columns="{{ \App\Presenters\DepreciationPresenter::dataTableLayout() }}"
                   data-cookie-id-table="depreciationsTable"
@@ -39,9 +37,7 @@
                     "fileName": "export-depreciations-{{ date('Y-m-d') }}",
                     "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                     }'>
-
           </table>
-        </div>
       </div>
     </div>
   </div> <!-- /.col-md-9-->

--- a/resources/views/kits/index.blade.php
+++ b/resources/views/kits/index.blade.php
@@ -19,7 +19,6 @@
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-body">
-        <div class="table-responsive">
             <table
                 data-cookie-id-table="kitsTable"
                 data-columns="{{ \App\Presenters\PredefinedKitPresenter::dataTableLayout() }}"
@@ -40,7 +39,6 @@
             "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
             }'>
           </table>
-        </div>
       </div> <!--.box-body-->
     </div> <!-- /.box.box-default-->
   </div> <!-- .col-md-12-->

--- a/resources/views/locations/index.blade.php
+++ b/resources/views/locations/index.blade.php
@@ -18,8 +18,6 @@
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-body">
-        <div class="table-responsive">
-
           @include('partials.locations-bulk-actions')
 
           <table
@@ -47,7 +45,6 @@
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
               }'>
           </table>
-        </div>
       </div>
     </div>
   </div>

--- a/resources/views/manufacturers/index.blade.php
+++ b/resources/views/manufacturers/index.blade.php
@@ -29,8 +29,6 @@
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-body">
-        <div class="table-responsive">
-
           <table
             data-columns="{{ \App\Presenters\ManufacturerPresenter::dataTableLayout() }}"
             data-cookie-id-table="manufacturersTable"
@@ -50,9 +48,7 @@
               "fileName": "export-manufacturers-{{ date('Y-m-d') }}",
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
               }'>
-
           </table>
-        </div>
       </div><!-- /.box-body -->
     </div><!-- /.box -->
   </div>

--- a/resources/views/models/index.blade.php
+++ b/resources/views/models/index.blade.php
@@ -37,7 +37,6 @@
       <div class="box-body">
 
         @include('partials.models-bulk-actions')
-              <div class="table-responsive">
                 <table
                         data-columns="{{ \App\Presenters\AssetModelPresenter::dataTableLayout() }}"
                         data-cookie-id-table="asssetModelsTable"
@@ -61,8 +60,6 @@
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
               }'>
               </table>
-
-          </div>
         </div>
         </div>
         {{ Form::close() }}

--- a/resources/views/reports/accessories.blade.php
+++ b/resources/views/reports/accessories.blade.php
@@ -13,8 +13,6 @@
         <div class="col-md-12">
             <div class="box box-default">
                 <div class="box-body">
-                    <div class="table-responsive">
-
                         <table
                                 data-cookie-id-table="accessoriesReport"
                                 data-pagination="true"
@@ -45,8 +43,6 @@
                             <tbody>
                             </tbody>
                         </table>
-
-                    </div>
                 </div>
             </div>
         </div>

--- a/resources/views/reports/asset_maintenances.blade.php
+++ b/resources/views/reports/asset_maintenances.blade.php
@@ -12,9 +12,6 @@
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-body">
-
-        <div class="table-responsive">
-
             <table
                     data-cookie-id-table="maintenancesReport"
                     data-pagination="true"
@@ -54,8 +51,6 @@
                 </tr>
                 </thead>
             </table>
-
-        </div>
       </div>
     </div>
   </div>

--- a/resources/views/reports/depreciation.blade.php
+++ b/resources/views/reports/depreciation.blade.php
@@ -16,8 +16,6 @@
 
 
           @if (($depreciations) && ($depreciations->count() > 0))
-          <div class="table-responsive">
-
                   <table
                         data-cookie-id-table="depreciationReport"
                         data-pagination="true"
@@ -40,9 +38,7 @@
                           "fileName": "depreciation-report-{{ date('Y-m-d') }}",
                           "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                           }'>
-
           </table>
-        </div> <!-- /.table-responsive-->
               @else
               <div class="col-md-12">
                   <div class="alert alert-warning fade in">

--- a/resources/views/reports/licenses.blade.php
+++ b/resources/views/reports/licenses.blade.php
@@ -12,8 +12,6 @@
     <div class="col-md-12">
         <div class="box box-default">
             <div class="box-body">
-                <div class="table-responsive">
-
                     <table
                             data-cookie-id-table="licensesReport"
                             data-pagination="true"
@@ -78,7 +76,6 @@
                             @endforeach
                         </tbody>
                     </table>
-                </div> <!-- /.table-responsive-->
             </div>
         </div>
     </div>

--- a/resources/views/reports/unaccepted_assets.blade.php
+++ b/resources/views/reports/unaccepted_assets.blade.php
@@ -34,8 +34,6 @@
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-body">
-        <div class="table-responsive">
-
             <table
                 data-cookie-id-table="unacceptedAssetsReport"
                 data-pagination="true"
@@ -105,7 +103,6 @@
               </tr>
             </tfoot>
           </table>
-        </div>
       </div>
     </div>
   </div>

--- a/resources/views/statuslabels/index.blade.php
+++ b/resources/views/statuslabels/index.blade.php
@@ -22,8 +22,6 @@
   <div class="col-md-9">
     <div class="box box-default">
       <div class="box-body">
-        <div class="table-responsive">
-
             <table
                     data-columns="{{ \App\Presenters\StatusLabelPresenter::dataTableLayout() }}"
                     data-cookie-id-table="statuslabelsTable"
@@ -46,7 +44,6 @@
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                 }'>
           </table>
-        </div>
       </div>
     </div>
   </div>

--- a/resources/views/suppliers/index.blade.php
+++ b/resources/views/suppliers/index.blade.php
@@ -20,8 +20,6 @@
   <div class="col-md-12">
     <div class="box box-default">
       <div class="box-body">
-      <div class="table-responsive">
-
         <table
             data-cookie-id-table="suppliersTable"
             data-pagination="true"
@@ -60,7 +58,6 @@
           </tr>
         </thead>
       </table>
-      </div>
     </div>
   </div>
   </div>


### PR DESCRIPTION
# Description
Removes the `table-responsive` class from several index tables, this allows the dropdown menus to expand further than the table length.

BEFORE:
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/99fbe54f-957f-415c-84f5-e5ac6e3aa18d">

AFTER:
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/587f0597-2328-4a42-a0c3-45c9c69b0174">

These changes were applied to the following index blades of:

1. Accessories
2. Predefined Kits
3. Custom Fields
4. Status Labels
5. Asset Models
6. Categories 
7. Manufacturers
8. Suppliers
9. Departments
10. Locations
11. Companies
12. Depreciations

Reports blades:
13. Depreciation
14. Licenses
15. Asset Maintenance
16. Unaccepted Assets
17. Accessories

Fixes #15665 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
