### PR TITLE
Adds a null check to label templates, adds return types for validation methods

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -798,11 +798,7 @@ class SettingsController extends Controller
             $setting->labels_display_model = 0;
         }
 
-
         if ($setting->save()) {
-            if ($setting->label2_template === null) {
-                return redirect()->route('settings.labels.index')->with('error', trans('admin/settings/message.labels.null_template'));
-            }
 
             return redirect()->route('settings.labels.index')
                 ->with('success', trans('admin/settings/message.update.success'));

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -798,7 +798,12 @@ class SettingsController extends Controller
             $setting->labels_display_model = 0;
         }
 
+
         if ($setting->save()) {
+            if ($setting->label2_template === null) {
+                return redirect()->route('settings.labels.index')->with('error', trans('admin/settings/message.labels.null_template'));
+            }
+
             return redirect()->route('settings.labels.index')
                 ->with('success', trans('admin/settings/message.update.success'));
         }

--- a/app/Http/Requests/StoreLabelSettings.php
+++ b/app/Http/Requests/StoreLabelSettings.php
@@ -2,8 +2,11 @@
 
 namespace App\Http\Requests;
 
+
+use App\Models\Labels\Label;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
 
 class StoreLabelSettings extends FormRequest
 {
@@ -22,6 +25,10 @@ class StoreLabelSettings extends FormRequest
      */
     public function rules(): array
     {
+        $names = Label::find()?->map(function ($label) {
+            return $label->getName();
+        })->values()->toArray();
+
         return [
             'labels_per_page'                     => 'numeric',
             'labels_width'                        => 'numeric',
@@ -36,7 +43,10 @@ class StoreLabelSettings extends FormRequest
             'labels_pagewidth'                    => 'numeric|nullable',
             'labels_pageheight'                   => 'numeric|nullable',
             'qr_text'                             => 'max:31|nullable',
-            'label2_template'                     => 'required|string',
+            'label2_template'                     => [
+                'required',
+                Rule::in($names),
+            ],
         ];
     }
 }

--- a/app/Http/Requests/StoreLabelSettings.php
+++ b/app/Http/Requests/StoreLabelSettings.php
@@ -36,6 +36,7 @@ class StoreLabelSettings extends FormRequest
             'labels_pagewidth'                    => 'numeric|nullable',
             'labels_pageheight'                   => 'numeric|nullable',
             'qr_text'                             => 'max:31|nullable',
+            'label2_template'                     => 'required|string',
         ];
     }
 }

--- a/app/Models/Labels/Label.php
+++ b/app/Models/Labels/Label.php
@@ -411,14 +411,14 @@ abstract class Label
     /**
      * Checks the template is internally valid
      */
