### PR TITLE
Add audit button to BS table partial, redirect if asset won't validate

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Log;
 use \Illuminate\Contracts\View\View;
 use \Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Validator;
 
 class AssetCheckinController extends Controller
 {
@@ -40,6 +41,15 @@ class AssetCheckinController extends Controller
         if (!$asset->model) {
             return redirect()->route('hardware.show', $asset->id)->with('error', trans('admin/hardware/general.model_invalid_fix'));
         }
+
+        // Validate custom fields on existing asset
+        $validator = Validator::make($asset->toArray(), $asset->customFieldValidationRules());
+
+        if ($validator->fails()) {
+            return redirect()->route('hardware.edit', $asset)
+                ->withErrors($validator);
+        }
+
         $target_option = match ($asset->assigned_type) {
             'App\Models\Asset' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.asset_previous')]),
             'App\Models\Location' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.location')]),

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Session;
 use \Illuminate\Contracts\View\View;
 use \Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Validator;
 
 class AssetCheckoutController extends Controller
 {
@@ -36,6 +37,14 @@ class AssetCheckoutController extends Controller
                 ->with('error', trans('admin/hardware/general.model_invalid_fix'));
         }
 
+        // Validate custom fields on existing asset
+        $validator = Validator::make($asset->toArray(), $asset->customFieldValidationRules());
+
+        if ($validator->fails()) {
+            return redirect()->route('hardware.edit', $asset)
+                ->withErrors($validator);
+        }
+        
         if ($asset->availableForCheckout()) {
             return view('hardware/checkout', compact('asset'))
                 ->with('statusLabel_list', Helper::deployableStatusLabelList())

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -877,10 +877,19 @@ class AssetsController extends Controller
     }
 
 
-    public function audit(Asset $asset)
+    public function audit(Asset $asset): View | RedirectResponse
     {
-        $settings = Setting::getSettings();
         $this->authorize('audit', Asset::class);
+        $settings = Setting::getSettings();
+
+        // Validate custom fields on existing asset
+        $validator = Validator::make($asset->toArray(), $asset->customFieldValidationRules());
+
+        if ($validator->fails()) {
+            return redirect()->route('hardware.edit', $asset)
+                ->withErrors($validator);
+        }
+
         $dt = Carbon::now()->addMonths($settings->audit_interval)->toDateString();
         return view('hardware/audit')->with('asset', $asset)->with('item', $asset)->with('next_audit_date', $dt)->with('locations_list');
     }

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -150,12 +150,13 @@ class AssetsTransformer
         }
 
         $permissions_array['available_actions'] = [
-            'checkout'      => ($asset->deleted_at=='' && Gate::allows('checkout', Asset::class)) ? true : false,
-            'checkin'       => ($asset->deleted_at=='' && Gate::allows('checkin', Asset::class)) ? true : false,
+            'checkout'      => ($asset->deleted_at=='' && Gate::allows('checkout', $asset)) ? true : false,
+            'checkin'       => ($asset->deleted_at=='' && Gate::allows('checkin', $asset)) ? true : false,
             'clone'         => Gate::allows('create', Asset::class) ? true : false,
-            'restore'       => ($asset->deleted_at!='' && Gate::allows('create', Asset::class)) ? true : false,
-            'update'        => ($asset->deleted_at=='' && Gate::allows('update', Asset::class)) ? true : false,
-            'delete'        => ($asset->deleted_at=='' && $asset->assigned_to =='' && Gate::allows('delete', Asset::class) && ($asset->deleted_at == '')) ? true : false,
+            'restore'       => ($asset->deleted_at!='' && Gate::allows('create', $asset)) ? true : false,
+            'update'        => ($asset->deleted_at=='' && Gate::allows('update', $asset)) ? true : false,
+            'audit'        => Gate::allows('audit', $asset) ? true : false,
+            'delete'        => ($asset->deleted_at=='' && $asset->assigned_to =='' && Gate::allows('delete', $asset) && ($asset->deleted_at == '')) ? true : false,
         ];      
 
 

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -150,13 +150,13 @@ class AssetsTransformer
         }
 
         $permissions_array['available_actions'] = [
-            'checkout'      => ($asset->deleted_at=='' && Gate::allows('checkout', $asset)) ? true : false,
-            'checkin'       => ($asset->deleted_at=='' && Gate::allows('checkin', $asset)) ? true : false,
+            'checkout'      => ($asset->deleted_at=='' && Gate::allows('checkout', Asset::class)) ? true : false,
+            'checkin'       => ($asset->deleted_at=='' && Gate::allows('checkin', Asset::class)) ? true : false,
             'clone'         => Gate::allows('create', Asset::class) ? true : false,
-            'restore'       => ($asset->deleted_at!='' && Gate::allows('create', $asset)) ? true : false,
-            'update'        => ($asset->deleted_at=='' && Gate::allows('update', $asset)) ? true : false,
-            'audit'        => Gate::allows('audit', $asset) ? true : false,
-            'delete'        => ($asset->deleted_at=='' && $asset->assigned_to =='' && Gate::allows('delete', $asset) && ($asset->deleted_at == '')) ? true : false,
+            'restore'       => ($asset->deleted_at!='' && Gate::allows('create', Asset::class)) ? true : false,
+            'update'        => ($asset->deleted_at=='' && Gate::allows('update', Asset::class)) ? true : false,
+            'audit'        => Gate::allows('audit', Asset::class) ? true : false,
+            'delete'        => ($asset->deleted_at=='' && $asset->assigned_to =='' && Gate::allows('delete', Asset::class) && ($asset->deleted_at == '')) ? true : false,
         ];      
 
 

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -198,7 +198,7 @@
 
               <th data-sortable="true" data-visible="false" data-searchable="false" class="text-center"
                   data-tooltip="{{ trans('admin/custom_fields/general.display_audit') }}">
