### PR TITLE
Improve Settings: Remove username and password requirement for ldap

### DIFF
--- a/app/Http/Requests/StoreLdapSettings.php
+++ b/app/Http/Requests/StoreLdapSettings.php
@@ -27,8 +27,6 @@ class StoreLdapSettings extends FormRequest
             'ldap_auth_filter_query' => 'not_in:uid=samaccountname|required_if:ldap_enabled,1',
             'ldap_filter' => 'nullable|regex:"^[^(]"|required_if:ldap_enabled,1',
             'ldap_server' => 'nullable|required_if:ldap_enabled,1|starts_with:ldap://,ldaps://',
-            'ldap_uname' => 'nullable|required_if:ldap_enabled,1',
-            'ldap_pword' => 'nullable|required_if:ldap_enabled,1',
             'ldap_basedn' => 'nullable|required_if:ldap_enabled,1',
             'ldap_fname_field' => 'nullable|required_if:ldap_enabled,1',
             'custom_forgot_pass_url' => 'nullable|url',


### PR DESCRIPTION
Since 9d62793 anonymous LDAP login is available. Remove username and password requirement in settings dialog.