### PR TITLE
Fixed edit routes in tests

### DIFF
--- a/tests/Feature/Licenses/Ui/UpdateLicenseTest.php
+++ b/tests/Feature/Licenses/Ui/UpdateLicenseTest.php
@@ -11,7 +11,7 @@ class UpdateLicenseTest extends TestCase
     public function testPageRenders()
     {
         $this->actingAs(User::factory()->superuser()->create())
-            ->get(route('licenses.update', License::factory()->create()->id))
+            ->get(route('licenses.edit', License::factory()->create()->id))
             ->assertOk();
     }
 }

--- a/tests/Feature/Locations/Ui/UpdateLocationsTest.php
+++ b/tests/Feature/Locations/Ui/UpdateLocationsTest.php
@@ -21,7 +21,7 @@ class UpdateLocationsTest extends TestCase
     public function testPageRenders()
     {
         $this->actingAs(User::factory()->superuser()->create())
-            ->get(route('locations.update', Location::factory()->create()))
+            ->get(route('locations.edit', Location::factory()->create()))
             ->assertOk();
     }
 


### PR DESCRIPTION
As noted in the comments of #16320, we should be using `.edit` routes for checking that the edit pages can render. This PR fixes two bad references.