### PR TITLE
Replaced some calls to the Form::radio helper

### DIFF
--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -581,15 +581,36 @@
 
               <div class="col-md-9 col-md-offset-3">
                   <label class="form-control">
-                    {{ Form::radio('deleted_assets', 'exclude_deleted', $template->radioValue('deleted_assets', 'exclude_deleted', true), ['aria-label'=>'deleted_assets', 'id'=>'deleted_assets_exclude_deleted'])}}
-                    {{ trans('general.exclude_deleted') }}
+                      <input
+                          name="deleted_assets"
+                          id="deleted_assets_exclude_deleted"
+                          type="radio"
+                          value="exclude_deleted"
+                          @checked($template->radioValue('deleted_assets', 'exclude_deleted', true))
+                          aria-label="deleted_assets"
+                      >
+                      {{ trans('general.exclude_deleted') }}
                   </label>
                   <label class="form-control">
-                    {{ Form::radio('deleted_assets', 'include_deleted', $template->radioValue('deleted_assets', 'include_deleted'), ['aria-label'=>'deleted_assets', 'id'=>'deleted_assets_include_deleted']) }}
+                      <input
+                          name="deleted_assets"
+                          id="deleted_assets_include_deleted"
+                          type="radio"
+                          value="include_deleted"
+                          @checked($template->radioValue('deleted_assets', 'include_deleted'))
+                          aria-label="deleted_assets"
+                      >
                     {{ trans('general.include_deleted') }}
                   </label>
                   <label class="form-control">
-                    {{ Form::radio('deleted_assets', 'only_deleted', $template->radioValue('deleted_assets', 'only_deleted'), ['aria-label'=>'deleted_assets','id'=>'deleted_assets_only_deleted']) }}
+                      <input
+                          name="deleted_assets"
+                          type="radio"
+                          id="deleted_assets_only_deleted"
+                          value="only_deleted"
+                          @checked($template->radioValue('deleted_assets', 'only_deleted'))
+                          aria-label="deleted_assets"
+                      >
                     {{ trans('general.only_deleted') }}
                   </label>
               </div>

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -124,8 +124,8 @@
                             </div>
                             <div class="col-sm-9">
 
-                                    <label for="no_change" class="form-control">
-                                        <input type="radio" name="remote" id="no_change" value="" checked="checked" aria-label="no_change">
+                                    <label for="no_change_remote" class="form-control">
+                                        <input type="radio" name="remote" id="no_change_remote" value="" checked aria-label="no_change_remote">
                                         {{  trans('general.do_not_change') }}
                                     </label>
                                     <label for="remote" class="form-control">
@@ -147,16 +147,16 @@
                                 {{ trans('general.user_managed_passwords') }}
                             </div>
                             <div class="col-sm-9">
-                                    <label for="no_change" class="form-control">
-                                        {{ Form::radio('ldap_import', '', true, ['id' => 'no_change', 'aria-label'=>'ldap_import']) }}
+                                    <label for="no_change_ldap_import" class="form-control">
+                                        <input type="radio" name="ldap_import" id="no_change_ldap_import" value="" checked aria-label="no_change_ldap_import">
                                         {{  trans('general.do_not_change') }}
                                     </label>
-                                    <label for="ldap_import" class="form-control">
-                                        {{ Form::radio('ldap_import', '0', old('ldap_import'), ['id' => 'ldap_import', 'aria-label'=>'ldap_import']) }}
+                                    <label for="no_ldap_import" class="form-control">
+                                        <input type="radio" name="ldap_import" id="no_ldap_import" value="0" aria-label="no_ldap_import">
                                         {{ trans('general.user_managed_passwords_allow') }}
                                     </label>
                                     <label for="ldap_import" class="form-control">
-                                        {{ Form::radio('ldap_import', '1', old('ldap_import'), ['id' => 'ldap_import', 'aria-label'=>'ldap_import']) }}
+                                        <input type="radio" name="ldap_import" id="ldap_import" value="1" aria-label="ldap_import">
                                         {{ trans('general.user_managed_passwords_disallow') }}
                                     </label>
                             </div>
@@ -170,15 +170,15 @@
                             <div class="col-sm-9">
 
                                 <label for="no_change_autoassign_licenses" class="form-control">
