### PR TITLE
Fixed #16259 - mismatch in asset count if archived assets are hidden

### DIFF
--- a/app/Http/Controllers/Api/CompaniesController.php
+++ b/app/Http/Controllers/Api/CompaniesController.php
@@ -43,7 +43,7 @@ class CompaniesController extends Controller
 
         $companies = Company::withCount(['assets as assets_count'  => function ($query) {
             $query->AssetsForShow();
-        }])->withCount('assets as assets_count', 'licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'users as users_count');
+        }])->withCount('licenses as licenses_count', 'accessories as accessories_count', 'consumables as consumables_count', 'components as components_count', 'users as users_count');
 
         if ($request->filled('search')) {
             $companies->TextSearch($request->input('search'));


### PR DESCRIPTION
This is a small fix that fixes #16259. We were correctly scoping that API controller's assets using the `AssetsForShow()` scope, however the next section overwrote that scoped version, thus returning all of the assets, scoped for showing (aka archived or not.)