### PR TITLE
Fixed asset show page erroring when asset not associated with model

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1384,21 +1384,23 @@
                         </div> <!-- /.row -->
                     </div> <!-- /.tab-pane files -->
 
-                    @can('view', $asset->model)
-                        <div class="tab-pane fade" id="modelfiles">
-                            <div class="row{{ (($asset->model) && ($asset->model->uploads->count() > 0)) ? '' : ' hidden-print' }}">
-                                <div class="col-md-12">
+                    @if ($asset->model)
+                        @can('view', $asset->model)
+                            <div class="tab-pane fade" id="modelfiles">
+                                <div class="row{{ (($asset->model) && ($asset->model->uploads->count() > 0)) ? '' : ' hidden-print' }}">
+                                    <div class="col-md-12">
 
-                                    <x-filestable
-                                            filepath="private_uploads/assetmodels/"
-                                            showfile_routename="show/modelfile"
-                                            deletefile_routename="delete/modelfile"
-                                            :object="$asset->model" />
+                                        <x-filestable
+                                                filepath="private_uploads/assetmodels/"
+                                                showfile_routename="show/modelfile"
+                                                deletefile_routename="delete/modelfile"
+                                                :object="$asset->model" />
 
-                                </div> <!-- /.col-md-12 -->
-                            </div> <!-- /.row -->
-                        </div> <!-- /.tab-pane files -->
-                    @endcan
+                                    </div> <!-- /.col-md-12 -->
+                                </div> <!-- /.row -->
+                            </div> <!-- /.tab-pane files -->
+                        @endcan
+                    @endif
             </div><!-- /.tab-content -->
         </div><!-- nav-tabs-custom -->
     </div>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1385,19 +1385,19 @@
                     </div> <!-- /.tab-pane files -->
 
                     @can('view', $asset->model)
-                    <div class="tab-pane fade" id="modelfiles">
-                        <div class="row{{ (($asset->model) && ($asset->model->uploads->count() > 0)) ? '' : ' hidden-print' }}">
-                            <div class="col-md-12">
+                        <div class="tab-pane fade" id="modelfiles">
+                            <div class="row{{ (($asset->model) && ($asset->model->uploads->count() > 0)) ? '' : ' hidden-print' }}">
+                                <div class="col-md-12">
 
-                                <x-filestable
-                                        filepath="private_uploads/assetmodels/"
-                                        showfile_routename="show/modelfile"
-                                        deletefile_routename="delete/modelfile"
-                                        :object="$asset->model" />
+                                    <x-filestable
+                                            filepath="private_uploads/assetmodels/"
+                                            showfile_routename="show/modelfile"
+                                            deletefile_routename="delete/modelfile"
+                                            :object="$asset->model" />
 
-                            </div> <!-- /.col-md-12 -->
-                        </div> <!-- /.row -->
-                    </div> <!-- /.tab-pane files -->
+                                </div> <!-- /.col-md-12 -->
+                            </div> <!-- /.row -->
+                        </div> <!-- /.tab-pane files -->
                     @endcan
             </div><!-- /.tab-content -->
         </div><!-- nav-tabs-custom -->

--- a/tests/Feature/Assets/Ui/ShowAssetTest.php
+++ b/tests/Feature/Assets/Ui/ShowAssetTest.php
@@ -11,7 +11,7 @@ class ShowAssetTest extends TestCase
     public function testPageForAssetWithMissingModelStillRenders()
     {
         $asset = Asset::factory()->create();
-        
+
         $asset->model_id = null;
         $asset->forceSave();
 

--- a/tests/Feature/Assets/Ui/ShowAssetTest.php
+++ b/tests/Feature/Assets/Ui/ShowAssetTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature\Assets\Ui;
+
+use App\Models\Asset;
+use App\Models\User;
+use Tests\TestCase;
+
+class ShowAssetTest extends TestCase
+{
+    public function testPageForAssetWithMissingModelStillRenders()
+    {
+        $asset = Asset::factory()->create();
+        
+        $asset->model_id = null;
+        $asset->forceSave();
+
+        $asset->refresh();
+
+        $this->assertNull($asset->fresh()->model_id, 'This test needs model_id to be null to be helpful.');
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->get(route('hardware.show', $asset))
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
The system encourages assets having an associated model but it is not enforced on the database level. 

This PR allows the asset display page to render without 500ing when an asset does not have a model associated.