### PR TITLE
Fixed: Manage API Keys > New name field not marked required

### DIFF
--- a/resources/views/livewire/personal-access-tokens.blade.php
+++ b/resources/views/livewire/personal-access-tokens.blade.php
@@ -104,6 +104,7 @@
                                        wire:keydown.enter="createToken(name)"
                                        wire:model="name"
                                        autofocus
+                                       required
                                 >
                             </div>
                         </div>


### PR DESCRIPTION
This one isn't technically a form, but this at least styles it more as you would expect.

![image](https://github.com/user-attachments/assets/ff09dd03-2827-4dd4-8961-9f59965e7b38)
