### PR TITLE
Updated default Dockerfile to handle newer PHP versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 LABEL maintainer="Brady Wetherington <bwetherington@grokability.com>"
 
 # No need to add `apt-get clean` here, reference:
@@ -14,16 +14,16 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
 apt-utils \
 apache2 \
 apache2-bin \
-libapache2-mod-php8.1 \
-php8.1-curl \
-php8.1-ldap \
-php8.1-mysql \
-php8.1-gd \
-php8.1-xml \
-php8.1-mbstring \
-php8.1-zip \
-php8.1-bcmath \
-php8.1-redis \
+libapache2-mod-php8.3 \
+php8.3-curl \
+php8.3-ldap \
+php8.3-mysql \
+php8.3-gd \
+php8.3-xml \
+php8.3-mbstring \
+php8.3-zip \
+php8.3-bcmath \
+php8.3-redis \
 php-memcached \
 patch \
 curl \
@@ -41,7 +41,7 @@ libc-dev \
 libldap-common \
 pkg-config \
 libmcrypt-dev \
-php8.1-dev \
+php8.3-dev \
 ca-certificates \
 unzip \
 dnsutils \
@@ -53,16 +53,16 @@ RUN php go-pear.phar
 
 RUN pecl install mcrypt
 
-RUN bash -c "echo extension=/usr/lib/php/20210902/mcrypt.so > /etc/php/8.1/mods-available/mcrypt.ini"
+RUN bash -c "echo extension=/usr/lib/php/20210902/mcrypt.so > /etc/php/8.3/mods-available/mcrypt.ini"
 
 RUN phpenmod mcrypt
 RUN phpenmod gd
 RUN phpenmod bcmath
 
-RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/8.1/apache2/php.ini
-RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/8.1/cli/php.ini
+RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/8.3/apache2/php.ini
+RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php/8.3/cli/php.ini
 
-RUN useradd -m --uid 1000 --gid 50 docker
+RUN useradd -m --uid 10000 --gid 50 docker
 
 RUN echo export APACHE_RUN_USER=docker >> /etc/apache2/envvars
 RUN echo export APACHE_RUN_GROUP=staff >> /etc/apache2/envvars


### PR DESCRIPTION
Now that our minimum PHP version is higher than it used to be, the default Docker image needs to be updated accordingly. Since it looks like we need to use a later Ubuntu version to have access to newer PHP versions, I upgraded us to the latest LTS version of Ubuntu. Then I was able to install PHP8.3.

Additionally, it seems that now Ubuntu creates an Ubuntu user as userid=1000, which we were using for our own user previously. I instead shifted the UID of our created user to 10000, which, if we were using uid 1000 just for 'visibility' should also be pretty easy to visually distinguish. I'm not sure, though, if the uid of 1000 was used anywhere else in the system, and if we were, we should definitely change it there as well.