### PR TITLE
Fixes #16331 - Don't make passport:install command require user input

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -256,7 +256,7 @@ class SettingsController extends Controller
         Artisan::call('migrate', ['--force' => true]);
         if ((! file_exists(storage_path().'/oauth-private.key')) || (! file_exists(storage_path().'/oauth-public.key'))) {
             Artisan::call('migrate', ['--path' => 'vendor/laravel/passport/database/migrations', '--force' => true]);
-            Artisan::call('passport:install');
+            Artisan::call('passport:install', ['--no-interaction' => true]);
         }
 
         return view('setup/migrate')


### PR DESCRIPTION
At some point, `php artisan passport:install` started to require some level of user-input in order to function - and this isn't going to at all work well when it's being run via `Artisan::call()` - which is in a web-context. PHP docs explicitly mention that `STDIN` is only defined when running in a command-line context, which we definitely are not doing in a web GUI context.

This change just adds a `--no-interaction` flag to the Passport artisan command so it won't get hung up looking for user input on `STDIN`.

I tested on my local on a blank database and this did, actually, seem to wwork.