### PR TITLE
Fixed #16262 - Check for quantity before allowing component deletion

### DIFF
--- a/app/Http/Controllers/Api/ComponentsController.php
+++ b/app/Http/Controllers/Api/ComponentsController.php
@@ -48,7 +48,8 @@ class ComponentsController extends Controller
             ];
 
         $components = Component::select('components.*')
-            ->with('company', 'location', 'category', 'assets', 'supplier', 'adminuser', 'manufacturer');
+            ->with('company', 'location', 'category', 'assets', 'supplier', 'adminuser', 'manufacturer', 'uncontrainedAssets')
+            ->withSum('uncontrainedAssets', 'components_assets.assigned_qty');
 
         if ($request->filled('search')) {
             $components = $components->TextSearch($request->input('search'));
@@ -197,6 +198,11 @@ class ComponentsController extends Controller
         $this->authorize('delete', Component::class);
         $component = Component::findOrFail($id);
         $this->authorize('delete', $component);
+
+        if ($component->numCheckedOut() > 0) {
+            return response()->json(Helper::formatStandardApiResponse('error', null,  trans('admin/components/message.delete.error_qty')));
+        }
+
         $component->delete();
 
         return response()->json(Helper::formatStandardApiResponse('success', null, trans('admin/components/message.delete.success')));

--- a/app/Http/Controllers/Components/ComponentsController.php
+++ b/app/Http/Controllers/Components/ComponentsController.php
@@ -196,6 +196,10 @@ class ComponentsController extends Controller
             }
         }
 
+        if ($component->numCheckedOut() > 0) {
+            return redirect()->route('components.index')->with('error', trans('admin/components/message.delete.error_qty'));
+        }
+
         $component->delete();
 
         return redirect()->route('components.index')->with('success', trans('admin/components/message.delete.success'));

--- a/app/Http/Transformers/ComponentsTransformer.php
+++ b/app/Http/Transformers/ComponentsTransformer.php
@@ -62,7 +62,7 @@ class ComponentsTransformer
             'checkout' => Gate::allows('checkout', Component::class),
             'checkin' => Gate::allows('checkin', Component::class),
             'update' => Gate::allows('update', Component::class),
-            'delete' => Gate::allows('delete', Component::class),
+            'delete' => $component->isDeletable(),
         ];
         $array += $permissions_array;
 

--- a/resources/lang/en-US/admin/components/message.php
+++ b/resources/lang/en-US/admin/components/message.php
@@ -17,7 +17,8 @@ return array(
     'delete' => array(
         'confirm'   => 'Are you sure you wish to delete this component?',
         'error'   => 'There was an issue deleting the component. Please try again.',
-        'success' => 'The component was deleted successfully.'
+        'success' => 'The component was deleted successfully.',
+        'error_qty'   => 'Some components of this type are still checked out. Please check them in and try again.',
     ),
 
      'checkout' => array(

--- a/tests/Feature/Components/Api/DeleteComponentTest.php
+++ b/tests/Feature/Components/Api/DeleteComponentTest.php
@@ -9,7 +9,7 @@ use Tests\Concerns\TestsFullMultipleCompaniesSupport;
 use Tests\Concerns\TestsPermissionsRequirement;
 use Tests\TestCase;
 
-class DeleteComponentsTest extends TestCase implements TestsFullMultipleCompaniesSupport, TestsPermissionsRequirement
+class DeleteComponentTest extends TestCase implements TestsFullMultipleCompaniesSupport, TestsPermissionsRequirement
 {
     public function testRequiresPermission()
     {
@@ -62,5 +62,14 @@ class DeleteComponentsTest extends TestCase implements TestsFullMultipleCompanie
             ->assertStatusMessageIs('success');
 
         $this->assertSoftDeleted($component);
+    }
+
+    public function testCannotDeleteComponentIfCheckedOut()
+    {
+        $component = Component::factory()->checkedOutToAsset()->create();
+
+        $this->actingAsForApi(User::factory()->deleteComponents()->create())
+            ->deleteJson(route('api.components.destroy', $component))
+            ->assertStatusMessageIs('error');
     }
 }

--- a/tests/Feature/Components/Ui/DeleteComponentTest.php
+++ b/tests/Feature/Components/Ui/DeleteComponentTest.php
@@ -48,8 +48,6 @@ class DeleteComponentTest extends TestCase implements TestsFullMultipleCompanies
             ->delete(route('components.destroy', $component->id))
             ->assertSessionHas('error')
             ->assertRedirect(route('components.index'));
-
-        $this->assertSoftDeleted($component);
     }
 
     public function testDeletingComponentRemovesComponentImage()

--- a/tests/Feature/Components/Ui/DeleteComponentTest.php
+++ b/tests/Feature/Components/Ui/DeleteComponentTest.php
@@ -40,6 +40,18 @@ class DeleteComponentTest extends TestCase implements TestsFullMultipleCompanies
         $this->assertSoftDeleted($component);
     }
 
+    public function testCannotDeleteComponentIfCheckedOut()
+    {
+        $component = Component::factory()->checkedOutToAsset()->create();
+
+        $this->actingAs(User::factory()->deleteComponents()->create())
+            ->delete(route('components.destroy', $component->id))
+            ->assertSessionHas('error')
+            ->assertRedirect(route('components.index'));
+
+        $this->assertSoftDeleted($component);
+    }
+
     public function testDeletingComponentRemovesComponentImage()
     {
         Storage::fake('public');


### PR DESCRIPTION
This PR fixes #16262 (and [SC-28425]), and disallows deletion of components while there are still some checked out. This also introduces a new scope whereas we remove the company constraint in the case of a user checking out components across several companies and then *later* turns on full multiple company support. 

This also adds tests to confirm that deletion is not possible if some components are still checked out.