### PR TITLE
Replace Form::open and Form::close pt3

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -252,18 +252,21 @@
                                 @endcan
 
                                 <div class="col-md-12 hidden-print" style="padding-top: 5px;">
-                                    {{ Form::open([
-                                                     'method' => 'POST',
-                                                     'route' => ['hardware/bulkedit'],
-                                                     'class' => 'form-inline',
-                                                      'target'=>'_blank',
-                                                      'id' => 'bulkForm']) }}
+                                    <form
+                                        method="POST"
+                                        action="{{ route('hardware/bulkedit') }}"
+                                        accept-charset="UTF-8"
+                                        class="form-inline"
+                                        target="_blank"
+                                        id="bulkForm"
+                                    >
+                                    @csrf
                                     <input type="hidden" name="bulk_actions" value="labels" />
                                     <input type="hidden" name="ids[{{$asset->id}}]" value="{{ $asset->id }}" />
                                     <button class="btn btn-block btn-social btn-sm btn-default" id="bulkEdit"{{ (!$asset->model ? ' disabled' : '') }}{!! (!$asset->model ? ' data-tooltip="true" title="'.trans('admin/hardware/general.model_invalid').'"' : '') !!}>
                                         <x-icon type="assets" />
                                         {{ trans_choice('button.generate_labels', 1) }}</button>
-                                        {{ Form::close() }}
+                                    </form>
                                 </div>
 
                                 @can('delete', $asset)
@@ -430,7 +433,7 @@
                                                     {{ $asset->assetstatus->name }}
                                                     <label class="label label-default">{{ trans('general.deployed') }}</label>
 
-                                                
+
                                                     <x-icon type="long-arrow-right" />
                                                     <x-icon type="{{ $asset->assignedType() }}" class="fa-fw" />
                                                     {!!  $asset->assignedTo->present()->nameUrl() !!}
@@ -1112,7 +1115,7 @@
                                             {{ ($asset->userRequests) ? (int) $asset->userRequests->count() : '0' }}
                                         </div>
                                     </div>
-                                    
+
                                 </div> <!--/end striped container-->
                             </div> <!-- end col-md-9 -->
                         </div><!-- end info-stack-container -->
@@ -1230,11 +1233,14 @@
                                 @if ($asset->assignedAssets->count() > 0)
 
 
-                                    {{ Form::open([
-                                              'method' => 'POST',
-                                              'route' => ['hardware/bulkedit'],
-                                              'class' => 'form-inline',
-                                               'id' => 'bulkForm']) }}
+                                    <form
+                                        method="POST"
+                                        action="{{ route('hardware/bulkedit') }}"
+                                        accept-charset="UTF-8"
+                                        class="form-inline"
+                                        id="bulkForm"
+                                    >
+                                    @csrf
                                     <div id="toolbar">
                                         <label for="bulk_actions"><span class="sr-only">{{ trans('general.bulk_actions')}}</span></label>
                                         <select name="bulk_actions" class="form-control select2" style="width: 150px;" aria-label="bulk_actions">
@@ -1272,7 +1278,7 @@
                                         </table>
 
 
-                                        {{ Form::close() }}
+                                        </form>
                                     </div>
 
                                 @else

--- a/resources/views/modals/upload-file.blade.php
+++ b/resources/views/modals/upload-file.blade.php
@@ -6,11 +6,13 @@
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                 <h4 class="modal-title" id="uploadFileModalLabel">{{ trans('general.file_upload') }}</h4>
             </div>
-            {{ Form::open([
-            'method' => 'POST',
-            'route' => ['upload/'.$item_type, $item_id],
-            'files' => true,
-            'class' => 'form-horizontal' ]) }}
+            <form
+                method="POST"
+                action="{{ route('upload/' . $item_type, $item_id) }}"
+                accept-charset="UTF-8"
+                class="form-horizontal"
+                enctype="multipart/form-data"
+            >
             <input type="hidden" name="_token" value="{{ csrf_token() }}" />
             <div class="modal-body">
 
@@ -46,7 +48,7 @@
                 <a href="#" class="pull-left" data-dismiss="modal">{{ trans('button.cancel') }}</a>
                 <button type="submit" class="btn btn-primary">{{ trans('button.upload') }}</button>
             </div>
-            {{ Form::close() }}
+            </form>
         </div>
     </div>
 </div>

--- a/resources/views/models/index.blade.php
+++ b/resources/views/models/index.blade.php
@@ -62,7 +62,6 @@
               </table>
         </div>
         </div>
