### PR TITLE
Replace calls to Form::password

### DIFF
--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -324,7 +324,7 @@
                                 {{ Form::label('ldap_pword', trans('admin/settings/general.ldap_pword')) }}
                             </div>
                             <div class="col-md-8">
-                                <input class="form-control" type="password" name="ldap_pword" id="ldap_pword" value="" autocomplete="off" onfocus="this.removeAttribute('readonly');" readonly="">
+                                <input class="form-control" type="password" name="ldap_pword" id="ldap_pword" value="" autocomplete="off" onfocus="this.removeAttribute('readonly');" readonly>
                                 @error('ldap_pword')
                                     <span class="alert-msg">
                                          <x-icon type="x" />

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -324,7 +324,7 @@
                                 {{ Form::label('ldap_pword', trans('admin/settings/general.ldap_pword')) }}
                             </div>
                             <div class="col-md-8">
-                                {{ Form::password('ldap_pword', ['class' => 'form-control', 'autocomplete' => 'off', 'onfocus' => "this.removeAttribute('readonly');", ' readonly']) }}
+                                <input class="form-control" type="password" name="ldap_pword" id="ldap_pword" value="" autocomplete="off" onfocus="this.removeAttribute('readonly');" readonly="">
                                 @error('ldap_pword')
                                     <span class="alert-msg">
                                          <x-icon type="x" />

--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -141,14 +141,14 @@
       <!-- password -->
       <div class="form-group col-lg-6{{  (Helper::checkIfRequired(\App\Models\User::class, 'password')) ? ' required' : '' }} {{ $errors->has('password') ? 'error' : '' }}">
         {{ Form::label('password', trans('admin/users/table.password')) }}
-        {{ Form::password('password', array('class' => 'form-control','required' => true)) }}
+        <input class="form-control" type="password" name="password" id="password" value="" required>
         {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>
 
       <!-- password confirm -->
       <div class="form-group col-lg-6{{  (Helper::checkIfRequired(\App\Models\User::class, 'password')) ? ' required' : '' }} {{ $errors->has('password_confirm') ? 'error' : '' }}">
         {{ Form::label('password_confirmation', trans('admin/users/table.password_confirm')) }}
-        {{ Form::password('password_confirmation', array('class' => 'form-control','required' => true)) }}
+        <input class="form-control" type="password" name="password_confirmation" id="password_confirmation" value="" required>
         {!! $errors->first('password_confirmation', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>
     </div>


### PR DESCRIPTION
This PR replaces calls to `Form::password()` with plain old html.

# Pages Affected
- [LDAP settings](https://snipe-it.test/admin/ldap)
- [Setup: user](https://snipe-it.test/setup/user)