### PR TITLE
Replace calls to Form::label pt6

### DIFF
--- a/resources/views/settings/google.blade.php
+++ b/resources/views/settings/google.blade.php
@@ -65,7 +65,7 @@
                         <!-- Google Client ID -->
                         <div class="form-group {{ $errors->has('google_client_id') ? 'error' : '' }}">
                             <div class="col-md-3 text-right">
-                                {{ Form::label('google_client_id', 'Client ID') }}
+                                <label for="google_client_id">Client ID</label>
                             </div>
                             <div class="col-md-8">
                                 {{ Form::text('google_client_id', old('google_client_id', $setting->google_client_id), ['class' => 'form-control','placeholder' => trans('general.example') .'000000000000-XXXXXXXXXXX.apps.googleusercontent.com', (config('app.lock_passwords')===true) ? 'disabled': '']) }}
@@ -79,7 +79,7 @@
                         <!-- Google Client Secret -->
                         <div class="form-group {{ $errors->has('google_client_secret') ? 'error' : '' }}">
                             <div class="col-md-3 text-right">
-                                {{ Form::label('google_client_secret', 'Client Secret') }}
+                                <label for="google_client_secret">Client Secret</label>
                             </div>
                             <div class="col-md-8">
 

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -43,7 +43,7 @@
                         <!-- Language -->
                         <div class="form-group {{ $errors->has('site_name') ? 'error' : '' }}">
                             <div class="col-md-3 col-xs-12">
-                                {{ Form::label('site_name', trans('admin/settings/general.default_language')) }}
+                                <label for="site_name">{{ trans('admin/settings/general.default_language') }}</label>
                             </div>
                             <div class="col-md-5 col-xs-12">
                                 {!! Form::locales('locale', old('locale', $setting->locale), 'select2') !!}
@@ -55,7 +55,7 @@
                         <!-- name display format -->
                         <div class="form-group {{ $errors->has('name_display_format') ? 'error' : '' }}">
                             <div class="col-md-3 col-xs-12">
-                                {{ Form::label('name_display_format', trans('general.name_display_format')) }}
+                                <label for="name_display_format">{{ trans('general.name_display_format') }}</label>
                             </div>
                             <div class="col-md-5 col-xs-12">
                                 {!! Form::name_display_format('name_display_format', old('name_display_format', $setting->name_display_format), 'select2') !!}
@@ -69,7 +69,7 @@
                         <!-- Date format -->
                         <div class="form-group {{ $errors->has('time_display_format') ? 'error' : '' }}">
                             <div class="col-md-3 col-xs-12">
-                                {{ Form::label('time_display_format', trans('general.time_and_date_display')) }}
+                                <label for="time_display_format">{{ trans('general.time_and_date_display') }}</label>
                             </div>
                             <div class="col-md-5 col-xs-12">
                                 {!! Form::date_display_format('date_display_format', old('date_display_format', $setting->date_display_format), 'select2') !!}
@@ -85,7 +85,7 @@
                         <!-- Currency -->
                         <div class="form-group {{ $errors->has('default_currency') ? 'error' : '' }}">
                             <div class="col-md-3 col-xs-12">
-                                {{ Form::label('default_currency', trans('admin/settings/general.default_currency')) }}
+                                <label for="default_currency">{{ trans('admin/settings/general.default_currency') }}</label>
                             </div>
                             <div class="col-md-9 col-xs-12">
                                 {{ Form::text('default_currency', old('default_currency', $setting->default_currency), array('class' => 'form-control select2-container','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px; display: inline-block; ')) }}

--- a/resources/views/settings/purge-form.blade.php
+++ b/resources/views/settings/purge-form.blade.php
@@ -28,7 +28,7 @@
                 <div class="box-body">
                     <p>{{ trans('admin/settings/general.confirm_purge_help') }}</p>
                     <div class="col-md-3{{ $errors->has('confirm_purge') ? 'error' : '' }}">
-                        {{ Form::label('confirm_purge', trans('admin/settings/general.confirm_purge')) }}
+                        <label for="confirm_purge">{{ trans('admin/settings/general.confirm_purge') }}</label>
                     </div>
                     <div class="col-md-9{{ $errors->has('confirm_purge') ? 'error' : '' }}">
                         @if (config('app.lock_passwords')===true)

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -69,25 +69,25 @@
                                     <div class="col-md-9 col-md-offset-3">
                                     <!-- SAML SP Details -->
                                     <!-- SAML SP Entity ID -->
-                                    {{ Form::label('saml_sp_entitiyid', trans('admin/settings/general.saml_sp_entityid')) }}
+                                    <label for="saml_sp_entitiyid">{{ trans('admin/settings/general.saml_sp_entityid') }}</label>
                                     {{ Form::text('saml_sp_entitiyid', config('app.url'), ['class' => 'form-control', 'readonly']) }}
                                     <br>
                                     <!-- SAML SP ACS -->
