### PR TITLE
Fixes #16610, regression in #16543

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -8,6 +8,22 @@
  | be modified directly.
 */
 
+
+// This is used by the mysql dump options in spatie backup
+$dump_options = [
+    'dump_binary_path' => env('DB_DUMP_PATH', '/usr/local/bin'),  // only the path, so without 'mysqldump'
+    'use_single_transaction' => false,
+    'timeout' => 60 * 5, // 5 minute timeout
+    //'exclude_tables' => ['table1', 'table2'],
+    //'add_extra_option' => '--optionname=optionvalue',
+];
+
+// Some versions of mysql do not support the --skip-ssl option and will fail if it is
+if (env('DB_DUMP_SKIP_SSL') == 'true') {
+    $dump_options['skip_ssl'] = true;
+}
+
+
 return [
 
     /*
@@ -79,15 +95,7 @@ return [
             'strict'    => false,
             'engine'    => 'InnoDB',
             'unix_socket' => env('DB_SOCKET', ''),
-            'dump' => [
-                'dump_binary_path' => env('DB_DUMP_PATH', '/usr/local/bin'),  // only the path, so without 'mysqldump'
-                'skip_ssl' => env('DB_DUMP_SKIP_SSL', false),  // turn off SSL if not available
-                'use_single_transaction' => false,
-                'timeout' => 60 * 5, // 5 minute timeout
-                //'exclude_tables' => ['table1', 'table2'],
-                //'add_extra_option' => '--optionname=optionvalue',
-            ],
-
+            'dump' => $dump_options,
             'dump_command_timeout' => 60 * 5, // 5 minute timeout
             'dump_using_single_transaction' => true, // perform dump using a single transaction
             'options' => (env('DB_SSL')) ? ((env('DB_SSL_IS_PAAS')) ? [


### PR DESCRIPTION
This fixes a regression created in #16543 that was meant to solve the database backup needing an SSL connection, however it created a new problem where if the version of mysql was not compatible with the `--skip-ssl` flag, it would crash. Unfortunately, setting that `DB_DUMP_SKIP_SSL` env var to `false`, `null`, or `''` did not resolve the issue.

Fixes https://github.com/snipe/snipe-it/issues/16610 which was a result of that regression.