### PR TITLE
OMG fix 2 more (only 1 active) dockerhub repo references

### DIFF
--- a/.github/workflows/docker-arm.yml
+++ b/.github/workflows/docker-arm.yml
@@ -66,7 +66,7 @@ jobs:
         id: meta_build
         uses: docker/metadata-action@v5
         with:
-          images: grokability/snipe-it
+          images: snipe/snipe-it
           tags: ${{ env.IMAGE_TAGS }}
           flavor: ${{ env.TAGS_FLAVOR }}
 
@@ -123,7 +123,7 @@ jobs:
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       ###############################################
-      # Build/Push the 'grokability/snipe-it' image
+      # Build/Push the 'snipe/snipe-it' image
       ###############################################
       # https://github.com/docker/metadata-action
       # Get Metadata for docker_build step below


### PR DESCRIPTION
missed one active reference to get things back in the snipe/ dockhub repo rather than the grokability/ dockerhub repo