### PR TITLE
Set appropriate category for licenses when seeding

### DIFF
--- a/database/seeders/LicenseSeeder.php
+++ b/database/seeders/LicenseSeeder.php
@@ -8,6 +8,7 @@ use App\Models\LicenseSeat;
 use App\Models\Supplier;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Log;
 
 class LicenseSeeder extends Seeder
 {
@@ -20,7 +21,20 @@ class LicenseSeeder extends Seeder
             $this->call(CategorySeeder::class);
         }
 
-        $categoryIds = Category::all()->pluck('id');
+        $categories = Category::where('category_type', 'license')->get();
+
+        $graphicsSoftwareCategory = $categories->first(fn($category) => $category->name === 'Graphics Software');
+        $officeSoftwareCategory = $categories->first(fn($category) => $category->name === 'Office Software');
+
+        if (!$graphicsSoftwareCategory) {
+            Log::info('Graphics Software category not created. Using random category for seeding.');
+            $graphicsSoftwareCategory = Category::inRandomOrder()->first();
+        }
+
+        if (!$officeSoftwareCategory) {
+            Log::info('Office Software category not created. Using random category for seeding.');
+            $officeSoftwareCategory = Category::inRandomOrder()->first();
+        }
 
         if (! Supplier::count()) {
             $this->call(SupplierSeeder::class);
@@ -31,25 +45,25 @@ class LicenseSeeder extends Seeder
         $admin = User::where('permissions->superuser', '1')->first() ?? User::factory()->firstAdmin()->create();
 
         License::factory()->count(1)->photoshop()->create([
-            'category_id' => $categoryIds->random(),
+            'category_id' => $graphicsSoftwareCategory->id,
             'supplier_id' => $supplierIds->random(),
             'created_by' => $admin->id,
         ]);
 
         License::factory()->count(1)->acrobat()->create([
-            'category_id' => $categoryIds->random(),
+            'category_id' => $officeSoftwareCategory->id,
             'supplier_id' => $supplierIds->random(),
             'created_by' => $admin->id,
         ]);
 
         License::factory()->count(1)->indesign()->create([
-            'category_id' => $categoryIds->random(),
+            'category_id' => $graphicsSoftwareCategory->id,
             'supplier_id' => $supplierIds->random(),
             'created_by' => $admin->id,
         ]);
 
         License::factory()->count(1)->office()->create([
-            'category_id' => $categoryIds->random(),
+            'category_id' => $officeSoftwareCategory->id,
             'supplier_id' => $supplierIds->random(),
             'created_by' => $admin->id,
         ]);


### PR DESCRIPTION
Currently, categories for licenses are completely randomized when seeding leading to things like InDesign being categorized as Printer Ink
![License page](https://github.com/user-attachments/assets/6d660d35-e7db-4720-a030-ea9d6072554c)

This PR adjusts the license seeder so it uses the appropriate category for each license. 

It falls back to using a random category if the isn't a category seeded with the name "Office Software" and/or "Graphics Software".