### PR TITLE
Added option to redirect back to checkedInFrom user for assets/licenses/accessories

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1475,7 +1475,7 @@ class Helper
     }
 
 
-    static public function getRedirectOption($request, $id, $table, $item_id = null)
+    static public function getRedirectOption($request, $id, $table, $checkedInBy=null, $item_id = null)
     {
 
         $redirect_option = Session::get('redirect_option');
@@ -1516,12 +1516,11 @@ class Helper
                     return route('consumables.show', $id ?? $item_id);
             }
         }
-
         // return to assignment target
         if ($redirect_option == 'target') {
             switch ($checkout_to_type) {
                 case 'user':
-                    return route('users.show', $request->assigned_user);
+                    return route('users.show', $request->assigned_user ?? $checkedInBy);
                 case 'location':
                     return route('locations.show', $request->assigned_location);
                 case 'asset':

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1475,7 +1475,7 @@ class Helper
     }
 
 
-    static public function getRedirectOption($request, $id, $table,$item_id = null)
+    static public function getRedirectOption($request, $id, $table, $item_id = null)
     {
 
         $redirect_option = Session::get('redirect_option');
@@ -1517,6 +1517,7 @@ class Helper
                     return route('consumables.show', $id ?? $item_id);
             }
         }
+
         // return to assignment target
         if ($redirect_option == 'target') {
             switch ($checkout_to_type) {

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1480,7 +1480,7 @@ class Helper
 
         $redirect_option = Session::get('redirect_option');
         $checkout_to_type = Session::get('checkout_to_type');
-        $checkedInBy = Session::get('checkedInBy');
+        $checkedInFrom = Session::get('checkedInFrom');
 
         // return to index
         if ($redirect_option == 'index') {
@@ -1522,11 +1522,11 @@ class Helper
         if ($redirect_option == 'target') {
             switch ($checkout_to_type) {
                 case 'user':
-                    return route('users.show', $request->assigned_user ?? $checkedInBy);
+                    return route('users.show', $request->assigned_user ?? $checkedInFrom);
                 case 'location':
-                    return route('locations.show', $request->assigned_location);
+                    return route('locations.show', $request->assigned_location ?? $checkedInFrom);
                 case 'asset':
-                    return route('hardware.show', $request->assigned_asset);
+                    return route('hardware.show', $request->assigned_asset ?? $checkedInFrom);
             }
         }
         return redirect()->back()->with('error', trans('admin/hardware/message.checkout.error'));

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1475,11 +1475,19 @@ class Helper
     }
 
 
-    static public function getRedirectOption($request, $id, $table, $checkedInBy=null, $item_id = null)
+    static public function getRedirectOption($request, $id, $table,$item_id = null)
     {
 
         $redirect_option = Session::get('redirect_option');
         $checkout_to_type = Session::get('checkout_to_type');
+        $checkedInBy = Session::get('checkedInBy');
+//        dd([
+//            'called from' => __FILE__,
+//            'line' => __LINE__,
+//            'redirect_option' => Session::get('redirect_option'),
+//            'checkout_to_type' => Session::get('checkout_to_type'),
+//            'target_id_param' => $checkedInBy,
+//        ]);
 
         // return to index
         if ($redirect_option == 'index') {

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1481,13 +1481,6 @@ class Helper
         $redirect_option = Session::get('redirect_option');
         $checkout_to_type = Session::get('checkout_to_type');
         $checkedInBy = Session::get('checkedInBy');
-//        dd([
-//            'called from' => __FILE__,
-//            'line' => __LINE__,
-//            'redirect_option' => Session::get('redirect_option'),
-//            'checkout_to_type' => Session::get('checkout_to_type'),
-//            'target_id_param' => $checkedInBy,
-//        ]);
 
         // return to index
         if ($redirect_option == 'index') {

--- a/app/Http/Controllers/Accessories/AccessoryCheckinController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckinController.php
@@ -7,6 +7,7 @@ use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Models\Accessory;
 use App\Models\AccessoryCheckout;
+use App\Models\Asset;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -50,9 +51,14 @@ class AccessoryCheckinController extends Controller
         }
 
         $accessory = Accessory::find($accessory_checkout->accessory_id);
+        $checkedInBy = 0;
+        if($accessory_checkout->assigned_type === 'App\Models\User') {
+            $checkedInBy = $accessory_checkout->assigned_to;
+            session()->put('checkout_to_type', 'user');
+            session()->put('checkedInBy', $checkedInBy);
+        }
 
         $this->authorize('checkin', $accessory);
-
         $checkin_hours = date('H:i:s');
         $checkin_at = date('Y-m-d H:i:s');
         if ($request->filled('checkin_at')) {

--- a/app/Http/Controllers/Accessories/AccessoryCheckinController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckinController.php
@@ -51,9 +51,8 @@ class AccessoryCheckinController extends Controller
         $accessory = Accessory::find($accessory_checkout->accessory_id);
 
         if($accessory_checkout->assigned_type === 'App\Models\User') {
-            $checkedInBy = $accessory_checkout->assigned_to;
             session()->put('checkout_to_type', 'user');
-            session()->put('checkedInBy', $checkedInBy);
+            session()->put('checkedInBy', $accessory_checkout->assigned_to);
         }
 
         $this->authorize('checkin', $accessory);

--- a/app/Http/Controllers/Accessories/AccessoryCheckinController.php
+++ b/app/Http/Controllers/Accessories/AccessoryCheckinController.php
@@ -7,8 +7,6 @@ use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Models\Accessory;
 use App\Models\AccessoryCheckout;
-use App\Models\Asset;
-use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use \Illuminate\Contracts\View\View;
@@ -51,7 +49,7 @@ class AccessoryCheckinController extends Controller
         }
 
         $accessory = Accessory::find($accessory_checkout->accessory_id);
-        $checkedInBy = 0;
+
         if($accessory_checkout->assigned_type === 'App\Models\User') {
             $checkedInBy = $accessory_checkout->assigned_to;
             session()->put('checkout_to_type', 'user');

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -134,6 +134,7 @@ class AssetCheckinController extends Controller
         $asset->customFieldsForCheckinCheckout('display_checkin');
 
         if ($asset->save()) {
+
             event(new CheckoutableCheckedIn($asset, $target, auth()->user(), $request->input('note'), $checkin_at, $originalValues));
             return redirect()->to(Helper::getRedirectOption($request, $asset->id, 'Assets'))->with('success', trans('admin/hardware/message.checkin.success'));
         }

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -77,6 +77,7 @@ class AssetCheckinController extends Controller
 
         if ($asset->assignedType() == Asset::USER) {
             $user = $asset->assignedTo;
+            session()->put('checkedInBy', $user->id);
         }
 
         $asset->expected_checkin = null;
@@ -133,13 +134,8 @@ class AssetCheckinController extends Controller
         $asset->customFieldsForCheckinCheckout('display_checkin');
 
         if ($asset->save()) {
-            Log::debug([
-                'redirect_option' => $request->get('redirect_option'),
-                'checkout_to_type' => session()->get('checkout_to_type'),
-                'assigned_user' => session()->get('assigned_user'),
-            ]);
             event(new CheckoutableCheckedIn($asset, $target, auth()->user(), $request->input('note'), $checkin_at, $originalValues));
-            return redirect()->to(Helper::getRedirectOption($request, $asset->id, 'Assets', $user->id))->with('success', trans('admin/hardware/message.checkin.success'));
+            return redirect()->to(Helper::getRedirectOption($request, $asset->id, 'Assets'))->with('success', trans('admin/hardware/message.checkin.success'));
         }
         // Redirect to the asset management page with error
         return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.checkin.error').$asset->getErrors());

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -133,9 +133,13 @@ class AssetCheckinController extends Controller
         $asset->customFieldsForCheckinCheckout('display_checkin');
 
         if ($asset->save()) {
-
+            Log::debug([
+                'redirect_option' => $request->get('redirect_option'),
+                'checkout_to_type' => session()->get('checkout_to_type'),
+                'assigned_user' => session()->get('assigned_user'),
+            ]);
             event(new CheckoutableCheckedIn($asset, $target, auth()->user(), $request->input('note'), $checkin_at, $originalValues));
-            return redirect()->to(Helper::getRedirectOption($request, $asset->id, 'Assets'))->with('success', trans('admin/hardware/message.checkin.success'));
+            return redirect()->to(Helper::getRedirectOption($request, $asset->id, 'Assets', $user->id))->with('success', trans('admin/hardware/message.checkin.success'));
         }
         // Redirect to the asset management page with error
         return redirect()->route('hardware.index')->with('error', trans('admin/hardware/message.checkin.error').$asset->getErrors());

--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -87,6 +87,7 @@ class LicenseCheckinController extends Controller
 
         if($licenseSeat->assigned_to != null){
             $return_to = User::find($licenseSeat->assigned_to);
+            session()->put('checkedInBy', $return_to->id);
         } else {
             $return_to = Asset::find($licenseSeat->asset_id);
         }

--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -87,7 +87,7 @@ class LicenseCheckinController extends Controller
 
         if($licenseSeat->assigned_to != null){
             $return_to = User::find($licenseSeat->assigned_to);
-            session()->put('checkedInBy', $return_to->id);
+            session()->put('checkedInFrom', $return_to->id);
         } else {
             $return_to = Asset::find($licenseSeat->asset_id);
         }

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -23,6 +23,7 @@ return [
     'asset_models'			=> 'Asset Models',
     'asset_model'			=> 'Model',
     'asset'					=> 'Asset',
+    'asset_previous'        => 'Asset (Previously Assigned)',
     'asset_report'          => 'Asset Report',
     'asset_tag'				=> 'Asset Tag',
     'asset_tags'            => 'Asset Tags',

--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -77,7 +77,7 @@
                                 :options="[
                                 'index' => trans('admin/hardware/form.redirect_to_all', ['type' => trans('general.accessories')]),
                                 'item' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.accessory')]),
-                                'target' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.user')]),
+                                'target' => $target_option
                                ]"
                         />
 

--- a/resources/views/accessories/checkin.blade.php
+++ b/resources/views/accessories/checkin.blade.php
@@ -77,7 +77,7 @@
                                 :options="[
                                 'index' => trans('admin/hardware/form.redirect_to_all', ['type' => trans('general.accessories')]),
                                 'item' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.accessory')]),
-
+                                'target' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.user')]),
                                ]"
                         />
 

--- a/resources/views/components/checkin.blade.php
+++ b/resources/views/components/checkin.blade.php
@@ -62,6 +62,7 @@
                                 :options="[
                                 'index' => trans('admin/hardware/form.redirect_to_all', ['type' => trans('general.components')]),
                                 'item' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.component')]),
+                                'target' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.user')]),
                                ]"
                         />
                     </div> <!-- /.box-->

--- a/resources/views/components/checkin.blade.php
+++ b/resources/views/components/checkin.blade.php
@@ -62,7 +62,6 @@
                                 :options="[
                                 'index' => trans('admin/hardware/form.redirect_to_all', ['type' => trans('general.components')]),
                                 'item' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.component')]),
-                                'target' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.user')]),
                                ]"
                         />
                     </div> <!-- /.box-->

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -171,7 +171,7 @@
                         :options="[
                                 'index' => trans('admin/hardware/form.redirect_to_all', ['type' => trans('general.assets')]),
                                 'item' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.asset')]),
-                                'target' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.user')]),
+                                'target' => $target_option,
                                ]"
                 />
                 </form>

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -171,6 +171,7 @@
                         :options="[
                                 'index' => trans('admin/hardware/form.redirect_to_all', ['type' => trans('general.assets')]),
                                 'item' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.asset')]),
+                                'target' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.user')]),
                                ]"
                 />
                 </form>

--- a/resources/views/licenses/checkin.blade.php
+++ b/resources/views/licenses/checkin.blade.php
@@ -72,6 +72,7 @@
                                 :options="[
                                 'index' => trans('admin/hardware/form.redirect_to_all', ['type' => trans('general.licenses')]),
                                 'item' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.license')]),
+                                'target' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.user')]),
                                ]"
                         />
                     </div> <!-- /.box-->


### PR DESCRIPTION
This adds the option to redirect to the user that an asset/license/accessory was just checked in for. 

Accessories and Assets being able to be checked out to multiple things (Asset/Location/User) now have the `target_option` handled in the create method.

added a session variable of `checkedInFrom`, this worked consistently compared to adding a 5th parameter to the `getRedirectOptions()` method.
[sc-28817]

Checking in an Asset from an Asset is distinguished with (previously assigned):
<img width="908" alt="image" src="https://github.com/user-attachments/assets/b4c19f36-31d3-4c64-bb02-6f9e1a2f9b73" />

The option is listed as `Go to User`:
<img width="764" alt="image" src="https://github.com/user-attachments/assets/01046daf-9c66-430b-847a-48580aa4978d" />