-                <x-icon type="due" />
+                <x-icon type="audit" />
                 <span class="sr-only">
                     {{ trans('admin/custom_fields/general.display_audit') }}
                   </span>

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -371,6 +371,10 @@
                 actions += '<a href="{{ config('app.url') }}/' + dest + '/' + row.id + '/clone" class="actions btn btn-sm btn-info" data-tooltip="true" title="{{ trans('general.clone_item') }}"><x-icon type="clone" /><span class="sr-only">{{ trans('general.clone_item') }}</span></a>&nbsp;';
             }
 
+            if ((row.available_actions) && (row.available_actions.audit === true)) {
+                actions += '<a href="{{ config('app.url') }}/' + dest + '/' + row.id + '/audit" class="actions btn btn-sm btn-primary" data-tooltip="true" title="{{ trans('general.audit') }}"><x-icon type="audit" /><span class="sr-only">{{ trans('general.audit') }}</span></a>&nbsp;';
+            }
+
             if ((row.available_actions) && (row.available_actions.update === true)) {
                 actions += '<a href="{{ config('app.url') }}/' + dest + '/' + row.id + '/edit" class="actions btn btn-sm btn-warning" data-tooltip="true" title="{{ trans('general.update') }}"><x-icon type="edit" /><span class="sr-only">{{ trans('general.update') }}</span></a>&nbsp;';
             } else {


### PR DESCRIPTION
This addresses an occasional issue we see where a custom field's required-ness or validation rules might have changed *after* the custom field has been created. If the non-editing action being taken (such an an audit, checkin, or checkout) will touch the asset itself, the model-level validation can then fail, but since it was not an edit form, the fields would not be visible, thus making it difficult to see what about the asset is invalid. 

This change adds the audit button to the listing, and also redirects to the edit screen with errors if the asset would fail validation (and therefore the checkin, checkout, or audit would inevitably fail.)