### PR TITLE
Replace Form::open and Form::close pt1

### DIFF
--- a/resources/views/account/change-password.blade.php
+++ b/resources/views/account/change-password.blade.php
@@ -11,7 +11,7 @@
 
 <div class="row">
     <div class="col-md-9">
-    <form method="POST" action="{{ route('account.password.update') }}" accept-charset="UTF-8" class="form-horizontal" autocomplete="off" enctype="multipart/form-data">
+    <form method="POST" action="{{ route('account.password.update') }}" accept-charset="UTF-8" class="form-horizontal" autocomplete="off">
     <!-- CSRF Token -->
         <input type="hidden" name="_token" value="{{ csrf_token() }}" />
         <div class="box box-default">

--- a/resources/views/account/change-password.blade.php
+++ b/resources/views/account/change-password.blade.php
@@ -11,7 +11,7 @@
 
 <div class="row">
     <div class="col-md-9">
-    {{ Form::open(['method' => 'POST', 'files' => true, 'class' => 'form-horizontal', 'autocomplete' => 'off']) }}
+    <form method="POST" action="{{ route('account.password.update') }}" accept-charset="UTF-8" class="form-horizontal" autocomplete="off" enctype="multipart/form-data">
     <!-- CSRF Token -->
         <input type="hidden" name="_token" value="{{ csrf_token() }}" />
         <div class="box box-default">

--- a/resources/views/account/change-password.blade.php
+++ b/resources/views/account/change-password.blade.php
@@ -63,7 +63,7 @@
             </div>
 
         </div> <!-- .box-default -->
-        {{ Form::close() }}
+        </form>
     </div> <!-- .col-md-9 -->
 </div> <!-- .row-->
 @stop

--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -187,7 +187,7 @@
         <button type="submit" class="btn btn-primary"><x-icon type="checkmark" /> {{ trans('general.save') }}</button>
       </div>
     </div> <!-- .box-default -->
-    {{ Form::close() }}
+    </form>
   </div> <!-- .col-md-9 -->
 </div> <!-- .row-->
 

--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -10,7 +10,7 @@
 
 <div class="row">
   <div class="col-md-9">
-  {{ Form::open(['method' => 'POST', 'files' => true, 'class' => 'form-horizontal', 'autocomplete' => 'off']) }}
+  <form method="POST" action="{{ route('profile.update') }}" accept-charset="UTF-8" class="form-horizontal" autocomplete="off" enctype="multipart/form-data">
   <!-- CSRF Token -->
     <input type="hidden" name="_token" value="{{ csrf_token() }}" />
     <div class="box box-default">

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -23,10 +23,10 @@
 
     <!-- Horizontal Form -->
     @if ($field->id)
-        {{ Form::open(['route' => ['fields.update', $field->id], 'class'=>'form-horizontal']) }}
+        <form method="POST" action="{{ route('fields.update', $field->id) }}" accept-charset="UTF-8" class="form-horizontal">
         {{ method_field('PUT') }}
     @else
-        {{ Form::open(['route' => 'fields.store', 'class'=>'form-horizontal']) }}
+        <form method="POST" action="{{ route('fields.store') }}" accept-charset="UTF-8" class="form-horizontal">
     @endif
 
     @csrf

--- a/resources/views/custom_fields/fields/edit.blade.php
+++ b/resources/views/custom_fields/fields/edit.blade.php
@@ -269,7 +269,7 @@
 
 
 </div>
-{{ Form::close() }}
+</form>
 @stop
 
 @section('moar_scripts')

--- a/resources/views/custom_fields/fieldsets/view.blade.php
+++ b/resources/views/custom_fields/fieldsets/view.blade.php
@@ -88,11 +88,8 @@
           <tfoot>
             <tr>
               <td colspan="8">
-                {{ Form::open(['route' =>
-                ["fieldsets.associate",$custom_fieldset->id],
-                'class'=>'form-inline',
-                'id' => 'ordering']) }}
-
+                <form method="POST" action="{{ route('fieldsets.associate', $custom_fieldset->id) }}" accept-charset="UTF-8" class="form-inline" id="ordering">
+                  @csrf
 
                 <div class="form-group">
                   <label for="field_id" class="sr-only">

--- a/resources/views/custom_fields/fieldsets/view.blade.php
+++ b/resources/views/custom_fields/fieldsets/view.blade.php
@@ -115,7 +115,7 @@
                   <button type="submit" class="btn btn-primary"> {{ trans('general.save') }}</button>
                 </span>
 
