### PR TITLE
Fixes #9660 - Adds location qr code option to labels

### DIFF
--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -38,6 +38,7 @@ class LabelsController extends Controller
         $exampleAsset->order_number = '12345';
         $exampleAsset->purchase_date = '2023-01-01';
         $exampleAsset->status_id = 1;
+        $exampleAsset->location_id = 1;
 
         $exampleAsset->company = new Company([
             'name' => trans('admin/labels/table.example_company'),

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -139,6 +139,9 @@ class Label implements View
                             case 'plain_serial_number': 
                                 $barcode2DTarget = $asset->serial; 
                                 break;
+                            case 'location':
+                                $barcode2DTarget = route('locations.show', $asset->location_id);
+                                break;
                             case 'hardware_id':
                             default:
                                 $barcode2DTarget = route('hardware.show', $asset);

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -301,7 +301,10 @@
                                     <x-input.select
                                         name="label2_2d_target"
                                         id="label2_2d_target"
-                                        :options="['hardware_id'=>'/hardware/{id} ('.trans('admin/settings/general.default').')', 'ht_tag'=>'/ht/{asset_tag}', 'location' => '/location/{location_id}']"
+                                        :options="['hardware_id'=>'/hardware/{id} ('.trans('admin/settings/general.default').')',
+                                                   'ht_tag'=>'/ht/{asset_tag}',
+                                                   'location' => '/location/{location_id}',
+                                                   ]"
                                         :selected="old('label2_2d_target', $setting->label2_2d_target)"
                                         class="col-md-4"
                                         aria-label="label2_2d_target"

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -301,7 +301,7 @@
                                     <x-input.select
                                         name="label2_2d_target"
                                         id="label2_2d_target"
-                                        :options="['hardware_id'=>'/hardware/{id} ('.trans('admin/settings/general.default').')', 'ht_tag'=>'/ht/{asset_tag}']"
+                                        :options="['hardware_id'=>'/hardware/{id} ('.trans('admin/settings/general.default').')', 'ht_tag'=>'/ht/{asset_tag}', 'location' => '/location/{location_id}']"
                                         :selected="old('label2_2d_target', $setting->label2_2d_target)"
                                         class="col-md-4"
                                         aria-label="label2_2d_target"


### PR DESCRIPTION
This adds an option to link qr codes to locations.
The location is pulled through the asset's current `location_id`

<img width="1006" alt="image" src="https://github.com/user-attachments/assets/e2ebf938-f73d-4893-ab71-33a3203dc8d2" />

[sc-28642]