### PR TITLE
Fixed: Admin > Labels - Use HTML5 controls for numeric inputs

### DIFF
--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -400,13 +400,13 @@
                                 </div>
                                 <div class="col-md-3">
                                     <div class="input-group">
-                                        <input class="form-control" aria-label="labels_width" name="labels_width" type="text" value="{{ old('labels_width', $setting->labels_width) }}" id="labels_width">
+                                        <input class="form-control" aria-label="labels_width" name="labels_width" type="number" value="{{ old('labels_width', $setting->labels_width) }}" id="labels_width">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.width_w') }}</div>
                                     </div>
                                 </div>
                                 <div class="col-md-3">
                                     <div class="input-group">
-                                        <input class="form-control" aria-label="labels_height" name="labels_height" type="text" value="{{ old('labels_height', $setting->labels_height) }}">
+                                        <input class="form-control" aria-label="labels_height" name="labels_height" type="number" value="{{ old('labels_height', $setting->labels_height) }}">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.height_h') }}</div>
                                     </div>
                                 </div>
@@ -422,13 +422,13 @@
                                 </div>
                                 <div class="col-md-3">
                                     <div class="input-group">
-                                        <input class="form-control" aria-label="labels_display_sgutter" name="labels_display_sgutter" type="text" value="{{ old('labels_display_sgutter', $setting->labels_display_sgutter) }}" id="labels_display_sgutter">
+                                        <input class="form-control" aria-label="labels_display_sgutter" name="labels_display_sgutter" type="number" value="{{ old('labels_display_sgutter', $setting->labels_display_sgutter) }}" id="labels_display_sgutter">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.horizontal') }}</div>
                                     </div>
                                 </div>
                                 <div class="col-md-3">
                                     <div class="input-group">
-                                        <input class="form-control" aria-label="labels_display_bgutter" name="labels_display_bgutter" type="text" value="{{ old('labels_display_bgutter', $setting->labels_display_bgutter) }}">
+                                        <input class="form-control" aria-label="labels_display_bgutter" name="labels_display_bgutter" type="number" value="{{ old('labels_display_bgutter', $setting->labels_display_bgutter) }}">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.vertical') }}</div>
                                     </div>
                                 </div>
@@ -444,21 +444,21 @@
                                 </div>
                                 <div class="col-md-3">
                                     <div class="input-group" style="margin-bottom: 15px;">
-                                        <input class="form-control" aria-label="labels_pmargin_top" name="labels_pmargin_top" type="text" value="{{ old('labels_pmargin_top', $setting->labels_pmargin_top) }}" id="labels_pmargin_top">
+                                        <input class="form-control" aria-label="labels_pmargin_top" name="labels_pmargin_top" type="number" value="{{ old('labels_pmargin_top', $setting->labels_pmargin_top) }}" id="labels_pmargin_top">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.top') }}</div>
                                     </div>
                                     <div class="input-group">
-                                        <input class="form-control" aria-label="labels_pmargin_right" name="labels_pmargin_right" type="text" value="{{ old('labels_pmargin_right', $setting->labels_pmargin_right) }}">
+                                        <input class="form-control" aria-label="labels_pmargin_right" name="labels_pmargin_right" type="number" value="{{ old('labels_pmargin_right', $setting->labels_pmargin_right) }}">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.right') }}</div>
                                     </div>
                                 </div>
                                 <div class="col-md-3" style="margin-left: 10px; ">
                                     <div class="input-group" style="margin-bottom: 15px;">
-                                        <input class="form-control" aria-label="labels_pmargin_bottom" name="labels_pmargin_bottom" type="text" value="{{ old('labels_pmargin_bottom', $setting->labels_pmargin_bottom) }}">
+                                        <input class="form-control" aria-label="labels_pmargin_bottom" name="labels_pmargin_bottom" type="number" value="{{ old('labels_pmargin_bottom', $setting->labels_pmargin_bottom) }}">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.bottom') }}</div>
                                     </div>
                                     <div class="input-group">
-                                        <input class="form-control" aria-label="labels_pmargin_left" name="labels_pmargin_left" type="text" value="{{ old('labels_pmargin_left', $setting->labels_pmargin_left) }}">
+                                        <input class="form-control" aria-label="labels_pmargin_left" name="labels_pmargin_left" type="number" value="{{ old('labels_pmargin_left', $setting->labels_pmargin_left) }}">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.left') }}</div>
                                     </div>
 
@@ -475,13 +475,13 @@
                                 </div>
                                 <div class="col-md-3">
                                     <div class="input-group">
-                                        <input class="form-control" aria-label="labels_pagewidth" name="labels_pagewidth" type="text" value="{{ old('labels_pagewidth', $setting->labels_pagewidth) }}" id="labels_pagewidth">
+                                        <input class="form-control" aria-label="labels_pagewidth" name="labels_pagewidth" type="number" value="{{ old('labels_pagewidth', $setting->labels_pagewidth) }}" id="labels_pagewidth">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.width_w') }}</div>
                                     </div>
                                 </div>
                                 <div class="col-md-3 form-group" style="margin-left: 10px">
                                     <div class="input-group">
-                                        <input class="form-control" aria-label="labels_pageheight" name="labels_pageheight" type="text" value="{{ old('labels_pageheight', $setting->labels_pageheight) }}">
+                                        <input class="form-control" aria-label="labels_pageheight" name="labels_pageheight" type="number" value="{{ old('labels_pageheight', $setting->labels_pageheight) }}">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.height_h') }}</div>
                                     </div>
                                 </div>

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -374,7 +374,7 @@
                                     <label for="labels_per_page" class="control-label">{{ trans('admin/settings/general.labels_per_page') }}</label>
                                 </div>
                                 <div class="col-md-9">
-                                    <input class="form-control" style="width: 100px;" aria-label="labels_per_page" name="labels_per_page" type="text" value="{{ old('labels_per_page', $setting->labels_per_page) }}" id="labels_per_page">
+                                    <input class="form-control" style="width: 100px;" aria-label="labels_per_page" name="labels_per_page" type="number" value="{{ old('labels_per_page', $setting->labels_per_page) }}" id="labels_per_page">
                                     {!! $errors->first('labels_per_page', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 </div>
                             </div>
@@ -385,7 +385,7 @@
                                 </div>
                                 <div class="col-md-2">
                                     <div class="input-group">
-                                        <input class="form-control" aria-label="labels_fontsize" name="labels_fontsize" type="text" value="{{ old('labels_fontsize', $setting->labels_fontsize) }}" id="labels_fontsize">
+                                        <input class="form-control" aria-label="labels_fontsize" name="labels_fontsize" type="number" min="5" max="127" value="{{ old('labels_fontsize', $setting->labels_fontsize) }}" id="labels_fontsize">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.text_pt') }}</div>
                                     </div>
                                 </div>


### PR DESCRIPTION
Arguably, labels per page; some of the page dimensions, etc should have backend validations. I didn't split off a new bug for this yet.

* Adds a max of 127, though that's a silly font size for a label as the backend didn't validate it; but suffered loss of precision with inputs like 999.
* Potentially a step of some kind would be useful to specify

![image](https://github.com/user-attachments/assets/76bf9fdb-8075-4ebc-9fdf-ef110f1c090d)


