### PR TITLE
min_amt wasn't correctly being set to required or not

### DIFF
--- a/resources/views/partials/forms/edit/minimum_quantity.blade.php
+++ b/resources/views/partials/forms/edit/minimum_quantity.blade.php
@@ -3,7 +3,10 @@
     <label for="min_amt" class="col-md-3 control-label">{{ trans('general.min_amt') }}</label>
     <div class="col-md-9">
        <div class="col-md-2" style="padding-left:0px">
-            <input class="form-control col-md-3" maxlength="5" type="text" name="min_amt" id="min_amt" aria-label="min_amt" value="{{ old('min_amt', ($item->min_amt ?? '')) }}"{{   (isset($item) ?? (Helper::checkIfRequired($item, 'min_amt')) ? ' required' : '') }}/>
+           <input class="form-control col-md-3" maxlength="5" type="text" name="min_amt" id="min_amt"
+                  aria-label="min_amt"
+                  value="{{ old('min_amt', ($item->min_amt ?? '')) }}"
+                   {{   (isset($item) && (Helper::checkIfRequired($item, 'min_amt')) ? ' required' : '') }}/>
         </div>
             <div class="col-md-7" style="margin-left: -15px;">
 


### PR DESCRIPTION
The logic in the blade was:

```php
(isset($item) ?? (Helper::checkIfRequired($item, 'min_amt')) ? ' required' : '')
```

Which, unwrapped, would look closer to:

```php
if( isset($item) ?? (Helper::checkIfRequired($item, 'min_amt')) {
    ' required';
} else {
    '';
}
```

And what that was doing is, *if* `$item` was _set_ at all (not even necessarily 'truthily'), **then** we mark the item as required.

Instead, this changes `??` to `&&` which means more, like, "if this item is set, *and* `checkIfRequired()` returns `true`, then mark it as required." 

As a side note, anywhere we use this the field has been not-required. But still, better to stick with the standard way we do stuff.