### PR TITLE
Allow updating asset model image via api

### DIFF
--- a/app/Http/Requests/StoreAssetModelRequest.php
+++ b/app/Http/Requests/StoreAssetModelRequest.php
@@ -19,6 +19,7 @@ class StoreAssetModelRequest extends ImageUploadRequest
 
     public function prepareForValidation(): void
     {
+        parent::prepareForValidation();
 
         if ($this->category_id) {
             if ($category = Category::find($this->category_id)) {


### PR DESCRIPTION
Prior to this PR, sending a base64'd image via asset model update endpoint would cause a validation error. We were missing calling the parent `prepareForValidation` method which exists on the `ConvertsBase64ToFiles` trait.