### PR TITLE
Replace calls to Form::label pt3

### DIFF
--- a/resources/views/partials/forms/edit/kit-select.blade.php
+++ b/resources/views/partials/forms/edit/kit-select.blade.php
@@ -1,6 +1,6 @@
 <div id="kit_id" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
 
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
 
     <div class="col-md-7">
         <select class="js-data-ajax" data-endpoint="kits" data-placeholder="{{ trans('partials/forms/general.placeholder_kit') }}" name="{{ $fieldname }}" style="width: 100%" id="kit_id_select"{{  ((isset($required)) && ($required=='true')) ? ' required' : '' }}>

--- a/resources/views/partials/forms/edit/license-select.blade.php
+++ b/resources/views/partials/forms/edit/license-select.blade.php
@@ -1,6 +1,6 @@
 <!-- License -->
 <div id="assigned_license" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
     <div class="col-md-7">
         <select class="js-data-ajax select2" data-endpoint="licenses" data-placeholder="{{ trans('general.select_license') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ (isset($select_id)) ? $select_id : 'assigned_license_select' }}"{{ (isset($multiple)) ? ' multiple' : '' }}{{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}>
 

--- a/resources/views/partials/forms/edit/location-profile-select.blade.php
+++ b/resources/views/partials/forms/edit/location-profile-select.blade.php
@@ -1,7 +1,7 @@
 <!-- Location -->
 <div id="location_id" class="form-group{{ $errors->has('location_id') ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
 
-    {{ Form::label('location_id', $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="location_id" class="col-md-3 control-label">{{ $translated_name }}</label>
     <div class="col-md-8">
         <select class="js-data-ajax" data-endpoint="locations" data-placeholder="{{ trans('general.select_location') }}" name="location_id" style="width: 100%" id="location_id_location_select" aria-label="location_id">
             @if ($location_id = old('location_id', (isset($user)) ? $user->location_id : ''))

--- a/resources/views/partials/forms/edit/location-select.blade.php
+++ b/resources/views/partials/forms/edit/location-select.blade.php
@@ -1,7 +1,7 @@
 <!-- Location -->
 <div id="{{ $fieldname }}" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}"{!!  (isset($style)) ? ' style="'.e($style).'"' : ''  !!}>
 
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
     <div class="col-md-7">
         <select class="js-data-ajax" data-endpoint="locations" data-placeholder="{{ trans('general.select_location') }}" name="{{ $fieldname }}" style="width: 100%" id="{{ $fieldname }}_location_select" aria-label="{{ $fieldname }}"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}{!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' required ' : '' !!}>
             @isset($selected)

--- a/resources/views/partials/forms/edit/manufacturer-select.blade.php
+++ b/resources/views/partials/forms/edit/manufacturer-select.blade.php
@@ -1,7 +1,7 @@
 <!-- Asset Model -->
 <div id="{{ $fieldname }}" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}">
 
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
 
     <div class="col-md-7">
         <select class="js-data-ajax" data-endpoint="manufacturers" data-placeholder="{{ trans('general.select_manufacturer') }}" name="{{ $fieldname }}" style="width: 100%" id="manufacturer_select_id" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' required ' : '' !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>

--- a/resources/views/partials/forms/edit/model-select.blade.php
+++ b/resources/views/partials/forms/edit/model-select.blade.php
@@ -1,7 +1,7 @@
 <!-- Asset Model -->
 <div id="{{ $fieldname }}" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}">
 
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
 
     <div class="col-md-7">
         <select class="js-data-ajax" data-endpoint="models" data-placeholder="{{ trans('general.select_model') }}" name="{{ $fieldname }}" style="width: 100%" id="model_select_id" aria-label="{{ $fieldname }}"{{  ((isset($field_req)) || ((isset($required) && ($required =='true')))) ?  ' required' : '' }}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>

--- a/resources/views/partials/forms/edit/phone.blade.php
+++ b/resources/views/partials/forms/edit/phone.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group {{ $errors->has('phone') ? ' has-error' : '' }}">
-    {{ Form::label('phone', trans('admin/suppliers/table.phone'), array('class' => 'col-md-3 control-label')) }}
+    <label for="phone" class="col-md-3 control-label">{{ trans('admin/suppliers/table.phone') }}</label>
     <div class="col-md-7">
     {{Form::text('phone', old('phone', $item->phone), array('class' => 'form-control', 'aria-label'=>'phone', 'maxlength'=>'191')) }}
         {!! $errors->first('phone', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}

--- a/resources/views/partials/forms/edit/status-select.blade.php
+++ b/resources/views/partials/forms/edit/status-select.blade.php
@@ -1,7 +1,7 @@
 <!-- Asset Model -->
 <div id="{{ $fieldname }}" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}">
 
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+    <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
 
     <div class="col-md-7">
         <select class="js-data-ajax" data-endpoint="statuslabels" data-placeholder="{{ trans('general.select_statuslabel') }}" name="{{ $fieldname }}" style="width: 100%" id="status_select_id" aria-label="{{ $fieldname }}" {!!  ((isset($item)) && (Helper::checkIfRequired($item, $fieldname))) ? ' required ' : '' !!}{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>


### PR DESCRIPTION
This PR replaces calls to `Form::label` with inline html on the following pages:

- Kit select that doesn't seem to be used
- License select partial used within pre-defined kits
- Location select like on [profile edit](https://snipe-it.test/account/profile)
- Location select like on [create location](https://snipe-it.test/locations/create)
- Manufacturer select like on [create license](https://snipe-it.test/licenses/create)
- Asset model select like on [create asset](https://snipe-it.test/hardware/create)
- Phone input like on [create location](https://snipe-it.test/locations/create)
- Status select on [custom asset report](https://snipe-it.test/reports/custom)

