### PR TITLE
Better handle model_id arrays passed to the API

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -298,9 +298,15 @@ class AssetsController extends Controller
         if ($request->input('requestable') == 'true') {
             $assets->where('assets.requestable', '=', '1');
         }
-
+        
         if ($request->filled('model_id')) {
-            $assets->InModelList([$request->input('model_id')]);
+            // If model_id is already an array, just use it as-is
+            if (is_array($request->input('model_id'))) {
+                $assets->InModelList($request->input('model_id'));
+            } else {
+                // Otherwise, turn it into an array
+                $assets->InModelList([$request->input('model_id')]);
+            }
         }
 
         if ($request->filled('category_id')) {


### PR DESCRIPTION
Saw this one come up in a rollbar with the error `InvalidArgumentException: Nested arrays may not be passed to whereIn method.`. The user was passing `/api/v1/hardware?limit=100&offset=0&sort=id&location_id=1&status_id=5&model_id[0]=251&model_id[1]=229&model_id[2]=2122&model_id[3]=253&model_id[4]=2105&model_id[5]=252&model_id[6]=1870&model_id[7]` to the API, and since we were already array-ifying the `$request->input('model_id')`, this was causing a nested array if you passed it more than one `model_id`.