### PR TITLE
Early return null from location transformer for missing accessory

### DIFF
--- a/app/Http/Transformers/LocationsTransformer.php
+++ b/app/Http/Transformers/LocationsTransformer.php
@@ -101,11 +101,8 @@ class LocationsTransformer
             $array = [
                 'id' => $accessory_checkout->id,
                 'assigned_to' => $accessory_checkout->assigned_to,
-                'accessory' => [
-                    'id' => $accessory_checkout->accessory->id,
-                    'name' => $accessory_checkout->accessory->name,
-                ],
-                'image' => ($accessory_checkout->accessory->image) ? Storage::disk('public')->url('accessories/'.e($accessory_checkout->accessory->image)) : null,
+                'accessory' => $this->transformAccessory($accessory_checkout->accessory),
+                'image' => ($accessory_checkout?->accessory?->image) ? Storage::disk('public')->url('accessories/' . e($accessory_checkout->accessory->image)) : null,
                 'note' => $accessory_checkout->note ? e($accessory_checkout->note) : null,
                 'created_by' => $accessory_checkout->adminuser ? [
                     'id' => (int) $accessory_checkout->adminuser->id,
@@ -152,5 +149,17 @@ class LocationsTransformer
 
             return $array;
         }
+    }
+
+    private function transformAccessory(?Accessory $accessory): ?array
+    {
+        if ($accessory) {
+            return [
+                'id' => $accessory->id,
+                'name' => $accessory->name,
+            ];
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
This PR returns `null`s for deleted accessories in the Location Transformer. This will only happen if there is bad data but handles throwing a hard 500.

**This is technically an API change** since we were previously returning an array of information and now it might be null.

![image](https://github.com/user-attachments/assets/98115b58-86be-49e0-b8b9-64f7305b162e)

Another approach would be to continue to return an array but make the `id` and `name` null within it. Let me know if I should make that change.