### PR TITLE
Fixed regression from #16150 where branding page could not be saved

### DIFF
--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -78,13 +78,11 @@
                                 <label for="brand">{{ trans('admin/settings/general.web_brand') }}</label>
                             </div>
                             <div class="col-md-9">
-                                <select name="brand" id="brand" class="form-control select2 minimumResultsForSearch" style="width: 150px;">
-                                    @foreach($optionTypes as $value => $label)
-                                        <option value="{{ $value }}" {{ old('brand', $setting->brand) == $value ? 'selected' : '' }}>
-                                            {{ $label }}
-                                        </option>
-                                    @endforeach
-                                </select>
+                                {!! Form::select('brand', [
+                                                '1'=> trans('admin/settings/general.logo_option_types.text'),
+                                                '2'=> trans('admin/settings/general.logo_option_types.logo'),
+                                                '3'=> trans('admin/settings/general.logo_option_types.logo_and_text')], old('brand', $setting->brand), array('class' => 'form-control select2', 'style'=>'width: 150px ;')) !!}
+
                             </div>
                         </div>
 


### PR DESCRIPTION
This fixes a regression created in #16150 where the branding page sent a text value instead of a number value, preventing the page from being saved.