### PR TITLE
Refactored audit notification to mail, added test, added alerts check to scheduler

### DIFF
--- a/app/Console/Commands/SendUpcomingAuditReport.php
+++ b/app/Console/Commands/SendUpcomingAuditReport.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Mail\SendUpcomingAuditMail;
 use App\Models\Asset;
 use App\Models\Recipients\AlertRecipient;
 use App\Models\Setting;
@@ -9,6 +10,7 @@ use App\Notifications\SendUpcomingAuditNotification;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
 
 class SendUpcomingAuditReport extends Command
 {
@@ -48,19 +50,19 @@ class SendUpcomingAuditReport extends Command
         $today = Carbon::now();
         $interval_date = $today->copy()->addDays($interval);
 
-        $assets = Asset::whereNull('deleted_at')->DueOrOverdueForAudit($settings)->orderBy('assets.next_audit_date', 'desc')->get();
-        $this->info($assets->count().' assets must be audited in on or before '.$interval_date.' is deadline');
+        $assets = Asset::whereNull('deleted_at')->dueOrOverdueForAudit($settings)->orderBy('assets.next_audit_date', 'desc')->get();
+        $this->info($assets->count() . ' assets must be audited in on or before ' . $interval_date . ' is deadline');
 
 
-        if (($assets) && ($assets->count() > 0) && ($settings->alert_email != '')) {
+        if ((count($assets) !== 0) && ($assets->count() > 0) && ($settings->alert_email != '')) {
             // Send a rollup to the admin, if settings dictate
-            $recipients = collect(explode(',', $settings->alert_email))->map(function ($item) {
-                return new AlertRecipient($item);
-            });
+            $recipients = collect(explode(',', $settings->alert_email))
+                ->map(fn($item) => trim($item))
+                ->all();
 
-            $this->info('Sending Admin SendUpcomingAuditNotification to: '.$settings->alert_email);
-            \Notification::send($recipients, new SendUpcomingAuditNotification($assets, $settings->audit_warning_days));
 
+            $this->info('Sending Admin SendUpcomingAuditNotification to: ' . $settings->alert_email);
+            Mail::to($recipients)->send(new SendUpcomingAuditMail($assets, $settings->audit_warning_days));
         }
 
     }

--- a/app/Console/Commands/SendUpcomingAuditReport.php
+++ b/app/Console/Commands/SendUpcomingAuditReport.php
@@ -4,11 +4,8 @@ namespace App\Console\Commands;
 
 use App\Mail\SendUpcomingAuditMail;
 use App\Models\Asset;
-use App\Models\Recipients\AlertRecipient;
 use App\Models\Setting;
-use App\Notifications\SendUpcomingAuditNotification;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace App\Console;
 use App\Console\Commands\ImportLocations;
 use App\Console\Commands\ReEncodeCustomFieldNames;
 use App\Console\Commands\RestoreDeletedUsers;
+use App\Models\Setting;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -18,12 +19,14 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('snipeit:inventory-alerts')->daily();
-        $schedule->command('snipeit:expiring-alerts')->daily();
-        $schedule->command('snipeit:expected-checkin')->daily();
+        if(Setting::getSettings()->alerts_enabled === 1) {
+            $schedule->command('snipeit:inventory-alerts')->daily();
+            $schedule->command('snipeit:expiring-alerts')->daily();
+            $schedule->command('snipeit:expected-checkin')->daily();
+            $schedule->command('snipeit:upcoming-audits')->daily();
+        }
         $schedule->command('snipeit:backup')->weekly();
         $schedule->command('backup:clean')->daily();
-        $schedule->command('snipeit:upcoming-audits')->daily();
         $schedule->command('auth:clear-resets')->everyFifteenMinutes();
         $schedule->command('saml:clear_expired_nonces')->weekly();
     }

