### PR TITLE
Conditionally update assets when user's location moves via LDAP

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -427,7 +427,13 @@ class LdapSync extends Command
                     $user->groups()->attach($ldap_default_group);
                 }
                 //updates assets location based on user's location
-                Asset::where('assigned_to', '=', $user->id)->where('assigned_type', '=', User::class)->update(['location_id' => $user->location_id]);
+                if ($user->wasChanged('location_id')) {
+                    foreach ($user->assets as $asset) {
+                        $asset->location_id = $user->location_id;
+                        // TODO: somehow add note? "Asset Location Changed because of thing"
+                        $asset->save();
+                    }
+                }
 
             } else {
                 foreach ($user->getErrors()->getMessages() as $key => $err) {


### PR DESCRIPTION
Fixes: [fd-45970]

We added code to change assets' locations if the _user's_ location changes via LDAP. But the way the query was working, it would tweak the 'updated at' attribute on the user whether or not it actually changed the location of the asset in question. This was confusing for one of our customers in how they use the app.

Additionally, if a change *was* made, there wasn't going to be any log entry in the asset history to explain _why_ it wasn't in the location that it had been before.

This fixes both problems - only making changes to the assets of the user *if* the user's location has actually changed, **and** making sure that it's a regular `save()` so that a log entry with an 'update' will still get created.

I tested this on our test LDAP server, setting the ldap_location attribute to physicaldeliveryofficename, and setting the 'Office' value of one of the users to one of our locations. Then I changed the user's location on my development environment, did a checkout of an asset to that user, then ran an LDAP sync. When I did that, the asset showed an 'update' action of it moving from the old location to the LDAP-based one.