### PR TITLE
Fixed #16257 - Added acceptance PDF logo upload

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -208,9 +208,12 @@ class AcceptanceController extends Controller
              */
             $branding_settings = SettingsController::getPDFBranding();
 
-            if (is_null($branding_settings->logo)){
-                $path_logo = "";
-            } else {
+            $path_logo = "";
+
+            // Check for the PDF logo path and use that, otherwise use the regular logo path
+            if (!is_null($branding_settings->acceptance_pdf_logo)) {
+                $path_logo = public_path() . '/uploads/' . $branding_settings->acceptance_pdf_logo;
+            } elseif (!is_null($branding_settings->logo)) {
                 $path_logo = public_path() . '/uploads/' . $branding_settings->logo;
             }
             

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -428,12 +428,20 @@ class SettingsController extends Controller
                 $setting->label_logo = null;
             }
 
+            // Acceptance PDF upload
+            $setting = $request->handleImages($setting, 600, 'acceptance_pdf_logo', '', 'acceptance_pdf_logo');
+            if ('1' == $request->input('clear_acceptance_pdf_logo')) {
+                $setting = $request->deleteExistingImage($setting, '', 'acceptance_pdf_logo');
+                $setting->acceptance_pdf_logo = null;
+            }
+
             // Favicon upload
             $setting = $request->handleImages($setting, 100, 'favicon', '', 'favicon');
             if ('1' == $request->input('clear_favicon')) {
                 $setting = $request->deleteExistingImage($setting, '', 'favicon');
                 $setting->favicon = null;
             }
+
 
             // Default avatar upload
             $setting = $request->handleImages($setting, 500, 'default_avatar', 'avatars', 'default_avatar');

