### PR TITLE
Fixes deletion of assigned assets through bulk delete

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -529,18 +529,18 @@ class BulkAssetsController extends Controller
         if ($request->session()->has('bulk_back_url')) {
             $bulk_back_url = $request->session()->pull('bulk_back_url');
         }
-        $assetIds = $request->get('ids') ?? [];
+        $assetIds = $request->get('ids');
 
         if(empty($assetIds)) {
             return redirect($bulk_back_url)->with('error', trans('admin/hardware/message.delete.nothing_updated'));
         }
 
         $assignedAssets = Asset::whereIn('id', $assetIds)->whereNotNull('assigned_to')->get();
-
         if($assignedAssets->isNotEmpty()) {
+
             //if assets are checked out, return a list of asset tags that would need to be checked in first.
             $assetTags = $assignedAssets->pluck('asset_tag')->implode(', ');
-            return redirect()->route($bulk_back_url)->with('error', trans_choice('admin/hardware/message.delete.assigned_to_error', $assignedAssets->count(), ['asset_tag' => $assetTags] ));
+            return redirect($bulk_back_url)->with('error', trans_choice('admin/hardware/message.delete.assigned_to_error', $assignedAssets->count(), ['asset_tag' => $assetTags] ));
         }
 
         foreach (Asset::wherein('id', $assetIds)->get() as $asset) {

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -525,19 +525,24 @@ class BulkAssetsController extends Controller
         $this->authorize('delete', Asset::class);
 
         $bulk_back_url = route('hardware.index');
+
         if ($request->session()->has('bulk_back_url')) {
             $bulk_back_url = $request->session()->pull('bulk_back_url');
         }
+        $assetIds = $request->get('ids');
+        $assignedAssets = Asset::whereIn('id', $assetIds)->whereNotNull('assigned_to')->get();
 
-        if ($request->filled('ids')) {
-            $assets = Asset::find($request->get('ids'));
-            foreach ($assets as $asset) {
-                $asset->delete();
-            } // endforeach
-
-            return redirect($bulk_back_url)->with('success', trans('admin/hardware/message.delete.success'));
-            // no values given, nothing to update
+        if($assignedAssets->isNotEmpty()) {
+            //if assets are checked out, return a list of asset tags that would need to be checked in first.
+            $assetTags = $assignedAssets->pluck('asset_tag')->implode(', ');
+            return redirect()->route('hardware.index')->with('error', trans_choice('admin/hardware/message.delete.assigned_to_error', $assignedAssets->count(), ['asset_tag' => $assetTags] ));
         }
+
+        if($assetIds) {
+            Asset::wherein('id', $assetIds)->delete();
+            return redirect($bulk_back_url)->with('success', trans('admin/hardware/message.delete.success'));
+        }
+            // no values given, nothing to update
 
         return redirect($bulk_back_url)->with('error', trans('admin/hardware/message.delete.nothing_updated'));
     }

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -529,22 +529,27 @@ class BulkAssetsController extends Controller
         if ($request->session()->has('bulk_back_url')) {
             $bulk_back_url = $request->session()->pull('bulk_back_url');
         }
-        $assetIds = $request->get('ids');
+        $assetIds = $request->get('ids') ?? [];
+
+        if(empty($assetIds)) {
+            return redirect($bulk_back_url)->with('error', trans('admin/hardware/message.delete.nothing_updated'));
+        }
+
         $assignedAssets = Asset::whereIn('id', $assetIds)->whereNotNull('assigned_to')->get();
 
         if($assignedAssets->isNotEmpty()) {
             //if assets are checked out, return a list of asset tags that would need to be checked in first.
             $assetTags = $assignedAssets->pluck('asset_tag')->implode(', ');
-            return redirect()->route('hardware.index')->with('error', trans_choice('admin/hardware/message.delete.assigned_to_error', $assignedAssets->count(), ['asset_tag' => $assetTags] ));
+            return redirect()->route($bulk_back_url)->with('error', trans_choice('admin/hardware/message.delete.assigned_to_error', $assignedAssets->count(), ['asset_tag' => $assetTags] ));
         }
 
-        if($assetIds) {
-            Asset::wherein('id', $assetIds)->delete();
-            return redirect($bulk_back_url)->with('success', trans('admin/hardware/message.delete.success'));
-        }
+        foreach (Asset::wherein('id', $assetIds)->get() as $asset) {
+                $asset->delete();
+            }
+
+        return redirect($bulk_back_url)->with('success', trans('admin/hardware/message.delete.success'));
             // no values given, nothing to update
 
-        return redirect($bulk_back_url)->with('error', trans('admin/hardware/message.delete.nothing_updated'));
     }
 
     /**

--- a/resources/lang/en-US/admin/hardware/message.php
+++ b/resources/lang/en-US/admin/hardware/message.php
@@ -72,6 +72,7 @@ return [
     'delete' => [
         'confirm'   	=> 'Are you sure you wish to delete this asset?',
         'error'   		=> 'There was an issue deleting the asset. Please try again.',
+        'assigned_to_error' => '{1}Asset Tag: :asset_tag is currently checked out. Check in this device before deletion.|[2,*]Asset Tags: :asset_tag are currently checked out. Check in these devices before deletion.',
         'nothing_updated'   => 'No assets were selected, so nothing was deleted.',
         'success' 		=> 'The asset was deleted successfully.',
     ],


### PR DESCRIPTION
This checks that an asset is not assigned before deletion. If an assigned asset is selected, you are redirected back to the asset index with a list of the asset tags that need to be handled with before deletion. The same is true for Assets that are assigned other assets.

This also adds test around deleting assets that are checked out.
#16261
[sc-28426]
Multiple Assigned Assets
<img width="946" alt="image" src="https://github.com/user-attachments/assets/321d5457-b39f-4397-a560-7cafd40b8bc9" />
Single Assigned Asset
<img width="946" alt="image" src="https://github.com/user-attachments/assets/a170686b-dcf7-4391-bfde-53c764550f34" />

Parent Asset:
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/e3494d1e-aa0f-4ec9-ab13-d49a00e4e5d2" />

