### PR TITLE
Removed seat "name" from licenses seats API/UI response

### DIFF
--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -34,7 +34,7 @@ class LicenseSeatsController extends Controller
             if ($request->input('sort') == 'department') {
                 $seats->OrderDepartments($order);
             } else {
-                $seats->orderBy('id', $order);
+                $seats->orderBy('updated_at', $order);
             }
 
             $total = $seats->count();

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -13,16 +13,15 @@ class LicenseSeatsTransformer
     public function transformLicenseSeats(Collection $seats, $total)
     {
         $array = [];
-        $seat_count = 0;
+
         foreach ($seats as $seat) {
-            $seat_count++;
-            $array[] = self::transformLicenseSeat($seat, $seat_count);
+            $array[] = self::transformLicenseSeat($seat);
         }
 
         return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
-    public function transformLicenseSeat(LicenseSeat $seat, $seat_count = 0)
+    public function transformLicenseSeat(LicenseSeat $seat)
     {
         $array = [
             'id' => (int) $seat->id,
@@ -54,10 +53,6 @@ class LicenseSeatsTransformer
             'notes' => e($seat->notes),
             'user_can_checkout' => (($seat->assigned_to == '') && ($seat->asset_id == '')),
         ];
-
-        if ($seat_count != 0) {
-            $array['name'] = trans('admin/licenses/general.seat_count', ['count' => $seat_count]);
-        }
 
         $permissions_array['available_actions'] = [
             'checkout' => Gate::allows('checkout', License::class),

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -230,16 +230,7 @@ class LicensePresenter extends Presenter
                 'switchable' => true,
                 'title' => trans('general.id'),
                 'visible' => false,
-           ],
-           [
-                'field' => 'name',
-                'searchable' => false,
-                'sortable' => false,
-                'sorter'   => 'numericOnly',
-                'switchable' => true,
-                'title' => trans('admin/licenses/general.seat'),
-                'visible' => true,
-            ], [
+           ],[
                 'field' => 'assigned_user',
                 'searchable' => false,
                 'sortable' => false,
@@ -285,7 +276,7 @@ class LicensePresenter extends Presenter
                 'searchable' => false,
                 'sortable' => true,
                 'visible' => false,
-                'title' => trans('general.date'),
+                'title' => trans('general.updated_at'),
                 'formatter' => 'dateDisplayFormatter',
             ],
             [


### PR DESCRIPTION
The seat "name" was never real in the first place, and the math we were doing to make it try to look real was wrong, so since it never actually really worked, this felt okay to remove. 

Once the big license refactor happens, this may be re-added in a non-borked way.