### PR TITLE
Fix active table tab and double scroll bar under locations

### DIFF
--- a/resources/views/locations/view.blade.php
+++ b/resources/views/locations/view.blade.php
@@ -157,11 +157,39 @@
 
 
           <div class="tab-content">
+              @can('view', \App\Models\User::class)
+                    <div id="users" @class(['tab-pane','active' => $location->users->count() > 0 ]) >
+              @endcan
+                  <h2 class="box-title">{{ trans('general.users') }}</h2>
+                      @include('partials.users-bulk-actions')
+                      <table
+                              data-columns="{{ \App\Presenters\UserPresenter::dataTableLayout() }}"
+                              data-cookie-id-table="usersTable"
+                              data-pagination="true"
+                              data-id-table="usersTable"
+                              data-search="true"
+                              data-side-pagination="server"
+                              data-show-columns="true"
+                              data-show-export="true"
+                              data-show-refresh="true"
+                              data-sort-order="asc"
+                              data-toolbar="#userBulkEditToolbar"
+                              data-bulk-button-id="#bulkUserEditButton"
+                              data-bulk-form-id="#usersBulkForm"
+                              data-click-to-select="true"
+                              id="usersTable"
+                              class="table table-striped snipe-table"
+                              data-url="{{route('api.users.index', ['location_id' => $location->id])}}"
+                              data-export-options='{
+                              "fileName": "export-locations-{{ str_slug($location->name) }}-users-{{ date('Y-m-d') }}",
+                              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+                              }'>
+                      </table>
+                    </div><!-- /.tab-pane -->
+                <div id="assets" @class(['tab-pane', 'active' => $location->users->count() == 0]) >
 
-              <div class="tab-pane active" id="assets">
                   <h2 class="box-title">{{ trans('admin/locations/message.current_location') }}</h2>
 
-                  <div class="table table-responsive">
                       @include('partials.asset-bulk-actions')
                       <table
                               data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
@@ -186,50 +214,13 @@
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
                       </table>
-
-                  </div><!-- /.table-responsive -->
               </div><!-- /.tab-pane -->
-
-
-              
-              <div class="tab-pane" id="users">
-                    <h2 class="box-title">{{ trans('general.users') }}</h2>
-                      <div class="table table-responsive">
-                          @include('partials.users-bulk-actions')
-                          <table
-                                  data-columns="{{ \App\Presenters\UserPresenter::dataTableLayout() }}"
-                                  data-cookie-id-table="usersTable"
-                                  data-pagination="true"
-                                  data-id-table="usersTable"
-                                  data-search="true"
-                                  data-side-pagination="server"
-                                  data-show-columns="true"
-                                  data-show-export="true"
-                                  data-show-refresh="true"
-                                  data-sort-order="asc"
-                                  data-toolbar="#userBulkEditToolbar"
-                                  data-bulk-button-id="#bulkUserEditButton"
-                                  data-bulk-form-id="#usersBulkForm"
-                                  data-click-to-select="true"
-                                  id="usersTable"
-                                  class="table table-striped snipe-table"
-                                  data-url="{{route('api.users.index', ['location_id' => $location->id])}}"
-                                  data-export-options='{
-                              "fileName": "export-locations-{{ str_slug($location->name) }}-users-{{ date('Y-m-d') }}",
-                              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
-                              }'>
-
-                          </table>
-                      </div><!-- /.table-responsive -->
-              </div><!-- /.tab-pane -->
-
 
               <div class="tab-pane" id="assets_assigned">
                   <h2 class="box-title">
                       {{ trans('admin/locations/message.assigned_assets') }}
                   </h2>
 
-                  <div class="table table-responsive">
                       @include('partials.asset-bulk-actions', ['id_divname' => 'AssignedAssetsBulkEditToolbar', 'id_formname' => 'assignedAssetsBulkForm', 'id_button' => 'AssignedbulkAssetEditButton'])
                       <table
                               data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
@@ -254,14 +245,11 @@
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
                       </table>
-
-                  </div><!-- /.table-responsive -->
               </div><!-- /.tab-pane -->
 
               <div class="tab-pane" id="rtd_assets">
                   <h2 class="box-title">{{ trans('admin/hardware/form.default_location') }}</h2>
 
-                  <div class="table table-responsive">
                       @include('partials.asset-bulk-actions', ['id_divname' => 'RTDassetsBulkEditToolbar', 'id_formname' => 'RTDassets', 'id_button' => 'RTDbulkAssetEditButton'])
                       <table
                               data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
@@ -286,15 +274,12 @@
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
                       </table>
-
-                  </div><!-- /.table-responsive -->
               </div><!-- /.tab-pane -->
               
 
 
               <div class="tab-pane" id="accessories">
                   <h2 class="box-title">{{ trans('general.accessories') }}</h2>
-                  <div class="table table-responsive">
                       <table
                               data-columns="{{ \App\Presenters\AccessoryPresenter::dataTableLayout() }}"
                               data-cookie-id-table="accessoriesListingTable"
@@ -314,13 +299,9 @@
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
                       </table>
-                  </div><!-- /.table-responsive -->
               </div><!-- /.tab-pane -->
 
               <div class="tab-pane" id="accessories_assigned">
-
-                  <div class="table table-responsive">
-
                       <h2 class="box-title" style="float:left">
                           {{ trans('general.accessories_assigned') }}
                       </h2>
@@ -345,15 +326,11 @@
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
                       </table>
-
-                  </div><!-- /.table-responsive -->
               </div><!-- /.tab-pane -->
 
 
               <div class="tab-pane" id="consumables">
                   <h2 class="box-title">{{ trans('general.consumables') }}</h2>
-
-                      <div class="table table-responsive">
                           <table
                                   data-columns="{{ \App\Presenters\ConsumablePresenter::dataTableLayout() }}"
                                   data-cookie-id-table="consumablesListingTable"
@@ -373,14 +350,10 @@
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
                           </table>
-
-                      </div><!-- /.table-responsive -->
               </div><!-- /.tab-pane -->
 
               <div class="tab-pane" id="components">
                   <h2 class="box-title">{{ trans('general.components') }}</h2>
-                      <div class="table table-responsive">
-
                           <table
                                   data-columns="{{ \App\Presenters\ComponentPresenter::dataTableLayout() }}"
                                   data-cookie-id-table="componentsTable"
@@ -399,9 +372,7 @@
                               "fileName": "export-locations-{{ str_slug($location->name) }}-components-{{ date('Y-m-d') }}",
                               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                               }'>
-
                           </table>
-                      </div><!-- /.table-responsive -->
               </div><!-- /.tab-pane -->
 
                 <div class="tab-pane" id="history">


### PR DESCRIPTION
This fixes the active tab when viewing locations. if there are users and the current user has permission to view users the users tab will be first active, otherwise it will default to the assets tab.

for the double scroll bar, I removed `<div class="table table-responsive">` around the tables which load the table class already. This solves the double scroll bars on the tables. Not sure if this just old code..but functionality is as intended now.

Repositioned the users table code above the assets table code for symmetry with the tabs' order.
[SC-28710]
#16523 

Before image provided by @swift2512
![image](https://github.com/user-attachments/assets/232b26f4-41b1-458d-bd47-d060882f16c3)

After:
<img width="857" alt="image" src="https://github.com/user-attachments/assets/ab2ec229-65f6-46cc-b60a-e4d1e09dce30" />
