### PR TITLE
Replaced calls to Form::radio helper on user create and edit pages

### DIFF
--- a/resources/views/partials/forms/edit/permissions-base.blade.php
+++ b/resources/views/partials/forms/edit/permissions-base.blade.php
@@ -124,11 +124,15 @@
             />
           </td>
           <td class="col-md-1 permissions-item">
-            @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-              {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ["value"=>"inherit", 'disabled'=>'disabled', 'class'=>'radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
-            @else
-              {{ Form::radio('permission['.$permission['permission'].']', '0', $userPermissions[$permission['permission']] =='0', ["value"=>"inherit", 'class'=>'radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
-            @endif
+            <input
+                value="0"
+                class="radiochecker-{{ str_slug($area) }}"
+                aria-label="permission[{{ $permission['permission'] }}]"
+                @checked($userPermissions[$permission['permission']] =='0')
+                @disabled(($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+                name="permission[{{ $permission['permission'] }}]"
+                type="radio"
+            />
           </td>
         @endif
       </tr>

--- a/resources/views/partials/forms/edit/permissions-base.blade.php
+++ b/resources/views/partials/forms/edit/permissions-base.blade.php
@@ -37,11 +37,11 @@
           />
         @else
           <input
-              value="1"
               aria-label="permission[{{ $localPermission['permission'] }}]"
               @checked($userPermissions[$localPermission['permission']] == '1')
               name="permission[{{ $localPermission['permission'] }}]"
               type="radio"
+              value="1"
           />
         @endif
 
@@ -50,11 +50,31 @@
       <td class="col-md-1 permissions-item">
         <label class="sr-only" for="{{ 'permission['.$localPermission['permission'].']' }}">{{ 'permission['.$localPermission['permission'].']' }}</label>
         @if (($localPermission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-          {{ Form::radio('permission['.$localPermission['permission'].']', '-1',$userPermissions[$localPermission['permission'] ] == '-1',['disabled'=>"disabled", 'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+          <input
+              disabled="disabled"
+              aria-label="permission[{{ $localPermission['permission'] }}]"
+              @checked($userPermissions[$localPermission['permission']] == '-1')
+              name="permission[{{ $localPermission['permission'] }}]"
+              type="radio"
+              value="-1"
+          />
         @elseif (($localPermission['permission'] == 'admin') && (!Auth::user()->hasAccess('admin')))
-          {{ Form::radio('permission['.$localPermission['permission'].']', '-1',$userPermissions[$localPermission['permission'] ] == '-1',['disabled'=>"disabled", 'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+          <input
+              disabled="disabled"
+              aria-label="permission[{{ $localPermission['permission'] }}]"
+              @checked($userPermissions[$localPermission['permission']] == '-1')
+              name="permission[{{ $localPermission['permission'] }}]"
+              type="radio"
+              value="-1"
+          />
         @else
-          {{ Form::radio('permission['.$localPermission['permission'].']', '-1',$userPermissions[$localPermission['permission'] ] == '-1',['value'=>"deny",   'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+          <input
+              aria-label="permission[{{ $localPermission['permission'] }}]"
+              @checked($userPermissions[$localPermission['permission']] == '-1')
+              name="permission[{{ $localPermission['permission'] }}]"
+              type="radio"
+              value="-1"
+          />
         @endif
       </td>
       <td class="col-md-1 permissions-item">

--- a/resources/views/partials/forms/edit/permissions-base.blade.php
+++ b/resources/views/partials/forms/edit/permissions-base.blade.php
@@ -113,11 +113,15 @@
             />
           </td>
           <td class="col-md-1 permissions-item">
-            @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-              {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ["value"=>"deny", 'disabled'=>'disabled', 'class'=>'radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
-            @else
-              {{ Form::radio('permission['.$permission['permission'].']', '-1', $userPermissions[$permission['permission'] ] == '-1', ["value"=>"deny",'class'=>'radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
-            @endif
+            <input
+                value="-1"
+                class="radiochecker-{{ str_slug($area) }}"
+                aria-label="permission[{{ $permission['permission'] }}]"
+                @checked($userPermissions[$permission['permission']] == '-1')
+                @disabled(($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+                name="permission[{{ $permission['permission'] }}]"
+                type="radio"
+            />
           </td>
           <td class="col-md-1 permissions-item">
             @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))

--- a/resources/views/partials/forms/edit/permissions-base.blade.php
+++ b/resources/views/partials/forms/edit/permissions-base.blade.php
@@ -18,11 +18,31 @@
       <td class="col-md-1 permissions-item">
         <label class="sr-only" for="{{ 'permission['.$localPermission['permission'].']' }}">{{ 'permission['.$localPermission['permission'].']' }}</label>
         @if (($localPermission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-          {{ Form::radio('permission['.$localPermission['permission'].']', '1',$userPermissions[$localPermission['permission'] ] == '1',['disabled'=>"disabled", 'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+          <input
+              disabled="disabled"
+              aria-label="permission[{{ $localPermission['permission'] }}]"
+              @checked($userPermissions[$localPermission['permission']] == '1')
+              name="permission[{{ $localPermission['permission'] }}]"
+              type="radio"
+              value="1"
+          />
         @elseif (($localPermission['permission'] == 'admin') && (!Auth::user()->hasAccess('admin')))
-          {{ Form::radio('permission['.$localPermission['permission'].']', '1',$userPermissions[$localPermission['permission'] ] == '1',['disabled'=>"disabled", 'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+          <input
+              disabled="disabled"
+              aria-label="permission[{{ $localPermission['permission'] }}]"
+              @checked($userPermissions[$localPermission['permission']] == '1')
+              name="permission[{{ $localPermission['permission'] }}]"
+              type="radio"
+              value="1"
+          />
         @else
-          {{ Form::radio('permission['.$localPermission['permission'].']', '1',$userPermissions[$localPermission['permission'] ] == '1',['value'=>"grant",  'aria-label'=> 'permission['.$localPermission['permission'].']']) }}
+          <input
+              value="1"
+              aria-label="permission[{{ $localPermission['permission'] }}]"
+              @checked($userPermissions[$localPermission['permission']] == '1')
+              name="permission[{{ $localPermission['permission'] }}]"
+              type="radio"
+          />
         @endif
 
         

--- a/resources/views/partials/forms/edit/permissions-base.blade.php
+++ b/resources/views/partials/forms/edit/permissions-base.blade.php
@@ -59,15 +59,33 @@
       </td>
       <td class="col-md-1 permissions-item">
         <label for="{{ $area }}" class="sr-only">{{ $area }}</label>
-        {{ Form::radio("$area", '1',false,['value'=>"grant", 'data-checker-group' => str_slug($area), 'aria-label' => $area]) }}
+        <input
+            value="1"
+            data-checker-group="{{ str_slug($area) }}"
+            aria-label="{{ $area }}"
+            name="{{ $area }}"
+            type="radio"
+        />
       </td>
       <td class="col-md-1 permissions-item">
         <label for="{{ $area }}" class="sr-only">{{ $area }}</label>
-        {{ Form::radio("$area", '-1',false,['value'=>"deny", 'data-checker-group' => str_slug($area), 'aria-label' => $area]) }}
+        <input
+            value="-1"
+            data-checker-group="{{ str_slug($area) }}"
+            aria-label="{{ $area }}"
+            name="{{ $area }}"
+            type="radio"
+        />
       </td>
       <td class="col-md-1 permissions-item">
         <label for="{{ $area }}" class="sr-only">{{ $area }}</label>
-        {{ Form::radio("$area", '0',false,['value'=>"inherit", 'data-checker-group' => str_slug($area), 'aria-label' => $area] ) }}
+        <input
+            value="0"
+            data-checker-group="{{ str_slug($area) }}"
+            aria-label="{{ $area }}"
+            name="{{ $area }}"
+            type="radio"
+        />
       </td>
     </tr>
 

--- a/resources/views/partials/forms/edit/permissions-base.blade.php
+++ b/resources/views/partials/forms/edit/permissions-base.blade.php
@@ -102,12 +102,15 @@
           </td>
           <td class="col-md-1 permissions-item">
             <label class="sr-only" for="{{ 'permission['.$permission['permission'].']' }}">{{ 'permission['.$permission['permission'].']' }}</label>
-
-            @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-              {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[$permission['permission'] ] == '1', ["value"=>"grant", 'disabled'=>'disabled', 'class'=>'radiochecker-'.str_slug($area), 'aria-label'=>'permission['.$permission['permission'].']']) }}
-            @else
-              {{ Form::radio('permission['.$permission['permission'].']', '1', $userPermissions[ $permission['permission'] ] == '1', ["value"=>"grant",'class'=>'radiochecker-'.str_slug($area), 'aria-label' =>'permission['.$permission['permission'].']']) }}
-            @endif
+            <input
+                value="1"
+                class="radiochecker-{{ str_slug($area) }}"
+                aria-label="permission[{{ $permission['permission'] }}]"
+                @checked($userPermissions[$permission['permission']] == '1')
+                @disabled(($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
+                name="permission[{{ $permission['permission'] }}]"
+                type="radio"
+            />
           </td>
           <td class="col-md-1 permissions-item">
             @if (($permission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))

--- a/resources/views/partials/forms/edit/permissions-base.blade.php
+++ b/resources/views/partials/forms/edit/permissions-base.blade.php
@@ -81,11 +81,31 @@
         <label class="sr-only" for="{{ 'permission['.$localPermission['permission'].']' }}">
            {{ 'permission['.$localPermission['permission'].']' }}</label>
         @if (($localPermission['permission'] == 'superuser') && (!Auth::user()->isSuperUser()))
-          {{ Form::radio('permission['.$localPermission['permission'].']','0',$userPermissions[$localPermission['permission'] ] == '0',['disabled'=>"disabled", 'aria-label'=> 'permission['.$localPermission['permission'].']'] ) }}
+          <input
+              disabled="disabled"
+              aria-label="permission[{{ $localPermission['permission'] }}]"
+              @checked($userPermissions[$localPermission['permission']] == '0')
+              name="permission[{{ $localPermission['permission'] }}]"
+              type="radio"
+              value="0"
+          />
         @elseif (($localPermission['permission'] == 'admin') && (!Auth::user()->hasAccess('admin')))
-          {{ Form::radio('permission['.$localPermission['permission'].']','0',$userPermissions[$localPermission['permission'] ] == '0',['disabled'=>"disabled", 'aria-label'=> 'permission['.$localPermission['permission'].']'] ) }}
+          <input
+              disabled="disabled"
+              aria-label="permission[{{ $localPermission['permission'] }}]"
+              @checked($userPermissions[$localPermission['permission']] == '0')
+              name="permission[{{ $localPermission['permission'] }}]"
+              type="radio"
+              value="0"
+          />
         @else
-          {{ Form::radio('permission['.$localPermission['permission'].']','0',$userPermissions[$localPermission['permission'] ] == '0',['value'=>"inherit",   'aria-label'=> 'permission['.$localPermission['permission'].']'] ) }}
+          <input
+              aria-label="permission[{{ $localPermission['permission'] }}]"
+              @checked($userPermissions[$localPermission['permission']] == '0')
+              name="permission[{{ $localPermission['permission'] }}]"
+              type="radio"
+              value="0"
+          />
         @endif
       </td>
     </tr>


### PR DESCRIPTION
This PR replaces calls to `Form::radio` on the user create/edit pages with plain html.

The dynamic nature of the inputs made these replacements a little more difficult but I checked the changes via a bunch of diff checking on what is rendered to the browser as well as manual testing.