### PR TITLE
Fixed #16815: Avoids potential error when settings table is empty

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -19,7 +19,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        if(Setting::getSettings()->alerts_enabled === 1) {
+        if(Setting::getSettings()?->alerts_enabled === 1) {
             $schedule->command('snipeit:inventory-alerts')->daily();
             $schedule->command('snipeit:expiring-alerts')->daily();
             $schedule->command('snipeit:expected-checkin')->daily();


### PR DESCRIPTION
This PR adds a null safe operator to `app/Console/Kernal.php`.

I was having the same issue as #16815 on a fresh install of Snipe-IT using docker.

The schedule is trying to access `alerts_enabled` from the `Setting` model but on a fresh install it doesn't exist yet.