### PR TITLE
Check for valid asset before accessing properties

### DIFF
--- a/app/Http/Controllers/Api/AssetMaintenancesController.php
+++ b/app/Http/Controllers/Api/AssetMaintenancesController.php
@@ -122,7 +122,7 @@ class AssetMaintenancesController extends Controller
      * @version v1.0
      * @since [v1.8]
      */
-    public function store(Request $request) : JsonResponse
+    public function store(Request $request) : JsonResponse | array
     {
         $this->authorize('update', Asset::class);
         // create a new model instance
@@ -149,7 +149,7 @@ class AssetMaintenancesController extends Controller
      * @version v1.0
      * @since [v4.0]
      */
-    public function update(Request $request, $id) : JsonResponse
+    public function update(Request $request, $id) : JsonResponse | array
     {
         $this->authorize('update', Asset::class);
 
@@ -186,7 +186,7 @@ class AssetMaintenancesController extends Controller
      * @version v1.0
      * @since [v4.0]
      */
-    public function destroy($assetMaintenanceId) : JsonResponse
+    public function destroy($assetMaintenanceId) : JsonResponse | array
     {
         $this->authorize('update', Asset::class);
         // Check if the asset maintenance exists
@@ -208,7 +208,7 @@ class AssetMaintenancesController extends Controller
      * @version v1.0
      * @since [v4.0]
      */
-    public function show($assetMaintenanceId) : JsonResponse
+    public function show($assetMaintenanceId) : JsonResponse | array
     {
         $this->authorize('view', Asset::class);
         $assetMaintenance = AssetMaintenance::findOrFail($assetMaintenanceId);

--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -26,17 +26,18 @@ class AssetMaintenancesTransformer
             'id'            => (int) $assetmaintenance->id,
             'asset' => ($assetmaintenance->asset) ? [
                 'id' => (int) $assetmaintenance->asset->id,
-                'name'=> ($assetmaintenance->asset->name) ? e($assetmaintenance->asset->name) : null,
+                'name'=> (($assetmaintenance->asset) && ($assetmaintenance->asset->name)) ? e($assetmaintenance->asset->name) : null,
                 'asset_tag'=> e($assetmaintenance->asset->asset_tag),
                 'serial'=> e($assetmaintenance->asset->serial),
-                'deleted_at'=> e($assetmaintenance->asset->deleted_at),
-                'created_at'=> e($assetmaintenance->asset->created_at),
+                'deleted_at'=> ($assetmaintenance->asset) ?  Helper::getFormattedDateObject($assetmaintenance->asset->deleted_at, 'datetime') : null,
+                'created_at' => ($assetmaintenance->asset) ?  Helper::getFormattedDateObject($assetmaintenance->asset->created_at, 'datetime') : null,
+                'updated_at' => ($assetmaintenance->asset) ?  Helper::getFormattedDateObject($assetmaintenance->asset->updated_at, 'datetime') : null,
             ] : null,
             'model' => (($assetmaintenance->asset) && ($assetmaintenance->asset->model)) ? [
                 'id' => (int) $assetmaintenance->asset->model->id,
                 'name'=> ($assetmaintenance->asset->model->name) ? e($assetmaintenance->asset->model->name).' '.e($assetmaintenance->asset->model->model_number) : null,
             ] : null,
-            'status_label' => ($assetmaintenance->asset->assetstatus) ? [
+            'status_label' => (($assetmaintenance->asset) && ($assetmaintenance->asset->assetstatus)) ? [
                 'id' => (int) $assetmaintenance->asset->assetstatus->id,
                 'name'=> e($assetmaintenance->asset->assetstatus->name),
                 'status_type'=> e($assetmaintenance->asset->assetstatus->getStatuslabelType()),
@@ -79,7 +80,7 @@ class AssetMaintenancesTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'update' => (Gate::allows('update', Asset::class) && ($assetmaintenance->asset->deleted_at=='')) ? true : false,
+            'update' => (Gate::allows('update', Asset::class) && ((($assetmaintenance->asset) && $assetmaintenance->asset->deleted_at==''))) ? true : false,
             'delete' => Gate::allows('delete', Asset::class),
         ];
 

--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -26,12 +26,12 @@ class AssetMaintenancesTransformer
             'id'            => (int) $assetmaintenance->id,
             'asset' => ($assetmaintenance->asset) ? [
                 'id' => (int) $assetmaintenance->asset->id,
-                'name'=> (($assetmaintenance->asset) && ($assetmaintenance->asset->name)) ? e($assetmaintenance->asset->name) : null,
+                'name'=> ($assetmaintenance->asset->name) ? e($assetmaintenance->asset->name) : null,
                 'asset_tag'=> e($assetmaintenance->asset->asset_tag),
                 'serial'=> e($assetmaintenance->asset->serial),
-                'deleted_at'=> ($assetmaintenance->asset) ?  Helper::getFormattedDateObject($assetmaintenance->asset->deleted_at, 'datetime') : null,
-                'created_at' => ($assetmaintenance->asset) ?  Helper::getFormattedDateObject($assetmaintenance->asset->created_at, 'datetime') : null,
-                'updated_at' => ($assetmaintenance->asset) ?  Helper::getFormattedDateObject($assetmaintenance->asset->updated_at, 'datetime') : null,
+                'deleted_at'=> Helper::getFormattedDateObject($assetmaintenance->asset->deleted_at, 'datetime'),
+                'created_at' => Helper::getFormattedDateObject($assetmaintenance->asset->created_at, 'datetime'),
+                'updated_at' => Helper::getFormattedDateObject($assetmaintenance->asset->updated_at, 'datetime'),
             ] : null,
             'model' => (($assetmaintenance->asset) && ($assetmaintenance->asset->model)) ? [
                 'id' => (int) $assetmaintenance->asset->model->id,


### PR DESCRIPTION
This fixes a rare 500 that can occur when the maintenances API is loaded, but the asset does not exist anymore. We see this most commonly in the demo, where the data can be unpredictable, and people can end up hitting the demo just as it's resetting/re-seeding. 

Fixes RB-3934, RB-3759, RB-3935, and RB-3936.
