### PR TITLE
Paveit had old Doctrine code to list tables; use the new method

### DIFF
--- a/app/Console/Commands/PaveIt.php
+++ b/app/Console/Commands/PaveIt.php
@@ -51,8 +51,7 @@ class PaveIt extends Command
         }
 
         // List all the tables in the database so we don't have to worry about missing some as the app grows
-        $tables = DB::connection()->getDoctrineSchemaManager()->listTableNames();
-
+        $tables = Schema::getTables();
         $except_tables = [
             'oauth_access_tokens',
             'oauth_clients',
@@ -74,7 +73,8 @@ class PaveIt extends Command
             }
         }
 
-        foreach ($tables as $table) {
+        foreach ($tables as $table_obj) {
+            $table = $table_obj['name'];
             if (in_array($table, $except_tables)) {
                 $this->info($table. ' is SKIPPED.');
             } else {


### PR DESCRIPTION
The Paveit command was using old Doctrine-style ways of listing table names. Laravel now has a new command, `Schema::getTables()` which works similarly - though not the same. And, frustratingly, not documented very well in the upgrade guide.

But after doing some debugging, it seems like `getTables()` returns an array of arrays, each of which have a `name` element - so this uses that instead.

I'm not sure whether or not this will work with table prefixes, but this isn't used very often and if someone reports back that that it doesn't work there, I'm sure we can fix it pretty easily.