### PR TITLE
Better hide reset password functionality for LDAP users

### DIFF
--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -103,21 +103,23 @@ class ResetPasswordController extends Controller
                     ], $messages);
             }
 
+            if ($user->ldap_import != '1') {
 
-            // set the response
-            $response = $broker->reset(
-                $this->credentials($request), function ($user, $password) {
-                $this->resetPassword($user, $password);
-            });
+                    // set the response
+                    $response = $broker->reset(
+                        $this->credentials($request), function ($user, $password) {
+                        $this->resetPassword($user, $password);
+                    });
 
-            // Check if the password reset above actually worked
-            if ($response == \Password::PASSWORD_RESET) {
-                Log::debug('Password reset for '.$user->username.' worked');
-                return redirect()->guest('login')->with('success', trans('passwords.reset'));
+                    // Check if the password reset above actually worked
+                    if ($response == \Password::PASSWORD_RESET) {
+                        Log::debug('Password reset for ' . $user->username . ' worked');
+                        return redirect()->guest('login')->with('success', trans('passwords.reset'));
+                    }
+
+                    Log::debug('Password reset for ' . $user->username . ' FAILED - this user exists but the token is not valid');
+                    return redirect()->back()->withInput($request->only('email'))->with('success', trans('passwords.reset'));
             }
-
-            Log::debug('Password reset for '.$user->username.' FAILED - this user exists but the token is not valid');
-            return redirect()->back()->withInput($request->only('email'))->with('success', trans('passwords.reset'));
 
         }
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -99,9 +99,13 @@ class ProfileController extends Controller
      * User change email page.
      *
      */
-    public function password() : View
+    public function password() : View | RedirectResponse
     {
+
         $user = auth()->user();
+        if ($user->ldap_import=='1') {
+            return redirect()->route('account')->with('error', trans('admin/users/message.error.password_ldap'));
+        }
         return view('account/change-password', compact('user'));
     }
 
@@ -116,7 +120,7 @@ class ProfileController extends Controller
 
         $user = auth()->user();
         if ($user->ldap_import == '1') {
-            return redirect()->route('account.password.index')->with('error', trans('admin/users/message.error.password_ldap'));
+            return redirect()->route('account')->with('error', trans('admin/users/message.error.password_ldap'));
         }
 
         $rules = [

--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -70,7 +70,7 @@ class BulkUsersController extends Controller
             // bulk password reset, just do the thing
             } elseif ($request->input('bulk_actions') == 'bulkpasswordreset') {
                 foreach ($users as $user) {
-                    if (($user->activated == '1') && ($user->email != '')) {
+                    if (($user->activated == '1') && ($user->email != '') && ($user->ldap_import != '1')) {
                         $credentials = ['email' => $user->email];
                         Password::sendResetLink($credentials/* , function (Message $message) {
                         $message->subject($this->getEmailSubject()); // TODO - I'm not sure if we still need this, but this second parameter is no longer accepted in later Laravel versions.

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -573,5 +573,8 @@ return [
     'import_asset_tag_exists' => 'An asset with the asset tag :asset_tag already exists and an update was not requested. No change was made.',
     'countries_manually_entered_help' => 'Values with an asterisk (*) were manually entered and do not match existing ISO 3166 dropdown values',
     'accessories_assigned' => 'Assigned Accessories',
+    'user_managed_passwords' => 'Password Management',
+    'user_managed_passwords_disallow' => 'Disallow users from managing their own passwords',
+    'user_managed_passwords_allow' => 'Allow users to manage their own passwords',
 
 ];

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -109,12 +109,15 @@
                     </a>
                   </div>
                 @endcan
+
+                @if ($user->ldap_import!='1')
                 <div class="col-md-12" style="padding-top: 5px;">
                   <a href="{{ route('account.password.index') }}" style="width: 100%;" class="btn btn-sm btn-primary btn-social btn-block hidden-print" target="_blank" rel="noopener">
                     <x-icon type="password" class="fa-fw" />
                     {{ trans('general.changepassword') }}
                   </a>
                 </div>
+                @endif
 
                 @can('self.api')
                 <div class="col-md-12" style="padding-top: 5px;">

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -373,12 +373,14 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                         </li>
                                         @endcan
 
+                                        @if (Auth::user()->ldap_import!='1')
                                         <li>
                                             <a href="{{ route('account.password.index') }}">
                                                 <x-icon type="password" class="fa-fw" />
                                                 {{ trans('general.changepassword') }}
                                             </a>
                                         </li>
+                                        @endif
 
 
                                         @can('self.api')

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -144,7 +144,7 @@
                         <!-- ldap_sync -->
                         <div class="form-group">
                             <div class="col-sm-3 control-label">
-                                {{ trans('general.ldap_sync') }}
+                                {{ trans('general.user_managed_passwords') }}
                             </div>
                             <div class="col-sm-9">
                                     <label for="no_change" class="form-control">
@@ -153,7 +153,11 @@
                                     </label>
                                     <label for="ldap_import" class="form-control">
                                         {{ Form::radio('ldap_import', '0', old('ldap_import'), ['id' => 'ldap_import', 'aria-label'=>'ldap_import']) }}
-                                        {{ trans('general.ldap_import') }}
+                                        {{ trans('general.user_managed_passwords_allow') }}
+                                    </label>
+                                    <label for="ldap_import" class="form-control">
+                                        {{ Form::radio('ldap_import', '1', old('ldap_import'), ['id' => 'ldap_import', 'aria-label'=>'ldap_import']) }}
+                                        {{ trans('general.user_managed_passwords_disallow') }}
                                     </label>
                             </div>
                         </div> <!--/form-group-->


### PR DESCRIPTION
We were already disallowing LDAP users to save new passwords, but there were a few places where we didn't hide the buttons. (It would redirect with error on save, and didn't actually save the password, but it was a clunkier user experience.

This now does a better job of hiding those elements if the user has `ldap_import` set to `1` on their account. 

TODO: We should probably come up with a better way of explaining what `ldap_import` actually does in the modern world. Really, it just determines whether or not the user can edit their password, and we could probably do a better job of explaining that instead of the old "LDAP Enabled" text. In fact, perhaps change the actual fieldname to reflect what this actually does. 