### PR TITLE
Replaced calls to Form::radio helper on group create and edit pages

### DIFF
--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -91,7 +91,7 @@
                         <input
                             value="1"
                             aria-label="permission[{{ $localPermission['permission'] }}]"
-                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '1' : null)
+                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) && $groupPermissions[$localPermission['permission']] == '1')
                             name="permission[{{ $localPermission['permission'] }}]"
                             type="radio"
                         >
@@ -101,7 +101,7 @@
                         <input
                             value="0"
                             aria-label="permission[{{ $localPermission['permission'] }}]"
-                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '0' : null)
+                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) && $groupPermissions[$localPermission['permission']] == '0')
                             name="permission[{{ $localPermission['permission'] }}]"
                             type="radio"
                         >

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -156,6 +156,7 @@
                             <input
                                 class="radiochecker-{{ str_slug($area) }}"
                                 aria-label="permission[{{ $this_permission['permission'] }}]"
+                                @checked(array_key_exists($this_permission['permission'], $groupPermissions) && $groupPermissions[$this_permission['permission']] == '1')
                                 name="permission[{{ $this_permission['permission'] }}]"
                                 type="radio"
                                 value="1"
@@ -166,7 +167,7 @@
                             <input
                                 class="radiochecker-{{ str_slug($area) }}"
                                 aria-label="permission[{{ $this_permission['permission'] }}]"
-                                @checked(array_key_exists($this_permission['permission'], $groupPermissions) ? $groupPermissions[$this_permission['permission'] ] == '0' : null)
+                                @checked(array_key_exists($this_permission['permission'], $groupPermissions) && $groupPermissions[$this_permission['permission']] == '0')
                                 name="permission[{{ $this_permission['permission'] }}]"
                                 type="radio"
                                 value="0"

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -153,11 +153,24 @@
                         </td>
                         <td class="col-md-1 permissions-item">
                             <label for="{{ 'permission['.$this_permission['permission'].']' }}"><span class="sr-only">{{ trans('admin/groups/titles.allow')}} {{ 'permission['.$this_permission['permission'].']' }}</span></label>
-                            {{ Form::radio('permission['.$this_permission['permission'].']', '1',(array_key_exists($this_permission['permission'], $groupPermissions) ? $groupPermissions[$this_permission['permission'] ] == '1' : null),['class'=>'radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$this_permission['permission'].']']) }}
+                            <input
+                                class="radiochecker-{{ str_slug($area) }}"
+                                aria-label="permission[{{ $this_permission['permission'] }}]"
+                                name="permission[{{ $this_permission['permission'] }}]"
+                                type="radio"
+                                value="1"
+                            >
                         </td>
                         <td class="col-md-1 permissions-item">
                             <label for="{{ 'permission['.$this_permission['permission'].']' }}"><span class="sr-only">{{ trans('admin/groups/titles.deny')}} {{ 'permission['.$this_permission['permission'].']' }}</span></label>
-                            {{ Form::radio('permission['.$this_permission['permission'].']', '0',(array_key_exists($this_permission['permission'], $groupPermissions) ? $groupPermissions[$this_permission['permission'] ] == '0' : null),['class'=>'radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$this_permission['permission'].']']) }}
+                            <input
+                                class="radiochecker-{{ str_slug($area) }}"
+                                aria-label="permission[{{ $this_permission['permission'] }}]"
+                                @checked(array_key_exists($this_permission['permission'], $groupPermissions) ? $groupPermissions[$this_permission['permission'] ] == '0' : null)
+                                name="permission[{{ $this_permission['permission'] }}]"
+                                type="radio"
+                                value="0"
+                            >
                         </td>
 
                     </tr>

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -91,9 +91,9 @@
                         <input
                             value="1"
                             aria-label="permission[{{ $localPermission['permission'] }}]"
+                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '1' : null)
                             name="permission[{{ $localPermission['permission'] }}]"
                             type="radio"
-                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '1' : null)
                         >
                     </td>
                     <td class="col-md-1 permissions-item">
@@ -101,9 +101,9 @@
                         <input
                             value="0"
                             aria-label="permission[{{ $localPermission['permission'] }}]"
+                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '0' : null)
                             name="permission[{{ $localPermission['permission'] }}]"
                             type="radio"
-                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '0' : null)
                         >
                     </td>
                 </tr>

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -89,21 +89,21 @@
                     <td class="col-md-1 permissions-item">
                         <label for="{{ 'permission['.$localPermission['permission'].']' }}" style="form-control"><span class="sr-only">{{ trans('admin/groups/titles.allow')}} {{ 'permission['.$localPermission['permission'].']' }}</span></label>
                         <input
-                            value="1"
-                            aria-label="permission[{{ $localPermission['permission'] }}]"
-                            name="permission[{{ $localPermission['permission'] }}]"
                             type="radio"
+                            name="permission[{{ $localPermission['permission'] }}]"
+                            value="1"
                             @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '1' : null)
+                            aria-label="permission[{{ $localPermission['permission'] }}]"
                         >
                     </td>
                     <td class="col-md-1 permissions-item">
                         <label for="{{ 'permission['.$localPermission['permission'].']' }}"><span class="sr-only">{{ trans('admin/groups/titles.deny')}} {{ 'permission['.$localPermission['permission'].']' }}</span></label>
                         <input
-                            value="0"
-                            aria-label="permission[{{ $localPermission['permission'] }}]"
-                            name="permission[{{ $localPermission['permission'] }}]"
                             type="radio"
+                            name="permission[{{ $localPermission['permission'] }}]"
+                            value="0"
                             @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '0' : null)
