### PR TITLE
Fix for QR code on old label engine

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -535,7 +535,7 @@ class AssetsController extends Controller
     {
         $settings = Setting::getSettings();
 
-        if (($settings->qr_code === '1') && ($settings->label2_2d_type !== 'none')) {
+        if (($settings->qr_code == '1') && ($settings->label2_2d_type !== 'none')) {
             $asset = Asset::withTrashed()->find($assetId);
             if ($asset) {
                 $size = Helper::barcodeDimensions($settings->label2_2d_type);


### PR DESCRIPTION
This should fix the issue of broken QR codes on the old label engine