### PR TITLE
Replace calls to Form::checkbox pt9

### DIFF
--- a/app/Livewire/CategoryEditForm.php
+++ b/app/Livewire/CategoryEditForm.php
@@ -12,7 +12,7 @@ class CategoryEditForm extends Component
 
     public $originalSendCheckInEmailValue;
 
-    public $requireAcceptance;
+    public bool $requireAcceptance;
 
     public $sendCheckInEmail;
 

--- a/app/Livewire/CategoryEditForm.php
+++ b/app/Livewire/CategoryEditForm.php
@@ -14,7 +14,7 @@ class CategoryEditForm extends Component
 
     public bool $requireAcceptance;
 
-    public $sendCheckInEmail;
+    public bool $sendCheckInEmail;
 
     public bool $useDefaultEula;
 

--- a/app/Livewire/CategoryEditForm.php
+++ b/app/Livewire/CategoryEditForm.php
@@ -16,7 +16,7 @@ class CategoryEditForm extends Component
 
     public $sendCheckInEmail;
 
-    public $useDefaultEula;
+    public bool $useDefaultEula;
 
     public function mount()
     {

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -28,7 +28,7 @@
     :eula-text="old('eula_text', $item->eula_text)"
     :require-acceptance="old('require_acceptance', $item->require_acceptance)"
     :send-check-in-email="old('checkin_email', $item->checkin_email)"
-    :use-default-eula="old('use_default_eula', $item->use_default_eula)"
+    :use-default-eula="(bool) old('use_default_eula', $item->use_default_eula)"
 />
 
 @include ('partials.forms.edit.image-upload', ['image_path' => app('categories_upload_path')])

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -27,7 +27,7 @@
     :default-eula-text="$snipeSettings->default_eula_text"
     :eula-text="old('eula_text', $item->eula_text)"
     :require-acceptance="(bool) old('require_acceptance', $item->require_acceptance)"
-    :send-check-in-email="old('checkin_email', $item->checkin_email)"
+    :send-check-in-email="(bool) old('checkin_email', $item->checkin_email)"
     :use-default-eula="(bool) old('use_default_eula', $item->use_default_eula)"
 />
 

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -26,7 +26,7 @@
 <livewire:category-edit-form
     :default-eula-text="$snipeSettings->default_eula_text"
     :eula-text="old('eula_text', $item->eula_text)"
-    :require-acceptance="old('require_acceptance', $item->require_acceptance)"
+    :require-acceptance="(bool) old('require_acceptance', $item->require_acceptance)"
     :send-check-in-email="old('checkin_email', $item->checkin_email)"
     :use-default-eula="(bool) old('use_default_eula', $item->use_default_eula)"
 />

--- a/resources/views/livewire/category-edit-form.blade.php
+++ b/resources/views/livewire/category-edit-form.blade.php
@@ -29,7 +29,6 @@
                         value="1"
                         wire:model.live="useDefaultEula"
                         aria-label="use_default_eula"
-                        @checked($useDefaultEula)
                     />
                     <span>{!! trans('admin/categories/general.use_default_eula') !!}</span>
                 </label>

--- a/resources/views/livewire/category-edit-form.blade.php
+++ b/resources/views/livewire/category-edit-form.blade.php
@@ -68,7 +68,14 @@
     <div class="form-group">
         <div class="col-md-9 col-md-offset-3">
             <label class="form-control">
-                {{ Form::checkbox('checkin_email', '1', $sendCheckInEmail, ['wire:model.live' => 'sendCheckInEmail', 'aria-label'=>'checkin_email', 'disabled' => $this->sendCheckInEmailDisabled]) }}
+                <input
+                    type="checkbox"
+                    name="checkin_email"
+                    value="1"
+                    wire:model.live="sendCheckInEmail"
+                    aria-label="checkin_email"
+                    @disabled($this->sendCheckInEmailDisabled)
+                />
                 {{ trans('admin/categories/general.checkin_email') }}
             </label>
             @if ($this->shouldDisplayEmailMessage)

--- a/resources/views/livewire/category-edit-form.blade.php
+++ b/resources/views/livewire/category-edit-form.blade.php
@@ -23,7 +23,14 @@
         <div class="col-md-9 col-md-offset-3">
             @if ($defaultEulaText!='')
                 <label class="form-control">
-                    {{ Form::checkbox('use_default_eula', '1', $useDefaultEula, ['wire:model.live' => 'useDefaultEula', 'aria-label'=>'use_default_eula']) }}
+                    <input
+                        type="checkbox"
+                        name="use_default_eula"
+                        value="1"
+                        wire:model.live="useDefaultEula"
+                        aria-label="use_default_eula"
+                        @checked($useDefaultEula)
+                    />
                     <span>{!! trans('admin/categories/general.use_default_eula') !!}</span>
                 </label>
             @else

--- a/resources/views/livewire/category-edit-form.blade.php
+++ b/resources/views/livewire/category-edit-form.blade.php
@@ -52,7 +52,13 @@
     <div class="form-group">
         <div class="col-md-9 col-md-offset-3">
             <label class="form-control">
-                {{ Form::checkbox('require_acceptance', '1', $requireAcceptance, ['wire:model.live' => 'requireAcceptance', 'aria-label'=>'require_acceptance']) }}
+                <input
+                    type="checkbox"
+                    name="require_acceptance"
+                    value="1"
+                    wire:model.live="requireAcceptance"
+                    aria-label="require_acceptance"
+                />
                 {{ trans('admin/categories/general.require_acceptance') }}
             </label>
         </div>

--- a/resources/views/livewire/category-edit-form.blade.php
+++ b/resources/views/livewire/category-edit-form.blade.php
@@ -34,7 +34,14 @@
                 </label>
             @else
                 <label class="form-control form-control--disabled">
-                    {{ Form::checkbox('use_default_eula', '0', $useDefaultEula, ['wire:model.live' => 'useDefaultEula', 'class'=>'disabled','disabled' => 'disabled', 'aria-label'=>'use_default_eula']) }}
+                    <input
+                        type="checkbox"
+                        name="use_default_eula"
+                        value="0"
+                        wire:model.live="useDefaultEula"
+                        aria-label="use_default_eula"
+                        disabled
+                    />
                     <span>{!! trans('admin/categories/general.use_default_eula_disabled') !!}</span>
                 </label>
             @endif

--- a/tests/Feature/Livewire/CategoryEditFormTest.php
+++ b/tests/Feature/Livewire/CategoryEditFormTest.php
@@ -10,7 +10,10 @@ class CategoryEditFormTest extends TestCase
 {
     public function testTheComponentCanRender()
     {
-        Livewire::test(CategoryEditForm::class)->assertStatus(200);
+        Livewire::test(CategoryEditForm::class, [
+            'sendCheckInEmail' => true,
+            'useDefaultEula' => true,
+        ])->assertStatus(200);
     }
 
     public function testSendEmailCheckboxIsCheckedOnLoadWhenSendEmailIsExistingSetting()


### PR DESCRIPTION
This PR replaces calls to `Form::checkbox` with inline html on the following pages:

- [Category create](https://snipe-it.test/categories/create)
- [Category edit](https://snipe-it.test/categories/1/edit)

