### PR TITLE
Fixed migration causing issues with mariadb

### DIFF
--- a/database/migrations/2023_08_23_232739_create_report_templates_table.php
+++ b/database/migrations/2023_08_23_232739_create_report_templates_table.php
@@ -17,7 +17,19 @@ class CreateReportTemplatesTable extends Migration
             $table->id();
             $table->integer('created_by')->nullable();
             $table->string('name');
-            $table->json('options');
+
+            /*
+             * The "options" column was originally json but this causes issues
+             * with older versions of mariadb so it was changed text.
+             *
+             * A follow-up migration definitively changes it to a text column
+             * for the systems that had successfully run the migration:
+             * 2025_01_06_210534_change_report_templates_options_to_column_text_field.
+             *
+             * https://github.com/snipe/snipe-it/issues/16015
+             */
+            $table->text('options');
+
             $table->softDeletes();
             $table->timestamps();
             $table->index('created_by');

--- a/database/migrations/2025_01_06_210534_change_report_templates_options_to_column_text_field.php
+++ b/database/migrations/2025_01_06_210534_change_report_templates_options_to_column_text_field.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        /*
+         * The "options" column was originally json but the migration was amended to change it to a text column
+         * since json columns cause issues with older versions of mariadb.
+         *
+         * This migration definitively changes it to a text column
+         * for the systems that had successfully run the migration.
+         *
+         * https://github.com/snipe/snipe-it/issues/16015
+         */
+        if (Schema::hasTable('report_templates') && Schema::hasColumn('report_templates', 'options')) {
+            Schema::table('report_templates', function (Blueprint $table) {
+                $table->text('options')->change();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('report_templates', function (Blueprint $table) {
+            // Instead of attempting to roll this back to json let's just
+            // keep it as text since that works for mysql, mariadb, and sqlite.
+        });
+    }
+};


### PR DESCRIPTION
This PR amends a migration that was included in #15714 that does not work on older versions of mariadb (v10 and below I believe).

That PR introduced a `json` column and mariadb (<v11) doesn't like that so this PR changes it to a text type like we have elsewhere in the application.

Some people may have already successfully run the migration and so another migration was created to "change" the column to `text`. To the best of my knowledge and from testing, if the column is already `text` then the operation is essentially a no-op so it shouldn't cause any issues "changing" the column from "text" to "text".

---

Fixes #16015