### PR TITLE
Replace Form::open and Form::close pt2

### DIFF
--- a/resources/views/hardware/audit.blade.php
+++ b/resources/views/hardware/audit.blade.php
@@ -21,11 +21,7 @@
         <div class="col-md-8 col-md-offset-2">
             <div class="box box-default">
 
-                {{ Form::open([
-                  'method' => 'POST',
-                  'route' => ['asset.audit.store', $asset->id],
-                  'files' => true,
-                  'class' => 'form-horizontal' ]) }}
+                <form method="POST" action="{{ route('asset.audit.store', $asset->id) }}" accept-charset="UTF-8" class="form-horizontal" enctype="multipart/form-data">
 
                     <div class="box-header with-border">
                         <h2 class="box-title"> {{ trans('admin/hardware/form.tag') }} {{ $asset->asset_tag }}</h2>

--- a/resources/views/hardware/quickscan-checkin.blade.php
+++ b/resources/views/hardware/quickscan-checkin.blade.php
@@ -16,10 +16,10 @@
         }
     </style>
 
-    
+
 
     <div class="row">
-    {{ Form::open(['method' => 'POST', 'class' => 'form-horizontal', 'role' => 'form', 'id' => 'checkin-form' ]) }}
+    <form method="POST" action="{{ route('hardware/quickscancheckin') }}" accept-charset="UTF-8" class="form-horizontal" role="form" id="checkin-form">
         <!-- left column -->
         <div class="col-md-6">
             <div class="box box-default">
@@ -63,8 +63,8 @@
                                 {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
-    
-    
+
+
 
                 </div> <!--/.box-body-->
                 <div class="box-footer">
@@ -78,7 +78,7 @@
 
 
 
-            {{Form::close()}}
+            </form>
         </div> <!--/.col-md-6-->
 
         <div class="col-md-6">
@@ -87,7 +87,7 @@
                     <h2 class="box-title"> {{ trans('general.quickscan_checkin_status') }} (<span id="checkin-counter">0</span> {{ trans('general.assets_checked_in_count') }}) </h2>
                 </div>
                 <div class="box-body">
-    
+
                     <table id="checkedin" class="table table-striped snipe-table">
                         <thead>
                         <tr>

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -19,7 +19,7 @@
 
 
     <div class="row">
-    {{ Form::open(['method' => 'POST', 'class' => 'form-horizontal', 'role' => 'form', 'id' => 'audit-form' ]) }}
+    <form method="POST" accept-charset="UTF-8" class="form-horizontal" role="form" id="audit-form">
         <!-- left column -->
         <div class="col-md-6">
             <div class="box box-default">
@@ -92,7 +92,7 @@
 
 
 
-            {{Form::close()}}
+            </form>
         </div> <!--/.col-md-6-->
 
         <div class="col-md-6">

--- a/resources/views/hardware/requested.blade.php
+++ b/resources/views/hardware/requested.blade.php
@@ -100,18 +100,19 @@
                             </td>
                             <td>{{ App\Helpers\Helper::getFormattedDateObject($request->created_at, 'datetime', false) }}</td>
                             <td>
-                                {{ Form::open([
-                                    'method' => 'POST',
-                                    'route' => [
-                                        'account/request-item',
+                                <form
+                                    method="POST"
+                                    action="{{ route('account/request-item', [
                                         $request->itemType(),
                                         $request->requestable->id,
-                                        true,
-                                        $request->requestingUser()->id
-                                    ],
-                                    ]) }}
+                                         true,
+                                         $request->requestingUser()->id
+                                    ]) }}"
+                                    accept-charset="UTF-8"
+                                >
+                                    @csrf
                                     <button class="btn btn-warning btn-sm" data-tooltip="true" title="{{ trans('general.cancel_request') }}">{{ trans('button.cancel') }}</button>
-                                {{ Form::close() }}
+                                </form>
                             </td>
                             <td>
                                 @if ($request->itemType() == "asset")


### PR DESCRIPTION
This PR replaces `Form::open` and `Form::close` on the following pages:

- [Asset Audit](https://snipe-it.test/hardware/audit/1)
- [Quick Scan Check in ](https://snipe-it.test/hardware/quickscancheckin)
- [Hardware Bulk Edit](https://snipe-it.test/hardware/bulkaudit)
- [Requested Assets](https://snipe-it.test/hardware/requested)

