### PR TITLE
Handle settings not being available in full name accessor

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -320,7 +320,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     {
         $setting = Setting::getSettings();
 
-        if ($setting->name_display_format=='last_first') {
+        if ($setting?->name_display_format == 'last_first') {
             return ($this->last_name) ? $this->last_name.' '.$this->first_name : $this->first_name;
         }
         return $this->last_name ? $this->first_name.' '.$this->last_name : $this->first_name;


### PR DESCRIPTION
I ran into an exception being thrown while going through the application set up workflow. Oddly enough it was sporadic and at times I was able to successfully set up the application without hitting it.

From the best I can tell the problem stems from the chunk below:
https://github.com/grokability/snipe-it/blob/407962d9989867faadfd357f5db27342bd154dba/app/Http/Controllers/SettingsController.php#L201-L203

The user listener was firing on the `->save()` line and somewhere along the line `$user->full_name` was being called before the settings were saved.

---

I haven't had a chance to full test thing to make sure there aren't any side-effects I'm not considering but here it is if other people report set up issues.