### PR TITLE
Fixed: Admin > Webhooks > Swap to url input

### DIFF
--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -90,7 +90,7 @@
                                 <label for="webhook_endpoint">{{ trans('admin/settings/general.webhook_endpoint',['app' => $webhook_name ]) }}</label>
                             </div>
                             <div class="col-md-9 required">
-                                    <input type="text" wire:model.blur="webhook_endpoint" class="form-control" placeholder="{{$webhook_placeholder}}" value="{{old('webhook_endpoint', $webhook_endpoint)}}"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
+                                    <input type="url" wire:model.blur="webhook_endpoint" class="form-control" placeholder="{{$webhook_placeholder}}" value="{{old('webhook_endpoint', $webhook_endpoint)}}"{{ Helper::isDemoMode() ? ' disabled' : ''}}>
                                 {!! $errors->first('webhook_endpoint', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
                         </div>


### PR DESCRIPTION
This one isn't too important, as onblur validations do occur.
![image](https://github.com/user-attachments/assets/948c5543-117f-4849-b20d-60a0d0ed2717)

Not sure if this needs better backend validation before being passed off to make a HTTP request:
![image](https://github.com/user-attachments/assets/fea8b7b7-68a9-4a19-8fc1-b44df3444d50)

libcurl does appear to be locked down to ignore dodgy protocols - ie https://curl.se/libcurl/security.html