### PR TITLE
Fixed #16699 - Better handle user locales in mailables

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -339,6 +339,7 @@ class UsersController extends Controller
             $users = $users->where(function ($query) use ($request) {
                 $query->SimpleNameSearch($request->get('search'))
                     ->orWhere('username', 'LIKE', '%'.$request->get('search').'%')
+                    ->orWhere('email', 'LIKE', '%'.$request->get('search').'%')
                     ->orWhere('employee_num', 'LIKE', '%'.$request->get('search').'%');
             });
         }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -53,7 +53,7 @@ class ProfileController extends Controller
         $user->enable_confetti = $request->input('enable_confetti', false);
 
         if (! config('app.lock_passwords')) {
-            $user->locale = $request->input('locale', 'en-US');
+            $user->locale = $request->input('locale');
         }
 
         if ((Gate::allows('self.two_factor')) && ((Setting::getSettings()->two_factor_enabled == '1') && (! config('app.lock_passwords')))) {

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -63,11 +63,9 @@ class CheckoutableListener
         }
         $ccEmails = array_filter($adminCcEmailsArray);
         $mailable = $this->getCheckoutMailType($event, $acceptance);
-        $notifiable = $this->getNotifiables($event);
+        $notifiable = $this->getNotifiableUsers($event);
 
