### PR TITLE
Fixed various carbon displays

### DIFF
--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -117,7 +117,7 @@ class AssetMaintenancesController extends Controller
         ) {
             $startDate = Carbon::parse($assetMaintenance->start_date);
             $completionDate = Carbon::parse($assetMaintenance->completion_date);
-            $assetMaintenance->asset_maintenance_time = $completionDate->diffInDays($startDate);
+            $assetMaintenance->asset_maintenance_time = (int) $completionDate->diffInDays($startDate, true);
         }
 
         // Was the asset maintenance created?

--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -210,7 +210,7 @@ class AssetMaintenancesController extends Controller
         ) {
             $startDate = Carbon::parse($maintenance->start_date);
             $completionDate = Carbon::parse($maintenance->completion_date);
-            $maintenance->asset_maintenance_time = $completionDate->diffInDays($startDate);
+            $maintenance->asset_maintenance_time = (int) $completionDate->diffInDays($startDate, true);
         }
 
       // Was the asset maintenance created?

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -318,7 +318,7 @@ class AssetsController extends Controller
             $asset->eol_explicit = false;
         } elseif ($request->filled('asset_eol_date')) {
            $asset->asset_eol_date = $request->input('asset_eol_date', null);
-           $months = Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date);
+            $months = (int) Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date, true);
            if($asset->model->eol) {
                if($months != $asset->model->eol > 0) {
                    $asset->eol_explicit = true;

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1081,10 +1081,10 @@ class ReportsController extends Controller
             $row[] = e($assetMaintenance->start_date);
             $row[] = e($assetMaintenance->completion_date);
             if (is_null($assetMaintenance->asset_maintenance_time)) {
-                $improvementTime = intval(Carbon::now()
-                                                 ->diffInDays(Carbon::parse($assetMaintenance->start_date)));
+                $improvementTime = (int) Carbon::now()
+                    ->diffInDays(Carbon::parse($assetMaintenance->start_date), true);
             } else {
-                $improvementTime = intval($assetMaintenance->asset_maintenance_time);
+                $improvementTime = (int) $assetMaintenance->asset_maintenance_time;
             }
             $row[]  = $improvementTime;
             $row[]  = trans('general.currency') . Helper::formatCurrencyOutput($assetMaintenance->cost);

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -42,7 +42,7 @@ class AssetsTransformer
             'requestable' => ($asset->requestable ? true : false),
 
             'model_number' => (($asset->model) && ($asset->model->model_number)) ? e($asset->model->model_number) : null,
-            'eol' => (($asset->asset_eol_date != '') && ($asset->purchase_date != '')) ? Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date).' months' : null,
+            'eol' => (($asset->asset_eol_date != '') && ($asset->purchase_date != '')) ? (int) Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date, true) . ' months' : null,
             'asset_eol_date' => ($asset->asset_eol_date != '') ? Helper::getFormattedDateObject($asset->asset_eol_date, 'date') : null,
             'status_label' => ($asset->assetstatus) ? [
                 'id' => (int) $asset->assetstatus->id,

--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -295,13 +295,13 @@ class Actionlog extends SnipeModel
         $now = Carbon::now();
         $last_audit_date = $this->created_at; // this is the action log's created at, not the asset itself
         $next_audit = $last_audit_date->addMonth($monthInterval); // this actually *modifies* the $last_audit_date
-        $next_audit_days = round($now->diffInDays($next_audit, true));
+        $next_audit_days = (int) round($now->diffInDays($next_audit, true));
         $override_default_next = $next_audit;
 
         // Override the default setting for interval if the asset has its own next audit date
         if (($asset) && ($asset->next_audit_date)) {
             $override_default_next = Carbon::parse($asset->next_audit_date);
-            $next_audit_days = round($override_default_next->diffInDays($now, true));
+            $next_audit_days = (int) round($override_default_next->diffInDays($now, true));
         }
 
         // Show as negative number if the next audit date is before the audit date we're looking at

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -171,7 +171,7 @@ class AssetObserver
        // determine if explicit and set eol_explicit to true
        if (!is_null($asset->asset_eol_date) && !is_null($asset->purchase_date)) {
             if($asset->model->eol > 0) {
-                $months = Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date); 
+                $months = (int) Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date, true);
                 if($months != $asset->model->eol) {
                     $asset->eol_explicit = true;
                 }

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -957,7 +957,7 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-9">
-                                                {{ Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date) }}
+                                                {{ (int) Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date, true) }}
                                                 {{ trans('admin/hardware/form.months') }}
 
                                             </div>

