### PR TITLE
Replace Form::open and Form::close pt5

### DIFF
--- a/resources/views/settings/asset_tags.blade.php
+++ b/resources/views/settings/asset_tags.blade.php
@@ -21,7 +21,7 @@
     </style>
 
 
-    {{ Form::open(['method' => 'POST', 'files' => false, 'autocomplete' => 'off', 'class' => 'form-horizontal', 'role' => 'form' ]) }}
+    <form method="POST" action="{{ route('settings.asset_tags.save') }}" accept-charset="UTF-8" autocomplete="off" class="form-horizontal" role="form">
     <!-- CSRF Token -->
     {{csrf_field()}}
 
@@ -106,6 +106,6 @@
         </div> <!-- /.col-md-8-->
     </div> <!-- /.row-->
 
-    {{Form::close()}}
+    </form>
 
 @stop

--- a/resources/views/settings/backups.blade.php
+++ b/resources/views/settings/backups.blade.php
@@ -158,12 +158,8 @@
         @if (config('app.lock_passwords')===true)
         <p class="alert alert-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
           @else
-              
-      {{ Form::open([
-        'method' => 'POST',
-        'route' => 'settings.backups.upload',
-        'files' => true,
-        'class' => 'form-horizontal' ]) }}
+
+      <form method="POST" action="{{ route('settings.backups.upload') }}" accept-charset="UTF-8" class="form-horizontal" enctype="multipart/form-data">
         @csrf
 
         
@@ -194,7 +190,7 @@
             
     </div>
     
-    {{ Form::close() }}
+    </form>
     @endif  
       </div>
     </div>

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -21,7 +21,17 @@
     </style>
 
 
-    {{ Form::open(['method' => 'POST', 'files' => true, 'autocomplete' => 'off', 'class' => 'form-horizontal', 'role' => 'form', 'id' => 'create-form' ]) }}
+    <form
+        method="POST"
+        action="{{ route('settings.branding.save') }}"
+        accept-charset="UTF-8"
+        autocomplete="off"
+        class="form-horizontal"
+        role="form"
+        id="create-form"
+        enctype="multipart/form-data"
+        novalidate="novalidate"
+    >
     <!-- CSRF Token -->
     {{csrf_field()}}
 
@@ -341,7 +351,7 @@
         </div> <!-- /.col-md-8-->
     </div> <!-- /.row-->
 
-    {{Form::close()}}
+    </form>
 
 @stop
 

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -366,7 +366,7 @@
                            </div>
                        </div>
 
-                       
+
                        <!-- Depreciation method -->
                        <div class="form-group {{ $errors->has('depreciation_method') ? 'error' : '' }}">
                            <div class="col-md-3">
@@ -374,9 +374,9 @@
                            </div>
                            <div class="col-md-9">
                                {{ Form::select('depreciation_method', array(
-                                    'default' => 'Linear (default)', 
-                                    'half_1' => 'Half-year convention, always applied', 
-                                    'half_2' => 'Half-year convention, applied with condition', 
+                                    'default' => 'Linear (default)',
+                                    'half_1' => 'Half-year convention, always applied',
+                                    'half_2' => 'Half-year convention, applied with condition',
                                 ), old('username_format', $setting->depreciation_method), ['class' =>'select2', 'style' => 'width: 80%']) }}
                            </div>
                        </div>
@@ -423,7 +423,7 @@
     </div> <!-- /.col-md-8-->
 
 
-    {{ Form::close() }}
+    </form>
 
 @stop
 

--- a/resources/views/settings/google.blade.php
+++ b/resources/views/settings/google.blade.php
@@ -16,7 +16,7 @@
 
 
 
-    {{ Form::open(['method' => 'POST', 'files' => false, 'autocomplete' => 'off', 'class' => 'form-horizontal', 'role' => 'form' ]) }}
+    <form method="POST" action="{{ route('settings.google.save') }}" accept-charset="UTF-8" autocomplete="off" class="form-horizontal" role="form">
     <!-- CSRF Token -->
     {{csrf_field()}}
 
@@ -113,6 +113,6 @@
         </div> <!-- /.col-md-8-->
     </div> <!-- /.row-->
 
-    {{Form::close()}}
+    </form>
 
 @stop

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -20,7 +20,7 @@
         }
     </style>
 
-    {{ Form::open(['id' => 'settingsForm', 'method' => 'POST', 'files' => false, 'autocomplete' => 'off', 'class' => 'form-horizontal', 'role' => 'form' ]) }}
+    <form method="POST" action="{{ route('settings.labels.save') }}" accept-charset="UTF-8" id="settingsForm" autocomplete="off" class="form-horizontal" role="form">
     <!-- CSRF Token -->
     {{csrf_field()}}
 
@@ -513,7 +513,7 @@
         </div> <!-- /.col-md-8-->
     </div> <!-- /.row-->
 
-    {{Form::close()}}
+    </form>
 
 @stop
 

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -341,8 +341,6 @@
                         }
                     </style>
 
-
-                    {{ Form::open(['method' => 'POST', 'files' => false, 'autocomplete' => 'off', 'class' => 'form-horizontal', 'role' => 'form' ]) }}
                     <!-- CSRF Token -->
                     {{csrf_field()}}
 


### PR DESCRIPTION
This PR replaces `Form::open` and `Form::close` on the following pages:

- [Asset Tag settings](https://snipe-it.test/admin/asset_tags)
- [Backups](https://snipe-it.test/admin/backups)
- [Branding settings](https://snipe-it.test/admin/branding)
- [General settings](https://snipe-it.test/admin/settings)
- [Google settings](https://snipe-it.test/admin/google)
- [Label settings](https://snipe-it.test/admin/labels)

Accidentally included some whitespace formatting.