### PR TITLE
WIP: Include "child" assets in inventory email and other views

### DIFF
--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -41,6 +41,14 @@ class ViewAssetsController extends Controller
             'licenses',
         )->find(auth()->id());
 
+        if (Setting::getSettings()->show_assigned_assets) {
+            $user->load([
+                'assets.assignedAssets',
+                'assets.assignedAssets.model',
+                'assets.assignedAssets.model.fieldset.fields',
+            ]);
+        }
+
         $field_array = array();
 
         // Loop through all the custom fields that are applied to any model the user has assigned
@@ -55,6 +63,20 @@ class ViewAssetsController extends Controller
                         $field_array[$field->db_column] = $field->name;
                     }
                     
+                }
+            }
+
+            foreach ($asset->assignedAssets as $assignedAsset) {
+                // Make sure the model has a custom fieldset before trying to loop through the associated fields
+                if ($assignedAsset->model->fieldset) {
+
+                    foreach ($assignedAsset->model->fieldset->fields as $field) {
+                        // check and make sure they're allowed to see the value of the custom field
+                        if ($field->display_in_user_view == '1') {
+                            $field_array[$field->db_column] = $field->name;
+                        }
+
+                    }
                 }
             }
 

--- a/app/Notifications/CurrentInventory.php
+++ b/app/Notifications/CurrentInventory.php
@@ -39,7 +39,7 @@ class CurrentInventory extends Notification
     public function toMail()
     {
         $this->user->load([
-            'assets',
+            'assets.assignedAssets',
             'accessories',
             'licenses',
             'consumables',

--- a/app/Notifications/CurrentInventory.php
+++ b/app/Notifications/CurrentInventory.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Models\Setting;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
@@ -51,6 +52,7 @@ class CurrentInventory extends Notification
                 'accessories'  => $this->user->accessories,
                 'licenses'  => $this->user->licenses,
                 'consumables'  => $this->user->consumables,
+                'show_assigned_assets' => Setting::getSettings()->show_assigned_assets,
             ])
             ->subject(trans('mail.inventory_report'));
 

--- a/app/Notifications/CurrentInventory.php
+++ b/app/Notifications/CurrentInventory.php
@@ -38,6 +38,13 @@ class CurrentInventory extends Notification
      */
     public function toMail()
     {
+        $this->user->load([
+            'assets',
+            'accessories',
+            'licenses',
+            'consumables',
+        ]);
+
         $message = (new MailMessage)->markdown('notifications.markdown.user-inventory',
             [
                 'assets'  => $this->user->assets,

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -312,12 +312,12 @@ class AssetFactory extends Factory
         });
     }
 
-    public function assignedToAsset()
+    public function assignedToAsset(Asset $asset = null)
     {
-        return $this->state(function () {
+        return $this->state(function () use ($asset) {
             return [
                 'model_id' => 1,
-                'assigned_to' => Asset::factory(),
+                'assigned_to' => $asset->id ?? Asset::factory(),
                 'assigned_type' => Asset::class,
             ];
         });

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -316,7 +316,6 @@ class AssetFactory extends Factory
     {
         return $this->state(function () use ($asset) {
             return [
-                'model_id' => 1,
                 'assigned_to' => $asset->id ?? Asset::factory(),
                 'assigned_type' => Asset::class,
             ];

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -455,15 +455,14 @@
 
                     </thead>
                     <tbody>
-                    @php
-                      $counter = 1
-                    @endphp
                     @foreach ($user->assets as $asset)
-                      <x-asset-table-row :asset="$asset" :field_array="$field_array" :counter="$counter" />
+                      <x-asset-table-row :asset="$asset" :field_array="$field_array" :counter="$loop->iteration" />
 
-                      @php
-                        $counter++
-                      @endphp
+                      @if ($settings->show_assigned_assets && $asset->assignedAssets->count())
+                        @foreach($asset->assignedAssets as $assignedAsset)
+                            <x-asset-table-row :asset="$assignedAsset" :field_array="$field_array" :counter="$loop->parent->iteration . '.' . $loop->iteration" />
+                        @endforeach
+                      @endif
                     @endforeach
                     </tbody>
                   </table>

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -459,65 +459,7 @@
                       $counter = 1
                     @endphp
                     @foreach ($user->assets as $asset)
-                      <tr>
-                        <td>{{ $counter }}</td>
-                        <td>
-                          @if (($asset->image) && ($asset->image!=''))
-                            <img src="{{ Storage::disk('public')->url(app('assets_upload_path').e($asset->image)) }}" style="max-height: 30px; width: auto" class="img-responsive" alt="">
-                          @elseif (($asset->model) && ($asset->model->image!=''))
-                            <img src="{{ Storage::disk('public')->url(app('models_upload_path').e($asset->model->image)) }}" style="max-height: 30px; width: auto" class="img-responsive" alt="">
-                          @endif
-                        </td>
-                        <td>
-                          @if (($asset->model) && ($asset->model->category))
-                          {{ $asset->model->category->name }}
-                          @endif
-                        </td>
-                        <td>
-                          {{ $asset->asset_tag }}
-                        </td>
-                        <td>
-                          {{ $asset->name }}
-                        </td>
-                        <td>
-                            {{ $asset->model->name }}
-                        </td>
-                        <td>
-                          {{ $asset->model->model_number }}
-                        </td>
-                        <td>
-                          {{ $asset->serial }}
-                        </td>
-                        <td>
-                          {{ ($asset->defaultLoc) ? $asset->defaultLoc->name : '' }}
-                        </td>
-                        <td>
-                          {{ ($asset->location) ? $asset->location->name : '' }}
-                        </td>
-                        @can('self.view_purchase_cost')
-                        <td>
-                          {!! Helper::formatCurrencyOutput($asset->purchase_cost) !!}
-                        </td>
-                        @endcan
-
-                        <td>
-                          {{ ($asset->asset_eol_date != '') ? Helper::getFormattedDateObject($asset->asset_eol_date, 'date', false) : null }}
-                        </td>
-
-                        <td>
-                          {{ Helper::getFormattedDateObject($asset->last_audit_date, 'datetime', false) }}
-                        </td>
-                        <td>
-                          {{ Helper::getFormattedDateObject($asset->next_audit_date, 'date', false) }}
-                        </td>
-
-                        @foreach ($field_array as $db_column => $field_value)
-                          <td>
-                            {{ $asset->{$db_column} }}
-                          </td>
-                        @endforeach
-
-                      </tr>
+                      <x-asset-table-row :asset="$asset" :field_array="$field_array" :counter="$counter" />
 
                       @php
                         $counter++

--- a/resources/views/blade/asset-table-row.blade.php
+++ b/resources/views/blade/asset-table-row.blade.php
@@ -1,0 +1,68 @@
+@props([
+    'asset',
+    'field_array',
+    'counter',
+])
+
+{{--
+    This component was extracted for the account.view_assets view. Not guaranteed to work in other views.
+--}}
+
+<tr>
+    <td>{{ $counter }}</td>
+    <td>
+        @if (($asset->image) && ($asset->image!=''))
+            <img src="{{ Storage::disk('public')->url(app('assets_upload_path').e($asset->image)) }}" style="max-height: 30px; width: auto" class="img-responsive" alt="">
+        @elseif (($asset->model) && ($asset->model->image!=''))
+            <img src="{{ Storage::disk('public')->url(app('models_upload_path').e($asset->model->image)) }}" style="max-height: 30px; width: auto" class="img-responsive" alt="">
+        @endif
+    </td>
+    <td>
+        @if (($asset->model) && ($asset->model->category))
+            {{ $asset->model->category->name }}
+        @endif
+    </td>
+    <td>
+        {{ $asset->asset_tag }}
+    </td>
+    <td>
+        {{ $asset->name }}
+    </td>
+    <td>
+        {{ $asset->model->name }}
+    </td>
+    <td>
+        {{ $asset->model->model_number }}
+    </td>
+    <td>
+        {{ $asset->serial }}
+    </td>
+    <td>
+        {{ ($asset->defaultLoc) ? $asset->defaultLoc->name : '' }}
+    </td>
+    <td>
+        {{ ($asset->location) ? $asset->location->name : '' }}
+    </td>
+    @can('self.view_purchase_cost')
+        <td>
+            {!! Helper::formatCurrencyOutput($asset->purchase_cost) !!}
+        </td>
+    @endcan
+
+    <td>
+        {{ ($asset->asset_eol_date != '') ? Helper::getFormattedDateObject($asset->asset_eol_date, 'date', false) : null }}
+    </td>
+
+    <td>
+        {{ Helper::getFormattedDateObject($asset->last_audit_date, 'datetime', false) }}
+    </td>
+    <td>
+        {{ Helper::getFormattedDateObject($asset->next_audit_date, 'date', false) }}
+    </td>
+
+    @foreach ($field_array as $db_column => $field_value)
+        <td>
+            {{ $asset->{$db_column} }}
+        </td>
+    @endforeach
+</tr>

--- a/resources/views/notifications/markdown/user-inventory.blade.php
+++ b/resources/views/notifications/markdown/user-inventory.blade.php
@@ -9,11 +9,12 @@
 ## {{ $assets->count() }} {{ trans('general.assets') }}
 
 <table width="100%">
-    <tr><th align="left">{{ trans('mail.name') }} </th><th align="left">{{ trans('mail.asset_tag') }}</th><th align="left">{{ trans('admin/hardware/table.serial') }}</th><th align="left">{{ trans('general.category') }}</th> <th></th> </tr>
+    <tr><th>#</th><th align="left">{{ trans('mail.name') }} </th><th align="left">{{ trans('mail.asset_tag') }}</th><th align="left">{{ trans('admin/hardware/table.serial') }}</th><th align="left">{{ trans('general.category') }}</th> <th></th> </tr>
 
 
 @foreach($assets as $asset)
 <tr>
+    <td>{{ $loop->iteration }}</td>
     <td>{{ $asset->present()->name }}</td>
     <td> {{ $asset->asset_tag }} </td>
     <td> {{ $asset->serial }} </td>
@@ -27,6 +28,7 @@
 @if ($show_assigned_assets && $asset->assignedAssets->count())
 @foreach($asset->assignedAssets as $assignedAsset)
 <tr>
+    <td>{{ $loop->parent->iteration }}.{{ $loop->iteration }}</td>
     <td>{{ $assignedAsset->present()->name }}</td>
     <td> {{ $assignedAsset->asset_tag }} </td>
     <td> {{ $assignedAsset->serial }} </td>

--- a/resources/views/notifications/markdown/user-inventory.blade.php
+++ b/resources/views/notifications/markdown/user-inventory.blade.php
@@ -9,7 +9,7 @@
 ## {{ $assets->count() }} {{ trans('general.assets') }}
 
 <table width="100%">
-    <tr><th>#</th><th align="left">{{ trans('mail.name') }} </th><th align="left">{{ trans('mail.asset_tag') }}</th><th align="left">{{ trans('admin/hardware/table.serial') }}</th><th align="left">{{ trans('general.category') }}</th> <th></th> </tr>
+    <tr><th align="left">#</th><th align="left">{{ trans('mail.name') }} </th><th align="left">{{ trans('mail.asset_tag') }}</th><th align="left">{{ trans('admin/hardware/table.serial') }}</th><th align="left">{{ trans('general.category') }}</th> <th></th> </tr>
 
 
 @foreach($assets as $asset)

--- a/resources/views/notifications/markdown/user-inventory.blade.php
+++ b/resources/views/notifications/markdown/user-inventory.blade.php
@@ -24,7 +24,7 @@
     </td>
     @endif
 </tr>
-@if ($asset->assignedAssets->count())
+@if ($show_assigned_assets && $asset->assignedAssets->count())
 @foreach($asset->assignedAssets as $assignedAsset)
 <tr>
     <td>{{ $assignedAsset->present()->name }}</td>

--- a/resources/views/notifications/markdown/user-inventory.blade.php
+++ b/resources/views/notifications/markdown/user-inventory.blade.php
@@ -24,6 +24,21 @@
     </td>
     @endif
 </tr>
+@if ($asset->assignedAssets->count())
+@foreach($asset->assignedAssets as $assignedAsset)
+<tr>
+    <td>{{ $assignedAsset->present()->name }}</td>
+    <td> {{ $assignedAsset->asset_tag }} </td>
+    <td> {{ $assignedAsset->serial }} </td>
+    <td> {{ $assignedAsset->model->category->name }}</td>
+    @if (($snipeSettings->show_images_in_email =='1') && $assignedAsset->getImageUrl())
+        <td>
+            <img src="{{ asset($assignedAsset->getImageUrl()) }}" alt="Asset" style="max-width: 64px;">
+        </td>
+    @endif
+</tr>
+@endforeach
+@endif
 @endforeach
 </table>
 @endif

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -785,7 +785,7 @@
                     data-url="{{ route('api.assets.index', [
                         'assigned_to' => e($user->id),
                         'assigned_type' => 'App\Models\User',
-                        'include_child_assets' => 'true',
+                        'include_child_assets' => $snipeSettings->show_assigned_assets ? 'true' : 'false',
                     ]) }}"
                     data-export-options='{
                 "fileName": "export-{{ str_slug($user->present()->fullName()) }}-assets-{{ date('Y-m-d') }}",

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -782,7 +782,7 @@
                     data-bulk-form-id="#assetsBulkForm"
                     id="userAssetsListingTable"
                     class="table table-striped snipe-table"
-                    data-url="{{ route('api.assets.index',['assigned_to' => e($user->id), 'assigned_type' => 'App\Models\User']) }}"
+                    data-url="{{ route('api.assets.index',['assigned_to' => e($user->id), 'assigned_type' => 'App\Models\User', 'include_child_assets' => 'true']) }}"
                     data-export-options='{
                 "fileName": "export-{{ str_slug($user->present()->fullName()) }}-assets-{{ date('Y-m-d') }}",
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -782,7 +782,11 @@
                     data-bulk-form-id="#assetsBulkForm"
                     id="userAssetsListingTable"
                     class="table table-striped snipe-table"
-                    data-url="{{ route('api.assets.index',['assigned_to' => e($user->id), 'assigned_type' => 'App\Models\User', 'include_child_assets' => 'true']) }}"
+                    data-url="{{ route('api.assets.index', [
+                        'assigned_to' => e($user->id),
+                        'assigned_type' => 'App\Models\User',
+                        'include_child_assets' => 'true',
+                    ]) }}"
                     data-export-options='{
                 "fileName": "export-{{ str_slug($user->present()->fullName()) }}-assets-{{ date('Y-m-d') }}",
                 "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]