-                                    {{ Form::label('saml_sp_acs_url', trans('admin/settings/general.saml_sp_acs_url')) }}
+                                    <label for="saml_sp_acs_url">{{ trans('admin/settings/general.saml_sp_acs_url') }}</label>
                                     {{ Form::text('saml_sp_acs_url', route('saml.acs'), ['class' => 'form-control', 'readonly']) }}
                                     <br>
                                     <!-- SAML SP SLS -->
-                                    {{ Form::label('saml_sp_sls_url', trans('admin/settings/general.saml_sp_sls_url')) }}
+                                    <label for="saml_sp_sls_url">{{ trans('admin/settings/general.saml_sp_sls_url') }}</label>
                                     {{ Form::text('saml_sp_sls_url', route('saml.sls'), ['class' => 'form-control', 'readonly']) }}
                                     <br>
                                     <!-- SAML SP Certificate -->
                                     @if (!empty($setting->saml_sp_x509cert))
-                                        {{ Form::label('saml_sp_x509cert', trans('admin/settings/general.saml_sp_x509cert')) }}
+                                        <label for="saml_sp_x509cert">{{ trans('admin/settings/general.saml_sp_x509cert') }}</label>
                                         {{ Form::textarea('saml_sp_x509cert', $setting->saml_sp_x509cert, ['class' => 'form-control', 'wrap' => 'off', 'readonly']) }}
                                         <br>
                                     @endif
                                     <!-- SAML SP Metadata URL -->
-                                    {{ Form::label('saml_sp_metadata_url', trans('admin/settings/general.saml_sp_metadata_url')) }}
+                                    <label for="saml_sp_metadata_url">{{ trans('admin/settings/general.saml_sp_metadata_url') }}</label>
                                     {{ Form::text('saml_sp_metadata_url', route('saml.metadata'), ['class' => 'form-control', 'readonly']) }}
                                     <br>
                                     <p class="help-block">
@@ -103,7 +103,7 @@
                         <!-- SAML IdP Metadata -->
                         <div class="form-group {{ $errors->has('saml_idp_metadata') ? 'error' : '' }}">
                         <div class="col-md-3">
-                            {{ Form::label('saml_idp_metadata', trans('admin/settings/general.saml_idp_metadata')) }}
+                            <label for="saml_idp_metadata">{{ trans('admin/settings/general.saml_idp_metadata') }}</label>
                         </div>
                         <div class="col-md-9">
                             {{ Form::textarea('saml_idp_metadata', old('saml_idp_metadata', $setting->saml_idp_metadata), ['class' => 'form-control','placeholder' => 'https://example.com/idp/metadata', 'wrap' => 'off', $setting->demoMode]) }}
@@ -120,7 +120,7 @@
                         <!-- SAML Attribute Mapping Username -->
                         <div class="form-group {{ $errors->has('saml_attr_mapping_username') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('saml_attr_mapping_username', trans('admin/settings/general.saml_attr_mapping_username')) }}
+                                <label for="saml_attr_mapping_username">{{ trans('admin/settings/general.saml_attr_mapping_username') }}</label>
                             </div>
                             <div class="col-md-9">
                                 {{ Form::text('saml_attr_mapping_username', old('saml_attr_mapping_username', $setting->saml_attr_mapping_username), ['class' => 'form-control','placeholder' => '', $setting->demoMode]) }}
@@ -163,7 +163,7 @@
                         <!-- SAML Custom Options -->
                         <div class="form-group {{ $errors->has('saml_custom_settings') ? 'error' : '' }}">
                         <div class="col-md-3">
-                            {{ Form::label('saml_custom_settings', trans('admin/settings/general.saml_custom_settings')) }}
+                            <label for="saml_custom_settings">{{ trans('admin/settings/general.saml_custom_settings') }}</label>
                         </div>
                         <div class="col-md-9">
                             {{ Form::textarea('saml_custom_settings', old('saml_custom_settings', $setting->saml_custom_settings), ['class' => 'form-control','placeholder' => 'example.option=false&#13;&#10;sp_x509cert=file:///...&#13;&#10;sp_private_key=file:///', 'wrap' => 'off', $setting->demoMode]) }}

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -41,7 +41,7 @@
                         <!-- Two Factor -->
                         <div class="form-group {{ $errors->has('brand') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('two_factor_enabled', trans('admin/settings/general.two_factor_enabled_text')) }}
+                                <label for="two_factor_enabled">{{ trans('admin/settings/general.two_factor_enabled_text') }}</label>
                             </div>
                             <div class="col-md-9">
 
@@ -59,7 +59,7 @@
                         <!-- Min characters -->
                         <div class="form-group {{ $errors->has('pwd_secure_min') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('pwd_secure_min', trans('admin/settings/general.pwd_secure_min')) }}
+                                <label for="pwd_secure_min">{{ trans('admin/settings/general.pwd_secure_min') }}</label>
                             </div>
                             <div class="col-md-9">
                                 {{ Form::text('pwd_secure_min', old('pwd_secure_min', $setting->pwd_secure_min), array('class' => 'form-control',  'style'=>'width: 50px;')) }}
