### PR TITLE
Prevent undefined array key in asset observer

### DIFF
--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -48,7 +48,7 @@ class AssetObserver
             $changed = [];
 
             foreach ($asset->getRawOriginal() as $key => $value) {
-                if (isset($asset->getAttributes()[$key]) && ($asset->getRawOriginal()[$key] != $asset->getAttributes()[$key])) {
+                if ((array_key_exists($key, $asset->getAttributes())) && ($asset->getRawOriginal()[$key] != $asset->getAttributes()[$key])) {
                     $changed[$key]['old'] = $asset->getRawOriginal()[$key];
                     $changed[$key]['new'] = $asset->getAttributes()[$key];
                 }

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -48,7 +48,7 @@ class AssetObserver
             $changed = [];
 
             foreach ($asset->getRawOriginal() as $key => $value) {
-                if ($asset->getRawOriginal()[$key] != $asset->getAttributes()[$key]) {
+                if (isset($asset->getAttributes()[$key]) && ($asset->getRawOriginal()[$key] != $asset->getAttributes()[$key])) {
                     $changed[$key]['old'] = $asset->getRawOriginal()[$key];
                     $changed[$key]['new'] = $asset->getAttributes()[$key];
                 }


### PR DESCRIPTION
This PR simply adds an `array_key_exists` to help prevent "undefined array key" exceptions.

I haven't tracked down exactly how this happens but adding an `array_key_exists` check should prevent the issue.