### PR TITLE
Disallow deleting accessories that have active checkouts

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -192,7 +192,7 @@ class AccessoriesController extends Controller
 
 
         if ($accessory->checkouts_count > 0) {
-            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.assoc_checkouts', ['count' => $accessory->checkouts_count]));
+            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/general.delete_disabled'));
         }
 
         if ($accessory->image) {

--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -184,15 +184,15 @@ class AccessoriesController extends Controller
      */
     public function destroy($accessoryId) : RedirectResponse
     {
-        if (is_null($accessory = Accessory::find($accessoryId))) {
+        if (is_null($accessory = Accessory::withCount('checkouts as checkouts_count')->find($accessoryId))) {
             return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.not_found'));
         }
 
         $this->authorize($accessory);
 
 
-        if ($accessory->hasUsers() > 0) {
-            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.assoc_users', ['count'=> $accessory->hasUsers()]));
+        if ($accessory->checkouts_count > 0) {
+            return redirect()->route('accessories.index')->with('error', trans('admin/accessories/message.assoc_checkouts', ['count' => $accessory->checkouts_count]));
         }
 
         if ($accessory->image) {

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -253,7 +253,7 @@ class AccessoriesController extends Controller
         $this->authorize($accessory);
 
         if ($accessory->checkouts_count > 0) {
-            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/accessories/message.assoc_checkouts', ['count' => $accessory->checkouts_count])));
+            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/accessories/general.delete_disabled')));
         }
 
         $accessory->delete();

--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -249,11 +249,11 @@ class AccessoriesController extends Controller
     public function destroy($id)
     {
         $this->authorize('delete', Accessory::class);
-        $accessory = Accessory::findOrFail($id);
+        $accessory = Accessory::withCount('checkouts as checkouts_count')->findOrFail($id);
         $this->authorize($accessory);
 
-        if ($accessory->hasUsers() > 0) {
-            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/accessories/message.assoc_users', ['count'=> $accessory->hasUsers()])));
+        if ($accessory->checkouts_count > 0) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/accessories/message.assoc_checkouts', ['count' => $accessory->checkouts_count])));
         }
 
         $accessory->delete();

--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -53,7 +53,7 @@ class AccessoriesTransformer
             'checkout' => Gate::allows('checkout', Accessory::class),
             'checkin' =>  false,
             'update' => Gate::allows('update', Accessory::class),
-            'delete' => Gate::allows('delete', Accessory::class),
+            'delete' => $accessory->checkouts_count === 0 && Gate::allows('delete', Accessory::class),
             'clone' => Gate::allows('create', Accessory::class),
             
         ];

--- a/database/factories/AccessoryFactory.php
+++ b/database/factories/AccessoryFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Accessory;
+use App\Models\Asset;
 use App\Models\Category;
 use App\Models\Location;
 use App\Models\Manufacturer;
@@ -168,6 +169,32 @@ class AccessoryFactory extends Factory
                     'assigned_type' => User::class,
                 ]);
             }
+        });
+    }
+
+    public function checkedOutToAsset(Asset $asset = null)
+    {
+        return $this->afterCreating(function (Accessory $accessory) use ($asset) {
+            $accessory->checkouts()->create([
+                'accessory_id' => $accessory->id,
+                'created_at' => Carbon::now(),
+                'created_by' => 1,
+                'assigned_to' => $asset->id ?? Asset::factory()->create()->id,
+                'assigned_type' => Asset::class,
+            ]);
+        });
+    }
+
+    public function checkedOutToLocation(Location $location = null)
+    {
+        return $this->afterCreating(function (Accessory $accessory) use ($location) {
+            $accessory->checkouts()->create([
+                'accessory_id' => $accessory->id,
+                'created_at' => Carbon::now(),
+                'created_by' => 1,
+                'assigned_to' => $location->id ?? Location::factory()->create()->id,
+                'assigned_type' => Location::class,
+            ]);
         });
     }
 }

