### PR TITLE
Replace calls to Form::label pt8

### DIFF
--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -369,6 +369,7 @@ return [
     'label2_2d_target_help'   => 'The data that will be contained in the 2D barcode',
     'label2_fields'           => 'Field Definitions',
     'label2_fields_help'      => 'Fields can be added, removed, and reordered in the left column. For each field, multiple options for Label and DataSource can be added, removed, and reordered in the right column.',
+    'purge_barcodes' => 'Purge Barcodes',
     'help_asterisk_bold'    => 'Text entered as <code>**text**</code> will be displayed as bold',
     'help_blank_to_use'     => 'Leave blank to use the value from <code>:setting_name</code>',
     'help_default_will_use' => '<code>:default</code> will use the value from <code>:setting_name</code>. <br>Note that the value of the barcodes must comply with the respective barcode spec in order to be successfully generated. Please see <a href="https://snipe-it.readme.io/docs/barcodes">the documentation <i class="fa fa-external-link"></i></a> for more details. ',

--- a/resources/views/partials/forms/edit/company-select.blade.php
+++ b/resources/views/partials/forms/edit/company-select.blade.php
@@ -2,7 +2,7 @@
 @if (($snipeSettings->full_multiple_companies_support=='1') && (!Auth::user()->isSuperUser()))
     <!-- full company support is enabled and this user isn't a superadmin -->
     <div class="form-group">
-    {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+        <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
         <div class="col-md-6">
             <select class="js-data-ajax" disabled="true" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" id="company_select" aria-label="{{ $fieldname }}"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
                 @if ($company_id = old($fieldname, (isset($item)) ? $item->{$fieldname} : ''))
@@ -19,7 +19,7 @@
 @else
     <!-- full company support is enabled or this user is a superadmin -->
     <div id="{{ $fieldname }}" class="form-group{{ $errors->has($fieldname) ? ' has-error' : '' }}">
-        {{ Form::label($fieldname, $translated_name, array('class' => 'col-md-3 control-label')) }}
+        <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ $translated_name }}</label>
         <div class="col-md-8">
             <select class="js-data-ajax" data-endpoint="companies" data-placeholder="{{ trans('general.select_company') }}" name="{{ $fieldname }}" style="width: 100%" id="company_select"{{ (isset($multiple) && ($multiple=='true')) ? " multiple='multiple'" : '' }}>
                 @isset ($selected)

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -45,7 +45,7 @@
 
                                 <label class="form-control">
                                     <input type="checkbox" value="1" name="label2_enable"{{ ((old('label2_enable') == '1') || ($setting->label2_enable) == '1') ? ' checked="checked"' : '' }} aria-label="label2_enable">
