### PR TITLE
Store accepted_at and declined_at in action log when accepting/declining assets

### DIFF
--- a/app/Listeners/LogListener.php
+++ b/app/Listeners/LogListener.php
@@ -83,6 +83,7 @@ class LogListener
         $logaction->accept_signature = $event->acceptance->signature_filename;
         $logaction->note = $event->acceptance->note;
         $logaction->action_type = 'declined';
+        $logaction->action_date = $event->acceptance->declined_at;
 
         // TODO: log the actual license seat that was checked out
         if ($event->acceptance->checkoutable instanceof LicenseSeat) {

--- a/app/Listeners/LogListener.php
+++ b/app/Listeners/LogListener.php
@@ -65,6 +65,7 @@ class LogListener
         $logaction->filename = $event->acceptance->stored_eula_file;
         $logaction->note = $event->acceptance->note;
         $logaction->action_type = 'accepted';
+        $logaction->action_date = $event->acceptance->accepted_at;
 
         // TODO: log the actual license seat that was checked out
         if ($event->acceptance->checkoutable instanceof LicenseSeat) {

--- a/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
@@ -136,4 +136,28 @@ class AssetAcceptanceTest extends TestCase
             ->exists()
         );
     }
+
+    public function testActionLoggedWhenDecliningAsset()
+    {
+        $checkoutAcceptance = CheckoutAcceptance::factory()->pending()->create();
+
+        $this->actingAs($checkoutAcceptance->assignedTo)
+            ->post(route('account.store-acceptance', $checkoutAcceptance), [
+                'asset_acceptance' => 'declined',
+                'note' => 'my note',
+            ]);
+
+        $this->assertTrue(Actionlog::query()
+            ->where([
+                'action_type' => 'declined',
+                'target_id' => $checkoutAcceptance->assignedTo->id,
+                'target_type' => User::class,
+                'note' => 'my note',
+                'item_type' => Asset::class,
+                'item_id' => $checkoutAcceptance->checkoutable->id,
+            ])
+            ->whereNotNull('action_date')
+            ->exists()
+        );
+    }
 }

--- a/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\CheckoutAcceptances\Ui;
+
+use App\Events\CheckoutAccepted;
+use App\Models\CheckoutAcceptance;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class AssetAcceptanceTest extends TestCase
+{
+    public function testAssetCheckoutAcceptPageRenders()
+    {
+        $checkoutAcceptance = CheckoutAcceptance::factory()->pending()->create();
+
+        $this->actingAs($checkoutAcceptance->assignedTo)
+            ->get(route('account.accept.item', $checkoutAcceptance))
+            ->assertViewIs('account.accept.create');
+    }
+
+    public function testCannotAcceptAssetAlreadyAccepted()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testCannotAcceptAssetForAnotherUser()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testUserCanAcceptAssetCheckout()
+    {
+        Event::fake([CheckoutAccepted::class]);
+
+        $checkoutAcceptance = CheckoutAcceptance::factory()->pending()->create();
+
+        $this->assertTrue($checkoutAcceptance->isPending());
+
+        $this->actingAs($checkoutAcceptance->assignedTo)
+            ->post(route('account.store-acceptance', $checkoutAcceptance), [
+                'asset_acceptance' => 'accepted',
+                'note' => 'my note',
+            ])
+            ->assertRedirectToRoute('account.accept');
+
+        $this->assertFalse($checkoutAcceptance->fresh()->isPending());
+
+        Event::assertDispatched(CheckoutAccepted::class);
+    }
+
+    public function testActionLoggedWhenAcceptingAsset()
+    {
+        $this->markTestIncomplete();
+    }
+
+
+}

--- a/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
@@ -79,7 +79,11 @@ class AssetAcceptanceTest extends TestCase
             ->assertRedirectToRoute('account.accept')
             ->assertSessionHas('success');
 
-        $this->assertFalse($checkoutAcceptance->fresh()->isPending());
+        $checkoutAcceptance->refresh();
+
+        $this->assertFalse($checkoutAcceptance->isPending());
+        $this->assertNotNull($checkoutAcceptance->accepted_at);
+        $this->assertNull($checkoutAcceptance->declined_at);
 
         Event::assertDispatched(CheckoutAccepted::class);
     }

--- a/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
@@ -63,7 +63,7 @@ class AssetAcceptanceTest extends TestCase
         Event::assertNotDispatched(CheckoutAccepted::class);
     }
 
-    public function testUserCanAcceptAssetCheckout()
+    public function testUserCanAcceptAsset()
     {
         Event::fake([CheckoutAccepted::class]);
 


### PR DESCRIPTION
This PR fixes a small bug where `action_date` was not being saved in the action logs when accepting or decline assets.