### PR TITLE
Replaced call to Form::close()

### DIFF
--- a/resources/views/depreciations/view.blade.php
+++ b/resources/views/depreciations/view.blade.php
@@ -171,7 +171,7 @@
                                 </div>
 
                             </div>
-                            {{ Form::close() }}
+                            </form>
 
                         </div> <!--/.row-->
                     </div> <!-- /.tab-pane -->


### PR DESCRIPTION
This PR replaces the last `Form::close()` with inline html (I missed it on the first passes).
