### PR TITLE
Replace calls to Form::label pt2

### DIFF
--- a/resources/views/partials/forms/edit/asset-select.blade.php
+++ b/resources/views/partials/forms/edit/asset-select.blade.php
@@ -1,7 +1,7 @@
 <!-- Asset -->
 <div id="{{ $asset_selector_div_id ?? "assigned_asset" }}"
      class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
     <div class="col-md-7">
         <select class="js-data-ajax select2" data-endpoint="hardware" data-placeholder="{{ trans('general.select_asset') }}" aria-label="{{ $fieldname }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_asset_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}{!! (!empty($asset_status_type)) ? ' data-asset-status-type="' . $asset_status_type . '"' : '' !!}{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}>
 

--- a/resources/views/partials/forms/edit/category-select.blade.php
+++ b/resources/views/partials/forms/edit/category-select.blade.php
@@ -1,7 +1,7 @@
 <!-- Asset Model -->
 <div id="{{ $fieldname }}" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}">
 
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
 
     <div class="col-md-7">
         <select class="js-data-ajax" data-endpoint="categories/{{ (isset($category_type)) ? $category_type : 'assets' }}" data-placeholder="{{ trans('general.select_category') }}" name="{{ $fieldname }}" style="width: 100%" id="category_select_id" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' required ' : '' !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>

--- a/resources/views/partials/forms/edit/company.blade.php
+++ b/resources/views/partials/forms/edit/company.blade.php
@@ -1,7 +1,7 @@
 @if (\App\Models\Company::isCurrentUserAuthorized())
 <div class="form-group {{ $errors->has('company_id') ? ' has-error' : '' }}">
    <div class="col-md-3 control-label">
-       {{ Form::label('company_id', trans('general.company'), array('class' => 'col-md-3 control-label', 'for' => 'company_id')) }}
+       <label for="company_id" class="col-md-3 control-label">{{ trans('general.company') }}</label>
    </div>
     <div class="col-md-7 col-sm-12">
        {{ Form::select('company_id', $company_list , old('company_id', $item->company_id), array('class'=>'select2', 'style'=>'width:100%', 'required' => Helper::checkIfRequired($item, 'company_id') ? true : '')) }}

--- a/resources/views/partials/forms/edit/consumable-select.blade.php
+++ b/resources/views/partials/forms/edit/consumable-select.blade.php
@@ -1,6 +1,6 @@
 <!-- Consumable -->
 <div id="assigned_consumable" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
     <div class="col-md-7{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}">
         <select class="js-data-ajax select2" data-endpoint="consumables" data-placeholder="{{ trans('general.select_consumable') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_consumable_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}>
         

--- a/resources/views/partials/forms/edit/datepicker.blade.php
+++ b/resources/views/partials/forms/edit/datepicker.blade.php
@@ -1,6 +1,6 @@
 <!-- Datepicker -->
 <div class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}">
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
     <div class="input-group col-md-4">
         <div class="input-group date" data-provide="datepicker" data-date-clear-btn="true" data-date-format="yyyy-mm-dd"  data-autoclose="true">
             <input type="text" class="form-control" placeholder="{{ trans('general.select_date') }}" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old($fieldname, ($item->{$fieldname}) ? date('Y-m-d', strtotime($item->{$fieldname})) : '') }}" readonly style="background-color:inherit" maxlength="10">

--- a/resources/views/partials/forms/edit/department-select.blade.php
+++ b/resources/views/partials/forms/edit/department-select.blade.php
@@ -1,6 +1,6 @@
 <div id="assigned_user" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}">
 
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
 
     <div class="col-md-6">
         <select class="js-data-ajax" data-endpoint="departments" data-placeholder="{{ trans('general.select_department') }}" name="{{ $fieldname }}" style="width: 100%" id="department_select" aria-label="{{ $fieldname }}"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>

--- a/resources/views/partials/forms/edit/fax.blade.php
+++ b/resources/views/partials/forms/edit/fax.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group {{ $errors->has('fax') ? ' has-error' : '' }}">
-    {{ Form::label('fax', trans('admin/suppliers/table.fax'), array('class' => 'col-md-3 control-label')) }}
+    <label for="fax" class="col-md-3 control-label">{{ trans('admin/suppliers/table.fax') }}</label>
     <div class="col-md-7">
         <input class="form-control" type="text" name="fax" aria-label="fax" id="fax" value="{{ old('fax', $item->fax) }}"  maxlength="34"  />
         {!! $errors->first('fax', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}


### PR DESCRIPTION
This PR replaces calls to `Form::label` with inline html on the following pages:

- Asset select like on [component checkout](https://snipe-it.test/components/1/checkout)
- Category select like on [create accessory](https://snipe-it.test/accessories/create)
- Company select partial that doesn't seem to be used
- Consumable select for pre-defined kits
- Date picker partial on pages like [create user](https://snipe-it.test/users/create)
- Department select on pages like [custom asset report](https://snipe-it.test/reports/custom)
- Fax input partial on pages like [create location](https://snipe-it.test/locations/create)