### PR TITLE
Moving warranty/depreciation to be with the other cost/eol values

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -493,6 +493,17 @@ class ReportsController extends Controller
                 $header[] = trans('admin/hardware/table.eol');
             }
 
+            if ($request->filled('warranty')) {
+                $header[] = trans('admin/hardware/form.warranty');
+                $header[] = trans('admin/hardware/form.warranty_expires');
+            }
+
+            if ($request->filled('depreciation')) {
+                $header[] = trans('admin/hardware/table.book_value');
+                $header[] = trans('admin/hardware/table.diff');
+                $header[] = trans('admin/hardware/form.fully_depreciated');
+            }
+
             if ($request->filled('order')) {
                 $header[] = trans('admin/hardware/form.order');
             }
@@ -577,17 +588,6 @@ class ReportsController extends Controller
 
             if ($request->filled('status')) {
                 $header[] = trans('general.status');
-            }
-
-            if ($request->filled('warranty')) {
-                $header[] = trans('admin/hardware/form.warranty');
-                $header[] = trans('admin/hardware/form.warranty_expires');
-            }
-
-            if ($request->filled('depreciation')) {
-                $header[] = trans('admin/hardware/table.book_value');
-                $header[] = trans('admin/hardware/table.diff');
-                $header[] = trans('admin/hardware/form.fully_depreciated');
             }
 
             if ($request->filled('checkout_date')) {
@@ -805,6 +805,19 @@ class ReportsController extends Controller
                         $row[] = ($asset->purchase_date != '') ? $asset->asset_eol_date : '';
                     }
 
+                    if ($request->filled('warranty')) {
+                        $row[] = ($asset->warranty_months) ? $asset->warranty_months : '';
+                        $row[] = $asset->present()->warranty_expires();
+                    }
+
+                    if ($request->filled('depreciation')) {
+                        $depreciation = $asset->getDepreciatedValue();
+                        $diff = ($asset->purchase_cost - $depreciation);
+                        $row[] = Helper::formatCurrencyOutput($depreciation);
+                        $row[] = Helper::formatCurrencyOutput($diff);
+                        $row[] = (($asset->depreciation) && ($asset->depreciated_date())) ? $asset->depreciated_date()->format('Y-m-d') : '';
+                    }
+
                     if ($request->filled('order')) {
                         $row[] = ($asset->order_number) ? $asset->order_number : '';
                     }
@@ -936,19 +949,6 @@ class ReportsController extends Controller
 
                     if ($request->filled('status')) {
                         $row[] = ($asset->assetstatus) ? $asset->assetstatus->name.' ('.$asset->present()->statusMeta.')' : '';
-                    }
-
-                    if ($request->filled('warranty')) {
-                        $row[] = ($asset->warranty_months) ? $asset->warranty_months : '';
-                        $row[] = $asset->present()->warranty_expires();
-                    }
-
-                    if ($request->filled('depreciation')) {
-                            $depreciation = $asset->getDepreciatedValue();
-                            $diff = ($asset->purchase_cost - $depreciation);
-                        $row[] = Helper::formatCurrencyOutput($depreciation);
-                        $row[] = Helper::formatCurrencyOutput($diff);
-                        $row[] = (($asset->depreciation) && ($asset->depreciated_date())) ? $asset->depreciated_date()->format('Y-m-d') : '';
                     }
 
                     if ($request->filled('checkout_date')) {

--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -148,6 +148,16 @@
                 </label>
 
                 <label class="form-control">
+                    <input type="checkbox" name="warranty" value="1" @checked($template->checkmarkValue('warranty')) />
+                    {{ trans('admin/hardware/form.warranty') }}
+                </label>
+
+                <label class="form-control">
+                    <input type="checkbox" name="depreciation" value="1" @checked($template->checkmarkValue('depreciation')) />
+                    {{ trans('general.depreciation') }}
+                </label>
+
+                <label class="form-control">
                     <input type="checkbox" name="order" value="1" @checked($template->checkmarkValue('order')) />
                     {{ trans('admin/hardware/form.order') }}
                 </label>
@@ -180,16 +190,6 @@
                 <label class="form-control">
                     <input type="checkbox" name="status" value="1" @checked($template->checkmarkValue('status')) />
                     {{ trans('general.status') }}
-                </label>
-
-                <label class="form-control">
-                    <input type="checkbox" name="warranty" value="1" @checked($template->checkmarkValue('warranty')) />
-                    {{ trans('admin/hardware/form.warranty') }}
-                </label>
-
-                <label class="form-control">
-                    <input type="checkbox" name="depreciation" value="1" @checked($template->checkmarkValue('depreciation')) />
-                    {{ trans('general.depreciation') }}
                 </label>
 
                 <label class="form-control">


### PR DESCRIPTION
This simply is moving the information that is related to each other.

No functionality is changing, columns are just shifted.

OLD:
<img width="819" alt="Screenshot 2025-03-19 at 3 25 51 PM" src="https://github.com/user-attachments/assets/60fa1e26-29cc-4d87-b405-2138aadb7f5c" />
<img width="776" alt="Screenshot 2025-03-19 at 3 26 00 PM" src="https://github.com/user-attachments/assets/596abee6-d34d-4767-9834-9bc65f947081" />

NEW:
<img width="886" alt="Screenshot 2025-03-19 at 3 25 36 PM" src="https://github.com/user-attachments/assets/7238cccc-7c60-47d2-b32b-498cd1fc6f9c" />
