### PR TITLE
changes translation from Admin Settings to Created By on the Activity Report

### DIFF
--- a/resources/views/reports/activity.blade.php
+++ b/resources/views/reports/activity.blade.php
@@ -56,7 +56,7 @@
                                 {{ trans('general.date') }}
                             </th>
                             <th class="col-sm-2" data-searchable="true" data-sortable="true" data-field="created_by" data-formatter="usersLinkObjFormatter">
-                                {{ trans('general.admin') }}
+                                {{ trans('general.created_by') }}
                             </th>
                             <th class="col-sm-2" data-field="action_type">
                                 {{ trans('general.action') }}


### PR DESCRIPTION
Changes the column title from Admin Settings to Created By
[sc-28737]
Before:
![image](https://github.com/user-attachments/assets/56f8dd4e-5a61-4ede-b98f-641d15c2f2eb)
After:
<img width="639" alt="image" src="https://github.com/user-attachments/assets/a2165810-74c7-43c3-ac55-6bd2861f5882" />
