### PR TITLE
Fixed #16173: `useraccountcontrol` was not included in the ldap query attributes

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -125,6 +125,10 @@ class LdapSync extends Command
              */
             $attributes = array_values(array_filter($ldap_map));
 
+            if (is_null($ldap_map['active_flag'])) {
+                $attributes[] = 'useraccountcontrol';
+            }
+
             $results = Ldap::findLdapUsers($search_base, -1, $filter, $attributes);
 
         } catch (\Exception $e) {

--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -125,7 +125,7 @@ class LdapSync extends Command
              */
             $attributes = array_values(array_filter($ldap_map));
 
-            if (is_null($ldap_map['active_flag'])) {
+            if (Setting::getSettings()->is_ad === 1 && is_null($ldap_map['active_flag'])) {
                 $attributes[] = 'useraccountcontrol';
             }
 


### PR DESCRIPTION
 `$results` did not include the `useraccountcontrol` and thus rendered the fallback logic void when `active_flag` was blank.

 Added a condition to check if `active_flag` is blank and only then add `useraccountcontrol` to the ldap query since it is then a requirement in accordance with "we respect the userAccountControl attribute" text in the `admin/ldap` route.

[`elseif' will become true when `active_flag` is blank](https://github.com/snipe/snipe-it/blob/b141945add94eb0839436278a5b2dc2e0e116306/app/Console/Commands/LdapSync.php#L364)