### PR TITLE
Fixed #16863 - better handle custom fields validation when unique but not required

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -42,12 +42,11 @@ class AssetCheckinController extends Controller
             return redirect()->route('hardware.show', $asset->id)->with('error', trans('admin/hardware/general.model_invalid_fix'));
         }
 
-        // Validate custom fields on existing asset
-        $validator = Validator::make($asset->toArray(), $asset->customFieldValidationRules());
+        // Invoke the validation to see if the audit will complete successfully
+        $asset->setRules($asset->getRules() + $asset->customFieldValidationRules());
 
-        if ($validator->fails()) {
-            return redirect()->route('hardware.edit', $asset)
-                ->withErrors($validator);
+        if ($asset->isInvalid()) {
+            return redirect()->route('hardware.edit', $asset)->withErrors($asset->getErrors());
         }
 
         $target_option = match ($asset->assigned_type) {

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -37,13 +37,13 @@ class AssetCheckoutController extends Controller
                 ->with('error', trans('admin/hardware/general.model_invalid_fix'));
         }
 
-        // Validate custom fields on existing asset
-        $validator = Validator::make($asset->toArray(), $asset->customFieldValidationRules());
+        // Invoke the validation to see if the audit will complete successfully
+        $asset->setRules($asset->getRules() + $asset->customFieldValidationRules());
 
-        if ($validator->fails()) {
-            return redirect()->route('hardware.edit', $asset)
-                ->withErrors($validator);
+        if ($asset->isInvalid()) {
+            return redirect()->route('hardware.edit', $asset)->withErrors($asset->getErrors());
         }
+
         
         if ($asset->availableForCheckout()) {
             return view('hardware/checkout', compact('asset'))

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -882,12 +882,12 @@ class AssetsController extends Controller
         $this->authorize('audit', Asset::class);
         $settings = Setting::getSettings();
 
-        // Validate custom fields on existing asset
-        $validator = Validator::make($asset->toArray(), $asset->customFieldValidationRules());
 
-        if ($validator->fails()) {
-            return redirect()->route('hardware.edit', $asset)
-                ->withErrors($validator);
+        // Invoke the validation to see if the audit will complete successfully
+        $asset->setRules($asset->getRules() + $asset->customFieldValidationRules());
+
+        if ($asset->isInvalid()) {
+            return redirect()->route('hardware.edit', $asset)->withErrors($asset->getErrors());
         }
 
         $dt = Carbon::now()->addMonths($settings->audit_interval)->toDateString();

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -113,7 +113,10 @@ class CustomFieldset extends Model
                     $rule[] = 'unique_undeleted';
             }
 
-            array_push($rule, $field->attributes['format']);
+            if ($field->attributes['format']!='') {
+                array_push($rule, $field->attributes['format']);
+            }
+
             $rules[$field->db_column_name()] = $rule;
 
 


### PR DESCRIPTION
On the redirect if data is not complete (or the validation rules have changed since the asset was created/last updated), it was incorrectly redirecting to the edit asset page if the field was marked as unique, even if it was already unique. This is because the `UniqueUndeletedTrait` and therefore the `unique_undeleted` validator could not see the present model, so the existing record couldn't exclude its own ID from validation. 

Thanks for the rubber ducking @marcusmoore and @uberbrady! 🫶🏻
