### PR TITLE
Separate docker builds into Intel/ARM builds

### DIFF
--- a/.github/workflows/docker-arm.yml
+++ b/.github/workflows/docker-arm.yml
@@ -1,5 +1,5 @@
 # Snipe-IT Docker image build for hub.docker.com
-name: Docker images
+name: Docker Intel/amd64 images (Ubuntu)
 
 # Run this Build for all pushes to 'master' or develop branch, or tagged releases.
 # Also run for PRs to ensure PR doesn't break Docker build process
@@ -19,10 +19,10 @@ permissions:
   contents: read
 
 jobs:
-  docker:
+  docker-ubuntu-arm:
     # Ensure this job never runs on forked repos. It's only executed for 'grokability/snipe-it'
     if: github.repository == 'grokability/snipe-it'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     env:
       # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)
       # For a new commit on default branch (master), use the literal tag 'latest' on Docker image.
@@ -77,7 +77,72 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
+          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
+          # but we ONLY do an image push to DockerHub if it's NOT a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          # Use tags / labels provided by 'docker/metadata-action' above
+          tags: ${{ steps.meta_build.outputs.tags }}
+          labels: ${{ steps.meta_build.outputs.labels }}
+  docker-alpine-arm:
+    # Ensure this job never runs on forked repos. It's only executed for 'grokability/snipe-it'
+    if: github.repository == 'grokability/snipe-it'
+    runs-on: ubuntu-24.04-arm
+    env:
+      # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)
+      # For a new commit on default branch (master), use the literal tag 'latest' on Docker image.
+      # For a new commit on other branches, use the branch name as the tag for Docker image.
+      # For a new tag, copy that tag name as the tag for Docker image.
+      IMAGE_TAGS: |
+        type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},suffix=-alpine
+        type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }},suffix=-alpine
+        type=ref,event=tag,suffix=-alpine
+        type=semver,pattern=v{{major}}-latest-alpine 
+      # Define default tag "flavor" for docker/metadata-action per
+      # https://github.com/docker/metadata-action#flavor-input
+      # We turn off 'latest' tag by default.
+      TAGS_FLAVOR: |
+        latest=false
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # https://github.com/docker/login-action
+      - name: Login to DockerHub
+        # Only login if not a PR, as PRs only trigger a Docker build and not a push
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      ###############################################
+      # Build/Push the 'grokability/snipe-it' image
+      ###############################################
+      # https://github.com/docker/metadata-action
+      # Get Metadata for docker_build step below
+      - name: Sync metadata (tags, labels) from GitHub to Docker for 'snipe-it' image
+        id: meta_build
+        uses: docker/metadata-action@v5
+        with:
+          images: grokability/snipe-it
+          tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push 'snipe-it' image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.alpine
+          platforms: linux/arm64
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker-intel.yml
+++ b/.github/workflows/docker-intel.yml
@@ -1,5 +1,5 @@
-# Snipe-IT (Alpine) Docker image build for hub.docker.com
-name: Docker images (Alpine)
+# Snipe-IT Docker image build for hub.docker.com
+name: Docker Intel/amd64 images (Ubuntu)
 
 # Run this Build for all pushes to 'master' or develop branch, or tagged releases.
 # Also run for PRs to ensure PR doesn't break Docker build process
@@ -19,7 +19,72 @@ permissions:
   contents: read
 
 jobs:
-  docker:
+  docker-ubuntu-intel:
+    # Ensure this job never runs on forked repos. It's only executed for 'grokability/snipe-it'
+    if: github.repository == 'grokability/snipe-it'
+    runs-on: ubuntu-latest
+    env:
+      # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)
+      # For a new commit on default branch (master), use the literal tag 'latest' on Docker image.
+      # For a new commit on other branches, use the branch name as the tag for Docker image.
+      # For a new tag, copy that tag name as the tag for Docker image.
+      IMAGE_TAGS: |
+        type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+        type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }}
+        type=ref,event=tag
+        type=semver,pattern=v{{major}}-latest
+      # Define default tag "flavor" for docker/metadata-action per
+      # https://github.com/docker/metadata-action#flavor-input
+      # We turn off 'latest' tag by default.
+      TAGS_FLAVOR: |
+        latest=false
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # https://github.com/docker/login-action
+      - name: Login to DockerHub
+        # Only login if not a PR, as PRs only trigger a Docker build and not a push
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      ###############################################
+      # Build/Push the 'grokability/snipe-it' image
+      ###############################################
+      # https://github.com/docker/metadata-action
+      # Get Metadata for docker_build step below
+      - name: Sync metadata (tags, labels) from GitHub to Docker for 'snipe-it' image
+        id: meta_build
+        uses: docker/metadata-action@v5
+        with:
+          images: grokability/snipe-it
+          tags: ${{ env.IMAGE_TAGS }}
+          flavor: ${{ env.TAGS_FLAVOR }}
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push 'snipe-it' image
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          # For pull requests, we run the Docker build (to ensure no PR changes break the build),
+          # but we ONLY do an image push to DockerHub if it's NOT a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          # Use tags / labels provided by 'docker/metadata-action' above
+          tags: ${{ steps.meta_build.outputs.tags }}
+          labels: ${{ steps.meta_build.outputs.labels }}
+  docker-alpine-intel:
     # Ensure this job never runs on forked repos. It's only executed for 'grokability/snipe-it'
     if: github.repository == 'grokability/snipe-it'
     runs-on: ubuntu-latest
@@ -32,7 +97,7 @@ jobs:
         type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},suffix=-alpine
         type=ref,event=branch,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }},suffix=-alpine
         type=ref,event=tag,suffix=-alpine
-        type=semver,pattern=v{{major}}-latest-alpine 
+        type=semver,pattern=v{{major}}-latest-alpine
       # Define default tag "flavor" for docker/metadata-action per
       # https://github.com/docker/metadata-action#flavor-input
       # We turn off 'latest' tag by default.
@@ -77,7 +142,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.alpine
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Now that we're moving to a paid org, we have native ARM github action
runners available, which means we can streamline our ARM-based docker
image builds by not having them run emulated.

I've switched our worker split from ubuntu/alpine to Intel/ARM...  if we
hate this we can make it 4 separate workflows, but i don't see an issue
with this one.