--- a/tests/Feature/Assets/Api/AssetIndexTest.php
+++ b/tests/Feature/Assets/Api/AssetIndexTest.php
@@ -177,7 +177,8 @@ class AssetIndexTest extends TestCase
         $user = User::factory()->create();
 
         $parentAsset = Asset::factory()->assignedToUser($user)->create(['asset_tag' => 'parent-asset-tag']);
-        Asset::factory()->assignedToAsset($parentAsset)->create(['asset_tag' => 'child-asset-tag']);
+        $childAsset = Asset::factory()->assignedToAsset($parentAsset)->create(['asset_tag' => 'child-asset-tag']);
+        Asset::factory()->assignedToAsset($childAsset)->create(['asset_tag' => 'grandchild-asset-tag']);
 
         $this->actingAsForApi(User::factory()->superuser()->create())
             ->getJson(
@@ -196,9 +197,10 @@ class AssetIndexTest extends TestCase
                 'rows',
             ])
             ->assertJson(function (AssertableJson $json) {
-                return $json->has('rows', 2)
+                return $json->has('rows', 3)
                     ->where('rows.0.asset_tag', 'parent-asset-tag')
                     ->where('rows.1.asset_tag', 'child-asset-tag')
+                    ->where('rows.1.asset_tag', 'grandchild-asset-tag')
                     ->etc();
             });
     }

