### PR TITLE
Properly handle route model bound LicenseSeat not being found

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -141,6 +141,8 @@ class Handler extends ExceptionHandler
                 $route = 'kits.index';
             } elseif ($route == 'assetmaintenances.index') {
                 $route = 'maintenances.index';
+            } elseif ($route === 'licenseseats.index') {
+                $route = 'licenses.index';
             }
 
             return redirect()

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -150,6 +150,11 @@ class UserFactory extends Factory
         return $this->appendPermission(['models.delete' => '1']);
     }
 
+    public function viewAssetModels()
+    {
+        return $this->appendPermission(['models.view' => '1']);
+    }
+
     public function viewAccessories()
     {
         return $this->appendPermission(['accessories.view' => '1']);
@@ -358,6 +363,11 @@ class UserFactory extends Factory
     public function deletePredefinedKits()
     {
         return $this->appendPermission(['kits.delete' => '1']);
+    }
+
+    public function viewPredefinedKits()
+    {
+        return $this->appendPermission(['kits.view' => '1']);
     }
 
     public function deleteStatusLabels()

--- a/tests/Feature/Redirects/ModelNotFoundRedirectTest.php
+++ b/tests/Feature/Redirects/ModelNotFoundRedirectTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Feature\Redirects;
+
+use App\Models\User;
+use Tests\TestCase;
+
+class ModelNotFoundRedirectTest extends TestCase
+{
+    public function testHandlesLicenseSeat404()
+    {
+        $this->actingAs(User::factory()->viewLicenses()->create())
+            ->get(route('licenses.checkin', 9999))
+            ->assertRedirectToRoute('licenses.index');
+    }
+}

--- a/tests/Feature/Redirects/ModelNotFoundRedirectTest.php
+++ b/tests/Feature/Redirects/ModelNotFoundRedirectTest.php
@@ -7,10 +7,45 @@ use Tests\TestCase;
 
 class ModelNotFoundRedirectTest extends TestCase
 {
+    public function testHandlesAsset404()
+    {
+        $this->actingAs(User::factory()->viewAssets()->create())
+            ->get(route('hardware.checkout.create', 9999))
+            ->assertRedirectToRoute('hardware.index');
+    }
+
+    public function testHandlesAssetMaintenance404()
+    {
+        $this->actingAs(User::factory()->viewAssets()->create())
+            ->get(route('maintenances.show', 9999))
+            ->assertRedirectToRoute('maintenances.index');
+    }
+
+    public function testHandlesAssetModel404()
+    {
+        $this->actingAs(User::factory()->viewAssetModels()->create())
+            ->get(route('models.show', 9999))
+            ->assertRedirectToRoute('models.index');
+    }
+
     public function testHandlesLicenseSeat404()
     {
         $this->actingAs(User::factory()->viewLicenses()->create())
             ->get(route('licenses.checkin', 9999))
             ->assertRedirectToRoute('licenses.index');
+    }
+
+    public function testHandlesPredefinedKit404()
+    {
+        $this->actingAs(User::factory()->viewPredefinedKits()->create())
+            ->get(route('kits.show', 9999))
+            ->assertRedirectToRoute('kits.index');
+    }
+
+    public function testHandlesReportTemplate404()
+    {
+        $this->actingAs(User::factory()->canViewReports()->create())
+            ->get(route('report-templates.show', 9999))
+            ->assertRedirectToRoute('reports/custom');
     }
 }


### PR DESCRIPTION
This PR handles attempting to load a route, like https://snipe-it.test/licenses/9999999/checkin,  with a bound `LicenseSeat` that does not exist but properly redirecting to the license index:
![image](https://github.com/user-attachments/assets/03f23fbb-6493-4d07-8a84-fbba4e57fee4)


I also added tests for the new and existing changes to `Handler`