### PR TITLE
Replace calls to Form::label in QuickStart

### DIFF
--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -40,7 +40,7 @@
 
     <!-- Currency -->
     <div class="form-group col-lg-6{{$errors->has('default_currency') ? ' error' : ''}}">
-      {{ Form::label('default_currency', trans('admin/settings/general.default_currency')) }}
+      <label for="default_currency">{{ trans('admin/settings/general.default_currency') }}</label>
       {{ Form::text('default_currency', old('default_currency'), array('class' => 'form-control','placeholder' => 'USD', 'maxlength'=>'3', 'style'=>'width: 60px;')) }}
 
       {!! $errors->first('default_currency', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -71,14 +71,14 @@
   <div class="row">
 
     <div class="form-group col-lg-6{{ $errors->has('auto_increment_prefix') ? ' error' : '' }}">
-      {{ Form::label('auto_increment_prefix', trans('admin/settings/general.auto_increment_prefix')) }}
+      <label for="auto_increment_prefix">{{ trans('admin/settings/general.auto_increment_prefix') }}</label>
       {{ Form::text('auto_increment_prefix', old('auto_increment_prefix'), array('class' => 'form-control')) }}
 
       {!! $errors->first('auto_increment_prefix', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
     </div>
 
     <div class="form-group col-lg-6{{ $errors->has('zerofill_count') ? ' error' : '' }}">
-      {{ Form::label('zerofill_count', trans('admin/settings/general.zerofill_count')) }}
+      <label for="zerofill_count">{{ trans('admin/settings/general.zerofill_count') }}</label>
       {{ Form::text('zerofill_count', old('zerofill_count', 5), array('class' => 'form-control')) }}
 
       {!! $errors->first('zerofill_count', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -89,7 +89,7 @@
     <!-- email domain -->
     <div class="row">
       <div class="form-group col-lg-6 required {{ $errors->has('email_domain') ? 'error' : '' }}">
-        {{ Form::label('email_domain', trans('general.email_domain')) }}
+        <label for="email_domain">{{ trans('general.email_domain') }}</label>
         {{ Form::text('email_domain', old('email_domain'), array('class' => 'form-control','placeholder' => 'example.com','required' => true)) }}
         <span class="help-block">{{ trans('general.email_domain_help')  }}</span>
 
@@ -98,7 +98,7 @@
 
       <!-- email format  -->
       <div class="form-group col-lg-6 {{ $errors->has('email_format') ? 'error' : '' }}">
-        {{ Form::label('email_format', trans('general.email_format')) }}
+        <label for="email_format">{{ trans('general.email_format') }}</label>
         {!! Form::username_format('email_format', old('email_format', 'filastname'), 'select2') !!}
         {!! $errors->first('email_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>
@@ -108,14 +108,14 @@
     <div class="row">
       <!-- first name -->
       <div class="form-group col-lg-6">
-        {{ Form::label('first_name', trans('general.first_name'), 'required') }}
+        <label for="first_name">{{ trans('general.first_name') }}</label>
         {{ Form::text('first_name', old('first_name'), array('class' => 'form-control','placeholder' => 'Jane', 'required' => true)) }}
         {!! $errors->first('first_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>
 
       <!-- last name -->
       <div class="form-group col-lg-6 required {{ $errors->has('last_name') ? 'error' : '' }}">
-        {{ Form::label('last_name', trans('general.last_name')) }}
+        <label for="last_name">{{ trans('general.last_name') }}</label>
         {{ Form::text('last_name', old('last_name'), array('class' => 'form-control','placeholder' => 'Smith', 'required' => true)) }}
         {!! $errors->first('last_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>
@@ -124,14 +124,14 @@
     <div class="row">
       <!-- email-->
       <div class="form-group col-lg-6{{ $errors->has('email') ? 'error' : '' }}">
-        {{ Form::label('email', trans('admin/users/table.email')) }}
+        <label for="email">{{ trans('admin/users/table.email') }}</label>
         {{ Form::email('email', config('mail.from.address'), array('class' => 'form-control','placeholder' => 'you@example.com', 'required' => true)) }}
         {!! $errors->first('email', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>
 
       <!-- username -->
       <div class="form-group col-lg-6{{  (Helper::checkIfRequired(\App\Models\User::class, 'username')) ? ' required' : '' }} {{ $errors->has('username') ? 'error' : '' }}">
-        {{ Form::label('username', trans('admin/users/table.username')) }}
+        <label for="username">{{ trans('admin/users/table.username') }}</label>
         {{ Form::text('username', old('username'), array('class' => 'form-control','placeholder' => 'jsmith', 'required' => true)) }}
         {!! $errors->first('username', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>
@@ -140,14 +140,14 @@
     <div class="row">
       <!-- password -->
       <div class="form-group col-lg-6{{  (Helper::checkIfRequired(\App\Models\User::class, 'password')) ? ' required' : '' }} {{ $errors->has('password') ? 'error' : '' }}">
-        {{ Form::label('password', trans('admin/users/table.password')) }}
+        <label for="password">{{ trans('admin/users/table.password') }}</label>
         <input class="form-control" type="password" name="password" id="password" value="" required>
         {!! $errors->first('password', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>
 
       <!-- password confirm -->
       <div class="form-group col-lg-6{{  (Helper::checkIfRequired(\App\Models\User::class, 'password')) ? ' required' : '' }} {{ $errors->has('password_confirm') ? 'error' : '' }}">
-        {{ Form::label('password_confirmation', trans('admin/users/table.password_confirm')) }}
+        <label for="password_confirmation">{{ trans('admin/users/table.password_confirm') }}</label>
         <input class="form-control" type="password" name="password_confirmation" id="password_confirmation" value="" required>
         {!! $errors->first('password_confirmation', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>


### PR DESCRIPTION
This PR replaces calls to `Form::label` with inline html on the user page in the setup guide.

