### PR TITLE
Fixed issue with bad email addresses in expiration alerts and upcoming audits

### DIFF
--- a/app/Console/Commands/SendExpirationAlerts.php
+++ b/app/Console/Commands/SendExpirationAlerts.php
@@ -49,6 +49,7 @@ class SendExpirationAlerts extends Command
             // Send a rollup to the admin, if settings dictate
             $recipients = collect(explode(',', $settings->alert_email))
                 ->map(fn($item) => trim($item)) // Trim each email
+                ->filter(fn($item) => !empty($item))
                 ->all();
             // Expiring Assets
             $assets = Asset::getExpiringWarrantee($alert_interval);

--- a/app/Console/Commands/SendUpcomingAuditReport.php
+++ b/app/Console/Commands/SendUpcomingAuditReport.php
@@ -55,6 +55,7 @@ class SendUpcomingAuditReport extends Command
             // Send a rollup to the admin, if settings dictate
             $recipients = collect(explode(',', $settings->alert_email))
                 ->map(fn($item) => trim($item))
+                ->filter(fn($item) => !empty($item))
                 ->all();
 
 


### PR DESCRIPTION
This PR fixes an issue where having an empty email in `alert_email` (something like `a,,b,c`) will cause two commands to fail.