### PR TITLE
Fixed acceptance reminder email formatting

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1172,10 +1172,10 @@ class ReportsController extends Controller
         $locale = $assetItem->assignedTo?->locale;
         // Only send notification if assigned
         if ($locale && $email) {
-                Mail::to($email)->send((new CheckoutAssetMail($assetItem, $assetItem->assignedTo, $logItem->user, $logItem->note, $acceptance))->locale($locale));
+            Mail::to($email)->send((new CheckoutAssetMail($assetItem, $assetItem->assignedTo, $logItem->user, $acceptance, $logItem->note))->locale($locale));
 
             } elseif ($email) {
-                Mail::to($email)->send((new CheckoutAssetMail($assetItem, $assetItem->assignedTo, $logItem->user, $logItem->note, $acceptance)));
+            Mail::to($email)->send((new CheckoutAssetMail($assetItem, $assetItem->assignedTo, $logItem->user, $acceptance, $logItem->note)));
             }
 
         if ($email == ''){


### PR DESCRIPTION
When hitting the "Re-send Reminder" button on the Unaccepted Assets page (`/reports/unaccepted_assets`) the email that is sent isn't formatted correctly. This PR fixes that.

**The keys are squished:**
![](https://github.com/user-attachments/assets/baaacfa6-726f-4c49-997c-0ac6ce03df68)

**This is due to the "notes" actually being set to the acceptance itself.**
![](https://github.com/user-attachments/assets/458c39ec-c729-4869-9581-41cee4641782)

**By fixing the parameter order we fix the issue:**
![](https://github.com/user-attachments/assets/c25e8dbb-e518-46e8-a741-e9a6d447aa9c)