--- a/resources/lang/en-US/admin/accessories/message.php
+++ b/resources/lang/en-US/admin/accessories/message.php
@@ -5,7 +5,6 @@ return array(
     'does_not_exist' => 'The accessory [:id] does not exist.',
     'not_found' => 'That accessory was not found.',
     'assoc_users'	 => 'This accessory currently has :count items checked out to users. Please check in the accessories and and try again. ',
-    'assoc_checkouts' => 'This accessory currently has :count items checked out. Please check in the accessories and and try again.',
 
     'create' => array(
         'error'   => 'The accessory was not created, please try again.',

--- a/resources/lang/en-US/admin/accessories/message.php
+++ b/resources/lang/en-US/admin/accessories/message.php
@@ -5,6 +5,7 @@ return array(
     'does_not_exist' => 'The accessory [:id] does not exist.',
     'not_found' => 'That accessory was not found.',
     'assoc_users'	 => 'This accessory currently has :count items checked out to users. Please check in the accessories and and try again. ',
+    'assoc_checkouts' => 'This accessory currently has :count items checked out. Please check in the accessories and and try again.',
 
     'create' => array(
         'error'   => 'The accessory was not created, please try again.',

--- a/tests/Feature/Accessories/Api/DeleteAccessoriesTest.php
+++ b/tests/Feature/Accessories/Api/DeleteAccessoriesTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Accessories\Api;
 use App\Models\Accessory;
 use App\Models\Company;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\Concerns\TestsFullMultipleCompaniesSupport;
 use Tests\Concerns\TestsPermissionsRequirement;
 use Tests\TestCase;
@@ -53,9 +54,17 @@ class DeleteAccessoriesTest extends TestCase implements TestsFullMultipleCompani
         $this->assertSoftDeleted($accessoryC);
     }
 
-    public function testCannotDeleteAccessoryThatHasCheckouts()
+    public static function checkedOutAccessories()
     {
-        $accessory = Accessory::factory()->checkedOutToUser()->create();
+        yield 'checked out to user' => [fn() => Accessory::factory()->checkedOutToUser()->create()];
+        yield 'checked out to asset' => [fn() => Accessory::factory()->checkedOutToAsset()->create()];
+        yield 'checked out to location' => [fn() => Accessory::factory()->checkedOutToLocation()->create()];
+    }
+
+    #[DataProvider('checkedOutAccessories')]
+    public function testCannotDeleteAccessoryThatHasCheckouts($data)
+    {
+        $accessory = $data();
 
         $this->actingAsForApi(User::factory()->deleteAccessories()->create())
             ->deleteJson(route('api.accessories.destroy', $accessory))

--- a/tests/Feature/Accessories/Ui/DeleteAccessoryTest.php
+++ b/tests/Feature/Accessories/Ui/DeleteAccessoryTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Accessories\Ui;
 use App\Models\Accessory;
 use App\Models\Company;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class DeleteAccessoryTest extends TestCase
@@ -29,9 +30,17 @@ class DeleteAccessoryTest extends TestCase
         $this->assertFalse($accessoryForCompanyA->refresh()->trashed(), 'Accessory should not be deleted');
     }
 
-    public function testCannotDeleteAccessoryThatHasCheckouts()
+    public static function checkedOutAccessories()
     {
-        $accessory = Accessory::factory()->checkedOutToUser()->create();
+        yield 'checked out to user' => [fn() => Accessory::factory()->checkedOutToUser()->create()];
+        yield 'checked out to asset' => [fn() => Accessory::factory()->checkedOutToAsset()->create()];
+        yield 'checked out to location' => [fn() => Accessory::factory()->checkedOutToLocation()->create()];
+    }
+
+    #[DataProvider('checkedOutAccessories')]
+    public function testCannotDeleteAccessoryThatHasCheckouts($data)
+    {
+        $accessory = $data();
 
         $this->actingAs(User::factory()->deleteAccessories()->create())
             ->delete(route('accessories.destroy', $accessory->id))


### PR DESCRIPTION
This PR prevents deleting accessories that are checked out to assets or locations (we already prevent deleting accessories checked out to users). We already disable the button on the accessory show page but did not on the index page.

The API and UI controllers now take into account all checkouts to the accessory and the index has been updated to disable the button if the item has checkouts:
![image](https://github.com/user-attachments/assets/1bcc58cb-fcf7-4ca8-b10a-4b479d1f1980)
