### PR TITLE
Fixed Dark Mode color choices for fieldset links

### DIFF
--- a/resources/assets/less/skins/skin-blue-dark.less
+++ b/resources/assets/less/skins/skin-blue-dark.less
@@ -380,7 +380,7 @@ input[type=text], input[type=search] {
   background-color: var(--back-sub);
 }
 .table-striped>tbody>tr:nth-of-type(even){
-  background-color: var(--back-sub-alt);
+  background-color: var(--back-main);
 }
 #webui>div>div>div>div>div>table>tbody>tr>td>a>i.fa, .box-body, .box-footer, .box-header {
   color: var(--text-main);
@@ -404,7 +404,16 @@ a {
   }
 }
 #customFieldsTable a[href*='/models'] {
-  color: var(--back-sub);
+  background-color: var(--back-sub-alt);
+  color: var(--link);
+}
+#customFieldsTable a[href*='/models']:hover {
+  background-color: var(--text-sub);
+  color: var(--button-hover);
+}
+#customFieldsTable a[href*='/models']:visited {
+  background-color: var(--background);
+  color: var(--visited-link);
 }
 #customFieldsTable a[href*='/fieldsets']{
   background-color: transparent;

--- a/resources/assets/less/skins/skin-green-dark.less
+++ b/resources/assets/less/skins/skin-green-dark.less
@@ -391,7 +391,16 @@ a {
   }
 }
 #customFieldsTable a[href*='/models'] {
-  color: var(--back-sub);
+  background-color: var(--back-sub-alt);
+  color: var(--link);
+}
+#customFieldsTable a[href*='/models']:hover {
+  background-color: var(--text-sub);
+  color: var(--button-hover);
+}
+#customFieldsTable a[href*='/models']:visited {
+  background-color: var(--background);
+  color: var(--visited-link);
 }
 #customFieldsTable a[href*='/fieldsets']{
   background-color: transparent;

--- a/resources/assets/less/skins/skin-orange-dark.less
+++ b/resources/assets/less/skins/skin-orange-dark.less
@@ -389,7 +389,16 @@ input[type=text], input[type=search] {
   border-bottom: #000;
 }
 #customFieldsTable a[href*='/models'] {
-  color: var(--back-sub);
+  background-color: var(--back-sub-alt);
+  color: var(--link);
+}
+#customFieldsTable a[href*='/models']:hover {
+  background-color: var(--text-sub);
+  color: var(--button-hover);
+}
+#customFieldsTable a[href*='/models']:visited {
+  background-color: var(--background);
+  color: var(--visited-link);
 }
 #customFieldsTable a[href*='/fieldsets']{
   background-color: transparent;

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -414,6 +414,18 @@ a {
   display: table;
 
 }
+#customFieldsTable a[href*='/models'] {
+  background-color: var(--back-sub-alt);
+  color: var(--link);
+}
+#customFieldsTable a[href*='/models']:hover {
+  background-color: var(--text-sub);
+  color: var(--button-hover);
+}
+#customFieldsTable a[href*='/models']:visited {
+  background-color: var(--back-sub);
+  color: var(--visited-link);
+}
 
 .row-striped .row:nth-of-type(odd) div {
   background-color: var(--back-sub);

--- a/resources/assets/less/skins/skin-red-dark.less
+++ b/resources/assets/less/skins/skin-red-dark.less
@@ -409,7 +409,16 @@ a {
   }
 }
 #customFieldsTable a[href*='/models'] {
-  color: var(--back-sub);
+  background-color: var(--back-sub-alt);
+  color: var(--link);
+}
+#customFieldsTable a[href*='/models']:hover {
+  background-color: var(--text-sub);
+  color: var(--button-hover);
+}
+#customFieldsTable a[href*='/models']:visited {
+  background-color: var(--back-sub);
+  color: var(--visited-link);
 }
 #customFieldsTable a[href*='/fieldsets']{
   background-color: transparent;

--- a/resources/assets/less/skins/skin-yellow-dark.less
+++ b/resources/assets/less/skins/skin-yellow-dark.less
@@ -383,6 +383,18 @@ tr th div.th-inner {
 .box-header.with-border {
   border-bottom: #000;
 }
+#customFieldsTable a[href*='/models'] {
+  background-color: var(--back-sub-alt);
+  color: var(--link);
+}
+#customFieldsTable a[href*='/models']:hover {
+  background-color: var(--text-sub);
+  color: var(--button-hover);
+}
+#customFieldsTable a[href*='/models']:visited {
+  background-color: var(--background);
+  color: var(--visited-link);
+}
 
 .row-striped {
   vertical-align: top;


### PR DESCRIPTION
adds a color correction for the field set links:
<img width="853" alt="image" src="https://github.com/user-attachments/assets/00bc8588-e5f4-4445-90fb-0ff1b57f413a" />
<img width="853" alt="image" src="https://github.com/user-attachments/assets/bffde747-1312-431f-9c5d-4cdebdb89435" />
<img width="853" alt="image" src="https://github.com/user-attachments/assets/60931fad-a20e-4569-8455-3e51bf09e4f4" />
<img width="853" alt="image" src="https://github.com/user-attachments/assets/35294b90-7662-4681-acbf-6e038a884c01" />
<img width="853" alt="image" src="https://github.com/user-attachments/assets/6aa312e5-2157-4f2c-9bd2-335f0b825b98" />
<img width="853" alt="image" src="https://github.com/user-attachments/assets/d516aba3-3019-49a5-bc1c-2a38bc3a4642" />
[sc-28849]