--- a/tests/Feature/Notifications/Email/CurrentInventoryTest.php
+++ b/tests/Feature/Notifications/Email/CurrentInventoryTest.php
@@ -61,8 +61,30 @@ class CurrentInventoryTest extends TestCase
         $this->assertStringContainsString('Complex Consumable Name', $emailContents);
     }
 
-    public function test_current_inventory_includes_child_assets()
+    public function test_current_inventory_does_not_include_child_assets_when_disabled()
     {
+        $this->markTestIncomplete();
+
+        $this->settings->disableShowingAssignedAssets();
+
+        $user = User::factory()->create();
+
+        $parentAsset = Asset::factory()->assignedToUser($user)->create(['asset_tag' => 'parent-asset-tag']);
+        Asset::factory()->assignedToAsset($parentAsset)->create(['asset_tag' => 'child-asset-tag']);
+
+        $emailContents = (new CurrentInventory($user))->toMail()->render();
+
+        $this->assertStringContainsString('parent-asset-tag', $emailContents);
+        $this->assertStringNotContainsString('child-asset-tag', $emailContents);
+    }
+
+    public function test_current_inventory_includes_child_assets_when_enabled()
+    {
+        $this->markTestIncomplete();
+
+        $this->settings->enableShowingAssignedAssets();
+
+
         $user = User::factory()->create();
 
         $parentAsset = Asset::factory()->assignedToUser($user)->create(['asset_tag' => 'parent-asset-tag']);

--- a/tests/Feature/Notifications/Email/CurrentInventoryTest.php
+++ b/tests/Feature/Notifications/Email/CurrentInventoryTest.php
@@ -46,8 +46,6 @@ class CurrentInventoryTest extends TestCase
 
     public function test_current_inventory_contents()
     {
-        Notification::fake();
-
         $user = User::factory()->create();
 
         Asset::factory()->assignedToUser($user)->create(['asset_tag' => 'complex-asset-tag']);
@@ -65,9 +63,14 @@ class CurrentInventoryTest extends TestCase
 
     public function test_current_inventory_includes_child_assets()
     {
-        $this->markTestIncomplete();
-
         $user = User::factory()->create();
 
+        $parentAsset = Asset::factory()->assignedToUser($user)->create(['asset_tag' => 'parent-asset-tag']);
+        Asset::factory()->assignedToAsset($parentAsset)->create(['asset_tag' => 'child-asset-tag']);
+
+        $emailContents = (new CurrentInventory($user))->toMail()->render();
+
+        $this->assertStringContainsString('parent-asset-tag', $emailContents);
+        $this->assertStringContainsString('child-asset-tag', $emailContents);
     }
 }

--- a/tests/Feature/Notifications/Email/CurrentInventoryTest.php
+++ b/tests/Feature/Notifications/Email/CurrentInventoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Notifications\Email;
+
+use App\Models\Accessory;
+use App\Models\Asset;
+use App\Models\Consumable;
+use App\Models\License;
+use App\Models\LicenseSeat;
+use App\Models\User;
+use App\Notifications\CurrentInventory;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class CurrentInventoryTest extends TestCase
+{
+    public function test_must_have_permission_to_send_current_inventory_email()
+    {
+        $this->actingAs(User::factory()->create())
+            ->post(route('users.email', User::factory()->create()->id))
+            ->assertForbidden();
+    }
+
+    public function test_handles_attempt_to_send_to_user_without_email_address()
+    {
+        $user = User::factory()->create(['email' => null]);
+
+        $this->actingAs(User::factory()->viewUsers()->create())
+            ->post(route('users.email', $user->id))
+            ->assertSessionHas('error');
+    }
+
+    public function test_can_send_users_current_inventory()
+    {
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'hi@there.com']);
+
+        Asset::factory()->assignedToUser($user)->create(['asset_tag' => 'complex-asset-tag']);
+        Accessory::factory()->checkedOutToUser($user)->create(['name' => 'Complex Accessory Name']);
+        LicenseSeat::factory()->for(License::factory()->state(['name' => 'Complex License Name']))->assignedToUser($user)->create();
+        Consumable::factory()->checkedOutToUser($user)->create(['name' => 'Complex Consumable Name']);
+
+        $this->actingAs(User::factory()->viewUsers()->create())
+            ->post(route('users.email', $user->id))
+            ->assertSessionHas('success');
+
+        Notification::assertCount(1);
+        Notification::assertSentTo($user, function (CurrentInventory $notification) {
+            $emailContents = $notification->toMail()->render();
+
+            $this->assertStringContainsString('complex-asset-tag', $emailContents);
+            $this->assertStringContainsString('Complex Accessory Name', $emailContents);
+            $this->assertStringContainsString('Complex License Name', $emailContents);
+            $this->assertStringContainsString('Complex Consumable Name', $emailContents);
+
+            return true;
+        });
+    }
+}

