### PR TITLE
Fixes #14734: Only show signatures for the printed user

### DIFF
--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -594,18 +594,18 @@ class UsersController extends Controller
 
         $user = User::where('id', $id)
             ->with([
-                'assets.assetlog',
-                'assets.assignedAssets.assetlog',
+                'assets.log' => fn($query) => $query->withTrashed()->where('target_type', User::class)->where('target_id', $id)->where('action_type', 'accepted'),
+                'assets.assignedAssets.log' => fn($query) => $query->withTrashed()->where('target_type', User::class)->where('target_id', $id)->where('action_type', 'accepted'),
                 'assets.assignedAssets.defaultLoc',
                 'assets.assignedAssets.location',
                 'assets.assignedAssets.model.category',
                 'assets.defaultLoc',
                 'assets.location',
                 'assets.model.category',
-                'accessories.assetlog',
+                'accessories.log' => fn($query) => $query->withTrashed()->where('target_type', User::class)->where('target_id', $id)->where('action_type', 'accepted'),
                 'accessories.category',
                 'accessories.manufacturer',
-                'consumables.assetlog',
+                'consumables.log' => fn($query) => $query->withTrashed()->where('target_type', User::class)->where('target_id', $id)->where('action_type', 'accepted'),
                 'consumables.category',
                 'consumables.manufacturer',
                 'licenses.category',

--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -343,4 +343,24 @@ trait Loggable
 
         return $log;
     }
+
+    /**
+     * Get latest signature from a specific user
+     *
+     * This just makes the print view a bit cleaner
+     * Returns the latest acceptance ActionLog that contains a signature
+     * from $user or null if there is none
+     *
+     * @param User $user
+     * @return null|Actionlog
+     **/
+    public function getLatestSignedAcceptance(User $user)
+    {
+        return $this->log->where('target_type', User::class)
+            ->where('target_id', $user->id)
+            ->where('action_type', 'accepted')
+            ->where('accept_signature', '!=', null)
+            ->sortByDesc('created_at')
+            ->first();
+    }
 }

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -147,8 +147,8 @@
                     <td>
                         {{ Helper::getFormattedDateObject($asset->last_checkout, 'datetime', false) }}</td>
                     <td>
-                        @if (($asset->assetlog->firstWhere('action_type', 'accepted')) && ($asset->assetlog->firstWhere('action_type', 'accepted')->accept_signature!=''))
-                            <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->firstWhere('action_type', 'accepted')->accept_signature }}">
+                        @if ($asset->getLatestSignedAcceptance($show_user))
+                            <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->getLatestSignedAcceptance($show_user)->accept_signature }}">
                         @endif
                     </td>
                 </tr>
@@ -175,8 +175,8 @@
                                 {{ Helper::getFormattedDateObject($asset->last_checkout, 'datetime', false) }}
                             </td>
                             <td>
-                                @if (($asset->assetlog->firstWhere('action_type', 'accepted')) && ($asset->assetlog->firstWhere('action_type', 'accepted')->accept_signature!=''))
-                                    <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->assetlog->firstWhere('action_type', 'accepted')->accept_signature }}">
+                                @if ($asset->getLatestSignedAcceptance($show_user))
+                                    <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $asset->getLatestSignedAcceptance($show_user)->accept_signature }}">
                                 @endif
                             </td>
                         </tr>
@@ -243,8 +243,8 @@
                         {{ Helper::getFormattedDateObject($license->pivot->updated_at, 'datetime', false) }}
                     </td>
                     <td>
-                        @if (($license->assetlog->firstWhere('action_type', 'accepted')) && ($license->assetlog->firstWhere('action_type', 'accepted')->accept_signature!=''))
-                            <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $license->assetlog->firstWhere('action_type', 'accepted')->accept_signature }}">
+                        @if ($license->getLatestSignedAcceptance($show_user))
+                            <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $license->getLatestSignedAcceptance($show_user)->accept_signature }}">
                         @endif
                     </td>
                 </tr>
@@ -308,8 +308,8 @@
                         </td>
 
                         <td>
-                            @if (($accessory->assetlog->first()) && ($accessory->assetlog->first()->accept_signature!=''))
-                                <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $accessory->assetlog->first()->accept_signature }}">
+                            @if ($accessory->getLatestSignedAcceptance($show_user))
+                                <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $accessory->getLatestSignedAcceptance($show_user)->accept_signature }}">
                             @endif
                         </td>
                     </tr>
@@ -373,8 +373,8 @@
                                 {{ Helper::getFormattedDateObject($consumable->pivot->created_at, 'datetime', false) }}
                             </td>
                             <td>
-                                @if (($consumable->assetlog->first()) && ($consumable->assetlog->first()->accept_signature!=''))
-                                    <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $consumable->assetlog->first()->accept_signature }}">
+                                @if ($consumable->getLatestSignedAcceptance($show_user))
+                                    <img style="width:auto;height:100px;" src="{{ asset('/') }}display-sig/{{ $consumable->getLatestSignedAcceptance($show_user)->accept_signature }}">
                                 @endif
                             </td>
                     </tr>


### PR DESCRIPTION
Fixes #14734.

Also only loads log entries for the current user. We only care about the last log entry that contains a signature on this page. This should speed up the page a bit for cases where assets have long histories. There's room for improvement there but I'm not sure how well limits work on eager loaded relations.

The assetlog relation was only being used for this, and because of the new method being in the Loggable trait, it makes sense to use the log relation instead.