### PR TITLE
Livewire component for smoother check for location companies

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1641,7 +1641,6 @@ class Helper
                 }
             }
         }
-        \Log::error(count($mismatched));
         return $mismatched;
     }        
 }

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1562,6 +1562,11 @@ class Helper
             $locations = Location::all();
         }
 
+        // Bail out early if there are no locations
+        if ($locations->count() == 0) {
+            return [];
+        }
+
         foreach($locations as $location) {
             // in case of an update of a single location, use the newly requested company_id
             if ($new_company_id) {
@@ -1600,14 +1605,17 @@ class Helper
                         $items = collect([])->push($location->$keyword);
                     }
 
+                    $count = 0;
                     foreach ($items as $item) {
 
+
                         if ($item && $item->company_id != $location_company) {
+
                             $mismatched[] = [
                                     class_basename(get_class($item)),
                                     $item->id,
                                     $item->name ?? $item->asset_tag ?? $item->serial ?? $item->username,
-                                    str_replace('App\\Models\\', '', $item->assigned_type) ?? null,
+                                    $item->assigned_type ? str_replace('App\\Models\\', '', $item->assigned_type) : null,
                                     $item->company_id ?? null,
                                     $item->company->name ?? null,
 //                                    $item->defaultLoc->id ?? null,
@@ -1619,11 +1627,21 @@ class Helper
                                     $location_company ?? null,
                                 ];
 
+                            $count++;
+
+                            // Bail early if this is not being run via artisan
+                            if ((!$artisan) && ($count > 0)) {
+                                return $mismatched;
+                            }
+
+
+
                         }
                     }
                 }
             }
         }
+        \Log::error(count($mismatched));
         return $mismatched;
     }        
 }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -290,8 +290,7 @@ class SettingsController extends Controller
     public function getSettings() : View
     {
         $setting = Setting::getSettings();
-        $total_locations = count(Helper::test_locations_fmcs(false));
-        return view('settings/general', compact('setting'))->with('total_locations', $total_locations);
+        return view('settings/general', compact('setting'));
     }
 
     /**

--- a/app/Livewire/LocationScopeCheck.php
+++ b/app/Livewire/LocationScopeCheck.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Helpers\Helper;
+use App\Models\Setting;
+use Livewire\Component;
+
+class LocationScopeCheck extends Component
+{
+    public $mismatched = [];
+    public $setting;
+
+    public function check_locations()
+    {
+        $this->mismatched = Helper::test_locations_fmcs(false);
+    }
+
+    public function mount() {
+        $this->setting = Setting::getSettings();
+        $this->mismatched = Helper::test_locations_fmcs(false);
+    }
+
+    public function render()
+    {
+        return view('livewire.location-scope-check');
+    }
+}

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -152,6 +152,7 @@ return [
     'full_multiple_companies_support_text' => 'Full Multiple Companies Support',
     'scope_locations_fmcs_support_text'  => 'Scope Locations with Full Multiple Companies Support',
     'scope_locations_fmcs_support_help_text'  => 'Restrict locations to their selected company.',
+    'scope_locations_fmcs_check_button' => 'Check Compatibility',
     'scope_locations_fmcs_support_disabled_text'  => 'This option is disabled because you have conflicting locations set for :count or more items.',
     'show_in_model_list'   => 'Show in Model Dropdowns',
     'optional'					=> 'optional',

--- a/resources/views/livewire/location-scope-check.blade.php
+++ b/resources/views/livewire/location-scope-check.blade.php
@@ -1,0 +1,11 @@
+<div>
+    <label class="form-control{{ (count($mismatched) > 0) ? ' form-control--disabled' : '' }}">
+        <input type="checkbox" name="scope_locations_fmcs" value="1" @checked(old('scope_locations_fmcs', $setting->scope_locations_fmcs)) aria-label="scope_locations_fmcs" {{ (count($mismatched) > 0) ? ' disabled' : '' }}/>
+        {{ trans('admin/settings/general.scope_locations_fmcs_support_text') }}
+    </label>
+    <p class="help-block">
+        {{ trans('admin/settings/general.scope_locations_fmcs_support_help_text') }}
+        <strong>{{ (count($mismatched) > 0) ? trans('admin/settings/general.scope_locations_fmcs_support_disabled_text', ['count' => count($mismatched)]) : '' }}</strong>
+    </p>
+    <button class="btn btn-sm btn-default" wire:click.prevent="check_locations">{{ trans('admin/settings/general.scope_locations_fmcs_check_button') }}</button>
+</div>

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -56,19 +56,7 @@
                             <!-- Scope Locations with Full Multiple Companies Support -->
                             <div class="form-group {{ $errors->has('scope_locations_fmcs') ? 'error' : '' }}">
                                 <div class="col-md-8 col-md-offset-3">
-                                    <label class="form-control{{ ($total_locations > 0) ? ' form-control--disabled' : '' }}">
-                                        <input type="checkbox" name="scope_locations_fmcs" value="1" @checked(old('scope_locations_fmcs', $setting->scope_locations_fmcs)) aria-label="scope_locations_fmcs" {{ ($total_locations > 0) ? ' disabled' : '' }}/>
-                                        {{ trans('admin/settings/general.scope_locations_fmcs_support_text') }}
-                                    </label>
-
-
-                                    {!! $errors->first('scope_locations_fmcs', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                    <p class="help-block">
-                                        {{ trans('admin/settings/general.scope_locations_fmcs_support_help_text') }}
-
-                                        <strong>{{ ($total_locations > 0) ? trans('admin/settings/general.scope_locations_fmcs_support_disabled_text', ['count' => $total_locations]) : '' }}</strong>
-
-                                    </p>
+                                    <livewire:location-scope-check />
                                 </div>
                             </div>
                             <!-- /.form-group -->


### PR DESCRIPTION
This is an improvement on how we check to see whether location scoping can be enabled. Previously, we were returning the entire array of objects so we could give you a specific count, now we're just checking if it's more than one. This should make that page load faster.

<img width="1590" alt="Screenshot 2025-05-05 at 2 00 38 PM" src="https://github.com/user-attachments/assets/29348870-8f71-4619-b0de-d724cfef592a" />

It's a bummer that we can't still get the exact count, but that query is just too expensive for folks with a lot of items or users.
