### PR TITLE
Fixed: [RB-19645] Suppress error message about 'action_date' not existing

### DIFF
--- a/app/Models/Loggable.php
+++ b/app/Models/Loggable.php
@@ -100,13 +100,15 @@ trait Loggable
 
 
         foreach ($originalValues as $key => $value) {
+            // TODO - action_date isn't a valid attribute of any first-class object, so we might want to remove this?
             if ($key == 'action_date' && $value != $action_date) {
                 $changed[$key]['old'] = $value;
                 $changed[$key]['new'] = is_string($action_date) ? $action_date : $action_date->format('Y-m-d H:i:s');
-            } elseif ($value != $this->getAttributes()[$key]) {
+            } elseif (array_key_exists($key, $this->getAttributes()) && $value != $this->getAttributes()[$key]) {
                 $changed[$key]['old'] = $value;
                 $changed[$key]['new'] = $this->getAttributes()[$key];
             }
+            // NOTE - if the attribute exists in $originalValues, but *not* in ->getAttributes(), it isn't added to $changed
         }
 
         if (!empty($changed)){


### PR DESCRIPTION
This stops that particular Rollbar from firing, so that's nice.

But the problem I'm having here is that there is a decent chunk of code here that's two years old and _looks_, to me, at face value, incorrect. But I'm not so arrogant to go running around tearing up two-year old code because it "looks wrong" to me.

This is because `action_date` is not an attribute of any First-Class Object (FCO) in our system. It's a column on the `action_logs` table, and 'changes' to it should not be logged anywhere (and it shouldn't ever 'change' after creation).

This change just checks whether or not an array key exists in the `$this->getAttributes()` call, which seems like a reasonable thing to do. As a side-effect, if we have some attribute in the `$originalValues` array, and it does *not* exist in `$this->getAttributes()`, then that change won't be logged. This would've just caused an error before so it's not like we're hiding the changes of something that we had been reporting on.

But some problems remain and I'm kinda loathe to try to address them here. They are:
 - We shouldn't be referring to `action_date` at all.
 - If we *are* going to be referring to it, we should interpret that `$key == 'action_date' && $value == $action_date` means we should skip this value.
 - The place where we are _setting_ this, in app/Http/Controllers/Api/AssetsController.php - we shouldn't set it there. And the calculation of the effective `action_date` is done in two different tri-states, which is weird and hard to track:
 
 https://github.com/grokability/snipe-it/blob/3b661e5a99d6bfd12706cad5ffc86975a6c3972f/app/Http/Controllers/Api/AssetsController.php#L997-L1003

Instead the logic should probably be something like:
```php
 if ($request->filled('checkin_at') {
   if($request->get('checkin_at') == date('Y-m-d') {
      $checkin_at = date('Y-m-d H:i:s'); //checkin date is today, make it be explicitly 'now'
   } else {
      $checkin_at = $request->get('checkin_at').' '.date('H:i:s'); // checkin date is some other date, append current time to timestamp (do we really want to make up data like this?)
   }
} else {
   $checkin_at = date('Y-m-d H:i:s');
}
```

And nothing to do with `$originalValues` at all.

But instead, I simply comment-out my shame, and humbly submit this small change to make that error go away.