### PR TITLE
Fixed #16901 - use default currency for asset maintenance cost

### DIFF
--- a/resources/views/asset_maintenances/view.blade.php
+++ b/resources/views/asset_maintenances/view.blade.php
@@ -99,7 +99,7 @@ use Carbon\Carbon;
                 {{ trans('admin/asset_maintenances/form.cost') }}
               </div>
               <div class="col-md-9">
-                {{ trans( 'general.currency' ) . Helper::formatCurrencyOutput($assetMaintenance->cost) }}
+                {{ \App\Models\Setting::getSettings()->default_currency .' '. Helper::formatCurrencyOutput($assetMaintenance->cost) }}
               </div>
             </div> <!-- /row -->
             @endif


### PR DESCRIPTION
This fixes #16901 where we were using a generic currency placeholder instead of the setting in localizations.