--- a/tests/Feature/Notifications/Email/CurrentInventoryTest.php
+++ b/tests/Feature/Notifications/Email/CurrentInventoryTest.php
@@ -80,7 +80,6 @@ class CurrentInventoryTest extends TestCase
     {
         $this->settings->enableShowingAssignedAssets();
 
-
         $user = User::factory()->create();
 
         $parentAsset = Asset::factory()->assignedToUser($user)->create(['asset_tag' => 'parent-asset-tag']);

--- a/tests/Feature/Notifications/Email/CurrentInventoryTest.php
+++ b/tests/Feature/Notifications/Email/CurrentInventoryTest.php
@@ -63,8 +63,6 @@ class CurrentInventoryTest extends TestCase
 
     public function test_current_inventory_does_not_include_child_assets_when_disabled()
     {
-        $this->markTestIncomplete();
-
         $this->settings->disableShowingAssignedAssets();
 
         $user = User::factory()->create();
@@ -80,8 +78,6 @@ class CurrentInventoryTest extends TestCase
 
     public function test_current_inventory_includes_child_assets_when_enabled()
     {
-        $this->markTestIncomplete();
-
         $this->settings->enableShowingAssignedAssets();
 
 

--- a/tests/Feature/Users/Ui/PrintUserInventoryTest.php
+++ b/tests/Feature/Users/Ui/PrintUserInventoryTest.php
@@ -42,7 +42,7 @@ class PrintUserInventoryTest extends TestCase
 
     public function testPrintingUserInventoryDoesNotIncludeChildAssetsWhenDisabled()
     {
-        $this->markTestIncomplete();
+        $this->settings->disableShowingAssignedAssets();
 
         $actor = User::factory()->viewUsers()->create();
         $user = User::factory()->create();
@@ -58,7 +58,7 @@ class PrintUserInventoryTest extends TestCase
 
     public function testPrintingUserInventoryIncludesChildAssetsWhenEnabled()
     {
-        $this->markTestIncomplete();
+        $this->settings->enableShowingAssignedAssets();
 
         $actor = User::factory()->viewUsers()->create();
         $user = User::factory()->create();

--- a/tests/Feature/Users/Ui/PrintUserInventoryTest.php
+++ b/tests/Feature/Users/Ui/PrintUserInventoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Users\Ui;
 
+use App\Models\Asset;
 use App\Models\Company;
 use App\Models\User;
 use Tests\TestCase;
@@ -37,5 +38,19 @@ class PrintUserInventoryTest extends TestCase
         $this->actingAs($actor)
             ->get(route('users.print', $user))
             ->assertStatus(302);
+    }
+
+    public function testPrintingUserInventoryIncludesChildAssets()
+    {
+        $actor = User::factory()->viewUsers()->create();
+        $user = User::factory()->create();
+
+        $parentAsset = Asset::factory()->assignedToUser($user)->create(['asset_tag' => 'parent-asset-tag']);
+        Asset::factory()->assignedToAsset($parentAsset)->create(['asset_tag' => 'child-asset-tag']);
+
+        $this->actingAs($actor)
+            ->get(route('users.print', $user->id))
+            ->assertSeeText('parent-asset-tag')
+            ->assertSeeText('child-asset-tag');
     }
 }

--- a/tests/Feature/Users/Ui/PrintUserInventoryTest.php
+++ b/tests/Feature/Users/Ui/PrintUserInventoryTest.php
@@ -40,8 +40,26 @@ class PrintUserInventoryTest extends TestCase
             ->assertStatus(302);
     }
 
-    public function testPrintingUserInventoryIncludesChildAssets()
+    public function testPrintingUserInventoryDoesNotIncludeChildAssetsWhenDisabled()
     {
+        $this->markTestIncomplete();
+
+        $actor = User::factory()->viewUsers()->create();
+        $user = User::factory()->create();
+
+        $parentAsset = Asset::factory()->assignedToUser($user)->create(['asset_tag' => 'parent-asset-tag']);
+        Asset::factory()->assignedToAsset($parentAsset)->create(['asset_tag' => 'child-asset-tag']);
+
+        $this->actingAs($actor)
+            ->get(route('users.print', $user->id))
+            ->assertSeeText('parent-asset-tag')
+            ->assertDontSeeText('child-asset-tag');
+    }
+
+    public function testPrintingUserInventoryIncludesChildAssetsWhenEnabled()
+    {
+        $this->markTestIncomplete();
+
         $actor = User::factory()->viewUsers()->create();
         $user = User::factory()->create();
 

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -145,6 +145,21 @@ class Settings
             'ldap_basedn' => 'CN=Users,DC=ad,DC=example,Dc=com'
         ]);
     }
