### PR TITLE
Added `--no-interaction` to additional passport commands

### DIFF
--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           php artisan key:generate
           php artisan migrate --force
-          php artisan passport:install
+          php artisan passport:install --no-interaction
           chmod -R 777 storage bootstrap/cache
 
       - name: Execute tests (Unit and Feature tests) via PHPUnit

--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           php artisan key:generate
           php artisan migrate --force
-          php artisan passport:install
+          php artisan passport:install --no-interaction
           chmod -R 777 storage bootstrap/cache
 
       - name: Execute tests (Unit and Feature tests) via PHPUnit

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -40,7 +40,7 @@ class DashboardController extends Controller
 
             if ((! file_exists(storage_path().'/oauth-private.key')) || (! file_exists(storage_path().'/oauth-public.key'))) {
                 Artisan::call('migrate', ['--force' => true]);
-                \Artisan::call('passport:install');
+                Artisan::call('passport:install', ['--no-interaction' => true]);
             }
 
             return view('dashboard')->with('asset_stats', $asset_stats)->with('counts', $counts);

--- a/upgrade.php
+++ b/upgrade.php
@@ -580,7 +580,7 @@ echo "--------------------------------------------------------\e[39m\n\n";
 
 if ((!file_exists('storage/oauth-public.key')) || (!file_exists('storage/oauth-private.key'))) {
     echo $info_icon." No OAuth keys detected. Running passport install now.\n\n";
-    $passport = shell_exec('php artisan passport:install');
+    $passport = shell_exec('php artisan passport:install --no-interaction');
     echo $passport;
 } else {
     echo $success_icon." OAuth keys detected. Skipping passport install.\n\n";


### PR DESCRIPTION
Looks like we missed a few `php artisan passport:install` calls with the newly required `--no-interaction` flag. 