--- a/app/Mail/SendUpcomingAuditMail.php
+++ b/app/Mail/SendUpcomingAuditMail.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class SendUpcomingAuditMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct($params, $threshold)
+    {
+        $this->assets = $params;
+        $this->threshold = $threshold;
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        $from = new Address(config('mail.from.address'), config('mail.from.name'));
+
+        return new Envelope(
+            from: $from,
+            subject: trans_choice('mail.upcoming-audits', $this->assets->count(), ['count' => $this->assets->count(), 'threshold' => $this->threshold]),
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+
+
+        return new Content(
+
+            markdown: 'notifications.markdown.upcoming-audits',
+            with:  [
+                'assets'  => $this->assets,
+                'threshold'  => $this->threshold,
+            ],
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/tests/Feature/Notifications/Email/ExpiringAlertsNotificationTest.php
+++ b/tests/Feature/Notifications/Email/ExpiringAlertsNotificationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Notifications\Email;
 
 use App\Mail\ExpiringAssetsMail;
 use App\Mail\ExpiringLicenseMail;
+use App\Mail\SendUpcomingAuditMail;
 use App\Models\Asset;
 use App\Models\License;
 use App\Models\Setting;
@@ -86,6 +87,35 @@ class ExpiringAlertsNotificationTest extends TestCase
 
          Mail::assertNotSent(ExpiringLicenseMail::class, function($mail) use ($expiredLicense, $notExpiringLicense) {
              return $mail->licenses->contains($expiredLicense) || $mail->licenses->contains($notExpiringLicense);
+         });
+     }
+
+     public function testAuditWarningThresholdEmailNotification()
+     {
+         $this->markIncompleteIfSqlite();
+         Mail::fake();
+         $this->settings->enableAlertEmail('admin@example.com');
+         $this->settings->setAuditWarningDays(15);
+
+         $alert_email = Setting::first()->alert_email;
+
+         $upcomingAuditableAsset = Asset::factory()->create([
+             'next_audit_date' => now()->addDays(14)->format('Y-m-d'),
+             'deleted_at' => null,
+         ]);
+
+         $notAuditableAsset = Asset::factory()->create([
+             'next_audit_date' => now()->addDays(30)->format('Y-m-d'),
+             'deleted_at' => null,
+         ]);
+
+         $this->artisan('snipeit:upcoming-audits')->assertExitCode(0);
+
+         Mail::assertSent(SendUpcomingAuditMail::class, function($mail) use ($alert_email, $upcomingAuditableAsset) {
+             return $mail->hasTo($alert_email) && $mail->assets->contains($upcomingAuditableAsset);
+         });
+         Mail::assertNotSent(SendUpcomingAuditMail::class, function($mail) use ($alert_email, $notAuditableAsset) {
+             return $mail->hasTo($alert_email) && $mail->assets->contains($notAuditableAsset);
          });
      }
 }

--- a/tests/Feature/Notifications/Email/ExpiringAlertsNotificationTest.php
+++ b/tests/Feature/Notifications/Email/ExpiringAlertsNotificationTest.php
@@ -104,6 +104,11 @@ class ExpiringAlertsNotificationTest extends TestCase
              'deleted_at' => null,
          ]);
 
+         $overDueForAuditableAsset = Asset::factory()->create([
+             'next_audit_date' => now()->subDays(1)->format('Y-m-d'),
+             'deleted_at' => null,
+         ]);
+
          $notAuditableAsset = Asset::factory()->create([
              'next_audit_date' => now()->addDays(30)->format('Y-m-d'),
              'deleted_at' => null,
@@ -111,8 +116,8 @@ class ExpiringAlertsNotificationTest extends TestCase
 
          $this->artisan('snipeit:upcoming-audits')->assertExitCode(0);
 
-         Mail::assertSent(SendUpcomingAuditMail::class, function($mail) use ($alert_email, $upcomingAuditableAsset) {
-             return $mail->hasTo($alert_email) && $mail->assets->contains($upcomingAuditableAsset);
+         Mail::assertSent(SendUpcomingAuditMail::class, function($mail) use ($alert_email, $upcomingAuditableAsset, $overDueForAuditableAsset) {
+             return $mail->hasTo($alert_email) && ($mail->assets->contains($upcomingAuditableAsset) && $mail->assets->contains($overDueForAuditableAsset));
          });
          Mail::assertNotSent(SendUpcomingAuditMail::class, function($mail) use ($alert_email, $notAuditableAsset) {
              return $mail->hasTo($alert_email) && $mail->assets->contains($notAuditableAsset);

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -32,6 +32,12 @@ class Settings
             'alert_threshold' => $days,
         ]);
     }
+    public function setAuditWarningDays(int $days): Settings
+    {
+        return $this->update([
+            'audit_warning_days' => $days,
+        ]);
+    }
     public function disableAlertEmail(): Settings
     {
         return $this->update([


### PR DESCRIPTION
This adds an `alerts_enabled` check around the following scheduled daily alerts:

- `inventory-alerts`
- `expiring-alerts`
- `expected-checkin`
- `upcoming-audits`

This also refactors the Audit notification to use mailable. 
A test has been added for this that checks 
- due for audit
- overdue for audit 
- not due yet

Fixes: #16221
<img width="1788" alt="image" src="https://github.com/user-attachments/assets/b16ad6c9-e991-4a9b-b1f0-c2b4d889ef1b" />