### PR TITLE
Add some safeties around the charset-detection and transliteration

### DIFF
--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -69,20 +69,28 @@ class ImportController extends Controller
                 if (function_exists('iconv')) {
                     $file_contents = $file->getContent(); //TODO - this *does* load the whole file in RAM, but we need that to be able to 'iconv' it?
                     $encoding = $detector->getEncoding($file_contents);
+                    \Log::warning("Discovered encoding: $encoding in uploaded CSV");
                     $reader = null;
                     if (strcasecmp($encoding, 'UTF-8') != 0) {
                         $transliterated = false;
                         try {
                             $transliterated = iconv(strtoupper($encoding), 'UTF-8', $file_contents);
                         } catch (\Exception $e) {
-                            $transliterated = false;
-                            \Log::info("Unable to transliterate from $encoding to UTF-8");
+                            $transliterated = false; //blank out the partially-decoded string
+                            return response()->json(
+                                Helper::formatStandardApiResponse(
+                                    'error',
+                                    null,
+                                    trans('admin/hardware/message.import.transliterate_failure', ["encoding" => $encoding])
+                                ),
+                                422
+                            );
                         }
                         if ($transliterated !== false) {
                             $tmpname = tempnam(sys_get_temp_dir(), '');
                             $tmpresults = file_put_contents($tmpname, $transliterated);
+                            $transliterated = null; //save on memory?
                             if ($tmpresults !== false) {
-                                $transliterated = null; //save on memory?
                                 $newfile = new UploadedFile($tmpname, $file->getClientOriginalName(), null, null, true); //WARNING: this is enabling 'test mode' - which is gross, but otherwise the file won't be treated as 'uploaded'
                                 if ($newfile->isValid()) {
                                     $file = $newfile;

--- a/app/Http/Controllers/Api/ImportController.php
+++ b/app/Http/Controllers/Api/ImportController.php
@@ -66,25 +66,33 @@ class ImportController extends Controller
                 if (! ini_get('auto_detect_line_endings')) {
                     ini_set('auto_detect_line_endings', '1');
                 }
-                $file_contents = $file->getContent(); //TODO - this *does* load the whole file in RAM, but we need that to be able to 'iconv' it?
-                $encoding = $detector->getEncoding($file_contents);
-                $reader = null;
-                if (strcasecmp($encoding, 'UTF-8') != 0) {
-                    $transliterated = iconv($encoding, 'UTF-8', $file_contents);
-                    if ($transliterated !== false) {
-                        $tmpname = tempnam(sys_get_temp_dir(), '');
-                        $tmpresults = file_put_contents($tmpname, $transliterated);
-                        if ($tmpresults !== false) {
-                            $transliterated = null; //save on memory?
-                            $newfile = new UploadedFile($tmpname, $file->getClientOriginalName(), null, null, true); //WARNING: this is enabling 'test mode' - which is gross, but otherwise the file won't be treated as 'uploaded'
-                            if ($newfile->isValid()) {
-                                $file = $newfile;
+                if (function_exists('iconv')) {
+                    $file_contents = $file->getContent(); //TODO - this *does* load the whole file in RAM, but we need that to be able to 'iconv' it?
+                    $encoding = $detector->getEncoding($file_contents);
+                    $reader = null;
+                    if (strcasecmp($encoding, 'UTF-8') != 0) {
+                        $transliterated = false;
+                        try {
+                            $transliterated = iconv(strtoupper($encoding), 'UTF-8', $file_contents);
+                        } catch (\Exception $e) {
+                            $transliterated = false;
+                            \Log::info("Unable to transliterate from $encoding to UTF-8");
+                        }
+                        if ($transliterated !== false) {
+                            $tmpname = tempnam(sys_get_temp_dir(), '');
+                            $tmpresults = file_put_contents($tmpname, $transliterated);
+                            if ($tmpresults !== false) {
+                                $transliterated = null; //save on memory?
+                                $newfile = new UploadedFile($tmpname, $file->getClientOriginalName(), null, null, true); //WARNING: this is enabling 'test mode' - which is gross, but otherwise the file won't be treated as 'uploaded'
+                                if ($newfile->isValid()) {
+                                    $file = $newfile;
+                                }
                             }
                         }
                     }
+                    $file_contents = null; //try to save on memory, I guess?
                 }
                 $reader = Reader::createFromFileObject($file->openFile('r')); //file pointer leak?
-                $file_contents = null; //try to save on memory, I guess?
 
                 try {
                     $import->header_row = $reader->fetchOne(0);

--- a/resources/lang/en-US/admin/hardware/message.php
+++ b/resources/lang/en-US/admin/hardware/message.php
@@ -66,6 +66,7 @@ return [
         'file_already_deleted' => 'The file selected was already deleted',
         'header_row_has_malformed_characters' => 'One or more attributes in the header row contain malformed UTF-8 characters',
         'content_row_has_malformed_characters' => 'One or more attributes in the first row of content contain malformed UTF-8 characters',
+        'transliterate_failure' => 'Transliteration from :encoding to UTF-8 failed due to invalid characters in input'
     ],
 
 


### PR DESCRIPTION
Should prevent some rollbars we get around `iconv()` - this puts a try/catch around the `iconv()` call and returns a new translation string for the error which hopefully will be informative for the end-user as they're trying to upload a CSV file.

I also added a test with a very gnarly fake WINDOWS-1251 string in it to trigger the new transliteration-failure mode.