### PR TITLE
Fixed updating CONTRIBUTORS.md via cli

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3328,7 +3328,7 @@
     },
     {
       "login": "36864",
-      "name": 36864,
+      "name": "36864",
       "avatar_url": "https://avatars.githubusercontent.com/u/109086466?v=4",
       "profile": "https://github.com/36864",
       "contributions": [


### PR DESCRIPTION
`npm run contributors:generate` was throwing an error: `TypeError: name.replace is not a function`

`npm run contributors:generate` doesn't like if a username is an integer and not a string 😅 

`npm run contributors:generate` can now be run without error.