### PR TITLE
Set empty array if group permission is a string or null

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -83,6 +83,10 @@ class GroupsController extends Controller
     {
         $permissions = config('permissions');
         $groupPermissions = $group->decodePermissions();
+
+        if ((!is_array($groupPermissions)) || (!$groupPermissions)) {
+            $groupPermissions = [];
+        }
         $selected_array = Helper::selectedPermissionsArray($permissions, $groupPermissions);
         return view('groups.edit', compact('group', 'permissions', 'selected_array', 'groupPermissions'));
     }


### PR DESCRIPTION
This should generally only affect the demo and/or people using the API to create groups. Since we don't have a lot of good validation around that endpoint, you can end up with data that doesn't make sense, which was causing a 500 error. This causes it to gracefully fall back to an empty array if a string or null is passed.

Fixes the `Argument #2 ($array) must be of type array, string given`, RB-3943, RB-3861, RB-3862.