### PR TITLE
Fix OneLogin PHP SAML toolkit, doesn’t automatically extract NotOnOrAfter response from OKTA

### DIFF
--- a/app/Services/Saml.php
+++ b/app/Services/Saml.php
@@ -386,7 +386,30 @@ class Saml
     public function extractData()
     {
         $auth = $this->getAuth();
-
+        $auth->processResponse(); // Ensure this is called beforehand
+    
+        $assertionNotOnOrAfter = $auth->getLastAssertionNotOnOrAfter();
+    
+        // If null, try manually parsing the raw XML
+        if ($assertionNotOnOrAfter === null) {
+            try {
+                $responseXml = $auth->getLastResponseXml();
+    
+                libxml_use_internal_errors(true);
+                $xml = new \SimpleXMLElement($responseXml);
+                $xml->registerXPathNamespace('saml', 'urn:oasis:names:tc:SAML:2.0:assertion');
+    
+                $conditions = $xml->xpath('//saml:Conditions');
+    
+                if (!empty($conditions) && isset($conditions[0]['NotOnOrAfter'])) {
+                    $assertionNotOnOrAfter = (string) $conditions[0]['NotOnOrAfter'];
+                    \Log::debug("Manually extracted NotOnOrAfter: " . $assertionNotOnOrAfter);
+                }
+            } catch (\Exception $e) {
+                \Log::error("Failed to extract NotOnOrAfter manually: " . $e->getMessage());
+            }
+        }
+    
         return [
             'attributes' => $auth->getAttributes(),
             'attributesWithFriendlyName' => $auth->getAttributesWithFriendlyName(),
@@ -397,7 +420,7 @@ class Saml
             'sessionIndex' => $auth->getSessionIndex(),
             'sessionExpiration' => $auth->getSessionExpiration(),
             'nonce' => $auth->getLastAssertionId(),
-            'assertionNotOnOrAfter' => $auth->getLastAssertionNotOnOrAfter(),
+            'assertionNotOnOrAfter' => $assertionNotOnOrAfter,
         ];
     }
 


### PR DESCRIPTION
SAML integration with OKTA has issue 

```
Oops! An Error Occurred
The server returned a "400 Bad Request".
Something is broken. Please let us know what you were doing when this error occurred. We will fix it as soon as possible. Sorry for any inconvenience caused.
```

the root cause is OneLogin SAML PHP library didn't well handle assertionNotOnOrAfter from OKTA response.
hence
1.  patch the saml.php extractData, manually extract NotOnOrAfter from raw xml
2. remove the Expired SAML Assertion or allow 5 seconds of clock skew if we got null `notValidAfter` 

```
if ($nowUtc->greaterThanOrEqualTo($notValidAfter->addSeconds(5))) {
    Log::warning('SAML assertion is expired (with 5s clock skew).');
    abort(400, "Expired SAML Assertion");
}
```

here's a patch of solution 1: patch the saml.php extractData, manually extract NotOnOrAfter from raw xml
