### PR TITLE
Fixes Accessories history table color contrast

### DIFF
--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -102,7 +102,7 @@
 
                     <!-- history tab pane -->
                      <div class="tab-pane fade" id="history">
-                         <div class="table table-responsive">
+                         <div class="table-responsive">
                              <div class="row">
                                  <div class="col-md-12">
                                 <table


### PR DESCRIPTION
This removes a duplicate usage of the class `table` from the accessories history table correcting the row background color.
(missing translation in pictures is from local db)
Before:

<img width="1880" alt="image" src="https://github.com/user-attachments/assets/06d0bd82-f682-41f5-996b-1a8ca62d33ba" />

After:

<img width="1880" alt="image" src="https://github.com/user-attachments/assets/5143a3fc-a1b5-4e91-bce9-8272a1898f7c" />

