### PR TITLE
Fixed notes not being saved and update for companies via api

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -67,7 +67,8 @@ final class Company extends SnipeModel
         'phone',
         'fax',
         'email',
-        'created_by'
+        'created_by',
+        'notes',
     ];
 
     private static function isFullMultipleCompanySupportEnabled()

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -295,6 +295,11 @@ class UserFactory extends Factory
         return $this->appendPermission(['companies.delete' => '1']);
     }
 
+    public function editCompanies()
+    {
+        return $this->appendPermission(['companies.edit' => '1']);
+    }
+
     public function viewUsers()
     {
         return $this->appendPermission(['users.view' => '1']);

--- a/tests/Feature/Companies/Api/CreateCompaniesTest.php
+++ b/tests/Feature/Companies/Api/CreateCompaniesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Companies\Api;
+
+use App\Models\User;
+use Tests\Concerns\TestsPermissionsRequirement;
+use Tests\TestCase;
+
+class CreateCompaniesTest extends TestCase implements TestsPermissionsRequirement
+{
+    public function testRequiresPermission()
+    {
+        $this->actingAsForApi(User::factory()->create())
+            ->postJson(route('api.companies.store'))
+            ->assertForbidden();
+    }
+
+    public function testValidationForCreatingCompany()
+    {
+        $this->actingAsForApi(User::factory()->createCompanies()->create())
+            ->postJson(route('api.companies.store'))
+            ->assertStatus(200)
+            ->assertStatusMessageIs('error')
+            ->assertJsonStructure([
+                'messages' => [
+                    'name',
+                ],
+            ]);
+    }
+
+    public function testCanCreateCompany()
+    {
+        $this->actingAsForApi(User::factory()->createCompanies()->create())
+            ->postJson(route('api.companies.store'), [
+                'name' => 'My Cool Company',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $this->assertDatabaseHas('companies', [
+            'name' => 'My Cool Company',
+        ]);
+    }
+}

--- a/tests/Feature/Companies/Api/CreateCompaniesTest.php
+++ b/tests/Feature/Companies/Api/CreateCompaniesTest.php
@@ -33,12 +33,14 @@ class CreateCompaniesTest extends TestCase implements TestsPermissionsRequiremen
         $this->actingAsForApi(User::factory()->createCompanies()->create())
             ->postJson(route('api.companies.store'), [
                 'name' => 'My Cool Company',
+                'notes' => 'A Cool Note',
             ])
             ->assertStatus(200)
             ->assertStatusMessageIs('success');
 
         $this->assertDatabaseHas('companies', [
             'name' => 'My Cool Company',
+            'notes' => 'A Cool Note',
         ]);
     }
 }

--- a/tests/Feature/Companies/Api/UpdateCompaniesTest.php
+++ b/tests/Feature/Companies/Api/UpdateCompaniesTest.php
@@ -41,10 +41,13 @@ class UpdateCompaniesTest extends TestCase
         $this->actingAsForApi(User::factory()->editCompanies()->create())
             ->patchJson(route('api.companies.update', ['company' => $company->id]), [
                 'name' => 'A Changed Name',
+                'notes' => 'A Changed Note',
             ])
             ->assertStatus(200)
             ->assertStatusMessageIs('success');
 
-        $this->assertEquals('A Changed Name', $company->fresh()->name);
+        $company->refresh();
+        $this->assertEquals('A Changed Name', $company->name);
+        $this->assertEquals('A Changed Note', $company->notes);
     }
 }

--- a/tests/Feature/Companies/Api/UpdateCompaniesTest.php
+++ b/tests/Feature/Companies/Api/UpdateCompaniesTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature\Companies\Api;
+
+use App\Models\Company;
+use App\Models\User;
+use Tests\TestCase;
+
+class UpdateCompaniesTest extends TestCase
+{
+    public function testRequiresPermissionToPatchCompany()
+    {
+        $company = Company::factory()->create();
+
+        $this->actingAsForApi(User::factory()->create())
+            ->patchJson(route('api.companies.update', $company))
+            ->assertForbidden();
+    }
+
+    public function testValidationForPatchingCompany()
+    {
+        $company = Company::factory()->create();
+
+        $this->actingAsForApi(User::factory()->editCompanies()->create())
+            ->patchJson(route('api.companies.update', ['company' => $company->id]), [
+                'name' => '',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('error')
+            ->assertJsonStructure([
+                'messages' => [
+                    'name',
+                ],
+            ]);
+    }
+
+    public function testCanPatchCompany()
+    {
+        $company = Company::factory()->create();
+
+        $this->actingAsForApi(User::factory()->editCompanies()->create())
+            ->patchJson(route('api.companies.update', ['company' => $company->id]), [
+                'name' => 'A Changed Name',
+            ])
+            ->assertStatus(200)
+            ->assertStatusMessageIs('success');
+
+        $this->assertEquals('A Changed Name', $company->fresh()->name);
+    }
+}


### PR DESCRIPTION
This PR adds `notes` to the `Company` model's `$fillable` array so it can be set and updated via the api.

Fixes #16572