### PR TITLE
Fixes to backup-restore 'clean' mode to better handle character sets and zero-values [Fixes: fd-45757, fd-44714, fd-44737, fd-44692]

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -51,6 +51,8 @@ class SQLStreamer {
             /* we *could* have made the ^INSERT INTO blah VALUES$ turn on the capturing state, and closed it with
                a ^(blahblah);$ but it's cleaner to not have to manage the state machine. We're just going to
                assume that (blahblah), or (blahblah); are values for INSERT and are always acceptable. */
+            "<^/\*!40101 SET NAMES '?[a-zA-Z0-9_-]+'? \*/;$>"                                   => false, //using weird delimiters (<,>) for readability. allow quoted or unquoted charsets
+            "<^/\*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' \*/;$>" => false, //same, now handle zero-values
         ];
 
         foreach($allowed_statements as $statement => $statechange) {


### PR DESCRIPTION
We've had a few international customers who have run into character-encoding problems doing restores of backups generated from our hosted Snipe-IT system.

It seems like our SQL cleaner - which is enabled by default in the hosted platform - had been stripping out some SQL statements that declare character sets.

Additionally, we've seen in the past when customers try to run a restore into their new cloud-hosted instance from their own hosted instance, where if they have some 'bad data', that they can run into other errors during the restore.

This attempts to fix both of those issues, by allow-listing a few new SQL statements in the cleaner system.