### PR TITLE
Fixed new user modal pre-populating with first name and last name of acting user

### DIFF
--- a/app/Http/Controllers/ModalController.php
+++ b/app/Http/Controllers/ModalController.php
@@ -41,10 +41,11 @@ class ModalController extends Controller
         $view = view("modals.${type}");
 
             if ($type == "statuslabel") {
-            $view->with('statuslabel_types', Helper::statusTypeList());
-        }
-        if (in_array($type, ['kit-model', 'kit-license', 'kit-consumable', 'kit-accessory'])) {
-            $view->with('kitId', $itemId);
+                $view->with('statuslabel_types', Helper::statusTypeList());
+            }
+
+            if (in_array($type, ['kit-model', 'kit-license', 'kit-consumable', 'kit-accessory'])) {
+                $view->with('kitId', $itemId);
             }
             return $view;
         }

--- a/resources/views/modals/user.blade.php
+++ b/resources/views/modals/user.blade.php
@@ -42,10 +42,10 @@
                         @include ('partials.forms.edit.location-profile-select', ['translated_name' => trans('general.location'), 'fieldname' => 'location_id'])
                     </div>
                     <div class="dynamic-form-row">
-                        @include('partials.forms.edit.name-first', [ 'required' => 'true', 'class' => 'col-md-8 col-xs-12-pull', 'style' => 'width:67%;'])
+                        @include('partials.forms.edit.name-first', ['value' => '', 'required' => 'true', 'class' => 'col-md-8 col-xs-12-pull', 'style' => 'width:67%;'])
                     </div>
                     <div class="dynamic-form-row">
-                    @include('partials.forms.edit.name-last', ['required' => 'true', 'class' => 'col-md-8 col-xs-12-pull', 'style' => 'width:67%;'])
+                    @include('partials.forms.edit.name-last', ['value' => '', 'required' => 'true', 'class' => 'col-md-8 col-xs-12-pull', 'style' => 'width:67%;'])
                     </div>
                     <div class="dynamic-form-row">
                         @include('partials.forms.edit.email')

--- a/resources/views/partials/forms/edit/name-first.blade.php
+++ b/resources/views/partials/forms/edit/name-first.blade.php
@@ -3,11 +3,12 @@
     $class = $class ?? 'col-md-6';
     $style = $style ?? '';
     $required = $required ?? '';
+    $value = $value ?? $user->first_name;
 @endphp
 <div class="form-group {{ $errors->has('first_name') ? 'has-error' : '' }}">
     <label class="col-md-3 control-label" for="first_name">{{ trans('general.first_name') }}</label>
     <div class="{{$class ? $class : 'col-md-6'}}" style= "{{$style}}">
-        <input class="form-control" type="text" name="first_name" id="first_name" value="{{ old('first_name', $user->first_name) }}" {{$required ? 'required' : ''}} maxlength="191" {{  (Helper::checkIfRequired($user, 'first_name')) ? ' required' : '' }}/>
+        <input class="form-control" type="text" name="first_name" id="first_name" value="{{ old('first_name', ($value ?? $user->first_name)) }}" {{$required ? 'required' : ''}} maxlength="191" {{  (Helper::checkIfRequired($user, 'first_name')) ? ' required' : '' }}/>
         {!! $errors->first('first_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
     </div>
 </div>

--- a/resources/views/partials/forms/edit/name-last.blade.php
+++ b/resources/views/partials/forms/edit/name-last.blade.php
@@ -2,12 +2,13 @@
 @php
     $class = $class ?? 'col-md-6';
     $style = $style ?? '';
-        $required = $required ?? '';
+    $required = $required ?? '';
+    $value = $value ?? $user->last_name;
 @endphp
 <div class="form-group {{ $errors->has('last_name') ? 'has-error' : '' }}">
     <label class="col-md-3 control-label" for="last_name">{{ trans('general.last_name') }} </label>
     <div class="{{$class}}" style= "{{$style ? $style : ''}}">
-        <input class="form-control" type="text" name="last_name" id="last_name"  value="{{ old('last_name', $user->last_name) }}" maxlength="191"{{  (Helper::checkIfRequired($user, 'last_name')) ? ' required' : '' }} />
+        <input class="form-control" type="text" name="last_name" id="last_name"  value="{{ old('last_name', ($value ?? $user->last_name)) }}" maxlength="191"{{  (Helper::checkIfRequired($user, 'last_name')) ? ' required' : '' }} />
         {!! $errors->first('last_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
     </div>
 </div>

--- a/tests/Feature/Modals/Ui/ShowModalsTest.php
+++ b/tests/Feature/Modals/Ui/ShowModalsTest.php
@@ -9,9 +9,15 @@ class ShowModalsTest extends TestCase
 {
     public function testUserModalRenders()
     {
-        $this->actingAs(User::factory()->createUsers()->create())
+        $admin = User::factory()->createUsers()->create();
+        $response = $this->actingAs($admin)
             ->get('modals/user')
             ->assertOk();
+
+        $response->assertStatus(200);
+        $response->assertDontSee($admin->first_name);
+        $response->assertDontSee($admin->last_name);
+        $response->assertDontSee($admin->email);
     }
 
     public function testDepartmentModalRenders()

--- a/tests/Feature/Users/Ui/CreateUserTest.php
+++ b/tests/Feature/Users/Ui/CreateUserTest.php
@@ -9,8 +9,12 @@ class CreateUserTest extends TestCase
 {
     public function testPageRenders()
     {
-        $this->actingAs(User::factory()->superuser()->create())
+        $admin = User::factory()->createUsers()->create();
+        $response = $this->actingAs(User::factory()->superuser()->create())
             ->get(route('users.create'))
             ->assertOk();
+        $response->assertDontSee($admin->first_name);
+        $response->assertDontSee($admin->last_name);
+        $response->assertDontSee($admin->email);
     }
 }


### PR DESCRIPTION
Because Laravel assumes `$user` is the logged in user if one has not beed explicitly passed, the new user modal would pre-populate some information from the admin trying to create them. 

<img width="607" alt="Screenshot 2025-03-12 at 5 04 34 PM" src="https://github.com/user-attachments/assets/28874429-f908-48ce-8012-988a529c0ef5" />

This also adds some tests around that so we can make sure future Laravel upgrades do not change the expected outcome.
