### PR TITLE
Fixed #16689: re-add `note` field in API files listing for AssetModel

### DIFF
--- a/app/Http/Transformers/AssetModelsTransformer.php
+++ b/app/Http/Transformers/AssetModelsTransformer.php
@@ -105,6 +105,7 @@ class AssetModelsTransformer
         $array = [
             'id' => (int) $file->id,
             'filename' => e($file->filename),
+            'note' => $file->note,
             'url' => route('show/modelfile', [$assetmodel->id, $file->id]),
             'created_by' => ($file->adminuser) ? [
                 'id' => (int) $file->adminuser->id,

--- a/tests/Feature/AssetModels/Api/AssetModelFilesTest.php
+++ b/tests/Feature/AssetModels/Api/AssetModelFilesTest.php
@@ -59,11 +59,24 @@ class AssetModelFilesTest extends TestCase
 	// Create a superuser to run this as
 	$user = User::factory()->superuser()->create();
 
-	//Upload a file
+	// Upload a file
 	$this->actingAsForApi($user)
             ->post(
                route('api.models.files.store', ['model_id' => $model[0]["id"]]), [
-		       'file' => [UploadedFile::fake()->create("test.jpg", 100)]
+		       'file' => [UploadedFile::fake()->create("test.jpg", 100)],
+	       ])
+            ->assertOk()
+            ->assertJsonStructure([
+                'status',
+                'messages',
+            ]);
+
+    // Upload a file with notes
+    $this->actingAsForApi($user)
+            ->post(
+                route('api.models.files.store', ['model_id' => $model[0]["id"]]), [
+                'file' => [UploadedFile::fake()->create("test.jpg", 100)],
+                'notes' => 'manual'
 	       ])
             ->assertOk()
             ->assertJsonStructure([
@@ -75,7 +88,26 @@ class AssetModelFilesTest extends TestCase
 	$result = $this->actingAsForApi($user)
             ->getJson(
 		    route('api.models.files.index', ['model_id' => $model[0]["id"]]))
-            ->assertOk();
+            ->assertOk()
+            ->assertJsonStructure([
+                'total',
+                'rows'=>[
+                    '*' => [
+                        'id',
+                        'filename',
+                        'url',
+                        'created_by',
+                        'created_at',
+                        'updated_at',
+                        'deleted_at',
+                        'note',
+                        'available_actions'
+                    ]
+                ]
+            ])
+            ->assertJsonPath('rows.0.note','')
+            ->assertJsonPath('rows.1.note','manual');
+
 
 
 	// Get the file


### PR DESCRIPTION
Fixes #16689 reintroducing `note` field in API files listing for AssetModel.

Also improved the tests, to avoid removal by accident in the future.