### PR TITLE
Fixed renaming custom fields

### DIFF
--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -149,11 +149,6 @@ class CustomField extends Model
                     return true;
                 }
 
-                // This is just a dumb thing we have to include because Laraval/Doctrine doesn't
-                // play well with enums or a table that EVER had enums. :(
-                $platform = Schema::getConnection()->getDoctrineSchemaManager()->getDatabasePlatform();
-                $platform->registerDoctrineTypeMapping('enum', 'string');
-
                 // Rename the field if the name has changed
                 Schema::table(self::$table_name, function ($table) use ($custom_field) {
                     $table->renameColumn($custom_field->convertUnicodeDbSlug($custom_field->getOriginal('name')), $custom_field->convertUnicodeDbSlug());


### PR DESCRIPTION
Currently users are not able to update the name of custom fields. This PR fixes that by removing a call to a method that was removed during the Laravel upgrade.

I've tested this best I could (on MySQL) and it works for me but I'm not 100% positive this won't cause unforeseen issues.

Should fix #16343