### PR TITLE
Added checkout date to license seats

### DIFF
--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Transformers;
 
+use App\Helpers\Helper;
 use App\Models\License;
 use App\Models\LicenseSeat;
 use Illuminate\Support\Facades\Gate;
@@ -26,6 +27,7 @@ class LicenseSeatsTransformer
         $array = [
             'id' => (int) $seat->id,
             'license_id' => (int) $seat->license->id,
+            'updated_at' => Helper::getFormattedDateObject($seat->updated_at, 'datetime'), // we use updated_at here because the record gets updated when it's checked in or out
             'assigned_user' => ($seat->user) ? [
                 'id' => (int) $seat->user->id,
                 'name'=> e($seat->user->present()->fullName),
@@ -36,14 +38,17 @@ class LicenseSeatsTransformer
                             'name' => e($seat->user->department->name),
 
                         ] : null,
+                'created_at' => Helper::getFormattedDateObject($seat->created_at, 'datetime'),
             ] : null,
             'assigned_asset' => ($seat->asset) ? [
                 'id' => (int) $seat->asset->id,
                 'name'=> e($seat->asset->present()->fullName),
+                'created_at' => Helper::getFormattedDateObject($seat->created_at, 'datetime'),
             ] : null,
             'location' => ($seat->location()) ? [
                 'id' => (int) $seat->location()->id,
                 'name'=> e($seat->location()->name),
+                'created_at' => Helper::getFormattedDateObject($seat->created_at, 'datetime'),
             ] : null,
             'reassignable' => (bool) $seat->license->reassignable,
             'notes' => e($seat->notes),

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -281,6 +281,14 @@ class LicensePresenter extends Presenter
                 'formatter' => 'locationsLinkObjFormatter',
             ],
             [
+                'field' => 'updated_at',
+                'searchable' => false,
+                'sortable' => true,
+                'visible' => false,
+                'title' => trans('general.date'),
+                'formatter' => 'dateDisplayFormatter',
+            ],
+            [
                 'field' => 'notes',
                 'searchable' => false,
                 'sortable' => false,


### PR DESCRIPTION
This uses the `updated_at` on the license pivot. 