-                {{ Form::close() }}
+                </form>
 
               </td>
             </tr>

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -87,13 +87,15 @@
                 @endcan
 
                 @can('delete', $fieldset)
-                {{ Form::open(['route' => array('fieldsets.destroy', $fieldset->id), 'method' => 'delete','style' => 'display:inline-block']) }}
+                <form method="POST" action="{{ route('fieldsets.destroy', $fieldset->id) }}" accept-charset="UTF-8" style="display:inline-block">
+                  {{ method_field('DELETE') }}
+                  @csrf
                   @if($fieldset->models->count() > 0)
                   <button type="submit" class="btn btn-danger btn-sm disabled" data-tooltip="true" title="{{ trans('general.cannot_be_deleted') }}" disabled><i class="fas fa-trash"></i></button>
                   @else
                   <button type="submit" class="btn btn-danger btn-sm" data-tooltip="true" title="{{ trans('general.delete') }}"><i class="fas fa-trash"></i></button>
                   @endif
-                {{ Form::close() }}
+                </form>
                 @endcan
                   </nobr>
               </td>
@@ -192,7 +194,9 @@
               </td>
               <td>
                 <nobr>
-                  {{ Form::open(array('route' => array('fields.destroy', $field->id), 'method' => 'delete', 'style' => 'display:inline-block')) }}
+                  <form method="POST" action="{{ route('fields.destroy', $field->id) }}" accept-charset="UTF-8" style="display:inline-block">
+                    {{ method_field('DELETE') }}
+                    @csrf
                   @can('update', $field)
                     <a href="{{ route('fields.edit', $field->id) }}" class="btn btn-warning btn-sm" data-tooltip="true" title="{{ trans('general.update') }}">
                       <i class="fas fa-pencil-alt" aria-hidden="true"></i>
@@ -214,7 +218,7 @@
                   @endif
 
                 @endcan
-                  {{ Form::close() }}
+                  </form>
                 </nobr>
               </td>
             </tr>

--- a/resources/views/depreciations/view.blade.php
+++ b/resources/views/depreciations/view.blade.php
@@ -129,13 +129,8 @@
                     <div class="tab-pane" id="models">
 
                         <div class="row">
-                            {{ Form::open(
-                                      [
-                                     'method' => 'POST',
-                                     'route' => ['models.bulkedit.index'],
-                                     'class' => 'form-inline',
-                                     'id' => 'bulkForm']
-                                      ) }}
+                            <form method="POST" action="{{ route('models.bulkedit.index') }}" accept-charset="UTF-8" class="form-inline" id="bulkForm">
+                            @csrf
                             <div class="col-md-12">
                                 <div id="toolbar">
                                     <label for="bulk_actions" class="sr-only">{{ trans('general.bulk_actions') }}</label>

--- a/routes/web.php
+++ b/routes/web.php
@@ -285,7 +285,7 @@ Route::group(['prefix' => 'account', 'middleware' => ['auth']], function () {
     Route::get('menu', [ProfileController::class, 'getMenuState'])->name('account.menuprefs');
 
     Route::get('password', [ProfileController::class, 'password'])->name('account.password.index');
-    Route::post('password', [ProfileController::class, 'passwordSave']);
+    Route::post('password', [ProfileController::class, 'passwordSave'])->name('account.password.update');
 
     Route::get('api', [ProfileController::class, 'api'])->name('user.api');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -280,7 +280,7 @@ Route::group(['prefix' => 'account', 'middleware' => ['auth']], function () {
 
     // Profile
     Route::get('profile', [ProfileController::class, 'getIndex'])->name('profile');
-    Route::post('profile', [ProfileController::class, 'postIndex']);
+    Route::post('profile', [ProfileController::class, 'postIndex'])->name('profile.update');
 
     Route::get('menu', [ProfileController::class, 'getMenuState'])->name('account.menuprefs');
 


### PR DESCRIPTION
This PR replaces `Form::open` and `Form::close` on the following pages:

- Account
	- [snipe-it.test/account/password](https://snipe-it.test/account/password)
	- [snipe-it.test/account/profile](https://snipe-it.test/account/profile)
-Custom Fields
	- [snipe-it.test/fields](https://snipe-it.test/fields)
		- deleting fieldset
		- deleting custom field
	- [snipe-it.test/fields/create](https://snipe-it.test/fields/create)
	- [snipe-it.test/fields/1/edit](https://snipe-it.test/fields/1/edit)
-Depreciations
	- [snipe-it.test/depreciations/1#models](https://snipe-it.test/depreciations/1#models)
	- 	Bulk Edit button