### PR TITLE
FIXED: Created user does not show on user history

### DIFF
--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -984,7 +984,7 @@
                     data-sort-order="desc"
                     id="usersHistoryTable"
                     class="table table-striped snipe-table"
-                    data-url="{{ route('api.activity.index', ['target_id' => $user->id, 'target_type' => 'user']) }}"
+                    data-url="{{ route('api.activity.index', ['item_id' => $user->id, 'item_type' => 'user']) }}"
                     data-export-options='{
                 "fileName": "export-{{ str_slug($user->present()->fullName ) }}-history-{{ date('Y-m-d') }}",
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]


### PR DESCRIPTION
User creating, when done through the gui, was not showing on the history tab for the user.

<img width="996" alt="Screenshot 2025-03-26 at 5 11 28 PM" src="https://github.com/user-attachments/assets/98e034ea-9759-41df-ba3c-057395dfd3a9" />
<img width="1651" alt="Screenshot 2025-03-26 at 5 11 49 PM" src="https://github.com/user-attachments/assets/84cb9b87-186d-4fd9-80d2-34ead2670f1c" />


All tests passed. From manual testing all looks good too.