### PR TITLE
Fixed: Correct spelling and add codespell configuration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+skip = ./phpmd.xml,./CONTRIBUTORS.md,./composer.lock,*.min.js,*.map,./resources/lang/*,./node_modules/*,./public/vendor/*,./sample_csvs/*,./database/migrations/*,./public/js/*
+count =
+quiet-level = 3
+ignore-words-list = checkin,Checkin,currentY,userA

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+name: codespell
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+
+jobs:
+  codespell:
+    runs-on: \${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run codespell
+        uses: codespell-project/actions-codespell@v2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,9 @@ Add codespell as a linter:
 
 Add a precommit hook:
 `cp contrib/hooks/pre-commit .git/hooks/`
+
+Add phpcs:
+`curl -OL https://phars.phpcodesniffer.com/phpcs.phar`
+
+Check against PSR12:
+`php phpcs.phar -n --standard=PSR12 app/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,3 +4,11 @@ Please see the documentation on [contributing and developing for Snipe-IT](https
 
 
 Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+### Useful tools
+
+Add codespell as a linter:
+`pip install codespell`
+
+Add a precommit hook:
+`cp contrib/hooks/pre-commit .git/hooks/`

--- a/ansible/freebsd/vagrant_playbook.yml
+++ b/ansible/freebsd/vagrant_playbook.yml
@@ -45,9 +45,9 @@
       become: true          
 
     #
-    # Install php and php dependancies
+    # Install php and php dependencies
     #
-    - name: Install PHP dependancies
+    - name: Install PHP dependencies
       pkgng:
         name: "{{ item }}"
         state: present
@@ -94,7 +94,7 @@
       become: true   
 
     #
-    # Install the lastest version of composer
+    # Install the latest version of composer
     #
     - name: Composer check
       stat:

--- a/ansible/ubuntu/vagrant_playbook.yml
+++ b/ansible/ubuntu/vagrant_playbook.yml
@@ -44,7 +44,7 @@
           - unzip
           - python-pymysql
     #
-    # Install the lastest version of composer
+    # Install the latest version of composer
     #
     - name: Composer check
       stat:

--- a/app/Console/Commands/LdapTroubleshooter.php
+++ b/app/Console/Commands/LdapTroubleshooter.php
@@ -273,7 +273,7 @@ class LdapTroubleshooter extends Command
             $this->line("Trying TLS first for port $port");
             $ldap_url = "ldaps://".$parsed['host'].":$port";
             if($this->test_anonymous_bind($ldap_url)) {
-                $this->info("Anonymous bind succesful to $ldap_url!");
+                $this->info("Anonymous bind successful to $ldap_url!");
                 $ldap_urls[] = [ $ldap_url, true, false ];
                 $pretty_ldap_urls[] = [ $ldap_url, "YES", "no" ];
                 continue; // TODO - lots of copypasta in these if(test_anonymous_bind()) routines...
@@ -282,7 +282,7 @@ class LdapTroubleshooter extends Command
             }
 
             if($this->test_anonymous_bind($ldap_url, false)) {
-                $this->info("Anonymous bind succesful to $ldap_url with certifcate-checks disabled");
+                $this->info("Anonymous bind successful to $ldap_url with certificate-checks disabled");
                 $ldap_urls[] = [ $ldap_url, false, false ]; 
                 $pretty_ldap_urls[] = [ $ldap_url, "no", "no" ]; 
                 continue;
@@ -292,7 +292,7 @@ class LdapTroubleshooter extends Command
 
             $ldap_url = "ldap://".$parsed['host'].":$port";
             if($this->test_anonymous_bind($ldap_url, true, true)) {
-                $this->info("Plain connection to $ldap_url with STARTTLS succesful!");
+                $this->info("Plain connection to $ldap_url with STARTTLS successful!");
                 $ldap_urls[] = [ $ldap_url, true, true ];
                 $pretty_ldap_urls[] = [ $ldap_url, "YES", "YES" ];
                 continue;
@@ -301,7 +301,7 @@ class LdapTroubleshooter extends Command
             }
 
             if($this->test_anonymous_bind($ldap_url)) {
-                $this->info("Plain connection to $ldap_url succesful!");
+                $this->info("Plain connection to $ldap_url successful!");
                 $ldap_urls[] = [ $ldap_url, true, false ];
                 $pretty_ldap_urls[] = [ $ldap_url, "YES", "no" ];
                 continue;

--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -93,7 +93,7 @@ class SQLStreamer {
         $parser->should_guess = true;
         $parser->line_aware_piping(); // <----- THIS is doing the heavy lifting!
 
-        $check_tables = ['settings' => null, 'migrations' => null /* 'assets' => null */]; //TODO - move to statics?
+        $check_tables = ['settings' => null, 'migrations' => null /* 'assets' => null */]; //TODO - move to static?
         //can't use 'users' because the 'accessories_checkout' table?
         // can't use 'assets' because 'ver1_components_assets'
         foreach($check_tables as $check_table => $_ignore) {
@@ -508,7 +508,7 @@ class RestoreFromBackup extends Command
             $bar->finish();
             $this->line('');
         } else {
-            $this->info(count($interesting_files).' files were succesfully transferred');
+            $this->info(count($interesting_files).' files were successfully transferred');
         }
         if (count($unsafe_files) > 0) {
             foreach ($unsafe_files as $unsafe_file) {

--- a/app/Events/CheckoutableCheckedIn.php
+++ b/app/Events/CheckoutableCheckedIn.php
@@ -14,7 +14,7 @@ class CheckoutableCheckedIn
     public $checkedOutTo;
     public $checkedInBy;
     public $note;
-    public $action_date; // Date setted in the hardware.checkin view at the checkin_at input, for the action log
+    public $action_date; // Date set in the hardware.checkin view at the checkin_at input, for the action log
     public $originalValues;
 
     /**

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1534,7 +1534,7 @@ class Helper
 
     /**
      * Check for inconsistencies before activating scoped locations with FullMultipleCompanySupport
-     * If there are locations with different companies than related objects unforseen problems could arise
+     * If there are locations with different companies than related objects unforeseen problems could arise
      *
      * @author T. Regnery <tobias.regnery@gmail.com>
      * @since 7.0

--- a/app/Http/Controllers/Api/PredefinedKitsController.php
+++ b/app/Http/Controllers/Api/PredefinedKitsController.php
@@ -121,7 +121,7 @@ class PredefinedKitsController extends Controller
         $this->authorize('delete', PredefinedKit::class);
         $kit = PredefinedKit::findOrFail($id);
 
-        // Delete childs
+        // Delete children
         $kit->models()->detach();
         $kit->licenses()->detach();
         $kit->consumables()->detach();

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -333,7 +333,7 @@ class AssetModelsController extends Controller
 
 
     /**
-     * Returns a view that allows the user to bulk edit model attrbutes
+     * Returns a view that allows the user to bulk edit model attributes
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v1.7]

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -604,7 +604,7 @@ class BulkAssetsController extends Controller
             }
 
             $errors = [];
-            DB::transaction(function () use ($target, $admin, $checkout_at, $expected_checkin, &$errors, $assets, $request) { //NOTE: $errors is passsed by reference!
+            DB::transaction(function () use ($target, $admin, $checkout_at, $expected_checkin, &$errors, $assets, $request) { //NOTE: $errors is passed by reference!
                 foreach ($assets as $asset) {
                     $this->authorize('checkout', $asset);
 

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -99,7 +99,7 @@ class ResetPasswordController extends Controller
             if (strpos(Setting::passwordComplexityRulesSaving('store'), 'disallow_same_pwd_as_user_fields') !== false) {
                 $request->validate(
                     [
-                        'password' => 'required|notIn:["'.$user->email.'","'.$user->username.'","'.$user->first_name.'","'.$user->last_name.'"',
+                        'password' => 'required|notIn:["'.$user->email.'","'.$user->username.'","'.$user->first_name.'","'.$user->last_name.'"',  // codespell:ignore
                     ], $messages);
             }
 

--- a/app/Http/Controllers/BulkAssetModelsController.php
+++ b/app/Http/Controllers/BulkAssetModelsController.php
@@ -11,7 +11,7 @@ use \Illuminate\Contracts\View\View;
 class BulkAssetModelsController extends Controller
 {
     /**
-     * Returns a view that allows the user to bulk edit model attrbutes
+     * Returns a view that allows the user to bulk edit model attributes
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v1.7]
@@ -55,7 +55,7 @@ class BulkAssetModelsController extends Controller
     }
 
     /**
-     * Returns a view that allows the user to bulk edit model attrbutes
+     * Returns a view that allows the user to bulk edit model attributes
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v1.7]

--- a/app/Http/Controllers/Kits/PredefinedKitsController.php
+++ b/app/Http/Controllers/Kits/PredefinedKitsController.php
@@ -125,7 +125,7 @@ class PredefinedKitsController extends Controller
             return redirect()->route('kits.index')->with('error', trans('admin/kits/general.kit_not_found'));
         }
 
-        // Delete childs
+        // Delete children
         $kit->models()->detach();
         $kit->licenses()->detach();
         $kit->consumables()->detach();
@@ -217,7 +217,7 @@ class PredefinedKitsController extends Controller
             return redirect()->route('kits.index')->with('error', trans('admin/kits/general.kit_none'));
         }
 
-        // Delete childs
+        // Delete children
         $kit->models()->detach($model_id);
 
         // Redirect to the kit management page
@@ -250,7 +250,7 @@ class PredefinedKitsController extends Controller
     }
 
     /**
-     * Update attached licese
+     * Update attached license
      *
      * @author [D. Minaev] [<dmitriy.minaev.v@gmail.com>]
      * @param int $kit_id
@@ -296,7 +296,7 @@ class PredefinedKitsController extends Controller
             return redirect()->route('kits.index')->with('error', trans('admin/kits/general.kit_none'));
         }
 
-        // Delete childs
+        // Delete children
         $kit->licenses()->detach($license_id);
 
         // Redirect to the kit management page
@@ -374,7 +374,7 @@ class PredefinedKitsController extends Controller
             return redirect()->route('kits.index')->with('error', trans('admin/kits/general.kit_none'));
         }
 
-        // Delete childs
+        // Delete children
         $kit->accessories()->detach($accessory_id);
 
         // Redirect to the kit management page
@@ -452,7 +452,7 @@ class PredefinedKitsController extends Controller
             return redirect()->route('kits.index')->with('error', trans('admin/kits/general.kit_none'));
         }
 
-        // Delete childs
+        // Delete children
         $kit->consumables()->detach($consumable_id);
 
         // Redirect to the kit management page

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -60,7 +60,7 @@ class ViewAssetsController extends Controller
 
         }
 
-        // Since some models may re-use the same fieldsets/fields, let's make the array unique so we don't repeat columns
+        // Since some models may reuse the same fieldsets/fields, let's make the array unique so we don't repeat columns
         array_unique($field_array);
 
         if (isset($user->id)) {

--- a/app/Http/Requests/DeleteUserRequest.php
+++ b/app/Http/Requests/DeleteUserRequest.php
@@ -48,7 +48,7 @@ class DeleteUserRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'user' =>  Rule::notIn([auth()->id()]), # codespell:ignore
+            'user' =>  Rule::notIn([auth()->id()]), // codespell:ignore
             'managed_users' =>  Rule::in([0]),
             'managed_locations' => Rule::in([0]),
             'assigned_assets' => Rule::in([0]),

--- a/app/Http/Requests/DeleteUserRequest.php
+++ b/app/Http/Requests/DeleteUserRequest.php
@@ -48,7 +48,7 @@ class DeleteUserRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'user' =>  Rule::notIn([auth()->id()]),
+            'user' =>  Rule::notIn([auth()->id()]), # codespell:ignore
             'managed_users' =>  Rule::in([0]),
             'managed_locations' => Rule::in([0]),
             'assigned_assets' => Rule::in([0]),

--- a/app/Http/Requests/SettingsSamlRequest.php
+++ b/app/Http/Requests/SettingsSamlRequest.php
@@ -96,7 +96,7 @@ class SettingsSamlRequest extends FormRequest
                 $x509 = openssl_x509_read($custom_x509cert);
                 $pkey = openssl_pkey_get_private($custom_privateKey);
             } elseif ($this->input('saml_sp_regenerate_keypair') == '1' || ! $this->has('saml_sp_x509cert') || $was_custom_x509cert) {
-                // key regeneration requested, no certificate defined yet or previous custom certicate was removed
+                // key regeneration requested, no certificate defined yet or previous custom certificate was removed
                 error_log('regen');
                 $cert_updated = true;
                 $dn = [

--- a/app/Http/Transformers/DepreciationReportTransformer.php
+++ b/app/Http/Transformers/DepreciationReportTransformer.php
@@ -6,9 +6,9 @@ use App\Models\Asset;
 use Illuminate\Database\Eloquent\Collection;
 
 /**
- *  This tranformer looks like it's extraneous, since we return as much or more
+ *  This transformer looks like it's extraneous, since we return as much or more
  * info in the AssetsTransformer, but we want to flatten these results out so that they 
- * don't dislose more information than we want. Folks with depreciation powers don't necessaily 
+ * don't dislose more information than we want. Folks with depreciation powers don't necessarily 
  * have the right to see additional info, and inspecting the API call here could disclose 
  * info they're not supposed to see.
  * 

--- a/app/Http/Transformers/PredefinedKitsTransformer.php
+++ b/app/Http/Transformers/PredefinedKitsTransformer.php
@@ -54,7 +54,7 @@ class PredefinedKitsTransformer
     }
 
     /**
-     * transform collection of any elemets attached to kit
+     * transform collection of any elements attached to kit
      * @return array
      */
     public function transformElements(Collection $elements, $total)

--- a/app/Importer/AccessoryImporter.php
+++ b/app/Importer/AccessoryImporter.php
@@ -28,7 +28,7 @@ class AccessoryImporter extends ItemImporter
         $accessory = Accessory::where('name', $this->item['name'])->first();
         if ($accessory) {
             if (! $this->updating) {
-                $this->log('A matching Accessory '.$this->item['name'].' already exists.  ');
+                $this->log('A matching Accessory ' . $this->item['name'] . ' already exists.  ');
 
                 return;
             }
@@ -50,7 +50,7 @@ class AccessoryImporter extends ItemImporter
         // This sets an attribute on the Loggable trait for the action log
         $accessory->setImported(true);
         if ($accessory->save()) {
-            $this->log('Accessory '.$this->item['name'].' was created');
+            $this->log('Accessory ' . $this->item['name'] . ' was created');
 
             return;
         }

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -47,10 +47,10 @@ class AssetImporter extends ItemImporter
                 if ($customFieldValue) {
                     if ($customField->field_encrypted == 1) {
                         $this->item['custom_fields'][$customField->db_column_name()] = Crypt::encrypt($customFieldValue);
-                        $this->log('Custom Field '.$customField->name.': '.Crypt::encrypt($customFieldValue));
+                        $this->log('Custom Field ' . $customField->name . ': ' . Crypt::encrypt($customFieldValue));
                     } else {
                         $this->item['custom_fields'][$customField->db_column_name()] = $customFieldValue;
-                        $this->log('Custom Field '.$customField->name.': '.$customFieldValue);
+                        $this->log('Custom Field ' . $customField->name . ': ' . $customFieldValue);
                     }
                 } else {
                     // Clear out previous data.

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -76,11 +76,11 @@ class AssetImporter extends ItemImporter
         $editingAsset = false;
         $asset_tag = $this->findCsvMatch($row, 'asset_tag');
 
-        if (empty($asset_tag)){
+        if (empty($asset_tag)) {
             $asset_tag = Asset::autoincrement_asset();
         }
 
-        $asset = Asset::where(['asset_tag'=> (string) $asset_tag])->first();
+        $asset = Asset::where(['asset_tag' => (string) $asset_tag])->first();
         if ($asset) {
             if (! $this->updating) {
                 $exists_error = trans('general.import_asset_tag_exists', ['asset_tag' => $asset_tag]);
@@ -93,7 +93,7 @@ class AssetImporter extends ItemImporter
             $editingAsset = true;
         } else {
             $this->log('No Matching Asset, Creating a new one');
-            $asset = new Asset;
+            $asset = new Asset();
         }
 
         // If no status ID is found
@@ -137,7 +137,7 @@ class AssetImporter extends ItemImporter
          * We use this to backdate the checkin action further down
          */
         $checkin_date = date('Y-m-d H:i:s');
-        if ($this->item['last_checkin']!='') {
+        if ($this->item['last_checkin'] != '') {
             $item['last_checkin'] = $this->parseOrNullDate('last_checkin', 'datetime');
             $checkout_date = $this->item['last_checkin'];
         }
@@ -146,24 +146,24 @@ class AssetImporter extends ItemImporter
          * We use this to backdate the checkout action further down
          */
         $checkout_date = date('Y-m-d H:i:s');
-        if ($this->item['last_checkout']!='') {
+        if ($this->item['last_checkout'] != '') {
             $item['last_checkout'] = $this->parseOrNullDate('last_checkout', 'datetime');
             $checkout_date = $this->item['last_checkout'];
         }
 
-        if ($this->item['expected_checkin']!='') {
+        if ($this->item['expected_checkin'] != '') {
             $item['expected_checkin'] = $this->parseOrNullDate('expected_checkin');
         }
 
-        if ($this->item['last_audit_date']!='') {
+        if ($this->item['last_audit_date'] != '') {
             $item['last_audit_date'] = $this->parseOrNullDate('last_audit_date');
         }
 
-        if ($this->item['next_audit_date']!='') {
+        if ($this->item['next_audit_date'] != '') {
             $item['next_audit_date'] = $this->parseOrNullDate('next_audit_date');
         }
 
-        if ($this->item['asset_eol_date']!='') {
+        if ($this->item['asset_eol_date'] != '') {
             $item['asset_eol_date'] = $this->parseOrNullDate('asset_eol_date');
         }
 
@@ -185,26 +185,23 @@ class AssetImporter extends ItemImporter
         $asset->setImported(true);
 
         if ($asset->save()) {
-
-            $this->log('Asset '.$this->item['name'].' with serial number '.$this->item['serial'].' was created');
+            $this->log('Asset ' . $this->item['name'] . ' with serial number ' . $this->item['serial'] . ' was created');
 
             // If we have a target to checkout to, lets do so.
             //-- created_by is a property of the abstract class Importer, which this class inherits from and it's set by
             //-- the class that needs to use it (command importer or GUI importer inside the project).
             if (isset($target) && ($target !== false)) {
-                if (!is_null($asset->assigned_to)){
+                if (!is_null($asset->assigned_to)) {
                     if ($asset->assigned_to != $target->id) {
                         event(new CheckoutableCheckedIn($asset, User::find($asset->assigned_to), auth()->user(), 'Checkin from CSV Importer', $checkin_date));
                     }
                 }
 
-                $asset->fresh()->checkOut($target, $this->created_by, $checkout_date, null, 'Checkout from CSV Importer',  $asset->name);
+                $asset->fresh()->checkOut($target, $this->created_by, $checkout_date, null, 'Checkout from CSV Importer', $asset->name);
             }
 
             return;
         }
-        $this->logError($asset, 'Asset "'.$this->item['name'].'"');
+        $this->logError($asset, 'Asset "' . $this->item['name'] . '"');
     }
-
-
 }

--- a/app/Importer/AssetModelImporter.php
+++ b/app/Importer/AssetModelImporter.php
@@ -44,7 +44,7 @@ class AssetModelImporter extends ItemImporter
 
         if ($assetModel) {
             if (! $this->updating) {
-                $this->log('A matching Model '.$this->item['name'].' already exists');
+                $this->log('A matching Model ' . $this->item['name'] . ' already exists');
                 return;
             }
 
@@ -104,15 +104,13 @@ class AssetModelImporter extends ItemImporter
         }
 
         if ($assetModel->save()) {
-            $this->log('AssetModel '.$assetModel->name.' created or updated from CSV import');
+            $this->log('AssetModel ' . $assetModel->name . ' created or updated from CSV import');
             return $assetModel;
-
         } else {
             $this->log($assetModel->getErrors()->first());
-            $this->addErrorToBag($assetModel,  $assetModel->getErrors()->keys()[0], $assetModel->getErrors()->first());
+            $this->addErrorToBag($assetModel, $assetModel->getErrors()->keys()[0], $assetModel->getErrors()->first());
             return $assetModel->getErrors();
         }
-
     }
 
 
@@ -130,9 +128,8 @@ class AssetModelImporter extends ItemImporter
     public function fetchDepreciation($depreciation_name) : ?int
     {
         if ($depreciation_name != '') {
-
             if ($depreciation = Depreciation::where('name', '=', $depreciation_name)->first()) {
-                $this->log('A matching Depreciation '.$depreciation_name.' already exists');
+                $this->log('A matching Depreciation ' . $depreciation_name . ' already exists');
                 return $depreciation->id;
             }
         }
@@ -154,7 +151,7 @@ class AssetModelImporter extends ItemImporter
             $fieldset = CustomFieldset::where('name', '=', $fieldset_name)->first();
 
             if ($fieldset) {
-                $this->log('A matching fieldset '.$fieldset_name.' already exists');
+                $this->log('A matching fieldset ' . $fieldset_name . ' already exists');
                 return $fieldset->id;
             }
 
@@ -162,7 +159,7 @@ class AssetModelImporter extends ItemImporter
             $fieldset->name = $fieldset_name;
 
             if ($fieldset->save()) {
-                $this->log('Fieldset '.$fieldset_name.' was created');
+                $this->log('Fieldset ' . $fieldset_name . ' was created');
 
                 return $fieldset->id;
             }

--- a/app/Importer/ComponentImporter.php
+++ b/app/Importer/ComponentImporter.php
@@ -22,7 +22,7 @@ class ComponentImporter extends ItemImporter
      * Create a component if a duplicate does not exist
      *
      * @author Daniel Melzter
-     * @since 3.0
+     * @since  3.0
      */
     public function createComponentIfNotExists()
     {
@@ -33,7 +33,7 @@ class ComponentImporter extends ItemImporter
                         ->first();
 
         if ($component) {
-            $this->log('A matching Component '.$this->item['name'].' with serial '.$this->item['serial'].' already exists.  ');
+            $this->log('A matching Component ' . $this->item['name'] . ' with serial ' . $this->item['serial'] . ' already exists.  ');
             if (! $this->updating) {
                 $this->log('Skipping Component');
 
@@ -46,14 +46,14 @@ class ComponentImporter extends ItemImporter
             return;
         }
         $this->log('No matching component, creating one');
-        $component = new Component;
+        $component = new Component();
         $component->created_by = auth()->id();
         $component->fill($this->sanitizeItemForStoring($component));
 
         // This sets an attribute on the Loggable trait for the action log
         $component->setImported(true);
         if ($component->save()) {
-            $this->log('Component '.$this->item['name'].' was created');
+            $this->log('Component ' . $this->item['name'] . ' was created');
 
             // If we have an asset tag, checkout to that asset.
             if (isset($this->item['asset_tag']) && ($asset = Asset::where('asset_tag', $this->item['asset_tag'])->first())) {

--- a/app/Importer/ConsumableImporter.php
+++ b/app/Importer/ConsumableImporter.php
@@ -28,9 +28,8 @@ class ConsumableImporter extends ItemImporter
     {
         $consumable = Consumable::where('name', trim($this->item['name']))->first();
         if ($consumable) {
-
             if (! $this->updating) {
-                $this->log('A matching Consumable '.$this->item['name'].' already exists.  ');
+                $this->log('A matching Consumable ' . $this->item['name'] . ' already exists.  ');
                 return;
             }
             $this->log('Updating Consumable');
@@ -48,7 +47,7 @@ class ConsumableImporter extends ItemImporter
         // This sets an attribute on the Loggable trait for the action log
         $consumable->setImported(true);
         if ($consumable->save()) {
-            $this->log('Consumable '.$this->item['name'].' was created');
+            $this->log('Consumable ' . $this->item['name'] . ' was created');
 
             return;
         }

--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -272,7 +272,7 @@ abstract class Importer
         }
     }
 
-    protected function addErrorToBag($item, $field,  $error_message)
+    protected function addErrorToBag($item, $field, $error_message)
     {
         if ($this->errorCallback) {
             call_user_func($this->errorCallback, $item, $field, [$field => [$error_message]]);
@@ -299,8 +299,8 @@ abstract class Importer
             'first_name' => $this->findCsvMatch($row, 'first_name'),
             'last_name' => $this->findCsvMatch($row, 'last_name'),
             'email'     => $this->findCsvMatch($row, 'email'),
-            'manager_id'=>  '',
-            'department_id' =>  '',
+            'manager_id' => '',
+            'department_id' => '',
             'username'  => $this->findCsvMatch($row, 'username'),
             'activated'  => $this->fetchHumanBoolean($this->findCsvMatch($row, 'activated')),
             'remote'    => $this->fetchHumanBoolean(($this->findCsvMatch($row, 'remote'))),
@@ -314,7 +314,7 @@ abstract class Importer
         // Maybe we're lucky and the username was passed and it already exists.
         if (!empty($user_array['username'])) {
             if ($user = User::where('username', $user_array['username'])->first()) {
-                $this->log('User '.$user_array['username'].' already exists');
+                $this->log('User ' . $user_array['username'] . ' already exists');
                 return $user;
             }
         }
@@ -352,7 +352,7 @@ abstract class Importer
 
             // Check for a matching username one more time after trying to guess username.
             if ($user = User::where('username', $user_array['username'])->first()) {
-                $this->log('User '.$user_array['username'].' already exists');
+                $this->log('User ' . $user_array['username'] . ' already exists');
                 return $user;
             }
         }
@@ -363,7 +363,7 @@ abstract class Importer
         }
 
         // No luck finding a user on username or first name, let's create one.
-        $user = new User;
+        $user = new User();
 
         $user->first_name = $user_array['first_name'];
         $user->last_name = $user_array['last_name'];
@@ -374,14 +374,14 @@ abstract class Importer
         $user->activated = 1;
         $user->password = $this->tempPassword;
 
-        Log::debug('Creating a user with the following attributes: '.print_r($user_array, true));
+        Log::debug('Creating a user with the following attributes: ' . print_r($user_array, true));
 
         if ($user->save()) {
-            $this->log('User '.$user_array['username'].' created');
+            $this->log('User ' . $user_array['username'] . ' created');
             return $user;
         }
 
-        $this->logError($user, 'User "'.$user_array['username'].'" was not able to be created.');
+        $this->logError($user, 'User "' . $user_array['username'] . '" was not able to be created.');
 
         return false;
     }
@@ -395,7 +395,7 @@ abstract class Importer
     {
         // A number was given instead of a name
         if (is_numeric($user_name)) {
-            $this->log('User '.$user_name.' is a number - lets see if it matches a user id');
+            $this->log('User ' . $user_name . ' is a number - lets see if it matches a user id');
 
             return User::find($user_name);
         }
@@ -521,7 +521,7 @@ abstract class Importer
             $department = Department::where('name', '=', $user_department_name)->first();
 
             if ($department) {
-                $this->log('A matching Department '.$user_department_name.' already exists');
+                $this->log('A matching Department ' . $user_department_name . ' already exists');
 
                 return $department->id;
             }
@@ -530,7 +530,7 @@ abstract class Importer
             $department->name = $user_department_name;
 
             if ($department->save()) {
-                $this->log('Department '.$user_department_name.' was created');
+                $this->log('Department ' . $user_department_name . ' was created');
 
                 return $department->id;
             }
@@ -554,11 +554,11 @@ abstract class Importer
         $manager = User::where('first_name', '=', $user_manager_first_name)
             ->where('last_name', '=', $user_manager_last_name)->first();
         if ($manager) {
-            $this->log('A matching Manager '.$user_manager_first_name.' '.$user_manager_last_name.' already exists');
+            $this->log('A matching Manager ' . $user_manager_first_name . ' ' . $user_manager_last_name . ' already exists');
 
             return $manager->id;
         }
-        $this->log('No matching Manager '.$user_manager_first_name.' '.$user_manager_last_name.' found. If their user account is being created through this import, you should re-process this file again. ');
+        $this->log('No matching Manager ' . $user_manager_first_name . ' ' . $user_manager_last_name . ' found. If their user account is being created through this import, you should re-process this file again. ');
 
         return null;
     }
@@ -573,8 +573,8 @@ abstract class Importer
      * @return string|null
 
      */
-    public function parseOrNullDate($field, $format = 'date') {
-
+    public function parseOrNullDate($field, $format = 'date')
+    {
         $date_format = 'Y-m-d';
 
         if ($format == 'datetime') {
@@ -582,7 +582,6 @@ abstract class Importer
         }
 
         if (array_key_exists($field, $this->item) && $this->item[$field] != '') {
-
             try {
                 $value = CarbonImmutable::parse($this->item[$field])->format($date_format);
                 return $value;

--- a/app/Importer/Importer.php
+++ b/app/Importer/Importer.php
@@ -170,7 +170,7 @@ abstract class Importer
 
                 $this->log('------------- Action Summary ----------------');
             }
-            Model::reguard();
+            Model::reguard(); # codespell:ignore
         });
     }
 

--- a/app/Importer/ItemImporter.php
+++ b/app/Importer/ItemImporter.php
@@ -114,7 +114,7 @@ class ItemImporter extends Importer
             return;
         }
 
-        if (strtolower($this->item['checkout_class']) === 'location' && $this->findCsvMatch($row, 'checkout_location') != null ) {
+        if (strtolower($this->item['checkout_class']) === 'location' && $this->findCsvMatch($row, 'checkout_location') != null) {
             return Location::findOrFail($this->createOrFetchLocation($this->findCsvMatch($row, 'checkout_location')));
         }
 
@@ -221,7 +221,6 @@ class ItemImporter extends Importer
         $asset_model = $asset_model->first();
 
         if ($asset_model) {
-
             if (! $this->updating) {
                 $this->log('A matching model already exists, returning it.');
                 return $asset_model->id;
@@ -232,16 +231,15 @@ class ItemImporter extends Importer
             $item['name'] = $asset_model_name;
             $item['notes'] = $this->findCsvMatch($row, 'model_notes');
 
-            if (!empty($asset_modelNumber)){
+            if (!empty($asset_modelNumber)) {
                 $item['model_number'] = $asset_modelNumber;
             }
 
             $asset_model->update($item);
             $asset_model->save();
             $this->log('Asset Model Updated');
-            
-            return $asset_model->id;
 
+            return $asset_model->id;
         }
 
         $this->log('No Matching Model, Creating a new one');
@@ -257,12 +255,12 @@ class ItemImporter extends Importer
         $item = null;
 
         if ($asset_model->save()) {
-            $this->log('Asset Model '.$asset_model_name.' with model number '.$asset_modelNumber.' was created');
+            $this->log('Asset Model ' . $asset_model_name . ' with model number ' . $asset_modelNumber . ' was created');
 
             return $asset_model->id;
         }
-        $this->log('Asset Model Errors: '.$asset_model->getErrors());
-        $this->logError($asset_model, 'Asset Model "'.$asset_model_name.'"');
+        $this->log('Asset Model Errors: ' . $asset_model->getErrors());
+        $this->logError($asset_model, 'Asset Model "' . $asset_model_name . '"');
 
         return null;
     }
@@ -296,7 +294,7 @@ class ItemImporter extends Importer
 
 
         if ($category) {
-            $this->log('A matching category: '.$category->name.' already exists');
+            $this->log('A matching category: ' . $category->name . ' already exists');
             return $category->id;
         }
 
@@ -306,11 +304,11 @@ class ItemImporter extends Importer
         $category->category_type = $item_type;
 
         if ($category->save()) {
-            $this->log('Category '.$asset_category.' was created');
+            $this->log('Category ' . $asset_category . ' was created');
 
             return $category->id;
         }
-        $this->logError($category, 'Category "'. $asset_category. '"');
+        $this->logError($category, 'Category "' . $asset_category . '"');
 
         return null;
     }
@@ -327,7 +325,7 @@ class ItemImporter extends Importer
     {
         $company = Company::where(['name' => $asset_company_name])->first();
         if ($company) {
-            $this->log('A matching Company '.$asset_company_name.' already exists');
+            $this->log('A matching Company ' . $asset_company_name . ' already exists');
 
             return $company->id;
         }
@@ -336,7 +334,7 @@ class ItemImporter extends Importer
         $company->name = $asset_company_name;
 
         if ($company->save()) {
-            $this->log('Company '.$asset_company_name.' was created');
+            $this->log('Company ' . $asset_company_name . ' was created');
 
             return $company->id;
         }
@@ -358,11 +356,11 @@ class ItemImporter extends Importer
         $manager = User::where('first_name', '=', $user_manager_first_name)
             ->where('last_name', '=', $user_manager_last_name)->first();
         if ($manager) {
-            $this->log('A matching Manager '.$user_manager_first_name.' '.$user_manager_last_name.' already exists');
+            $this->log('A matching Manager ' . $user_manager_first_name . ' ' . $user_manager_last_name . ' already exists');
 
             return $manager->id;
         }
-        $this->log('No matching Manager '.$user_manager_first_name.' '.$user_manager_last_name.' found. If their user account is being created through this import, you should re-process this file again. ');
+        $this->log('No matching Manager ' . $user_manager_first_name . ' ' . $user_manager_last_name . ' found. If their user account is being created through this import, you should re-process this file again. ');
 
         return null;
     }
@@ -380,10 +378,10 @@ class ItemImporter extends Importer
         if (empty($asset_statuslabel_name)) {
             return null;
         }
-       $status = Statuslabel::where(['name' => trim($asset_statuslabel_name)])->first();
+        $status = Statuslabel::where(['name' => trim($asset_statuslabel_name)])->first();
 
         if ($status) {
-            $this->log('A matching Status '.$asset_statuslabel_name.' already exists');
+            $this->log('A matching Status ' . $asset_statuslabel_name . ' already exists');
 
             return $status->id;
         }
@@ -397,11 +395,11 @@ class ItemImporter extends Importer
         $status->archived = 0;
 
         if ($status->save()) {
-            $this->log('Status '.$asset_statuslabel_name.' was created');
+            $this->log('Status ' . $asset_statuslabel_name . ' was created');
             return $status->id;
         }
 
-        $this->logError($status, 'Status "'.$asset_statuslabel_name.'"');
+        $this->logError($status, 'Status "' . $asset_statuslabel_name . '"');
         return null;
     }
 
@@ -418,10 +416,10 @@ class ItemImporter extends Importer
         if (empty($item_manufacturer)) {
             $item_manufacturer = 'Unknown';
         }
-        $manufacturer = Manufacturer::where(['name'=> $item_manufacturer])->first();
+        $manufacturer = Manufacturer::where(['name' => $item_manufacturer])->first();
 
         if ($manufacturer) {
-            $this->log('Manufacturer '.$item_manufacturer.' already exists');
+            $this->log('Manufacturer ' . $item_manufacturer . ' already exists');
 
             return $manufacturer->id;
         }
@@ -432,11 +430,11 @@ class ItemImporter extends Importer
         $manufacturer->created_by = auth()->id();
 
         if ($manufacturer->save()) {
-            $this->log('Manufacturer '.$manufacturer->name.' was created');
+            $this->log('Manufacturer ' . $manufacturer->name . ' was created');
 
             return $manufacturer->id;
         }
-        $this->logError($manufacturer, 'Manufacturer "'.$manufacturer->name.'"');
+        $this->logError($manufacturer, 'Manufacturer "' . $manufacturer->name . '"');
 
         return null;
     }
@@ -459,7 +457,7 @@ class ItemImporter extends Importer
         $location = Location::where(['name' => $asset_location])->first();
 
         if ($location) {
-            $this->log('Location '.$asset_location.' already exists');
+            $this->log('Location ' . $asset_location . ' already exists');
             return $location->id;
         }
         // No matching locations in the collection, create a new one.
@@ -472,7 +470,7 @@ class ItemImporter extends Importer
         $location->created_by = auth()->id();
 
         if ($location->save()) {
-            $this->log('Location '.$asset_location.' was created');
+            $this->log('Location ' . $asset_location . ' was created');
 
             return $location->id;
         }
@@ -498,7 +496,7 @@ class ItemImporter extends Importer
         $supplier = Supplier::where(['name' => $item_supplier])->first();
 
         if ($supplier) {
-            $this->log('Supplier '.$item_supplier.' already exists');
+            $this->log('Supplier ' . $item_supplier . ' already exists');
 
             return $supplier->id;
         }
@@ -508,12 +506,11 @@ class ItemImporter extends Importer
         $supplier->created_by = auth()->id();
 
         if ($supplier->save()) {
-            $this->log('Supplier '.$item_supplier.' was created');
+            $this->log('Supplier ' . $item_supplier . ' was created');
             return $supplier->id;
         }
         $this->logError($supplier, 'Supplier');
 
         return null;
     }
-
 }

--- a/app/Importer/LicenseImporter.php
+++ b/app/Importer/LicenseImporter.php
@@ -29,7 +29,6 @@ class LicenseImporter extends ItemImporter
      * @return License|mixed|null
      * updated @author Jes Vinsmoke
      * @since 6.1
-     *
      */
     public function createLicenseIfNotExists(array $row)
     {
@@ -37,12 +36,10 @@ class LicenseImporter extends ItemImporter
         $license = License::where('serial', $this->item['serial'])->where('name', $this->item['name'])
                     ->first();
         if ($license) {
-            if (! $this->updating) {
-
-                if($this->item['serial'] != "") {
+            if (!$this->updating) {
+                if ($this->item['serial'] != "") {
                     $this->log('A matching License ' . $this->item['name'] . ' with serial ' . $this->item['serial'] . ' already exists');
-                }
-                else {
+                } else {
                     $this->log('A matching License ' . $this->item['name'] . ' with no serial number already exists');
                 }
 
@@ -53,12 +50,12 @@ class LicenseImporter extends ItemImporter
             $editingLicense = true;
         } else {
             $this->log('No Matching License, Creating a new one');
-            $license = new License;
+            $license = new License();
         }
         $asset_tag = $this->item['asset_tag'] = trim($this->findCsvMatch($row, 'asset_tag')); // used for checkout out to an asset.
 
         $this->item["expiration_date"] = null;
-        if ($this->findCsvMatch($row, "expiration_date")!='') {
+        if ($this->findCsvMatch($row, "expiration_date") != '') {
             $this->item["expiration_date"] = date("Y-m-d 00:00:01", strtotime(trim($this->findCsvMatch($row, "expiration_date"))));
         }
         $this->item['license_email'] = trim($this->findCsvMatch($row, 'license_email'));
@@ -70,14 +67,13 @@ class LicenseImporter extends ItemImporter
         $this->item['manufacturer'] = $this->createOrFetchManufacturer(trim($this->findCsvMatch($row, 'manufacturer')));
         $this->item['min_amt'] = trim($this->findCsvMatch($row, 'min_amt'));
 
-        if($this->item['reassignable'] == "")
-        {
+        if ($this->item['reassignable'] == "") {
             $this->item['reassignable'] = 1;
         }
         $this->item['seats'] = $this->findCsvMatch($row, 'seats');
-        
+
         $this->item["termination_date"] = null;
-        if ($this->findCsvMatch($row, "termination_date")!='') {
+        if ($this->findCsvMatch($row, "termination_date") != '') {
             $this->item["termination_date"] = date("Y-m-d 00:00:01", strtotime($this->findCsvMatch($row, "termination_date")));
         }
 
@@ -91,7 +87,7 @@ class LicenseImporter extends ItemImporter
         // This sets an attribute on the Loggable trait for the action log
         $license->setImported(true);
         if ($license->save()) {
-            $this->log('License '.$this->item['name'].' with serial number '.$this->item['serial'].' was created');
+            $this->log('License ' . $this->item['name'] . ' with serial number ' . $this->item['serial'] . ' was created');
 
             // Lets try to checkout seats if the fields exist and we have seats.
             if ($license->seats > 0) {
@@ -99,7 +95,7 @@ class LicenseImporter extends ItemImporter
                 $asset = Asset::where('asset_tag', $asset_tag)->first();
                 $targetLicense = $license->freeSeat();
 
-                if (is_null($targetLicense)){
+                if (is_null($targetLicense)) {
                     return;
                 }
 
@@ -119,6 +115,6 @@ class LicenseImporter extends ItemImporter
 
             return;
         }
-        $this->logError($license, 'License "'.$this->item['name'].'"');
+        $this->logError($license, 'License "' . $this->item['name'] . '"');
     }
 }

--- a/app/Importer/LocationImporter.php
+++ b/app/Importer/LocationImporter.php
@@ -58,7 +58,7 @@ class LocationImporter extends ItemImporter
             $editingLocation = true;
         } else {
             $this->log('No Matching Location, Create a new one');
-            $location = new Location;
+            $location = new Location();
             $location->created_by = auth()->id();
         }
 
@@ -100,15 +100,12 @@ class LocationImporter extends ItemImporter
         }
 
         if ($location->save()) {
-            $this->log('Location '.$location->name.' created or updated from CSV import');
+            $this->log('Location ' . $location->name . ' created or updated from CSV import');
             return $location;
-
         } else {
             Log::debug($location->getErrors());
-            $this->logError($location, 'Location "'.$this->item['name'].'"');
+            $this->logError($location, 'Location "' . $this->item['name'] . '"');
             return $location->errors;
         }
-
-
     }
 }

--- a/app/Importer/LocationImporter.php
+++ b/app/Importer/LocationImporter.php
@@ -41,16 +41,16 @@ class LocationImporter extends ItemImporter
 
         $location = Location::where('name', '=', $this->findCsvMatch($row, 'name'))->first();
 
-        if ($this->findCsvMatch($row, 'id')!='') {
+        if ($this->findCsvMatch($row, 'id') != '') {
             // Override location if an ID was given
-            \Log::debug('Finding location by ID: '.$this->findCsvMatch($row, 'id'));
+            \Log::debug('Finding location by ID: ' . $this->findCsvMatch($row, 'id'));
             $location = Location::find($this->findCsvMatch($row, 'id'));
         }
 
 
         if ($location) {
             if (! $this->updating) {
-                $this->log('A matching Location '.$this->item['name'].' already exists');
+                $this->log('A matching Location ' . $this->item['name'] . ' already exists');
                 return;
             }
 

--- a/app/Importer/UserImporter.php
+++ b/app/Importer/UserImporter.php
@@ -64,8 +64,8 @@ class UserImporter extends ItemImporter
         $this->item['department_id'] = trim($this->createOrFetchDepartment(trim($this->findCsvMatch($row, 'department'))));
         $this->item['manager_id'] = $this->fetchManager(trim($this->findCsvMatch($row, 'manager_first_name')), trim($this->findCsvMatch($row, 'manager_last_name')));
         $this->item['remote'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'remote'))) == 1 ) ? '1' : 0;
-        $this->item['vip'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'vip'))) ==1 ) ? '1' : 0;
-        $this->item['autoassign_licenses'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'autoassign_licenses'))) ==1 ) ? '1' : 0;
+        $this->item['vip'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'vip'))) == 1 ) ? '1' : 0;
+        $this->item['autoassign_licenses'] = ($this->fetchHumanBoolean(trim($this->findCsvMatch($row, 'autoassign_licenses'))) == 1 ) ? '1' : 0;
 
         $this->handleEmptyStringsForDates();
 
@@ -81,16 +81,15 @@ class UserImporter extends ItemImporter
         }
 
         // Check if a numeric ID was passed. If it does, use that above all else.
-        if ((array_key_exists('id', $this->item) && ($this->item['id'] != "") && (is_numeric($this->item['id']))))  {
+        if ((array_key_exists('id', $this->item) && ($this->item['id'] != "") && (is_numeric($this->item['id'])))) {
             $user = User::find($this->item['id']);
         } else {
             $user = User::where('username', $this->item['username'])->first();
         }
 
         if ($user) {
-
             if (! $this->updating) {
-                Log::debug('A matching User '.$this->item['name'].' already exists.  ');
+                Log::debug('A matching User ' . $this->item['name'] . ' already exists.  ');
                 return;
             }
             $this->log('Updating User');
@@ -101,7 +100,7 @@ class UserImporter extends ItemImporter
             Asset::where('assigned_type', User::class)
                 ->where('assigned_to', $user->id)
                 ->update(['location_id' => $user->location_id]);
-            
+
             // Log::debug('UserImporter.php Updated User ' . print_r($user, true));
             return;
         }
@@ -118,7 +117,7 @@ class UserImporter extends ItemImporter
         $user->fill($this->sanitizeItemForStoring($user));
 
         if ($user->save()) {
-            $this->log('User '.$this->item['name'].' was created');
+            $this->log('User ' . $this->item['name'] . ' was created');
 
             if (($user->email) && ($user->activated == '1')) {
                 $data = [
@@ -153,7 +152,7 @@ class UserImporter extends ItemImporter
      */
     public function createOrFetchDepartment($department_name)
     {
-        if (is_null($department_name) || $department_name == ''){
+        if (is_null($department_name) || $department_name == '') {
             return null;
         }
 
@@ -176,7 +175,7 @@ class UserImporter extends ItemImporter
         $this->logError($department, 'Department');
         return null;
     }
-    
+
     public function sendWelcome($send = true)
     {
         $this->send_welcome = $send;

--- a/app/Models/Accessory.php
+++ b/app/Models/Accessory.php
@@ -299,7 +299,7 @@ class Accessory extends SnipeModel
     }
 
     /**
-     * Determins whether or not an email should be sent for checkin/checkout of this
+     * Determines whether or not an email should be sent for checkin/checkout of this
      * accessory based on the category it belongs to.
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -250,7 +250,7 @@ final class Company extends SnipeModel
     /**
      * Scoping table queries, determining if a logged in user is part of a company, and only allows the user to access items associated with that company if FMCS is enabled.
      *
-     * This method is the one that the CompanyableTrait uses to contrain queries automatically, however that trait CANNOT be
+     * This method is the one that the CompanyableTrait uses to constrain queries automatically, however that trait CANNOT be
      * applied to the user's model, since it causes an infinite loop against the authenticated user.
      *
      * @todo - refactor that trait to handle the user's model as well.

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -16,7 +16,7 @@ class CustomField extends Model
         UniqueUndeletedTrait;
 
     /**
-     * Custom field predfined formats
+     * Custom field predefined formats
      *
      * @var array
      */

--- a/app/Models/Labels/Field.php
+++ b/app/Models/Labels/Field.php
@@ -17,7 +17,7 @@ class Field {
     
     public function toArray(Asset $asset) { return Field::makeArray($this, $asset); }
 
-    /* Statics */
+    /* Static functions */
 
     public static function makeArray(Field $field, Asset $asset) {
         return $field->getOptions()

--- a/app/Models/Labels/FieldOption.php
+++ b/app/Models/Labels/FieldOption.php
@@ -42,7 +42,7 @@ class FieldOption {
     public function toArray(Asset $asset=null) { return FieldOption::makeArray($this, $asset); }
     public function toString() { return FieldOption::makeString($this); }
 
-    /* Statics */
+    /* Static functions */
 
     public static function makeArray(FieldOption $option, Asset $asset=null) {
         return [

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -126,11 +126,11 @@ class Ldap extends Model
                  * TODO PLEASE:
                  *
                  * this isn't very clear, so it's important to note: the $ldapbind value is never correctly returned - we never 'return true' from self::bindAdminToLdap() (the function
-                 * just "falls off the end" without ever explictly returning 'true')
+                 * just "falls off the end" without ever explicitly returning 'true')
                  *
                  * but it *does* have an interesting side-effect of checking for the LDAP password being incorrectly encrypted with the wrong APP_KEY, so I'm leaving it in for now.
                  *
-                 * If it *did* correctly return 'true' on a succesful bind, it would _probably_ allow users to log in with an incorrect password. Which would be horrible!
+                 * If it *did* correctly return 'true' on a successful bind, it would _probably_ allow users to log in with an incorrect password. Which would be horrible!
                  *
                  * Let's definitely fix this at the next refactor!!!!
                  *

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -553,7 +553,7 @@ class License extends Depreciable
     }
 
     /**
-     * Retuns the number of assigned seats for this asset
+     * Returns the number of assigned seats for this asset
      *
      * @author A. Gianotto <snipe@snipe.net>
      * @since [v3.0]

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -143,7 +143,7 @@ class Setting extends Model
     }
 
     /**
-     * Check wether to show in model dropdowns.
+     * Check whether to show in model dropdowns.
      *
      * @param string $element
      *

--- a/app/Presenters/DepreciationReportPresenter.php
+++ b/app/Presenters/DepreciationReportPresenter.php
@@ -369,7 +369,7 @@ class DepreciationReportPresenter extends Presenter
     }
 
     /**
-     * Date the warantee expires.
+     * Date the warranty expires.
      * @return false|string
      */
     public function warranty_expires()

--- a/app/Providers/ValidationServiceProvider.php
+++ b/app/Providers/ValidationServiceProvider.php
@@ -199,7 +199,7 @@ class ValidationServiceProvider extends ServiceProvider
 
                 $test_string = 'My hovercraft is full of eels';
 
-                // We have to stip out the regex: part here to check with preg_match
+                // We have to strip out the regex: part here to check with preg_match
                 $test_pattern = str_replace('regex:', '', $value);
 
                 try {

--- a/config/app.php
+++ b/config/app.php
@@ -162,7 +162,7 @@ return [
     | ENABLE HTTP Strict Transport Security (HSTS)
     |--------------------------------------------------------------------------
     |
-    | This is set to default false for backwards compatibilty but should be
+    | This is set to default false for backwards compatibility but should be
     | set to true if the hosting environment allows it.
     |
     | See https://scotthelme.co.uk/hsts-the-missing-link-in-tls/
@@ -421,7 +421,7 @@ return [
   | Escape Excel formulas in CSV exports
   |--------------------------------------------------------------------------
   |
-  | This determins whether or not we should escape Excel formulas in CSV exports.
+  | This determines whether or not we should escape Excel formulas in CSV exports.
   | This can be UNSAFE in untrusted environments, and therefore defaults to true
   | so that Excel forumals WILL be escaped in CSV exports, however if your workflow
   | is designed around using formulas in your fields, you

--- a/config/dompdf.php
+++ b/config/dompdf.php
@@ -124,7 +124,7 @@ return array(
          *
          * @link http://www.pdflib.com
          *
-         * If pdflib present in web server and auto or selected explicitely above,
+         * If pdflib present in web server and auto or selected explicitly above,
          * a real license code must exist!
          */
         //"DOMPDF_PDFLIB_LICENSE" => "your license key here",
@@ -162,7 +162,7 @@ return array(
          * Image DPI setting
          *
          * This setting determines the default DPI setting for images and fonts.  The
-         * DPI may be overridden for inline images by explictly setting the
+         * DPI may be overridden for inline images by explicitly setting the
          * image's width & height style attributes (i.e. if the image's native
          * width is 600 pixels and you specify the image's width as 72 points,
          * the image will have a DPI of 600 in the rendered PDF.  The DPI of

--- a/contrib/hooks/pre-commit
+++ b/contrib/hooks/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep ".php")
+
+if ! [ -z "${FILES}" ]; then
+    codespell $FILES
+fi

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -57,7 +57,7 @@ class AssetFactory extends Factory
     public function configure()
     {
         return $this->afterMaking(function (Asset $asset) {
-            // calculates the EOL date most of the time, but sometimes sets a random date so we have some explicits
+            // calculates the EOL date most of the time, but sometimes sets a random date
             // the explicit boolean gets set in the saving() method on the observer 
             $asset->asset_eol_date = $this->faker->boolean(5) 
                 ? CarbonImmutable::parse($asset->purchase_date)->addMonths(rand(0, 20))->format('Y-m-d')

--- a/database/factories/ConsumableFactory.php
+++ b/database/factories/ConsumableFactory.php
@@ -63,7 +63,7 @@ class ConsumableFactory extends Factory
     {
         return $this->state(function () {
             return [
-                'name' => 'Laserjet Paper (Ream)',
+                'name' => 'Laserjet Paper (Ream)', // codespell:ignore
                 'category_id' => function () {
                     return Category::where('name', 'Printer Paper')->first() ?? Category::factory()->consumablePaperCategory();
                 },

--- a/database/factories/LocationFactory.php
+++ b/database/factories/LocationFactory.php
@@ -27,7 +27,7 @@ class LocationFactory extends Factory
         ];
     }
   
-    // one of these can eventuall go away - left temporarily for conflict resolution
+    // one of these can eventually go away - left temporarily for conflict resolution
     public function deleted(): self
     {
         return $this->state(['deleted_at' => $this->faker->dateTime()]);

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -50,7 +50,7 @@ class DatabaseSeeder extends Seeder
         $output = Artisan::output();
         Log::info($output);
 
-        Model::reguard();
+        Model::reguard(); // codespell:ignore
 
         DB::table('imports')->truncate();
         DB::table('asset_maintenances')->truncate();

--- a/docker/001-default-ssl.conf
+++ b/docker/001-default-ssl.conf
@@ -48,7 +48,7 @@
 		#   certificate chain for the server certificate. Alternatively
 		#   the referenced file can be the same as SSLCertificateFile
 		#   when the CA certificates are directly appended to the server
-		#   certificate for convinience.
+		#   certificate for convenience.
 		#SSLCertificateChainFile /etc/apache2/ssl.crt/server-ca.crt
 		SSLCertificateChainFile /var/lib/snipeit/ssl/snipeit-ssl.crt
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 # ensure running as root
 if [ "$(id -u)" != "0" ]; then
-    #Debian doesnt have sudo if root has a password.
+    # Debian doesn't have sudo if root has a password.
     if ! hash sudo 2>/dev/null; then
         exec su -c "$0" "$@"
     else

--- a/resources/assets/js/bootstrap-table-reorder-columns.js
+++ b/resources/assets/js/bootstrap-table-reorder-columns.js
@@ -2063,31 +2063,31 @@
                         if (_this.options.cookie) {
                             _this.persistReorderColumnsState(_this);
                         }
-                        var ths = [];
+                        var table_headers = [];
                         var formatters = [];
                         var columns = [];
                         var columnsHidden = [];
                         var columnIndex = -1;
                         var optionsColumns = [];
                         _this.$header.find('th:not(.detail)').each(function (i, el) {
-                            ths.push($$6(el).data('field'));
+                            table_headers.push($$6(el).data('field'));
                             formatters.push($$6(el).data('formatter'));
                         });
 
                         // Exist columns not shown
-                        if (ths.length < _this.columns.length) {
+                        if (table_headers.length < _this.columns.length) {
                             columnsHidden = _this.columns.filter(function (column) {
                                 return !column.visible;
                             });
                             for (var i = 0; i < columnsHidden.length; i++) {
-                                ths.push(columnsHidden[i].field);
+                                table_headers.push(columnsHidden[i].field);
                                 formatters.push(columnsHidden[i].formatter);
                             }
                         }
-                        for (var _i2 = 0; _i2 < ths.length; _i2++) {
-                            columnIndex = _this.fieldsColumnsIndex[ths[_i2]];
+                        for (var _i2 = 0; _i2 < table_headers.length; _i2++) {
+                            columnIndex = _this.fieldsColumnsIndex[table_headers[_i2]];
                             if (columnIndex !== -1) {
-                                _this.fieldsColumnsIndex[ths[_i2]] = _i2;
+                                _this.fieldsColumnsIndex[table_headers[_i2]] = _i2;
                                 _this.columns[columnIndex].fieldIndex = _i2;
                                 columns.push(_this.columns[columnIndex]);
                             }
@@ -2107,14 +2107,14 @@
                             });
                         });
                         _this.options.columns[0] = optionsColumns;
-                        _this.header.fields = ths;
+                        _this.header.fields = table_headers;
                         _this.header.formatters = formatters;
                         _this.initHeader();
                         _this.initToolbar();
                         _this.initSearchText();
                         _this.initBody();
                         _this.resetView();
-                        _this.trigger('reorder-column', ths);
+                        _this.trigger('reorder-column', table_headers);
                     }
                 });
             }

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -8,14 +8,14 @@ window._ = require('lodash');
 //window.$ = window.jQuery = require('jquery');
 
 /**
- * jQuery UI is loaded here and then the tooltip is assigned another funtion name
+ * jQuery UI is loaded here and then the tooltip is assigned another function name
  * This resolves the issue of jquery-ui & bootstrap tooltip conflict
  */
 require('jquery-ui');
 jQuery.fn.uitooltip = jQuery.fn.tooltip; 
 
 /**
- * Load boostrap
+ * Load bootstrap
  */
 require('bootstrap-less');
 

--- a/resources/assets/js/dragtable.js
+++ b/resources/assets/js/dragtable.js
@@ -8,7 +8,7 @@
  * and GPL (GPL-LICENSE.txt) licenses.
  *
  * Inspired by the the dragtable from Dan Vanderkam (danvk.org/dragtable/)
- * Thanks to the jquery and jqueryui comitters
+ * Thanks to the jquery and jqueryui committers
  *
  * Any comment, bug report, feature-request is welcome
  * Feel free to contact me.
@@ -49,7 +49,7 @@
  * beforeStop: beforeStop
  */
 /*
- * Special thx to all pull requests comitters
+ * Special thx to all pull requests committers
  */
 
 (function($) {
@@ -65,7 +65,7 @@
             restoreState: null,          // JSON-Object or function:  some kind of experimental aka Quick-Hack TODO: do it better
             exact: true,                 // removes pixels, so that the overlay table width fits exactly the original table width
             clickDelay: 10,              // ms to wait before rendering sortable list and delegating click event
-            containment: null,           // @see http://api.jqueryui.com/sortable/#option-containment, use it if you want to move in 2 dimesnions (together with axis: null)
+            containment: null,           // @see http://api.jqueryui.com/sortable/#option-containment, use it if you want to move in 2 dimensions (together with axis: null)
             cursor: 'move',              // @see http://api.jqueryui.com/sortable/#option-cursor
             cursorAt: false,             // @see http://api.jqueryui.com/sortable/#option-cursorAt
             distance: 0,                 // @see http://api.jqueryui.com/sortable/#option-distance, for immediate feedback use "0"
@@ -395,9 +395,9 @@
     }
 
     function swapNodes(a, b) {
-        var aparent = a.parentNode;
+        var aparent = a.parentNode; // codespell:ignore
         var asibling = a.nextSibling === b ? a : a.nextSibling;
         b.parentNode.insertBefore(a, b);
-        aparent.insertBefore(b, asibling);
+        aparent.insertBefore(b, asibling); // codespell:ignore
     }
 })(jQuery);

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -346,7 +346,7 @@ $(function () {
             var inner_div = $("<div style='width: 30px;'>");
             /******************************************************************
              * 
-             * We are specifically chosing empty alt-text below, because this 
+             * We are specifically choosing empty alt-text below, because this 
              * image conveys no additional information, relative to the text
              * that will *always* be there in any select2 list that is in use
              * in Snipe-IT. If that changes, we would probably want to change

--- a/resources/assets/js/snipeit_modals.js
+++ b/resources/assets/js/snipeit_modals.js
@@ -178,7 +178,7 @@ function formatDatalistSafe(datalist) {
         var inner_div = $("<div style='width: 30px;'>");
         /******************************************************************
          * 
-         * We are specifically chosing empty alt-text below, because this 
+         * We are specifically choosing empty alt-text below, because this 
          * image conveys no additional information, relative to the text
          * that will *always* be there in any select2 list that is in use
          * in Snipe-IT. If that changes, we would probably want to change

--- a/resources/assets/less/mixins.less
+++ b/resources/assets/less/mixins.less
@@ -42,7 +42,7 @@
   }
 }
 
-//Box solid color variantion creator
+//Box solid color variation creator
 .box-solid-variant(@color; @text-color: #fff) {
   border: 1px solid @color;
   > .box-header {

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -109,8 +109,8 @@
                 onPostHeader: function () {
                     var lookup = {};
                     var lookup_initialized = false;
-                    var ths = $('th');
-                    ths.each(function (index, element) {
+                    var table_headers = $('th');
+                    table_headers.each(function (index, element) {
                         th = $(element);
                         //only populate the lookup table once; don't need to keep doing it.
                         if (!lookup_initialized) {

--- a/resources/views/setup/index.blade.php
+++ b/resources/views/setup/index.blade.php
@@ -126,7 +126,7 @@ Create a User ::
         @if (!$start_settings['owner_is_admin'])
           Your app files are owned by <code>{{ $start_settings['owner'] }}</code>. That doesn't look like a default root/admin account. Nice!
         @else
-          It looks like your files are owned by <code>{{ $start_settings['owner'] }}</code>, which might be a root/admin account. It's never a good idea to run a website with escalated priveliges.
+          It looks like your files are owned by <code>{{ $start_settings['owner'] }}</code>, which might be a root/admin account. It's never a good idea to run a website with escalated privileges.
         @endif
       </td>
     </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -128,7 +128,7 @@ Route::group(['middleware' => 'auth'], function () {
 /*
 |
 |--------------------------------------------------------------------------
-| Re-Usable Modal Dialog routes.
+| Reusable Modal Dialog routes.
 |--------------------------------------------------------------------------
 |
 | Routes for various modal dialogs to interstitially create various things
@@ -338,7 +338,7 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth', 'authorize:superuser
 
     /**
      * This breadcrumb is repeated for groups in the BreadcrumbServiceProvider, since groups uses resource routes
-     * and that servcie provider cannot see the breadcrumbs defined below
+     * and that service provider cannot see the breadcrumbs defined below
      */
     Route::get('/', [SettingsController::class, 'index'])
         ->name('settings.index')

--- a/snipeit.sh
+++ b/snipeit.sh
@@ -73,7 +73,7 @@ fi
 
 # ensure running as root
 if [ "$(id -u)" != "0" ]; then
-    #Debian doesnt have sudo if root has a password.
+    # Debian doesn't have sudo if root has a password.
     if ! hash sudo 2>/dev/null; then
         exec su -c "$0" "$@"
     else
@@ -394,8 +394,8 @@ set_fqdn () {
 }
 
 set_dbpass () {
-   ans=default
-   until [[ $ans == "yes" ]] || [[ $ans == "no" ]]; do
+   answer=default
+   until [[ $answer == "yes" ]] || [[ $answer == "no" ]]; do
       echo -n "  Q. Do you want to automatically create the SnipeIT database user password? (y/n) "
       read -r setpw
 
@@ -403,13 +403,13 @@ set_dbpass () {
          [yY] | [yY][Ee][Ss] )
          mysqluserpw="$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c16; echo)"
          echo ""
-         ans="yes"
+         answer="yes"
       ;;
       [nN] | [n|N][O|o] )
          echo -n  "  Q. What do you want your snipeit user password to be?"
          read -rs mysqluserpw
          echo ""
-         ans="no"
+         answer="no"
       ;;
       *)  echo "  Invalid answer. Please type y or n"
       ;;

--- a/upgrade.php
+++ b/upgrade.php
@@ -415,7 +415,7 @@ echo $dirs_writable."\n";
 // Print out a useful error message
 if ($dirs_not_writable!='') {
     echo "\e[91m--------------------------------------------------------\n";
-    echo "\eThe following directories/files do not seem writable: \n";
+    echo "\eThe following directories/files do not seem writable: \n"; // codespell:ignore
     echo "\e--------------------------------------------------------\e[39m\n";
 
     echo $dirs_not_writable;


### PR DESCRIPTION
https://github.com/codespell-project/codespell is a useful linter. While this is a widespread change, I did hand apply these. If wanted, can break this up into smaller chunks.

To using the tooling; assuming you have python - add via `pip install codespell` and run as `codespell`

Optional extras:

- [x] Precommit hook
- [x] GIthub actions
