### PR TITLE
Nicer model name formatting on RMB model not found

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -127,7 +127,7 @@ class Handler extends ExceptionHandler
         if ($e instanceof \Illuminate\Database\Eloquent\ModelNotFoundException) {
 
             // This gets the MVC model name from the exception and formats in a way that's less fugly
-            $model_name = implode(" ", preg_split('/(?=[A-Z])/', last(explode('\\', $e->getModel()))));
+            $model_name = strtolower(implode(" ", preg_split('/(?=[A-Z])/', last(explode('\\', $e->getModel())))));
             $route = str_plural(strtolower(last(explode('\\', $e->getModel())))).'.index';
 
             // Sigh.

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -127,7 +127,7 @@ class Handler extends ExceptionHandler
         if ($e instanceof \Illuminate\Database\Eloquent\ModelNotFoundException) {
 
             // This gets the MVC model name from the exception and formats in a way that's less fugly
-            $model_name =  implode("",preg_split('/(?=[A-Z])/',last(explode('\\', $e->getModel()))));
+            $model_name = implode(" ", preg_split('/(?=[A-Z])/', last(explode('\\', $e->getModel()))));
             $route = str_plural(strtolower(last(explode('\\', $e->getModel())))).'.index';
 
             // Sigh.

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -125,7 +125,9 @@ class Handler extends ExceptionHandler
         // This is traaaaash but it handles models that are not found while using route model binding :(
         // The only alternative is to set that at *each* route, which is crazypants
         if ($e instanceof \Illuminate\Database\Eloquent\ModelNotFoundException) {
-            $model_name = last(explode('\\', $e->getModel()));
+
+            // This gets the MVC model name from the exception and formats in a way that's less fugly
+            $model_name =  implode("",preg_split('/(?=[A-Z])/',last(explode('\\', $e->getModel()))));
             $route = str_plural(strtolower(last(explode('\\', $e->getModel())))).'.index';
 
             // Sigh.


### PR DESCRIPTION
This is a small (code-ugly) change that changes the red alert redirect message on multi-word MVC model names, from (for example): "Error: That AssetMaintenance was not found or you do not have permission to access it" to "Error: That asset maintenance was not found or you do not have permission to access it". 

<img width="1325" alt="Screenshot 2025-03-04 at 7 31 30 PM" src="https://github.com/user-attachments/assets/2b274638-8d5c-4918-b7d8-d80fc67d81d5" />
