### PR TITLE
Adds null safe operator to accepter reminder command

### DIFF
--- a/app/Console/Commands/SendAcceptanceReminder.php
+++ b/app/Console/Commands/SendAcceptanceReminder.php
@@ -72,7 +72,7 @@ class SendAcceptanceReminder extends Command
             $locale = $acceptance->assignedTo?->locale;
             $email = $acceptance->assignedTo?->email;
             if(!$email){
-                $this->info($acceptance->assignedTo->present()->fullName().' has no email address.');
+                $this->info($acceptance->assignedTo?->present()->fullName().' has no email address.');
             }
             $item_count = $unacceptedAssetGroup->count();
 


### PR DESCRIPTION
A null safe operator was missing from the info line of the acceptance reminder command

Fixes #15951

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

