### PR TITLE
Avoid using authenticated user's email address in email partial

### DIFF
--- a/resources/views/partials/forms/edit/email.blade.php
+++ b/resources/views/partials/forms/edit/email.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group {{ $errors->has('email') ? ' has-error' : '' }}">
     <label for="email" class="col-md-3 col-xs-12 control-label">{{ trans('admin/suppliers/table.email') }}</label>
     <div class="col-md-8 col-xs-12">
-        <input type="text" name="email" id="email" value="{{ old('email', ($item->email ?? $user->email)) }}" class="form-control"  maxlength="191" style="width:100%; display:flex;">
+        <input type="text" name="email" id="email" value="{{ old('email', $item->email) }}" class="form-control"  maxlength="191" style="width:100%; display:flex;">
         {!! $errors->first('email', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>


### PR DESCRIPTION
This PR removes the potential pre-filling of the authenticated user's email address when creating or editing a company or supplier.

Fixes #16353