### PR TITLE
Updated login attempts and throttle duration

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -284,8 +284,11 @@ class LoginController extends Controller
             return redirect()->back()->withInput()->withErrors($validator);
         }
 
-        $this->maxLoginAttempts = config('auth.passwords.users.throttle.max_attempts');
-        $this->lockoutTime = config('auth.passwords.users.throttle.lockout_duration');
+        // Set the custom lockout attempts from the env and sett the custom lockout throttle from the env.
+        // We divide decayMinutes by 60 here to get minutes, since Laravel changed the default from minutes
+        // to seconds, and we don't want to break limits on existing systems
+        $this->maxAttempts = config('auth.passwords.users.throttle.max_attempts');
+        $this->decayMinutes = (config('auth.passwords.users.throttle.lockout_duration') / 60);
 
         if ($lockedOut = $this->hasTooManyLoginAttempts($request)) {
             $this->fireLockoutEvent($request);
@@ -355,7 +358,7 @@ class LoginController extends Controller
 
         // We wouldn't normally see this page if 2FA isn't enforced via the
         // \App\Http\Middleware\CheckForTwoFactor middleware AND if a device isn't enrolled,
-        // but let's check check anyway in case there's a browser history or back button thing.
+        // but let's check anyway in case there's a browser history or back button thing.
         // While you can access this page directly, enrolling a device when 2FA isn't enforced
         // won't cause any harm.
 
@@ -521,45 +524,6 @@ class LoginController extends Controller
         return 'username';
     }
 
-    /**
-     * Redirect the user after determining they are locked out.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse
-     */
-    protected function sendLockoutResponse(Request $request)
-    {
-        $seconds = $this->limiter()->availableIn(
-            $this->throttleKey($request)
-        );
-
-        $minutes = round($seconds / 60);
-
-        $message = trans('auth/message.throttle', ['minutes' => $minutes]);
-
-        return redirect()->back()
-            ->withInput($request->only($this->username(), 'remember'))
-            ->withErrors([$this->username() => $message]);
-    }
-
-
-    /**
-     * Override the lockout time and duration
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return bool
-     */
-    protected function hasTooManyLoginAttempts(Request $request)
-    {
-        $lockoutTime = config('auth.passwords.users.throttle.lockout_duration');
-        $maxLoginAttempts = config('auth.passwords.users.throttle.max_attempts');
-
-        return $this->limiter()->tooManyAttempts(
-            $this->throttleKey($request),
-            $maxLoginAttempts,
-            $lockoutTime
-        );
-    }
 
     public function legacyAuthRedirect()
     {

--- a/resources/lang/en-US/auth.php
+++ b/resources/lang/en-US/auth.php
@@ -15,6 +15,6 @@ return array(
 
     'failed' => 'These credentials do not match our records.',
     'password' => 'The provided password is incorrect.',
-    'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
+    'throttle' => 'Too many login attempts. Please try again in :minutes minute(s).',
 
 );

--- a/resources/lang/en-US/auth/message.php
+++ b/resources/lang/en-US/auth/message.php
@@ -6,8 +6,6 @@ return array(
     'account_not_found'      => 'The username or password is incorrect.',
     'account_not_activated'  => 'This user account is not activated.',
     'account_suspended'      => 'This user account is suspended.',
-    'account_banned'         => 'This user account is banned.',
-    'throttle'               => 'Too many failed login attempts. Please try again in :minutes minutes.',
 
     'two_factor' => array(
         'already_enrolled'      => 'Your device is already enrolled.',

--- a/tests/Feature/Authentication/LoginTest.php
+++ b/tests/Feature/Authentication/LoginTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature\Authentication;
+namespace Tests\Feature\Authentication;
 
 use App\Models\User;
 use Tests\TestCase;
@@ -32,7 +32,6 @@ class LoginTest extends TestCase
     public function testLoginThrottleConfigIsRespected()
     {
 
-        // Why do we need this? The app should already be set up
        User::factory()->create(['username' => 'username_here']);
 
        config(['auth.passwords.users.throttle.max_attempts' => 1]);


### PR DESCRIPTION
In Laravel 11, they changed the way login throttling works (to make it work closer to how we were making it work via trait overrides). 

This PR updates the `LoginController.php` to remove our own trait overrides and use the updated Laravel way by setting the `maxAttempts` and `decayMinutes` manually on the request. 

We also do a little math here since existing installations will have had the `LOGIN_LOCKOUT_DURATION` in seconds (as was the old Laravel way) and now it expects minutes, but we don't want everyone to have to update their `.env` files. Our existing documentation:

<img width="830" alt="Screenshot 2025-04-01 at 3 06 41 PM" src="https://github.com/user-attachments/assets/2bbeae51-503d-457c-8525-c6288f6855d8" />

This was originally reported via Discord:

<img width="620" alt="Screenshot 2025-04-01 at 3 14 27 PM" src="https://github.com/user-attachments/assets/2ddd4857-c9f5-478e-a938-39396cb5455c" />
