### PR TITLE
Avoid logging consumable checkins and purge action log of bad entries

### DIFF
--- a/app/Http/Controllers/Users/BulkUsersController.php
+++ b/app/Http/Controllers/Users/BulkUsersController.php
@@ -298,7 +298,6 @@ class BulkUsersController extends Controller
         $this->logItemCheckinAndDelete($assets, Asset::class);
         $this->logAccessoriesCheckin($accessoryUserRows);
         $this->logItemCheckinAndDelete($licenses, License::class);
-        $this->logConsumablesCheckin($consumableUserRows);
 
         Asset::whereIn('id', $assets->pluck('id'))->update([
             'status_id'     => e(request('status_id')),
@@ -359,20 +358,6 @@ class BulkUsersController extends Controller
             $logAction->item_id = $accessoryUserRow->accessory_id;
             $logAction->item_type = Accessory::class;
             $logAction->target_id = $accessoryUserRow->assigned_to;
-            $logAction->target_type = User::class;
-            $logAction->created_by = auth()->id();
-            $logAction->note = 'Bulk checkin items';
-            $logAction->logaction('checkin from');
-        }
-    }
-
-    private function logConsumablesCheckin(Collection $consumableUserRows): void
-    {
-        foreach ($consumableUserRows as $consumableUserRow) {
-            $logAction = new Actionlog();
-            $logAction->item_id = $consumableUserRow->consumable_id;
-            $logAction->item_type = Consumable::class;
-            $logAction->target_id = $consumableUserRow->assigned_to;
             $logAction->target_type = User::class;
             $logAction->created_by = auth()->id();
             $logAction->note = 'Bulk checkin items';

--- a/database/migrations/2025_03_12_184851_purge_action_logs_table_of_consumable_checkin_entries.php
+++ b/database/migrations/2025_03_12_184851_purge_action_logs_table_of_consumable_checkin_entries.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Consumable;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('action_logs')
+            ->where([
+                'action_type' => 'checkin from',
+                'note' => 'Bulk checkin items',
+                'item_type' => Consumable::class,
+            ])
+            ->delete();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // nothing to do here...
+    }
+};


### PR DESCRIPTION
**THIS PR MAKES CHANGES TO THE ACTION LOG**

---

This PR follows up a comment in #16489 where it was noticed we were logging consumable checkins when bulk deleting a user.

This PR stops that type of logging and purges the action log of existing entries for consumable checkins.