### PR TITLE
Changed Parameter Name for RMB

### DIFF
--- a/resources/views/notifications/markdown/report-expected-checkins.blade.php
+++ b/resources/views/notifications/markdown/report-expected-checkins.blade.php
@@ -10,7 +10,7 @@
 @php
 $checkin = Helper::getFormattedDateObject($asset->expected_checkin, 'date');
 @endphp
-| [{{ $asset->present()->name }}]({{ route('hardware.show', ['hardware' => $asset->id]) }}) | [{{ $asset->assignedTo->present()->fullName }}]({{ route($asset->targetShowRoute().'.show', [$asset->assignedTo->id]) }})  | {{ $checkin['formatted'] }}
+| [{{ $asset->present()->name }}]({{ route('hardware.show', ['asset' => $asset]) }}) | [{{ $asset->assignedTo->present()->fullName }}]({{ route($asset->targetShowRoute().'.show', [$asset->assignedTo->id]) }})  | {{ $checkin['formatted'] }}
 @endforeach
 @endcomponent
 


### PR DESCRIPTION
I'm not quite sure what the `->parameters(['hardware' => 'asset'])` in `routes/hardware.php:193` does, but I don't think it works as intended, at least all the time. This issue was resolved by changing `hardware` to `asset`