### PR TITLE
Meta Status Fix for Multi Company

### DIFF
--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -555,7 +555,7 @@ class AssetPresenter extends Presenter
      */
     public function statusMeta()
     {
-        if ($this->model->assigned) {
+        if ($this->model->assigned_to) {
             return 'deployed';
         }
 


### PR DESCRIPTION
Changes the meta status to use `assigned_to` column rather than `assigned` relationship, seems like we do this all over the app and doesn't seem to cause any issues. 

Fixes #16558 

We could go a step further in fixing this to show that the asset is assigned to someone out of the company, but this works for now. 