### PR TITLE
Create default label when importing assets if none exists

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -16,10 +16,23 @@ class AssetImporter extends ItemImporter
     {
         parent::__construct($filename);
 
-        $this->defaultStatusLabelId = Statuslabel::first()->id;
-        
+        $this->defaultStatusLabelId = Statuslabel::first()?->id;
+
         if (!is_null(Statuslabel::deployable()->first())) {
-            $this->defaultStatusLabelId = Statuslabel::deployable()->first()->id;
+            $this->defaultStatusLabelId = Statuslabel::deployable()->first()?->id;
+        }
+
+        if (is_null($this->defaultStatusLabelId)) {
+            $defaultLabel = Statuslabel::create([
+                'name' => 'Default Status',
+                'deployable' => 0,
+                'pending' => 1,
+                'archived' => 0,
+                'notes' => 'Default status label created by AssetImporter',
+                'created_by' => $this->created_by,
+            ]);
+
+            $this->defaultStatusLabelId = $defaultLabel->id;
         }
     }
 

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -29,7 +29,6 @@ class AssetImporter extends ItemImporter
                 'pending' => 1,
                 'archived' => 0,
                 'notes' => 'Default status label created by AssetImporter',
-                'created_by' => $this->created_by,
             ]);
 
             $this->defaultStatusLabelId = $defaultLabel->id;

--- a/tests/Unit/Importer/AssetImportTest.php
+++ b/tests/Unit/Importer/AssetImportTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Importer;
+
+use Tests\TestCase;
+
+class AssetImportTest extends TestCase
+{
+    public function test_uses_first_deployable_status_label_as_default_if_one_exists()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_uses_first_status_label_as_default_if_deployable_status_label_does_not_exist()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_creates_default_status_label_if_one_does_not_exist()
+    {
+        $this->markTestIncomplete();
+    }
+}

--- a/tests/Unit/Importer/AssetImportTest.php
+++ b/tests/Unit/Importer/AssetImportTest.php
@@ -2,22 +2,55 @@
 
 namespace Tests\Unit\Importer;
 
+use App\Importer\AssetImporter;
+use App\Models\Statuslabel;
 use Tests\TestCase;
+use function Livewire\invade;
 
 class AssetImportTest extends TestCase
 {
     public function test_uses_first_deployable_status_label_as_default_if_one_exists()
     {
-        $this->markTestIncomplete();
+        Statuslabel::truncate();
+
+        $pendingStatusLabel = Statuslabel::factory()->pending()->create();
+        $readyToDeployStatusLabel = Statuslabel::factory()->readyToDeploy()->create();
+
+        $importer = new AssetImporter('assets.csv');
+
+        $this->assertEquals(
+            $readyToDeployStatusLabel->id,
+            invade($importer)->defaultStatusLabelId
+        );
     }
 
     public function test_uses_first_status_label_as_default_if_deployable_status_label_does_not_exist()
     {
-        $this->markTestIncomplete();
+        Statuslabel::truncate();
+
+        $statusLabel = Statuslabel::factory()->pending()->create();
+
+        $importer = new AssetImporter('assets.csv');
+
+        $this->assertEquals(
+            $statusLabel->id,
+            invade($importer)->defaultStatusLabelId
+        );
     }
 
     public function test_creates_default_status_label_if_one_does_not_exist()
     {
-        $this->markTestIncomplete();
+        Statuslabel::truncate();
+
+        $this->assertEquals(0, Statuslabel::count());
+
+        $importer = new AssetImporter('assets.csv');
+
+        $this->assertEquals(1, Statuslabel::count());
+
+        $this->assertEquals(
+            Statuslabel::first()->id,
+            invade($importer)->defaultStatusLabelId
+        );
     }
 }


### PR DESCRIPTION
Currently, if a user attempts to import assets and there isn't a status label they are presented with an unhelpful error message:
![image](https://github.com/user-attachments/assets/5b692c81-023f-41f8-a449-677594a895b8)
> Your file import is complete, but we did receive an error. This is usually caused by third-party API throttling from a notification webhook (such as Slack) and would not have interfered with the import itself, but you should confirm this.

This PR allows the import to go through by creating a new "Default" status label with the "**Pending**" status:
![image](https://github.com/user-attachments/assets/26f0175a-1135-44b5-88e8-d232080e21e0)
A note is added to the status label that indicates how it was created, "Default status label created by AssetImporter".