### PR TITLE
Add tooltips to custom fields display, especially for icons

### DIFF
--- a/resources/lang/en-US/admin/custom_fields/general.php
+++ b/resources/lang/en-US/admin/custom_fields/general.php
@@ -35,7 +35,7 @@ return [
     'create_field_title' => 'Create a new custom field',
     'value_encrypted'      	        => 'The value of this field is encrypted in the database. Only admin users will be able to view the decrypted value',
     'show_in_email'     => 'Include the value of this field in checkout emails sent to the user? Encrypted fields cannot be included in emails',
-    'show_in_email_short'     => 'Include in emails.',
+    'show_in_email_short' => 'Include in emails',
     'help_text' => 'Help Text',
     'help_text_description' => 'This is optional text that will appear below the form elements while editing an asset to provide context on the field.',
     'about_custom_fields_title' => 'About Custom Fields',

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -150,16 +150,34 @@
               <th data-sortable="true" data-searchable="true">{{ trans('admin/custom_fields/general.unique') }}</th>
               <th data-sortable="true" data-visible="false">{{ trans('admin/custom_fields/general.db_field') }}</th>
               <th data-sortable="true" data-searchable="true">{{ trans('admin/custom_fields/general.field_format') }}</th>
-              <th data-sortable="true"><i class="fa fa-lock" aria-hidden="true"></i>
+              <th data-sortable="true" data-tooltip="{{ trans('admin/custom_fields/general.encrypted') }}"><i
+                        class="fa fa-lock" aria-hidden="true"></i>
                 <span class="hidden-xs hidden-sm hidden-md hidden-lg">{{ trans('admin/custom_fields/general.encrypted') }}</span>
               </th>
-              <th data-sortable="true" class="text-center"><i class="fa fa-list" aria-hidden="true"></i>
+              <th data-sortable="true" class="text-center"
+                  data-tooltip="{{ trans('admin/custom_fields/general.show_in_listview_short') }}"><i class="fa fa-list"
+                                                                                                      aria-hidden="true"></i>
                 <span class="hidden-xs hidden-sm hidden-md hidden-lg">{{ trans('admin/custom_fields/general.show_in_listview_short') }}</span>
               </th>
-              <th data-visible="false" data-sortable="true" class="text-center"><i class="fa fa-eye" aria-hidden="true"><span class="sr-only">Visible to User</span></i></th>
-              <th data-sortable="true" data-searchable="true" class="text-center"><i class="fa fa-envelope" aria-hidden="true"><span class="sr-only">{{ trans('admin/custom_fields/general.show_in_email_short') }}</span></i></th>
-              <th data-sortable="true" data-searchable="true" class="text-center"><i class="fa fa-laptop fa-fw" aria-hidden="true"><span class="sr-only">{{ trans('admin/custom_fields/general.show_in_requestable_list_short') }}</span></i></th>
-              <th data-sortable="true" data-searchable="true" class="text-center"><i class="fa-solid fa-fingerprint"><span class="sr-only">{{ trans('admin/custom_fields/general.unique') }}</span></i></th>
+              <th data-visible="false" data-sortable="true" class="text-center"
+                  data-tooltip="{{ trans('admin/custom_fields/general.display_in_user_view_table') }}"><i
+                        class="fa fa-eye"
+                        aria-hidden="true"><span
+                          class="sr-only">{{ trans('admin/custom_fields/general.display_in_user_view_table') }}</span></i>
+              </th>
+              <th data-sortable="true" data-searchable="true" class="text-center"
+                  data-tooltip="{{ trans('admin/custom_fields/general.show_in_email_short') }}"><i
+                        class="fa fa-envelope" aria-hidden="true"><span
+                          class="sr-only">{{ trans('admin/custom_fields/general.show_in_email_short') }}</span></i></th>
+              <th data-sortable="true" data-searchable="true" class="text-center"
+                  data-tooltip="{{ trans('admin/custom_fields/general.show_in_requestable_list_short') }}"><i
+                        class="fa fa-laptop fa-fw" aria-hidden="true"><span
+                          class="sr-only">{{ trans('admin/custom_fields/general.show_in_requestable_list_short') }}</span></i>
+              </th>
+              <th data-sortable="true" data-searchable="true" class="text-center"
+                  data-tooltip="{{ trans('admin/custom_fields/general.unique') }}"><i
+                        class="fa-solid fa-fingerprint"><span
+                          class="sr-only">{{ trans('admin/custom_fields/general.unique') }}</span></i></th>
               <th data-sortable="true" data-searchable="true" class="text-center">{{ trans('admin/custom_fields/general.field_element_short') }}</th>
               <th data-searchable="true">{{ trans('admin/custom_fields/general.fieldsets') }}</th>
               <th>{{ trans('button.actions') }}</th>
@@ -234,4 +252,14 @@
 @stop
 @section('moar_scripts')
   @include ('partials.bootstrap-table')
+  <script>
+    $(function () {
+      $('th').each(function (index, raw_element) {
+        var element = $(raw_element);
+        if (element.data('tooltip')) {
+          element.tooltip({container: 'body', title: element.data('tooltip')})
+        }
+      });
+    })
+  </script>
 @stop


### PR DESCRIPTION
Custom Fields don't use the same types of dynamic listings we do elsewhere - since there don't tend to be huge numbers of them. So I had to use a different approach to get similar Bootstrap tooltips to show up for them, especially for the columns that are just simple icons.

When I was showing this to @snipe , she noticed there was a period at the end a sentence she didn't like, so I fixed that as well.