### PR TITLE
QR Code Settings Check

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -531,7 +531,7 @@ class AssetsController extends Controller
      * @param int $assetId
      * @since [v1.0]
      */
-    public function getQrCode($assetId = null) : Response | BinaryFileResponse | string | bool
+    public function getQrCode($assetId = null): Response|BinaryFileResponse|string|bool
     {
         $settings = Setting::getSettings();
 
@@ -548,6 +548,9 @@ class AssetsController extends Controller
                         return response()->file($qr_file, $header);
                     } else {
                         $barcode = new \Com\Tecnick\Barcode\Barcode();
+                        if ($settings->label2_2d_type == 'none') {
+                            return false;
+                        }
                         $barcode_obj = $barcode->getBarcodeObj($settings->label2_2d_type, route('hardware.show', $asset->id), $size['height'], $size['width'], 'black', [-2, -2, -2, -2]);
                         file_put_contents($qr_file, $barcode_obj->getPngData());
 

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -248,6 +248,7 @@ return [
     'labels_pagewidth'          => 'Label sheet width',
     'labels_pageheight'         => 'Label sheet height',
     'label_gutters'        => 'Label spacing (inches)',
+    'label_qr_setting_invalid' => 'Your QR Code type is set to \'None\', but you have enabled QR Codes. Please select a QR Code type.',
     'page_dimensions'        => 'Page dimensions (inches)',
     'label_fields'          => 'Label visible fields',
     'inches'        => 'inches',

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -120,7 +120,7 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->label2_1d_type!=
     <?php $count++; ?>
     <div class="label">
 
-        @if ($settings->qr_code=='1' && (!$settings->label2_2d_type == 'none'))
+        @if ($settings->qr_code=='1')
             <div class="qr_img">
                 <img src="{{ config('app.url') }}/hardware/{{ $asset->id }}/qr_code" class="qr_img">
             </div>

--- a/resources/views/hardware/labels.blade.php
+++ b/resources/views/hardware/labels.blade.php
@@ -83,6 +83,10 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->label2_1d_type!=
     .next-padding {
         margin: {{ $settings->labels_pmargin_top }}in {{ $settings->labels_pmargin_right }}in {{ $settings->labels_pmargin_bottom }}in {{ $settings->labels_pmargin_left }}in;
     }
+
+    .qr-warning {
+        color: red;
+    }
     @media print {
         .noprint {
             display: none !important;
@@ -105,12 +109,18 @@ $qr_size = ($settings->alt_barcode_enabled=='1') && ($settings->label2_1d_type!=
         {!! $snipeSettings->show_custom_css() !!}
     @endif
 </style>
+@if ($settings->qr_code=='1' && ($settings->label2_2d_type == 'none'))
+    <div class="qr-warning">
+        <p></p>
+        {{ __('admin/settings/general.label_qr_setting_invalid') }}
+    </div>
+@endif
 
 @foreach ($assets as $asset)
     <?php $count++; ?>
     <div class="label">
 
-        @if ($settings->qr_code=='1')
+        @if ($settings->qr_code=='1' && (!$settings->label2_2d_type == 'none'))
             <div class="qr_img">
                 <img src="{{ config('app.url') }}/hardware/{{ $asset->id }}/qr_code" class="qr_img">
             </div>


### PR DESCRIPTION
Adds a check and error message to the QR code sheet if QR codes are enabled but 'none' is selected as the type. 

<img width="645" alt="image" src="https://github.com/user-attachments/assets/a72d5493-df20-4010-a7e4-452f9fa9e68d" />
