### PR TITLE
Don’t delete avatar file on soft-delete

### DIFF
--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -333,13 +333,6 @@ class UsersController extends Controller
             $this->authorize('delete', $user);
 
             if ($user->delete()) {
-                if (Storage::disk('public')->exists('avatars/' . $user->avatar)) {
-                    try {
-                        Storage::disk('public')->delete('avatars/' . $user->avatar);
-                    } catch (\Exception $e) {
-                        Log::debug($e);
-                    }
-                }
                 return redirect()->route('users.index')->with('success', trans('admin/users/message.success.delete'));
             }
         }


### PR DESCRIPTION
This should resolve [SC-28474], where we were deleting the user's avatar file from the server on delete, but never clearing the avatar field, which meant that the file would be gone and a broken image would be displayed when you view them in the deleted list, and also if you restore them.

Since we already delete those files on purge, there's no need to delete them here, and this allows them to be cleanly restored without broken image files.