-        if ($event->checkedOutTo->locale) {
-            $mailable->locale($event->checkedOutTo->locale);
-        }
+
         // Send email notifications
         try {
             /**
@@ -79,7 +77,7 @@ class CheckoutableListener
 
             if ($event->checkoutable->requireAcceptance() || $event->checkoutable->getEula() ||
                 $this->checkoutableShouldSendEmail($event)) {
-                Log::info('Sending checkout email, Locale: ' . ($event->checkedOutTo->locale ?? 'default'));
+                //Log::info('Sending checkout email, Locale: ' . ($event->checkedOutTo->locale ?? 'default'));
                 if (!empty($notifiable)) {
                     Mail::to($notifiable)->cc($ccEmails)->send($mailable);
                 } elseif (!empty($ccEmails)) {
@@ -161,10 +159,8 @@ class CheckoutableListener
         }
         $ccEmails = array_filter($adminCcEmailsArray);
         $mailable =  $this->getCheckinMailType($event);
-        $notifiable = $this->getNotifiables($event);
-        if ($event->checkedOutTo?->locale) {
-            $mailable->locale($event->checkedOutTo->locale);
-        }
+        $notifiable = $this->getNotifiableUsers($event);
+
         // Send email notifications
         try {
             /**
@@ -175,7 +171,6 @@ class CheckoutableListener
              */
                 if ($event->checkoutable->requireAcceptance() || $event->checkoutable->getEula() ||
                     $this->checkoutableShouldSendEmail($event)) {
-                    Log::info('Sending checkin email, Locale: ' . ($event->checkedOutTo->locale ?? 'default'));
                     if (!empty($notifiable)) {
                         Mail::to($notifiable)->cc($ccEmails)->send($mailable);
                     } elseif (!empty($ccEmails)){
@@ -324,17 +319,26 @@ class CheckoutableListener
         return new $mailable($event->checkoutable, $event->checkedOutTo, $event->checkedInBy, $event->note);
 
     }
-    private function getNotifiables($event){
+
+    /**
+     * This gets the recipient objects based on the type of checkoutable.
+     * The 'name' property for users is set in the boot method in the User model.
+     *
+     * @see \App\Models\User::boot()
+     * @param $event
+     * @return mixed
+     */
+    private function getNotifiableUsers($event){
 
         if($event->checkedOutTo instanceof Asset){
             $event->checkedOutTo->load('assignedTo');
-            return $event->checkedOutTo->assignedto?->email ?? '';
+            return $event->checkedOutTo->assignedto;
         }
         else if($event->checkedOutTo instanceof Location) {
-            return $event->checkedOutTo->manager?->email ?? '';
+            return $event->checkedOutTo->manager;
         }
         else{
-            return $event->checkedOutTo?->email ?? '';
+            return $event->checkedOutTo;
         }
     }
     private function webhookSelected(){

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -143,7 +143,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
 
     /**
      * This sets the name property on the user. It's not a real field in the database
-     * (since we use first_name and last_name, but the Laravel mailable method
+     * (since we use first_name and last_name), but the Laravel mailable method
      * uses this to determine the name of the user to send emails to.
      *
      * We only have to do this on the User model and no other models because other
@@ -152,6 +152,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
 
     public $name;
+
     protected static function boot()
     {
         parent::boot();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Passport\HasApiTokens;
 use Watson\Validating\ValidatingTrait;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class User extends SnipeModel implements AuthenticatableContract, AuthorizableContract, CanResetPasswordContract, HasLocalePreference
 {
@@ -844,10 +845,33 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return $query->leftJoin('companies as companies_user', 'users.company_id', '=', 'companies_user.id')->orderBy('companies_user.name', $order);
     }
 
+
+
+    /**
+     * This is a mutator to allow the emails to fall back to the system settings if no locale is set.
+     *
+     * @return Attribute
+     *
+     */
+    protected function locale(): Attribute
+    {
+        return Attribute::make(
+            set: fn ($value) => $value ?? Setting::getSettings()->locale,
+        );
+    }
+
+    /**
+     * Get the preferred locale for the user.
+     * This is used via the HasLocalePreference interface, which is part of Laravel. This would
+     * normally work natively, but because we allow the override in the Settings model and we also
+     * manually set it in the notifications (for now), this doesn't handle all use cases.
+     *
+     */
     public function preferredLocale()
     {
         return $this->locale;
     }
+
     public function getUserTotalCost(){
         $asset_cost= 0;
         $license_cost= 0;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -151,6 +151,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      * @return void
      */
 
+    public $name;
     protected static function boot()
     {
         parent::boot();

--- a/tests/Feature/Users/Api/UsersForSelectListTest.php
+++ b/tests/Feature/Users/Api/UsersForSelectListTest.php
@@ -45,12 +45,12 @@ class UsersForSelectListTest extends TestCase
         User::factory()->create(['first_name' => 'Luke', 'last_name' => 'Skywalker', 'email' => 'luke@jedis.org']);
 
         Passport::actingAs(User::factory()->create());
-        $response = $this->getJson(route('api.users.selectlist', ['search' => 'jedis']))->assertOk();
+        $response = $this->getJson(route('api.users.selectlist', ['search' => 'luke@jedis']))->assertOk();
 
         $results = collect($response->json('results'));
 
         $this->assertEquals(1, $results->count());
-        $this->assertTrue($results->pluck('text')->contains(fn($text) => str_contains($text, 'luke@jedis')));
+        $this->assertTrue($results->pluck('text')->contains(fn($text) => str_contains($text, 'Luke')));
     }
 
     public function testUsersScopedToCompanyWhenMultipleFullCompanySupportEnabled()

--- a/tests/Feature/Users/Api/UsersForSelectListTest.php
+++ b/tests/Feature/Users/Api/UsersForSelectListTest.php
@@ -50,7 +50,7 @@ class UsersForSelectListTest extends TestCase
         $results = collect($response->json('results'));
 
         $this->assertEquals(1, $results->count());
-        $this->assertTrue($results->pluck('text')->contains(fn($text) => str_contains($text, 'Luke')));
+        $this->assertTrue($results->pluck('text')->contains(fn($text) => str_contains($text, 'luke@jedis')));
     }
 
     public function testUsersScopedToCompanyWhenMultipleFullCompanySupportEnabled()

--- a/tests/Feature/Users/Api/UsersForSelectListTest.php
+++ b/tests/Feature/Users/Api/UsersForSelectListTest.php
@@ -40,6 +40,19 @@ class UsersForSelectListTest extends TestCase
         $this->assertTrue($results->pluck('text')->contains(fn($text) => str_contains($text, 'Luke')));
     }
 
+    public function testUsersCanBeSearchedByEmail()
+    {
+        User::factory()->create(['first_name' => 'Luke', 'last_name' => 'Skywalker', 'email' => 'luke@jedis.org']);
+
+        Passport::actingAs(User::factory()->create());
+        $response = $this->getJson(route('api.users.selectlist', ['search' => 'jedis']))->assertOk();
+
+        $results = collect($response->json('results'));
+
+        $this->assertEquals(1, $results->count());
+        $this->assertTrue($results->pluck('text')->contains(fn($text) => str_contains($text, 'Luke')));
+    }
+
     public function testUsersScopedToCompanyWhenMultipleFullCompanySupportEnabled()
     {
         $this->settings->enableMultipleFullCompanySupport();


### PR DESCRIPTION
This fixes the Laravel built-in `preferredLocale()` method to use the user's local first, then the settings locale, and then finally the `APP_LOCALE` in the env if those two are empty. With that set, Laravel's mailable will automatically set the target's locale. 

I also added the a search by email address in the select list and fixed the mailable envelope so that we're correctly including the `to` name, not just the email address. 

The reason the `$mailable->locale` wasn't working as expected is because the `getNotifiables()` method was returning an email address, not the full object, so the locale on the checkout/checkin target was always null. 

This should fix https://github.com/snipe/snipe-it/issues/16699

Huge thanks to @uberbrady for all the rubber-ducking. I thought I was going crazy there for a moment.

