### PR TITLE
Add some safeties around charset detection and transliteration

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -66,25 +66,33 @@ class ImportController extends Controller
                 if (! ini_get('auto_detect_line_endings')) {
                     ini_set('auto_detect_line_endings', '1');
                 }
-                $file_contents = $file->getContent(); //TODO - this *does* load the whole file in RAM, but we need that to be able to 'iconv' it?
-                $encoding = $detector->getEncoding($file_contents);
-                $reader = null;
-                if (strcasecmp($encoding, 'UTF-8') != 0) {
-                    $transliterated = iconv($encoding, 'UTF-8', $file_contents);
-                    if ($transliterated !== false) {
-                        $tmpname = tempnam(sys_get_temp_dir(), '');
-                        $tmpresults = file_put_contents($tmpname, $transliterated);
-                        if ($tmpresults !== false) {
-                            $transliterated = null; //save on memory?
-                            $newfile = new UploadedFile($tmpname, $file->getClientOriginalName(), null, null, true); //WARNING: this is enabling 'test mode' - which is gross, but otherwise the file won't be treated as 'uploaded'
-                            if ($newfile->isValid()) {
-                                $file = $newfile;
+                if (function_exists('iconv')) {
+                    $file_contents = $file->getContent(); //TODO - this *does* load the whole file in RAM, but we need that to be able to 'iconv' it?
+                    $encoding = $detector->getEncoding($file_contents);
+                    $reader = null;
+                    if (strcasecmp($encoding, 'UTF-8') != 0) {
+                        $transliterated = false;
+                        try {
+                            $transliterated = iconv(strtoupper($encoding), 'UTF-8', $file_contents);
+                        } catch (\Exception $e) {
+                            $transliterated = false;
+                            \Log::info("Unable to transliterate from $encoding to UTF-8");
+                        }
+                        if ($transliterated !== false) {
+                            $tmpname = tempnam(sys_get_temp_dir(), '');
+                            $tmpresults = file_put_contents($tmpname, $transliterated);
+                            if ($tmpresults !== false) {
+                                $transliterated = null; //save on memory?
+                                $newfile = new UploadedFile($tmpname, $file->getClientOriginalName(), null, null, true); //WARNING: this is enabling 'test mode' - which is gross, but otherwise the file won't be treated as 'uploaded'
+                                if ($newfile->isValid()) {
+                                    $file = $newfile;
+                                }
                             }
                         }
                     }
+                    $file_contents = null; //try to save on memory, I guess?
                 }
                 $reader = Reader::createFromFileObject($file->openFile('r')); //file pointer leak?
-                $file_contents = null; //try to save on memory, I guess?
 
                 try {
                     $import->header_row = $reader->fetchOne(0);


### PR DESCRIPTION
In some environments, you *need* to specify character sets for `iconv()` in UPPERCASE. So this adds that.

In addition, sometimes the character set transformation can fail (such as when it's not in uppercase), and while that only usually raises an `E_NOTICE`, Laravel will tend to transform those notices into Exceptions, so we need to catch those.

And finally, if you don't happen to have `iconv` installed at all, we should gracefully detect that and default to the 'regular' behavior.