### PR TITLE
Fixed custom report template route

### DIFF
--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -37,7 +37,7 @@
 
         <form
             method="POST"
-            action="{{ request()->routeIs('report-templates.edit') ? route('report-templates.update', $template) : '/reports/custom' }}"
+            action="{{ request()->routeIs('report-templates.edit') ? route('report-templates.update', $template) : route('reports/custom') }}"
             accept-charset="UTF-8"
             class="form-horizontal"
             id="custom-report-form"

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -37,7 +37,7 @@
 
         <form
             method="POST"
-            action="{{ request()->routeIs('report-templates.edit') ? route('report-templates.update', $template) : route('reports/custom') }}"
+            action="{{ request()->routeIs('report-templates.edit') ? route('report-templates.update', $template) : route('reports.post-custom') }}"
             accept-charset="UTF-8"
             class="form-horizontal"
             id="custom-report-form"

--- a/routes/web.php
+++ b/routes/web.php
@@ -532,7 +532,8 @@ Route::group(['prefix' => 'reports', 'middleware' => ['auth']], function () {
         $trail->parent('home')
             ->push(trans('general.custom_report'), route('reports/custom')));
 
-    Route::post('custom', [ReportsController::class, 'postCustom']);
+    Route::post('custom', [ReportsController::class, 'postCustom'])
+        ->name('reports.post-custom');
 
 
     Route::prefix('templates')


### PR DESCRIPTION
This PR fixes #16387 by referencing a named route instead of a hard-coded `/reports/custom`.