### PR TITLE
Username dropdown to show Usernames and not Emails as Examples

### DIFF
--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -394,6 +394,19 @@ return [
     'due_checkin_days_help' => 'How many days before the expected checkin of an asset should it be listed in the "Due for checkin" page?',
     'no_groups' => 'No groups have been created yet. Visit <code>Admin Settings > Permission Groups</code> to add one.',
     'text' => 'Text',
+    'firstname_lastname_format'	=> 'First Name Last Name (jane.smith)',
+    'first_name_format'	        => 'First Name (jane)',
+    'filastname_format'			=> 'First Initial Last Name (jsmith)',
+    'lastnamefirstinitial_format' =>  'Last Name First Initial (smithj)',
+    'firstname_lastname_underscore_format' => 'First Name Last Name (jane_smith)',
+    'firstinitial.lastname' => 'First Initial Last Name (j.smith)',
+    'lastname_firstinitial' => 'Last Name First Initial (smith_j)',
+    'lastname_dot_firstinitial_format' => 'Last Name First Initial (smith.j)',
+    'firstnamelastname'     => 'First Name Last Name (janesmith)',
+    'firstnamelastinitial'  => 'First Name Last Initial (janes)',
+    'lastnamefirstname'      => 'Last Name.First Name (smith.jane)',
+
+
 
     'logo_labels' => [
         'acceptance_pdf_logo'       => 'PDF Logo',

--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -189,7 +189,7 @@ Form::macro('barcode_types', function ($name = 'barcode_type', $selected = null,
     return $select;
 });
 
-Form::macro('username_format', function ($name = 'username_format', $selected = null, $class = null) {
+Form::macro('email_format', function ($name = 'email_format', $selected = null, $class = null) {
     $formats = [
         'firstname.lastname' => trans('general.firstname_lastname_format'),
         'firstname' => trans('general.first_name_format'),
@@ -202,6 +202,31 @@ Form::macro('username_format', function ($name = 'username_format', $selected = 
         'firstnamelastname' => trans('general.firstnamelastname'),
         'firstnamelastinitial' => trans('general.firstnamelastinitial'),
         'lastname.firstname' => trans('general.lastnamefirstname'),
+    ];
+
+    $select = '<select name="'.$name.'" class="'.$class.'" style="width: 100%" aria-label="'.$name.'">';
+    foreach ($formats as $format => $label) {
+        $select .= '<option value="'.$format.'"'.($selected == $format ? ' selected="selected" role="option" aria-selected="true"' : ' aria-selected="false"').'>'.$label.'</option> '."\n";
+    }
+
+    $select .= '</select>';
+
+    return $select;
+});
+
+Form::macro('username_format', function ($name = 'username_format', $selected = null, $class = null) {
+    $formats = [
+        'firstname.lastname' => trans('admin/settings/general.firstname_lastname_format'),
+        'firstname' => trans('admin/settings/general.first_name_format'),
+        'filastname' => trans('admin/settings/general.filastname_format'),
+        'lastnamefirstinitial' => trans('admin/settings/general.lastnamefirstinitial_format'),
+        'firstname_lastname' => trans('admin/settings/general.firstname_lastname_underscore_format'),
+        'firstinitial.lastname' => trans('admin/settings/general.firstinitial.lastname'),
+        'lastname_firstinitial' => trans('admin/settings/general.lastname_firstinitial'),
+        'lastname.firstinitial' => trans('admin/settings/general.lastname_dot_firstinitial_format'),
+        'firstnamelastname' => trans('admin/settings/general.firstnamelastname'),
+        'firstnamelastinitial' => trans('admin/settings/general.firstnamelastinitial'),
+        'lastname.firstname' => trans('admin/settings/general.lastnamefirstname'),
     ];
 
     $select = '<select name="'.$name.'" class="'.$class.'" style="width: 100%" aria-label="'.$name.'">';

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -93,7 +93,7 @@
                             <label for="email_format">{{ trans('general.email_format') }}</label>
                         </div>
                         <div class="col-md-9">
-                            {!! Form::username_format('email_format', old('email_format', $setting->email_format), 'select2') !!}
+                            {!! Form::email_format('email_format', old('email_format', $setting->email_format), 'select2') !!}
                             {!! $errors->first('email_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                         </div>
                     </div>

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -24,12 +24,28 @@ class UserTest extends TestCase
         $this->assertEquals($expected_username, $user['username']);
     }
 
+    public function testFirstNameEmail()
+    {
+        $fullname = "Natalia Allanovna Romanova-O'Shostakova";
+        $expected_email = 'natalia@example.com';
+        $user = User::generateFormattedNameFromFullName($fullname, 'firstname');
+        $this->assertEquals($expected_email, $user['username'] . '@example.com');
+    }
+
     public function testFirstNameDotLastName()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
         $expected_username = 'natalia.allanovna-romanova-oshostakova';
         $user = User::generateFormattedNameFromFullName($fullname, 'firstname.lastname');
         $this->assertEquals($expected_username, $user['username']);
+    }
+
+    public function testFirstNameDotLastNameEmail()
+    {
+        $fullname = "Natalia Allanovna Romanova-O'Shostakova";
+        $expected_email = 'natalia.allanovna-romanova-oshostakova@example.com';
+        $user = User::generateFormattedNameFromFullName($fullname, 'firstname.lastname');
+        $this->assertEquals($expected_email, $user['username'] . '@example.com');
     }
 
     public function testLastNameFirstInitial()
@@ -40,12 +56,28 @@ class UserTest extends TestCase
         $this->assertEquals($expected_username, $user['username']);
     }
 
+    public function testLastNameFirstInitialEmail()
+    {
+        $fullname = "Natalia Allanovna Romanova-O'Shostakova";
+        $expected_email = 'allanovna-romanova-oshostakovan@example.com';
+        $user = User::generateFormattedNameFromFullName($fullname, 'lastnamefirstinitial');
+        $this->assertEquals($expected_email, $user['username'] . '@example.com');
+    }
+
     public function testFirstInitialLastName()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
         $expected_username = 'nallanovna-romanova-oshostakova';
         $user = User::generateFormattedNameFromFullName($fullname, 'filastname');
         $this->assertEquals($expected_username, $user['username']);
+    }
+
+    public function testFirstInitialLastNameEmail()
+    {
+        $fullname = "Natalia Allanovna Romanova-O'Shostakova";
+        $expected_email = 'nallanovna-romanova-oshostakova@example.com';
+        $user = User::generateFormattedNameFromFullName($fullname, 'filastname');
+        $this->assertEquals($expected_email, $user['username'] . '@example.com');
     }
 
     public function testFirstInitialUnderscoreLastName()
@@ -56,12 +88,28 @@ class UserTest extends TestCase
         $this->assertEquals($expected_username, $user['username']);
     }
 
+    public function testFirstInitialUnderscoreLastNameEmail()
+    {
+        $fullname = "Natalia Allanovna Romanova-O'Shostakova";
+        $expected_email = 'nallanovna-romanova-oshostakova@example.com';
+        $user = User::generateFormattedNameFromFullName($fullname, 'firstinitial_lastname');
+        $this->assertEquals($expected_email, $user['username'] . '@example.com');
+    }
+
     public function testSingleName()
     {
         $fullname = 'Natalia';
         $expected_username = 'natalia';
         $user = User::generateFormattedNameFromFullName($fullname, 'firstname_lastname',);
         $this->assertEquals($expected_username, $user['username']);
+    }
+
+    public function testSingleNameEmail()
+    {
+        $fullname = 'Natalia';
+        $expected_email = 'natalia@example.com';
+        $user = User::generateFormattedNameFromFullName($fullname, 'firstname_lastname',);
+        $this->assertEquals($expected_email, $user['username'] . '@example.com');
     }
 
     public function testFirstInitialDotLastname()
@@ -72,12 +120,28 @@ class UserTest extends TestCase
         $this->assertEquals($expected_username, $user['username']);
     }
 
+    public function testFirstInitialDotLastnameEmail()
+    {
+        $fullname = "Natalia Allanovna Romanova-O'Shostakova";
+        $expected_email = 'nallanovna-romanova-oshostakova@example.com';
+        $user = User::generateFormattedNameFromFullName($fullname, 'firstinitial.lastname');
+        $this->assertEquals($expected_email, $user['username'] . '@example.com');
+    }
+
     public function testLastNameDotFirstInitial()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
         $expected_username = 'allanovna-romanova-oshostakova.n';
         $user = User::generateFormattedNameFromFullName($fullname, 'lastname.firstinitial');
         $this->assertEquals($expected_username, $user['username']);
+    }
+
+    public function testLastNameDotFirstInitialEmail()
+    {
+        $fullname = "Natalia Allanovna Romanova-O'Shostakova";
+        $expected_email = 'allanovna-romanova-oshostakova.n@example.com';
+        $user = User::generateFormattedNameFromFullName($fullname, 'lastname.firstinitial');
+        $this->assertEquals($expected_email, $user['username'] . '@example.com');
     }
 
     public function testLastNameUnderscoreFirstInitial()
@@ -88,6 +152,14 @@ class UserTest extends TestCase
         $this->assertEquals($expected_username, $user['username']);
     }
 
+    public function testLastNameUnderscoreFirstInitialEmail()
+    {
+        $fullname = "Natalia Allanovna Romanova-O'Shostakova";
+        $expected_email = 'allanovna-romanova-oshostakova_n@example.com';
+        $user = User::generateFormattedNameFromFullName($fullname, 'lastname_firstinitial');
+        $this->assertEquals($expected_email, $user['username'] . '@example.com');
+    }
+
     public function testFirstNameLastName()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
@@ -96,11 +168,27 @@ class UserTest extends TestCase
         $this->assertEquals($expected_username, $user['username']);
     }
 
+    public function testFirstNameLastNameEmail()
+    {
+        $fullname = "Natalia Allanovna Romanova-O'Shostakova";
+        $expected_email = 'nataliaallanovna-romanova-oshostakova@example.com';
+        $user = User::generateFormattedNameFromFullName($fullname, 'firstnamelastname');
+        $this->assertEquals($expected_email, $user['username'] . '@example.com');
+    }
+
     public function testFirstNameLastInitial()
     {
         $fullname = "Natalia Allanovna Romanova-O'Shostakova";
         $expected_username = 'nataliaa';
         $user = User::generateFormattedNameFromFullName($fullname, 'firstnamelastinitial');
         $this->assertEquals($expected_username, $user['username']);
+    }
+
+    public function testFirstNameLastInitialEmail()
+    {
+        $fullname = "Natalia Allanovna Romanova-O'Shostakova";
+        $expected_email = 'nataliaa@example.com';
+        $user = User::generateFormattedNameFromFullName($fullname, 'firstnamelastinitial');
+        $this->assertEquals($expected_email, $user['username'] . '@example.com');
     }
 }


### PR DESCRIPTION
Changes the Username dropdown in general settings to show the `username` and not an email as its example.
<img width="1300" alt="Screenshot 2025-04-07 at 6 56 06 PM" src="https://github.com/user-attachments/assets/4b6a3e3e-f5ba-486b-96a5-5878fd6ce3fb" />

Tests were added as a differentiation between username and emails was added.