### PR TITLE
Fixed #16640 - FIFO for requestable assets

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -422,10 +422,6 @@ Route::group(['prefix' => 'account', 'middleware' => ['auth']], function () {
         $trail->parent('home')
             ->push(trans('general.requestable_items'), route('requestable-assets')));
 
-    Route::post(
-        'request-asset/{assetId}',
-        [ViewAssetsController::class, 'getRequestAsset']
-    )->name('account/request-asset');
 
     Route::post('request-asset/{asset}', [ViewAssetsController::class, 'store'])
         ->name('account.request-asset');


### PR DESCRIPTION
Laravel routes use FIFO (first in, first out) ordering. An older, no-longer-used route was above the ones that replaced it, so it was incorrectly referencing a method that no longer exists. This resolves that issue.