### PR TITLE
Set webhook content type (#15952)

### DIFF
--- a/app/Livewire/SlackSettingsForm.php
+++ b/app/Livewire/SlackSettingsForm.php
@@ -228,7 +228,7 @@ class SlackSettingsForm extends Component
 
         try {
             $response = Http::withHeaders([
-                'content-type' => 'applications/json',
+                'content-type' => 'application/json',
             ])->post($this->webhook_endpoint,
                 $payload)->throw();
 
@@ -263,7 +263,7 @@ class SlackSettingsForm extends Component
                         "text" => trans('general.webhook_test_msg', ['app' => $this->webhook_name]),
                     ];
                 $response = Http::withHeaders([
-                    'content-type' => 'applications/json',
+                    'content-type' => 'application/json',
                 ])->post($this->webhook_endpoint,
                     $payload)->throw();
             }
@@ -273,7 +273,7 @@ class SlackSettingsForm extends Component
                  $notification->success()->sendMessage($message);
 
                  $response = Http::withHeaders([
-                     'content-type' => 'applications/json',
+                     'content-type' => 'application/json',
                  ])->post($this->webhook_endpoint);
              }
 

--- a/app/Livewire/SlackSettingsForm.php
+++ b/app/Livewire/SlackSettingsForm.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use Livewire\Component;
@@ -158,8 +159,11 @@ class SlackSettingsForm extends Component
 
             ]);
 
+        $headers = ['content-type' => 'application/json'];
+        $request = new Request('POST', $this->webhook_endpoint, $headers, $payload);
+
         try {
-            $test = $webhook->post($this->webhook_endpoint, ['body' => $payload]);
+            $test = $webhook->send($request);
 
             if(($test->getStatusCode() == 302)||($test->getStatusCode() == 301)){
                 return session()->flash('error' , trans('admin/settings/message.webhook.error_redirect', ['endpoint' => $this->webhook_endpoint]));


### PR DESCRIPTION
# Description

Set correct content type for webhook's json payload.

Fixes #15952

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See related issue's reproduction steps

Result is now : `Your General Webhook Integration works!`
And the gitlab pipeline is actually triggered

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

