### PR TITLE
Remove remaining hardware references in favor of new RMB

### DIFF
--- a/app/Http/Controllers/Assets/AssetFilesController.php
+++ b/app/Http/Controllers/Assets/AssetFilesController.php
@@ -71,12 +71,12 @@ class AssetFilesController extends Controller
             try {
                  return StorageHelper::showOrDownloadFile($file, $log->filename);
             } catch (\Exception $e) {
-                return redirect()->route('hardware.show', ['hardware' => $asset])->with('error',  trans('general.file_not_found'));
+                return redirect()->route('hardware.show', $asset)->with('error', trans('general.file_not_found'));
             }
 
         }
 
-        return redirect()->route('hardware.show', ['hardware' => $asset])->with('error',  trans('general.log_record_not_found'));
+        return redirect()->route('hardware.show', $asset)->with('error', trans('general.log_record_not_found'));
 
 
     }
@@ -102,7 +102,7 @@ class AssetFilesController extends Controller
             return redirect()->back()->withFragment('files')->with('success', trans('admin/hardware/message.deletefile.success'));
         }
 
-        return redirect()->route('hardware.show', ['hardware' => $asset])->with('error',  trans('general.log_record_not_found'));
+        return redirect()->route('hardware.show', $asset)->with('error', trans('general.log_record_not_found'));
     }
 
 }

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -140,8 +140,8 @@ class Label implements View
                                 $barcode2DTarget = $asset->serial; 
                                 break;
                             case 'hardware_id':
-                            default: 
-                                $barcode2DTarget = route('hardware.show', ['hardware' => $asset->id]); 
+                            default:
+                                $barcode2DTarget = route('hardware.show', $asset);
                                 break;
                             }
                             $assetData->put('barcode2d', (object)[

--- a/resources/views/notifications/markdown/report-expected-checkins.blade.php
+++ b/resources/views/notifications/markdown/report-expected-checkins.blade.php
@@ -10,7 +10,7 @@
 @php
 $checkin = Helper::getFormattedDateObject($asset->expected_checkin, 'date');
 @endphp
-| [{{ $asset->present()->name }}]({{ route('hardware.show', ['asset' => $asset]) }}) | [{{ $asset->assignedTo->present()->fullName }}]({{ route($asset->targetShowRoute().'.show', [$asset->assignedTo->id]) }})  | {{ $checkin['formatted'] }}
+| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset) }}) | [{{ $asset->assignedTo->present()->fullName }}]({{ route($asset->targetShowRoute().'.show', [$asset->assignedTo->id]) }})  | {{ $checkin['formatted'] }}
 @endforeach
 @endcomponent
 

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -126,7 +126,7 @@ Route::group(
 
         // Redirect old legacy /asset_id/view urls to the resource route version
         Route::get('{assetId}/view', function ($assetId) {
-            return redirect()->route('hardware.show', ['hardware' => $assetId]);
+            return redirect()->route('hardware.show', $assetId);
         });
 
         Route::get('{asset}/qr_code',


### PR DESCRIPTION
This follows up on #16321 - in this I opted to bypass the parameter name and find all remaining references to the `hardware` parameter for `route('hardware.show')`. 

This _should_ be good to go, but it's getting late so I'm going to open as a WIP - feel free to check it out and merge if you're comfortable though @snipe - I can't see a reason it wouldn't work though. 