### PR TITLE
Check for assigned (not assigned_to) before trying to present() the name of the assignee on bulk delete

### DIFF
--- a/resources/views/hardware/bulk-delete.blade.php
+++ b/resources/views/hardware/bulk-delete.blade.php
@@ -49,7 +49,7 @@
                   @endif
                 </td>
                 <td>
-                  @if ($asset->assigned_to)
+                  @if ($asset->assigned)
                     {{ $asset->assigned->present()->name() }}
                   @endif
                 </td>


### PR DESCRIPTION
This handles the `Call to a member function present() on null ` error you might run into if data was inconsistent. Fixes RB-18772.