### PR TITLE
Fix whitespace encrypted custom fields display [FD-46570]

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -726,15 +726,21 @@
                                                             @endphp
                                                             @if ($fieldSize>0)
                                                                 <span id="text-{{ $field->id }}-to-hide">{{ str_repeat('*', $fieldSize) }}</span>
-                                                                <span class="js-copy-{{ $field->id }} hidden-print" id="text-{{ $field->id }}-to-show" style="font-size: 0px;">
-                                                                @if (($field->format=='URL') && ($asset->{$field->db_column_name()}!=''))
-                                                                        <a href="{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}" target="_new">{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}</a>
+                                                                    @if (($field->format=='URL') && ($asset->{$field->db_column_name()}!=''))
+                                                                        <span class="js-copy-{{ $field->id }} hidden-print"
+                                                                              id="text-{{ $field->id }}-to-show"
+                                                                              style="font-size: 0px;"><a
+                                                                                    href="{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}"
+                                                                                    target="_new">{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}</a></span>
                                                                     @elseif (($field->format=='DATE') && ($asset->{$field->db_column_name()}!=''))
-                                                                        {{ \App\Helpers\Helper::gracefulDecrypt($field, \App\Helpers\Helper::getFormattedDateObject($asset->{$field->db_column_name()}, 'date', false)) }}
+                                                                        <span class="js-copy-{{ $field->id }} hidden-print"
+                                                                              id="text-{{ $field->id }}-to-show"
+                                                                              style="font-size: 0px;">{{ \App\Helpers\Helper::gracefulDecrypt($field, \App\Helpers\Helper::getFormattedDateObject($asset->{$field->db_column_name()}, 'date', false)) }}</span>
                                                                     @else
-                                                                        {{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}
+                                                                        <span class="js-copy-{{ $field->id }} hidden-print"
+                                                                              id="text-{{ $field->id }}-to-show"
+                                                                              style="font-size: 0px;">{{ Helper::gracefulDecrypt($field, $asset->{$field->db_column_name()}) }}</span>
                                                                     @endif
-                                                                </span>
                                                                 <i class="fa-regular fa-clipboard js-copy-link hidden-print" data-clipboard-target=".js-copy-{{ $field->id }}" aria-hidden="true" data-tooltip="true" data-placement="top" title="{{ trans('general.copy_to_clipboard') }}">
                                                                     <span class="sr-only">{{ trans('general.copy_to_clipboard') }}</span>
                                                                 </i>


### PR DESCRIPTION
When viewing an asset, if you had encrypted custom fields and clicked the 'show' button, or clicked the 'copy to clipboard' button, it would also copy an extraneous trailing space at the end of the string. Not the end of the world or anything, but in a workflow where you're copying-and-pasting a lot, I bet it would be a bit of a pain.

I don't much like this solution, tbh, but I just copied the opening and closing `<span>` tags directly in to the `@if/@elsif/@else` branches directly, and it seems to eliminate the whitespace. It also makes the code duplicated a little bit, but I couldn't figure out a better way to do it...