### PR TITLE
Fixed fieldset display if custom fields are not available

### DIFF
--- a/app/Http/Controllers/CustomFieldsController.php
+++ b/app/Http/Controllers/CustomFieldsController.php
@@ -83,30 +83,30 @@ class CustomFieldsController extends Controller
     {
         $this->authorize('create', CustomField::class);
 
-        $show_in_email = $request->get("show_in_email", 0);
-        $display_in_user_view = $request->get("display_in_user_view", 0);
+        $show_in_email = $request->input("show_in_email", 0);
+        $display_in_user_view = $request->input("display_in_user_view", 0);
 
         // Override the display settings if the field is encrypted
-        if ($request->get("field_encrypted") == '1') {
+        if ($request->input("field_encrypted") == '1') {
             $show_in_email = '0';
             $display_in_user_view = '0';
         }
-
+        
         $field = new CustomField([
-            "name" => trim($request->get("name")),
-            "element" => $request->get("element"),
-            "help_text" => $request->get("help_text"),
-            "field_values" => $request->get("field_values"),
-            "field_encrypted" => $request->get("field_encrypted", 0),
+            "name" => trim($request->input("name")),
+            "element" => $request->input("element"),
+            "help_text" => $request->input("help_text"),
+            "field_values" => $request->input("field_values"),
+            "field_encrypted" => $request->input("field_encrypted", 0),
             "show_in_email" => $show_in_email,
-            "is_unique" => $request->get("is_unique", 0),
+            "is_unique" => $request->input("is_unique", 0),
             "display_in_user_view" => $display_in_user_view,
-            "auto_add_to_fieldsets" => $request->get("auto_add_to_fieldsets", 0),
-            "show_in_listview" => $request->get("show_in_listview", 0),
-            "show_in_requestable_list" => $request->get("show_in_requestable_list", 0),
-            "display_checkin" => $request->get("display_checkin", 0),
-            "display_checkout" => $request->get("display_checkout", 0),
-            "display_audit" => $request->get("display_audit", 0),
+            "auto_add_to_fieldsets" => $request->input("auto_add_to_fieldsets", 0),
+            "show_in_listview" => $request->input("show_in_listview", 0),
+            "show_in_requestable_list" => $request->input("show_in_requestable_list", 0),
+            "display_checkin" => $request->input("display_checkin", 0),
+            "display_checkout" => $request->input("display_checkout", 0),
+            "display_audit" => $request->input("display_audit", 0),
             "created_by" => auth()->id()
         ]);
 

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -79,6 +79,9 @@ class CustomField extends Model
         'auto_add_to_fieldsets',
         'show_in_listview',
         'show_in_email',
+        'display_checkout',
+        'display_checkin',
+        'display_audit',
         'show_in_requestable_list',
     ];
 

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -218,7 +218,7 @@ class CustomField extends Model
                 return $this->displayFieldInAuditForm();
             case 'checkin':
                 return $this->displayFieldInCheckinForm();
-            case 'checkin':
+            case 'checkout':
                 return $this->displayFieldInCheckoutForm();
         }
     }

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -183,7 +183,44 @@ class CustomField extends Model
     {
         return $this->belongsToMany(\App\Models\CustomFieldset::class);
     }
