### PR TITLE
Added select/unselect tooltip to presenters, added translation

### DIFF
--- a/app/Presenters/AssetAuditPresenter.php
+++ b/app/Presenters/AssetAuditPresenter.php
@@ -20,6 +20,7 @@ class AssetAuditPresenter extends Presenter
              [
                 'field' => 'checkbox',
                 'checkbox' => true,
+                'titleTooltip' => trans('general.select_all_none'),
              ],
              [
                 'field' => 'id',

--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -15,6 +15,7 @@ class AssetModelPresenter extends Presenter
             [
                 'field' => 'checkbox',
                 'checkbox' => true,
+                'titleTooltip' => trans('general.select_all_none'),
             ],
             [
                 'field' => 'id',

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -21,7 +21,7 @@ class AssetPresenter extends Presenter
             [
                 'field' => 'checkbox',
                 'checkbox' => true,
-                'titleTooltip' => 'Toggle Select All' //FIXME - translate.
+                'titleTooltip' => trans('general.select_all_none'),
             ], [
                 'field' => 'id',
                 'searchable' => false,

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -24,6 +24,7 @@ class UserPresenter extends Presenter
             [
                 'field' => 'checkbox',
                 'checkbox' => true,
+                'titleTooltip' => trans('general.select_all_none'),
             ],
             [
                 'field' => 'id',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -594,6 +594,7 @@ return [
         'checkin_item' => 'Checkin :name',
     ],
 
+    'select_all_none' => 'Select/Unselect All',
     'generic_model_not_found' => 'That :model was not found or you do not have permission to access it',
 
 ];


### PR DESCRIPTION
This builds on the great work by @uberbrady in #16287, which adds tooltips to column headers, adding "Select/Unselect All" to the checkboxes in the presenter, and also translates the string.