### PR TITLE
Fixed linking in saved report template dropdown

### DIFF
--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -627,7 +627,11 @@
                 >
                     <option></option>
                     @foreach($report_templates as $savedTemplate)
-                        <option value="{{ $savedTemplate->id }}" @selected($savedTemplate->is(request()->route()->parameter('reportTemplate')))>
+                        <option
+                            value="{{ $savedTemplate->id }}"
+                            data-route="{{ route('report-templates.show', $savedTemplate->id) }}"
+                            @selected($savedTemplate->is(request()->route()->parameter('reportTemplate')))
+                        >
                             {{ $savedTemplate->name }}
                         </option>
                     @endforeach
@@ -774,7 +778,7 @@
 
       $('#saved_report_select')
           .on('select2:select', function (event) {
-              window.location.href = '/reports/templates/' + event.params.data.id;
+              window.location.href = event.params.data.element.dataset.route;
           });
 
       $('#dataConfirmModal').on('show.bs.modal', function (event) {


### PR DESCRIPTION
This PR replaces the hard-coded url that is used when selecting a saved template in the following dropdown with the named route:

![image](https://github.com/user-attachments/assets/854cdb97-cfa0-49cc-97bd-9d53dd1179ef)

---

Fixes #16434