-   
+
+    public function displayFieldInCheckinForm()
+    {
+        if ($this->display_checkin == '1') {
+            return true;
+        }
+        return false;
+    }
+
+    public function displayFieldInCheckoutForm()
+    {
+        if ($this->display_checkout == '1') {
+            return true;
+        }
+        return false;
+    }
+
+    public function displayFieldInAuditForm()
+    {
+        if ($this->display_audit == '1') {
+            return true;
+        }
+        return false;
+    }
+
+    public function displayFieldInCurrentForm($form_type = null)
+    {
+        switch ($form_type) {
+            case 'audit':
+                return $this->displayFieldInAuditForm();
+            case 'checkin':
+                return $this->displayFieldInCheckinForm();
+            case 'checkin':
+                return $this->displayFieldInCheckoutForm();
+        }
+    }
+
+
     public function assetModels()
     {
        return $this->fieldset()->with('models')->get()->pluck('models')->flatten()->unique('id'); 

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -73,16 +73,24 @@ class CustomFieldset extends Model
 
     public function displayAnyFieldsInForm($form_type = null)
     {
-        switch ($form_type) {
-            case 'audit':
-                return $this->displayFieldInAuditForm();
-            case 'checkin':
-                return $this->displayFieldInCheckinForm();
-            case 'checkout':
-                return $this->displayFieldInCheckoutForm();
-            default:
-                return true;
+        if ($this->fields) {
+            // \Log::error(print_r($this->fields, true));
+            \Log::error($this->fields->where('display_audit', '1')->count());
+            \Log::error($this->fields->where('display_checkin', '1')->count());
+            \Log::error($this->fields->where('display_checkout', '1')->count());
+            switch ($form_type) {
+                case 'audit':
+                    return $this->fields->where('display_audit', '1')->count() > 0;
+                case 'checkin':
+                    return $this->fields->where('display_checkin', '1')->count() > 0;
+                case 'checkout':
+                    return $this->fields->where('display_checkout', '1')->count() > 0;
+                default:
+                    return true;
+            }
         }
+
+        return false;
     }
 
     /**

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -71,6 +71,20 @@ class CustomFieldset extends Model
         return $this->belongsTo(\App\Models\User::class); //WARNING - not all CustomFieldsets have a User!!
     }
 
+    public function displayAnyFieldsInForm($form_type = null)
+    {
+        switch ($form_type) {
+            case 'audit':
+                return $this->displayFieldInAuditForm();
+            case 'checkin':
+                return $this->displayFieldInCheckinForm();
+            case 'checkout':
+                return $this->displayFieldInCheckoutForm();
+            default:
+                return true;
+        }
+    }
+
     /**
      * Determine the validation rules we should apply based on the
      * custom field format

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -74,10 +74,7 @@ class CustomFieldset extends Model
     public function displayAnyFieldsInForm($form_type = null)
     {
         if ($this->fields) {
-            // \Log::error(print_r($this->fields, true));
-            \Log::error($this->fields->where('display_audit', '1')->count());
-            \Log::error($this->fields->where('display_checkin', '1')->count());
-            \Log::error($this->fields->where('display_checkout', '1')->count());
+
             switch ($form_type) {
                 case 'audit':
                     return $this->fields->where('display_audit', '1')->count() > 0;

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -702,9 +702,6 @@
                 </tbody>
               </table>
           </div><!-- /consumables-tab -->
-          <div class="tab-pane" id="test">
-            <p>fdlkgjljg</p>
-          </div>
 
         </div><!-- /.tab-content -->
       </div><!-- nav-tabs-custom -->

--- a/resources/views/hardware/audit.blade.php
+++ b/resources/views/hardware/audit.blade.php
@@ -115,12 +115,6 @@
                             </div>
                         </div>
 
-                        <!-- Custom fields -->
-                        @include("models/custom_fields_form", [
-                                'model' => $asset->model,
-                                'show_display_checkout_fields' => 'true'
-                        ])
-
 
                         <!-- Note -->
                         <div class="form-group{{ $errors->has('note') ? ' has-error' : '' }}">
@@ -135,6 +129,12 @@
 
                         <!-- Audit Image -->
                         @include ('partials.forms.edit.image-upload', ['help_text' => trans('general.audit_images_help')])
+
+                        <!-- Custom fields -->
+                        @include("models/custom_fields_form", [
+                                'model' => $asset->model,
+                                'show_custom_fields_type' => 'audit'
+                        ])
 
 
                     </div> <!--/.box-body-->

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -142,7 +142,7 @@
                                         <!-- Custom fields -->
                                         @include("models/custom_fields_form", [
                                                 'model' => $asset->model,
-                                                'show_display_checkin_fields' => 'true'
+                                                'show_custom_fields_type' => 'checkin'
                                         ])
 
 

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -139,6 +139,19 @@
                                             </div>
                                         </div>
 
+                                        <!-- Note -->
+                                        <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
+                                            <label for="note" class="col-md-3 control-label">
+                                                {{ trans('general.notes') }}
+                                            </label>
+                                            <div class="col-md-8">
+                                                <textarea class="col-md-6 form-control" id="note" @required($snipeSettings->require_checkinout_notes)
+                                                name="note">{{ old('note', $asset->note) }}</textarea>
+                                                {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                            </div>
+                                        </div>
+
+
                                         <!-- Custom fields -->
                                         @include("models/custom_fields_form", [
                                                 'model' => $asset->model,
@@ -146,22 +159,6 @@
                                         ])
 
 
-
-
-
-
-
-                        <!-- Note -->
-                        <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
-                            <label for="note" class="col-md-3 control-label">
-                                {{ trans('general.notes') }}
-                            </label>
-                            <div class="col-md-8">
-                                <textarea class="col-md-6 form-control" id="note" @required($snipeSettings->require_checkinout_notes)
-                                        name="note">{{ old('note', $asset->note) }}</textarea>
-                                {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
-                            </div>
-                        </div>
                     </div> <!--/.box-body-->
                 </div> <!--/.box-body-->
 

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -142,12 +142,6 @@
                             </div>
                         </div>
 
-                        <!-- Custom fields -->
-                        @include("models/custom_fields_form", [
-                                'model' => $asset->model,
-                                'show_custom_fields_type' => 'checkout'
-                        ])
-
                         <!-- Note -->
                         <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
                             <label for="note" class="col-md-3 control-label">
@@ -156,10 +150,18 @@
 
                             <div class="col-md-8">
                                 <textarea class="col-md-6 form-control" id="note" @required($snipeSettings->require_checkinout_notes)
-                                          name="note">{{ old('note', $asset->note) }}</textarea>
+                                name="note">{{ old('note', $asset->note) }}</textarea>
                                 {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
+                        
+                        <!-- Custom fields -->
+                        @include("models/custom_fields_form", [
+                                'model' => $asset->model,
+                                'show_custom_fields_type' => 'checkout'
+                        ])
+
+
 
                         @if ($asset->requireAcceptance() || $asset->getEula() || ($snipeSettings->webhook_endpoint!=''))
                             <div class="form-group notification-callout">

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -145,7 +145,7 @@
                         <!-- Custom fields -->
                         @include("models/custom_fields_form", [
                                 'model' => $asset->model,
-                                'show_display_checkout_fields' => 'true'
+                                'show_custom_fields_type' => 'checkout'
                         ])
 
                         <!-- Note -->

--- a/resources/views/models/custom_fields_form.blade.php
+++ b/resources/views/models/custom_fields_form.blade.php
@@ -1,25 +1,21 @@
-@if (($model) && ($model->fieldset))
+@if (($model) && ($model->fieldset) && $model->fieldset->displayAnyFieldsInForm($show_custom_fields_type ?? ''))
     <div class="col-md-12 col-sm-12">
+
     <fieldset name="custom-fields" class="bottom-padded">
         <legend class="highlight">
             {{ trans('admin/custom_fields/general.custom_fields') }}
         </legend>
 
-  @foreach($model->fieldset->fields AS $field)
-      @if (
-    ((!isset($show_display_checkin_fields))
-        || (($field->display_checkin == '1')
-        && ($show_display_checkin_fields =='true'))) &&
-         ((!isset($show_display_checkout_fields))
-        || (($field->display_checkout == '1')
-        && ($show_display_checkout_fields =='true')))
-        )
+  @foreach($model->fieldset->fields as $field)
+    @if (!isset($show_custom_fields_type) || ($field->displayFieldInCurrentForm($show_custom_fields_type)))
+
 
     <div class="form-group{{ $errors->has($field->db_column_name()) ? ' has-error' : '' }}">
 
 
       <label for="{{ $field->db_column_name() }}" class="col-md-3 control-label">
           {{ $field->name }}
+
       </label>
 
       <div class="col-md-7 col-sm-12">
@@ -105,9 +101,8 @@
         </div>
         @endif
 
-
     </div>
-    @endif
+            @endif
   @endforeach
     </fieldset>
     </div>

--- a/resources/views/partials/forms/edit/warranty.blade.php
+++ b/resources/views/partials/forms/edit/warranty.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('warranty_months') ? ' has-error' : '' }}">
     <label for="warranty_months" class="col-md-3 control-label">{{ trans('admin/hardware/form.warranty') }}</label>
     <div class="col-md-9">
-        <div class="input-group col-md-3" style="padding-left: 0px;">
+        <div class="input-group col-md-4 col-sm-6" style="padding-left: 0px;">
             <input class="form-control" type="text" name="warranty_months" id="warranty_months" value="{{ old('warranty_months', $item->warranty_months) }}" maxlength="3" />
             <span class="input-group-addon">{{ trans('admin/hardware/form.months') }}</span>
         </div>


### PR DESCRIPTION
This handles a scenario where there are no custom fields that should be visible (because it's a checkin form, checkout, audit, etc and there are no custom fields selected to be visible on those forms)

<img width="1382" alt="Screenshot 2025-04-29 at 8 14 08 PM" src="https://github.com/user-attachments/assets/d2debd0a-8fb4-49bb-acee-571aeee25312" />
<img width="2242" alt="Screenshot 2025-04-29 at 8 14 29 PM" src="https://github.com/user-attachments/assets/5db18f96-9229-4bb5-8221-c8b70e9a0f8e" />

Prior to this, the improvement I had made that used fieldsets for clearer delineation of custom fields would show up regardless of whether there were any eligible custom fields, which just made for a kind of confusing UI.

It also ended up fixing a bug where the display on checkout/in/audit fields would not be saved properly on first creation, only on edit.