@@ -78,7 +78,7 @@
                         <!-- Common Passwords -->
                         <div class="form-group {{ $errors->has('pwd_secure_complexity.*') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('pwd_secure_complexity', trans('admin/settings/general.pwd_secure_complexity')) }}
+                                <label for="pwd_secure_complexity">{{ trans('admin/settings/general.pwd_secure_complexity') }}</label>
                             </div>
                             <div class="col-md-9">
                                 <label class="form-control">
@@ -130,7 +130,7 @@
                                 @else
                                     <label class="form-control">
                                         {{ Form::checkbox('login_remote_user_enabled', '1', old('login_remote_user_enabled', $setting->login_remote_user_enabled),array('aria-label'=>'login_remote_user')) }}
-                                        {{ Form::label('login_remote_user_enabled',  trans('admin/settings/general.login_remote_user_enabled_text')) }}
+                                        <label for="login_remote_user_enabled">{{ trans('admin/settings/general.login_remote_user_enabled_text') }}</label>
                                     </label>
 
                                     {!! $errors->first('login_remote_user_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -138,14 +138,14 @@
                                         {{ trans('admin/settings/general.login_remote_user_enabled_help') }}
                                     </p>
                                     <!-- Use custom remote user header name -->
-                                    {{ Form::label('login_remote_user_header_name',  trans('admin/settings/general.login_remote_user_header_name_text')) }}
+                                    <label for="login_remote_user_header_name">{{ trans('admin/settings/general.login_remote_user_header_name_text') }}</label>
                                     {{ Form::text('login_remote_user_header_name', old('login_remote_user_header_name', $setting->login_remote_user_header_name),array('class' => 'form-control')) }}
                                     {!! $errors->first('login_remote_user_header_name', '<span class="alert-msg">:message</span>') !!}
                                     <p class="help-block">
                                         {{ trans('admin/settings/general.login_remote_user_header_name_help') }}
                                     </p>
                                     <!-- Custom logout url to redirect to authentication provider -->
-                                    {{ Form::label('login_remote_user_custom_logout_url',  trans('admin/settings/general.login_remote_user_custom_logout_url_text')) }}
+                                    <label for="login_remote_user_custom_logout_url">{{ trans('admin/settings/general.login_remote_user_custom_logout_url_text') }}</label>
                                     {{ Form::text('login_remote_user_custom_logout_url', old('login_remote_user_custom_logout_url', $setting->login_remote_user_custom_logout_url),array('class' => 'form-control', 'aria-label'=>'login_remote_user_custom_logout_url')) }}
 
                                     {!! $errors->first('login_remote_user_custom_logout_url', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}

--- a/resources/views/statuslabels/edit.blade.php
+++ b/resources/views/statuslabels/edit.blade.php
@@ -34,7 +34,7 @@
 
 <!-- Chart color -->
 <div class="form-group{{ $errors->has('color') ? ' has-error' : '' }}">
-    {{ Form::label('color', trans('admin/statuslabels/table.color'), ['class' => 'col-md-3 control-label']) }}
+    <label for="color" class="col-md-3 control-label">{{ trans('admin/statuslabels/table.color') }}</label>
     <div class="col-md-9">
         <div class="input-group color">
             {{ Form::text('color', old('color', $item->color), array('class' => 'form-control col-md-10', 'maxlength'=>'20')) }}

--- a/resources/views/suppliers/edit.blade.php
+++ b/resources/views/suppliers/edit.blade.php
@@ -14,7 +14,7 @@
 @include ('partials.forms.edit.address')
 
 <div class="form-group {{ $errors->has('contact') ? ' has-error' : '' }}">
-    {{ Form::label('contact', trans('admin/suppliers/table.contact'), array('class' => 'col-md-3 control-label')) }}
+    <label for="contact" class="col-md-3 control-label">{{ trans('admin/suppliers/table.contact') }}</label>
     <div class="col-md-7">
         {{Form::text('contact', old('contact', $item->contact), array('class' => 'form-control')) }}
         {!! $errors->first('contact', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
@@ -26,7 +26,7 @@
 @include ('partials.forms.edit.email')
 
 <div class="form-group {{ $errors->has('url') ? ' has-error' : '' }}">
-    {{ Form::label('url', trans('general.url'), array('class' => 'col-md-3 control-label')) }}
+    <label for="url" class="col-md-3 control-label">{{ trans('general.url') }}</label>
     <div class="col-md-7">
         {{Form::text('url', old('url', $item->url), array('class' => 'form-control')) }}
         {!! $errors->first('url', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}


### PR DESCRIPTION
This PR replaces calls to `Form::label` with inline html on the following pages:

- [Google settings](https://snipe-it.test/admin/google)
- [Localization settings](https://snipe-it.test/admin/localization)
- [Purge page](https://snipe-it.test/admin/purge)
- [SAML settings](https://snipe-it.test/admin/saml)
- [Security settings](https://snipe-it.test/admin/security)
- [Create and edit status label](https://snipe-it.test/statuslabels/create)
- [Create and edit supplier](https://snipe-it.test/suppliers/create)
