### PR TITLE
FIXED: Text Overflow on Settings Tiles

### DIFF
--- a/resources/assets/less/app.less
+++ b/resources/assets/less/app.less
@@ -384,18 +384,12 @@ a.logo.no-hover a:hover {
   background-color: transparent;
 }
 
-.index-blocks {
-  color: var(--text-sub);
-  max-width: 400px;
-  max-height: 15px;
+.index-block {
   overflow: hidden;
   text-overflow: ellipsis;
-  text-align: center;
   white-space: nowrap;
 }
-.index-blocks:hover{
-  background-color: var(--back-sub);
-  color: var(--text-main);
+.index-block:hover{
   overflow: visible;
   white-space: normal;
   height:auto;

--- a/resources/assets/less/app.less
+++ b/resources/assets/less/app.less
@@ -384,6 +384,23 @@ a.logo.no-hover a:hover {
   background-color: transparent;
 }
 
+.index-blocks {
+  color: var(--text-sub);
+  max-width: 400px;
+  max-height: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: center;
+  white-space: nowrap;
+}
+.index-blocks:hover{
+  background-color: var(--back-sub);
+  color: var(--text-main);
+  overflow: visible;
+  white-space: normal;
+  height:auto;
+}
+
 input:required, select:required, textarea:required {
   border-right: 6px solid orange;
 }

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -67,7 +67,7 @@
                 <span class="keywords" aria-hidden="true" style="display:none">{{ trans('admin/settings/general.keywords.brand') }}</span>
               </a>
               </h5>
-              <p class="help-block">{{ trans('admin/settings/general.brand_help') }}</p>
+              <p class="index-blocks">{{ trans('admin/settings/general.brand_help') }}</p>
             </div>
           </div>
         </div>
@@ -84,7 +84,7 @@
                   <span class="keywords" aria-hidden="true" style="display:none">{{ trans('admin/settings/general.keywords.general_settings') }}</span>
                 </a>
               </h5>
-              <p class="help-block">{{ trans('admin/settings/general.general_settings_help') }}</p>
+              <p class="index-blocks">{{ trans('admin/settings/general.general_settings_help') }}</p>
             </div>
           </div>
         </div>
@@ -101,7 +101,7 @@
                   <span class="keywords" aria-hidden="true" style="display:none">{{ trans('admin/settings/general.keywords.security') }}</span>
                 </a>
               </h5>
-              <p class="help-block">{{ trans('admin/settings/general.security_help') }}</p>
+              <p class="index-blocks">{{ trans('admin/settings/general.security_help') }}</p>
             </div>
           </div>
         </div>
@@ -117,7 +117,7 @@
                   <span class="keywords" aria-hidden="true" style="display:none"> {{ trans('admin/settings/general.keywords.groups') }}</span>
                   </a>
               </h5>
-              <p class="help-block">{{ trans('admin/settings/general.groups_help') }}</p>
+              <p class="index-blocks">{{ trans('admin/settings/general.groups_help') }}</p>
             </div>
           </div>
         </div>
@@ -134,7 +134,7 @@
                   <span class="keywords" aria-hidden="true" style="display:none"> {{ trans('admin/settings/general.keywords.localization') }}</span>
                 </a>
               </h5>
-              <p class="help-block">{{ trans('admin/settings/general.localization_help') }}</p>
+              <p class="index-blocks">{{ trans('admin/settings/general.localization_help') }}</p>
 
             </div>
           </div>
@@ -152,7 +152,7 @@
 
                 </a>
               </h5>
-              <p class="help-block">{{ trans('admin/settings/general.notifications_help') }}</p>
+              <p class="index-blocks">{{ trans('admin/settings/general.notifications_help') }}</p>
             </div>
           </div>
         </div>
@@ -167,7 +167,7 @@
                   <span class="name">{{ trans('admin/settings/general.integrations') }}</span>
                 </a>
               </h5>
-              <p class="help-block">{{ trans('admin/settings/general.webhook_help') }}</p>
+              <p class="index-blocks">{{ trans('admin/settings/general.webhook_help') }}</p>
             </div>
           </div>
         </div>
@@ -182,7 +182,7 @@
                   <span class="name">{{ trans('general.asset_tags') }}</span>
                 </a>
               </h5>
-              <p class="help-block">{{ trans('admin/settings/general.asset_tags_help') }}</p>
+              <p class="index-blocks">{{ trans('admin/settings/general.asset_tags_help') }}</p>
             </div>
           </div>
         </div>
@@ -198,7 +198,7 @@
                   <span class="keywords" aria-hidden="true" style="display:none"> {{ trans('admin/settings/general.keywords.labels') }}</span>
                 </a>
               </h5>
-              <p class="help-block">{!! trans('admin/settings/general.labels_help') !!}</p>
+              <p class="index-blocks">{!! trans('admin/settings/general.labels_help') !!}</p>
             </div>
           </div>
         </div>
@@ -214,7 +214,7 @@
                   <span class="name">{{ trans('admin/settings/general.ldap') }}</span>
                 </a>
               </h5>
-              <p class="help-block">{{ trans('admin/settings/general.ldap_help') }}</p>
+              <p class="index-blocks">{{ trans('admin/settings/general.ldap_help') }}</p>
             </div>
           </div>
         </div>
@@ -229,7 +229,7 @@
                 <span class="name">Google</span>
               </a>
             </h5>
-            <p class="help-block">{{ trans('admin/settings/general.google_login') }}</p>
+            <p class="index-blocks">{{ trans('admin/settings/general.google_login') }}</p>
           </div>
         </div>
       </div>
@@ -244,7 +244,7 @@
                 <span class="name">{{ trans('admin/settings/general.saml') }}</span>
               </a>
             </h5>
-            <p class="help-block">{{ trans('admin/settings/general.saml_help') }}</p>
+            <p class="index-blocks">{{ trans('admin/settings/general.saml_help') }}</p>
           </div>
         </div>
       </div>
@@ -259,7 +259,7 @@
                   <span class="name">{{ trans('admin/settings/general.backups') }}</span>
                 </a>
               </h5>
-              <p class="help-block">{!! trans('admin/settings/general.backups_help') !!}</p>
+              <p class="index-blocks">{!! trans('admin/settings/general.backups_help') !!}</p>
             </div>
           </div>
         </div>
@@ -275,7 +275,7 @@
                 <span class="name">{{ trans('admin/settings/general.login') }}</span>
               </a>
             </h5>
-            <p class="help-block">{{ trans('admin/settings/general.login_help') }} </p>
+            <p class="index-blocks">{{ trans('admin/settings/general.login_help') }} </p>
           </div>
         </div>
       </div>
@@ -290,7 +290,7 @@
                 <span class="name">{{  trans('admin/settings/general.oauth') }}</span>
               </a>
               </h5>
-              <p class="help-block">{{  trans('admin/settings/general.oauth_help') }}</p>
+              <p class="index-blocks">{{  trans('admin/settings/general.oauth_help') }}</p>
             </div>
           </div>
         </div>
@@ -307,7 +307,7 @@
                     <span class="keywords" aria-hidden="true" style="display:none">{{ trans('admin/settings/general.keywords.php_overview') }}</span>
                   </a>
                 </h5>
-                <p class="help-block">{{ trans('admin/settings/general.php_overview_help') }}</p>
+                <p class="index-blocks">{{ trans('admin/settings/general.php_overview_help') }}</p>
               </div>
             </div>
           </div>
@@ -325,7 +325,7 @@
               <span class="keywords" aria-hidden="true" style="display:none">{{ trans('admin/settings/general.keywords.purge') }}</span>
             </a>
           </h5>
-          <p class="help-block">{{ trans('admin/settings/general.purge_help') }}</p>
+          <p class="index-blocks">{{ trans('admin/settings/general.purge_help') }}</p>
         </div>
       </div>
     </div>
@@ -448,7 +448,7 @@
 
 
   var options = {
-    valueNames: [ 'name', 'keywords', 'summary', 'help-block']
+    valueNames: [ 'name', 'keywords', 'summary', 'index-blocks']
   };
 
   var settingList = new List('setting-list', options);

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -67,7 +67,7 @@
                 <span class="keywords" aria-hidden="true" style="display:none">{{ trans('admin/settings/general.keywords.brand') }}</span>
               </a>
               </h5>
-              <p class="index-blocks">{{ trans('admin/settings/general.brand_help') }}</p>
+              <p class="index-block">{{ trans('admin/settings/general.brand_help') }}</p>
             </div>
           </div>
         </div>
@@ -84,7 +84,7 @@
                   <span class="keywords" aria-hidden="true" style="display:none">{{ trans('admin/settings/general.keywords.general_settings') }}</span>
                 </a>
               </h5>
-              <p class="index-blocks">{{ trans('admin/settings/general.general_settings_help') }}</p>
+              <p class="index-block">{{ trans('admin/settings/general.general_settings_help') }}</p>
             </div>
           </div>
         </div>
@@ -101,7 +101,7 @@
                   <span class="keywords" aria-hidden="true" style="display:none">{{ trans('admin/settings/general.keywords.security') }}</span>
                 </a>
               </h5>
-              <p class="index-blocks">{{ trans('admin/settings/general.security_help') }}</p>
+              <p class="index-block">{{ trans('admin/settings/general.security_help') }}</p>
             </div>
           </div>
         </div>
@@ -117,7 +117,7 @@
                   <span class="keywords" aria-hidden="true" style="display:none"> {{ trans('admin/settings/general.keywords.groups') }}</span>
                   </a>
               </h5>
-              <p class="index-blocks">{{ trans('admin/settings/general.groups_help') }}</p>
+              <p class="index-block">{{ trans('admin/settings/general.groups_help') }}</p>
             </div>
           </div>
         </div>
@@ -134,7 +134,7 @@
                   <span class="keywords" aria-hidden="true" style="display:none"> {{ trans('admin/settings/general.keywords.localization') }}</span>
                 </a>
               </h5>
-              <p class="index-blocks">{{ trans('admin/settings/general.localization_help') }}</p>
+              <p class="index-block">{{ trans('admin/settings/general.localization_help') }}</p>
 
             </div>
           </div>
@@ -152,7 +152,7 @@
 
                 </a>
               </h5>
-              <p class="index-blocks">{{ trans('admin/settings/general.notifications_help') }}</p>
+              <p class="index-block">{{ trans('admin/settings/general.notifications_help') }}</p>
             </div>
           </div>
         </div>
@@ -167,7 +167,7 @@
                   <span class="name">{{ trans('admin/settings/general.integrations') }}</span>
                 </a>
               </h5>
-              <p class="index-blocks">{{ trans('admin/settings/general.webhook_help') }}</p>
+              <p class="index-block">{{ trans('admin/settings/general.webhook_help') }}</p>
             </div>
           </div>
         </div>
@@ -182,7 +182,7 @@
                   <span class="name">{{ trans('general.asset_tags') }}</span>
                 </a>
               </h5>
-              <p class="index-blocks">{{ trans('admin/settings/general.asset_tags_help') }}</p>
+              <p class="index-block">{{ trans('admin/settings/general.asset_tags_help') }}</p>
             </div>
           </div>
         </div>
@@ -198,7 +198,7 @@
                   <span class="keywords" aria-hidden="true" style="display:none"> {{ trans('admin/settings/general.keywords.labels') }}</span>
                 </a>
               </h5>
-              <p class="index-blocks">{!! trans('admin/settings/general.labels_help') !!}</p>
+              <p class="index-block">{!! trans('admin/settings/general.labels_help') !!}</p>
             </div>
           </div>
         </div>
@@ -214,7 +214,7 @@
                   <span class="name">{{ trans('admin/settings/general.ldap') }}</span>
                 </a>
               </h5>
-              <p class="index-blocks">{{ trans('admin/settings/general.ldap_help') }}</p>
+              <p class="index-block">{{ trans('admin/settings/general.ldap_help') }}</p>
             </div>
           </div>
         </div>
@@ -229,7 +229,7 @@
                 <span class="name">Google</span>
               </a>
             </h5>
-            <p class="index-blocks">{{ trans('admin/settings/general.google_login') }}</p>
+            <p class="index-block">{{ trans('admin/settings/general.google_login') }}</p>
           </div>
         </div>
       </div>
@@ -244,7 +244,7 @@
                 <span class="name">{{ trans('admin/settings/general.saml') }}</span>
               </a>
             </h5>
-            <p class="index-blocks">{{ trans('admin/settings/general.saml_help') }}</p>
+            <p class="index-block">{{ trans('admin/settings/general.saml_help') }}</p>
           </div>
         </div>
       </div>
@@ -259,7 +259,7 @@
                   <span class="name">{{ trans('admin/settings/general.backups') }}</span>
                 </a>
               </h5>
-              <p class="index-blocks">{!! trans('admin/settings/general.backups_help') !!}</p>
+              <p class="index-block">{!! trans('admin/settings/general.backups_help') !!}</p>
             </div>
           </div>
         </div>
@@ -275,7 +275,7 @@
                 <span class="name">{{ trans('admin/settings/general.login') }}</span>
               </a>
             </h5>
-            <p class="index-blocks">{{ trans('admin/settings/general.login_help') }} </p>
+            <p class="index-block">{{ trans('admin/settings/general.login_help') }} </p>
           </div>
         </div>
       </div>
@@ -290,7 +290,7 @@
                 <span class="name">{{  trans('admin/settings/general.oauth') }}</span>
               </a>
               </h5>
-              <p class="index-blocks">{{  trans('admin/settings/general.oauth_help') }}</p>
+              <p class="index-block">{{  trans('admin/settings/general.oauth_help') }}</p>
             </div>
           </div>
         </div>
@@ -307,7 +307,7 @@
                     <span class="keywords" aria-hidden="true" style="display:none">{{ trans('admin/settings/general.keywords.php_overview') }}</span>
                   </a>
                 </h5>
-                <p class="index-blocks">{{ trans('admin/settings/general.php_overview_help') }}</p>
+                <p class="index-block">{{ trans('admin/settings/general.php_overview_help') }}</p>
               </div>
             </div>
           </div>
@@ -325,7 +325,7 @@
               <span class="keywords" aria-hidden="true" style="display:none">{{ trans('admin/settings/general.keywords.purge') }}</span>
             </a>
           </h5>
-          <p class="index-blocks">{{ trans('admin/settings/general.purge_help') }}</p>
+          <p class="index-block">{{ trans('admin/settings/general.purge_help') }}</p>
         </div>
       </div>
     </div>
@@ -448,7 +448,7 @@
 
 
   var options = {
-    valueNames: [ 'name', 'keywords', 'summary', 'index-blocks']
+    valueNames: [ 'name', 'keywords', 'summary', 'index-block']
   };
 
   var settingList = new List('setting-list', options);


### PR DESCRIPTION
fixing/updating #15060 

In some laguages, the settings tiles would become unaligned when certain translations ended up being too long for the tile.
EX:
<img width="448" alt="347117572-281cf3f6-d98c-42cd-ba36-0dd62f5220df" src="https://github.com/user-attachments/assets/8d8a8db0-c34b-4075-8fb9-0ee302565152" />

That overflow has been fixed to hid behind an ellipsis and appear when hovered. This is true for ALL skins. Example photos were done in Dark Green theme.
EX:
<img width="384" alt="347117749-c1bcf8d1-8f28-49d1-a3e8-a367a0ac203e" src="https://github.com/user-attachments/assets/bbadb398-a798-4440-9695-e902e8692ec0" />
<img width="380" alt="347117808-cbb3eff5-bed0-482f-a373-a6ec45cb4c1b" src="https://github.com/user-attachments/assets/9f2b2fcd-9be9-4fe2-bd79-923052ebccae" />

[SC-25897](https://app.shortcut.com/grokability/story/25897/dumb-settings-index-layout-in-certain-languages-with-longer-translations)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested on a demo branch to confirm changes
test suite passed on PHP 8.2

# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
