### PR TITLE
Fixed default values for label types in the DB

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -105,7 +105,7 @@ class Label implements View
                     }
                 }
 
-                if ($settings->alt_barcode_enabled) {
+
                     if ($template->getSupport1DBarcode()) {
                         $barcode1DType = $settings->label2_1d_type;
                         if ($barcode1DType != 'none') {
@@ -115,21 +115,25 @@ class Label implements View
                             ]);
                         }
                     }
-                }
 
-                if ($template->getSupport2DBarcode()) {
-                    $barcode2DType = $settings->label2_2d_type;
-                    if (($barcode2DType != 'none') && (!is_null($barcode2DType))) {
-                        switch ($settings->label2_2d_target) {
-                            case 'ht_tag': $barcode2DTarget = route('ht/assetTag', $asset->asset_tag); break;
-                            case 'hardware_id':
+                    if ($template->getSupport2DBarcode()) {
+                        $barcode2DType = $settings->label2_2d_type;
+                        if (($barcode2DType != 'none') && (!is_null($barcode2DType))) {
+                            switch ($settings->label2_2d_target) {
+                                case 'ht_tag':
+                                    $barcode2DTarget = route('ht/assetTag', $asset->asset_tag);
+                                    break;
+                                case 'hardware_id':
+                                default:
+                                    $barcode2DTarget = route('hardware.show', ['hardware' => $asset->id]);
+                                    break;
+                            }
+                            $assetData->put('barcode2d', (object)[
+                                'type' => $barcode2DType,
+                                'content' => $barcode2DTarget,
+                            ]);
                         }
-                        $assetData->put('barcode2d', (object)[
-                            'type' => $barcode2DType,
-                            'content' => $barcode2DTarget,
-                        ]);
                     }
-                }
 
                 $fields = $fieldDefinitions
                     ->map(fn($field) => $field->toArray($asset))

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -119,14 +119,10 @@ class Label implements View
 
                 if ($template->getSupport2DBarcode()) {
                     $barcode2DType = $settings->label2_2d_type;
-                    $barcode2DType = ($barcode2DType == 'default') ? 
-                        $settings->barcode_type :
-                        $barcode2DType;
                     if (($barcode2DType != 'none') && (!is_null($barcode2DType))) {
                         switch ($settings->label2_2d_target) {
                             case 'ht_tag': $barcode2DTarget = route('ht/assetTag', $asset->asset_tag); break;
                             case 'hardware_id':
-                            default: $barcode2DTarget = route('hardware.show', ['hardware' => $asset->id]); break;
                         }
                         $assetData->put('barcode2d', (object)[
                             'type' => $barcode2DType,

--- a/database/migrations/2025_01_07_172419_fix_label_types_on_settings_table.php
+++ b/database/migrations/2025_01_07_172419_fix_label_types_on_settings_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('settings')->where('label2_2d_type', 'default')->update([
+            'label2_2d_type' => 'QRCODE',
+        ]);
+
+        DB::table('settings')->where('label2_1d_type', 'default')->update([
+            'label2_1d_type' => 'C128',
+        ]);
+
+        DB::table('settings')->whereNull('label2_2d_type')->orWhere('label2_2d_type', '')->update([
+            'label2_2d_type' => 'none',
+        ]);
+
+        DB::table('settings')->whereNull('label2_1d_type')->orWhere('label2_1d_type', '')->update([
+            'label2_1d_type' => 'none',
+        ]);
+
+        Schema::table('settings', function (Blueprint $table) {
+            $table->string('label2_2d_type')->default('QRCODE')->change();
+            $table->string('label2_1d_type')->default('C128')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -367,7 +367,7 @@ return [
     'label2_fields_help'      => 'Fields can be added, removed, and reordered in the left column. For each field, multiple options for Label and DataSource can be added, removed, and reordered in the right column.',
     'help_asterisk_bold'    => 'Text entered as <code>**text**</code> will be displayed as bold',
     'help_blank_to_use'     => 'Leave blank to use the value from <code>:setting_name</code>',
-    'help_default_will_use' => '<code>:default</code> will use the value from <code>:setting_name</code>. <br>Note that the value of the barcodes must comply with the respective barcode spec in order to be successfully generated. Please see <a href="https://snipe-it.readme.io/docs/barcodes">the documentation <i class="fa fa-external-link"></i></a> for more details. ',
+    'help_default_will_use' => '<br>Note that the value of the barcodes must comply with the respective barcode spec in order to be successfully generated. Please see <a href="https://snipe-it.readme.io/docs/barcodes">the documentation <i class="fa fa-external-link"></i></a> for more details. ',
     'default'               => 'Default',
     'none'                  => 'None',
     'google_callback_help' => 'This should be entered as the callback URL in your Google OAuth app settings in your organization&apos;s <strong><a href="https://console.cloud.google.com/" target="_blank">Google developer console <i class="fa fa-external-link" aria-hidden="true"></i></a></strong>.',

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -175,10 +175,7 @@
                                         <p class="help-block">
                                             {{ trans('admin/settings/general.label2_1d_type_help') }}.
                                             {!!
-                                                trans('admin/settings/general.help_default_will_use', [
-                                                    'default' => trans('admin/settings/general.default'),
-                                                    'setting_name' => trans('admin/settings/general.barcodes').' &gt; '.trans('admin/settings/general.alt_barcode_type'),
-                                                ])
+                                                trans('admin/settings/general.help_default_will_use')
                                             !!}
                                         </p>
                                     </div>
@@ -218,10 +215,7 @@
                                         <p class="help-block">
                                             {{ trans('admin/settings/general.label2_2d_type_help', ['current' => $setting->barcode_type]) }}.
                                             {!!
-                                                trans('admin/settings/general.help_default_will_use', [
-                                                    'default' => trans('admin/settings/general.default'),
-                                                    'setting_name' => trans('admin/settings/general.barcodes').' &gt; '.trans('admin/settings/general.barcode_type'),
-                                                ])
+                                                trans('admin/settings/general.help_default_will_use')
                                             !!}
                                         </p>
                                     </div>


### PR DESCRIPTION
This updates the db values for `label2_2d_type` and `label2_1d_type`. The changes in #15446 overlooked that there were default column values set to `default` which needed to be changed. The new default values are `QRCODE` and `C128` respectively. If the DB value is set to blank it will be replaced with `none`.

Also fixes the entanglement of each 1d/2d codes visibility from the old and new engines.

Help block has been updated:
Before:
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/48888beb-967c-4cb3-9372-c9ae36e52177" />

After:
<img width="681" alt="image" src="https://github.com/user-attachments/assets/e99ede31-95e5-4cb7-9d79-678472a30c83" />
