### PR TITLE
Use default BS tables “no results” view, small UI formatting improvements

### DIFF
--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -465,6 +465,9 @@ return [
         'logos' => 'Logos & Display',
         'colors' => 'Colors & Skins',
         'footer' => 'Footer Preferences',
+        'security' => 'Security Preferences',
+        'general' => 'General',
+        'intervals' => 'Intervals & Thresholds',
     ],
 
 

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -38,129 +38,147 @@
                 </div>
                 <div class="box-body">
 
+                    <div class="col-md-12">
 
-                    <div class="col-md-11 col-md-offset-1">
 
-                        <!-- Alerts Enabled -->
-                        <div class="form-group {{ $errors->has('alerts_enabled') ? 'error' : '' }}">
-                            <div class="col-md-9 col-md-offset-3">
-                                <label class="form-control">
-                                    <input type="checkbox" name="alerts_enabled" value="1" @checked(old('alerts_enabled', $setting->alerts_enabled))>
-                                    {{  trans('admin/settings/general.alerts_enabled') }}
-                                </label>
+                        <fieldset name="remote-login" class="bottom-padded">
+                            <legend class="highlight">
+                                {{ trans('admin/settings/general.legends.general') }}
+                            </legend>
+
+                            <!-- Menu Alerts Enabled -->
+                            <div class="form-group {{ $errors->has('show_alerts_in_menu') ? 'error' : '' }}">
+                                <div class="col-md-9 col-md-offset-3">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="show_alerts_in_menu" value="1" @checked(old('show_alerts_in_menu', $setting->show_alerts_in_menu))>
+                                        {{ trans('admin/settings/general.show_alerts_in_menu') }}
+                                    </label>
+                                </div>
                             </div>
