### PR TITLE
Fixed #16475 - Allow deleting oauth client

### DIFF
--- a/app/Livewire/OauthClients.php
+++ b/app/Livewire/OauthClients.php
@@ -47,7 +47,7 @@ class OauthClients extends Component
     {
         // test for safety
         // ->delete must be of type Client - thus the model binding
-        if ($clientId->created_by == auth()->id()) {
+        if ($clientId->user_id == auth()->id()) {
             app(ClientRepository::class)->delete($clientId);
         } else {
             Log::warning('User ' . auth()->id() . ' attempted to delete client ' . $clientId->id . ' which belongs to user ' . $clientId->created_by);


### PR DESCRIPTION
This corrects a regression where we were looking for `created_at` on the `oauth_clients` table when that field does not exist. Fixes #16475.