### PR TITLE
Fixes CVE-2025-46734: league/commonmark contains a XSS vulnerability in Attributes extension 

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3558,16 +3558,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.6.1",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "d990688c91cedfb69753ffc2512727ec646df2ad"
+                "reference": "6fbb36d44824ed4091adbcf4c7d4a3923cdb3405"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d990688c91cedfb69753ffc2512727ec646df2ad",
-                "reference": "d990688c91cedfb69753ffc2512727ec646df2ad",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/6fbb36d44824ed4091adbcf4c7d4a3923cdb3405",
+                "reference": "6fbb36d44824ed4091adbcf4c7d4a3923cdb3405",
                 "shasum": ""
             },
             "require": {
@@ -3604,7 +3604,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.7-dev"
+                    "dev-main": "2.8-dev"
                 }
             },
             "autoload": {
@@ -3661,7 +3661,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-29T14:10:59+00:00"
+            "time": "2025-05-05T12:20:28+00:00"
         },
         {
             "name": "league/config",


### PR DESCRIPTION
```
❯ composer audit
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | league/commonmark                                                                |
| Severity          | medium                                                                           |
| CVE               | CVE-2025-46734                                                                   |
| Title             | league/commonmark contains a XSS vulnerability in Attributes extension           |
| URL               | https://github.com/advisories/GHSA-3527-qv2q-pfvx                                |
| Affected versions | <2.7.0                                                                           |
| Reported at       | 2025-05-05T20:40:36+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
```

Fixes XSS vulnerability in attributes