### PR TITLE
Replace calls to Form::label pt1

### DIFF
--- a/resources/views/hardware/quickscan-checkin.blade.php
+++ b/resources/views/hardware/quickscan-checkin.blade.php
@@ -31,7 +31,7 @@
 
                     <!-- Asset Tag -->
                     <div class="form-group {{ $errors->has('asset_tag') ? 'error' : '' }}">
-                        {{ Form::label('asset_tag', trans('general.asset_tag'), array('class' => 'col-md-3 control-label', 'id' => 'checkin_tag')) }}
+                        <label for="asset_tag" class="col-md-3 control-label" id="checkin_tag">{{ trans('general.asset_tag') }}</label>
                         <div class="col-md-9">
                             <div class="input-group col-md-11 required">
                                 <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ old('asset_tag') }}" required>
@@ -57,7 +57,7 @@
 
                     <!-- Note -->
                         <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
-                            {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                             <div class="col-md-8">
                                 <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
                                 {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -16,7 +16,7 @@
         }
     </style>
 
-    
+
 
     <div class="row">
     {{ Form::open(['method' => 'POST', 'class' => 'form-horizontal', 'role' => 'form', 'id' => 'audit-form' ]) }}
@@ -29,7 +29,7 @@
 
                     <!-- Next Audit -->
                         <div class="form-group {{ $errors->has('asset_tag') ? 'error' : '' }}">
-                            {{ Form::label('asset_tag', trans('general.asset_tag'), array('class' => 'col-md-3 control-label', 'id' => 'audit_tag')) }}
+                            <label for="asset_tag" class="col-md-3 control-label" id="audit_tag">{{ trans('general.asset_tag') }}</label>
                             <div class="col-md-9">
                                 <div class="input-group date col-md-11 required" data-date-format="yyyy-mm-dd">
                                     <input type="text" class="form-control" name="asset_tag" id="asset_tag" value="{{ old('asset_tag') }}">
@@ -60,7 +60,7 @@
 
                         <!-- Next Audit -->
                         <div class="form-group {{ $errors->has('next_audit_date') ? 'error' : '' }}">
-                            {{ Form::label('next_audit_date', trans('general.next_audit_date'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="next_audit_date" class="col-md-3 control-label">{{ trans('general.next_audit_date') }}</label>
                             <div class="col-md-9">
                                 <div class="input-group date col-md-5" data-provide="datepicker" data-date-format="yyyy-mm-dd" data-date-clear-btn="true">
                                     <input type="text" class="form-control" placeholder="{{ trans('general.next_audit_date') }}" name="next_audit_date" id="next_audit_date" value="{{ old('next_audit_date', $next_audit_date) }}">
@@ -73,7 +73,7 @@
 
                         <!-- Note -->
                         <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
-                            {{ Form::label('note', trans('admin/hardware/form.notes'), array('class' => 'col-md-3 control-label')) }}
+                            <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
                             <div class="col-md-8">
                                 <textarea class="col-md-6 form-control" id="note" name="note">{{ old('note') }}</textarea>
                                 {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
@@ -101,7 +101,7 @@
                     <h2 class="box-title"> {{ trans('general.bulkaudit_status') }} (<span id="audit-counter">0</span> {{ trans('general.assets_audited') }}) </h2>
                 </div>
                 <div class="box-body">
-    
+
                     <table id="audited" class="table table-striped snipe-table">
                         <thead>
                         <tr>
@@ -158,7 +158,7 @@
                         var audio = new Audio('{{ config('app.url') }}/sounds/success.mp3');
                         audio.play()
                         @endif
-                            
+
                         incrementOnSuccess();
                     } else {
                         handleAuditFail(data);

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -83,7 +83,7 @@
                         <!--Webhook endpoint-->
                         <div class="form-group{{ $errors->has('webhook_endpoint') ? ' error' : '' }}">
                             <div class="col-md-2">
-                                {{ Form::label('webhook_endpoint', trans('admin/settings/general.webhook_endpoint',['app' => $webhook_name ])) }}
+                                <label for="webhook_endpoint">{{ trans('admin/settings/general.webhook_endpoint',['app' => $webhook_name ]) }}</label>
                             </div>
                             <div class="col-md-9 required">
                                     <input type="text" wire:model.blur="webhook_endpoint" class="form-control" placeholder="{{$webhook_placeholder}}" value="{{old('webhook_endpoint', $webhook_endpoint)}}"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
@@ -100,7 +100,7 @@
                         @if($webhook_selected != 'microsoft' && $webhook_selected!= 'google')
                             <div class="form-group{{ $errors->has('webhook_channel') ? ' error' : '' }}">
                                 <div class="col-md-2">
-                                    {{ Form::label('webhook_channel', trans('admin/settings/general.webhook_channel',['app' => $webhook_name ])) }}
+                                    <label for="webhook_channel">{{ trans('admin/settings/general.webhook_channel',['app' => $webhook_name ]) }}</label>
                                 </div>
                                 <div class="col-md-9 required">
                                         <input type="text" wire:model.blur="webhook_channel" class="form-control" placeholder="#IT-Ops" value="{{ old('webhook_channel', $webhook_channel) }}"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
@@ -118,7 +118,7 @@
                         @if($webhook_selected != 'microsoft' && $webhook_selected != 'google')
                             <div class="form-group{{ $errors->has('webhook_botname') ? ' error' : '' }}">
                                 <div class="col-md-2">
-                                    {{ Form::label('webhook_botname', trans('admin/settings/general.webhook_botname',['app' => $webhook_name ])) }}
+                                    <label for="webhook_botname">{{ trans('admin/settings/general.webhook_botname',['app' => $webhook_name ]) }}</label>
                                 </div>
                                 <div class="col-md-9">
                                         <input type="text" wire:model.blur="webhook_botname" class='form-control' placeholder="Snipe-Bot" {{ old('webhook_botname', $webhook_botname)}}{{ Helper::isDemoMode() ? ' disabled' : ''}}>

--- a/resources/views/partials/forms/edit/accessory-select.blade.php
+++ b/resources/views/partials/forms/edit/accessory-select.blade.php
@@ -1,6 +1,6 @@
 <!-- Accessory -->
 <div id="assigned_accessory" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
     <div class="col-md-7">
         <select class="js-data-ajax select2" data-endpoint="accessories" data-placeholder="{{ trans('general.select_accessory') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_accessory_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}>
 

--- a/resources/views/partials/forms/edit/address.blade.php
+++ b/resources/views/partials/forms/edit/address.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group {{ $errors->has('address') ? ' has-error' : '' }}">
-    {{ Form::label('address', trans('general.address'), array('class' => 'col-md-3 control-label')) }}
+    <label for="address" class="col-md-3 control-label">{{ trans('general.address') }}</label>
     <div class="col-md-7">
         {{Form::text('address', old('address', $item->address), array('class' => 'form-control', 'aria-label'=>'address', 'maxlength'=>'191')) }}
         {!! $errors->first('address', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
@@ -15,7 +15,7 @@
 </div>
 
 <div class="form-group {{ $errors->has('city') ? ' has-error' : '' }}">
-    {{ Form::label('city', trans('general.city'), array('class' => 'col-md-3 control-label')) }}
+    <label for="city" class="col-md-3 control-label">{{ trans('general.city') }}</label>
     <div class="col-md-7">
     {{Form::text('city', old('city', $item->city), array('class' => 'form-control', 'aria-label'=>'city', 'maxlength'=>'191')) }}
         {!! $errors->first('city', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
@@ -23,7 +23,7 @@
 </div>
 
 <div class="form-group {{ $errors->has('state') ? ' has-error' : '' }}">
-    {{ Form::label('state', trans('general.state'), array('class' => 'col-md-3 control-label')) }}
+    <label for="state" class="col-md-3 control-label">{{ trans('general.state') }}</label>
     <div class="col-md-7">
     {{Form::text('state', old('state', $item->state), array('class' => 'form-control', 'aria-label'=>'state', 'maxlength'=>'191')) }}
         {!! $errors->first('state', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
@@ -32,7 +32,7 @@
 </div>
 
 <div class="form-group {{ $errors->has('country') ? ' has-error' : '' }}">
-    {{ Form::label('country', trans('general.country'), array('class' => 'col-md-3 control-label')) }}
+    <label for="country" class="col-md-3 control-label">{{ trans('general.country') }}</label>
     <div class="col-md-7">
     {!! Form::countries('country', old('country', $item->country), 'select2') !!}
         <p class="help-block">{{ trans('general.countries_manually_entered_help') }}</p>
@@ -41,7 +41,7 @@
 </div>
 
 <div class="form-group {{ $errors->has('zip') ? ' has-error' : '' }}">
-    {{ Form::label('zip', trans('general.zip'), array('class' => 'col-md-3 control-label', 'maxlength'=>'10')) }}
+    <label for="zip" class="col-md-3 control-label" maxlength="10">{{ trans('general.zip') }}</label>
     <div class="col-md-7">
     {{Form::text('zip', old('zip', $item->zip), array('class' => 'form-control')) }}
         {!! $errors->first('zip', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}


### PR DESCRIPTION
This PR replaces calls to `Form::label` with inline html on the following pages:

- [Quick Scan Checkin](https://snipe-it.test/hardware/quickscancheckin)
- [Bulk Audit](https://snipe-it.test/hardware/bulkaudit)
- [Webhook Settings](https://snipe-it.test/admin/slack)
- Locations
	- [Create](https://snipe-it.test/locations/create)
	- [Edit](https://snipe-it.test/locations/1/edit)
