### PR TITLE
Reversed order of the acceptance and note parameters in Mail listener

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -282,7 +282,7 @@ class CheckoutableListener
         ];
         $mailable= $lookup[get_class($event->checkoutable)];
 
-        return new $mailable($event->checkoutable, $event->checkedOutTo, $event->checkedOutBy, $event->note, $acceptance);
+        return new $mailable($event->checkoutable, $event->checkedOutTo, $event->checkedOutBy, $acceptance, $event->note);
 
     }
     private function getCheckinMailType($event){

--- a/app/Mail/CheckoutAccessoryMail.php
+++ b/app/Mail/CheckoutAccessoryMail.php
@@ -21,7 +21,7 @@ class CheckoutAccessoryMail extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct(Accessory $accessory, $checkedOutTo, User $checkedOutBy,$note, $acceptance)
+    public function __construct(Accessory $accessory, $checkedOutTo, User $checkedOutBy, $acceptance, $note)
     {
         $this->item = $accessory;
         $this->admin = $checkedOutBy;

--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -23,7 +23,7 @@ class CheckoutAssetMail extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct(Asset $asset, $checkedOutTo, User $checkedOutBy, $note, $acceptance)
+    public function __construct(Asset $asset, $checkedOutTo, User $checkedOutBy,  $acceptance, $note)
     {
         $this->item = $asset;
         $this->admin = $checkedOutBy;

--- a/app/Mail/CheckoutLicenseMail.php
+++ b/app/Mail/CheckoutLicenseMail.php
@@ -27,7 +27,6 @@ class CheckoutLicenseMail extends Mailable
         $this->note = $note;
         $this->target = $checkedOutTo;
         $this->acceptance = $acceptance;
-
         $this->settings = Setting::getSettings();
     }
 


### PR DESCRIPTION
This reverses the order of the `$note` and `$acceptance` parameters in the `getCheckoutMailType()` method.

Fixing the blank acceptance url  and nonsensical note.

Fixes: [sc-27728]