### PR TITLE
Migrate Form::submit helper

### DIFF
--- a/resources/views/account/requestable-assets.blade.php
+++ b/resources/views/account/requestable-assets.blade.php
@@ -148,9 +148,9 @@
                                                         {{ csrf_field() }}
                                                     <input type="text" style="width: 70px; margin-right: 10px;" class="form-control pull-left" name="request-quantity" value="" placeholder="{{ trans('general.qty') }}">
                                                     @if ($requestableModel->isRequestedBy(Auth::user()))
-                                                        {{ Form::submit(trans('button.cancel'), ['class' => 'btn btn-danger btn-sm'])}}
+                                                        <input class="btn btn-danger btn-sm" type="submit" value="{{ trans('button.cancel') }}">
                                                     @else
-                                                        {{ Form::submit(trans('button.request'), ['class' => 'btn btn-primary btn-sm'])}}
+                                                        <input class="btn btn-primary btn-sm" type="submit" value="{{ trans('button.request') }}">
                                                     @endif
                                                     </form>
                                                 </td>


### PR DESCRIPTION
This PR migrates calls to `Form::submit` to plain old html.

# Pages Affected 
- [Requestable Items](https://snipe-it.test/account/requestable-assets#models)

