### PR TITLE
Removed cols property from textarea component

### DIFF
--- a/resources/views/blade/input/textarea.blade.php
+++ b/resources/views/blade/input/textarea.blade.php
@@ -1,11 +1,9 @@
 @props([
     'value' => '',
-    'cols' => 50,
     'rows' => 10,
 ])
 
 <textarea
     {{ $attributes->merge(['class' => 'form-control']) }}
-    cols="{{ $cols }}"
     rows="{{ $rows }}"
 >{{ $value }}</textarea>


### PR DESCRIPTION
Following up on a [comment](https://github.com/snipe/snipe-it/pull/16075#discussion_r1950072320) in #16075, this PR simply removes `cols` from the props on the textarea component. It doesn't actually change anything visually since bootstrap takes over styling so why imply it is supported?