### PR TITLE
Fixed reset demo command

### DIFF
--- a/app/Console/Commands/ResetDemoSettings.php
+++ b/app/Console/Commands/ResetDemoSettings.php
@@ -50,12 +50,12 @@ class ResetDemoSettings extends Command
         $settings->alert_email = 'service@snipe-it.io';
         $settings->login_note = 'Use `admin` / `password` to login to the demo.';
         $settings->header_color = null;
-        $settings->barcode_type = 'QRCODE';
+        $settings->label2_2d_type = 'QRCODE';
         $settings->default_currency = 'USD';
         $settings->brand = 2;
         $settings->ldap_enabled = 0;
         $settings->full_multiple_companies_support = 0;
-        $settings->alt_barcode = 'C128';
+        $settings->label2_1d_type = 'C128';
         $settings->skin = '';
         $settings->email_domain = 'snipeitapp.com';
         $settings->email_format = 'filastname';


### PR DESCRIPTION
This PR follows up #15986 and updates `barcode_type` and `alt_barcode` to `label2_2d_type` and `label2_1d_type` in the `ResetDemoSettings` command.