### PR TITLE
Replace calls to Form::checkbox pt3

### DIFF
--- a/resources/views/partials/forms/edit/image-upload.blade.php
+++ b/resources/views/partials/forms/edit/image-upload.blade.php
@@ -4,7 +4,7 @@
     <div class="form-group{{ $errors->has('image_delete') ? ' has-error' : '' }}">
         <div class="col-md-9 col-md-offset-3">
             <label class="form-control">
-                {{ Form::checkbox('image_delete', '1', old('image_delete'), ['aria-label'=>'image_delete']) }}
+                <input type="checkbox" name="image_delete" value="1" @checked(old('image_delete')) aria-label="image_delete">
                 {{ trans('general.image_delete') }}
                 {!! $errors->first('image_delete', '<span class="alert-msg">:message</span>') !!}
             </label>

--- a/resources/views/partials/forms/edit/uploadLogo.blade.php
+++ b/resources/views/partials/forms/edit/uploadLogo.blade.php
@@ -47,7 +47,7 @@
 
     <div class="col-md-9 col-md-offset-3">
         <label id="{{ $logoId }}-deleteCheckbox" for="{{ $logoClearVariable }}" style="font-weight: normal" class="form-control">
-            {{ Form::checkbox($logoClearVariable, '1', old($logoClearVariable)) }}
+            <input type="checkbox" name="{{ $logoClearVariable }}" value="1" @checked(old($logoClearVariable))>
             Remove current {{ ucwords(str_replace('_', ' ', $logoVariable)) }} image
         </label>
     </div>

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -45,7 +45,7 @@
                         <div class="form-group {{ $errors->has('alerts_enabled') ? 'error' : '' }}">
                             <div class="col-md-9 col-md-offset-3">
                                 <label class="form-control">
-                                    {{ Form::checkbox('alerts_enabled', '1', old('alerts_enabled', $setting->alerts_enabled)) }}
+                                    <input type="checkbox" name="alerts_enabled" value="1" @checked(old('alerts_enabled', $setting->alerts_enabled))>
                                     {{  trans('admin/settings/general.alerts_enabled') }}
                                 </label>
                             </div>
@@ -55,7 +55,7 @@
                         <div class="form-group {{ $errors->has('show_alerts_in_menu') ? 'error' : '' }}">
                             <div class="col-md-9 col-md-offset-3">
                                 <label class="form-control">
-                                    {{ Form::checkbox('show_alerts_in_menu', '1', old('show_alerts_in_menu', $setting->show_alerts_in_menu)) }}
+                                    <input type="checkbox" name="show_alerts_in_menu" value="1" @checked(old('show_alerts_in_menu', $setting->show_alerts_in_menu))>
                                     {{ trans('admin/settings/general.show_alerts_in_menu') }}
                                 </label>
                             </div>

--- a/resources/views/settings/asset_tags.blade.php
+++ b/resources/views/settings/asset_tags.blade.php
@@ -47,7 +47,7 @@
                             </div>
                             <div class="col-md-7">
                                 <label class="form-control">
-                                    {{ Form::checkbox('auto_increment_assets', '1', old('auto_increment_assets', $setting->auto_increment_assets),array('aria-label'=>'auto_increment_assets')) }}
+                                    <input type="checkbox" name="auto_increment_assets" value="1" @checked(old('auto_increment_assets', $setting->auto_increment_assets)) aria-label="auto_increment_assets">
                                     {{ trans('admin/settings/general.enabled') }}
                                 </label>
                             </div>

--- a/resources/views/settings/google.blade.php
+++ b/resources/views/settings/google.blade.php
@@ -54,7 +54,7 @@
                             <div class="col-md-8 col-md-offset-3">
                                 <label class="form-control{{ (config('app.lock_passwords')===true) ? ' form-control--disabled': '' }}">
                                     <span class="sr-only">{{ trans('admin/settings/general.pwd_secure_uncommon') }}</span>
-                                    {{ Form::checkbox('google_login', '1', old('google_login', $setting->google_login),array('aria-label'=>'google_login', (config('app.lock_passwords')===true) ? 'disabled': '')) }}
+                                    <input type="checkbox" name="google_login" value="1" @checked(old('google_login', $setting->google_login)) @disabled(config('app.lock_passwords')) aria-label="google_login">
                                     {{ trans('admin/settings/general.enable_google_login') }}
                                 </label>
                                 <p class="help-block">{{ trans('admin/settings/general.enable_google_login_help') }}</p>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -213,7 +213,7 @@
                               @elseif ($user->id === Auth::user()->id)
                                   <!-- disallow the user from editing their own login status -->
                                   <label class="form-control form-control--disabled">
-                                      {{ Form::checkbox('activated', '1', old('activated', $user->activated), ['disabled' => true, 'checked'=> 'checked', 'aria-label'=>'update_real_loc']) }}
+                                      <input type="checkbox" name="activated" value="1" checked disabled aria-label="activated">
                                       {{ trans('admin/users/general.activated_help_text') }}
                                   </label>
                                   <p class="text-warning">{{ trans('admin/users/general.activated_disabled_help_text') }}</p>
@@ -259,7 +259,7 @@
                           <div class="col-md-8 col-md-offset-3">
                               <label class="form-control form-control--disabled">
 
-                                  {{ Form::checkbox('email_user', '1', old('email_user'), ['id' => "email_user_checkbox", 'aria-label'=>'email_user']) }}
+                                  <input type="checkbox" name="email_user" value="1" id="email_user_checkbox" @checked(old('email_user')) aria-label="email_user">
 
                                   {{ trans('admin/users/general.email_user_creds_on_create') }}
                               </label>


### PR DESCRIPTION
This PR replaces calls to `Form::checkbox` with inline html on the following pages:

- Image upload like on [location edit](https://snipe-it.test/locations/1/edit)
- Logo upload like on [branding settings page](https://snipe-it.test/admin/branding)
- [Notification settings page](https://snipe-it.test/admin/notifications)
- [Asset tag settings](https://snipe-it.test/admin/asset_tags)
- [Google settings](https://snipe-it.test/admin/google)
- [User create page](https://snipe-it.test/users/create)
- [User edit page](https://snipe-it.test/users/1/edit) (when editing self)