### PR TITLE
Added tooltip for currency in table

### DIFF
--- a/app/Presenters/LocationPresenter.php
+++ b/app/Presenters/LocationPresenter.php
@@ -102,13 +102,13 @@ class LocationPresenter extends Presenter
                 'titleTooltip' =>  trans('general.people'),
                 'visible' => true,
                 'class' => 'css-house-user',
-                // 'data-tooltip' => true, - not working, but I want to try to use regular tooltips here
             ], [
                 'field' => 'currency',
                 'searchable' => true,
                 'sortable' => true,
                 'switchable' => true,
-                'title' =>  trans('general.currency'),
+                'title' =>  trans('general.currency_text'),
+                'titleTooltip' =>  trans('general.currency_text'),
                 'visible' => true,
                 'class' => 'css-currency',
             ], [

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -88,6 +88,7 @@ return [
     'record_created' 		=> 'Record Created',
     'updated_at' 			=> 'Updated at',
     'currency'  			=> '$', // this is deprecated
+    'currency_text'  		=> 'Currency', //
     'current'  				=> 'Current',
     'current_password'      => 'Current Password',
     'customize_report'      => 'Customize Report',


### PR DESCRIPTION
Added tooltip to show "Currency" above the "$" in the locations table.

<img width="1258" alt="Screenshot 2025-02-23 at 12 21 35 PM" src="https://github.com/user-attachments/assets/38ad8532-9512-4173-a980-a55a9615d0aa" />
