### PR TITLE
Adds a check for category email alert boolean, bolster Check in Test

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -385,8 +385,24 @@ class CheckoutableListener
 
     private function shouldNotSendAnyNotifications($checkoutable): bool
     {
-        return in_array(get_class($checkoutable), $this->skipNotificationsFor);
+        if(in_array(get_class($checkoutable), $this->skipNotificationsFor)) {
+            return true;
+        }
+        //runs a check if the category wants to send checkin/checkout emails to users
+        $category = match (true) {
+            $checkoutable instanceof Asset => $checkoutable->model->category,
+            $checkoutable instanceof Accessory,
+            $checkoutable instanceof Consumable => $checkoutable->category,
+            $checkoutable instanceof LicenseSeat => $checkoutable->license->category,
+            default => null,
+        };
+
+        if (!$category->checkin_email) {
+            return true;
+        }
+        return false;
     }
+
 
     private function shouldSendWebhookNotification(): bool
     {

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -25,7 +25,7 @@ class CategoryFactory extends Factory
         return [
             'name' => $this->faker->catchPhrase(),
             'category_type' => 'asset',
-            'checkin_email' => $this->faker->boolean(),
+            'checkin_email' => true,
             'eula_text' => $this->faker->paragraph(),
             'require_acceptance' => false,
             'use_default_eula' => $this->faker->boolean(),

--- a/tests/Feature/Notifications/Email/EmailNotificationsUponCheckinTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsUponCheckinTest.php
@@ -66,7 +66,7 @@ class EmailNotificationsUponCheckinTest extends TestCase
                 $checkoutable = $checkoutable->fresh(['model.category']);
             }
 
-            if ($checkoutable instanceof Accessory || $checkoutable instanceof \App\Models\Consumable) {
+            if ($checkoutable instanceof Accessory || $checkoutable instanceof Consumable) {
                 $checkoutable->category->update([
                     'checkin_email' => false,
                     'eula_text' => null,


### PR DESCRIPTION
This adds a check of a category's checkin/out alert boolean to the `shouldNotSendAnyNotifications()` method. 
Also the  `testCheckInEmailNotSentToUserIfSettingDisabled()` test now attempts to send an email for Assets, License seats, Accessories, and Consumables.

The `checkin_email` field has been set to always true in the Category factory rather than random. this was causing other tests to fail with the new logic.