### PR TITLE
remove duplicate input-group color corrections from theme skins

### DIFF
--- a/resources/assets/less/skins/skin-black-dark.less
+++ b/resources/assets/less/skins/skin-black-dark.less
@@ -311,10 +311,7 @@ input[type=text], input[type=search] {
 .search-highlight, .search-highlight:hover{
   background-color: var(--back-sub) !important;
 }
-.input-group, .input-group-addon {
-  background-color: var(--back-sub);
-  color: var(--text-main);
-}
+
 #licensesTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);
 }

--- a/resources/assets/less/skins/skin-blue-dark.less
+++ b/resources/assets/less/skins/skin-blue-dark.less
@@ -298,10 +298,6 @@ input[type=text], input[type=search] {
   background-color: var(--back-sub);
   color: var(--text-main);
 }
-.input-group, .input-group-addon {
-  background-color: var(--back-sub)!important;
-  color: var(--text-main);
-}
 #licensesTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);
 }

--- a/resources/assets/less/skins/skin-green-dark.less
+++ b/resources/assets/less/skins/skin-green-dark.less
@@ -289,10 +289,6 @@ input[type=text], input[type=search] {
   background-color: var(--back-sub);
   color: var(--text-main);
 }
-.input-group, .input-group-addon {
-  background-color: var(--back-sub)!important;
-  color: var(--text-main);
-}
 #licensesTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);
 }

--- a/resources/assets/less/skins/skin-orange-dark.less
+++ b/resources/assets/less/skins/skin-orange-dark.less
@@ -297,10 +297,6 @@ input[type=text], input[type=search] {
   background-color: var(--back-sub);
   color: var(--text-main);
 }
-.input-group, .input-group-addon {
-  background-color: var(--back-sub)!important;
-  color: var(--text-main);
-}
 #licensesTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);
 }

--- a/resources/assets/less/skins/skin-purple-dark.less
+++ b/resources/assets/less/skins/skin-purple-dark.less
@@ -297,10 +297,6 @@ input[type=text], input[type=search] {
   background-color: var(--back-sub);
   color: var(--text-main);
 }
-.input-group, .input-group-addon {
-  background-color: var(--back-sub)!important;
-  color: var(--text-main);
-}
 #licensesTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);
 }

--- a/resources/assets/less/skins/skin-red-dark.less
+++ b/resources/assets/less/skins/skin-red-dark.less
@@ -298,10 +298,6 @@ input[type=text], input[type=search] {
   background-color: var(--back-sub);
   color: var(--text-main);
 }
-.input-group, .input-group-addon {
-  background-color: var(--back-sub)!important;
-  color: var(--text-main);
-}
 #licensesTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);
 }

--- a/resources/assets/less/skins/skin-yellow-dark.less
+++ b/resources/assets/less/skins/skin-yellow-dark.less
@@ -289,10 +289,6 @@ input[type=text], input[type=search] {
   background-color: var(--back-sub);
   color: var(--text-main);
 }
-.input-group, .input-group-addon {
-  background-color: var(--back-sub)!important;
-  color: var(--text-main);
-}
 #licensesTable>tbody>tr>td>nobr>a>i.fa {
   color: var(--text-main);
 }

--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -292,8 +292,8 @@ Form::macro('skin', function ($name = 'skin', $selected = null, $class = null) {
         'black-dark' => trans('general.skins.black_dark'),
         'purple' => trans('general.skins.purple'),
         'purple-dark' => trans('general.skins.purple_dark'),
-        'yellow' => trans('general.skins.yellow_dark'),
-        'yellow-dark' => trans('general.skins.yellow'),
+        'yellow' => trans('general.skins.yellow'),
+        'yellow-dark' => trans('general.skins.yellow_dark'),
         'contrast' => trans('general.skins.high_contrast'),
     ];
 


### PR DESCRIPTION
Removed a duplicate less rule that was causing the input addons to be unreadable.
Below is just two of the themes represented but all have been checked and corrected.

Before:
<img width="582" alt="image" src="https://github.com/user-attachments/assets/17342f8b-e162-4324-8be2-202eb91874c1" />
After:
Create new in Black Dark Mode
<img width="489" alt="image" src="https://github.com/user-attachments/assets/73457ba3-b66f-48aa-90c1-b8dfddc23fb8" />
Bulk Edit in Yellow Dark mode
<img width="684" alt="image" src="https://github.com/user-attachments/assets/ce5fe8f4-b2b4-43dc-9c5e-83a911e087ce" />

Also fixed a bug where selecting yellow dark mode was actually just yellow and vice versa.
[sc-27322]
