### PR TITLE
Feature/settings ldap invert active flag

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -361,9 +361,15 @@ class LdapSync extends Command
                 // (Specifically, we don't handle a value of '0.0' correctly)
                 $raw_value = @$results[$i][$ldap_map["active_flag"]][0];
                 $filter_var = filter_var($raw_value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                
                 $boolean_cast = (bool) $raw_value;
-
-                $user->activated = $filter_var ?? $boolean_cast; // if filter_var() was true or false, use that. If it's null, use the $boolean_cast
+                
+                if (Setting::getSettings()->ldap_invert_active_flag === 1) {
+                    // Because ldap_active_flag is set, if filter_var is true or boolean_cast is true, then user is suspended
+                    $user->activated = !($filter_var ?? $boolean_cast);
+                }else{
+                    $user->activated = $filter_var ?? $boolean_cast; // if filter_var() was true or false, use that. If it's null, use the $boolean_cast
+                }
 
             } elseif (array_key_exists('useraccountcontrol', $results[$i])) {
                 // ....otherwise, (ie if no 'active' LDAP flag is defined), IF the UAC setting exists,

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -851,6 +851,7 @@ class SettingsController extends Controller
             $setting->ldap_auth_filter_query = $request->input('ldap_auth_filter_query');
             $setting->ldap_version = $request->input('ldap_version', 3);
             $setting->ldap_active_flag = $request->input('ldap_active_flag');
+            $setting->ldap_invert_active_flag = $request->input('ldap_invert_active_flag');
             $setting->ldap_emp_num = $request->input('ldap_emp_num');
             $setting->ldap_email = $request->input('ldap_email');
             $setting->ldap_manager = $request->input('ldap_manager');

--- a/database/migrations/2025_02_26_153413_add_ldap_invert_active_flag_to_setting_table.php
+++ b/database/migrations/2025_02_26_153413_add_ldap_invert_active_flag_to_setting_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->boolean('ldap_invert_active_flag')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('ldap_invert_active_flag');
+        });
+    }
+};

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -118,6 +118,8 @@ return [
     'ldap_version'              => 'LDAP Version',
     'ldap_active_flag'          => 'LDAP Active Flag',
     'ldap_activated_flag_help'  => 'This value is used to determine whether a synced user can login to Snipe-IT. <strong>It does not affect the ability to check items in or out to them</strong>, and should be the <strong>attribute name</strong> within your AD/LDAP, <strong>not the value</strong>. <br><br>If this field is set to a field name that does not exist in your AD/LDAP, or the value in the AD/LDAP field is set to <code>0</code> or <code>false</code>, <strong>user login will be disabled</strong>. If the value in the AD/LDAP field is set to <code>1</code> or <code>true</code> or <em>any other text</em> means the user can log in. When the field is blank in your AD, we respect the <code>userAccountControl</code> attribute, which usually allows non-suspended users to log in.',
+    'ldap_invert_active_flag'   => 'LDAP Invert Active Flad',
+    'ldap_invert_active_flag_help'     => 'If enabled: when the value returned by LDAP Active Flag is <code>0</code> or <code>false</code> the user account will be active.',
     'ldap_emp_num'              => 'LDAP Employee Number',
     'ldap_email'                => 'LDAP Email',
     'ldap_test'                 => 'Test LDAP',

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -118,7 +118,7 @@ return [
     'ldap_version'              => 'LDAP Version',
     'ldap_active_flag'          => 'LDAP Active Flag',
     'ldap_activated_flag_help'  => 'This value is used to determine whether a synced user can login to Snipe-IT. <strong>It does not affect the ability to check items in or out to them</strong>, and should be the <strong>attribute name</strong> within your AD/LDAP, <strong>not the value</strong>. <br><br>If this field is set to a field name that does not exist in your AD/LDAP, or the value in the AD/LDAP field is set to <code>0</code> or <code>false</code>, <strong>user login will be disabled</strong>. If the value in the AD/LDAP field is set to <code>1</code> or <code>true</code> or <em>any other text</em> means the user can log in. When the field is blank in your AD, we respect the <code>userAccountControl</code> attribute, which usually allows non-suspended users to log in.',
-    'ldap_invert_active_flag'   => 'LDAP Invert Active Flad',
+    'ldap_invert_active_flag'   => 'LDAP Invert Active Flag',
     'ldap_invert_active_flag_help'     => 'If enabled: when the value returned by LDAP Active Flag is <code>0</code> or <code>false</code> the user account will be active.',
     'ldap_emp_num'              => 'LDAP Employee Number',
     'ldap_email'                => 'LDAP Email',

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -554,6 +554,32 @@
                             </div>
                         </div>
 
+                        <!-- LDAP invert active flag -->
+                        <div class="form-group">
+                            <div class="col-md-3">
+                                {{ Form::label('ldap_invert_active_flag', trans('admin/settings/general.ldap_invert_active_flag')) }}
+                            </div>
+                            <div class="col-md-8">
+                                <label class="form-control">
+                                    <input type="checkbox" name="ldap_invert_active_flag" value="1" id="ldap_invert_active_flag" @checked(old('ldap_invert_active_flag', $setting->ldap_invert_active_flag)) />
+                                    <p class="help-block">{!! trans('admin/settings/general.ldap_invert_active_flag_help') !!}</p>
+                                </label>
+                                @error('ldap_invert_active_flag')
+                                    <span class="alert-msg">
+                                         <x-icon type="x" />
+                                        {{ $message }}
+                                    </span>
+                                @enderror
+
+                                @if (config('app.lock_passwords')===true)
+                                    <p class="text-warning">
+                                        <x-icon type="locked" />
+                                        {{ trans('general.feature_disabled') }}
+                                    </p>
+                                @endif
+                            </div>
+                        </div>
+
                         <!-- LDAP emp number -->
                         <div class="form-group {{ $errors->has('ldap_emp_num') ? 'error' : '' }}">
                             <div class="col-md-3">


### PR DESCRIPTION
Feature Request #14926
LDAP Add config option to make FASLE = Enabled

Adds a option to LDAP Settings:  ```'ldap_invert_active_flag'```

Setting defaults to disabled.  When disabled, LDAP syncing works as it does now.

When enabled:  The result of the LDAP Active Flag value is inverted.  The end result changes the active flag to:
If LDAP Active Flag is ```true``` or ```1``` then ```$user->activated``` is set to ```false```
If LDAP Active Flag is ```false``` or ```0``` then ```$user->activated``` is set to true

This is allow syncing with LDAP Services where the account status flag is true when a user is not active.  For instance, Google LDAP provides a "suspended" attribute that is set to true when the user is not active and false when the user is active.

![image](https://github.com/user-attachments/assets/bb3d8447-cab7-4df2-b315-421c610bc5ba)