+
+                            <!-- Alerts Enabled -->
+                            <div class="form-group {{ $errors->has('alerts_enabled') ? 'error' : '' }}">
+                                <div class="col-md-9 col-md-offset-3">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="alerts_enabled" value="1" @checked(old('alerts_enabled', $setting->alerts_enabled))>
+                                        {{  trans('admin/settings/general.alerts_enabled') }}
+                                    </label>
+                                </div>
+                            </div>
+
+                        </fieldset>
+
+                        <fieldset name="remote-login" class="bottom-padded">
+                            <legend class="highlight">
+                                {{ trans('admin/settings/general.legends.email') }}
+                            </legend>
+
+                            <!-- Alert Email -->
+                            <div class="form-group {{ $errors->has('alert_email') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="alert_email">{{ trans('admin/settings/general.alert_email') }}</label>
+                                </div>
+                                <div class="col-md-7">
+                                    <input type="text" name="alert_email" value="{{ old('alert_email', $setting->alert_email) }}" class="form-control" placeholder="admin@yourcompany.com,it@yourcompany.com" maxlength="191">
+                                    {!! $errors->first('alert_email', '<span class="alert-msg" aria-hidden="true">:message</span><br>') !!}
+                                    <p class="help-block">{{ trans('admin/settings/general.alert_email_help') }}</p>
+
+                                </div>
+                            </div>
+
+
+                            <!-- Admin CC Email -->
+                            <div class="form-group {{ $errors->has('admin_cc_email') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="admin_cc_email">{{ trans('admin/settings/general.admin_cc_email') }}</label>
+                                </div>
+                                <div class="col-md-7">
+                                    <input type="email" name="admin_cc_email" value="{{ old('admin_cc_email', $setting->admin_cc_email) }}" class="form-control" placeholder="admin@yourcompany.com" maxlength="191">
+                                    {!! $errors->first('admin_cc_email', '<span class="alert-msg" aria-hidden="true">:message</span><br>') !!}
+                                    <p class="help-block">{{ trans('admin/settings/general.admin_cc_email_help') }}</p>
+
+
+                                </div>
+                            </div>
+                        </fieldset>
+
+                        <fieldset name="remote-login" class="bottom-padded">
+                            <legend class="highlight">
+                                {{ trans('admin/settings/general.legends.intervals') }}
+                            </legend>
+
+
+                            <!-- Alert interval -->
+                            <div class="form-group {{ $errors->has('alert_interval') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="alert_interval">{{ trans('admin/settings/general.alert_interval') }}</label>
+                                </div>
+                                <div class="col-md-9">
+                                    <input class="form-control" placeholder="30" maxlength="3" style="width: 70px;" name="alert_interval" type="number" value="{{ old('alert_interval', $setting->alert_interval) }}" id="alert_interval">
+                                    {!! $errors->first('alert_interval', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                </div>
+                            </div>
+
+                            <!-- Alert threshold -->
+                            <div class="form-group {{ $errors->has('alert_threshold') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="alert_threshold">{{ trans('admin/settings/general.alert_inv_threshold') }}</label>
+                                </div>
+                                <div class="col-md-8">
+                                    <input class="form-control" placeholder="5" maxlength="3" style="width: 70px;" name="alert_threshold" type="number" value="{{ old('alert_threshold', $setting->alert_threshold) }}" id="alert_threshold">
+                                    {!! $errors->first('alert_threshold', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                </div>
+                            </div>
+
+
+                            <!-- Audit interval -->
+                            <div class="form-group {{ $errors->has('audit_interval') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="audit_interval">{{ trans('admin/settings/general.audit_interval') }}</label>
+                                </div>
+                                <div class="input-group col-xs-10 col-sm-6 col-md-6 col-lg-2 col-xl-2">
+                                    <input class="form-control" placeholder="12" maxlength="3" name="audit_interval" type="number" id="audit_interval" value="{{ old('audit_interval', $setting->audit_interval) }}">
+                                    <span class="input-group-addon">{{ trans('general.months') }}</span>
+                                </div>
+                                <div class="col-md-8 col-md-offset-3">
+                                    {!! $errors->first('audit_interval', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    <p class="help-block">{{ trans('admin/settings/general.audit_interval_help') }}</p>
+                                </div>
+                            </div>
+
+                            <!-- Alert threshold -->
+                            <div class="form-group {{ $errors->has('audit_warning_days') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="audit_warning_days">{{ trans('admin/settings/general.audit_warning_days') }}</label>
+                                </div>
+                                <div class="input-group col-xs-10 col-sm-6 col-md-4 col-lg-2 col-xl-2">
+                                    <input class="form-control" placeholder="14" maxlength="3" name="audit_warning_days" type="number" id="audit_warning_days" value="{{ old('audit_warning_days', $setting->audit_warning_days) }}">
+                                    <span class="input-group-addon">{{ trans('general.days') }}</span>
+                                </div>
+                                <div class="col-md-8 col-md-offset-3">
+                                    {!! $errors->first('audit_warning_days', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    <p class="help-block">{{ trans('admin/settings/general.audit_warning_days_help') }}</p>
+                                </div>
+                            </div>
+
+                            <!-- Due for checkin days -->
+                            <div class="form-group {{ $errors->has('due_checkin_days') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="due_checkin_days">{{ trans('admin/settings/general.due_checkin_days') }}</label>
+                                </div>
+                                <div class="input-group col-xs-10 col-sm-6 col-md-4 col-lg-2 col-xl-2">
+                                    <input class="form-control" placeholder="14" maxlength="3" name="due_checkin_days" type="number" id="due_checkin_days" value="{{ old('due_checkin_days', $setting->due_checkin_days) }}">
+                                    <span class="input-group-addon">{{ trans('general.days') }}</span>
+                                </div>
+                                <div class="col-md-8 col-md-offset-3">
+                                    {!! $errors->first('due_checkin_days', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    <p class="help-block">{{ trans('admin/settings/general.due_checkin_days_help') }}</p>
+                                </div>
+                            </div>
+                        </fieldset>
+
                         </div>
 
-                        <!-- Menu Alerts Enabled -->
-                        <div class="form-group {{ $errors->has('show_alerts_in_menu') ? 'error' : '' }}">
-                            <div class="col-md-9 col-md-offset-3">
-                                <label class="form-control">
-                                    <input type="checkbox" name="show_alerts_in_menu" value="1" @checked(old('show_alerts_in_menu', $setting->show_alerts_in_menu))>
-                                    {{ trans('admin/settings/general.show_alerts_in_menu') }}
-                                </label>
-                            </div>
-                        </div>
-
-
-
-                        <!-- Alert Email -->
-                        <div class="form-group {{ $errors->has('alert_email') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="alert_email">{{ trans('admin/settings/general.alert_email') }}</label>
-                            </div>
-                            <div class="col-md-7">
-                                <input type="text" name="alert_email" value="{{ old('alert_email', $setting->alert_email) }}" class="form-control" placeholder="admin@yourcompany.com" maxlength="191">
-                                {!! $errors->first('alert_email', '<span class="alert-msg" aria-hidden="true">:message</span><br>') !!}
-                                <p class="help-block">{{ trans('admin/settings/general.alert_email_help') }}</p>
-
-                            </div>
-                        </div>
-
-
-                        <!-- Admin CC Email -->
-                        <div class="form-group {{ $errors->has('admin_cc_email') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="admin_cc_email">{{ trans('admin/settings/general.admin_cc_email') }}</label>
-                            </div>
-                            <div class="col-md-7">
-                                <input type="text" name="admin_cc_email" value="{{ old('admin_cc_email', $setting->admin_cc_email) }}" class="form-control" placeholder="admin@yourcompany.com" maxlength="191">
-                                {!! $errors->first('admin_cc_email', '<span class="alert-msg" aria-hidden="true">:message</span><br>') !!}
-
-                                <p class="help-block">{{ trans('admin/settings/general.admin_cc_email_help') }}</p>
-
-
-                            </div>
-                        </div>
-
-                        <!-- Alert interval -->
-                        <div class="form-group {{ $errors->has('alert_interval') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="alert_interval">{{ trans('admin/settings/general.alert_interval') }}</label>
-                            </div>
-                            <div class="col-md-9">
-                                <input class="form-control" placeholder="30" maxlength="3" style="width: 60px;" name="alert_interval" type="text" value="{{ old('alert_interval', $setting->alert_interval) }}" id="alert_interval">
-                                {!! $errors->first('alert_interval', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                            </div>
-                        </div>
-
-                        <!-- Alert threshold -->
-                        <div class="form-group {{ $errors->has('alert_threshold') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="alert_threshold">{{ trans('admin/settings/general.alert_inv_threshold') }}</label>
-                            </div>
-                            <div class="col-md-9">
-                                <input class="form-control" placeholder="5" maxlength="3" style="width: 60px;" name="alert_threshold" type="text" value="{{ old('alert_threshold', $setting->alert_threshold) }}" id="alert_threshold">
-                                {!! $errors->first('alert_threshold', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                            </div>
-                        </div>
-
-
-                        <!-- Alert interval -->
-                        <div class="form-group {{ $errors->has('audit_interval') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="audit_interval">{{ trans('admin/settings/general.audit_interval') }}</label>
-                            </div>
-                            <div class="input-group col-md-3">
-                                <input class="form-control" placeholder="12" maxlength="3" name="audit_interval" type="text" id="audit_interval" value="{{ old('audit_interval', $setting->audit_interval) }}">
-                                <span class="input-group-addon">{{ trans('general.months') }}</span>
-                            </div>
-                            <div class="col-md-9 col-md-offset-3">
-                                {!! $errors->first('audit_interval', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                <p class="help-block">{{ trans('admin/settings/general.audit_interval_help') }}</p>
-                            </div>
-                        </div>
-
-                        <!-- Alert threshold -->
-                        <div class="form-group {{ $errors->has('audit_warning_days') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="audit_warning_days">{{ trans('admin/settings/general.audit_warning_days') }}</label>
-                            </div>
-                            <div class="input-group col-md-3">
-                                <input class="form-control" placeholder="14" maxlength="3" name="audit_warning_days" type="text" id="audit_warning_days" value="{{ old('audit_warning_days', $setting->audit_warning_days) }}">
-                                <span class="input-group-addon">{{ trans('general.days') }}</span>
-                            </div>
-                            <div class="col-md-9 col-md-offset-3">
-                                {!! $errors->first('audit_warning_days', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                <p class="help-block">{{ trans('admin/settings/general.audit_warning_days_help') }}</p>
-                            </div>
-                        </div>
-
-                        <!-- Due for checkin days -->
-                        <div class="form-group {{ $errors->has('due_checkin_days') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="due_checkin_days">{{ trans('admin/settings/general.due_checkin_days') }}</label>
-                            </div>
-                            <div class="input-group col-md-3">
-                                <input class="form-control" placeholder="14" maxlength="3" name="due_checkin_days" type="text" id="due_checkin_days" value="{{ old('due_checkin_days', $setting->due_checkin_days) }}">
-                                <span class="input-group-addon">{{ trans('general.days') }}</span>
-                            </div>
-                            <div class="col-md-9 col-md-offset-3">
-                                {!! $errors->first('due_checkin_days', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                <p class="help-block">{{ trans('admin/settings/general.due_checkin_days_help') }}</p>
-                            </div>
-                        </div>
-
-                    </div>
 
                 </div> <!--/.box-body-->
                 <div class="box-footer">

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -22,7 +22,7 @@
     {{ csrf_field() }}
 
     <div class="row">
-        <div class="col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
+        <div class="col-sm-9 col-sm-offset-1 col-md-9 col-md-offset-2">
 
 
             <div class="panel box box-default">
@@ -35,142 +35,151 @@
                 <div class="box-body">
 
 
-                    <div class="col-md-11 col-md-offset-1">
+                    <div class="col-md-12">
 
+                        <fieldset name="password-preferences" class="bottom-padded">
+                            <legend class="highlight">
+                                {{ trans('admin/settings/general.legends.security') }}
+                            </legend>
 
-                        <!-- Two Factor -->
-                        <div class="form-group {{ $errors->has('brand') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="two_factor_enabled">{{ trans('admin/settings/general.two_factor_enabled_text') }}</label>
-                            </div>
-                            <div class="col-md-9">
+                            <!-- Two Factor -->
+                            <div class="form-group {{ $errors->has('brand') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="two_factor_enabled">{{ trans('admin/settings/general.two_factor_enabled_text') }}</label>
+                                </div>
+                                <div class="col-md-9">
 
-                                {!! Form::two_factor_options('two_factor_enabled', old('two_factor_enabled', $setting->two_factor_enabled), 'select2') !!}
-                                <p class="help-block">{{ trans('admin/settings/general.two_factor_enabled_warning') }}</p>
+                                    {!! Form::two_factor_options('two_factor_enabled', old('two_factor_enabled', $setting->two_factor_enabled), 'select2') !!}
+                                    <p class="help-block">{{ trans('admin/settings/general.two_factor_enabled_warning') }}</p>
 
-                                @if (config('app.lock_passwords'))
-                                    <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-                                @endif
-
-                                {!! $errors->first('two_factor_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                            </div>
-                        </div>
-
-                        <!-- Min characters -->
-                        <div class="form-group {{ $errors->has('pwd_secure_min') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="pwd_secure_min">{{ trans('admin/settings/general.pwd_secure_min') }}</label>
-                            </div>
-                            <div class="col-md-9">
-                                <input class="form-control" style="width: 50px;" name="pwd_secure_min" type="text" value="{{ old('pwd_secure_min', $setting->pwd_secure_min) }}" id="pwd_secure_min">
-
-                                {!! $errors->first('pwd_secure_min', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                <p class="help-block">
-                                    {{ trans('admin/settings/general.pwd_secure_min_help') }}
-                                </p>
-
-
-                            </div>
-                        </div>
-
-
-
-                        <!-- Common Passwords -->
-                        <div class="form-group {{ $errors->has('pwd_secure_complexity.*') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <label for="pwd_secure_complexity">{{ trans('admin/settings/general.pwd_secure_complexity') }}</label>
-                            </div>
-                            <div class="col-md-9">
-                                <label class="form-control">
-                                    <span class="sr-only">{{ trans('admin/settings/general.pwd_secure_uncommon') }}</span>
-                                    <input type="checkbox" name="pwd_secure_uncommon" value="1" @checked(old('pwd_secure_uncommon', $setting->pwd_secure_uncommon)) aria-label="pwd_secure_uncommon"/>
-                                    {{ trans('admin/settings/general.pwd_secure_uncommon') }}
-                                </label>
-                                <label class="form-control">
-                                    <input type="checkbox" name="pwd_secure_complexity['disallow_same_pwd_as_user_fields']" value="disallow_same_pwd_as_user_fields" @checked(old('disallow_same_pwd_as_user_fields', strpos($setting->pwd_secure_complexity, 'disallow_same_pwd_as_user_fields')!==false)) aria-label="pwd_secure_complexity"/>
-                                    {{ trans('admin/settings/general.pwd_secure_complexity_disallow_same_pwd_as_user_fields') }}
-                                </label>
-                                <label class="form-control">
-                                    <input type="checkbox" name="pwd_secure_complexity['letters']" value="letters" @checked(old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'letters')!==false)) aria-label="pwd_secure_complexity"/>
-                                    {{ trans('admin/settings/general.pwd_secure_complexity_letters') }}
-                                </label>
-                                <label class="form-control">
-                                    <input type="checkbox" name="pwd_secure_complexity['numbers']" value="numbers" @checked(old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'numbers')!==false)) aria-label="pwd_secure_complexity"/>
-                                    {{ trans('admin/settings/general.pwd_secure_complexity_numbers') }}
-                                </label>
-                                <label class="form-control">
-                                    <input type="checkbox" name="pwd_secure_complexity['symbols']" value="symbols" @checked(old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'symbols')!==false)) aria-label="pwd_secure_complexity"/>
-                                    {{ trans('admin/settings/general.pwd_secure_complexity_symbols') }}
-                                </label>
-                                <label class="form-control">
-                                    <input type="checkbox" name="pwd_secure_complexity['case_diff']" value="case_diff" @checked(old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'case_diff')!==false)) aria-label="pwd_secure_complexity"/>
-                                    {{ trans('admin/settings/general.pwd_secure_complexity_case_diff') }}
-                                </label>
-
-                                @if ($errors->has('pwd_secure_complexity.*'))
-                                    <span class="alert-msg">{{ trans('validation.generic.invalid_value_in_field') }}</span>
-                                @endif
-                                <p class="help-block">
-                                    {{ trans('admin/settings/general.pwd_secure_complexity_help') }}
-                                </p>
-                            </div>
-                        </div>
-                        <!-- /.form-group -->
-                        <hr>
-                        <!-- Remote User Authentication -->
-                        <div class="form-group {{ $errors->has('login_remote_user') ? 'error' : '' }}">
-                            <div class="col-md-3">
-                                <strong>{{ trans('admin/settings/general.login_remote_user_text') }}</strong>
-                            </div>
-                            <div class="col-md-9">
-                                <!--  Enable Remote User Login -->
-
-                                @if (config('app.lock_passwords'))
-                                    <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
-                                @else
-                                    <label class="form-control">
-                                        <input type="checkbox" name="login_remote_user_enabled" value="1" @checked(old('login_remote_user_enabled', $setting->login_remote_user_enabled)) aria-label="login_remote_user"/>
-                                        <label for="login_remote_user_enabled">{{ trans('admin/settings/general.login_remote_user_enabled_text') }}</label>
-                                    </label>
-
-                                    {!! $errors->first('login_remote_user_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                    <p class="help-block">
-                                        {{ trans('admin/settings/general.login_remote_user_enabled_help') }}
-                                    </p>
-                                    <!-- Use custom remote user header name -->
-                                    <label for="login_remote_user_header_name">{{ trans('admin/settings/general.login_remote_user_header_name_text') }}</label>
-                                    <input class="form-control" name="login_remote_user_header_name" type="text" value="{{ old('login_remote_user_header_name', $setting->login_remote_user_header_name) }}" id="login_remote_user_header_name">
-                                    {!! $errors->first('login_remote_user_header_name', '<span class="alert-msg">:message</span>') !!}
-                                    <p class="help-block">
-                                        {{ trans('admin/settings/general.login_remote_user_header_name_help') }}
-                                    </p>
-                                    <!-- Custom logout url to redirect to authentication provider -->
-                                    <label for="login_remote_user_custom_logout_url">{{ trans('admin/settings/general.login_remote_user_custom_logout_url_text') }}</label>
-                                    <input class="form-control" aria-label="login_remote_user_custom_logout_url" name="login_remote_user_custom_logout_url" type="url" value="{{ old('login_remote_user_custom_logout_url', $setting->login_remote_user_custom_logout_url) }}" id="login_remote_user_custom_logout_url">
-
-                                    {!! $errors->first('login_remote_user_custom_logout_url', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                    <p class="help-block">
-                                        {{ trans('admin/settings/general.login_remote_user_custom_logout_url_help') }}
-                                    </p>
-
-                                    @if ($setting->login_remote_user_enabled == '1')
-
-                                    <!--  Disable other logins mechanism -->
-                                    <label class="form-control">
-
-                                        <input type="checkbox" name="login_common_disabled" value="1" @checked(old('login_common_disabled', $setting->login_common_disabled)) aria-label="login_common_disabled"/>
-                                        {{ trans('admin/settings/general.login_common_disabled_text') }}
-                                    </label>
-                                    {!! $errors->first('login_common_disabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                    <p class="help-block">
-                                        {{ trans('admin/settings/general.login_common_disabled_help') }}
-                                    </p>
+                                    @if (config('app.lock_passwords'))
+                                        <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
                                     @endif
 
-                                @endif
-
+                                    {!! $errors->first('two_factor_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                </div>
                             </div>
-                        </div>
+
+                            <!-- Min characters -->
+                            <div class="form-group {{ $errors->has('pwd_secure_min') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="pwd_secure_min">{{ trans('admin/settings/general.pwd_secure_min') }}</label>
+                                </div>
+                                <div class="col-md-9">
+                                    <input class="form-control" style="width: 60px;" name="pwd_secure_min" type="number" value="{{ old('pwd_secure_min', $setting->pwd_secure_min) }}" id="pwd_secure_min" maxlength="2" min="8">
+                                    {!! $errors->first('pwd_secure_min', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                    <p class="help-block">
+                                        {{ trans('admin/settings/general.pwd_secure_min_help') }}
+                                    </p>
+                                </div>
+                            </div>
+
+
+
+                            <!-- Common Passwords -->
+                            <div class="form-group {{ $errors->has('pwd_secure_complexity.*') ? 'error' : '' }}">
+                                <div class="col-md-3">
+                                    <label for="pwd_secure_complexity">{{ trans('admin/settings/general.pwd_secure_complexity') }}</label>
+                                </div>
+                                <div class="col-md-9">
+                                    <label class="form-control">
+                                        <input type="checkbox" name="pwd_secure_uncommon" value="1" @checked(old('pwd_secure_uncommon', $setting->pwd_secure_uncommon)) aria-label="pwd_secure_uncommon"/>
+                                        {{ trans('admin/settings/general.pwd_secure_uncommon') }}
+                                    </label>
+                                    <label class="form-control">
+                                        <input type="checkbox" name="pwd_secure_complexity['disallow_same_pwd_as_user_fields']" value="disallow_same_pwd_as_user_fields" @checked(old('disallow_same_pwd_as_user_fields', strpos($setting->pwd_secure_complexity, 'disallow_same_pwd_as_user_fields')!==false)) aria-label="pwd_secure_complexity"/>
+                                        {{ trans('admin/settings/general.pwd_secure_complexity_disallow_same_pwd_as_user_fields') }}
+                                    </label>
+                                    <label class="form-control">
+                                        <input type="checkbox" name="pwd_secure_complexity['letters']" value="letters" @checked(old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'letters')!==false)) aria-label="pwd_secure_complexity"/>
+                                        {{ trans('admin/settings/general.pwd_secure_complexity_letters') }}
+                                    </label>
+                                    <label class="form-control">
+                                        <input type="checkbox" name="pwd_secure_complexity['numbers']" value="numbers" @checked(old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'numbers')!==false)) aria-label="pwd_secure_complexity"/>
+                                        {{ trans('admin/settings/general.pwd_secure_complexity_numbers') }}
+                                    </label>
+                                    <label class="form-control">
+                                        <input type="checkbox" name="pwd_secure_complexity['symbols']" value="symbols" @checked(old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'symbols')!==false)) aria-label="pwd_secure_complexity"/>
+                                        {{ trans('admin/settings/general.pwd_secure_complexity_symbols') }}
+                                    </label>
+                                    <label class="form-control">
+                                        <input type="checkbox" name="pwd_secure_complexity['case_diff']" value="case_diff" @checked(old('pwd_secure_uncommon', strpos($setting->pwd_secure_complexity, 'case_diff')!==false)) aria-label="pwd_secure_complexity"/>
+                                        {{ trans('admin/settings/general.pwd_secure_complexity_case_diff') }}
+                                    </label>
+
+                                    @if ($errors->has('pwd_secure_complexity.*'))
+                                        <span class="alert-msg">{{ trans('validation.generic.invalid_value_in_field') }}</span>
+                                    @endif
+                                    <p class="help-block">
+                                        {{ trans('admin/settings/general.pwd_secure_complexity_help') }}
+                                    </p>
+                                </div>
+                            </div>
+                        </fieldset>
+
+                        <fieldset name="remote-login" class="bottom-padded">
+                            <legend class="highlight">
+                                {{ trans('admin/settings/general.login_remote_user_text') }}
+                            </legend>
+                            <!-- Remote User Authentication -->
+                            <div class="form-group {{ $errors->has('login_remote_user') ? 'error' : '' }}">
+
+                                <div class="col-md-9 col-md-offset-3">
+                                    <!--  Enable Remote User Login -->
+
+                                    @if (config('app.lock_passwords'))
+                                        <p class="text-warning"><i class="fas fa-lock"></i> {{ trans('general.feature_disabled') }}</p>
+                                    @else
+                                        <label class="form-control">
+                                            <input type="checkbox" name="login_remote_user_enabled" value="1" @checked(old('login_remote_user_enabled', $setting->login_remote_user_enabled)) aria-label="login_remote_user"/>
+                                            <label for="login_remote_user_enabled">{{ trans('admin/settings/general.login_remote_user_enabled_text') }}</label>
+                                        </label>
+
+                                        {!! $errors->first('login_remote_user_enabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        <p class="help-block">
+                                            {{ trans('admin/settings/general.login_remote_user_enabled_help') }}
+                                        </p>
+                                </div>
+                                <div class="col-md-3">
+                                        <!-- Use custom remote user header name -->
+                                        <label for="login_remote_user_header_name">{{ trans('admin/settings/general.login_remote_user_header_name_text') }}</label>
+                                </div>
+                                <div class="col-md-9">
+                                        <input class="form-control" name="login_remote_user_header_name" type="text" value="{{ old('login_remote_user_header_name', $setting->login_remote_user_header_name) }}" id="login_remote_user_header_name">
+                                        {!! $errors->first('login_remote_user_header_name', '<span class="alert-msg">:message</span>') !!}
+                                        <p class="help-block">
+                                            {{ trans('admin/settings/general.login_remote_user_header_name_help') }}
+                                        </p>
+                                </div>
+                                <div class="col-md-3">
+                                        <!-- Custom logout url to redirect to authentication provider -->
+                                        <label for="login_remote_user_custom_logout_url">{{ trans('admin/settings/general.login_remote_user_custom_logout_url_text') }}</label>
+                                </div>
+                                <div class="col-md-9">
+                                        <input class="form-control" aria-label="login_remote_user_custom_logout_url" name="login_remote_user_custom_logout_url" type="url" value="{{ old('login_remote_user_custom_logout_url', $setting->login_remote_user_custom_logout_url) }}" id="login_remote_user_custom_logout_url">
+                                        {!! $errors->first('login_remote_user_custom_logout_url', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        <p class="help-block">
+                                            {{ trans('admin/settings/general.login_remote_user_custom_logout_url_help') }}
+                                        </p>
+                                </div>
+                                @if ($setting->login_remote_user_enabled == '1')
+                                    <div class="col-md-3">
+                                        <!--  Disable other logins mechanism -->
+                                        <label class="form-control">
+                                            <input type="checkbox" name="login_common_disabled" value="1" @checked(old('login_common_disabled', $setting->login_common_disabled)) aria-label="login_common_disabled"/>
+                                            {{ trans('admin/settings/general.login_common_disabled_text') }}
+                                        </label>
+                                    </div>
+                                    <div class="col-md-9">
+                                        {!! $errors->first('login_common_disabled', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
+                                        <p class="help-block">
+                                            {{ trans('admin/settings/general.login_common_disabled_help') }}
+                                        </p>
+                                        @endif
+                                    </div>
+
+                                @endif
+                        </fieldset>
 
 
 


### PR DESCRIPTION
Added some fieldsets and UI tweaks for nicer formatting, and added some additional pa11y tests. This also improves some accessibility features for forms, and standardizes using BS tables "no results" display instead of our own. 

![FireShot Capture 006 - Update Notification Settings __ Snipe-IT Demo - snipe-it test](https://github.com/user-attachments/assets/a90a5c62-c7f5-4da3-806a-ed1188175dd3)

