### PR TITLE
Update Checkout Button Permission for Predefined Kits

### DIFF
--- a/app/Http/Transformers/PredefinedKitsTransformer.php
+++ b/app/Http/Transformers/PredefinedKitsTransformer.php
@@ -3,6 +3,8 @@
 namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
+use App\Models\Asset;
+use App\Models\AssetModel;
 use App\Models\PredefinedKit;
 use App\Models\SnipeModel;
 use Illuminate\Support\Facades\Gate;
@@ -42,7 +44,7 @@ class PredefinedKitsTransformer
         $permissions_array['available_actions'] = [
             'update' => Gate::allows('update', PredefinedKit::class),
             'delete' => Gate::allows('delete', PredefinedKit::class),
-            'checkout' => Gate::allows('checkout', PredefinedKit::class),
+            'checkout' => Gate::allows('checkout', Asset::class),
             // 'clone' => Gate::allows('create', PredefinedKit::class),
             // 'restore' => Gate::allows('create', PredefinedKit::class),
         ];

--- a/app/Http/Transformers/PredefinedKitsTransformer.php
+++ b/app/Http/Transformers/PredefinedKitsTransformer.php
@@ -4,7 +4,6 @@ namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
 use App\Models\Asset;
-use App\Models\AssetModel;
 use App\Models\PredefinedKit;
 use App\Models\SnipeModel;
 use Illuminate\Support\Facades\Gate;

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -279,8 +279,8 @@
             element_name = '';
         }
 
-        return function (value,row) {
 
+        return function (value,row) {
             var actions = '<nobr>';
 
             // Add some overrides for any funny urls we have
@@ -442,6 +442,7 @@
 
     function genericCheckinCheckoutFormatter(destination) {
         return function (value,row) {
+            // some extra logic for kits needs to go here
 
             // The user is allowed to check items out, AND the item is deployable
             if ((row.available_actions.checkout == true) && (row.user_can_checkout == true) && ((!row.asset_id) && (!row.assigned_to))) {

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -441,14 +441,10 @@
     }
 
     function genericCheckinCheckoutFormatter(destination) {
-        console.log(destination)
         return function (value,row) {
-            console.log(value)
-            console.log(row.user_can_checkout)
             // some extra logic for kits needs to go here
 
             // The user is allowed to check items out, AND the item is deployable
-            row.available_actions.checkout = true //this is for testing -- TODO: REMOVE!!!!
             if ((row.available_actions.checkout == true) && (row.user_can_checkout == true) && ((!row.asset_id) && (!row.assigned_to))) {
 
                     return '<a href="{{ config('app.url') }}/' + destination + '/' + row.id + '/checkout" class="btn btn-sm bg-maroon" data-tooltip="true" title="{{ trans('general.checkout_tooltip') }}">{{ trans('general.checkout') }}</a>';

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -441,8 +441,7 @@
     }
 
     function genericCheckinCheckoutFormatter(destination) {
-        return function (value,row) {
-            // some extra logic for kits needs to go here
+        return function (value, row) {
 
             // The user is allowed to check items out, AND the item is deployable
             if ((row.available_actions.checkout == true) && (row.user_can_checkout == true) && ((!row.asset_id) && (!row.assigned_to))) {

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -441,10 +441,14 @@
     }
 
     function genericCheckinCheckoutFormatter(destination) {
+        console.log(destination)
         return function (value,row) {
+            console.log(value)
+            console.log(row.user_can_checkout)
             // some extra logic for kits needs to go here
 
             // The user is allowed to check items out, AND the item is deployable
+            row.available_actions.checkout = true //this is for testing -- TODO: REMOVE!!!!
             if ((row.available_actions.checkout == true) && (row.user_can_checkout == true) && ((!row.asset_id) && (!row.assigned_to))) {
 
                     return '<a href="{{ config('app.url') }}/' + destination + '/' + row.id + '/checkout" class="btn btn-sm bg-maroon" data-tooltip="true" title="{{ trans('general.checkout_tooltip') }}">{{ trans('general.checkout') }}</a>';


### PR DESCRIPTION
Real simple PR to add the button back to predefined kits for users too checkout them out. Because pre-defined kits only work with assets right now it stands to reason that if you have permission to checkout assets you should be able to checkout pre-defined kits, so went ahead and made that change. 

I've got some ideas for re-writing predefined kits and using livewire for the interface, so will start to give that some more serious consideration in the new year. 