### PR TITLE
Replace calls to Form::checkbox pt5

### DIFF
--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -75,7 +75,7 @@
                             <div class="col-md-8">
 
                                 <label class="form-control">
-                                    {{ Form::checkbox('ldap_enabled', '1', old('ldap_enabled', $setting->ldap_enabled)) }}
+                                    <input type="checkbox" name="ldap_enabled" value="1" id="ldap_enabled" @checked(old('ldap_enabled', $setting->ldap_enabled)) />
                                 {{ trans('admin/settings/general.ldap_enabled') }}
                                 </label>
 
@@ -96,7 +96,7 @@
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
-                                {{ Form::checkbox('is_ad', '1', old('is_ad', $setting->is_ad)) }}
+                                    <input type="checkbox" name="is_ad" value="1" id="is_ad" @checked(old('is_ad', $setting->is_ad))/>
                                 {{ trans('admin/settings/general.is_ad') }}
                                 </label>
                                 @error('is_ad')
@@ -122,7 +122,7 @@
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
-                                {{ Form::checkbox('ldap_pw_sync', '1', old('ldap_pw_sync', $setting->ldap_pw_sync)) }}
+                                    <input type="checkbox" name="ldap_pw_sync" value="1" id="ldap_pw_sync" @checked(old('ldap_pw_sync', $setting->ldap_pw_sync)) />
                                 {{ trans('general.yes') }}
                                 </label>
 
@@ -255,7 +255,7 @@
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
-                                    {{ Form::checkbox('ldap_tls', '1', old('ldap_tls', $setting->ldap_tls)) }}
+                                    <input type="checkbox" name="ldap_tls" value="1" id="ldap_tls" @checked(old('ldap_tls', $setting->ldap_tls)) />
                                     {{ trans('admin/settings/general.ldap_tls_help') }}
                                 </label>
                                 @error('ldap_tls')
@@ -281,7 +281,7 @@
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
-                                    {{ Form::checkbox('ldap_server_cert_ignore', '1', old('ldap_server_cert_ignore', $setting->ldap_server_cert_ignore)) }}
+                                    <input type="checkbox" name="ldap_server_cert_ignore" value="1" id="ldap_server_cert_ignore" @checked(old('ldap_server_cert_ignore', $setting->ldap_server_cert_ignore)) />
                                     {{ trans('admin/settings/general.ldap_server_cert_ignore') }}
                                 </label>
                                 @error('ldap_server_cert_ignore')

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -52,7 +52,7 @@
                             <div class="col-md-9">
 
                                 <label class="form-control{{ config('app.lock_passwords') === true ? ' form-control--disabled': '' }}">
-                                    {{ Form::checkbox('saml_enabled', '1', old('saml_enabled', $setting->saml_enabled), ['class' => config('app.lock_passwords') === true ? 'disabled ': '',  config('app.lock_passwords') === true ? 'disabled ': '', ]) }}
+                                    <input type="checkbox" name="saml_enabled" value="1" @checked(old('saml_enabled', $setting->saml_enabled)) @disabled(config('app.lock_passwords')) @class(['disabled' => config('app.lock_passwords')])/>
                                     {{ trans('admin/settings/general.saml_enabled') }}
                                 </label>
 
@@ -146,7 +146,7 @@
                             </div>
                             <div class="col-md-9">
                                 <label class="form-control{{ config('app.lock_passwords') === true ? ' form-control--disabled': '' }}">
-                                    {{ Form::checkbox('saml_forcelogin', '1', old('saml_forcelogin', $setting->saml_forcelogin),['class' =>  $setting->demoMode, $setting->demoMode]) }}
+                                    <input type="checkbox" name="saml_forcelogin" value="1" @checked(old('saml_forcelogin', $setting->saml_forcelogin)) @disabled(config('app.lock_passwords')) @class(['disabled' => config('app.lock_passwords')]) />
                                     {{ trans('admin/settings/general.saml_forcelogin') }}
                                 </label>
                                 <p class="help-block">{{ trans('admin/settings/general.saml_forcelogin_help') }}</p>
@@ -162,7 +162,7 @@
                             </div>
                             <div class="col-md-9">
                                 <label class="form-control{{ config('app.lock_passwords') === true ? ' form-control--disabled': '' }}">
-                                    {{ Form::checkbox('saml_slo', '1', old('saml_slo', $setting->saml_slo),['class' => 'minimal '. $setting->demoMode, $setting->demoMode]) }}
+                                    <input type="checkbox" name="saml_slo" value="1" @checked(old('saml_slo', $setting->saml_slo)) @disabled(config('app.lock_passwords')) @class(['minimal', 'disabled' => config('app.lock_passwords')])/>
                                     {{ trans('admin/settings/general.saml_slo') }}
                                 </label>
                                 <p class="help-block">{{ trans('admin/settings/general.saml_slo_help') }}</p>


### PR DESCRIPTION
This PR replaces calls to `Form::checkbox` with inline html on the following pages:

- [LDAP settings](https://snipe-it.test/admin/ldap)
- [SAML settings](https://snipe-it.test/admin/saml)
	- I replaced , what I think was an accidental used of, `$setting->demoMode`, with `@disabled`