### PR TITLE
Fixes: [sc-28423] Better tooltips on lists, Bootstrap style

### DIFF
--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -21,6 +21,7 @@ class AssetPresenter extends Presenter
             [
                 'field' => 'checkbox',
                 'checkbox' => true,
+                'titleTooltip' => 'Toggle Select All' //FIXME - translate.
             ], [
                 'field' => 'id',
                 'searchable' => false,


### PR DESCRIPTION
(Please view this PR with whitespace disabled; my editor kept trying to fix the indents (which _were_ wrong) so I had to fix the indents everywhere so it didn't make me insane).

This adds nicer Bootstrap-formatted Tooltips to the columns in our Bootstrap Tables. This is especially useful when for when we use an icon to represent the name of a column, like we do in Locations. If we set a `titleTooltip` in the various presenters, we will display a Bootstrap tooltip when you hover over that column. When none is set, no tooltip shows up.

As a nice bonus, we can give a tooltip on the 'toggle select all' (or maybe some other nicer language) checkbox. I added one, untranslated, as an example.

**NOTE** - we will definitely want to check how this works out in screen-readers, since we're no longer using the standard `title` attribute (to avoid gross-looking double-tooltips).