### PR TITLE
Reworked fix for for 24mm_D label indent errror

### DIFF
--- a/app/Models/Labels/Tapes/Brother/TZe_24mm_D.php
+++ b/app/Models/Labels/Tapes/Brother/TZe_24mm_D.php
@@ -70,27 +70,38 @@ class TZe_24mm_D extends TZe_24mm
         }
 
         foreach ($record->get('fields') as $field) {
-            // Write label and value on the same line
-            // Calculate label width with proportional character spacing
-            $labelWidth = $pdf->GetStringWidth($field['label'], 'freemono', '', self::LABEL_SIZE);
-            $charCount = strlen($field['label']);
-            $spacingPerChar = 0.5;
-            $totalSpacing = $charCount * $spacingPerChar;
-            $adjustedWidth = $labelWidth + $totalSpacing;
+            if (!empty($field['label']) && $field['label'] !== "\u{200B}") {
+                // Write label and value on the same line
+                // Calculate label width with proportional character spacing
+                $labelWidth = $pdf->GetStringWidth($field['label'], 'freemono', '', self::LABEL_SIZE);
+                $charCount = strlen($field['label']);
+                $spacingPerChar = 0.5;
+                $totalSpacing = $charCount * $spacingPerChar;
+                $adjustedWidth = $labelWidth + $totalSpacing;
 
-            static::writeText(
-                $pdf, $field['label'],
-                $currentX, $currentY,
-                'freemono', 'B', self::LABEL_SIZE, 'L',
-                $adjustedWidth, self::LABEL_SIZE, true, 0, $spacingPerChar
-            );
+                static::writeText(
+                    $pdf, $field['label'],
+                    $currentX, $currentY,
+                    'freemono', 'B', self::LABEL_SIZE, 'L',
+                    $adjustedWidth, self::LABEL_SIZE, true, 0, $spacingPerChar
+                );
 
-            static::writeText(
-                $pdf, $field['value'],
-                $currentX + $adjustedWidth + 2, $currentY,
-                'freemono', 'B', self::FIELD_SIZE, 'L',
-                $usableWidth - $adjustedWidth - 2, self::FIELD_SIZE, true, 0, 0.3
-            );
+                static::writeText(
+                    $pdf, $field['value'],
+                    $currentX + $adjustedWidth + 2, $currentY,
+                    'freemono', 'B', self::FIELD_SIZE, 'L',
+                    $usableWidth - $adjustedWidth - 2, self::FIELD_SIZE, true, 0, 0.3
+                );
+            } else {
+
+                // Label is empty, so write value only.
+                static::writeText(
+                    $pdf, $field['value'],
+                    $currentX, $currentY, // No offset
+                    'freemono', 'B', self::FIELD_SIZE, 'L',
+                    $usableWidth, self::FIELD_SIZE, true, 0, 0.3
+                );
+            }
 
             $currentY += max(self::LABEL_SIZE, self::FIELD_SIZE) + self::FIELD_MARGIN;
         }

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -177,10 +177,13 @@ class Label implements View
                                 // The end result of this will be in this format:
                                 // {labelOne} {valueOne} | {labelTwo} {valueTwo} | {labelThree} {valueThree}
                                 $previous['value'] = trim(implode(' | ', [
-                                    implode(' ', [null, $previous['value']]),
+                                    implode(' ', [$previous['label'], $previous['value']]),
                                     implode(' ', [$current['label'], $current['value']]),
                                 ]));
 
+                                // We'll set the label to an empty string since we
+                                // injected the label into the value field above.
+                                $previous['label'] = '';
                                 return $previous;
                             });
 
@@ -199,6 +202,12 @@ class Label implements View
 
         $filename = $assets->count() > 1 ? 'assets.pdf' : $assets->first()->asset_tag.'.pdf';
         $pdf->Output($filename, 'I');
+    }
+    protected function adjustXIfLabelEmpty($pdf, $field)
+    {
+        if (empty($field['label']) || $field['label'] === "\u{200B}") {
+            $pdf->SetX($pdf->GetX() - 2);
+        }
     }
 
     /**

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -203,12 +203,6 @@ class Label implements View
         $filename = $assets->count() > 1 ? 'assets.pdf' : $assets->first()->asset_tag.'.pdf';
         $pdf->Output($filename, 'I');
     }
-    protected function adjustXIfLabelEmpty($pdf, $field)
-    {
-        if (empty($field['label']) || $field['label'] === "\u{200B}") {
-            $pdf->SetX($pdf->GetX() - 2);
-        }
-    }
 
     /**
      * Add a piece of data.


### PR DESCRIPTION
This fixes the write method of the Brother\TZe_24mm_D label class. if the `label` is blank or null it will only write for the `value` rather than write both value and label.
#16812 
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/8e89a800-3c66-4b31-b80f-1717d46a0233" />
