### PR TITLE
Return null from accessory transformer for missing assignment

### DIFF
--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -94,6 +94,10 @@ class AccessoriesTransformer
 
     public function transformAssignedTo($accessoryCheckout)
     {
+        if (is_null($accessoryCheckout->assigned)) {
+            return null;
+        }
+
         if ($accessoryCheckout->checkedOutToUser()) {
             return (new UsersTransformer)->transformUserCompact($accessoryCheckout->assigned);
         } elseif ($accessoryCheckout->checkedOutToLocation()) {


### PR DESCRIPTION
This PR simply returns null for `assigned_to` in the Accessory Transformer if the assignment is deleted. This will only happen if there is bad data but handles throwing a hard 500.

**This is technically an API change** since we were previously returning an array of information and now it might be null.

The response now:
![image](https://github.com/user-attachments/assets/ef810b9b-a0d5-4dfa-a42a-c30c69785db9)
