### PR TITLE
Update related asset when checkout acceptance created via factory

### DIFF
--- a/database/factories/CheckoutAcceptanceFactory.php
+++ b/database/factories/CheckoutAcceptanceFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Accessory;
 use App\Models\Asset;
+use App\Models\CheckoutAcceptance;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -21,6 +22,18 @@ class CheckoutAcceptanceFactory extends Factory
             'checkoutable_id' => Asset::factory(),
             'assigned_to_id' => User::factory(),
         ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (CheckoutAcceptance $acceptance) {
+            if ($acceptance->checkoutable instanceof Asset && $acceptance->assignedTo instanceof User) {
+                $acceptance->checkoutable->update([
+                    'assigned_to' => $acceptance->assigned_to_id,
+                    'assigned_type' => get_class($acceptance->assignedTo),
+                ]);
+            }
+        });
     }
 
     public function forAccessory()


### PR DESCRIPTION
I noticed that creating pending checkout acceptances via the factory wasn't populating the Unaccepted Assets report page. This is because the `assigned_to` and `assigned_type` on assets are [set in the `CheckoutableListener`](https://github.com/snipe/snipe-it/blob/f6abf90ba07dadfe4b26fc0a795069bdf5216a20/app/Listeners/CheckoutableListener.php#L201-L217) when the full request is actually made.

This PR updates the factory to update the checked out asset. There is probably additional cases that should have similar behavior but this is focused on this specific case.