### PR TITLE
FIXED: Purchase Cost Column Always Shown

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -485,7 +485,7 @@ class ReportsController extends Controller
                 $header[] = trans('admin/hardware/table.purchase_date');
             }
 
-            if (($request->filled('purchase_cost')) || ($request->filled('depreciation'))) {
+            if ($request->filled('purchase_cost')) {
                 $header[] = trans('admin/hardware/table.purchase_cost');
             }
 


### PR DESCRIPTION
FIXED: The purchase cost column was always being shown, even if the checkbox wasn't ticked in the custom reports. The logic on the line for the column was also checking for depreciation, and thus, would populate the header for the column, even though we do not gather the data for depreciation to then fill that field.

![CleanShot 2025-03-18 at 12 26 53@2x](https://github.com/user-attachments/assets/d72c0705-f7eb-4d29-91d9-b00d48317493)

This fixes the line for that logic so that it will properly disappear when the option is not selected. 

<img width="633" alt="Screenshot 2025-03-18 at 4 42 19 PM" src="https://github.com/user-attachments/assets/f65509ba-0571-4c4c-b7a4-373c9edb6602" />

Admittedly, we should put depreciation somewhere in the custom report. the current value of an asset is something that users probably will want.
(EDIT: so we do have this, its just not in an obvious spot next to the purchase cost)
