### PR TITLE
Check for Printing Location Tags for Assets without Locations

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -140,7 +140,11 @@ class Label implements View
                                 $barcode2DTarget = $asset->serial; 
                                 break;
                             case 'location':
-                                $barcode2DTarget = route('locations.show', $asset->location_id);
+                                if ($asset->location_id) {
+                                    $barcode2DTarget = route('locations.show', $asset->location_id);
+                                } else {
+                                    return redirect()->back()->with('error', trans('admin/hardware/form.location_required'));
+                                }
                                 break;
                             case 'hardware_id':
                             default:

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -40,6 +40,15 @@ class Label implements View
         $assets = $this->data->get('assets');
         $offset = $this->data->get('offset');
 
+        // if you're printing location target tags, make sure the assets have locations if not redirect with error
+        if (($settings->label2_2d_target == 'location')) {
+            foreach ($assets as $asset) {
+                if (!$asset->location_id) {
+                    return redirect()->back()->with('error', trans('admin/labels/message.asset_no_location'));
+                }
+            }
+        }
+
 
         // If disabled, pass to legacy view
         if ((!$settings->label2_enable)) {
@@ -140,11 +149,7 @@ class Label implements View
                                 $barcode2DTarget = $asset->serial; 
                                 break;
                             case 'location':
-                                if ($asset->location_id) {
-                                    $barcode2DTarget = route('locations.show', $asset->location_id);
-                                } else {
-                                    return redirect()->back()->with('error', trans('admin/hardware/form.location_required'));
-                                }
+                                $barcode2DTarget = route('locations.show', $asset->location_id);
                                 break;
                             case 'hardware_id':
                             default:

--- a/resources/lang/en-US/admin/labels/message.php
+++ b/resources/lang/en-US/admin/labels/message.php
@@ -6,6 +6,8 @@ return [
     'invalid_return_type'  => 'Invalid type returned from :name. Expected :expected, got :actual.',
     'invalid_return_value' => 'Invalid value returned from :name. Expected :expected, got :actual.',
 
+    'asset_no_location' => 'You have selected to target your labels to locations, and one or more of the assets\' tags you\'re trying to print do not have a location.',
+
     'does_not_exist' => 'Label does not exist',
     
 ];


### PR DESCRIPTION
This adds a condition and redirect for when you've selected to print labels with the Location as the target, and one or any of the assets don't have a location. (I'm all for making that error clearer, that was the first thing I came up with and now I can't think of a better way to say it) 

fixes #SC-28974