### PR TITLE
Fixed #15035 - adds company to slack message

### DIFF
--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -73,9 +73,17 @@ class CheckinAccessoryNotification extends Notification
         $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
-            'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
-            'By' => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
+            trans('general.from') => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
+            trans('general.by') => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
         ];
+
+        if ($item->location) {
+            $fields[trans('general.location')] = $item->location->name;
+        }
+
+        if ($item->company) {
+            $fields[trans('general.company')] = $item->company->name;
+        }
 
         return (new SlackMessage)
             ->content(':arrow_down: :keyboard: '.trans('mail.Accessory_Checkin_Notification'))

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -83,6 +83,15 @@ class CheckinAssetNotification extends Notification
             trans('general.location') => ($item->location) ? $item->location->name : '',
         ];
 
+        if ($item->location) {
+            $fields[trans('general.location')] = $item->location->name;
+        }
+
+        if ($item->company) {
+            $fields[trans('general.company')] = $item->company->name;
+        }
+
+
         return (new SlackMessage)
             ->content(':arrow_down: :computer: '.trans('mail.Asset_Checkin_Notification'))
             ->from($botname)

--- a/app/Notifications/CheckinLicenseSeatNotification.php
+++ b/app/Notifications/CheckinLicenseSeatNotification.php
@@ -77,9 +77,18 @@ class CheckinLicenseSeatNotification extends Notification
 
         if ($admin) {
             $fields = [
-                'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
-                'By' => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
+                trans('general.from')  => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
+                trans('general.by') => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
             ];
+
+            if ($item->location) {
+                $fields[trans('general.location')] = $item->location->name;
+            }
+
+            if ($item->company) {
+                $fields[trans('general.company')] = $item->company->name;
+            }
+
         } else {
             $fields = [
                 'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -100,9 +100,17 @@ class CheckoutAccessoryNotification extends Notification
         $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
-            'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
-            'By' => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
+            trans('general.to') => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
+            trans('general.by') => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
         ];
+
+        if ($item->location) {
+            $fields[trans('general.location')] = $item->location->name;
+        }
+
+        if ($item->company) {
+            $fields[trans('general.company')] = $item->company->name;
+        }
 
         return (new SlackMessage)
             ->content(':arrow_up: :keyboard: Accessory Checked Out')

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -93,12 +93,20 @@ class CheckoutAssetNotification extends Notification
         $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
-            'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
-            'By' => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
+            trans('general.to') => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
+            trans('general.by') => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
         ];
 
+        if ($item->location) {
+            $fields[trans('general.location')] = $item->location->name;
+        }
+
+        if ($item->company) {
+            $fields[trans('general.company')] = $item->company->name;
+        }
+
         if (($this->expected_checkin) && ($this->expected_checkin !== '')) {
-            $fields['Expected Checkin'] = $this->expected_checkin;
+            $fields[trans('general.expected_checkin')] = $this->expected_checkin;
         }
 
         return (new SlackMessage)

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -80,9 +80,17 @@ class CheckoutConsumableNotification extends Notification
         $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
-            'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
-            'By' => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
+            trans('general.to') => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
+            trans('general.by') => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
         ];
+
+        if ($item->location) {
+            $fields[trans('general.location')] = $item->location->name;
+        }
+
+        if ($item->company) {
+            $fields[trans('general.company')] = $item->company->name;
+        }
 
         return (new SlackMessage)
             ->content(':arrow_up: :paperclip: Consumable Checked Out')

--- a/app/Notifications/CheckoutLicenseSeatNotification.php
+++ b/app/Notifications/CheckoutLicenseSeatNotification.php
@@ -78,9 +78,17 @@ class CheckoutLicenseSeatNotification extends Notification
         $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
 
         $fields = [
-            'To' => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
-            'By' => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
+            trans('general.to') => '<'.$target->present()->viewUrl().'|'.$target->present()->fullName().'>',
+            trans('general.by') => '<'.$admin->present()->viewUrl().'|'.$admin->present()->fullName().'>',
         ];
+
+        if ($item->location) {
+            $fields[trans('general.location')] = $item->location->name;
+        }
+
+        if ($item->company) {
+            $fields[trans('general.company')] = $item->company->name;
+        }
 
         return (new SlackMessage)
             ->content(':arrow_up: :floppy_disk: License Checked Out')

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -574,6 +574,8 @@ return [
     'user_managed_passwords' => 'Password Management',
     'user_managed_passwords_disallow' => 'Disallow users from managing their own passwords',
     'user_managed_passwords_allow' => 'Allow users to manage their own passwords',
+    'from' => 'From',
+    'by' => 'By',
 
 // Add form placeholders here
     'placeholders' => [


### PR DESCRIPTION
This adds the company name to the slack message if one is associated with the item being checked in or out. It also now uses translated strings for `To`, `From`, and `By`, and corrects and error where we were using `To` on checkins, instead of `From`.

<img width="558" alt="Screenshot 2025-04-18 at 12 31 15 AM" src="https://github.com/user-attachments/assets/e28c83cd-fe3c-4740-88f5-eea0e87a42f8" />
