### PR TITLE
Removed index and destroy settings API endpoints

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -909,13 +909,11 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], functi
         Route::resource('settings', 
         Api\SettingsController::class,
         ['names' => [
-                'index' => 'api.settings.index',
                 'show' => 'api.settings.show',
                 'update' => 'api.settings.update',
                 'store' => 'api.settings.store',
-                'destroy' => 'api.settings.destroy',
             ],
-        'except' => ['create', 'edit'],
+        'except' => ['create', 'edit', 'index', 'destroy'],
         'parameters' => ['setting' => 'setting_id'],
         ]
         ); // end settings API


### PR DESCRIPTION
This fixes RB-19121 and returns an invalid endpoint error instead of a 500. (We don't currently offer an index or destroy method for settings, so due to resource groups, it was 500ing instead of giving the expected 404 payload.)

It now correctly returns:

```json
{
    "status": "error",
    "message": "404 endpoint not found. Please check the API reference at https://snipe-it.readme.io/reference to find a valid API endpoint.",
    "payload": null
}
```