### PR TITLE
Fixed label fields multiple option alignment bug

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -177,13 +177,9 @@ class Label implements View
                                 // The end result of this will be in this format:
                                 // {labelOne} {valueOne} | {labelTwo} {valueTwo} | {labelThree} {valueThree}
                                 $previous['value'] = trim(implode(' | ', [
-                                    implode(' ', [$previous['label'], $previous['value']]),
+                                    implode(' ', [null, $previous['value']]),
                                     implode(' ', [$current['label'], $current['value']]),
                                 ]));
-
-                                // We'll set the label to an empty string since we
-                                // injected the label into the value field above.
-                                $previous['label'] = '';
 
                                 return $previous;
                             });


### PR DESCRIPTION
This fixes the indent of the label field when there are multiple options added.
The `$previous['label']` was being added to the field value and showing as blankspace, this fix sets the previous label to `null` removing the indent.

Other labels work as intended still.

Fixes: #16812
Before:
![image](https://github.com/user-attachments/assets/c6c78a3b-98eb-43e3-ad12-da7734110ae4)

After:
**
<img width="727" alt="image" src="https://github.com/user-attachments/assets/6b3441b9-7d14-4fa4-847e-5e4363df4506" />
**