### PR TITLE
Small improvements to location-by-company scoping

### DIFF
--- a/app/Console/Commands/TestLocationsFMCS.php
+++ b/app/Console/Commands/TestLocationsFMCS.php
@@ -38,8 +38,10 @@ class TestLocationsFMCS extends Command
 
         $mismatched = Helper::test_locations_fmcs(true, $location_id);
         $this->warn(trans_choice('admin/settings/message.location_scoping.mismatch', count($mismatched)));
+        $this->newLine();
+        $this->info('Edit your locations to associate them with the correct company.');
 
-        $header = ['Item Type', 'Item ID', 'Item Company ID', 'Location Company ID'];
+        $header = ['Type', 'Name', 'ID', 'Item Company', 'Company ID', 'Item Location', 'Location Company ID'];
         sort($mismatched);
 
         $this->table($header, $mismatched);

--- a/app/Console/Commands/TestLocationsFMCS.php
+++ b/app/Console/Commands/TestLocationsFMCS.php
@@ -41,7 +41,7 @@ class TestLocationsFMCS extends Command
         $this->newLine();
         $this->info('Edit your locations to associate them with the correct company.');
 
-        $header = ['ID', 'Type', 'Name', 'Checkout Type',  'Company ID', 'Item Company','Item Location', 'Location Company', 'Location Company ID'];
+        $header = ['Type', 'ID', 'Name', 'Checkout Type',  'Company ID', 'Item Company', 'Item Location', 'Location Company', 'Location Company ID'];
         sort($mismatched);
 
         $this->table($header, $mismatched);

--- a/app/Console/Commands/TestLocationsFMCS.php
+++ b/app/Console/Commands/TestLocationsFMCS.php
@@ -36,10 +36,14 @@ class TestLocationsFMCS extends Command
             $location_id = $this->option('location_id');
         }
 
+        $mismatched = Helper::test_locations_fmcs(true, $location_id);
+        $this->warn(trans_choice('admin/settings/message.location_scoping.mismatch', count($mismatched)));
 
-        $ret = Helper::test_locations_fmcs(true, $location_id);
-        $this->warn('There are '.count($ret).' items in the database that need your attention before you can enable location scoping.');
-        $this->table(['Item Type', 'Item ID', 'Item Company ID', 'Location Company ID'], $ret);
+        $header = ['Item Type', 'Item ID', 'Item Company ID', 'Location Company ID'];
+        sort($mismatched);
+
+        $this->table($header, $mismatched);
 
     }
+
 }

--- a/app/Console/Commands/TestLocationsFMCS.php
+++ b/app/Console/Commands/TestLocationsFMCS.php
@@ -19,25 +19,27 @@ class TestLocationsFMCS extends Command
      *
      * @var string
      */
-    protected $description = 'Test for inconsistencies if FullMultipleCompanySupport with scoped locations will be used';
+    protected $description = 'Test for company ID inconsistencies if FullMultipleCompanySupport with scoped locations will be used.';
 
     /**
      * Execute the console command.
      */
     public function handle()
     {
-        $this->info('Test for inconsistencies if FullMultipleCompanySupport with scoped locations will be used');
-        $this->info('Depending on the database size this will take a while, output will be displayed after the complete test is over');
+        $this->info('This script checks for company ID inconsistencies if Full Multiple Company Support with scoped locations will be used.');
+        $this->info('This could take few moments if have a very large dataset.');
+        $this->newLine();
 
         // if parameter location_id is set, only test this location
         $location_id = null;
         if ($this->option('location_id')) {
             $location_id = $this->option('location_id');
         }
-        $ret = Helper::test_locations_fmcs(true, $location_id);
 
-        foreach($ret as $output) {
-            $this->info($output);
-        }
+
+        $ret = Helper::test_locations_fmcs(true, $location_id);
+        $this->warn('There are '.count($ret).' items in the database that need your attention before you can enable location scoping.');
+        $this->table(['Item Type', 'Item ID', 'Item Company ID', 'Location Company ID'], $ret);
+
     }
 }

--- a/app/Console/Commands/TestLocationsFMCS.php
+++ b/app/Console/Commands/TestLocationsFMCS.php
@@ -41,7 +41,7 @@ class TestLocationsFMCS extends Command
         $this->newLine();
         $this->info('Edit your locations to associate them with the correct company.');
 