+
+    public function enableShowingAssignedAssets(): Settings
+    {
+        return $this->update([
+            'show_assigned_assets' => 1,
+        ]);
+    }
+
+    public function disableShowingAssignedAssets(): Settings
+    {
+        return $this->update([
+            'show_assigned_assets' => 0,
+        ]);
+    }
+
     public function setEula($text = 'Default EULA text')
     {
         return $this->update(['default_eula_text' => $text]);


### PR DESCRIPTION
Here is the set up for the description that follows:
- asset-001, asset-002, asset-003, and asset-004 are checked out directly to the user 
- asset-001-01 is checked out to asset-001
- asset-003-01 is checked out to asset-003
- asset-003-02 is checked out to asset-003
- "Show assets assigned to assets" is enabled in settings
![image](https://github.com/user-attachments/assets/99334578-9105-4d6b-b57f-6b9fb500722a)

---

As pointed out in #16811, #13479 the email that is sent when clicking the "Email list of all Assigned" button does not include "child" assets (assets that are checked out to the assets checked out to the given user):
![image](https://github.com/user-attachments/assets/74f7741d-cf8b-4f5c-8269-a1b84e50891b)

But they are included in the view for "Printing All Assigned":
![image](https://github.com/user-attachments/assets/5d7b32da-f455-441d-b5e5-49f6e8b6d42c)
> Helpfully they are numbered `x.x`

This PR addresses that by including the child assets in the email along with the `x.x` numbering:
![image](https://github.com/user-attachments/assets/84ec70fc-b4e5-4457-b75e-0012da7476fd)

---

In addition, I noticed that child assets were missing when viewing a user's assets (`/users/1#asset`) or your own asset's (`/account/view-assets#assets`).

I've add this to your viewing your own assets:
Before: ![image](https://github.com/user-attachments/assets/e063950f-fb07-4889-829c-19923407d3e0)

After: 
![image](https://github.com/user-attachments/assets/5d94f909-825e-453a-9937-6a3419d894cb)

- [ ] And the last thing to do is add it to viewing a user's assets:
Before: 
![image](https://github.com/user-attachments/assets/2768614d-609a-4cfa-81fd-aafed971fb2c)


---

fixes #13479