### PR TITLE
Added better error handling around rendering barcodes

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -30,6 +30,7 @@ use Illuminate\Http\Response;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use TypeError;
 
 /**
  * This class controls all actions related to assets for
@@ -590,7 +591,7 @@ class AssetsController extends Controller
                         file_put_contents($barcode_file, $barcode_obj->getPngData());
 
                         return response($barcode_obj->getPngData())->header('Content-type', 'image/png');
-                    } catch (\Exception $e) {
+                    } catch (\Exception|TypeError $e) {
                         Log::debug('The barcode format is invalid.');
 
                         return response(file_get_contents(public_path('uploads/barcodes/invalid_barcode.gif')))->header('Content-type', 'image/gif');


### PR DESCRIPTION
This PR adds the catching of `TypeError` s when rendering barcodes.

We guide users to our [docs](https://snipe-it.readme.io/docs/barcodes#supported-1d-barcodes) which explain the limitations of each barcode type but in some cases an invalid asset tag / barcode type pairing will throw a `TypeError` and not an exception.

For example, using `UPCE` as a barcode type and attempting to render a barcode for an asset with a letter in it's tag will result in a `TypeError: Unsupported operand types: int + string`.

With this PR, instead of failing hard we'll display the invalid type image:

![invalid barcode type image](https://github.com/user-attachments/assets/33e16502-d1c9-4daf-a639-7c0c56dcef69)


