### PR TITLE
Replace call to Form::email

### DIFF
--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -125,7 +125,7 @@
       <!-- email-->
       <div class="form-group col-lg-6{{ $errors->has('email') ? 'error' : '' }}">
         {{ Form::label('email', trans('admin/users/table.email')) }}
-        {{ Form::email('email', config('mail.from.address'), array('class' => 'form-control','placeholder' => 'you@example.com', 'required' => true)) }}
+        <input class="form-control" type="email" name="email" id="email" value="{{ old('email', config('mail.from.address')) }}" placeholder="you@example.com" required>
         {!! $errors->first('email', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>
 


### PR DESCRIPTION
This PR replaces a call to `Form::email` with inline html on the user setup page.

