### PR TITLE
Fixed #16619 - cloning accessory was not populating fields

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -112,13 +112,13 @@ class AccessoriesController extends Controller
     {
 
         $this->authorize('create', Accessory::class);
-
-        $accessory = clone $accessory;
-        $accessory->id = null;
-        $accessory->location_id = null;
+        $cloned = clone $accessory;
+        $cloned->id = null;
+        $cloned->deleted_at = '';
+        $cloned->location_id = null;
 
         return view('accessories/edit')
-            ->with('item', $accessory);
+            ->with('item', $cloned);
         
     }
 

--- a/routes/web/accessories.php
+++ b/routes/web/accessories.php
@@ -42,7 +42,7 @@ Route::group(['prefix' => 'accessories', 'middleware' => ['auth']], function () 
         [Accessories\AccessoriesFilesController::class, 'show']
     )->name('show.accessoryfile');
 
-    Route::get('{accessoryId}/clone',
+    Route::get('{accessory}/clone',
             [Accessories\AccessoriesController::class, 'getClone']
         )->name('clone/accessories');
 


### PR DESCRIPTION
This corrects the variable in the route-model binding for cloning an accessory, allowing the fields to correctly populate.