### PR TITLE
Adds a check for email characters being non ASCII in the `snipeit:expected-checkin` command

### DIFF
--- a/app/Console/Commands/SendExpectedCheckinAlerts.php
+++ b/app/Console/Commands/SendExpectedCheckinAlerts.php
@@ -52,7 +52,17 @@ class SendExpectedCheckinAlerts extends Command
 
 
         foreach ($assets as $asset) {
-            if ($asset->assignedTo && (isset($asset->assignedTo->email)) && ($asset->assignedTo->email!='') && $asset->checkedOutToUser()) {
+            if ($asset->assignedTo
+                && (isset($asset->assignedTo->email))
+                && ($asset->assignedTo->email!='')
+                && $asset->checkedOutToUser()) {
+                $email = $asset->assignedTo->email;
+                // Check if the email contains only ASCII characters
+                if (!preg_match('/^[\x00-\x7F]+$/', $email)) {
+                    $this->info("Skipping invalid email: {$email}");
+                    continue;
+                }
+
                 $this->info('Sending User ExpectedCheckinNotification to: '.$asset->assignedTo->email);
                 $asset->assignedTo->notify((new ExpectedCheckinNotification($asset)));
             }


### PR DESCRIPTION
This adds a check to see if an email address contains any non ASCII chars in the email. If so, it will skip over it and continue to the next email.
<img width="950" alt="image" src="https://github.com/user-attachments/assets/33bacce5-22c4-488e-aab6-00e544f3b715" />
