### PR TITLE
Copy changes from 'master' to develop for docker builds

### DIFF
--- a/.github/workflows/docker-arm.yml
+++ b/.github/workflows/docker-arm.yml
@@ -1,5 +1,5 @@
 # Snipe-IT Docker image build for hub.docker.com
-name: Docker ARM64 images (Ubuntu)
+name: Docker cross-platform images (Ubuntu and Alpine)
 
 # Run this Build for all pushes to 'master' or develop branch, or tagged releases.
 # Also run for PRs to ensure PR doesn't break Docker build process
@@ -19,10 +19,10 @@ permissions:
   contents: read
 
 jobs:
-  docker-ubuntu-arm:
+  docker-ubuntu:
     # Ensure this job never runs on forked repos. It's only executed for 'grokability/snipe-it'
     if: github.repository == 'grokability/snipe-it'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     env:
       # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)
       # For a new commit on default branch (master), use the literal tag 'latest' on Docker image.
@@ -77,17 +77,17 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/amd64
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
           push: ${{ github.event_name != 'pull_request' }}
           # Use tags / labels provided by 'docker/metadata-action' above
           tags: ${{ steps.meta_build.outputs.tags }}
           labels: ${{ steps.meta_build.outputs.labels }}
-  docker-alpine-arm:
+  docker-alpine:
     # Ensure this job never runs on forked repos. It's only executed for 'grokability/snipe-it'
     if: github.repository == 'grokability/snipe-it'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     env:
       # Define tags to use for Docker images based on Git tags/branches (for docker/metadata-action)
       # For a new commit on default branch (master), use the literal tag 'latest' on Docker image.
@@ -142,7 +142,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.alpine
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/amd64
           # For pull requests, we run the Docker build (to ensure no PR changes break the build),
           # but we ONLY do an image push to DockerHub if it's NOT a PR
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
We had some docker builds that weren't firing for some reason - I really wasn't able to completely figure all of the reason 'why' out, tbh. But this change makes it so that we are building ARM and AMD64 builds of our docker images. This was tested on Master already.

It's unfortunately very SLOOOOOOOOW - I have no idea why, but I think @jerm was working on fixing that, and I think this change might have undone all his good work :( - hopefully he can take a look at it later and get it shored back up again.