### PR TITLE
Fixes SAML login issue

### DIFF
--- a/app/Services/Saml.php
+++ b/app/Services/Saml.php
@@ -313,7 +313,7 @@ class Saml
         $this->saveDataToSession($data);
         $this->loadDataFromSession();
         $username = $this->getUsername();
-        return User::where('username', '=', $username)->whereNull('deleted_at')->where('activated', '=', '1')->first();
+        return User::where('email', '=', $username)->whereNull('deleted_at')->where('activated', '=', '1')->first();
     }
 
     /**


### PR DESCRIPTION
While login via Samil (aka Microsoft Office 360) the user name retrieved is the email, so the end user does not add his email in the username field. He is going to get the "SAML user 'username' could not be found in database." error