+                            aria-label="permission[{{ $localPermission['permission'] }}]"
                         >
                     </td>
                 </tr>

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -88,11 +88,23 @@
                     </td>
                     <td class="col-md-1 permissions-item">
                         <label for="{{ 'permission['.$localPermission['permission'].']' }}" style="form-control"><span class="sr-only">{{ trans('admin/groups/titles.allow')}} {{ 'permission['.$localPermission['permission'].']' }}</span></label>
-                        {{ Form::radio('permission['.$localPermission['permission'].']', '1',(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '1' : null),['value'=>"grant", 'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+                        <input
+                            value="1"
+                            aria-label="permission[{{ $localPermission['permission'] }}]"
+                            name="permission[{{ $localPermission['permission'] }}]"
+                            type="radio"
+                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '1' : null)
+                        >
                     </td>
                     <td class="col-md-1 permissions-item">
                         <label for="{{ 'permission['.$localPermission['permission'].']' }}"><span class="sr-only">{{ trans('admin/groups/titles.deny')}} {{ 'permission['.$localPermission['permission'].']' }}</span></label>
-                        {{ Form::radio('permission['.$localPermission['permission'].']', '0',(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '0' : null),['value'=>"grant", 'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+                        <input
+                            value="0"
+                            aria-label="permission[{{ $localPermission['permission'] }}]"
+                            name="permission[{{ $localPermission['permission'] }}]"
+                            type="radio"
+                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '0' : null)
+                        >
                     </td>
                 </tr>
             </tbody>

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -121,11 +121,23 @@
                     </td>
                     <td class="col-md-1 permissions-item" style="vertical-align: bottom">
                         <label for="{{ $area }}"><span class="sr-only">{{ trans('admin/groups/titles.allow')}} {{ $area }}</span></label>
-                        {{ Form::radio("$area", '1',false,['value'=>"grant",  'data-checker-group' => str_slug($area), 'aria-label'=> $area]) }}
+                        <input
+                            value="1"
+                            data-checker-group="{{ str_slug($area) }}"
+                            aria-label="{{ $area }}"
+                            name="{{ $area }}"
+                            type="radio"
+                        >
                     </td>
                     <td class="col-md-1 permissions-item">
                         <label for="{{ $area }}"><span class="sr-only">{{ trans('admin/groups/titles.deny')}} {{ $area }}</span></label>
-                        {{ Form::radio("$area", '0',false,['value'=>"deny", 'data-checker-group' => str_slug($area), 'aria-label'=> $area]) }}
+                        <input
+                            value="0"
+                            data-checker-group="{{ str_slug($area) }}"
+                            aria-label="{{ $area }}"
+                            name="{{ $area }}"
+                            type="radio"
+                        >
                     </td>
                 </tr>
 

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -89,21 +89,21 @@
                     <td class="col-md-1 permissions-item">
                         <label for="{{ 'permission['.$localPermission['permission'].']' }}" style="form-control"><span class="sr-only">{{ trans('admin/groups/titles.allow')}} {{ 'permission['.$localPermission['permission'].']' }}</span></label>
                         <input
-                            type="radio"
-                            name="permission[{{ $localPermission['permission'] }}]"
                             value="1"
-                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '1' : null)
                             aria-label="permission[{{ $localPermission['permission'] }}]"
+                            name="permission[{{ $localPermission['permission'] }}]"
+                            type="radio"
+                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '1' : null)
                         >
                     </td>
                     <td class="col-md-1 permissions-item">
                         <label for="{{ 'permission['.$localPermission['permission'].']' }}"><span class="sr-only">{{ trans('admin/groups/titles.deny')}} {{ 'permission['.$localPermission['permission'].']' }}</span></label>
                         <input
-                            type="radio"
-                            name="permission[{{ $localPermission['permission'] }}]"
                             value="0"
-                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '0' : null)
                             aria-label="permission[{{ $localPermission['permission'] }}]"
+                            name="permission[{{ $localPermission['permission'] }}]"
+                            type="radio"
+                            @checked(array_key_exists($localPermission['permission'], $groupPermissions) ? $groupPermissions[$localPermission['permission'] ] == '0' : null)
                         >
                     </td>
                 </tr>

--- a/resources/views/groups/edit.blade.php
+++ b/resources/views/groups/edit.blade.php
@@ -56,7 +56,7 @@
 <div class="form-group {{ $errors->has('name') ? ' has-error' : '' }}">
     <label for="name" class="col-md-3 control-label">{{ trans('admin/groups/titles.group_name') }}</label>
     <div class="col-md-6 required">
-        <input class="form-control" type="text" name="name" id="name" value="{{ old('name', $group->name) }}" />
+        <input class="form-control" type="text" name="name" id="name" value="{{ old('name', $group->name) }}" required />
         {!! $errors->first('name', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>


### PR DESCRIPTION
This PR replaces calls to `Form::radio` with plain html on the group [create](https://snipe-it.test/admin/groups/create) and [edit](https://snipe-it.test/admin/groups/1/edit) pages.

I also added a `required` attribute to the `name` field to provide a little front end validation.

---

Related: #16176