--- a/database/migrations/2025_04_02_113438_add_acceptance_pdf_logo_to_settings.php
+++ b/database/migrations/2025_04_02_113438_add_acceptance_pdf_logo_to_settings.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->char('acceptance_pdf_logo')->after('label_logo')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('acceptance_pdf_logo');
+        });
+    }
+};

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -58,10 +58,8 @@ return [
     'display_eol'               => 'Display EOL in table view',
     'display_qr'                => 'Display 2D barcode',
     'display_alt_barcode'		=> 'Display 1D barcode',
-    'email_logo'                => 'Email Logo',
     'barcode_type'				=> '2D Barcode Type',
     'alt_barcode_type'			=> '1D barcode type',
-    'email_logo_size'       => 'Square logos in email look best. ',
     'enabled'                   => 'Enabled',
     'eula_settings'				=> 'EULA Settings',
     'eula_markdown'				=> 'This EULA allows <a href="https://help.github.com/articles/github-flavored-markdown/">Github flavored markdown</a>.',
@@ -77,7 +75,6 @@ return [
     'google_workspaces'         => 'Google Workspaces',
     'header_color'              => 'Header Color',
     'info'                      => 'These settings let you customize certain aspects of your installation.',
-    'label_logo'                => 'Label Logo',
     'label_logo_size'           => 'Square logos look best - will be displayed in the top right of each asset label. ',
     'laravel'                   => 'Laravel Version',
     'ldap'                      => 'LDAP',
@@ -389,7 +386,7 @@ return [
     'test_mail' => 'Test Mail',
     'profile_edit'          => 'Edit Profile',
     'profile_edit_help'          => 'Allow users to edit their own profiles.',
-    'default_avatar' => 'Upload custom default avatar',
+    'default_avatar' => 'Custom Default Avatar',
     'default_avatar_help' => 'This image will be displayed as a profile if a user does not have a profile photo.',
     'restore_default_avatar' => 'Restore <a href=":default_avatar" data-toggle="lightbox" data-type="image">original system default avatar</a>',
     'restore_default_avatar_help' => '',
@@ -398,6 +395,17 @@ return [
     'no_groups' => 'No groups have been created yet. Visit <code>Admin Settings > Permission Groups</code> to add one.',
     'text' => 'Text',
 
+    'logo_labels' => [
+        'acceptance_pdf_logo'       => 'PDF Logo',
+        'email_logo'                => 'Email Logo',
+        'label_logo'                => 'Label Logo',
+        'logo'                      => 'Site Logo',
+        'favicon'                   => 'Favicon',
+    ],
+
+    'logo_help' => [
+        'email_logo_size'       => 'Square logos in email look best. ',
+    ],
 
     'logo_option_types' => [
         'text' => 'Text',

--- a/resources/views/partials/forms/edit/uploadLogo.blade.php
+++ b/resources/views/partials/forms/edit/uploadLogo.blade.php
@@ -3,7 +3,7 @@
 <div class="form-group">
     <div class="col-md-3">
         <label {!! $errors->has($logoVariable) ? 'class="alert-msg"' : '' !!} for="{{ $logoVariable }}">
-        {{ ucwords(str_replace('_', ' ', $logoVariable)) }}
+        {{ trans($logoLabel) }}
         </label>
     </div>
     <div class="col-md-9">
@@ -48,7 +48,7 @@
     <div class="col-md-9 col-md-offset-3">
         <label id="{{ $logoId }}-deleteCheckbox" for="{{ $logoClearVariable }}" style="font-weight: normal" class="form-control">
             <input type="checkbox" name="{{ $logoClearVariable }}" value="1" @checked(old($logoClearVariable))>
-            Remove current {{ ucwords(str_replace('_', ' ', $logoVariable)) }} image
+            Remove current {{ $logoLabel }} image
         </label>
     </div>
     @endif

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -98,7 +98,7 @@
                     @include('partials/forms/edit/uploadLogo', [
                         "logoVariable" => "logo",
                         "logoId" => "uploadLogo",
-                        "logoLabel" => trans('admin/settings/general.logo'),
+                        "logoLabel" => trans('admin/settings/general.logo_labels.logo'),
                         "logoClearVariable" => "clear_logo",
                         "helpBlock" => trans('general.logo_size') . trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
                     ])
@@ -107,25 +107,34 @@
                     @include('partials/forms/edit/uploadLogo', [
                         "logoVariable" => "email_logo",
                         "logoId" => "uploadEmailLogo",
-                        "logoLabel" => trans('admin/settings/general.email_logo'),
+                        "logoLabel" => trans('admin/settings/general.logo_labels.email_logo'),
                         "logoClearVariable" => "clear_email_logo",
-                        "helpBlock" => trans('admin/settings/general.email_logo_size') . trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
+                        "helpBlock" => trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
                     ])
 
                     <!-- Label Logo -->
                     @include('partials/forms/edit/uploadLogo', [
                         "logoVariable" => "label_logo",
                         "logoId" => "uploadLabelLogo",
-                        "logoLabel" => trans('admin/settings/general.label_logo'),
+                        "logoLabel" => trans('admin/settings/general.logo_labels.label_logo'),
                         "logoClearVariable" => "clear_label_logo",
-                        "helpBlock" => trans('admin/settings/general.label_logo_size') . trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
+                        "helpBlock" => trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
+                    ])
+
+                    <!-- PDF Logo -->
+                    @include('partials/forms/edit/uploadLogo', [
+                        "logoVariable" => "acceptance_pdf_logo",
+                        "logoId" => "acceptancePdfEmailLogo",
+                        "logoLabel" => trans('admin/settings/general.logo_labels.acceptance_pdf_logo'),
+                        "logoClearVariable" => "clear_acceptance_pdf_logo",
+                        "helpBlock" => trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
                     ])
 
                     <!-- Favicon -->
                     @include('partials/forms/edit/uploadLogo', [
                         "logoVariable" => "favicon",
                         "logoId" => "uploadFavicon",
-                        "logoLabel" => trans('admin/settings/general.favicon'),
+                        "logoLabel" => trans('admin/settings/general.logo_labels.favicon'),
                         "logoClearVariable" => "clear_favicon",
                         "helpBlock" => trans('admin/settings/general.favicon_size') .' '. trans('admin/settings/general.favicon_format'),
                         "allowedTypes" => "image/x-icon,image/gif,image/jpeg,image/png,image/svg,image/svg+xml,image/vnd.microsoft.icon",


### PR DESCRIPTION
This adds the ability to upload a separate logo for the asset acceptance PDFs that get generated on asset/license/etc acceptance, while still falling back to the old behavior if none is given.