### PR TITLE
Fixed #15007 - Maintain checkbox and radio custom field values on asset edit page

### DIFF
--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -221,6 +221,17 @@
                     //now re-populate the custom fields based on the previously saved values
                     $('#custom_fields_content').find('input,select').each(function (index,elem) {
                         if(transformed_oldvals[elem.name]) {
+                            if (elem.type === 'checkbox' || elem.type === 'radio'){
+                                let shouldBeChecked = oldvals.find(oldValElement => {
+                                    return oldValElement.name === elem.name && oldValElement.value === $(elem).val();
+                                });
+
+                                if (shouldBeChecked){
+                                    $(elem).prop('checked', true);
+                                }
+
+                                return;
+                            }
                              {{-- If there already *is* is a previously-input 'transformed_oldvals' handy,
                                   overwrite with that previously-input value *IF* this is an edit of an existing item *OR*
                                   if there is no new default custom field value coming from the model --}}


### PR DESCRIPTION
This PR builds on the work done in #11160 and addresses #15007 by maintaining checkbox and radio values when switching between asset models on the asset edit screen.

<details><summary>Previously: switching between asset models would clear selected checkbox and radio values</summary>
<p>

![previous behavior](https://github.com/user-attachments/assets/ba5da45e-053c-461c-bfe8-e073cefeae5d)

</p>
</details> 

<details><summary>With this PR: the checkbox and radio values are maintained</summary>
<p>

![new behavior](https://github.com/user-attachments/assets/a43c3c55-7c17-4201-bb21-781136ba7927)

</p>
</details> 