### PR TITLE
Fixed zerofill_count field being ignored during set up

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -192,7 +192,7 @@ class SettingsController extends Controller
         $settings->next_auto_tag_base = 1;
         $settings->auto_increment_assets = $request->input('auto_increment_assets', 0);
         $settings->auto_increment_prefix = $request->input('auto_increment_prefix');
-        $settings->zerofill_count = $request->input('zerofill_count', 5);
+        $settings->zerofill_count = $request->input('zerofill_count') ?: 0;
 
         if ((! $user->isValid()) || (! $settings->isValid())) {
             return redirect()->back()->withInput()->withErrors($user->getErrors())->withErrors($settings->getErrors());

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -192,6 +192,7 @@ class SettingsController extends Controller
         $settings->next_auto_tag_base = 1;
         $settings->auto_increment_assets = $request->input('auto_increment_assets', 0);
         $settings->auto_increment_prefix = $request->input('auto_increment_prefix');
+        $settings->zerofill_count = $request->input('zerofill_count', 5);
 
         if ((! $user->isValid()) || (! $settings->isValid())) {
             return redirect()->back()->withInput()->withErrors($user->getErrors())->withErrors($settings->getErrors());


### PR DESCRIPTION
Currently, any user supplied value for the "Length of asset tags, including zerofill" on the set up page is ignored upon submission. This PR fixes that.

![Setup User page](https://github.com/user-attachments/assets/f315bee0-5c93-4517-84c5-91e00860a0af)
