### PR TITLE
Remove unneeded eager loading for user show page

### DIFF
--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -395,13 +395,22 @@ class UsersController extends Controller
         // Make sure the user can view users at all
         $this->authorize('view', User::class);
 
-        $user = User::with('assets', 'assets.model', 'consumables', 'accessories', 'licenses', 'userloc')->withTrashed()->find($user->id);
+        $user = User::with([
+            'consumables',
+            'accessories',
+            'licenses',
+            'userloc',
+        ])
+            ->withTrashed()
+            ->find($user->id);
 
         // Make sure they can view this particular user
         $this->authorize('view', $user);
 
-            $userlog = $user->userlog->load('item');
-            return view('users/view', compact('user', 'userlog'))->with('settings', Setting::getSettings());
+        return view('users/view', [
+            'user' => $user,
+            'settings' => Setting::getSettings(),
+        ]);
     }
 
 


### PR DESCRIPTION
This PR removes some unneeded related model loading for the user show page.

Most of the tables on the user show page are loaded via the api so we don't need to pass through `assets`, `assets.model`, or `userlog.item`.

When attempting to view a user with a lot of previous activity, the `$user->userlog->load('item')` line could potentially end up causing a memory exhaustion exception.