### PR TITLE
Fixed #15298 - use correct disk for S3 signatures

### DIFF
--- a/app/Http/Controllers/ActionlogController.php
+++ b/app/Http/Controllers/ActionlogController.php
@@ -17,9 +17,9 @@ class ActionlogController extends Controller
         error_reporting(0);
 
         $disk = config('filesystems.default');
-        switch (config("filesystems.disks.$disk.driver")) {
+        switch ($disk) {
 
-            case 's3':
+            case 's3_private':
                 $file = 'private_uploads/signatures/'.$filename;
                 return redirect()->away(Storage::disk($disk)->temporaryUrl($file, now()->addMinutes(5)));
             default:


### PR DESCRIPTION
This should fix #15298, where the S3 signature file was not rendering correctly. 

@uberbrady - can you double check this though? We do a lot of shenanigans around flysystem.