### PR TITLE
Fixed: Admin > OAuth > Mark fields required

### DIFF
--- a/resources/views/livewire/oauth-clients.blade.php
+++ b/resources/views/livewire/oauth-clients.blade.php
@@ -264,7 +264,7 @@
                             <label class="col-md-3 control-label" for="redirect">{{ trans('admin/settings/general.oauth_redirect_url') }}</label>
 
                             <div class="col-md-7">
-                                <input type="text"
+                                <input type="url"
                                        class="form-control"
                                        aria-label="redirect"
                                        name="redirect"

--- a/resources/views/livewire/oauth-clients.blade.php
+++ b/resources/views/livewire/oauth-clients.blade.php
@@ -250,6 +250,7 @@
                                        class="form-control"
                                        wire:model="name"
                                        wire:keydown.enter="createClient"
+                                       required
                                        autofocus>
 
                                 <span class="help-block">
@@ -269,6 +270,7 @@
                                        name="redirect"
                                        wire:model="redirect"
                                        wire:keydown.enter="createClient"
+                                       required
                                 >
 
                                 <span class="help-block">


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/ae35ff5c-0f0d-4748-bb33-6c6ef20a6b3e)

This won't stop invalid form submissions, but it will style the UI consistently.