### PR TITLE
Allow pending as an asset status type that does not automatically check the asset in

### DIFF
--- a/app/Http/Controllers/Api/StatuslabelsController.php
+++ b/app/Http/Controllers/Api/StatuslabelsController.php
@@ -290,10 +290,12 @@ class StatuslabelsController extends Controller
 
     /**
      * Returns a boolean response based on whether the status label
-     * is one that is deployable.
+     * is one that is deployable or pending.
      *
      * This is used by the hardware create/edit view to determine whether
-     * we should provide a dropdown of users for them to check the asset out to.
+     * we should provide a dropdown of users for them to check the asset out to,
+     * and whether we show a warning that the asset will be checked in if it's already
+     * assigned but the status is changed to one that isn't pending or deployable
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v4.0]
@@ -301,7 +303,7 @@ class StatuslabelsController extends Controller
     public function checkIfDeployable($id) : string
     {
         $statuslabel = Statuslabel::findOrFail($id);
-        if ($statuslabel->getStatuslabelType() == 'deployable') {
+        if (($statuslabel->getStatuslabelType() == 'pending') || ($statuslabel->getStatuslabelType() == 'deployable')) {
             return '1';
         }
 

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -342,7 +342,7 @@ class AssetsController extends Controller
 
         // This is an archived or undeployable - we should check the asset back in.
         // Pending is allowed here
-        if (($status) && (($status->getStatuslabelType() != 'pending') || ($status->getStatuslabelType() != 'deployable')) && ($target = $asset->assignedTo)) {
+        if (($status) && (($status->getStatuslabelType() != 'pending') && ($status->getStatuslabelType() != 'deployable')) && ($target = $asset->assignedTo)) {
             $originalValues = $asset->getRawOriginal();
             $asset->assigned_to = null;
             $asset->assigned_type = null;

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -340,15 +340,14 @@ class AssetsController extends Controller
 
         $status = Statuslabel::find($request->input('status_id'));
 
-        // This is a non-deployable status label - we should check the asset back in.
-        if (($status && $status->getStatuslabelType() != 'deployable') && ($target = $asset->assignedTo)) {
-
+        // This is an archived or undeployable - we should check the asset back in.
+        // Pending is allowed here
+        if (($status) && (($status->getStatuslabelType() != 'pending') || ($status->getStatuslabelType() != 'deployable')) && ($target = $asset->assignedTo)) {
             $originalValues = $asset->getRawOriginal();
             $asset->assigned_to = null;
             $asset->assigned_type = null;
             $asset->accepted = null;
-
-            event(new CheckoutableCheckedIn($asset, $target, auth()->user(), 'Checkin on asset update', date('Y-m-d H:i:s'), $originalValues));
+            event(new CheckoutableCheckedIn($asset, $target, auth()->user(), 'Checkin on asset update with '.$status->getStatuslabelType().' status', date('Y-m-d H:i:s'), $originalValues));
         }
 
         if ($asset->assigned_to == '') {

--- a/resources/lang/en-US/admin/hardware/form.php
+++ b/resources/lang/en-US/admin/hardware/form.php
@@ -56,7 +56,7 @@ return [
     'asset_location_update_actual' => 'Update only actual location',
     'asset_not_deployable' => 'That asset status is not deployable. This asset cannot be checked out.',
     'asset_not_deployable_checkin' => 'That asset status is not deployable. Using this status label will checkin the asset.',
-    'asset_deployable' => 'That status is deployable. This asset can be checked out.',
+    'asset_deployable' => 'This asset can be checked out.',
     'processing_spinner' => 'Processing... (This might take a bit of time on large files)',
     'optional_infos'  => 'Optional Information',
     'order_details'   => 'Order Related Information',


### PR DESCRIPTION
Via discord: 

<img width="719" alt="Screenshot 2025-02-26 at 10 47 30 AM" src="https://github.com/user-attachments/assets/6327676f-1fd3-4deb-9814-00dc5267e97f" />

Further down the line, we may want to add a property to the status labels where they can be set to auto-checkin.