### PR TITLE
Removed deprecation resulting in `Creation of dynamic property` error

### DIFF
--- a/app/Console/Commands/GeneratePersonalAccessToken.php
+++ b/app/Console/Commands/GeneratePersonalAccessToken.php
@@ -2,11 +2,9 @@
 
 namespace App\Console\Commands;
 
-use App\Helpers\Helper;
 use Illuminate\Console\Command;
 use App\Models\User;
 use Laravel\Passport\TokenRepository;
-use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Support\Facades\DB;
 
 class GeneratePersonalAccessToken extends Command
@@ -43,9 +41,9 @@ class GeneratePersonalAccessToken extends Command
      *
      * @return void
      */
-    public function __construct(TokenRepository $tokenRepository, ValidationFactory $validation)
+    public function __construct(TokenRepository $tokenRepository)
     {
-        $this->validation = $validation;
+        //$this->validation = $validation;
         $this->tokenRepository = $tokenRepository;
         parent::__construct();
     }

--- a/app/Console/Commands/GeneratePersonalAccessToken.php
+++ b/app/Console/Commands/GeneratePersonalAccessToken.php
@@ -43,7 +43,6 @@ class GeneratePersonalAccessToken extends Command
      */
     public function __construct(TokenRepository $tokenRepository)
     {
-        //$this->validation = $validation;
         $this->tokenRepository = $tokenRepository;
         parent::__construct();
     }
@@ -74,7 +73,7 @@ class GeneratePersonalAccessToken extends Command
 
             } else {
 
-                $this->warn('Your API Token has been created. Be sure to copy this token now, as it will not be accessible again.');
+                $this->warn('Your API Token has been created. Be sure to copy this token now, as it WILL NOT be accessible again.');
 
                 if ($token = DB::table('oauth_access_tokens')->where('user_id', '=', $user->id)->where('name','=',$accessTokenName)->orderBy('created_at', 'desc')->first()) {
                     $this->info('API Token ID: '.$token->id);


### PR DESCRIPTION
This fixes the deprecation warning:` PHP Deprecated:  Creation of dynamic property App\Console\Commands\GeneratePersonalAccessToken::$validation is deprecated in snipe-it/app/Console/Commands/GeneratePersonalAccessToken.php on line 48`