### PR TITLE
Fix tests and fix migrations to always explicitly include nullable()

### DIFF
--- a/database/migrations/2015_02_07_013537_add_soft_deleted_to_log.php
+++ b/database/migrations/2015_02_07_013537_add_soft_deleted_to_log.php
@@ -12,8 +12,8 @@ class AddSoftDeletedToLog extends Migration
      */
     public function up()
     {
-        $platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
-        $platform->registerDoctrineTypeMapping('enum', 'string');
+        //$platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
+        //$platform->registerDoctrineTypeMapping('enum', 'string');
 
         Schema::table('asset_logs', function ($table) {
             $table->string('asset_type', 100)->nullable()->change();

--- a/database/migrations/2015_02_12_024100_change_license_notes_type.php
+++ b/database/migrations/2015_02_12_024100_change_license_notes_type.php
@@ -14,7 +14,7 @@ class ChangeLicenseNotesType extends Migration
     {
         //
         Schema::table('licenses', function ($table) {
-            $table->text('notes')->change();
+            $table->text('notes')->nullable()->change();
         });
     }
 

--- a/database/migrations/2015_09_22_003413_migrate_mac_address.php
+++ b/database/migrations/2015_09_22_003413_migrate_mac_address.php
@@ -12,7 +12,7 @@ class MigrateMacAddress extends Migration
      */
     public function up()
     {
-        DB::getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+        //DB::getDoctrineSchemaManager()->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
 
         $f2 = new \App\Models\CustomFieldset(['name' => 'Asset with MAC Address']);
         $f2->timestamps = false; //when this model was first created, it had no timestamps. But later on it gets them.

--- a/database/migrations/2016_03_02_220517_update_ldap_filter_to_longer_field.php
+++ b/database/migrations/2016_03_02_220517_update_ldap_filter_to_longer_field.php
@@ -13,7 +13,7 @@ class UpdateLdapFilterToLongerField extends Migration
     public function up()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->text('ldap_filter')->default(null)->change();
+            $table->text('ldap_filter')->nullable()->default(null)->change();
         });
     }
 

--- a/database/migrations/2016_08_30_084634_make_purchase_cost_nullable.php
+++ b/database/migrations/2016_08_30_084634_make_purchase_cost_nullable.php
@@ -12,8 +12,8 @@ class MakePurchaseCostNullable extends Migration
      */
     public function up()
     {
-        $platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
-        $platform->registerDoctrineTypeMapping('enum', 'string');
+        //$platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
+        //$platform->registerDoctrineTypeMapping('enum', 'string');
 
         Schema::table('assets', function ($table) {
             $table->decimal('purchase_cost', 8, 2)->nullable()->default(null)->change();

--- a/database/migrations/2016_11_16_172119_increase_purchase_cost_size.php
+++ b/database/migrations/2016_11_16_172119_increase_purchase_cost_size.php
@@ -12,8 +12,8 @@ class IncreasePurchaseCostSize extends Migration
      */
     public function up()
     {
-        $platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
-        $platform->registerDoctrineTypeMapping('enum', 'string');
+        //$platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
+        //$platform->registerDoctrineTypeMapping('enum', 'string');
 
         Schema::table('assets', function ($table) {
             $table->decimal('purchase_cost', 20, 2)->nullable()->default(null)->change();
@@ -47,8 +47,8 @@ class IncreasePurchaseCostSize extends Migration
      */
     public function down()
     {
-        $platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
-        $platform->registerDoctrineTypeMapping('enum', 'string');
+        //$platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
+        //$platform->registerDoctrineTypeMapping('enum', 'string');
 
         Schema::table('assets', function ($table) {
             $table->decimal('purchase_cost', 8, 2)->nullable()->default(null)->change();

--- a/database/migrations/2017_01_25_063357_fix_utf8_custom_field_column_names.php
+++ b/database/migrations/2017_01_25_063357_fix_utf8_custom_field_column_names.php
@@ -43,8 +43,8 @@ class FixUtf8CustomFieldColumnNames extends Migration
      */
     public function up()
     {
-        $platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
-        $platform->registerDoctrineTypeMapping('enum', 'string');
+        //$platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
+        //$platform->registerDoctrineTypeMapping('enum', 'string');
 
         if (! Schema::hasColumn('custom_fields', 'db_column')) {
             Schema::table('custom_fields', function ($table) {

--- a/database/migrations/2017_08_03_160105_set_asset_archived_to_zero_default.php
+++ b/database/migrations/2017_08_03_160105_set_asset_archived_to_zero_default.php
@@ -13,11 +13,11 @@ class SetAssetArchivedToZeroDefault extends Migration
      */
     public function up()
     {
-        $platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
-        $platform->registerDoctrineTypeMapping('enum', 'string');
+        //$platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
+        //$platform->registerDoctrineTypeMapping('enum', 'string');
 
         Schema::table('assets', function (Blueprint $table) {
-            $table->boolean('archived')->default(0)->change();
+            $table->boolean('archived')->default(0)->nullable()->change();
         });
     }
 

--- a/database/migrations/2019_02_20_234421_make_serial_nullable.php
+++ b/database/migrations/2019_02_20_234421_make_serial_nullable.php
@@ -13,8 +13,8 @@ class MakeSerialNullable extends Migration
      */
     public function up()
     {
-        $platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
-        $platform->registerDoctrineTypeMapping('enum', 'string');
+        //$platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
+        //$platform->registerDoctrineTypeMapping('enum', 'string');
 
         Schema::table('assets', function (Blueprint $table) {
             $table->string('serial')->nullable()->default(null)->change();

--- a/database/migrations/2019_12_04_223111_passport_upgrade.php
+++ b/database/migrations/2019_12_04_223111_passport_upgrade.php
@@ -29,7 +29,7 @@ class PassportUpgrade extends Migration
     {
         if (Schema::hasTable('oauth_clients')) {
             Schema::table('oauth_clients', function (Blueprint $table) {
-                $table->string('secret', 100)->change();
+                $table->string('secret', 100)->nullable(false)->change();
             });
         }
     }

--- a/database/migrations/2023_08_01_174150_change_webhook_settings_variable_type.php
+++ b/database/migrations/2023_08_01_174150_change_webhook_settings_variable_type.php
@@ -14,7 +14,7 @@ class ChangeWebhookSettingsVariableType extends Migration
     public function up()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->text('webhook_endpoint')->change();
+            $table->text('webhook_endpoint')->nullable()->change();
         });
     }
 
@@ -26,7 +26,7 @@ class ChangeWebhookSettingsVariableType extends Migration
     public function down()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->string('webhook_endpoint')->change();
+            $table->string('webhook_endpoint')->nullable()->change();
         });
 
     }

--- a/database/migrations/2025_01_06_210534_change_report_templates_options_to_column_text_field.php
+++ b/database/migrations/2025_01_06_210534_change_report_templates_options_to_column_text_field.php
@@ -21,7 +21,7 @@ return new class extends Migration {
          */
         if (Schema::hasTable('report_templates') && Schema::hasColumn('report_templates', 'options')) {
             Schema::table('report_templates', function (Blueprint $table) {
-                $table->text('options')->change();
+                $table->text('options')->nullable(false)->change();
             });
         }
     }

--- a/database/migrations/2025_01_07_172419_fix_label_types_on_settings_table.php
+++ b/database/migrations/2025_01_07_172419_fix_label_types_on_settings_table.php
@@ -28,8 +28,8 @@ return new class extends Migration
         ]);
 
         Schema::table('settings', function (Blueprint $table) {
-            $table->string('label2_2d_type')->default('QRCODE')->change();
-            $table->string('label2_1d_type')->default('C128')->change();
+            $table->string('label2_2d_type')->default('QRCODE')->nullable(false)->change();
+            $table->string('label2_1d_type')->default('C128')->nullable(false)->change();
         });
     }
 

--- a/tests/Feature/Settings/ShowSetUpPageTest.php
+++ b/tests/Feature/Settings/ShowSetUpPageTest.php
@@ -21,6 +21,8 @@ use Tests\TestCase;
 
 class ShowSetUpPageTest extends TestCase
 {
+
+    static ?TestResponse $latestResponse;
     /**
      * We do not want to make actual http request on every test to check .env file
      * visibility because that can be really slow especially in some cases where an
@@ -34,7 +36,8 @@ class ShowSetUpPageTest extends TestCase
             Http::fake([URL::to('.env') => Http::response(null, 404)]);
         }
 
-        return $this->get('/setup');
+        self::$latestResponse = $this->get('/setup');
+        return self::$latestResponse;
     }
 
     public function testView(): void


### PR DESCRIPTION
In Laravel 11, Doctrine is no longer used, so we needed to remove our attempts to register enums (even though we don't use them anymore).

Additionally, it turns out that now, every time you change a schema in a migration using `->change()`, you need to *explicitly* include any additional modifiers - specifically, `nullable()` being one of the most important ones.

We also had some problems with the `showSetupPageTest` where we must've been relying on some side-effect that may not be there any more - so we just explicitly set a property, and explicitly set it to the results of the last test, in the setup method.