-                                    {{ Form::label('label2_enable', trans('admin/settings/general.label2_enable')) }}
+                                    <label for="label2_enable">{{ trans('admin/settings/general.label2_enable') }}</label>
                                 </label>
 
                                 {!! $errors->first('label2_enable', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
@@ -105,7 +105,7 @@
                             <!-- Title -->
                             <div class="form-group{{ $errors->has('label2_title') ? ' has-error' : '' }}">
                                 <div class="col-md-3 text-right">
-                                    {{ Form::label('label2_title', trans('admin/settings/general.label2_title'), ['class'=>'control-label']) }}
+                                    <label for="label2_title" class="control-label">{{trans('admin/settings/general.label2_title')}}</label>
                                 </div>
                                 <div class="col-md-7">
                                     <input class="form-control" aria-label="label2_title" name="label2_title" type="text" id="label2_title" value="{{ old('label2_title', $setting->label2_title) }}">
@@ -129,7 +129,7 @@
 
                                     <label class="form-control">
                                         <input type="checkbox" value="1" name="label2_asset_logo"{{ ((old('label2_asset_logo') == '1') || ($setting->label2_asset_logo) == '1') ? ' checked="checked"' : '' }} aria-label="label2_asset_logo">
-                                        {{ Form::label('label2_asset_logo', trans('admin/settings/general.label2_asset_logo')) }}
+                                        <label for="label2_asset_logo">{{ trans('admin/settings/general.label2_asset_logo') }}</label>
                                     </label>
                                     <p class="help-block">
                                         {!! trans('admin/settings/general.label2_asset_logo_help', ['setting_name' => trans('admin/settings/general.brand').' &gt; '.trans('admin/settings/general.label_logo')]) !!}
@@ -155,7 +155,7 @@
                             <!-- 1D Barcode Type -->
                             <div class="form-group{{ $errors->has('label2_1d_type') ? ' has-error' : '' }}">
                                 <div class="col-md-3 text-right">
-                                    {{ Form::label('label2_1d_type', trans('admin/settings/general.label2_1d_type'), ['class'=>'control-label']) }}
+                                    <label for="label2_1d_type" class="control-label">{{ trans('admin/settings/general.label2_1d_type') }}</label>
                                 </div>
                                 <div class="col-md-7">
                                     @php
@@ -198,7 +198,7 @@
                                 <!-- 2D Barcode Type -->
                                 <div class="form-group{{ $errors->has('label2_2d_type') ? ' has-error' : '' }}">
                                     <div class="col-md-3 text-right">
-                                        {{ Form::label('label2_2d_type', trans('admin/settings/general.label2_2d_type'), ['class'=>'control-label']) }}
+                                        <label for="label2_2d_type" class="control-label">{{ trans('admin/settings/general.label2_2d_type') }}</label>
                                     </div>
                                     <div class="col-md-7">
                                         @php
@@ -228,7 +228,7 @@
                                 <!-- QR Text -->
                                 <div class="form-group{{ $errors->has('qr_text') ? ' has-error' : '' }}">
                                     <div class="col-md-3 text-right">
-                                        {{ Form::label('qr_text', trans('admin/settings/general.qr_text'), ['class'=>'control-label']) }}
+                                        <label for="qr_text" class="control-label">{{ trans('admin/settings/general.qr_text') }}</label>
                                     </div>
                                     <div class="col-md-7">
                                         @if ($setting->qr_code == 1)
@@ -263,7 +263,7 @@
                                 <!-- Nuke barcode cache -->
                                 <div class="form-group">
                                     <div class="col-md-3 text-right">
-                                        {{ Form::label('purge_barcodes', 'Purge Barcodes', ['class'=>'control-label']) }}
+                                        <label for="purge_barcodes" class="control-label">{{ trans('admin/settings/general.purge_barcodes') }}</label>
                                     </div>
                                     <div class="col-md-7">
                                         <a class="btn btn-default btn-sm pull-left" id="purgebarcodes" style="margin-right: 10px;">
@@ -281,7 +281,7 @@
                             <!-- 2D Barcode Target -->
                             <div class="form-group{{ $errors->has('label2_2d_target') ? ' has-error' : '' }}">
                                 <div class="col-md-3 text-right">
-                                    {{ Form::label('label2_2d_target', trans('admin/settings/general.label2_2d_target'), ['class'=>'control-label']) }}
+                                    <label for="label2_2d_target" class="control-label">{{ trans('admin/settings/general.label2_2d_target') }}</label>
                                 </div>
                                 <div class="col-md-9">
                                     {{ Form::select('label2_2d_target', [
@@ -301,7 +301,7 @@
                             <!-- Fields -->
                             <div class="form-group {{ $errors->has('label2_fields') ? 'error' : '' }}">
                                 <div class="col-md-3 text-right">
-                                    {{ Form::label('label2_fields', trans('admin/settings/general.label2_fields')) }}
+                                    <label for="label2_fields">{{ trans('admin/settings/general.label2_fields') }}</label>
                                 </div>
                                 <div class="col-md-9">
                                     @include('partials.label2-field-definitions', [ 'name' => 'label2_fields', 'value' => old('label2_fields', $setting->label2_fields), 'customFields' => $customFields, 'template' => $setting->label2_template])
@@ -353,7 +353,7 @@
 
                             <div class="form-group{{ $errors->has('labels_per_page') ? ' has-error' : '' }}">
                                 <div class="col-md-3 text-right">
-                                    {{ Form::label('labels_per_page', trans('admin/settings/general.labels_per_page'), ['class'=>'control-label']) }}
+                                    <label for="labels_per_page" class="control-label">{{ trans('admin/settings/general.labels_per_page') }}</label>
                                 </div>
                                 <div class="col-md-9">
                                     <input class="form-control" style="width: 100px;" aria-label="labels_per_page" name="labels_per_page" type="text" value="{{ old('labels_per_page', $setting->labels_per_page) }}" id="labels_per_page">
@@ -363,7 +363,7 @@
 
                             <div class="form-group{{ $errors->has('labels_fontsize') ? ' has-error' : '' }}">
                                 <div class="col-md-3 text-right">
-                                    {{ Form::label('labels_fontsize', trans('admin/settings/general.labels_fontsize'), ['class'=>'control-label']) }}
+                                    <label for="labels_fontsize" class="control-label">{{ trans('admin/settings/general.labels_fontsize') }}</label>
                                 </div>
                                 <div class="col-md-2">
                                     <div class="input-group">
@@ -378,7 +378,7 @@
 
                             <div class="form-group{{ $errors->has('labels_width') ? ' has-error' : '' }}">
                                 <div class="col-md-3 text-right">
-                                    {{ Form::label('labels_width', trans('admin/settings/general.label_dimensions'), ['class'=>'control-label']) }}
+                                    <label for="labels_width" class="control-label">{{ trans('admin/settings/general.label_dimensions') }}</label>
                                 </div>
                                 <div class="col-md-3">
                                     <div class="input-group">
@@ -400,7 +400,7 @@
 
                             <div class="form-group{{ $errors->has('labels_display_sgutter') ? ' has-error' : '' }}">
                                 <div class="col-md-3 text-right">
-                                    {{ Form::label('labels_display_sgutter', trans('admin/settings/general.label_gutters')) }}
+                                    <label for="labels_display_sgutter">{{ trans('admin/settings/general.label_gutters') }}</label>
                                 </div>
                                 <div class="col-md-3">
                                     <div class="input-group">
@@ -422,7 +422,7 @@
 
                             <div class="form-group{{ $errors->has('labels_pmargin_top') ? ' has-error' : '' }}">
                                 <div class="col-md-3 text-right">
-                                    {{ Form::label('labels_pmargin_top', trans('admin/settings/general.page_padding')) }}
+                                    <label for="labels_pmargin_top">{{ trans('admin/settings/general.page_padding') }}</label>
                                 </div>
                                 <div class="col-md-3">
                                     <div class="input-group" style="margin-bottom: 15px;">
@@ -453,7 +453,7 @@
 
                             <div class="form-group{{ (($errors->has('labels_pageheight')) || $errors->has('labels_pagewidth')) ? ' has-error' : '' }}">
                                 <div class="col-md-3 text-right">
-                                    {{ Form::label('labels_pagewidth', trans('admin/settings/general.page_dimensions'), ['class'=>'control-label']) }}
+                                    <label for="labels_pagewidth" class="control-label">{{ trans('admin/settings/general.page_dimensions') }}</label>
                                 </div>
                                 <div class="col-md-3">
                                     <div class="input-group">
@@ -476,7 +476,7 @@
                         @if(!$setting->label2_enable)
                             <div class="form-group">
                                 <div class="col-md-3 text-right">
-                                {{ Form::label('labels_display', trans('admin/settings/general.label_fields'), ['class' => 'control-label']) }}
+                                    <label for="labels_display" class="control-label">{{ trans('admin/settings/general.label_fields') }}</label>
                                 </div>
                                 <div class="col-md-9">
                                         <label class="form-control">

--- a/resources/views/settings/ldap.blade.php
+++ b/resources/views/settings/ldap.blade.php
@@ -70,7 +70,7 @@
                         <!-- Enable LDAP -->
                         <div class="form-group {{ $errors->has('ldap_integration') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_enabled', trans('admin/settings/general.ldap_integration')) }}
+                                <label for="ldap_enabled">{{ trans('admin/settings/general.ldap_integration') }}</label>
                             </div>
                             <div class="col-md-8">
 
@@ -92,7 +92,7 @@
                         <!-- AD Flag -->
                         <div class="form-group">
                             <div class="col-md-3">
-                                {{ Form::label('is_ad', trans('admin/settings/general.ad')) }}
+                                <label for="is_ad">{{ trans('admin/settings/general.ad') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
@@ -118,7 +118,7 @@
                         <!-- LDAP Password Sync -->
                         <div class="form-group">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_pw_sync', trans('admin/settings/general.ldap_pw_sync')) }}
+                                <label for="ldap_pw_sync">{{ trans('admin/settings/general.ldap_pw_sync') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
@@ -147,7 +147,7 @@
                         <!-- AD Domain -->
                         <div class="form-group {{ $errors->has('ad_domain') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ad_domain', trans('admin/settings/general.ad_domain')) }}
+                                <label for="ad_domain">{{ trans('admin/settings/general.ad_domain') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder="{{ trans('general.example') .'example.com' }}" name="ad_domain" type="text" id="ad_domain" value="{{ old('ad_domain', $setting->ad_domain) }}">
@@ -200,7 +200,7 @@
                         <!-- LDAP Client-Side TLS certificate -->
                         <div class="form-group {{ $errors->has('ldap_client_tls_cert') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_client_tls_cert', trans('admin/settings/general.ldap_client_tls_cert')) }}
+                                <label for="ldap_client_tls_cert">{{ trans('admin/settings/general.ldap_client_tls_cert') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <x-input.textarea
@@ -228,7 +228,7 @@
                         <!-- LDAP Server -->
                         <div class="form-group {{ $errors->has('ldap_server') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_server', trans('admin/settings/general.ldap_server')) }}
+                                <label for="ldap_server">{{ trans('admin/settings/general.ldap_server') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder="{{ trans('general.example') .'ldap://ldap.example.com' }}" name="ldap_server" type="text" id="ldap_server" value="{{ old('ldap_server', $setting->ldap_server) }}">
@@ -253,7 +253,7 @@
                         <!-- Start TLS -->
                         <div class="form-group">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_tls', trans('admin/settings/general.ldap_tls')) }}
+                                <label for="ldap_tls">{{ trans('admin/settings/general.ldap_tls') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
@@ -279,7 +279,7 @@
                         <!-- Ignore LDAP Certificate -->
                         <div class="form-group {{ $errors->has('ldap_server_cert_ignore') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_server_cert_ignore', trans('admin/settings/general.ldap_server_cert')) }}
+                                <label for="ldap_server_cert_ignore">{{ trans('admin/settings/general.ldap_server_cert') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <label class="form-control">
@@ -308,7 +308,7 @@
                         <!-- LDAP Username -->
                         <div class="form-group {{ $errors->has('ldap_uname') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_uname', trans('admin/settings/general.ldap_uname')) }}
+                                <label for="ldap_uname">{{ trans('admin/settings/general.ldap_uname') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" autocomplete="off" placeholder="{{ trans('general.example') .'binduser@example.com' }}" name="ldap_uname" type="text" id="ldap_uname" value="{{ old('ldap_uname', $setting->ldap_uname) }}">
@@ -331,7 +331,7 @@
                         <!-- LDAP pword -->
                         <div class="form-group {{ $errors->has('ldap_pword') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_pword', trans('admin/settings/general.ldap_pword')) }}
+                                <label for="ldap_pword">{{ trans('admin/settings/general.ldap_pword') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" type="password" name="ldap_pword" id="ldap_pword" value="" autocomplete="off" onfocus="this.removeAttribute('readonly');" readonly>
@@ -354,7 +354,7 @@
                         <!-- LDAP basedn -->
                         <div class="form-group {{ $errors->has('ldap_basedn') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_basedn', trans('admin/settings/general.ldap_basedn')) }}
+                                <label for="ldap_basedn">{{ trans('admin/settings/general.ldap_basedn') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder="{{ trans('general.example') .'cn=users/authorized,dc=example,dc=com' }}" name="ldap_basedn" type="text" id="ldap_basedn" value="{{ old('ldap_basedn', $setting->ldap_basedn) }}">
@@ -377,7 +377,7 @@
                         <!-- LDAP filter -->
                         <div class="form-group {{ $errors->has('ldap_filter') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_filter', trans('admin/settings/general.ldap_filter')) }}
+                                <label for="ldap_filter">{{ trans('admin/settings/general.ldap_filter') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input type="text" name="ldap_filter" id="ldap_filter" value="{{  old('ldap_filter', $setting->ldap_filter) }}" class="form-control" placeholder="{{  trans('general.example') .'&(cn=*)' }}">
@@ -400,7 +400,7 @@
                         <!-- LDAP  username field-->
                         <div class="form-group {{ $errors->has('ldap_username_field') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_username_field', trans('admin/settings/general.ldap_username_field')) }}
+                                <label for="ldap_username_field">{{ trans('admin/settings/general.ldap_username_field') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input type="text" name="ldap_username_field" id="ldap_username_field" value="{{  old('ldap_username_field', $setting->ldap_username_field) }}" class="form-control" placeholder="{{  trans('general.example') .'samaccountname' }}">
@@ -423,7 +423,7 @@
                         <!-- LDAP Last Name Field -->
                         <div class="form-group {{ $errors->has('ldap_lname_field') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_lname_field', trans('admin/settings/general.ldap_lname_field')) }}
+                                <label for="ldap_lname_field">{{ trans('admin/settings/general.ldap_lname_field') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input type="text" name="ldap_lname_field" id="ldap_lname_field" value="{{  old('ldap_lname_field', $setting->ldap_lname_field) }}" class="form-control" placeholder="{{  trans('general.example') .'sn' }}">
@@ -446,7 +446,7 @@
                         <!-- LDAP First Name field -->
                         <div class="form-group {{ $errors->has('ldap_fname_field') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_fname_field', trans('admin/settings/general.ldap_fname_field')) }}
+                                <label for="ldap_fname_field">{{ trans('admin/settings/general.ldap_fname_field') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input type="text" name="ldap_fname_field" id="ldap_fname_field" value="{{  old('ldap_fname_field', $setting->ldap_fname_field) }}" class="form-control" placeholder="{{ trans('general.example') .'givenname'  }}">
@@ -494,7 +494,7 @@
 
                         <div class="form-group{{ $errors->has('group') ? ' has-error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_default_group', trans('admin/settings/general.ldap_default_group')) }}
+                                <label for="ldap_default_group">{{ trans('admin/settings/general.ldap_default_group') }}</label>
                             </div>
 
                             <div class="col-md-8">
@@ -534,7 +534,7 @@
                         <!-- LDAP active flag -->
                         <div class="form-group {{ $errors->has('ldap_active_flag') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_active_flag', trans('admin/settings/general.ldap_active_flag')) }}
+                                <label for="ldap_active_flag">{{ trans('admin/settings/general.ldap_active_flag') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input type="text" name="ldap_active_flag" id="ldap_active_flag" value="{{  old('ldap_active_flag', $setting->ldap_active_flag) }}" class="form-control">
@@ -592,7 +592,7 @@
                         <!-- LDAP emp number -->
                         <div class="form-group {{ $errors->has('ldap_emp_num') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_emp_num', trans('admin/settings/general.ldap_emp_num')) }}
+                                <label for="ldap_emp_num">{{ trans('admin/settings/general.ldap_emp_num') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder="{{ trans('general.example') .'employeenumber/employeeid' }}" name="ldap_emp_num" type="text" id="ldap_emp_num" value="{{ old('ldap_emp_num', $setting->ldap_emp_num) }}">
@@ -614,7 +614,7 @@
                         <!-- LDAP department -->
                         <div class="form-group {{ $errors->has('ldap_dept') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_dept', trans('admin/settings/general.ldap_dept')) }}
+                                <label for="ldap_dept">{{ trans('admin/settings/general.ldap_dept') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder="{{ trans('general.example') .'department' }}" name="ldap_dept" type="text" id="ldap_dept" value="{{ old('ldap_dept', $setting->ldap_dept) }}">
@@ -637,7 +637,7 @@
                         <!-- LDAP Manager -->
                         <div class="form-group {{ $errors->has('ldap_dept') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_dept', trans('admin/settings/general.ldap_manager')) }}
+                                <label for="ldap_manager">{{ trans('admin/settings/general.ldap_manager') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder=" {{ trans('general.example') .'manager' }}" name="ldap_manager" type="text" value="{{ old('ldap_manager', $setting->ldap_manager) }}">
@@ -660,7 +660,7 @@
                         <!-- LDAP email -->
                         <div class="form-group {{ $errors->has('ldap_email') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_email', trans('admin/settings/general.ldap_email')) }}
+                                <label for="ldap_email">{{ trans('admin/settings/general.ldap_email') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder="{{ trans('general.example') .'mail' }}" name="ldap_email" type="text" id="ldap_email" value="{{ old('ldap_email', $setting->ldap_email) }}">
@@ -683,7 +683,7 @@
                         <!-- LDAP Phone -->
                         <div class="form-group {{ $errors->has('ldap_phone') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_phone', trans('admin/settings/general.ldap_phone')) }}
+                                <label for="ldap_phone">{{ trans('admin/settings/general.ldap_phone') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder="{{ trans('general.example') .'telephonenumber' }}" name="ldap_phone" type="text" id="ldap_phone" value="{{ old('ldap_phone', $setting->ldap_phone_field) }}">
@@ -706,7 +706,7 @@
                         <!-- LDAP Job title -->
                         <div class="form-group {{ $errors->has('ldap_jobtitle') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_jobtitle', trans('admin/settings/general.ldap_jobtitle')) }}
+                                <label for="ldap_jobtitle">{{ trans('admin/settings/general.ldap_jobtitle') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder="{{ trans('general.example') .'title' }}" name="ldap_jobtitle" type="text" id="ldap_jobtitle" value="{{ old('ldap_jobtitle', $setting->ldap_jobtitle) }}">
@@ -729,7 +729,7 @@
                         <!-- LDAP Country -->
                         <div class="form-group {{ $errors->has('ldap_country') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_country', trans('admin/settings/general.ldap_country')) }}
+                                <label for="ldap_country">{{ trans('admin/settings/general.ldap_country') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder="{{ trans('general.example') .'c' }}" name="ldap_country" type="text" id="ldap_country" value="{{ old('ldap_country', $setting->ldap_country) }}">
@@ -751,7 +751,7 @@
                         <!-- LDAP Location -->
                         <div class="form-group {{ $errors->has('ldap_location') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('ldap_location', trans('admin/settings/general.ldap_location')) }}
+                                <label for="ldap_location">{{ trans('admin/settings/general.ldap_location') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder="{{ trans('general.example') .'physicaldeliveryofficename' }}" name="ldap_location" type="text" id="ldap_location" value="{{ old('ldap_location', $setting->ldap_location) }}">
@@ -834,7 +834,7 @@
                         <!-- LDAP Forgotten password -->
                         <div class="form-group {{ $errors->has('custom_forgot_pass_url') ? 'error' : '' }}">
                             <div class="col-md-3">
-                                {{ Form::label('custom_forgot_pass_url', trans('admin/settings/general.custom_forgot_pass_url')) }}
+                                <label for="custom_forgot_pass_url">{{ trans('admin/settings/general.custom_forgot_pass_url') }}</label>
                             </div>
                             <div class="col-md-8">
                                 <input class="form-control" placeholder="{{ trans('general.example') .'https://my.ldapserver-forgotpass.com' }}" name="custom_forgot_pass_url" type="text" id="custom_forgot_pass_url" value="{{ old('custom_forgot_pass_url', $setting->custom_forgot_pass_url) }}">


### PR DESCRIPTION
This PR replaces calls to `Form::label` with inline html on the following pages:

- [Label Settings](https://snipe-it.test/admin/labels)
- [LDAP Settings](https://snipe-it.test/admin/ldap)
- Company select partial

