### PR TITLE
Added a warning for  webhook `channel_not_found`.

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -106,7 +106,13 @@ class CheckoutableListener
                 }
             }
         } catch (ClientException $e) {
-            Log::error("ClientException caught during checkin notification: " . $e->getMessage());
+            if (strpos($e->getMessage(), 'channel_not_found') !== false) {
+                Log::warning(Setting::getSettings()->webhook_selected." notification failed: " . $e->getMessage());
+                return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) .trans('admin/settings/message.webhook.webhook_channel_not_found') );
+            }
+            else {
+                Log::error("ClientException caught during checkin notification: " . $e->getMessage());
+            }
             return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) .trans('admin/settings/message.webhook.webhook_fail') );
         } catch (Exception $e) {
             Log::error(ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed:', [
@@ -196,8 +202,14 @@ class CheckoutableListener
                 }
             }
         } catch (ClientException $e) {
-            Log::error("ClientException caught during checkin notification: " . $e->getMessage());
-            return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) .trans('admin/settings/message.webhook.webhook_fail'));
+            if (strpos($e->getMessage(), 'channel_not_found') !== false) {
+                Log::warning(Setting::getSettings()->webhook_selected." notification failed: " . $e->getMessage());
+                return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) .trans('admin/settings/message.webhook.webhook_channel_not_found') );
+            }
+            else {
+                Log::error("ClientException caught during checkin notification: " . $e->getMessage());
+                return redirect()->back()->with('warning', ucfirst(Setting::getSettings()->webhook_selected) . trans('admin/settings/message.webhook.webhook_fail'));
+            }
         } catch (Exception $e) {
             Log::error(ucfirst(Setting::getSettings()->webhook_selected) . ' webhook notification failed:', [
                 'error' => $e->getMessage(),

--- a/resources/lang/en-US/admin/settings/message.php
+++ b/resources/lang/en-US/admin/settings/message.php
@@ -46,5 +46,6 @@ return [
         'error_redirect' => 'ERROR: 301/302 :endpoint returns a redirect. For security reasons, we don’t follow redirects. Please use the actual endpoint.',
         'error_misc' => 'Something went wrong. :( ',
         'webhook_fail' => ' webhook notification failed: Check to make sure the URL is still valid.',
+        'webhook_channel_not_found' => ' webhook channel not found.'
     ]
 ];


### PR DESCRIPTION
if the webhook channel has been renamed or other this returns a useful warning when it can not find the webhook channel provided.
<img width="1401" alt="image" src="https://github.com/user-attachments/assets/a38022c5-ca1e-4887-b278-ec28952ef865" />

RB: 19471