-    public final function validate() {
+    public final function validate() : void {
         $this->validateUnits();
         $this->validateSize();
         $this->validateMargins();
         $this->validateSupport();
     }
 
-    private function validateUnits() {
+    private function validateUnits() : void {
         $validUnits = [ 'pt', 'mm', 'cm', 'in' ];
         $unit = $this->getUnit();
         if (!in_array(strtolower($unit), $validUnits)) {
@@ -430,7 +430,7 @@ abstract class Label
         }
     }
 
-    private function validateSize() {
+    private function validateSize() : void {
         $width = $this->getWidth();
         if (!is_numeric($width) || is_string($width)) {
             throw new \UnexpectedValueException(trans('admin/labels/message.invalid_return_type', [
@@ -450,7 +450,7 @@ abstract class Label
         }
     }
 
-    private function validateMargins() {
+    private function validateMargins() : void {
         $marginTop = $this->getMarginTop();
         if (!is_numeric($marginTop) || is_string($marginTop)) {
             throw new \UnexpectedValueException(trans('admin/labels/message.invalid_return_type', [
@@ -488,7 +488,7 @@ abstract class Label
         }
     }
 
-    private function validateSupport() {
+    private function validateSupport() : void{
         $support1D = $this->getSupport1DBarcode();
         if (!is_bool($support1D)) {
             throw new \UnexpectedValueException(trans('admin/labels/message.invalid_return_type', [

--- a/app/Models/Labels/Label.php
+++ b/app/Models/Labels/Label.php
@@ -488,7 +488,7 @@ abstract class Label
         }
     }
 
-    private function validateSupport() : void{
+    private function validateSupport() : void {
         $support1D = $this->getSupport1DBarcode();
         if (!is_bool($support1D)) {
             throw new \UnexpectedValueException(trans('admin/labels/message.invalid_return_type', [

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -38,7 +38,6 @@ class Label implements View
         $settings = $this->data->get('settings');
         $assets = $this->data->get('assets');
         $offset = $this->data->get('offset');
-        $template = LabelModel::find($settings->label2_template);
 
         // If disabled, pass to legacy view
         if ((!$settings->label2_enable)) {
@@ -49,11 +48,24 @@ class Label implements View
                 ->with('count', $this->data->get('count'));
         }
 
-        if ($template === null) {
-            throw new \UnexpectedValueException('Template is null.');
+        try {
+            $template = LabelModel::find($settings->label2_template);
+
+            if ($template === null) {
+                throw new \UnexpectedValueException('Template is null.');
+            }
+
+            $template->validate();
+        } catch (\UnexpectedValueException $e) {
+
+            \Log::error('Validation failed: ' . $e->getMessage());
+
+        } catch (\Throwable $e) {
+
+            \Log::error('An unexpected error occurred: ' . $e->getMessage());
+
         }
 
-        $template->validate();
 
         $pdf = new TCPDF(
             $template->getOrientation(),

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -50,23 +50,11 @@ class Label implements View
                 ->with('count', $this->data->get('count'));
         }
 
-        try {
             $template = LabelModel::find($settings->label2_template);
 
         if ($template === null) {
             return redirect()->route('settings.labels.index')->with('error', trans('admin/settings/message.labels.null_template'));
         }
-
-        $template->validate();
-    } catch (\UnexpectedValueException $e) {
-
-        \Log::error('Validation failed: ' . $e->getMessage());
-
-    } catch (\Throwable $e) {
-
-        \Log::error('An unexpected error occurred: ' . $e->getMessage());
-
-    }
 
         $template->validate();
 

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -49,6 +49,10 @@ class Label implements View
                 ->with('count', $this->data->get('count'));
         }
 
+        if ($template === null) {
+            throw new \UnexpectedValueException('Template is null.');
+        }
+
         $template->validate();
 
         $pdf = new TCPDF(

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -7,6 +7,7 @@ use App\Models\Labels\Label as LabelModel;
 use App\Models\Labels\Sheet;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Traits\Macroable;
 use TCPDF;
@@ -39,6 +40,7 @@ class Label implements View
         $assets = $this->data->get('assets');
         $offset = $this->data->get('offset');
 
+
         // If disabled, pass to legacy view
         if ((!$settings->label2_enable)) {
             return view('hardware/labels')
@@ -51,21 +53,22 @@ class Label implements View
         try {
             $template = LabelModel::find($settings->label2_template);
 
-            if ($template === null) {
-                throw new \UnexpectedValueException('Template is null.');
-            }
-
-            $template->validate();
-        } catch (\UnexpectedValueException $e) {
-
-            \Log::error('Validation failed: ' . $e->getMessage());
-
-        } catch (\Throwable $e) {
-
-            \Log::error('An unexpected error occurred: ' . $e->getMessage());
-
+        if ($template === null) {
+            return redirect()->route('settings.labels.index')->with('error', trans('admin/settings/message.labels.null_template'));
         }
 
+        $template->validate();
+    } catch (\UnexpectedValueException $e) {
+
+        \Log::error('Validation failed: ' . $e->getMessage());
+
+    } catch (\Throwable $e) {
+
+        \Log::error('An unexpected error occurred: ' . $e->getMessage());
+
+    }
+
+        $template->validate();
 
         $pdf = new TCPDF(
             $template->getOrientation(),

--- a/resources/lang/en-US/admin/settings/message.php
+++ b/resources/lang/en-US/admin/settings/message.php
@@ -36,6 +36,9 @@ return [
         'testing_authentication' => 'Testing LDAP Authentication...',
         'authentication_success' => 'User authenticated against LDAP successfully!'
     ],
+    'labels' => [
+        'null_template' => 'Label template not found, Please select a template.',
+        ],
     'webhook' => [
         'sending' => 'Sending :app test message...',
         'success' => 'Your :webhook_name Integration works!',

--- a/resources/lang/en-US/admin/settings/message.php
+++ b/resources/lang/en-US/admin/settings/message.php
@@ -37,7 +37,7 @@ return [
         'authentication_success' => 'User authenticated against LDAP successfully!'
     ],
     'labels' => [
-        'null_template' => 'Label template not found, Please select a template.',
+        'null_template' => 'Label template not found. Please select a template.',
         ],
     'webhook' => [
         'sending' => 'Sending :app test message...',

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -26,6 +26,7 @@
 
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-md-10">
+
             <div class="panel box box-default">
                 <div class="box-header with-border">
                     <h2 class="box-title">
@@ -34,6 +35,7 @@
                     </h2>
                 </div>
                 <div class="box-body">
+
                     <div class="col-md-12">
 
                         <!-- New Label Engine -->

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -26,7 +26,6 @@
 
     <div class="row">
         <div class="col-sm-10 col-sm-offset-1 col-md-10">
-
             <div class="panel box box-default">
                 <div class="box-header with-border">
                     <h2 class="box-title">
@@ -35,8 +34,6 @@
                     </h2>
                 </div>
                 <div class="box-body">
-
-
                     <div class="col-md-12">
 
                         <!-- New Label Engine -->


### PR DESCRIPTION
This adds a null check on the validation of the template for labels and a return type for the validation methods.

adds a notification if template is null:
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/229f5484-5788-44ca-92e0-14f12409fe53" />

This checks if the template selection is not null in the db at save and while trying to render the label preview