### PR TITLE
Docker Improvement: Change the logging channel to storage/logs/laravel.log file

### DIFF
--- a/.env.dev.docker
+++ b/.env.dev.docker
@@ -158,7 +158,7 @@ RESET_PASSWORD_LINK_EXPIRES=900
 # --------------------------------------------
 # OPTIONAL: MISC
 # --------------------------------------------
-LOG_CHANNEL=stderr
+LOG_CHANNEL=single
 LOG_MAX_DAYS=10
 APP_LOCKED=false
 APP_CIPHER=AES-256-CBC

--- a/docker/startup_alpine.sh
+++ b/docker/startup_alpine.sh
@@ -103,6 +103,7 @@ php artisan migrate --force
 php artisan config:clear
 php artisan config:cache
 
+touch /var/www/html/storage/logs/laravel.log
 chown -R apache:root /var/www/html/storage/logs/laravel.log
 
 export APACHE_LOG_DIR=/var/log/apache2


### PR DESCRIPTION
This is just a suggestion. As a new comer to the project I expected the logs to be where Laravel puts them by default. If there are any reasons for the current behavior you can close this pr. 