### PR TITLE
Fixed: Admin > Asset Tag Settings > Add UI and Model validations for Asset Tag Settings to prevent invalid inputs

### DIFF
--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -53,7 +53,9 @@ class Setting extends Model
     protected $rules = [
           'brand'                               => 'required|min:1|numeric',
           'thumbnail_max_h'                     => 'numeric|max:500|min:25',
-          'google_client_id'                    => 'nullable|ends_with:apps.googleusercontent.com'
+          'google_client_id'                    => 'nullable|ends_with:apps.googleusercontent.com',
+          'next_auto_tag_base'                  => 'nullable|min:1',
+          'zerofill_count'                      => 'nullable|min:0'
     ];
 
     protected $fillable = [

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -54,8 +54,8 @@ class Setting extends Model
           'brand'                               => 'required|min:1|numeric',
           'thumbnail_max_h'                     => 'numeric|max:500|min:25',
           'google_client_id'                    => 'nullable|ends_with:apps.googleusercontent.com',
-          'next_auto_tag_base'                  => 'nullable|min:1',
-          'zerofill_count'                      => 'nullable|min:0'
+          'next_auto_tag_base'                  => 'integer|nullable|min:1',
+          'zerofill_count'                      => 'integer|nullable|min:0'
     ];
 
     protected $fillable = [

--- a/resources/views/settings/asset_tags.blade.php
+++ b/resources/views/settings/asset_tags.blade.php
@@ -58,7 +58,7 @@
                                 <label for="next_auto_tag_base">{{ trans('admin/settings/general.next_auto_tag_base') }}</label>
                             </div>
                             <div class="col-md-7">
-                                <input class="form-control" style="width: 150px;" aria-label="next_auto_tag_base" name="next_auto_tag_base" type="text" value="{{ old('next_auto_tag_base', $setting->next_auto_tag_base) }}" id="next_auto_tag_base">
+                                <input class="form-control" style="width: 150px;" aria-label="next_auto_tag_base" name="next_auto_tag_base" type="number" min="1" value="{{ old('next_auto_tag_base', $setting->next_auto_tag_base) }}" id="next_auto_tag_base">
                                 {!! $errors->first('next_auto_tag_base', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
                         </div>
@@ -85,7 +85,7 @@
                                 <label for="zerofill_count">{{ trans('admin/settings/general.zerofill_count') }}</label>
                             </div>
                             <div class="col-md-7">
-                                <input class="form-control" style="width: 150px;" aria-label="zerofill_count" name="zerofill_count" type="text" value="{{ old('zerofill_count', $setting->zerofill_count) }}" id="zerofill_count">
+                                <input class="form-control" style="width: 150px;" aria-label="zerofill_count" name="zerofill_count" type="number" min="0" value="{{ old('zerofill_count', $setting->zerofill_count) }}" id="zerofill_count">
                                 {!! $errors->first('zerofill_count', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
                         </div>


### PR DESCRIPTION
Fix https://github.com/grokability/snipe-it/issues/16751

Manual testing:
![image](https://github.com/user-attachments/assets/cc69d7e0-e828-41eb-9f05-450bb40b5e20)
Bypassing UI:
![image](https://github.com/user-attachments/assets/0a30da17-e3f4-4175-b792-a51f33210b6c)
