### PR TITLE
Fix webserver/user file permissions issue

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -191,7 +191,7 @@ create_user () {
   # Now do the reverse -- so apache can write to the log that the user may
   # have created. This was actively a problem on new installs, hobbling
   # imports
-  # redefining these varaible just for clarity
+  # redefining these variables just for clarity
   apache_user="$apache_group"
   app_group="$APP_USER"
   usermod -a -G "$app_group" "$apache_user"

--- a/snipeit.sh
+++ b/snipeit.sh
@@ -179,11 +179,22 @@ create_user () {
 
   if [[ "$distro" == "Ubuntu" ]] || [[ "$distro" == "Debian" ]] || [[ "$distro" == "Raspbian" ]] ; then
     /usr/sbin/adduser --quiet --disabled-password --gecos 'Snipe-IT User' "$APP_USER"
-    su -c "/usr/sbin/usermod -a -G "$apache_group" "$APP_USER""
   else
-    adduser "$APP_USER"
-    usermod -a -G "$apache_group" "$APP_USER"
+    adduser -c "Snipe-IT User" "$APP_USER"
   fi
+
+  # Add the user to the apache group so the app can write to any files apache
+  # creates (eg, if apache process creates the log, but then a an app-user-owned
+  # cron also tries writing
+  usermod -a -G "$apache_group" "$APP_USER"
+
+  # Now do the reverse -- so apache can write to the log that the user may
+  # have created. This was actively a problem on new installs, hobbling
+  # imports
+  # redefining these varaible just for clarity
+  apache_user="$apache_group"
+  app_group="$APP_USER"
+  usermod -a -G "$app_group" "$apache_user"
 }
 
 run_as_app_user () {


### PR DESCRIPTION
Fixes https://github.com/grokability/snipe-it/issues/16777

We weren't adding the webserver user to the app-user's group, which was
a problem for the webserver trying to write to the log file if it had
been created by a user-owned process (like a cron) or the installation
script chown-ing everything... even though the log file was created 664

This would often present in mysterious ways. In the linked case, trying
to upload a cvs for import would fail with an unhelpful message, because
the actual error is swallowed in the generic error handler for the page.

I've filed an issue to hopefully help with that: https://github.com/grokability/snipe-it/issues/16893

Used this opportunity to condense some logic that was
identical between architectures, simplifying user creation a bit