### PR TITLE
Add 'maintenance_date' to the asset model attribute list

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -161,6 +161,7 @@ class Asset extends Depreciable
         'asset_eol_date',
         'last_checkin',
         'last_checkout',
+        'maintenance_date',
     ];
 
     use Searchable;


### PR DESCRIPTION
Fixed #16459 Add 'maintenance_date' to the asset model attribute list, because it won't add the date on create a new asset.