### PR TITLE
Fixed location being automatically populated on asset checkin screen

### DIFF
--- a/resources/views/blade/input/location-select.blade.php
+++ b/resources/views/blade/input/location-select.blade.php
@@ -1,0 +1,62 @@
+@use('App\Models\Location', 'Location')
+@use('Illuminate\Support\Arr', 'Arr')
+
+@props([
+    'label',
+    'name',
+    'selected',
+    'required' => false,
+    'multiple' => false,
+    'helpText' => null,
+    'hideNewButton' => false,
+])
+
+<div
+    @class([
+       'form-group',
+       'has-error' => $errors->has($name),
+    ])
+>
+
+    <label for="{{ $name }}" class="col-md-3 control-label">{{ $label }}</label>
+    <div class="col-md-7">
+        <select
+            class="js-data-ajax"
+            data-endpoint="locations"
+            data-placeholder="{{ trans('general.select_location') }}"
+            name="{{ $name }}"
+            style="width: 100%"
+            id="{{ $name }}_location_select"
+            aria-label="{{ $name }}"
+            @required($required)
+            @if ($multiple)
+                multiple
+            @endif
+        >
+            @if ($selected)
+                @foreach(Arr::wrap($selected) as $id)
+                    <option value="{{ $id }}" selected="selected" role="option" aria-selected="true"  role="option">
+                        {{ (Location::find($id))->name }}
+                    </option>
+                @endforeach
+            @endif
+        </select>
+    </div>
+
+    <div class="col-md-1 col-sm-1 text-left">
+        @unless($hideNewButton)
+            @can('create', Location::class)
+                <a href='{{ route('modal.show', 'location') }}' data-toggle="modal" data-target="#createModal" data-select='{{ $name }}_location_select' class="btn btn-sm btn-primary">{{ trans('button.new') }}</a>
+            @endcan
+        @endunless
+    </div>
+
+    {!! $errors->first($name, '<div class="col-md-8 col-md-offset-3"><span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span></div>') !!}
+
+    @if ($helpText)
+        <div class="col-md-7 col-sm-11 col-md-offset-3">
+            <p class="help-block">{{ $helpText }}</p>
+        </div>
+    @endif
+
+</div>

--- a/resources/views/blade/input/location-select.blade.php
+++ b/resources/views/blade/input/location-select.blade.php
@@ -36,7 +36,7 @@
             @if ($selected)
                 @foreach(Arr::wrap($selected) as $id)
                     <option value="{{ $id }}" selected="selected" role="option" aria-selected="true"  role="option">
-                        {{ (Location::find($id))->name }}
+                        {{ optional(Location::find($id))->name }}
                     </option>
                 @endforeach
             @endif

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -95,7 +95,26 @@
                                             </div>
                                         </div>
 
-                                        @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'location_id', 'help_text' => ($asset->defaultLoc) ? trans('general.checkin_to_diff_location', ['default_location' => $asset->defaultLoc->name]) : null, 'hide_location_radio' => true])
+                                        <x-input.location-select
+                                            :label="trans('general.location')"
+                                            name="location_id"
+                                            :help_text="($asset->defaultLoc) ? trans('general.checkin_to_diff_location', ['default_location' => $asset->defaultLoc->name]) : null"
+                                            :selected="old('location_id')"
+                                        />
+
+                                        <!-- Update actual location  -->
+                                        <div class="form-group">
+                                            <div class="col-md-9 col-md-offset-3">
+                                                <label class="form-control">
+                                                    {{ Form::radio('update_default_location', '1', old('update_default_location'), ['checked'=> 'checked', 'aria-label'=>'update_default_location']) }}
+                                                    {{ trans('admin/hardware/form.asset_location') }}
+                                                </label>
+                                                <label class="form-control">
+                                                    {{ Form::radio('update_default_location', '0', old('update_default_location'), ['aria-label'=>'update_default_location']) }}
+                                                    {{ trans('admin/hardware/form.asset_location_update_default_current') }}
+                                                </label>
+                                            </div>
+                                        </div> <!--/form-group-->
 
                                         <!-- Checkout/Checkin Date -->
                                         <div class="form-group{{ $errors->has('checkin_at') ? ' has-error' : '' }}">


### PR DESCRIPTION
This PR fixes a bug when checking in an asset where the asset's current location is pre-populated in the Location select:

![image](https://github.com/user-attachments/assets/1578abf2-93aa-4fe3-8b34-34d77a871da6)

Users then have to click the `x` so the location is not explicitly set. 

The issue stems from `$item` being [passed from the controller](https://github.com/snipe/snipe-it/blob/19fb45f4889ac0ac19b22ae19f0ee79d709b1fe4/app/Http/Controllers/Assets/AssetCheckinController.php#L45) and the variable being brought into scope within [the `location-select` partial](https://github.com/snipe/snipe-it/blob/2a156776a460bbc3cefa3b7671f046ce2a499531/resources/views/hardware/checkin.blade.php#L98) (@\include brings parent variables into scope within it).

Instead of writing additional logic in the existing partial to ignore `$item` in this specific context (the partial is already noisy with conditionals), I created a location-select blade component to bypass the scoping issue completely. (The component is mostly copy/paste/modify from the location-select partial).

This component is mainly focused on handling this specific screen but can probably replace the partial uses without much modification if the need arises down the line. I fought the desire to create a agnostic `ajax-select` component that the `location-select` extended but I can see that appearing in the future.

Also, I included the radio options "Update Asset Location" and "Update default location AND actual location" in the parent `checkin.blade.php` since, I believe, that is the only place it is used so it doesn't need to be in the location-select component.