--- a/resources/views/notifications/markdown/upcoming-audits.blade.php
+++ b/resources/views/notifications/markdown/upcoming-audits.blade.php
@@ -9,7 +9,7 @@
 @php
 $next_audit_date = Helper::getFormattedDateObject($asset->next_audit_date, 'date', false);
 $last_audit_date = Helper::getFormattedDateObject($asset->last_audit_date, 'date', false);
-$diff = Carbon::parse(Carbon::now())->diffInDays($asset->next_audit_date, false);
+$diff = (int) Carbon::parse(Carbon::now())->diffInDays($asset->next_audit_date, true);
 $icon = ($diff <= 7) ? '🚨' : (($diff <= 14) ? '⚠️' : ' ');
 @endphp
 |{{ $icon }}| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset->id) }}) | {{ $last_audit_date }}| {{ $next_audit_date }} | {{ $diff }}  | {{ ($asset->supplier ? e($asset->supplier->name) : '') }}|{{ ($asset->assignedTo ? $asset->assignedTo->present()->name() : '') }}|{{ $asset->notes }}

--- a/tests/Feature/AssetMaintenances/Ui/CreateAssetMaintenanceTest.php
+++ b/tests/Feature/AssetMaintenances/Ui/CreateAssetMaintenanceTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\AssetMaintenances\Ui;
 
+use App\Models\Asset;
+use App\Models\Supplier;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -12,5 +14,42 @@ class CreateAssetMaintenanceTest extends TestCase
         $this->actingAs(User::factory()->superuser()->create())
             ->get(route('maintenances.create'))
             ->assertOk();
+    }
+
+    public function testCanCreateAssetMaintenance()
+    {
+        $actor = User::factory()->superuser()->create();
+
+        $asset = Asset::factory()->create();
+        $supplier = Supplier::factory()->create();
+
+        $this->actingAs($actor)
+            ->followingRedirects()
+            ->post(route('maintenances.store'), [
+                'title' => 'Test Maintenance',
+                'asset_id' => $asset->id,
+                'supplier_id' => $supplier->id,
+                'asset_maintenance_type' => 'Maintenance',
+                'start_date' => '2021-01-01',
+                'completion_date' => '2021-01-10',
+                'is_warranty' => '1',
+                'cost' => '100.00',
+                'notes' => 'A note',
+            ])
+            ->assertOk();
+
+        $this->assertDatabaseHas('asset_maintenances', [
+            'asset_id' => $asset->id,
+            'supplier_id' => $supplier->id,
+            'asset_maintenance_type' => 'Maintenance',
+            'title' => 'Test Maintenance',
+            'is_warranty' => 1,
+            'start_date' => '2021-01-01',
+            'completion_date' => '2021-01-10',
+            'asset_maintenance_time' => '9',
+            'notes' => 'A note',
+            'cost' => '100.00',
+            'created_by' => $actor->id,
+        ]);
     }
 }

--- a/tests/Feature/AssetMaintenances/Ui/EditAssetMaintenanceTest.php
+++ b/tests/Feature/AssetMaintenances/Ui/EditAssetMaintenanceTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature\AssetMaintenances\Ui;
 
+use App\Models\Asset;
 use App\Models\AssetMaintenance;
+use App\Models\Supplier;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -14,4 +16,43 @@ class EditAssetMaintenanceTest extends TestCase
             ->get(route('maintenances.edit', AssetMaintenance::factory()->create()->id))
             ->assertOk();
     }
+
+    public function testCanUpdateAssetMaintenance()
+    {
+        $actor = User::factory()->superuser()->create();
+
+        $assetMaintenance = AssetMaintenance::factory()->create();
+
+        $asset = Asset::factory()->create();
+        $supplier = Supplier::factory()->create();
+
+        $this->actingAs($actor)
+            ->followingRedirects()
+            ->put(route('maintenances.update', $assetMaintenance->id), [
+                'title' => 'Test Maintenance',
+                'asset_id' => $asset->id,
+                'supplier_id' => $supplier->id,
+                'asset_maintenance_type' => 'Maintenance',
+                'start_date' => '2021-01-01',
+                'completion_date' => '2021-01-10',
+                'is_warranty' => '1',
+                'cost' => '100.00',
+                'notes' => 'A note',
+            ])
+            ->assertOk();
+
+        $this->assertDatabaseHas('asset_maintenances', [
+            'asset_id' => $asset->id,
+            'supplier_id' => $supplier->id,
+            'asset_maintenance_type' => 'Maintenance',
+            'title' => 'Test Maintenance',
+            'is_warranty' => 1,
+            'start_date' => '2021-01-01',
+            'completion_date' => '2021-01-10',
+            'asset_maintenance_time' => '9',
+            'notes' => 'A note',
+            'cost' => '100.00',
+        ]);
+    }
+
 }

