### PR TITLE
Fixed: Name Format Tests

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -623,7 +623,9 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
             } elseif ($format == 'firstname') {
                 $username = str_slug($first_name);
             } elseif ($format == 'lastname_firstinitial') {
-                $username = str_slug($last_name).'_'.str_slug(substr($first_name, 0, 1));
+                $username = str_slug($last_name) . '_' . str_slug(substr($first_name, 0, 1));
+            } elseif ($format == 'firstinitial_lastname') {
+                $username = str_slug(substr($first_name,0,1)).'_'.str_slug($last_name);
             } elseif ($format == 'firstnamelastname') {
                 $username = str_slug($first_name).str_slug($last_name);
             } elseif ($format == 'firstnamelastinitial') {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -616,14 +616,12 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
                 $username = str_slug($first_name) . '.' . str_slug($last_name);
             } elseif ($format == 'lastnamefirstinitial') {
                 $username = str_slug($last_name.substr($first_name, 0, 1));
-            } elseif ($format == 'firstintial.lastname') {
-                $username = substr($first_name, 0, 1).'.'.str_slug($last_name);
+            } elseif ($format == 'firstinitial.lastname') {
+                $username = str_slug(substr($first_name, 0, 1)).'.'.str_slug($last_name);
             } elseif ($format == 'firstname_lastname') {
                 $username = str_slug($first_name).'_'.str_slug($last_name);
             } elseif ($format == 'firstname') {
                 $username = str_slug($first_name);
-            } elseif ($format == 'firstinitial.lastname') {
-                $username = str_slug(substr($first_name, 0, 1).'.'.str_slug($last_name));
             } elseif ($format == 'lastname_firstinitial') {
                 $username = str_slug($last_name).'_'.str_slug(substr($first_name, 0, 1));
             } elseif ($format == 'firstnamelastname') {

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -51,7 +51,7 @@ class UserTest extends TestCase
     public function testFirstInitialUnderscoreLastName()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
-        $expected_username = 'nallanovna-romanova-oshostakova';
+        $expected_username = 'n_allanovna-romanova-oshostakova';
         $user = User::generateFormattedNameFromFullName($fullname, 'firstinitial_lastname');
         $this->assertEquals($expected_username, $user['username']);
     }
@@ -75,7 +75,7 @@ class UserTest extends TestCase
     public function testLastNameUnderscoreFirstInitial()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
-        $expected_username = 'allanovnaromanovaoshostakova_n';
+        $expected_username = 'allanovna-romanova-oshostakova_n';
         $user = User::generateFormattedNameFromFullName($fullname, 'lastname_firstinitial');
         $this->assertEquals($expected_username, $user['username']);
     }
@@ -83,7 +83,7 @@ class UserTest extends TestCase
     public function testFirstNameLastName()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
-        $expected_username = 'nataliaallanovnaromanovaoshostakova';
+        $expected_username = 'nataliaallanovna-romanova-oshostakova';
         $user = User::generateFormattedNameFromFullName($fullname, 'firstnamelastname');
         $this->assertEquals($expected_username, $user['username']);
     }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -67,7 +67,7 @@ class UserTest extends TestCase
     public function testFirstInitialDotLastname()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
-        $expected_username = 'n.allanovnaromanovaoshostakova';
+        $expected_username = 'n.allanovna-romanova-oshostakova';
         $user = User::generateFormattedNameFromFullName($fullname, 'firstinitial.lastname');
         $this->assertEquals($expected_username, $user['username']);
     }

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -64,7 +64,7 @@ class UserTest extends TestCase
         $this->assertEquals($expected_username, $user['username']);
     }
 
-    public function firstInitialDotLastname()
+    public function testFirstInitialDotLastname()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
         $expected_username = 'n.allanovnaromanovaoshostakova';
@@ -72,7 +72,7 @@ class UserTest extends TestCase
         $this->assertEquals($expected_username, $user['username']);
     }
 
-    public function lastNameUnderscoreFirstInitial()
+    public function testLastNameUnderscoreFirstInitial()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
         $expected_username = 'allanovnaromanovaoshostakova_n';
@@ -80,7 +80,7 @@ class UserTest extends TestCase
         $this->assertEquals($expected_username, $user['username']);
     }
 
-    public function firstNameLastName()
+    public function testFirstNameLastName()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
         $expected_username = 'nataliaallanovnaromanovaoshostakova';
@@ -88,7 +88,7 @@ class UserTest extends TestCase
         $this->assertEquals($expected_username, $user['username']);
     }
 
-    public function firstNameLastInitial()
+    public function testFirstNameLastInitial()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
         $expected_username = 'nataliaa';


### PR DESCRIPTION
Some User Unit tests were not prefixed with `test` so they were not running.
This adds the prefixes on those test to ensure they will run, and then fixed the tests that were failing.

