### PR TITLE
Adds try/catch around notification failing with an inactive webhook for better user experience

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -46,7 +46,7 @@ class CheckoutableListener
      */
     public function onCheckedOut($event)
     {
-        if ($this->shouldNotSendAnyNotifications($event->checkoutable)){
+        if ($this->shouldNotSendAnyNotifications($event->checkoutable)) {
             return;
         }
 
@@ -57,7 +57,7 @@ class CheckoutableListener
         $acceptance = $this->getCheckoutAcceptance($event);
         $adminCcEmailsArray = [];
 
-        if($settings->admin_cc_email !== '') {
+        if ($settings->admin_cc_email !== '') {
             $adminCcEmail = $settings->admin_cc_email;
             $adminCcEmailsArray = array_map('trim', explode(',', $adminCcEmail));
         }
@@ -65,7 +65,7 @@ class CheckoutableListener
         $mailable = $this->getCheckoutMailType($event, $acceptance);
         $notifiable = $this->getNotifiables($event);
 
-        if  ($event->checkedOutTo->locale){
+        if ($event->checkedOutTo->locale) {
             $mailable->locale($event->checkedOutTo->locale);
         }
         // Send email notifications
@@ -77,39 +77,48 @@ class CheckoutableListener
              * 3. The item should send an email at check-in/check-out
              */
 
-                if ($event->checkoutable->requireAcceptance() || $event->checkoutable->getEula() ||
-                    $this->checkoutableShouldSendEmail($event)) {
-                    Log::info('Sending checkout email, Locale: ' . ($event->checkedOutTo->locale ?? 'default'));
-                    if (!empty($notifiable)) {
-                        Mail::to($notifiable)->cc($ccEmails)->send($mailable);
-                    } elseif (!empty($ccEmails)) {
-                        Mail::cc($ccEmails)->send($mailable);
-                    }
-                    Log::info('Checkout Mail sent.');
+            if ($event->checkoutable->requireAcceptance() || $event->checkoutable->getEula() ||
+                $this->checkoutableShouldSendEmail($event)) {
+                Log::info('Sending checkout email, Locale: ' . ($event->checkedOutTo->locale ?? 'default'));
+                if (!empty($notifiable)) {
+                    Mail::to($notifiable)->cc($ccEmails)->send($mailable);
+                } elseif (!empty($ccEmails)) {
+                    Mail::cc($ccEmails)->send($mailable);
                 }
+                Log::info('Checkout Mail sent.');
+            }
         } catch (ClientException $e) {
             Log::debug("Exception caught during checkout email: " . $e->getMessage());
         } catch (Exception $e) {
             Log::debug("Exception caught during checkout email: " . $e->getMessage());
         }
 //                 Send Webhook notification
-        try{
-                if ($this->shouldSendWebhookNotification()) {
-                    if ($this->newMicrosoftTeamsWebhookEnabled()) {
-                        $message = $this->getCheckoutNotification($event)->toMicrosoftTeams();
-                        $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
-                        $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
-                    } else {
-                        Notification::route($this->webhookSelected(), Setting::getSettings()->webhook_endpoint)
-                            ->notify($this->getCheckoutNotification($event, $acceptance));
-                    }
+        try {
+            if ($this->shouldSendWebhookNotification()) {
+                if ($this->newMicrosoftTeamsWebhookEnabled()) {
+                    $message = $this->getCheckoutNotification($event)->toMicrosoftTeams();
+                    $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
+                    $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
+                } else {
+
+                    Notification::route($this->webhookSelected(), Setting::getSettings()->webhook_endpoint)
+                        ->notify($this->getCheckoutNotification($event, $acceptance));
                 }
+            }
         } catch (ClientException $e) {
-            Log::debug("Exception caught during checkout notification: " . $e->getMessage());
+            Log::warning("ClientException caught during checkin notification: " . $e->getMessage());
+            return redirect()->back()->with('error', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure your URL is still valid.');
         } catch (Exception $e) {
-            Log::debug("Exception caught during checkout notification: " . $e->getMessage());
+            Log::error(ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed:', [
+                'error' => $e->getMessage(),
+                'webhook_endpoint' => Setting::getSettings()->webhook_endpoint,
+                'event' => $event,
+            ]);
+            return redirect()->back()->with('error', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure your URL is still valid.');
         }
     }
+
+
 
 
     /**
@@ -178,18 +187,24 @@ class CheckoutableListener
         try {
             if ($this->shouldSendWebhookNotification()) {
                 if ($this->newMicrosoftTeamsWebhookEnabled()) {
-                        $message = $this->getCheckinNotification($event)->toMicrosoftTeams();
-                        $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
-                        $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
-                    } else {
-                        Notification::route($this->webhookSelected(), Setting::getSettings()->webhook_endpoint)
-                            ->notify($this->getCheckinNotification($event));
-                    }
+                    $message = $this->getCheckinNotification($event)->toMicrosoftTeams();
+                    $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
+                    $notification->success()->sendMessage($message[0], $message[1]); // Send the message to Microsoft Teams
+                } else {
+                    Notification::route($this->webhookSelected(), Setting::getSettings()->webhook_endpoint)
+                        ->notify($this->getCheckinNotification($event));
                 }
+            }
         } catch (ClientException $e) {
-            Log::warning("Exception caught during checkin notification: " . $e->getMessage());
+            Log::warning("ClientException caught during checkin notification: " . $e->getMessage());
+            return redirect()->back()->with('error', ucfirst(Setting::getSettings()->webhook_selected) .' webhook notification failed: Check to make sure the URL is still valid.');
         } catch (Exception $e) {
-            Log::warning("Exception caught during checkin notification: " . $e->getMessage());
+            Log::error(ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed:', [
+                'error' => $e->getMessage(),
+                'webhook_endpoint' => Setting::getSettings()->webhook_endpoint,
+                'event' => $event,
+            ]);
+            return redirect()->back()->with('error', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure the URL is still valid.');
         }
     }      
 

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -107,14 +107,14 @@ class CheckoutableListener
             }
         } catch (ClientException $e) {
             Log::error("ClientException caught during checkin notification: " . $e->getMessage());
-            return redirect()->back()->with('error', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure your URL is still valid.');
+            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure your URL is still valid.');
         } catch (Exception $e) {
             Log::error(ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed:', [
                 'error' => $e->getMessage(),
                 'webhook_endpoint' => Setting::getSettings()->webhook_endpoint,
                 'event' => $event,
             ]);
-            return redirect()->back()->with('error', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure your URL is still valid.');
+            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure your URL is still valid.');
         }
     }
 
@@ -197,14 +197,14 @@ class CheckoutableListener
             }
         } catch (ClientException $e) {
             Log::error("ClientException caught during checkin notification: " . $e->getMessage());
-            return redirect()->back()->with('error', ucfirst(Setting::getSettings()->webhook_selected) .' webhook notification failed: Check to make sure the URL is still valid.');
+            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) .' webhook notification failed: Check to make sure the URL is still valid.');
         } catch (Exception $e) {
             Log::error(ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed:', [
                 'error' => $e->getMessage(),
                 'webhook_endpoint' => Setting::getSettings()->webhook_endpoint,
                 'event' => $event,
             ]);
-            return redirect()->back()->with('error', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure the URL is still valid.');
+            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure the URL is still valid.');
         }
     }      
 

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -106,7 +106,7 @@ class CheckoutableListener
                 }
             }
         } catch (ClientException $e) {
-            Log::warning("ClientException caught during checkin notification: " . $e->getMessage());
+            Log::error("ClientException caught during checkin notification: " . $e->getMessage());
             return redirect()->back()->with('error', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure your URL is still valid.');
         } catch (Exception $e) {
             Log::error(ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed:', [
@@ -196,7 +196,7 @@ class CheckoutableListener
                 }
             }
         } catch (ClientException $e) {
-            Log::warning("ClientException caught during checkin notification: " . $e->getMessage());
+            Log::error("ClientException caught during checkin notification: " . $e->getMessage());
             return redirect()->back()->with('error', ucfirst(Setting::getSettings()->webhook_selected) .' webhook notification failed: Check to make sure the URL is still valid.');
         } catch (Exception $e) {
             Log::error(ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed:', [

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -107,14 +107,14 @@ class CheckoutableListener
             }
         } catch (ClientException $e) {
             Log::error("ClientException caught during checkin notification: " . $e->getMessage());
-            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure your URL is still valid.');
+            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) .trans('admin/settings/message.webhook.webhook_fail') );
         } catch (Exception $e) {
             Log::error(ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed:', [
                 'error' => $e->getMessage(),
                 'webhook_endpoint' => Setting::getSettings()->webhook_endpoint,
                 'event' => $event,
             ]);
-            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure your URL is still valid.');
+            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) . trans('admin/settings/message.webhook.webhook_fail'));
         }
     }
 
@@ -197,14 +197,14 @@ class CheckoutableListener
             }
         } catch (ClientException $e) {
             Log::error("ClientException caught during checkin notification: " . $e->getMessage());
-            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) .' webhook notification failed: Check to make sure the URL is still valid.');
+            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) .trans('admin/settings/message.webhook.webhook_fail'));
         } catch (Exception $e) {
             Log::error(ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed:', [
                 'error' => $e->getMessage(),
                 'webhook_endpoint' => Setting::getSettings()->webhook_endpoint,
                 'event' => $event,
             ]);
-            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed: Check to make sure the URL is still valid.');
+            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) .trans('admin/settings/message.webhook.webhook_fail'));
         }
     }      
 

--- a/resources/lang/en-US/admin/settings/message.php
+++ b/resources/lang/en-US/admin/settings/message.php
@@ -45,5 +45,6 @@ return [
         'error' => 'Something went wrong. :app responded with: :error_message',
         'error_redirect' => 'ERROR: 301/302 :endpoint returns a redirect. For security reasons, we don’t follow redirects. Please use the actual endpoint.',
         'error_misc' => 'Something went wrong. :( ',
+        'webhook_fail' => ' webhook notification failed: Check to make sure the URL is still valid.',
     ]
 ];


### PR DESCRIPTION
When checking in and checking out, if the webhook notification fires and there is an error, it now redirects back with an error message
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/2d690163-0179-45de-b7dd-584b2f0a3e45" />
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/630ee59d-c082-41d3-b799-1ceedef84cf3" />

<img width="2525" alt="image" src="https://github.com/user-attachments/assets/acc95df2-32fa-4cd3-90b5-0fb7b6bdf540" />

