### PR TITLE
Fixed #16054: fix incorrect compose service name in the APP_KEY generation command of the Docker env file

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -9,7 +9,7 @@ APP_PORT=8000
 # --------------------------------------------
 APP_ENV=production
 APP_DEBUG=false
-# Please regenerate the APP_KEY value by calling `docker compose run --rm snipeit php artisan key:generate --show`. Copy paste the value here
+# Please regenerate the APP_KEY value by calling `docker compose run --rm app php artisan key:generate --show`. Copy paste the value here
 APP_KEY=base64:3ilviXqB9u6DX1NRcyWGJ+sjySF+H18CPDGb3+IVwMQ=
 APP_URL=http://localhost:8000
 # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones - TZ identifier


### PR DESCRIPTION
This resolves the following error:

```
$ docker compose run --rm snipe-it php artisan key:generate --show
no such service: snipe-it
```

and is also how it is done in the documentation.

Refer-to: APP_KEY | Docker | Snipe-IT documentation <https://snipe-it.readme.io/docs/docker#app_key>

Note that the version in the `master` branch is also wrong, but the Contributing documentation says to target the `develop` branch so I'll leave it to you.

Fixes #16054 