### PR TITLE
Fixed: Asset Count on Users Index Page Counting Soft Deleted Items

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -20,6 +20,7 @@ use App\Models\License;
 use App\Models\User;
 use App\Notifications\CurrentInventory;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -80,7 +80,16 @@ class UsersController extends Controller
             'users.website',
 
         ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables', 'createdBy', 'managesUsers', 'managedLocations')
-            ->withCount('assets as assets_count', 'licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count', 'managesUsers as manages_users_count', 'managedLocations as manages_locations_count');
+            ->withCount([
+                'assets as assets_count' => function(Builder $query) {
+                    $query->withoutTrashed();
+                },
+                'licenses as licenses_count',
+                'accessories as accessories_count',
+                'consumables as consumables_count',
+                'managesUsers as manages_users_count',
+                'managedLocations as manages_locations_count'
+            ]);
 
 
         if ($request->filled('search') != '') {


### PR DESCRIPTION
This more robustly tallies the assets count on the users index page. Soft deleted assets could still show in the created table under certain circumstances.

old:
<img width="993" alt="Screenshot 2024-12-17 at 5 13 16 PM" src="https://github.com/user-attachments/assets/19a87614-281a-4b2f-97b7-8fb77c8ffddd" />

new:
<img width="987" alt="Screenshot 2024-12-17 at 5 12 53 PM" src="https://github.com/user-attachments/assets/ad685fa0-45a0-41f7-a476-79631f6fca8b" />

<img width="688" alt="Screenshot 2024-12-17 at 5 19 15 PM" src="https://github.com/user-attachments/assets/4ec9e19d-3373-4aeb-95e3-0c00bf1eba7b" />



Fixes: [27551](https://app.shortcut.com/grokability/story/27551/asset-count-on-users-index-page-counting-soft-deleted-items)