-                                    {{ Form::radio('autoassign_licenses', '', true, ['id' => 'no_change_autoassign_licenses', 'aria-label'=>'no_change_autoassign_licenses']) }}
+                                    <input type="radio" name="autoassign_licenses" id="no_change_autoassign_licenses" value="" checked aria-label="no_change_autoassign_licenses">
                                     {{  trans('general.do_not_change') }}
                                 </label>
                                 <label for="autoassign_licenses" class="form-control">
-                                    {{ Form::radio('autoassign_licenses', '1', old('autoassign_licenses'), ['id' => 'autoassign_licenses', 'aria-label'=>'autoassign_licenses']) }}
+                                    <input type="radio" name="autoassign_licenses" id="autoassign_licenses" value="1" aria-label="autoassign_licenses">
                                     {{  trans('general.autoassign_licenses_help')}}
                                 </label>
                                 <label for="dont_autoassign_licenses" class="form-control">
-                                    {{ Form::radio('autoassign_licenses', '0', old('autoassign_licenses'), ['id' => 'dont_autoassign_licenses', 'aria-label'=>'dont_autoassign_licenses']) }}
+                                    <input type="radio" name="autoassign_licenses" id="dont_autoassign_licenses" value="0" aria-label="dont_autoassign_licenses">
                                     {{  trans('general.no_autoassign_licenses_help')}}
                                 </label>
 
@@ -192,16 +192,16 @@
                             </div>
                             <div class="col-sm-9">
 
-                                    <label for="no_change" class="form-control">
-                                        {{ Form::radio('activated', '', true, ['id' => 'no_change', 'aria-label'=>'no_change']) }}
+                                    <label for="no_change_activated" class="form-control">
+                                        <input type="radio" name="activated" id="no_change_activated" value="" checked aria-label="no_change_activated">
                                         {{  trans('general.do_not_change') }}
                                     </label>
                                     <label for="activated" class="form-control">
-                                        {{ Form::radio('activated', '1', old('activated'), ['id' => 'activated', 'aria-label'=>'activated']) }}
+                                        <input type="radio" name="activated" id="activated" value="1" aria-label="activated">
                                         {{  trans('admin/users/general.user_activated')}}
                                     </label>
                                     <label for="deactivated" class="form-control">
-                                        {{ Form::radio('activated', '0', old('activated'), ['id' => 'deactivated', 'aria-label'=>'deactivated']) }}
+                                        <input type="radio" name="activated" id="deactivated" value="0" aria-label="deactivated">
                                         {{  trans('admin/users/general.user_deactivated')}}
                                     </label>
 

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -125,15 +125,15 @@
                             <div class="col-sm-9">
 
                                     <label for="no_change" class="form-control">
-                                        {{ Form::radio('remote', '', true, ['id' => 'no_change', 'aria-label'=>'no_change']) }}
+                                        <input type="radio" name="remote" id="no_change" value="" checked="checked" aria-label="no_change">
                                         {{  trans('general.do_not_change') }}
                                     </label>
                                     <label for="remote" class="form-control">
-                                        {{ Form::radio('remote', '1', old('remote'), ['id' => 'remote', 'aria-label'=>'remote']) }}
+                                        <input type="radio" name="remote" id="remote" value="1" aria-label="remote">
                                         {{ trans('admin/users/general.remote_label') }}
                                     </label>
                                     <label for="not_remote" class="form-control">
-                                        {{ Form::radio('remote', '0', old('remote'), ['id' => 'not_remote', 'aria-label'=>'not_remote']) }}
+                                        <input type="radio" name="remote" id="not_remote" value="0" aria-label="not_remote">
                                         {{ trans('admin/users/general.not_remote_label') }}
                                     </label>
 


### PR DESCRIPTION
This PR replaces calls to `Form::radio` with plain html on the [bulk users edit](https://snipe-it.test/users/bulkedit) and [custom report](https://snipe-it.test/reports/custom) pages.

**Bulk Users Edit:**
![radios on bulk edit users page](https://github.com/user-attachments/assets/0827ae20-5474-4e46-a2df-17bb0d5cccfc)

**Custom Report:**
![radios on custom report](https://github.com/user-attachments/assets/8a8a9af6-9609-460b-92e7-1317a5aa7d89)

---

On the Bulk Users Edit page I adjusted some `label`s as well since some `id`s were reused and made selecting "Do Not Change" wouldn't work:
![do not change unselectable](https://github.com/user-attachments/assets/203e5caa-0344-417f-88a0-cda7dd4d8e39)

