### PR TITLE
Scope API results by location ID

### DIFF
--- a/app/Http/Controllers/Api/LocationsController.php
+++ b/app/Http/Controllers/Api/LocationsController.php
@@ -258,7 +258,7 @@ class LocationsController extends Controller
     {
         $this->authorize('view', Accessory::class);
         $this->authorize('view', $location);
-        $accessory_checkouts = AccessoryCheckout::LocationAssigned()->with('adminuser')->with('accessories');
+        $accessory_checkouts = AccessoryCheckout::LocationAssigned()->where('assigned_to', $location->id)->with('adminuser')->with('accessories');
 
         $offset = ($request->input('offset') > $accessory_checkouts->count()) ? $accessory_checkouts->count() : app('api_offset_value');
         $limit = app('api_limit_value');


### PR DESCRIPTION
This fixes #16258 and should now properly scope by selected location.

I don't love the way this works exactly - I feel like this should really be coming from the Location model via `assignedAssets()`, but this fixes the issue for right now. Need to revisit once v8 is shipped.