### PR TITLE
Added: Add .well-known URL for changing your password

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -13,7 +13,7 @@
     # RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
     # https://www.w3.org/TR/change-password-url/
-    Redirect .well-known/change-password /account/password
+    Redirect /.well-known/change-password /account/password
 
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -12,7 +12,8 @@
     # RewriteCond %{HTTPS} off
     # RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
-
+    # https://www.w3.org/TR/change-password-url/
+    Redirect .well-known/change-password /account/password
 
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
https://www.w3.org/TR/change-password-url/

Helps password managers send people to the right spots, if using password logins.

# Testing

Test results by manually entering:
![image](https://github.com/user-attachments/assets/520ae392-5e4d-4dff-b069-151a787b95a3)

Redirects as expected.


Via google chrome's password manager UI:
![image](https://github.com/user-attachments/assets/a456c023-ac7b-41a1-9866-62a2384abc25)

Following the link hits the right URL, then redirects as above.
