### PR TITLE
Add `string` to Password Reset Username Rules

### DIFF
--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -50,11 +50,12 @@ class ForgotPasswordController extends Controller
      */
     public function sendResetLinkEmail(Request $request)
     {
-
+        dump($request);
         /**
          * Let's set a max character count here to prevent potential
          * buffer overflow issues with attackers sending very large
-         * payloads through.
+         * payloads through. The addition of the string rule prevents attackers
+         * sending arrays through and causing 500s
          */
         $request->validate([
             'username' => ['required', 'max:255', 'string'],

--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -50,7 +50,6 @@ class ForgotPasswordController extends Controller
      */
     public function sendResetLinkEmail(Request $request)
     {
-        dump($request);
         /**
          * Let's set a max character count here to prevent potential
          * buffer overflow issues with attackers sending very large

--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -57,7 +57,7 @@ class ForgotPasswordController extends Controller
          * payloads through.
          */
         $request->validate([
-            'username' => ['required', 'max:255'],
+            'username' => ['required', 'max:255', 'string'],
         ]);
 
         /**


### PR DESCRIPTION
This is just a quick addition to the `sendResetLinkEmail()` method's validation rules to prevent attempting to submit an array, this wasn't getting through before, but it will no longer 500 when someone attempts this. I couldn't trigger the 500 using dot notation, it just seems like that gets prevented because it's an unused parameter name, doesn't seem like it comes through as an array. 