### PR TITLE
Fixed #16524 - added notes as fillable to license seat model

### DIFF
--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -136,13 +136,13 @@ class LicenseSeatsController extends Controller
         if ($licenseSeat->save()) {
 
             if ($is_checkin) {
-                $licenseSeat->logCheckin($target, $request->input('note'));
+                $licenseSeat->logCheckin($target, $request->input('notes'));
 
                 return response()->json(Helper::formatStandardApiResponse('success', $licenseSeat, trans('admin/licenses/message.update.success')));
             }
 
             // in this case, relevant fields are touched but it's not a checkin operation. so it must be a checkout operation.
-            $licenseSeat->logCheckout($request->input('note'), $target);
+            $licenseSeat->logCheckout($request->input('notes'), $target);
 
             return response()->json(Helper::formatStandardApiResponse('success', $licenseSeat, trans('admin/licenses/message.update.success')));
         }

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -30,6 +30,7 @@ class LicenseSeat extends SnipeModel implements ICompanyableChild
     protected $fillable = [
         'assigned_to',
         'asset_id',
+        'notes',
     ];
 
     use Acceptable;

--- a/tests/Feature/Checkins/Api/LicenseCheckInTest.php
+++ b/tests/Feature/Checkins/Api/LicenseCheckInTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Feature\Checkins\Api;
+namespace Tests\Feature\Checkins\Api;
 
 use App\Models\License;
 use App\Models\LicenseSeat;
@@ -9,7 +9,7 @@ use Tests\TestCase;
 class LicenseCheckInTest extends TestCase {
     public function testLicenseCheckin()
     {
-        $authUser = User::factory()->superuser()->make();
+        $authUser = User::factory()->superuser()->create();
         $this->actingAsForApi($authUser);
 
         $license = License::factory()->create();

--- a/tests/Feature/Checkins/Api/LicenseCheckInTest.php
+++ b/tests/Feature/Checkins/Api/LicenseCheckInTest.php
@@ -1,0 +1,45 @@
+<?php
+namespace Feature\Checkins\Api;
+
+use App\Models\License;
+use App\Models\LicenseSeat;
+use App\Models\User;
+use Tests\TestCase;
+
+class LicenseCheckInTest extends TestCase {
+    public function testLicenseCheckin()
+    {
+        $authUser = User::factory()->superuser()->make();
+        $this->actingAsForApi($authUser);
+
+        $license = License::factory()->create();
+        $oldUser = User::factory()->create();
+
+        $licenseSeat = LicenseSeat::factory()->for($license)->create([
+            'assigned_to' => $oldUser->id,
+            'notes'       => 'Previously checked out',
+        ]);
+
+        $payload = [
+            'assigned_to' => null,
+            'asset_id'  => null,
+            'notes' => 'Checking in the seat',
+        ];
+
+        $response = $this->patchJson(
+            route('api.licenses.seats.update', [$license->id, $licenseSeat->id]),
+            $payload);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'status' => 'success',
+            ]);
+
+        $licenseSeat->refresh();
+
+        $this->assertNull($licenseSeat->assigned_to);
+        $this->assertNull($licenseSeat->asset_id);
+
+        $this->assertEquals('Checking in the seat', $licenseSeat->notes);
+    }
+}

--- a/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
+++ b/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Feature\Checkouts\Api;
+namespace Tests\Feature\Checkouts\Api;
 
 use App\Models\License;
 use App\Models\LicenseSeat;
@@ -9,7 +9,7 @@ use Tests\TestCase;
 class LicenseCheckOutTest extends TestCase {
     public function testLicenseCheckout()
     {
-        $authUser = User::factory()->superuser()->make();
+        $authUser = User::factory()->superuser()->create();
         $this->actingAsForApi($authUser);
 
         $license = License::factory()->create();

--- a/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
+++ b/tests/Feature/Checkouts/Api/LicenseCheckOutTest.php
@@ -1,0 +1,41 @@
+<?php
+namespace Feature\Checkouts\Api;
+
+use App\Models\License;
+use App\Models\LicenseSeat;
+use App\Models\User;
+use Tests\TestCase;
+
+class LicenseCheckOutTest extends TestCase {
+    public function testLicenseCheckout()
+    {
+        $authUser = User::factory()->superuser()->make();
+        $this->actingAsForApi($authUser);
+
+        $license = License::factory()->create();
+        $licenseSeat = LicenseSeat::factory()->for($license)->create([
+            'assigned_to' => null,
+        ]);
+
+        $targetUser = User::factory()->create();
+
+        $payload = [
+            'assigned_to' => $targetUser->id,
+            'notes' => 'Checking out the seat to a user',
+        ];
+
+        $response = $this->patchJson(
+            route('api.licenses.seats.update', [$license->id, $licenseSeat->id]),
+            $payload);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'status' => 'success',
+            ]);
+
+        $licenseSeat->refresh();
+
+        $this->assertEquals($targetUser->id, $licenseSeat->assigned_to);
+        $this->assertEquals('Checking out the seat to a user', $licenseSeat->notes);
+    }
+}


### PR DESCRIPTION
This adds `notes` as a fillable field in the license seat model.
also renames `note` to `notes` in the api/`LicenseSeatsController.php` allowing notes to be updating through the API

adds a test for check in and check out

This was very clearly pointed out by @Flo-R1der in #16524