### PR TITLE
Removed `2fa_authed` from session upon logout

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -484,6 +484,7 @@ class LoginController extends Controller
         }
 
         $request->session()->regenerate(true);
+        $request->session()->forget('2fa_authed');
 
         if ($request->session()->has('password_hash_'.Auth::getDefaultDriver())){
             $request->session()->remove('password_hash_'.Auth::getDefaultDriver());


### PR DESCRIPTION
If a user logged out and then logged in with the same browser tab they wouldn't need to re-enter their 2fa code.

This PR removes `2fa_authed` from the session when a user logs out so they are always prompted to enter their 2fa code.