### PR TITLE
[FIX] set upload-limit

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -101,8 +101,8 @@ chown -R docker:root /var/www/html/storage/framework/cache
 if [ -v "PHP_UPLOAD_LIMIT" ]
 then
     echo "Changing upload limit to ${PHP_UPLOAD_LIMIT}"
-    sed -i "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_LIMIT}M/" /etc/php/*/apache2/php.ini
-    sed -i "s/^post_max_size.*/post_max_size = ${PHP_UPLOAD_LIMIT}M/" /etc/php/*/apache2/php.ini
+    sed -i "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_LIMIT}M/" /etc/php*/php.ini
+    sed -i "s/^post_max_size.*/post_max_size = ${PHP_UPLOAD_LIMIT}M/" /etc/php*/php.ini
 fi
 
 # If the Oauth DB files are not present copy the vendor files over to the db migrations


### PR DESCRIPTION
Newer PHP-version store their ini-files like /etc/phpXY/... . This PR changes the syntax of sed in startup.sh to set the upload-limit correctly.
