### PR TITLE
Fix Form save error when using old label engine

### DIFF
--- a/app/Http/Requests/StoreLabelSettings.php
+++ b/app/Http/Requests/StoreLabelSettings.php
@@ -29,6 +29,12 @@ class StoreLabelSettings extends FormRequest
             return $label->getName();
         })->values()->toArray();
 
+        if (empty($this->input('label2_template'))) {
+            $this->merge([
+                'label2_template' => 'DefaultLabel',
+            ]);
+        }
+
         return [
             'labels_per_page'                     => 'numeric',
             'labels_width'                        => 'numeric',


### PR DESCRIPTION
When using the old label engine it did not pass a value for `label2_template` which is required in the validation rules. This change appends a `DefaultLabel` value in the request to store under `label2_template` in the DB. Which is the template the old label engine uses, allowing the form changes to be saved again.
[sc-28752]