### PR TITLE
Handle category being null in CheckoutableListener

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -397,7 +397,7 @@ class CheckoutableListener
             default => null,
         };
 
-        if (!$category->checkin_email) {
+        if (!$category?->checkin_email) {
             return true;
         }
         return false;


### PR DESCRIPTION
This PR fixes a bug where we can run into attempting to check `checkin_email` on null.