### PR TITLE
Fixed #16208 - don't call preg_split() with a null

### DIFF
--- a/app/Http/Requests/SettingsSamlRequest.php
+++ b/app/Http/Requests/SettingsSamlRequest.php
@@ -62,7 +62,7 @@ class SettingsSamlRequest extends FormRequest
             $custom_privateKey = '';
             $custom_x509certNew = '';
             if (! empty($this->input('saml_custom_settings'))) {
-                $req_custom_settings = preg_split('/\r\n|\r|\n/', $this->input('saml_custom_settings'));
+                $req_custom_settings = preg_split('/\r\n|\r|\n/', $this->input('saml_custom_settings', ''));
                 $custom_settings = [];
 
                 foreach ($req_custom_settings as $custom_setting) {

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -307,7 +307,7 @@ class CustomField extends Model
     public function formatFieldValuesAsArray()
     {
         $result = [];
-        $arr = preg_split('/\\r\\n|\\r|\\n/', $this->field_values);
+        $arr = preg_split('/\\r\\n|\\r|\\n/', $this->field_values ?? '');
 
         if (($this->element != 'checkbox') && ($this->element != 'radio')) {
             $result[''] = 'Select '.strtolower($this->format);

--- a/app/Services/Saml.php
+++ b/app/Services/Saml.php
@@ -209,7 +209,7 @@ class Saml
                 }
             }
 
-            $custom_settings = preg_split('/\r\n|\r|\n/', $setting->saml_custom_settings);
+            $custom_settings = preg_split('/\r\n|\r|\n/', $setting->saml_custom_settings ?? '');
             if ($custom_settings) {
                 foreach ($custom_settings as $custom_setting) {
                     $split = explode('=', $custom_setting, 2);


### PR DESCRIPTION
PHP has made the poor decision to start throwing deprecation warnings if you call `preg_split()` with a `null` as the second parameter - behavior that has been completely permissible for the last decade or more in PHP.

These somewhat pointless changes should silence those deprecation warnings and allow us to remain compatible with the latest versions of PHP.