### PR TITLE
Added validation around user store endpoint

### DIFF
--- a/app/Http/Requests/SaveUserRequest.php
+++ b/app/Http/Requests/SaveUserRequest.php
@@ -33,9 +33,9 @@ class SaveUserRequest extends FormRequest
     public function rules()
     {
         $rules = [
-            'department_id' => 'nullable|exists:departments,id',
+            'department_id' => 'nullable|integer|exists:departments,id',
             'manager_id' => 'nullable|exists:users,id',
-            'company_id' => ['nullable','exists:companies,id']
+            'company_id' => ['nullable', 'integer', 'exists:companies,id']
         ];
 
         switch ($this->method()) {

--- a/tests/Feature/Users/Api/StoreUsersTest.php
+++ b/tests/Feature/Users/Api/StoreUsersTest.php
@@ -10,6 +10,18 @@ use Tests\TestCase;
 
 class StoreUsersTest extends TestCase
 {
+    public function testRequiresPermission()
+    {
+        $this->actingAsForApi(User::factory()->create())
+            ->postJson(route('api.users.store'), [
+                'first_name' => 'Joe',
+                'username' => 'joe',
+                'password' => 'joe_password',
+                'password_confirmation' => 'joe_password',
+            ])
+            ->assertForbidden();
+    }
+
     public function testCompanyIdNeedsToBeInteger()
     {
         $company = Company::factory()->create();

--- a/tests/Feature/Users/Api/StoreUsersTest.php
+++ b/tests/Feature/Users/Api/StoreUsersTest.php
@@ -57,4 +57,22 @@ class StoreUsersTest extends TestCase
                 $json->has('messages.department_id')->etc();
             });
     }
+
+    public function testCanStoreUser()
+    {
+        $this->actingAsForApi(User::factory()->createUsers()->create())
+            ->postJson(route('api.users.store'), [
+                'first_name' => 'Darth',
+                'username' => 'darthvader',
+                'password' => 'darth_password',
+                'password_confirmation' => 'darth_password',
+            ])
+            ->assertStatusMessageIs('success')
+            ->assertOk();
+
+        $this->assertDatabaseHas('users', [
+            'first_name' => 'Darth',
+            'username' => 'darthvader',
+        ]);
+    }
 }

--- a/tests/Feature/Users/Api/StoreUsersTest.php
+++ b/tests/Feature/Users/Api/StoreUsersTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Users\Api;
+
+use App\Models\Company;
+use App\Models\Department;
+use App\Models\User;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class StoreUsersTest extends TestCase
+{
+    public function testCompanyIdNeedsToBeInteger()
+    {
+        $company = Company::factory()->create();
+
+        $this->actingAsForApi(User::factory()->createUsers()->create())
+            ->postJson(route('api.users.store'), [
+                'company_id' => [$company->id],
+                'first_name' => 'Joe',
+                'username' => 'joe',
+                'password' => 'joe_password',
+                'password_confirmation' => 'joe_password',
+            ])
+            ->assertStatusMessageIs('error')
+            ->assertJson(function (AssertableJson $json) {
+                $json->has('messages.company_id')->etc();
+            });
+    }
+
+    public function testDepartmentIdNeedsToBeInteger()
+    {
+        $department = Department::factory()->create();
+
+        $this->actingAsForApi(User::factory()->createUsers()->create())
+            ->postJson(route('api.users.store'), [
+                'department_id' => [$department->id],
+                'first_name' => 'Joe',
+                'username' => 'joe',
+                'password' => 'joe_password',
+                'password_confirmation' => 'joe_password',
+            ])
+            ->assertStatusMessageIs('error')
+            ->assertJson(function (AssertableJson $json) {
+                $json->has('messages.department_id')->etc();
+            });
+    }
+}


### PR DESCRIPTION
This PR adds validation to ensure `company_id` and `department_id` are `integers` when creating a user via the api.

It also adds some simple tests around the api endpoint.