--- a/tests/Feature/Assets/Ui/EditAssetTest.php
+++ b/tests/Feature/Assets/Ui/EditAssetTest.php
@@ -98,7 +98,7 @@ class EditAssetTest extends TestCase
         $this->assertEquals($achived_status->id, $asset->status_id);
 
         Event::assertDispatched(function (CheckoutableCheckedIn $event) use ($currentTimestamp) {
-            return Carbon::parse($event->action_date)->diffInSeconds($currentTimestamp) < 2;
+            return (int) Carbon::parse($event->action_date)->diffInSeconds($currentTimestamp, true) < 2;
         }, 1);
     }
 

--- a/tests/Feature/Checkins/Api/AssetCheckinTest.php
+++ b/tests/Feature/Checkins/Api/AssetCheckinTest.php
@@ -72,7 +72,7 @@ class AssetCheckinTest extends TestCase
 
         Event::assertDispatched(function (CheckoutableCheckedIn $event) use ($currentTimestamp) {
             // this could be better mocked but is ok for now.
-            return Carbon::parse($event->action_date)->diffInSeconds($currentTimestamp) < 2;
+            return (int) Carbon::parse($event->action_date)->diffInSeconds($currentTimestamp, true) < 2;
         }, 1);
     }
 

--- a/tests/Feature/Checkins/Ui/AssetCheckinTest.php
+++ b/tests/Feature/Checkins/Ui/AssetCheckinTest.php
@@ -86,7 +86,7 @@ class AssetCheckinTest extends TestCase
 
         Event::assertDispatched(function (CheckoutableCheckedIn $event) use ($currentTimestamp) {
             // this could be better mocked but is ok for now.
-            return Carbon::parse($event->action_date)->diffInSeconds($currentTimestamp) < 2;
+            return (int) Carbon::parse($event->action_date)->diffInSeconds($currentTimestamp, true) < 2;
         }, 1);
     }
 

--- a/tests/Feature/Checkouts/Api/AssetCheckoutTest.php
+++ b/tests/Feature/Checkouts/Api/AssetCheckoutTest.php
@@ -209,6 +209,6 @@ class AssetCheckoutTest extends TestCase
 
         $asset->refresh();
 
-        $this->assertTrue(Carbon::parse($asset->last_checkout)->diffInSeconds(now()) < 2);
+        $this->assertTrue((int) Carbon::parse($asset->last_checkout)->diffInSeconds(now(), true) < 2);
     }
 }

--- a/tests/Feature/Checkouts/Ui/AssetCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/AssetCheckoutTest.php
@@ -249,7 +249,7 @@ class AssetCheckoutTest extends TestCase
 
         $asset->refresh();
 
-        $this->assertTrue(Carbon::parse($asset->last_checkout)->diffInSeconds(now()) < 2);
+        $this->assertTrue((int) Carbon::parse($asset->last_checkout)->diffInSeconds(now(), true) < 2);
     }
 
     public function testAssetCheckoutPageIsRedirectedIfModelIsInvalid()


### PR DESCRIPTION
This PR fixes display issues around eol dates and rates.

We have to update Carbon `diffIn` calls now that we're on [v3](https://carbon.nesbot.com/docs/#api-carbon-3).

For example...
before:
![image](https://github.com/user-attachments/assets/def3f5a8-21d7-47b1-8bae-743e7eda62dd)

after:
![image](https://github.com/user-attachments/assets/ee2c8e0e-b9c9-4f70-9a8c-98b53aa0a4bd)

---

Note there is one place where I didn't make the change, the `DenormalizedEolAndAddColumnForExplicitDateToAssets` migration. I think the logic doesn't need to be updated there (since it's not displaying data).

---

Fixes #16452