-        {{ Form::close() }}
       </div><!-- /.box-body -->
     </div><!-- /.box -->
   </div>

--- a/resources/views/models/view.blade.php
+++ b/resources/views/models/view.blade.php
@@ -98,7 +98,6 @@
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                 }'>
                     </table>
-                    {{ Form::close() }}
                 </div> <!-- /.tab-pane assets -->
 
 

--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -1,10 +1,12 @@
 <div id="{{ (isset($id_divname)) ? $id_divname : 'assetsBulkEditToolbar' }}" style="min-width:400px">
-{{ Form::open([
-      'method' => 'POST',
-      'route' => ['hardware/bulkedit'],
-      'class' => 'form-inline',
-      'id' => (isset($id_formname)) ? $id_formname : 'assetsBulkForm',
- ]) }}
+    <form
+    method="POST"
+    action="{{ route('hardware/bulkedit') }}"
+    accept-charset="UTF-8"
+    class="form-inline"
+    id="{{ (isset($id_formname)) ? $id_formname : 'assetsBulkForm' }}"
+>
+    @csrf
 
     {{-- The sort and order will only be used if the cookie is actually empty (like on first-use) --}}
     <input name="sort" type="hidden" value="assets.id">
@@ -34,5 +36,5 @@
     </select>
 
     <button class="btn btn-primary" id="{{ (isset($id_button)) ? $id_button : 'bulkAssetEditButton' }}" disabled>{{ trans('button.go') }}</button>
-    {{ Form::close() }}
+    </form>
 </div>

--- a/resources/views/partials/locations-bulk-actions.blade.php
+++ b/resources/views/partials/locations-bulk-actions.blade.php
@@ -1,11 +1,13 @@
 @can('delete', \App\Models\Location::class)
     <div id="locationsBulkEditToolbar">
-    {{ Form::open([
-              'method' => 'POST',
-              'route' => ['locations.bulkdelete.show'],
-              'class' => 'form-inline',
-              'id' => 'locationsBulkForm']) }}
-
+    <form
+        method="POST"
+        action="{{ route('locations.bulkdelete.show') }}"
+        accept-charset="UTF-8"
+        class="form-inline"
+        id="locationsBulkForm"
+    >
+            @csrf
             <div id="locations-toolbar">
                 <label for="bulk_actions" class="sr-only">{{ trans('general.bulk_actions') }}</label>
                 <select name="bulk_actions" class="form-control select2" style="width: 200px;" aria-label="bulk_actions">
@@ -14,7 +16,7 @@
                 <button class="btn btn-primary" id="bulkLocationsEditButton" disabled>{{ trans('button.go') }}</button>
             </div>
 
-    {{ Form::close() }}
+    </form>
     </div>
 @endcan
 

--- a/resources/views/partials/models-bulk-actions.blade.php
+++ b/resources/views/partials/models-bulk-actions.blade.php
@@ -1,10 +1,12 @@
 <div id="modelsBulkEditToolbar">
-    {{ Form::open([
-              'method' => 'POST',
-              'route' => ['models.bulkedit.index'],
-              'class' => 'form-inline',
-              'id' => 'modelsBulkForm']) }}
-
+    <form
+        method="POST"
+        action="{{route('models.bulkedit.index')}}"
+        accept-charset="UTF-8"
+        class="form-inline"
+        id="modelsBulkForm"
+    >
+    @csrf
     @if (request('status')!='deleted')
         @can('delete', \App\Models\AssetModel::class)
             <div id="models-toolbar">
@@ -17,7 +19,7 @@
             </div>
         @endcan
     @endif
-    {{ Form::close() }}
+    </form>
 </div>
 
 


### PR DESCRIPTION
This PR replaces and removes some unneeded`Form::open` and `Form::close` on the following pages:

- [Asset view](https://snipe-it.test/hardware/1)
	- Generate Label button
	- [Assigned Assets](https://snipe-it.test/hardware/1#assets)
- [File upload modal like on asset view page](https://snipe-it.test/hardware/1#details)
- [Models index](https://snipe-it.test/models)
- [Model view](https://snipe-it.test/models/1)
- Bulk actions partial for assets like on [asset index page](https://snipe-it.test/hardware)
- Bulk actions partial for locations like on [location index page](https://snipe-it.test/locations)
- Bulk actions partial for models like on [model index page](https://snipe-it.test/models)
