### PR TITLE
Fixes tecnickcom/tcpdf security CVEs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11045,20 +11045,21 @@
         },
         {
             "name": "tecnickcom/tcpdf",
-            "version": "6.7.7",
+            "version": "6.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tecnickcom/TCPDF.git",
-                "reference": "cfbc0028cc23f057f2baf9e73bdc238153c22086"
+                "reference": "14ffa0e308f5634aa2489568b4b90b24073b6731"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/cfbc0028cc23f057f2baf9e73bdc238153c22086",
-                "reference": "cfbc0028cc23f057f2baf9e73bdc238153c22086",
+                "url": "https://api.github.com/repos/tecnickcom/TCPDF/zipball/14ffa0e308f5634aa2489568b4b90b24073b6731",
+                "reference": "14ffa0e308f5634aa2489568b4b90b24073b6731",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.0"
+                "ext-curl": "*",
+                "php": ">=7.1.0"
             },
             "type": "library",
             "autoload": {
@@ -11105,7 +11106,7 @@
             ],
             "support": {
                 "issues": "https://github.com/tecnickcom/TCPDF/issues",
-                "source": "https://github.com/tecnickcom/TCPDF/tree/6.7.7"
+                "source": "https://github.com/tecnickcom/TCPDF/tree/6.8.0"
             },
             "funding": [
                 {
@@ -11113,7 +11114,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-10-26T12:15:02+00:00"
+            "time": "2024-12-23T13:34:57+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",


### PR DESCRIPTION
Fixes the following CVE-2024-56522, CVE-2024-56527, CVE-2024-56519, CVE-2024-56521


```
❯ composer audit
Found 4 security vulnerability advisories affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | tecnickcom/tcpdf                                                                 |
| Severity          | medium                                                                           |
| CVE               | CVE-2024-56522                                                                   |
| Title             | TCPDF has incorrect comparison                                                   |
| URL               | https://github.com/advisories/GHSA-w95c-7994-ghpr                                |
| Affected versions | <6.8.0                                                                           |
| Reported at       | 2024-12-27T06:30:48+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | tecnickcom/tcpdf                                                                 |
| Severity          | medium                                                                           |
| CVE               | CVE-2024-56527                                                                   |
| Title             | TCPDF missing character escape on error messages                                 |
| URL               | https://github.com/advisories/GHSA-qx95-cwh6-9mvq                                |
| Affected versions | <6.8.0                                                                           |
| Reported at       | 2024-12-27T06:30:48+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | tecnickcom/tcpdf                                                                 |
| Severity          | medium                                                                           |
| CVE               | CVE-2024-56519                                                                   |
| Title             | TCPDF lacks SVG sanitization                                                     |
| URL               | https://github.com/advisories/GHSA-4p8j-vhjm-6pvw                                |
| Affected versions | <6.8.0                                                                           |
| Reported at       | 2024-12-27T06:30:47+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | tecnickcom/tcpdf                                                                 |
| Severity          | high                                                                             |
| CVE               | CVE-2024-56521                                                                   |
| Title             | TCPDF missing certificate validation                                             |
| URL               | https://github.com/advisories/GHSA-9mgx-552f-59p6                                |
| Affected versions | <6.8.0                                                                           |
| Reported at       | 2024-12-27T06:30:47+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
```

Minor semver updated 
```
❯ composer update tecnickcom/tcpdf
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading tecnickcom/tcpdf (6.7.7 => 6.8.0)
```