### PR TITLE
Renames variables to match columns for label settings

### DIFF
--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -19,12 +19,12 @@ class SettingsSeeder extends Seeder
         $settings->logo = 'snipe-logo.png';
         $settings->alert_email = 'service@snipe-it.io';
         $settings->header_color = null;
-        $settings->barcode_type = 'QRCODE';
+        $settings->label2_2d_type = 'QRCODE';
         $settings->default_currency = 'USD';
         $settings->brand = 3;
         $settings->ldap_enabled = 0;
         $settings->full_multiple_companies_support = 0;
-        $settings->alt_barcode = 'C128';
+        $settings->label2_1d_type = 'C128';
         $settings->skin = '';
         $settings->email_domain = 'example.org';
         $settings->email_format = 'filastname';


### PR DESCRIPTION
This just changes `barcode_type` and `alt_barcode` to `label2_2d_type` and `label2_1d_type` respectively in the settings seeder. as per the changes in  #15446 