### PR TITLE
Only update asset locations to assets checked out to users. [Fixes: fd-45583 and fd-45702]

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -427,7 +427,7 @@ class LdapSync extends Command
                     $user->groups()->attach($ldap_default_group);
                 }
                 //updates assets location based on user's location
-                Asset::where('assigned_to', '=', $user->id)->update(['location_id' => $user->location_id]);
+                Asset::where('assigned_to', '=', $user->id)->where('assigned_type', '=', User::class)->update(['location_id' => $user->location_id]);
 
             } else {
                 foreach ($user->getErrors()->getMessages() as $key => $err) {


### PR DESCRIPTION
When we're updating assets that are checked out to users who may have moved locations, we need to make sure that the `assigned_type` is also set to `User::class`.