### PR TITLE
FIXED: Location Being Overwritten By Default Location

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -351,11 +351,6 @@ class AssetsController extends Controller
             event(new CheckoutableCheckedIn($asset, $target, auth()->user(), 'Checkin on asset update with '.$status->getStatuslabelType().' status', date('Y-m-d H:i:s'), $originalValues));
         }
 
-        if ($asset->assigned_to == '') {
-            $asset->location_id = $request->input('rtd_location_id', null);
-        }
-
-
         if ($request->filled('image_delete')) {
             try {
                 unlink(public_path().'/uploads/assets/'.$asset->image);

--- a/tests/Feature/Assets/Ui/EditAssetTest.php
+++ b/tests/Feature/Assets/Ui/EditAssetTest.php
@@ -102,4 +102,27 @@ class EditAssetTest extends TestCase
         }, 1);
     }
 
+    public function testCurrentLocationIsNotUpdatedOnEdit()
+    {
+        $defaultLocation = Location::factory()->create();
+        $currentLocation = Location::factory()->create();
+        $asset = Asset::factory()->create([
+            'location_id' => $currentLocation->id,
+            'rtd_location_id' => $defaultLocation->id
+        ]);
+
+        $this->actingAs(User::factory()->viewAssets()->editAssets()->create())
+            ->put(route('hardware.update', $asset), [
+                'redirect_option' => 'item',
+                'name' => 'New name',
+                'asset_tags' => 'New Asset Tag',
+                'status_id' => $asset->status_id,
+                'model_id' => $asset->model_id,
+            ]);
+
+        $asset->refresh();
+        $this->assertEquals('New name', $asset->name);
+        $this->assertEquals($currentLocation->id, $asset->location_id);
+    }
+
 }


### PR DESCRIPTION
Default Location was overwriting the Current Location of an asset when editing that asset.

Our code was always resetting the location of an asset to the Default Location on any update. Current Location is NOT an editable field when editing an asset; it can only be done during an audit.


<img width="1485" alt="Screenshot 2025-04-10 at 2 48 36 PM" src="https://github.com/user-attachments/assets/d1e814e8-028d-461b-8feb-279140ec1c29" />
(The location updates, even when a user doesn't have the ability to even see the current location field)

<img width="1659" alt="Screenshot 2025-04-10 at 2 52 39 PM" src="https://github.com/user-attachments/assets/2798dddb-f0bb-4067-a7cc-8e53459517cc" />
(Asset Checked Out)

<img width="1008" alt="Screenshot 2025-04-10 at 2 52 53 PM" src="https://github.com/user-attachments/assets/a826ab8e-f5a3-437b-9d1a-b6ef816c4c72" />
<img width="1030" alt="Screenshot 2025-04-10 at 2 53 05 PM" src="https://github.com/user-attachments/assets/eb41059a-b0e4-480a-89d9-856d5fb55165" />
(Asset Checked in and set to its new current location)

<img width="1452" alt="Screenshot 2025-04-10 at 3 00 00 PM" src="https://github.com/user-attachments/assets/48077f08-bbc2-4bc5-93ee-581ddc72cb5c" />
<img width="792" alt="Screenshot 2025-04-10 at 3 01 13 PM" src="https://github.com/user-attachments/assets/eb3f24a9-58b7-4877-b211-e7ed1d0dbb7a" />
(Now updating an asset will not update that current location)