### PR TITLE
Replace Form::open and Form::close pt6

### DIFF
--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -837,7 +837,7 @@
         </div> <!-- /.col-md-8-->
     </div> <!-- /.row-->
 
-    {{Form::close()}}
+    </form>
 
 
 @endsection

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -21,7 +21,7 @@
     </style>
 
 
-    {{ Form::open(['method' => 'POST', 'files' => false, 'autocomplete' => 'off', 'class' => 'form-horizontal', 'role' => 'form' ]) }}
+    <form method="POST" action="{{ route('settings.localization.save') }}" accept-charset="UTF-8" autocomplete="off" class="form-horizontal" role="form">
     <!-- CSRF Token -->
     {{csrf_field()}}
 
@@ -113,7 +113,7 @@
         </div> <!-- /.col-md-8-->
     </div> <!-- /.row-->
 
-    {{Form::close()}}
+    </form>
 
 @stop
 

--- a/resources/views/settings/purge-form.blade.php
+++ b/resources/views/settings/purge-form.blade.php
@@ -22,7 +22,7 @@
                         <x-icon type="warning"/>
                         {{ trans('admin/settings/general.purge') }}</h2>
                 </div>
-            {{ Form::open(['method' => 'POST', 'files' => false, 'autocomplete' => 'off', 'class' => 'form-horizontal', 'role' => 'form' ]) }}
+                <form method="POST" action="{{ route('settings.purge.save') }}" accept-charset="UTF-8" autocomplete="off" class="form-horizontal" role="form">
             <!-- CSRF Token -->
                 {{csrf_field()}}
                 <div class="box-body">
@@ -45,11 +45,9 @@
                 <div class="box-footer text-right">
                     <button type="submit" class="btn btn-danger" {{ (config('app.lock_passwords')===true) ? ' disabled' : '' }}>{{ trans('admin/settings/general.purge') }}</button>
                 </div> <!--/box-footer-->
-                {{ Form::close() }}
+                </form>
             </div> <!--/.box-solid-->
         </div><!-- /.col-md-8-->
     </div><!--/.row-->
-
-    {{Form::close()}}
 
 @stop

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -21,7 +21,7 @@
     </style>
 
 
-    {{ Form::open(['method' => 'POST', 'files' => false, 'autocomplete' => 'false', 'class' => 'form-horizontal', 'role' => 'form']) }}
+    <form method="POST" action="{{ route('settings.saml.save') }}" accept-charset="UTF-8" autocomplete="false" class="form-horizontal" role="form">
     <!-- CSRF Token -->
     {{csrf_field()}}
 
@@ -202,7 +202,7 @@
         </div> <!-- /.col-md-8-->
     </div> <!-- /.row-->
 
-    {{Form::close()}}
+    </form>
 
 
 @stop

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -190,6 +190,6 @@
         </div> <!-- /.col-md-8-->
     </div> <!-- /.row-->
 
-    {{Form::close()}}
+    </form>
 
 @stop

--- a/resources/views/statuslabels/view.blade.php
+++ b/resources/views/statuslabels/view.blade.php
@@ -40,7 +40,6 @@
                                 </table>
                         </div><!-- /.col -->
                     </div><!-- /.row -->
-                    {{ Form::close() }}
                 </div><!-- ./box-body -->
             </div><!-- /.box -->
         </div>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -66,9 +66,6 @@
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                 }'>
                     </table>
-
-
-                    {{ Form::close() }}
                 </div><!-- /.box-body -->
             </div><!-- /.box -->
         </div>


### PR DESCRIPTION
This PR replaces `Form::open` and `Form::close` on the following pages:

- [LDAP settings](https://snipe-it.test/admin/ldap)
- [Localization settings](https://snipe-it.test/admin/localization)
- [Purge deleted records page](https://snipe-it.test/admin/purge)
- [SAML settings](https://snipe-it.test/admin/saml)
- [Security settings](https://snipe-it.test/admin/security)
- [View status label page](https://snipe-it.test/statuslabels/1/)
- [Users index](https://snipe-it.test/users)