-        $header = ['Type', 'Name', 'ID', 'Item Company', 'Company ID', 'Item Location', 'Location Company ID'];
+        $header = ['ID', 'Type', 'Name', 'Checkout Type',  'Company ID', 'Item Company','Item Location', 'Location Company', 'Location Company ID'];
         sort($mismatched);
 
         $this->table($header, $mismatched);

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1597,12 +1597,16 @@ class Helper
 
                         if ($item && $item->company_id != $location_company) {
                             $mismatched[] = [
-                                    $item->id,
                                     class_basename(get_class($item)),
+                                    $item->id,
                                     $item->name ?? $item->asset_tag ?? $item->serial ?? $item->username,
                                     str_replace('App\\Models\\', '', $item->assigned_type) ?? null,
                                     $item->company_id ?? null,
                                     $item->company->name ?? null,
+//                                    $item->defaultLoc->id ?? null,
+//                                    $item->defaultLoc->name ?? null,
+//                                    $item->defaultLoc->company->id ?? null,
+//                                    $item->defaultLoc->company->name ?? null,
                                     $item->location->name ?? null,
                                     $item->location->company->name ?? null,
                                     $location_company ?? null,

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1556,14 +1556,14 @@ class Helper
         }
 
         foreach($locations as $location) {
-            // in case of an update of a single location use the newly requested company_id
+            // in case of an update of a single location, use the newly requested company_id
             if ($new_company_id) {
                 $location_company = $new_company_id;
             } else {
                 $location_company = $location->company_id;
             }
 
-            // depending on the relationship, we must use different operations to retrieve the objects
+            // Depending on the relationship, we must use different operations to retrieve the objects
             $keywords_relation = [
                 'many' => [
                             'accessories',
@@ -1594,14 +1594,17 @@ class Helper
                     }
 
                     foreach ($items as $item) {
+
                         if ($item && $item->company_id != $location_company) {
                             $mismatched[] = [
-                                    class_basename(get_class($item)),
-                                    $item->name,
                                     $item->id,
-                                    $item->company->name ?? null,
+                                    class_basename(get_class($item)),
+                                    $item->name ?? $item->asset_tag ?? $item->serial ?? $item->username,
+                                    str_replace('App\\Models\\', '', $item->assigned_type) ?? null,
                                     $item->company_id ?? null,
+                                    $item->company->name ?? null,
                                     $item->location->name ?? null,
+                                    $item->location->company->name ?? null,
                                     $location_company ?? null,
                                 ];
 

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1597,9 +1597,12 @@ class Helper
                         if ($item && $item->company_id != $location_company) {
                             $mismatched[] = [
                                     class_basename(get_class($item)),
+                                    $item->name,
                                     $item->id,
-                                    $item->company_id,
-                                    $location_company ?? 'null',
+                                    $item->company->name ?? null,
+                                    $item->company_id ?? null,
+                                    $item->location->name ?? null,
+                                    $location_company ?? null,
                                 ];
 
                         }

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1563,11 +1563,24 @@ class Helper
                 $location_company = $location->company_id;
             }
 
-            // depending on the relationship we must use different operations to retrieve the objects
-            $keywords_relation = ['many' => ['users', 'assets', 'rtd_assets', 'consumables', 'components', 'accessories', 'assignedAssets', 'assignedAccessories'],
-                                  'one'  => ['parent', 'manager']];
+            // depending on the relationship, we must use different operations to retrieve the objects
+            $keywords_relation = [
+                'many' => [
+                            'users',
+                            'assets',
+                            'rtd_assets',
+                            'consumables',
+                            'components',
+                            'accessories',
+                            'assignedAssets',
+                            'assignedAccessories'
+                        ],
+                    'one'  => [
+                        'parent',
+                        'manager'
+                    ]];
 
-            // In case of a single location the children must be checked either, becuase we don't walk every location
+            // In case of a single location, the children must be checked as well, because we don't walk every location
             if ($location_id) {
                 $keywords_relation['many'][] = 'children';
             }
@@ -1575,14 +1588,20 @@ class Helper
             foreach ($keywords_relation as $relation => $keywords) {
                 foreach($keywords as $keyword) {
                     if ($relation == 'many') {
-                        $items = $location->$keyword->all();
+                        $items = $location->{$keyword}->all();
                     } else {
                         $items = collect([])->push($location->$keyword);
                     }
 
                     foreach ($items as $item) {
                         if ($item && $item->company_id != $location_company) {
-                            $ret[] = 'type: ' . get_class($item) . ', id: ' . $item->id . ', company_id: ' . $item->company_id . ', location company_id: ' . $location_company;
+                            $row[] = [
+                                    $ret['type'] = class_basename(get_class($item)),
+                                    $ret['id'] = $item->id,
+                                    $ret['company_id'] = $item->company_id,
+                                    $ret['location_company_id'] = $location_company ?? 'null',
+                                ];
+
                             // when not called from artisan command we bail out on the first error
                             if (!$artisan) {
                                 return $ret;
@@ -1592,6 +1611,6 @@ class Helper
                 }
             }
         }
-        return $ret;
+        return $row;
     }        
 }

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1544,7 +1544,7 @@ class Helper
      * @return string []
      */
     static public function test_locations_fmcs($artisan, $location_id = null, $new_company_id = null) {
-        $ret = [];
+        $mismatched = [];
 
         if ($location_id) {
             $location = Location::find($location_id);
@@ -1566,18 +1566,18 @@ class Helper
             // depending on the relationship, we must use different operations to retrieve the objects
             $keywords_relation = [
                 'many' => [
-                            'users',
-                            'assets',
-                            'rtd_assets',
-                            'consumables',
-                            'components',
                             'accessories',
+                            'assets',
+                            'assignedAccessories',
                             'assignedAssets',
-                            'assignedAccessories'
+                            'components',
+                            'consumables',
+                            'rtd_assets',
+                            'users',
                         ],
                     'one'  => [
+                        'manager',
                         'parent',
-                        'manager'
                     ]];
 
             // In case of a single location, the children must be checked as well, because we don't walk every location
@@ -1595,22 +1595,18 @@ class Helper
 
                     foreach ($items as $item) {
                         if ($item && $item->company_id != $location_company) {
-                            $row[] = [
-                                    $ret['type'] = class_basename(get_class($item)),
-                                    $ret['id'] = $item->id,
-                                    $ret['company_id'] = $item->company_id,
-                                    $ret['location_company_id'] = $location_company ?? 'null',
+                            $mismatched[] = [
+                                    class_basename(get_class($item)),
+                                    $item->id,
+                                    $item->company_id,
+                                    $location_company ?? 'null',
                                 ];
 
-                            // when not called from artisan command we bail out on the first error
-                            if (!$artisan) {
-                                return $ret;
-                            }
                         }
                     }
                 }
             }
         }
-        return $row;
+        return $mismatched;
     }        
 }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -325,9 +325,9 @@ class SettingsController extends Controller
 
         // check for inconsistencies when activating scoped locations
         if ($old_locations_fmcs == '0' && $setting->scope_locations_fmcs == '1') {
-            $ret = Helper::test_locations_fmcs(false);
-            if (count($ret) != 0) {
-                return redirect()->back()->withInput()->with('error', 'Inconsistencies with scoped locations found, please use php artisan snipeit:test-locations-fmcs for details');
+            $mismatched = Helper::test_locations_fmcs(false);
+            if (count($mismatched) != 0) {
+                return redirect()->back()->withInput()->with('error', trans_choice('admin/settings/message.location_scoping.mismatch', count($mismatched)));
             }
         }
 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -327,7 +327,7 @@ class SettingsController extends Controller
         if ($old_locations_fmcs == '0' && $setting->scope_locations_fmcs == '1') {
             $mismatched = Helper::test_locations_fmcs(false);
             if (count($mismatched) != 0) {
-                return redirect()->back()->withInput()->with('error', trans_choice('admin/settings/message.location_scoping.mismatch', count($mismatched)));
+                return redirect()->back()->withInput()->with('error', trans_choice('admin/settings/message.location_scoping.mismatch', count($mismatched)).' '.trans('admin/settings/message.location_scoping.not_saved'));
             }
         }
 

--- a/resources/lang/en-US/admin/settings/message.php
+++ b/resources/lang/en-US/admin/settings/message.php
@@ -50,5 +50,10 @@ return [
         'error_misc' => 'Something went wrong. :( ',
         'webhook_fail' => ' webhook notification failed: Check to make sure the URL is still valid.',
         'webhook_channel_not_found' => ' webhook channel not found.'
-    ]
+    ],
+
+    'location_scoping' => [
+        'mismatch' => 'There is 1 item in the database that need your attention before you can enable location scoping. Your settings were not saved.| There are :count items in the database that need your attention before you can enable location scoping. Your settings were not saved.',
+    ],
+
 ];

--- a/resources/lang/en-US/admin/settings/message.php
+++ b/resources/lang/en-US/admin/settings/message.php
@@ -53,7 +53,8 @@ return [
     ],
 
     'location_scoping' => [
-        'mismatch' => 'There is 1 item in the database that need your attention before you can enable location scoping. Your settings were not saved.| There are :count items in the database that need your attention before you can enable location scoping. Your settings were not saved.',
+        'not_saved' => 'Your settings were not saved.',
+        'mismatch' => 'There is 1 item in the database that need your attention before you can enable location scoping.|There are :count items in the database that need your attention before you can enable location scoping.',
     ],
 
 ];

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -36,7 +36,7 @@
 
                <div class="box-body">
 
-                   <div class="col-md-12">
+                   <div class="col-md-11">
 
                     <!-- Full Multiple Companies Support -->
                     <div class="form-group {{ $errors->has('full_multiple_companies_support') ? 'error' : '' }}">


### PR DESCRIPTION
This builds on the work from  #12577 by @Toreg87. 

Unfortunately, it's a bit as I feared. In "fixing" some of the items by updating the location to use the corresponding company, I've made things worse.

### Before
<img width="967" alt="Screenshot 2025-04-08 at 3 30 49 PM" src="https://github.com/user-attachments/assets/8f4bd505-30cc-40a8-8447-f42b52acbde6" />


### After a few "Fixes"
<img width="1023" alt="Screenshot 2025-04-08 at 3 31 05 PM" src="https://github.com/user-attachments/assets/aa2aa1b7-cd7e-4452-acd5-a1c4fb3a5e2f" />

My fear is that this is going to get really frustrating for users. :( After fixing two components, I went from 10 items that needed attention to 500+, and we don't have a way to bulk edit some of those things easily. 
