### PR TITLE
Removes deprecated MS Teams webhook methods and integration tests

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -722,7 +722,7 @@ class Helper
         $deprecations = [
             'ms_teams_deprecated' => array(
             'check' => !Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows'),
-            'message' => 'The Microsoft Teams webhook URL being used will be deprecated Jan 31st, 2025. <a class="btn btn-primary" href="' . route('settings.slack.index') . '">Change webhook endpoint</a>'),
+            'message' => 'The Microsoft Teams webhook URL being used was deprecated Jan 31st, 2025. <a class="btn btn-primary" href="' . route('settings.slack.index') . '">Change webhook endpoint</a>'),
         ];
 
         // if item of concern is being used and its being used with the deprecated values return the notification array.

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -102,10 +102,6 @@ class CheckoutableListener
                     $message = $this->getCheckoutNotification($event)->toMicrosoftTeams();
                     $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
                     $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
-                } else {
-
-                    Notification::route($this->webhookSelected(), Setting::getSettings()->webhook_endpoint)
-                        ->notify($this->getCheckoutNotification($event, $acceptance));
                 }
             }
         } catch (ClientException $e) {
@@ -196,12 +192,12 @@ class CheckoutableListener
         try {
             if ($this->shouldSendWebhookNotification()) {
                 if ($this->newMicrosoftTeamsWebhookEnabled()) {
+                    if(!Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')){
+                        return redirect()->back()->with('warning',trans('admin/settings/message.webhook.webhook_fail'));
+                    }
                     $message = $this->getCheckinNotification($event)->toMicrosoftTeams();
                     $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
                     $notification->success()->sendMessage($message[0], $message[1]); // Send the message to Microsoft Teams
-                } else {
-                    Notification::route($this->webhookSelected(), Setting::getSettings()->webhook_endpoint)
-                        ->notify($this->getCheckinNotification($event));
                 }
             }
         } catch (ClientException $e) {

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -94,15 +94,13 @@ class CheckoutableListener
         }
 //                 Send Webhook notification
         try {
-            if ($this->shouldSendWebhookNotification()) {
-                if ($this->newMicrosoftTeamsWebhookEnabled()) {
-                    if(!Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')){
-                        return redirect()->back()->with('warning',trans('admin/settings/message.webhook.webhook_fail'));
-                    }
-                    $message = $this->getCheckoutNotification($event)->toMicrosoftTeams();
-                    $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
-                    $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
+            if ($this->shouldSendWebhookNotification()){
+                if($this->isDeprecatedTeamsWebhook()){
+                    return redirect()->back()->with('warning',trans('admin/settings/message.webhook.webhook_fail'));
                 }
+                $message = $this->getCheckoutNotification($event)->toMicrosoftTeams();
+                $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
+                $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
             }
         } catch (ClientException $e) {
             if (strpos($e->getMessage(), 'channel_not_found') !== false) {
@@ -190,15 +188,13 @@ class CheckoutableListener
 
         // Send Webhook notification
         try {
-            if ($this->shouldSendWebhookNotification()) {
-                if ($this->newMicrosoftTeamsWebhookEnabled()) {
-                    if(!Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')){
-                        return redirect()->back()->with('warning',trans('admin/settings/message.webhook.webhook_fail'));
-                    }
-                    $message = $this->getCheckinNotification($event)->toMicrosoftTeams();
-                    $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
-                    $notification->success()->sendMessage($message[0], $message[1]); // Send the message to Microsoft Teams
+            if ($this->shouldSendWebhookNotification()){
+                if($this->isDeprecatedTeamsWebhook()){
+                    return redirect()->back()->with('warning',trans('admin/settings/message.webhook.webhook_fail'));
                 }
+                $message = $this->getCheckinNotification($event)->toMicrosoftTeams();
+                $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
+                $notification->success()->sendMessage($message[0], $message[1]); // Send the message to Microsoft Teams
             }
         } catch (ClientException $e) {
             if (strpos($e->getMessage(), 'channel_not_found') !== false) {
@@ -380,8 +376,8 @@ class CheckoutableListener
         return (method_exists($event->checkoutable, 'checkin_email') && $event->checkoutable->checkin_email());
     }
 
-    private function newMicrosoftTeamsWebhookEnabled(): bool
+    private function isDeprecatedTeamsWebhook(): bool
     {
-        return Setting::getSettings()->webhook_selected === 'microsoft' && Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows');
+        return !Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows');
     }
 }

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -94,13 +94,18 @@ class CheckoutableListener
         }
 //                 Send Webhook notification
         try {
-            if ($this->shouldSendWebhookNotification()){
-                if($this->isDeprecatedTeamsWebhook()){
-                    return redirect()->back()->with('warning',trans('admin/settings/message.webhook.webhook_fail'));
+            if ($this->shouldSendWebhookNotification()) {
+                if (Setting::getSettings()->webhook_selected === 'microsoft') {
+                    if ($this->isDeprecatedTeamsWebhook()) {
+                        return redirect()->back()->with('warning', trans('admin/settings/message.webhook.webhook_fail'));
+                    }
+                    $message = $this->getCheckoutNotification($event)->toMicrosoftTeams();
+                    $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
+                    $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
+                } else {
+                    Notification::route($this->webhookSelected(), Setting::getSettings()->webhook_endpoint)
+                        ->notify($this->getCheckoutNotification($event, $acceptance));
                 }
-                $message = $this->getCheckoutNotification($event)->toMicrosoftTeams();
-                $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
-                $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams
             }
         } catch (ClientException $e) {
             if (strpos($e->getMessage(), 'channel_not_found') !== false) {
@@ -188,13 +193,18 @@ class CheckoutableListener
 
         // Send Webhook notification
         try {
-            if ($this->shouldSendWebhookNotification()){
-                if($this->isDeprecatedTeamsWebhook()){
-                    return redirect()->back()->with('warning',trans('admin/settings/message.webhook.webhook_fail'));
+            if ($this->shouldSendWebhookNotification()) {
+                if (Setting::getSettings()->webhook_selected === 'microsoft') {
+                    if ($this->isDeprecatedTeamsWebhook()) {
+                        return redirect()->back()->with('warning', trans('admin/settings/message.webhook.webhook_fail'));
+                    }
+                    $message = $this->getCheckinNotification($event)->toMicrosoftTeams();
+                    $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
+                    $notification->success()->sendMessage($message[0], $message[1]); // Send the message to Microsoft Teams
+                } else {
+                    Notification::route($this->webhookSelected(), Setting::getSettings()->webhook_endpoint)
+                        ->notify($this->getCheckinNotification($event));
                 }
-                $message = $this->getCheckinNotification($event)->toMicrosoftTeams();
-                $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
-                $notification->success()->sendMessage($message[0], $message[1]); // Send the message to Microsoft Teams
             }
         } catch (ClientException $e) {
             if (strpos($e->getMessage(), 'channel_not_found') !== false) {

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -96,6 +96,9 @@ class CheckoutableListener
         try {
             if ($this->shouldSendWebhookNotification()) {
                 if ($this->newMicrosoftTeamsWebhookEnabled()) {
+                    if(!Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')){
+                        return redirect()->back()->with('warning',trans('admin/settings/message.webhook.webhook_fail'));
+                    }
                     $message = $this->getCheckoutNotification($event)->toMicrosoftTeams();
                     $notification = new TeamsNotification(Setting::getSettings()->webhook_endpoint);
                     $notification->success()->sendMessage($message[0], $message[1]);  // Send the message to Microsoft Teams

--- a/app/Livewire/SlackSettingsForm.php
+++ b/app/Livewire/SlackSettingsForm.php
@@ -247,23 +247,6 @@ class SlackSettingsForm extends Component
     public function msTeamTestWebhook(){
 
         try {
-
-            if($this->teams_webhook_deprecated){
-                //will use the deprecated webhook format
-                $payload =
-                    [
-                        "@type" => "MessageCard",
-                        "@context" => "http://schema.org/extensions",
-                        "summary" => trans('mail.snipe_webhook_summary'),
-                        "title" => trans('mail.snipe_webhook_test'),
-                        "text" => trans('general.webhook_test_msg', ['app' => $this->webhook_name]),
-                    ];
-                $response = Http::withHeaders([
-                    'content-type' => 'application/json',
-                ])->post($this->webhook_endpoint,
-                    $payload)->throw();
-            }
-             else {
                  $notification = new TeamsNotification($this->webhook_endpoint);
                  $message = trans('general.webhook_test_msg', ['app' => $this->webhook_name]);
                  $notification->success()->sendMessage($message);
@@ -271,7 +254,6 @@ class SlackSettingsForm extends Component
                  $response = Http::withHeaders([
                      'content-type' => 'application/json',
                  ])->post($this->webhook_endpoint);
-             }
 
          if(($response->getStatusCode() == 302)||($response->getStatusCode() == 301)){
              return session()->flash('error' , trans('admin/settings/message.webhook.error_redirect', ['endpoint' => $this->webhook_endpoint]));

--- a/app/Livewire/SlackSettingsForm.php
+++ b/app/Livewire/SlackSettingsForm.php
@@ -90,7 +90,7 @@ class SlackSettingsForm extends Component
             $this->isDisabled= '';
         }
         if($this->webhook_selected === 'microsoft' && $this->teams_webhook_deprecated) {
-            session()->flash('warning', 'The selected Microsoft Teams webhook URL will be deprecated Jan 31st, 2025. Please use a workflow URL. Microsofts Documentation on creating a workflow can be found <a href="https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498" target="_blank"> here.</a>');
+            session()->flash('warning', 'The selected Microsoft Teams webhook URL was deprecated Jan 31st, 2025. Please use a workflow URL. Microsofts Documentation on creating a workflow can be found <a href="https://support.microsoft.com/en-us/office/create-incoming-webhooks-with-workflows-for-microsoft-teams-8ae491c7-0394-4861-ba59-055e33f75498" target="_blank"> here.</a>');
         }
     }
     public function updated($field) {

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -51,11 +51,6 @@ class CheckinAccessoryNotification extends Notification
             $notifyBy[] = GoogleChatChannel::class;
         }
 
-        if (Setting::getSettings()->webhook_selected == 'microsoft' && Setting::getSettings()->webhook_endpoint) {
-
-            $notifyBy[] = MicrosoftTeamsChannel::class;
-        }
-
         if (Setting::getSettings()->webhook_selected == 'slack' || Setting::getSettings()->webhook_selected == 'general' ) {
             $notifyBy[] = SlackWebhookChannel::class;
         }
@@ -92,19 +87,6 @@ class CheckinAccessoryNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        if(!Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
-            return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
-                ->type('success')
-                ->addStartGroupToSection('activityTitle')
-                ->title(trans('Accessory_Checkin_Notification'))
-                ->addStartGroupToSection('activityText')
-                ->fact(htmlspecialchars_decode($item->present()->name), '', 'activityTitle')
-                ->fact(trans('mail.checked_into'), $item->location->name ? $item->location->name : '')
-                ->fact(trans('mail.Accessory_Checkin_Notification')." by ", $admin->present()->fullName())
-                ->fact(trans('admin/consumables/general.remaining'), $item->numRemaining())
-                ->fact(trans('mail.notes'), $note ?: '');
-        }
 
         $message = trans('mail.Accessory_Checkin_Notification');
         $details = [

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -57,10 +57,6 @@ class CheckinAssetNotification extends Notification
             $notifyBy[] = GoogleChatChannel::class;
         }
 
-        if (Setting::getSettings()->webhook_selected == 'microsoft' && Setting::getSettings()->webhook_endpoint) {
-
-            $notifyBy[] = MicrosoftTeamsChannel::class;
-        }
         if (Setting::getSettings()->webhook_selected == 'slack' || Setting::getSettings()->webhook_selected == 'general' ) {
             Log::debug('use webhook');
             $notifyBy[] = SlackWebhookChannel::class;
@@ -98,20 +94,6 @@ class CheckinAssetNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-
-        if(!Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
-            return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
-                ->type('success')
-                ->title(trans('mail.Asset_Checkin_Notification'))
-                ->addStartGroupToSection('activityText')
-                ->fact(htmlspecialchars_decode($item->present()->name), '', 'activityText')
-                ->fact(trans('mail.checked_into'), ($item->location) ? $item->location->name : '')
-                ->fact(trans('mail.Asset_Checkin_Notification') . " by ", $admin->present()->fullName())
-                ->fact(trans('admin/hardware/form.status'), $item->assetstatus?->name)
-                ->fact(trans('mail.notes'), $note ?: '');
-        }
-
 
         $message = trans('mail.Asset_Checkin_Notification');
         $details = [

--- a/app/Notifications/CheckinLicenseSeatNotification.php
+++ b/app/Notifications/CheckinLicenseSeatNotification.php
@@ -54,10 +54,6 @@ class CheckinLicenseSeatNotification extends Notification
 
             $notifyBy[] = GoogleChatChannel::class;
         }
-        if (Setting::getSettings()->webhook_selected == 'microsoft' && Setting::getSettings()->webhook_endpoint) {
-
-            $notifyBy[] = MicrosoftTeamsChannel::class;
-        }
 
         if (Setting::getSettings()->webhook_selected == 'slack' || Setting::getSettings()->webhook_selected == 'general' ) {
             $notifyBy[] = SlackWebhookChannel::class;
@@ -103,19 +99,6 @@ class CheckinLicenseSeatNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        if(!Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
-            return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
-                ->type('success')
-                ->addStartGroupToSection('activityTitle')
-                ->title(trans('mail.License_Checkin_Notification'))
-                ->addStartGroupToSection('activityText')
-                ->fact(htmlspecialchars_decode($item->present()->name), '', 'header')
-                ->fact(trans('mail.License_Checkin_Notification')." by ", $admin->present()->fullName() ?: 'CLI tool')
-                ->fact(trans('mail.checkedin_from'), $target->present()->fullName())
-                ->fact(trans('admin/consumables/general.remaining'), $item->availCount()->count())
-                ->fact(trans('mail.notes'), $note ?: '');
-        }
 
         $message = trans('mail.License_Checkin_Notification');
         $details = [

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -50,11 +50,6 @@ class CheckoutAccessoryNotification extends Notification
             $notifyBy[] = GoogleChatChannel::class;
         }
 
-        if (Setting::getSettings()->webhook_selected == 'microsoft' && Setting::getSettings()->webhook_endpoint) {
-
-            $notifyBy[] = MicrosoftTeamsChannel::class;
-        }
-
         if (Setting::getSettings()->webhook_selected == 'slack' || Setting::getSettings()->webhook_selected == 'general' ) {
             $notifyBy[] = 'slack';
         }
@@ -120,22 +115,6 @@ class CheckoutAccessoryNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-
-        if(!Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
-            return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
-                ->type('success')
-                ->addStartGroupToSection('activityTitle')
-                ->title(trans('mail.Accessory_Checkout_Notification'))
-                ->addStartGroupToSection('activityText')
-                ->fact(htmlspecialchars_decode($item->present()->name), '', 'activityTitle')
-                ->fact(trans('mail.assigned_to'), $target->present()->name)
-                ->fact(trans('general.qty'), $this->checkout_qty)
-                ->fact(trans('mail.checkedout_from'), $item->location->name ? $item->location->name : '')
-                ->fact(trans('mail.Accessory_Checkout_Notification') . " by ", $admin->present()->fullName())
-                ->fact(trans('admin/consumables/general.remaining'), $item->numRemaining())
-                ->fact(trans('mail.notes'), $note ?: '');
-        }
 
         $message = trans('mail.Accessory_Checkout_Notification');
         $details = [

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -68,12 +68,6 @@ class CheckoutAssetNotification extends Notification
             $notifyBy[] = GoogleChatChannel::class;
         }
 
-        if (Setting::getSettings()->webhook_selected === 'microsoft' && Setting::getSettings()->webhook_endpoint) {
-
-            $notifyBy[] = MicrosoftTeamsChannel::class;
-        }
-
-
         if (Setting::getSettings()->webhook_selected === 'slack' || Setting::getSettings()->webhook_selected === 'general' ) {
 
             Log::debug('use webhook');
@@ -118,18 +112,6 @@ class CheckoutAssetNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-
-        if(!Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
-            return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
-                ->type('success')
-                ->title(trans('mail.Asset_Checkout_Notification'))
-                ->addStartGroupToSection('activityText')
-                ->fact(trans('mail.assigned_to'), $target->present()->name)
-                ->fact(htmlspecialchars_decode($item->present()->name), '', 'activityText')
-                ->fact(trans('mail.Asset_Checkout_Notification') . " by ", $admin->present()->fullName())
-                ->fact(trans('mail.notes'), $note ?: '');
-        }
 
         $message = trans('mail.Asset_Checkout_Notification');
         $details = [

--- a/app/Notifications/CheckoutLicenseSeatNotification.php
+++ b/app/Notifications/CheckoutLicenseSeatNotification.php
@@ -56,10 +56,6 @@ class CheckoutLicenseSeatNotification extends Notification
 
             $notifyBy[] = GoogleChatChannel::class;
         }
-        if (Setting::getSettings()->webhook_selected == 'microsoft'){
-
-            $notifyBy[] = MicrosoftTeamsChannel::class;
-        }
 
         if (Setting::getSettings()->webhook_selected == 'slack' || Setting::getSettings()->webhook_selected == 'general' ) {
             $notifyBy[] = SlackWebhookChannel::class;
@@ -98,20 +94,6 @@ class CheckoutLicenseSeatNotification extends Notification
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-
-        if(!Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
-            return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
-                ->type('success')
-                ->addStartGroupToSection('activityTitle')
-                ->title(trans('mail.License_Checkout_Notification'))
-                ->addStartGroupToSection('activityText')
-                ->fact(htmlspecialchars_decode($item->present()->name), '', 'activityTitle')
-                ->fact(trans('mail.License_Checkout_Notification')." by ", $admin->present()->fullName())
-                ->fact(trans('mail.assigned_to'), $target->present()->fullName())
-                ->fact(trans('admin/consumables/general.remaining'), $item->availCount()->count())
-                ->fact(trans('mail.notes'), $note ?: '');
-        }
 
         $message = trans('mail.License_Checkout_Notification');
         $details = [


### PR DESCRIPTION
This removes all deprecated MS Teams integration tests and check in and check out methods. Webhooks were deprecated Jan 31st, 2025.

Updates the warning messages to be past tense if an old webhook URL is still stored:
<img width="1074" alt="image" src="https://github.com/user-attachments/assets/8fea3597-6562-4f94-b3ee-6472d1fd87ad" />
<img width="351" alt="image" src="https://github.com/user-attachments/assets/e84b5d71-f355-4d96-a239-915902845901" />

Also, a warning will be returned before trying and failing to send the notification, item will still be checked in/out though:
<img width="1078" alt="image" src="https://github.com/user-attachments/assets/7da21930-c530-4f5d-86bb-d85b62c225ed" />

