### PR TITLE
Replace Form::open and Form::close pt4

### DIFF
--- a/resources/views/partials/users-bulk-actions.blade.php
+++ b/resources/views/partials/users-bulk-actions.blade.php
@@ -10,7 +10,7 @@
                 class="form-inline"
                 id="usersBulkForm"
             >
-
+            @csrf
 
             <div id="users-toolbar" style="width:100% !important;">
                 <label for="bulk_actions" class="sr-only">{{ trans('general.bulk_actions') }}</label>

--- a/resources/views/partials/users-bulk-actions.blade.php
+++ b/resources/views/partials/users-bulk-actions.blade.php
@@ -3,11 +3,13 @@
 
         @if (request('status')!='deleted')
 
-            {{ Form::open([
-              'method' => 'POST',
-              'route' => ['users/bulkedit'],
-              'class' => 'form-inline',
-              'id' => 'usersBulkForm']) }}
+            <form
+                method="POST"
+                action="{{ route('users/bulkedit') }}"
+                accept-charset="UTF-8"
+                class="form-inline"
+                id="usersBulkForm"
+            >
 
 
             <div id="users-toolbar" style="width:100% !important;">
@@ -28,7 +30,7 @@
                 </select>
                 <button class="btn btn-primary" id="bulkUserEditButton" disabled>{{ trans('button.go') }}</button>
             </div>
-            {{ Form::close() }}
+            </form>
         @endif
 
     </div>

--- a/resources/views/reports/activity.blade.php
+++ b/resources/views/reports/activity.blade.php
@@ -7,13 +7,13 @@
 @stop
 
 @section('header_right')
-    {{ Form::open(['method' => 'post', 'class' => 'form-horizontal']) }}
+    <form method="POST" action="{{ route('reports.activity.post') }}" accept-charset="UTF-8" class="form-horizontal">
     {{csrf_field()}}
     <button type="submit" class="btn btn-default">
         <x-icon type="download" />
         {{ trans('general.download_all') }}
     </button>
-    {{ Form::close() }}
+    </form>
 @stop
 
 {{-- Page content --}}

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -35,12 +35,13 @@
 <div class="row">
     <div class="col-md-8 col-md-offset-1">
 
-        {{ Form::open([
-            'method' => 'post',
-            'class' => 'form-horizontal',
-            'id' => 'custom-report-form',
-            'url' => request()->routeIs('report-templates.edit') ? route('report-templates.update', $template) : '/reports/custom',
-        ]) }}
+        <form
+            method="POST"
+            action="{{ request()->routeIs('report-templates.edit') ? route('report-templates.update', $template) : '/reports/custom' }}"
+            accept-charset="UTF-8"
+            class="form-horizontal"
+            id="custom-report-form"
+        >
         {{csrf_field()}}
 
     <!-- Horizontal Form -->
@@ -631,7 +632,7 @@
                 @endif
             </div>
         </div> <!--/.box.box-default-->
-    {{ Form::close() }}
+        </form>
     </div>
 
     <!-- Saved Reports right column -->

--- a/resources/views/reports/unaccepted_assets.blade.php
+++ b/resources/views/reports/unaccepted_assets.blade.php
@@ -19,10 +19,10 @@
             @endif
         </div>
         <div class="btn-group mr-2" role="group">
-            {{ Form::open(['method' => 'post', 'class' => 'form-horizontal']) }}
+            <form method="POST" action="{{ route('reports/export/unaccepted_assets') }}" accept-charset="UTF-8" class="form-horizontal">
             {{csrf_field()}}
             <button type="submit" class="btn btn-default"><i class="fa fa-download icon-white" aria-hidden="true"></i> {{ trans('general.download_all') }}</button>
-            {{ Form::close() }}
+            </form>
         </div>
     </div>
 @stop

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -176,7 +176,7 @@
         </div> <!-- /.col-md-8-->
     </div> <!-- /.row-->
 
-    {{Form::close()}}
+    </form>
 
 @stop
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -390,7 +390,7 @@ Route::group(['middleware' => ['auth']], function () {
         [ReportsController::class, 'getActivityReport']
     )->name('reports.activity');
 
-    Route::post('reports/activity', [ReportsController::class, 'postActivityReport']);
+    Route::post('reports/activity', [ReportsController::class, 'postActivityReport'])->name('reports.activity.post');
 
     Route::get(
         'reports/unaccepted_assets/{deleted?}',


### PR DESCRIPTION
This PR replaces `Form::open` and `Form::close` on the following pages:

- Bulk actions partial for users like on [users index page](https://snipe-it.test/users)
- Download All button on [activity report page](https://snipe-it.test/reports/activity)
- [Custom Report](https://snipe-it.test/reports/custom) and [edit custom report](https://snipe-it.test/reports/templates/1/edit) pages
- Download all button on [unaccepted asset report page](https://snipe-it.test/reports/unaccepted_assets)
- [Notification settings page](https://snipe-it.test/admin/notifications)