### PR TITLE
Fix potential attempt to divide by zero in transformer

### DIFF
--- a/app/Http/Transformers/DepreciationReportTransformer.php
+++ b/app/Http/Transformers/DepreciationReportTransformer.php
@@ -61,7 +61,7 @@ class DepreciationReportTransformer
         /**
          * Override the previously set null values if there is a valid model and associated depreciation
          */
-        if (($asset->model) && ($asset->model->depreciation)) {
+        if (($asset->model) && ($asset->model->depreciation) && ($asset->model->depreciation->months !== 0)) {
             $depreciated_value = Helper::formatCurrencyOutput($asset->getDepreciatedValue());
             $monthly_depreciation =Helper::formatCurrencyOutput($asset->purchase_cost / $asset->model->depreciation->months);
             $diff = Helper::formatCurrencyOutput(($asset->purchase_cost - $asset->getDepreciatedValue()));

--- a/tests/Unit/Transformers/DepreciationReportTransformerTest.php
+++ b/tests/Unit/Transformers/DepreciationReportTransformerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\Transformers;
+
+use App\Http\Transformers\DepreciationReportTransformer;
+use App\Models\Asset;
+use App\Models\Depreciation;
+use Tests\TestCase;
+
+class DepreciationReportTransformerTest extends TestCase
+{
+    public function testHandlesModelDepreciationMonthsBeingZero()
+    {
+        $asset = Asset::factory()->create();
+        $depreciation = Depreciation::factory()->create(['months' => 0]);
+        $asset->model->depreciation()->associate($depreciation);
+
+        $transformer = new DepreciationReportTransformer;
+
+        $result = $transformer->transformAsset($asset);
+
+        $this->assertIsArray($result);
+    }
+}


### PR DESCRIPTION
This PR adds a guard against dividing by zero in the `DepreciationReportTransformer`.