### PR TITLE
Use fieldsets for branding page

### DIFF
--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -37,6 +37,20 @@
           ]
         },
         {
+          "url"     : "https://snipe-it.test/admin/branding",
+          "actions" : [
+            "navigate to https://snipe-it.test/admin/branding",
+            "screen capture tests/pa11y/admin-branding.png"
+          ]
+        },
+        {
+          "url"     : "https://snipe-it.test/admin/general",
+          "actions" : [
+            "navigate to https://snipe-it.test/admin/general",
+            "screen capture tests/pa11y/admin-general.png"
+          ]
+        },
+        {
           "url"     : "https://snipe-it.test/hardware/create",
           "actions" : [
             "navigate to https://snipe-it.test/hardware/create",
@@ -86,6 +100,27 @@
         ]
       },
       {
+        "url"     : "https://snipe-it.test/consumables",
+        "actions" : [
+          "navigate to https://snipe-it.test/consumables",
+          "screen capture tests/pa11y/consumable-list.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/consumables/create",
+        "actions" : [
+          "navigate to https://snipe-it.test/consumables/create",
+          "screen capture tests/pa11y/consumable-create.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/consumables/1",
+        "actions" : [
+          "navigate to https://snipe-it.test/consumables/1",
+          "screen capture tests/pa11y/consumable-view.png"
+        ]
+      },
+      {
         "url"     : "https://snipe-it.test/accessories",
         "actions" : [
           "navigate to https://snipe-it.test/accessories",
@@ -97,6 +132,108 @@
         "actions" : [
           "navigate to https://snipe-it.test/accessories/create",
           "screen capture tests/pa11y/accessory-create.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/accessories/1",
+        "actions" : [
+          "navigate to https://snipe-it.test/accessories/1",
+          "screen capture tests/pa11y/accessory-view.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/locations",
+        "actions" : [
+          "navigate to https://snipe-it.test/locations",
+          "screen capture tests/pa11y/location-list.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/locations/create",
+        "actions" : [
+          "navigate to https://snipe-it.test/locations/create",
+          "screen capture tests/pa11y/location-create.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/locations/1",
+        "actions" : [
+          "navigate to https://snipe-it.test/locations/1",
+          "screen capture tests/pa11y/location-view.png"
+        ]
+      },
+
+      {
+        "url"     : "https://snipe-it.test/models",
+        "actions" : [
+          "navigate to https://snipe-it.test/models",
+          "screen capture tests/pa11y/model-list.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/models/create",
+        "actions" : [
+          "navigate to https://snipe-it.test/models/create",
+          "screen capture tests/pa11y/model-create.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/models/1",
+        "actions" : [
+          "navigate to https://snipe-it.test/models/1",
+          "screen capture tests/pa11y/model-view.png"
+        ]
+      },
+
+      {
+        "url"     : "https://snipe-it.test/companies",
+        "actions" : [
+          "navigate to https://snipe-it.test/companies",
+          "screen capture tests/pa11y/company-list.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/companies/create",
+        "actions" : [
+          "navigate to https://snipe-it.test/companies/create",
+          "screen capture tests/pa11y/company-create.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/companies/1",
+        "actions" : [
+          "navigate to https://snipe-it.test/companies/1",
+          "screen capture tests/pa11y/company-view.png"
+        ]
+      },
+
+      {
+        "url"     : "https://snipe-it.test/departments",
+        "actions" : [
+          "navigate to https://snipe-it.test/departments",
+          "screen capture tests/pa11y/department-list.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/departments/create",
+        "actions" : [
+          "navigate to https://snipe-it.test/departments/create",
+          "screen capture tests/pa11y/department-create.png"
+        ]
+      },
+      {
+        "url"     : "https://snipe-it.test/departments/1",
+        "actions" : [
+          "navigate to https://snipe-it.test/departments/1",
+          "screen capture tests/pa11y/department-view.png"
+        ]
+      },
+
+      {
+        "url"     : "https://snipe-it.test/invalid-url",
+        "actions" : [
+          "navigate to https://snipe-it.test/invalid-url",
+          "screen capture tests/pa11y/404.png"
         ]
       }
     ]

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -462,7 +462,9 @@ return [
         'checkin' => 'Checkin Preferences',
         'dashboard' => 'Login & Dashboard Preferences',
         'misc' => 'Miscellaneous',
-
+        'logos' => 'Logos & Display',
+        'colors' => 'Colors & Skins',
+        'footer' => 'Footer Preferences',
     ],
 
 

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -16,7 +16,7 @@
   <div class="col-md-8 col-md-offset-2">
 
     <div style="padding-top: 200px">
-      <img src="{{ config('app.url') }}/img/sad-panda.png" style="width: 200px; height: 200px;" class="pull-left">
+      <img src="{{ config('app.url') }}/img/sad-panda.png" style="width: 200px; height: 200px;" class="pull-left" alt="Sad Panda cartoon" />
             <div class="error-content">
               <h2><x-icon type="warning" class="text-yellow" /> 404 Page not found.</h2>
               <p>

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -842,7 +842,7 @@
 
     function auditImageFormatter(value){
         if (value){
-            return '<a href="' + value.url + '" data-toggle="lightbox" data-type="image"><img src="' + value.url + '" style="max-height: {{ $snipeSettings->thumbnail_max_h }}px; width: auto;" class="img-responsive"></a>'
+            return '<a href="' + value.url + '" data-toggle="lightbox" data-type="image"><img src="' + value.url + '" style="max-height: {{ $snipeSettings->thumbnail_max_h }}px; width: auto;" class="img-responsive" alt=""></a>'
         }
     }
 
@@ -872,7 +872,7 @@
 
     function fileUploadFormatter(value) {
         if ((value) && (value.url) && (value.inlineable)) {
-            return '<a href="' + value.url + '" data-toggle="lightbox" data-type="image"><img src="' + value.url + '" style="max-height: {{ $snipeSettings->thumbnail_max_h }}px; width: auto;" class="img-responsive"></a>';
+            return '<a href="' + value.url + '" data-toggle="lightbox" data-type="image"><img src="' + value.url + '" style="max-height: {{ $snipeSettings->thumbnail_max_h }}px; width: auto;" class="img-responsive" alt=""></a>';
         } else if ((value) && (value.url)) {
             return '<a href="' + value.url + '" class="btn btn-default"><x-icon type="download" /></a>';
         }

--- a/resources/views/partials/forms/edit/uploadLogo.blade.php
+++ b/resources/views/partials/forms/edit/uploadLogo.blade.php
@@ -25,21 +25,24 @@
         </p>
 
         @if (config('app.lock_passwords')===true)
-            <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+            <p class="text-warning">
+                <x-icon type="locked" />
+                {{ trans('general.feature_disabled') }}</p>
         @endif
     </div>
 
     <div class="col-md-9 col-md-offset-3">
+
             @if (($setting->$logoVariable!='') && (Storage::disk('public')->exists(($logoPath ?? ''). $snipeSettings->$logoVariable)))
                 <div class="pull-left" style="padding-right: 20px;">
-                    <a href="{{ Storage::disk('public')->url(e(($logoPath ?? '').$snipeSettings->$logoVariable)) }}"{!! ($logoVariable!='favicon') ? ' data-toggle="lightbox"' : '' !!}>
-                        <img id="{{ $logoId }}-imagePreview" style="height: 80px; padding-bottom: 5px;" alt="" src="{{ Storage::disk('public')->url(e(($logoPath ?? ''). $snipeSettings->$logoVariable)) }}">
+                    <a href="{{ Storage::disk('public')->url(e(($logoPath ?? '').$snipeSettings->$logoVariable)) }}"{!! ($logoVariable!='favicon') ? ' data-toggle="lightbox"' : '' !!} title="Existing logo">
+                        <img style="height: 80px; padding-bottom: 5px;" alt="Current logo" src="{{ Storage::disk('public')->url(e(($logoPath ?? ''). $snipeSettings->$logoVariable)) }}">
                     </a>
                 </div>
             @endif
 
             <div id="{{ $logoId }}-previewContainer" style="display: none;">
-                <img id="{{ $logoId }}-imagePreview" style="height: 80px;">
+                <img id="{{ $logoId }}-imagePreview" style="height: 80px;" alt="Logo upload preview">
             </div>
 
 

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -51,338 +51,359 @@
 
                     <div class="col-md-12">
 
-                        <!-- Site name -->
-                        <div class="form-group {{ $errors->has('site_name') ? 'error' : '' }}">
+                        <fieldset name="logo-preferences" class="bottom-padded">
+                            <legend class="highlight">
+                                {{ trans('admin/settings/general.legends.logos') }}
+                            </legend>
 
-                            <div class="col-md-3">
-                                <label for="site_name">{{ trans('admin/settings/general.site_name') }}</label>
+                            <!-- Site name -->
+                            <div class="form-group {{ $errors->has('site_name') ? 'error' : '' }}">
+
+                                <div class="col-md-3">
+                                    <label for="site_name">{{ trans('admin/settings/general.site_name') }}</label>
+                                </div>
+                                <div class="col-md-7 required">
+                                    @if (config('app.lock_passwords')===true)
+                                        <input class="form-control" disabled="disabled" placeholder="Snipe-IT Asset Management" name="site_name" type="text" value="{{ old('site_name', $setting->site_name) }}" id="site_name">
+                                        <p class="text-warning">
+                                            <x-icon type="locked" />
+                                            {{ trans('general.feature_disabled') }}</p>
+                                    @else
+                                        <input class="form-control" placeholder="Snipe-IT Asset Management" required="required" name="site_name" type="text" value="{{ old('site_name', $setting->site_name) }}" id="site_name">
+                                    @endif
+                                    {!! $errors->first('site_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                </div>
                             </div>
-                            <div class="col-md-7 required">
-                                @if (config('app.lock_passwords')===true)
-                                    <input class="form-control" disabled="disabled" placeholder="Snipe-IT Asset Management" name="site_name" type="text" value="{{ old('site_name', $setting->site_name) }}" id="site_name">
-                                    <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-                                @else
-                                    <input class="form-control" placeholder="Snipe-IT Asset Management" required="required" name="site_name" type="text" value="{{ old('site_name', $setting->site_name) }}" id="site_name">
-                                @endif
-                                {!! $errors->first('site_name', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+
+                            @php
+                                $optionTypes = trans('admin/settings/general.logo_option_types');
+                            @endphp
+
+                            <!-- Branding -->
+                            <div class="form-group {{ $errors->has('brand') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="brand">{{ trans('admin/settings/general.web_brand') }}</label>
+                                </div>
+                                <div class="col-md-9">
+                                    <x-input.select
+                                        name="brand"
+                                        id="brand"
+                                        :options="[
+                                            '1' => trans('admin/settings/general.logo_option_types.text'),
+                                            '2' => trans('admin/settings/general.logo_option_types.logo'),
+                                            '3' => trans('admin/settings/general.logo_option_types.logo_and_text'),
+                                        ]"
+                                        :selected="old('brand', $setting->brand)"
+                                        class="form-control"
+                                        style="width: 150px"
+                                    />
+                                    {!! $errors->first('brand', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                </div>
                             </div>
-                        </div>
 
-                        @php
-                            $optionTypes = trans('admin/settings/general.logo_option_types');
-                        @endphp
+                            <!-- Logo -->
+                        @include('partials/forms/edit/uploadLogo', [
+                            "logoVariable" => "logo",
+                            "logoId" => "uploadLogo",
+                            "logoLabel" => trans('admin/settings/general.logo_labels.logo'),
+                            "logoClearVariable" => "clear_logo",
+                            "helpBlock" => trans('general.logo_size') . trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
+                        ])
 
-                        <!-- Branding -->
-                        <div class="form-group {{ $errors->has('brand') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="brand">{{ trans('admin/settings/general.web_brand') }}</label>
+                        <!-- Email Logo -->
+                        @include('partials/forms/edit/uploadLogo', [
+                            "logoVariable" => "email_logo",
+                            "logoId" => "uploadEmailLogo",
+                            "logoLabel" => trans('admin/settings/general.logo_labels.email_logo'),
+                            "logoClearVariable" => "clear_email_logo",
+                            "helpBlock" => trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
+                        ])
+
+                        <!-- Label Logo -->
+                        @include('partials/forms/edit/uploadLogo', [
+                            "logoVariable" => "label_logo",
+                            "logoId" => "uploadLabelLogo",
+                            "logoLabel" => trans('admin/settings/general.logo_labels.label_logo'),
+                            "logoClearVariable" => "clear_label_logo",
+                            "helpBlock" => trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
+                        ])
+
+                        <!-- PDF Logo -->
+                        @include('partials/forms/edit/uploadLogo', [
+                            "logoVariable" => "acceptance_pdf_logo",
+                            "logoId" => "acceptancePdfEmailLogo",
+                            "logoLabel" => trans('admin/settings/general.logo_labels.acceptance_pdf_logo'),
+                            "logoClearVariable" => "clear_acceptance_pdf_logo",
+                            "helpBlock" => trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
+                        ])
+
+                        <!-- Favicon -->
+                        @include('partials/forms/edit/uploadLogo', [
+                            "logoVariable" => "favicon",
+                            "logoId" => "uploadFavicon",
+                            "logoLabel" => trans('admin/settings/general.logo_labels.favicon'),
+                            "logoClearVariable" => "clear_favicon",
+                            "helpBlock" => trans('admin/settings/general.favicon_size') .' '. trans('admin/settings/general.favicon_format'),
+                            "allowedTypes" => "image/x-icon,image/gif,image/jpeg,image/png,image/svg,image/svg+xml,image/vnd.microsoft.icon",
+                            "maxSize" => 20000
+                        ])
+
+                        <!-- Default Avatar -->
+                        @include('partials/forms/edit/uploadLogo', [
+                            "logoVariable" => "default_avatar",
+                            "logoId" => "defaultAvatar",
+                            "logoLabel" => trans('admin/settings/general.default_avatar'),
+                            "logoClearVariable" => "clear_default_avatar",
+                            "logoPath" => "avatars/",
+                            "helpBlock" => trans('admin/settings/general.default_avatar_help').' '.trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
+                        ])
+
+                            @if (($setting->default_avatar == '') || (($setting->default_avatar == 'default.png') && (Storage::disk('public')->missing('default.png'))))
+                            <!-- Restore Default Avatar -->
+                            <div class="form-group">
+
+                                <div class="col-md-9 col-md-offset-3">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="restore_default_avatar" value="1" @checked(old('restore_default_avatar', $setting->restore_default_avatar)) />
+                                        <span>{!! trans('admin/settings/general.restore_default_avatar', ['default_avatar'=> Storage::disk('public')->url('default.png')]) !!}</span>
+                                    </label>
+                                    <p class="help-block">
+                                        {{ trans('admin/settings/general.restore_default_avatar_help') }}
+                                    </p>
+                                </div>
                             </div>
-                            <div class="col-md-9">
-                                <x-input.select
-                                    name="brand"
-                                    id="brand"
-                                    :options="[
-                                        '1' => trans('admin/settings/general.logo_option_types.text'),
-                                        '2' => trans('admin/settings/general.logo_option_types.logo'),
-                                        '3' => trans('admin/settings/general.logo_option_types.logo_and_text'),
-                                    ]"
-                                    :selected="old('brand', $setting->brand)"
-                                    class="form-control"
-                                    style="width: 150px"
-                                />
-                                {!! $errors->first('brand', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                            @endif
+
+                            <!-- Load gravatar -->
+                            <div class="form-group {{ $errors->has('load_remote') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <strong>{{ trans('admin/settings/general.load_remote') }}</strong>
+                                </div>
+                                <div class="col-md-9">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="load_remote" value="1" @checked(old('load_remote', $setting->load_remote)) />
+                                        {{ trans('general.yes') }}
+                                        {!! $errors->first('load_remote', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    </label>
+
+                                    <p class="help-block">
+                                        {{ trans('admin/settings/general.load_remote_help_text') }}
+                                    </p>
+
+                                </div>
                             </div>
-                        </div>
 
-                        <!-- Logo -->
-                    @include('partials/forms/edit/uploadLogo', [
-                        "logoVariable" => "logo",
-                        "logoId" => "uploadLogo",
-                        "logoLabel" => trans('admin/settings/general.logo_labels.logo'),
-                        "logoClearVariable" => "clear_logo",
-                        "helpBlock" => trans('general.logo_size') . trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
-                    ])
 
-                    <!-- Email Logo -->
-                    @include('partials/forms/edit/uploadLogo', [
-                        "logoVariable" => "email_logo",
-                        "logoId" => "uploadEmailLogo",
-                        "logoLabel" => trans('admin/settings/general.logo_labels.email_logo'),
-                        "logoClearVariable" => "clear_email_logo",
-                        "helpBlock" => trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
-                    ])
+                            <!-- Include logo in print assets -->
+                            <div class="form-group">
+                                <div class="col-md-3">
+                                    <strong>{{ trans('admin/settings/general.logo_print_assets') }}</strong>
+                                </div>
+                                <div class="col-md-9">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="logo_print_assets" value="1" @checked(old('logo_print_assets', $setting->logo_print_assets)) aria-label="logo_print_assets"/>
+                                    {{ trans('admin/settings/general.logo_print_assets_help') }}
+                                    </label>
 
-                    <!-- Label Logo -->
-                    @include('partials/forms/edit/uploadLogo', [
-                        "logoVariable" => "label_logo",
-                        "logoId" => "uploadLabelLogo",
-                        "logoLabel" => trans('admin/settings/general.logo_labels.label_logo'),
-                        "logoClearVariable" => "clear_label_logo",
-                        "helpBlock" => trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
-                    ])
-
-                    <!-- PDF Logo -->
-                    @include('partials/forms/edit/uploadLogo', [
-                        "logoVariable" => "acceptance_pdf_logo",
-                        "logoId" => "acceptancePdfEmailLogo",
-                        "logoLabel" => trans('admin/settings/general.logo_labels.acceptance_pdf_logo'),
-                        "logoClearVariable" => "clear_acceptance_pdf_logo",
-                        "helpBlock" => trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
-                    ])
-
-                    <!-- Favicon -->
-                    @include('partials/forms/edit/uploadLogo', [
-                        "logoVariable" => "favicon",
-                        "logoId" => "uploadFavicon",
-                        "logoLabel" => trans('admin/settings/general.logo_labels.favicon'),
-                        "logoClearVariable" => "clear_favicon",
-                        "helpBlock" => trans('admin/settings/general.favicon_size') .' '. trans('admin/settings/general.favicon_format'),
-                        "allowedTypes" => "image/x-icon,image/gif,image/jpeg,image/png,image/svg,image/svg+xml,image/vnd.microsoft.icon",
-                        "maxSize" => 20000
-                    ])
-
-                    <!-- Default Avatar -->
-                    @include('partials/forms/edit/uploadLogo', [
-                        "logoVariable" => "default_avatar",
-                        "logoId" => "defaultAvatar",
-                        "logoLabel" => trans('admin/settings/general.default_avatar'),
-                        "logoClearVariable" => "clear_default_avatar",
-                        "logoPath" => "avatars/",
-                        "helpBlock" => trans('admin/settings/general.default_avatar_help').' '.trans('general.image_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]),
-                    ])
-
-                        @if (($setting->default_avatar == '') || (($setting->default_avatar == 'default.png') && (Storage::disk('public')->missing('default.png'))))
-                        <!-- Restore Default Avatar -->
-                        <div class="form-group">
-
-                            <div class="col-md-9 col-md-offset-3">
-                                <label class="form-control">
-                                    <input type="checkbox" name="restore_default_avatar" value="1" @checked(old('restore_default_avatar', $setting->restore_default_avatar)) />
-                                    <span>{!! trans('admin/settings/general.restore_default_avatar', ['default_avatar'=> Storage::disk('public')->url('default.png')]) !!}</span>
-                                </label>
-                                <p class="help-block">
-                                    {{ trans('admin/settings/general.restore_default_avatar_help') }}
-                                </p>
+                                </div>
                             </div>
-                        </div>
-                        @endif
 
-                        <!-- Load gravatar -->
-                        <div class="form-group {{ $errors->has('load_remote') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <strong>{{ trans('admin/settings/general.load_remote') }}</strong>
+
+                            <!-- show urls in emails-->
+                            <div class="form-group">
+                                <div class="col-md-3">
+                                    <strong>{{ trans('admin/settings/general.show_url_in_emails') }}</strong>
+                                </div>
+                                <div class="col-md-9">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="show_url_in_emails" value="1" @checked(old('show_url_in_emails', $setting->show_url_in_emails)) aria-label="show_url_in_emails" />
+                                        {{ trans('general.yes') }}
+                                    </label>
+                                    <p class="help-block">{{ trans('admin/settings/general.show_url_in_emails_help_text') }}</p>
+                                </div>
                             </div>
-                            <div class="col-md-9">
-                                <label class="form-control">
-                                    <input type="checkbox" name="load_remote" value="1" @checked(old('load_remote', $setting->load_remote)) />
-                                    {{ trans('general.yes') }}
-                                    {!! $errors->first('load_remote', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                </label>
+                        </fieldset>
+                        <!-- colors and skins -->
 
-                                <p class="help-block">
-                                    {{ trans('admin/settings/general.load_remote_help_text') }}
-                                </p>
+                        <fieldset name="color-preferences" class="bottom-padded">
+                            <legend class="highlight">
+                                {{ trans('admin/settings/general.legends.colors') }}
+                            </legend>
 
+                            <!-- Header color -->
+                            <div class="form-group {{ $errors->has('header_color') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="header_color">{{ trans('admin/settings/general.header_color') }}</label>
+                                </div>
+                                <div class="col-md-2">
+                                    <div class="input-group header-color">
+                                        <input class="form-control" placeholder="#FF0000" aria-label="header_color" name="header_color" type="text" id="header_color" value="{{ old('header_color', ($setting->header_color ?? '#3c8dbc')) }}">
+                                        <div class="input-group-addon">
+                                            <i class="fa-solid fa-square" style="color: {{ old('header_color', ($setting->header_color ?? '#3c8dbc')) }}"></i>
+                                        </div>
+                                    </div><!-- /.input group -->
+                                    {!! $errors->first('header_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                </div>
                             </div>
-                        </div>
 
-
-                        <!-- Include logo in print assets -->
-                        <div class="form-group">
-                            <div class="col-md-3">
-                                <strong>{{ trans('admin/settings/general.logo_print_assets') }}</strong>
+                            <!-- Skin -->
+                            <div class="form-group {{ $errors->has('skin') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="skin">{{ trans('general.skin') }}</label>
+                                </div>
+                                <div class="col-md-9">
+                                    {!! Form::skin('skin', old('skin', $setting->skin), 'select2') !!}
+                                    {!! $errors->first('skin', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                </div>
                             </div>
-                            <div class="col-md-9">
-                                <label class="form-control">
-                                    <input type="checkbox" name="logo_print_assets" value="1" @checked(old('logo_print_assets', $setting->logo_print_assets)) aria-label="logo_print_assets"/>
-                                {{ trans('admin/settings/general.logo_print_assets_help') }}
-                                </label>
 
+                            <!-- Custom css -->
+                            <div class="form-group {{ $errors->has('custom_css') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="custom_css">{{ trans('admin/settings/general.custom_css') }}</label>
+                                </div>
+                                <div class="col-md-9">
+                                    @if (config('app.lock_passwords')===true)
+                                        <x-input.textarea
+                                            name="custom_css"
+                                            :value="old('custom_css', $setting->custom_css)"
+                                            placeholder="{{ trans('admin/settings/general.custom_css_placeholder') }}"
+                                            aria-label="custom_css"
+                                            disabled
+                                        />
+                                        {!! $errors->first('custom_css', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                    @else
+                                        <x-input.textarea
+                                            name="custom_css"
+                                            :value="old('custom_css', $setting->custom_css)"
+                                            placeholder="{{ trans('admin/settings/general.custom_css_placeholder') }}"
+                                            aria-label="custom_css"
+                                        />
+                                        {!! $errors->first('custom_css', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    @endif
+                                    <p class="help-block">{!! trans('admin/settings/general.custom_css_help') !!}</p>
+                                </div>
                             </div>
-                        </div>
+
+                            <!-- Allow User Skin -->
+                            <div class="form-group">
+                                <div class="col-md-9 col-md-offset-3">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="allow_user_skin" value="1" @checked(old('allow_user_skin', $setting->allow_user_skin))/>
+                                        {{ trans('admin/settings/general.allow_user_skin') }}
+                                    </label>
+                                    <p class="help-block">{{ trans('admin/settings/general.allow_user_skin_help_text') }}</p>
+                                </div>
+                            </div>
+
+                        </fieldset>
 
 
-                        <!-- show urls in emails-->
-                        <div class="form-group">
-                            <div class="col-md-3">
-                                <strong>{{ trans('admin/settings/general.show_url_in_emails') }}</strong>
-                            </div>
-                            <div class="col-md-9">
-                                <label class="form-control">
-                                    <input type="checkbox" name="show_url_in_emails" value="1" @checked(old('show_url_in_emails', $setting->show_url_in_emails)) aria-label="show_url_in_emails" />
-                                    {{ trans('general.yes') }}
-                                </label>
-                                <p class="help-block">{{ trans('admin/settings/general.show_url_in_emails_help_text') }}</p>
-                            </div>
-                        </div>
+                            <!-- colors and skins -->
 
-                        <!-- Header color -->
-                        <div class="form-group {{ $errors->has('header_color') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="header_color">{{ trans('admin/settings/general.header_color') }}</label>
-                            </div>
-                            <div class="col-md-2">
-                                <div class="input-group header-color">
-                                    <input class="form-control" style="width: 100px;" placeholder="#FF0000" aria-label="header_color" name="header_color" type="text" id="header_color" value="{{ old('header_color', $setting->header_color) }}">
-                                    <div class="input-group-addon">
-                                        <i></i>
+                            <fieldset name="footer-preferences" class="bottom-padded">
+                                <legend class="highlight">
+                                    {{ trans('admin/settings/general.legends.footer') }}
+                                </legend>
+
+                                <!-- Support Footer -->
+                                <div class="form-group {{ $errors->has('support_footer') ? 'error' : '' }}">
+                                    <div class="col-md-3">
+                                        <label for="support_footer">{{ trans('admin/settings/general.support_footer') }}</label>
                                     </div>
-                                </div><!-- /.input group -->
-                                {!! $errors->first('header_color', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                            </div>
-                        </div>
-
-                        <!-- Skin -->
-                        <div class="form-group {{ $errors->has('skin') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="skin">{{ trans('general.skin') }}</label>
-                            </div>
-                            <div class="col-md-9">
-                                {!! Form::skin('skin', old('skin', $setting->skin), 'select2') !!}
-                                {!! $errors->first('skin', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                            </div>
-                        </div>
-
-                        <!-- Allow User Skin -->
-                        <div class="form-group">
-                            <div class="col-md-3">
-                                <strong>{{ trans('admin/settings/general.allow_user_skin') }}</strong>
-                            </div>
-                            <div class="col-md-9">
-                                <label class="form-control">
-                                    <input type="checkbox" name="allow_user_skin" value="1" @checked(old('allow_user_skin', $setting->allow_user_skin))/>
-                                    {{ trans('general.yes') }}
-                                </label>
-                                <p class="help-block">{{ trans('admin/settings/general.allow_user_skin_help_text') }}</p>
-                            </div>
-                        </div>
-
-                        <!-- Custom css -->
-                        <div class="form-group {{ $errors->has('custom_css') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="custom_css">{{ trans('admin/settings/general.custom_css') }}</label>
-                            </div>
-                            <div class="col-md-9">
-                                @if (config('app.lock_passwords')===true)
-                                    <x-input.textarea
-                                        name="custom_css"
-                                        :value="old('custom_css', $setting->custom_css)"
-                                        placeholder="{{ trans('admin/settings/general.custom_css_placeholder') }}"
-                                        aria-label="custom_css"
-                                        disabled
-                                    />
-                                    {!! $errors->first('custom_css', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                    <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-                                @else
-                                    <x-input.textarea
-                                        name="custom_css"
-                                        :value="old('custom_css', $setting->custom_css)"
-                                        placeholder="{{ trans('admin/settings/general.custom_css_placeholder') }}"
-                                        aria-label="custom_css"
-                                    />
-                                    {!! $errors->first('custom_css', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                @endif
-                                <p class="help-block">{!! trans('admin/settings/general.custom_css_help') !!}</p>
-                            </div>
-                        </div>
+                                    <div class="col-md-9">
+                                        @if (config('app.lock_passwords')===true)
+                                            <x-input.select
+                                                name="support_footer"
+                                                id="support_footer"
+                                                :options="['on' => trans('admin/settings/general.enabled'), 'off' => trans('admin/settings/general.two_factor_disabled'), 'admin' => trans('admin/settings/general.super_admin_only')]"
+                                                :selected="old('support_footer', $setting->support_footer)"
+                                                disabled
+                                                class="form-control disabled"
+                                                style="width: 150px"
+                                            />
+                                            <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                        @else
+                                            <x-input.select
+                                                name="support_footer"
+                                                id="support_footer"
+                                                :options="['on' => trans('admin/settings/general.enabled'), 'off' => trans('admin/settings/general.two_factor_disabled'), 'admin' => trans('admin/settings/general.super_admin_only')]"
+                                                :selected="old('support_footer', $setting->support_footer)"
+                                                class="form-control"
+                                                style="width: 150px"
+                                            />
+                                        @endif
 
 
-                        <!-- Support Footer -->
-                        <div class="form-group {{ $errors->has('support_footer') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="support_footer">{{ trans('admin/settings/general.support_footer') }}</label>
-                            </div>
-                            <div class="col-md-9">
-                                @if (config('app.lock_passwords')===true)
-                                    <x-input.select
-                                        name="support_footer"
-                                        id="support_footer"
-                                        :options="['on' => trans('admin/settings/general.enabled'), 'off' => trans('admin/settings/general.two_factor_disabled'), 'admin' => trans('admin/settings/general.super_admin_only')]"
-                                        :selected="old('support_footer', $setting->support_footer)"
-                                        disabled
-                                        class="form-control disabled"
-                                        style="width: 150px"
-                                    />
-                                    <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-                                @else
-                                    <x-input.select
-                                        name="support_footer"
-                                        id="support_footer"
-                                        :options="['on' => trans('admin/settings/general.enabled'), 'off' => trans('admin/settings/general.two_factor_disabled'), 'admin' => trans('admin/settings/general.super_admin_only')]"
-                                        :selected="old('support_footer', $setting->support_footer)"
-                                        class="form-control"
-                                        style="width: 150px"
-                                    />
-                                @endif
+                                        {!! $errors->first('support_footer', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    </div>
+                                </div>
 
 
-                                {!! $errors->first('support_footer', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                            </div>
-                        </div>
+                                <!-- Version Footer -->
+                                <div class="form-group {{ $errors->has('version_footer') ? 'error' : '' }}">
+                                    <div class="col-md-3">
+                                        <label for="version_footer">{{ trans('admin/settings/general.version_footer') }}</label>
+                                    </div>
+                                    <div class="col-md-9">
+                                        @if (config('app.lock_passwords')===true)
+                                            <x-input.select
+                                                name="version_footer"
+                                                id="version_footer"
+                                                :options="['on' => trans('admin/settings/general.enabled'), 'off' => trans('admin/settings/general.two_factor_disabled'), 'admin' => trans('admin/settings/general.super_admin_only')]"
+                                                :selected="old('version_footer', $setting->version_footer)"
+                                                disabled
+                                                class="form-control disabled"
+                                                style="width: 150px"
+                                            />
+                                            <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                        @else
+                                            <x-input.select
+                                                name="version_footer"
+                                                id="version_footer"
+                                                :options="['on' => trans('admin/settings/general.enabled'), 'off' => trans('admin/settings/general.two_factor_disabled'), 'admin' => trans('admin/settings/general.super_admin_only')]"
+                                                :selected="old('version_footer', $setting->version_footer)"
+                                                class="form-control"
+                                                style="width: 150px"
+                                            />
+                                        @endif
 
+                                        <p class="help-block">{{ trans('admin/settings/general.version_footer_help') }}</p>
+                                        {!! $errors->first('version_footer', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    </div>
+                                </div>
 
-                        <!-- Version Footer -->
-                        <div class="form-group {{ $errors->has('version_footer') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="version_footer">{{ trans('admin/settings/general.version_footer') }}</label>
-                            </div>
-                            <div class="col-md-9">
-                                @if (config('app.lock_passwords')===true)
-                                    <x-input.select
-                                        name="version_footer"
-                                        id="version_footer"
-                                        :options="['on' => trans('admin/settings/general.enabled'), 'off' => trans('admin/settings/general.two_factor_disabled'), 'admin' => trans('admin/settings/general.super_admin_only')]"
-                                        :selected="old('version_footer', $setting->version_footer)"
-                                        disabled
-                                        class="form-control disabled"
-                                        style="width: 150px"
-                                    />
-                                    <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-                                @else
-                                    <x-input.select
-                                        name="version_footer"
-                                        id="version_footer"
-                                        :options="['on' => trans('admin/settings/general.enabled'), 'off' => trans('admin/settings/general.two_factor_disabled'), 'admin' => trans('admin/settings/general.super_admin_only')]"
-                                        :selected="old('version_footer', $setting->version_footer)"
-                                        class="form-control"
-                                        style="width: 150px"
-                                    />
-                                @endif
+                                <!-- Additional footer -->
+                                <div class="form-group {{ $errors->has('footer_text') ? 'error' : '' }}">
+                                    <div class="col-md-3">
+                                        <label for="footer_text">{{ trans('admin/settings/general.footer_text') }}</label>
+                                    </div>
+                                    <div class="col-md-9">
+                                        @if (config('app.lock_passwords')===true)
+                                            <x-input.textarea
+                                                name="footer_text"
+                                                :value="old('footer_text', $setting->footer_text)"
+                                                rows="4"
+                                                aria-labelledby="footer_text"
+                                                placeholder="{{ trans('admin/settings/general.footer_text_placeholder') }}"
+                                                disabled
+                                            />
+                                            <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                        @else
+                                            <x-input.textarea
+                                                name="footer_text"
+                                                :value="old('footer_text', $setting->footer_text)"
+                                                rows="4"
+                                                placeholder="{{ trans('admin/settings/general.footer_text_placeholder') }}"
+                                            />
+                                        @endif
+                                        <p class="help-block">{!! trans('admin/settings/general.footer_text_help') !!}</p>
+                                        {!! $errors->first('footer_text', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
 
-                                <p class="help-block">{{ trans('admin/settings/general.version_footer_help') }}</p>
-                                {!! $errors->first('version_footer', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                            </div>
-                        </div>
-
-                        <!-- Additional footer -->
-                        <div class="form-group {{ $errors->has('footer_text') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="footer_text">{{ trans('admin/settings/general.footer_text') }}</label>
-                            </div>
-                            <div class="col-md-9">
-                                @if (config('app.lock_passwords')===true)
-                                    <x-input.textarea
-                                        name="footer_text"
-                                        :value="old('footer_text', $setting->footer_text)"
-                                        rows="4"
-                                        placeholder="{{ trans('admin/settings/general.footer_text_placeholder') }}"
-                                        disabled
-                                    />
-                                    <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-                                @else
-                                    <x-input.textarea
-                                        name="footer_text"
-                                        :value="old('footer_text', $setting->footer_text)"
-                                        rows="4"
-                                        placeholder="{{ trans('admin/settings/general.footer_text_placeholder') }}"
-                                    />
-                                @endif
-                                <p class="help-block">{!! trans('admin/settings/general.footer_text_help') !!}</p>
-                                {!! $errors->first('footer_text', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-
-                            </div>
-                        </div>
-
+                                    </div>
+                                </div>
+                            </fieldset>
 
 
 


### PR DESCRIPTION
This applies the new fieldset style for the branding settings page, and also adds some small improvements for a11y and pa11y configuration. 

![FireShot Capture 005 - Update Branding Settings __ Snipe-IT Demo - snipe-it test](https://github.com/user-attachments/assets/baf5dd40-e49b-43d2-88ae-ff462547417e)
