### PR TITLE
Replace calls to Form::checkbox pt1

### DIFF
--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -128,7 +128,7 @@
           <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
             <div class="col-md-9 col-md-offset-3">
               <label for="image_delete" class="form-control">
-                {{ Form::checkbox('image_delete', '1', old('image_delete'), ['id' => 'image_delete', 'aria-label'=>'image_delete']) }}
+                <input type="checkbox" name="image_delete" id="image_delete" value="1" @checked(old('image_delete')) aria-label="image_delete">
                 {{ trans('general.image_delete') }}
               </label>
               {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}

--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -150,13 +150,23 @@
         @if ($snipeSettings->two_factor_enabled=='1')
         <div class="form-group {{ $errors->has('two_factor_optin') ? 'has-error' : '' }}">
           <div class="col-md-7 col-md-offset-3">
-            @can('self.two_factor')
-              <label class="form-control">{{ Form::checkbox('two_factor_optin', '1', old('two_factor_optin', $user->two_factor_optin)) }}
-            @else
-                <label class="form-control form-control--disabled">{{ Form::checkbox('two_factor_optin', '1', old('two_factor_optin', $user->two_factor_optin),['disabled' => 'disabled']) }}
-            @endcan
-
-            {{ trans('admin/settings/general.two_factor_enabled_text') }}</label>
+              <label
+                  for="two_factor_optin"
+                  @class([
+                    'form-control',
+                    'form-control--disabled' => auth()->user()->cannot('self.two_factor'),
+                  ])
+              >
+                <input
+                    type="checkbox"
+                    name="two_factor_optin"
+                    id="two_factor_optin"
+                    value="1"
+                    @checked(old('two_factor_optin', $user->two_factor_optin))
+                    @disabled(auth()->user()->cannot('self.two_factor'))
+                >
+                {{ trans('admin/settings/general.two_factor_enabled_text') }}
+              </label>
             @can('self.two_factor')
               <p class="help-block">{{ trans('admin/settings/general.two_factor_enabled_warning') }}</p>
             @else

--- a/resources/views/custom_fields/fieldsets/view.blade.php
+++ b/resources/views/custom_fields/fieldsets/view.blade.php
@@ -109,7 +109,7 @@
 
                 <div class="checkbox-inline">
                     <label>
-                    {{ Form::checkbox('required', 'on', old('required')) }}
+                      <input type="checkbox" name="required" value="on" @checked(old('required'))>
                       <span style="padding-left: 10px;">{{ trans('admin/custom_fields/general.required') }}</span>
                     </label>
                 </div>

--- a/resources/views/hardware/bulk.blade.php
+++ b/resources/views/hardware/bulk.blade.php
@@ -47,7 +47,7 @@
             </div>
             <div class="col-md-5">
               <label class="form-control">
-                {{ Form::checkbox('null_name', '1', false) }}
+                <input type="checkbox" name="null_name" value="1">
                 {{ trans_choice('general.set_to_null', count($assets), ['selection_count' => count($assets)]) }}
               </label>
             </div>
@@ -66,7 +66,7 @@
             </div>
             <div class="col-md-5">
               <label class="form-control">
-                {{ Form::checkbox('null_purchase_date', '1', false) }}
+                <input type="checkbox" name="null_purchase_date" value="1">
                 {{ trans_choice('general.set_to_null', count($assets),['selection_count' => count($assets)]) }}
               </label>
             </div>
@@ -85,7 +85,7 @@
              </div>
               <div class="col-md-5">
                 <label class="form-control">
-                  {{ Form::checkbox('null_expected_checkin_date', '1', false) }}
+                  <input type="checkbox" name="null_expected_checkin_date" value="1">
                   {{ trans_choice('general.set_to_null', count($assets), ['selection_count' => count($assets)]) }}
                 </label>
               </div>
@@ -103,7 +103,7 @@
             </div>
             <div class="col-md-5">
               <label class="form-control">
-                {{ Form::checkbox('null_asset_eol_date', '1', false) }}
+                <input type="checkbox" name="null_asset_eol_date" value="1">
                 {{ trans_choice('general.set_to_null', count($assets),['selection_count' => count($assets)]) }}
               </label>
             </div>
@@ -112,7 +112,7 @@
           <div class="form-group">
             <div class="col-md-9 col-md-offset-3">
               <label class="form-control">
-                {{ Form::checkbox('calc_eol', '1', false) }}
+                <input type="checkbox" name="calc_eol" value="1">
                 {{ trans('admin/hardware/form.calc_eol') }}
               </label>
             </div>
@@ -215,7 +215,7 @@
             </div>
             <div class="col-md-5">
               <label class="form-control">
-                {{ Form::checkbox('null_next_audit_date', '1', false) }}
+                <input type="checkbox" name="null_next_audit_date" value="1">
                 {{ trans_choice('general.set_to_null', count($assets), ['selection_count' => count($assets)]) }}
               </label>
             </div>


### PR DESCRIPTION
This PR replaces some calls to `Form::checkbox` with inline html on the following pages:

- [Account profile](https://snipe-it.test/account/profile)
- [Custom Fields settings](https://snipe-it.test/fields/fieldsets/1)
- [Bulk Edit Assets](https://snipe-it.test/hardware/bulkedit)

