### PR TITLE
Fixed: disabled Category EULA box when no Default EULA created

### DIFF
--- a/app/Livewire/CategoryEditForm.php
+++ b/app/Livewire/CategoryEditForm.php
@@ -41,6 +41,13 @@ class CategoryEditForm extends Component
         $this->sendCheckInEmail = $this->eulaText || $this->useDefaultEula ? 1 : $this->originalSendCheckInEmailValue;
     }
 
+    public function shouldUncheckDefaultEulaBox()
+    {
+        if($this->eulaText!='' && $this->defaultEulaText=='') {
+            return $this->useDefaultEula = false;
+        }
+    }
+
     public function getShouldDisplayEmailMessageProperty(): bool
     {
         return $this->eulaText || $this->useDefaultEula;

--- a/app/Livewire/CategoryEditForm.php
+++ b/app/Livewire/CategoryEditForm.php
@@ -32,7 +32,7 @@ class CategoryEditForm extends Component
         return view('livewire.category-edit-form');
     }
 
-    public function updated($property, $value)
+    public function updated($property, $value) //this is what's throwing us off i think. not quite sure what this is doing.
     {
         if (! in_array($property, ['eulaText', 'useDefaultEula'])) {
             return;

--- a/resources/views/livewire/category-edit-form.blade.php
+++ b/resources/views/livewire/category-edit-form.blade.php
@@ -35,12 +35,14 @@
                             type="checkbox"
                             name="use_default_eula"
                             value="0"
-                            wire:model.live="shouldUncheckDefaultEulaBox"
+                            wire:="shouldUncheckDefaultEulaBox"
                             aria-label="use_default_eula"
                     />
                     <span>{!! trans('admin/categories/general.use_default_eula_disabled') !!}</span>
                 </label>
             @else
+                {{--so if we delete the eula text, then it will skip the one above, and then get to this.
+                Putting us back where we started--}}
                 <label class="form-control form-control--disabled">
                     <input
                         type="checkbox"

--- a/resources/views/livewire/category-edit-form.blade.php
+++ b/resources/views/livewire/category-edit-form.blade.php
@@ -7,15 +7,11 @@
                 name="eula_text"
                 wire:model.live="eulaText"
                 aria-label="eula_text"
-                :disabled="$this->eulaTextDisabled"
             />
             <p class="help-block">{!! trans('admin/categories/general.eula_text_help') !!} </p>
             <p class="help-block">{!! trans('admin/settings/general.eula_markdown') !!} </p>
             {!! $errors->first('eula_text', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
         </div>
-        @if ($this->eulaTextDisabled)
-            <input type="hidden" name="eula_text" wire:model.live="eulaText" />
-        @endif
     </div>
 
     <!-- Use default checkbox -->
@@ -31,6 +27,18 @@
                         aria-label="use_default_eula"
                     />
                     <span>{!! trans('admin/categories/general.use_default_eula') !!}</span>
+                </label>
+            @elseif ($eulaText!='')
+                <label class="form-control form-control--disabled">
+
+                    <input
+                            type="checkbox"
+                            name="use_default_eula"
+                            value="0"
+                            wire:model.live="shouldUncheckDefaultEulaBox"
+                            aria-label="use_default_eula"
+                    />
+                    <span>{!! trans('admin/categories/general.use_default_eula_disabled') !!}</span>
                 </label>
             @else
                 <label class="form-control form-control--disabled">


### PR DESCRIPTION
fixes: [SC-29119](https://app.shortcut.com/grokability/story/29119/confusing-inconsistent-messaging-functionality-on-category-detail-page)

EULA on the Category settings page for each category was disabled while there was no default EULA made, even when there was a EULA specifically set on the Category itself.

This makes it so that EULA is always editable, and if there is no Default EULA, then it will uncheck and grey out the "use Default EULA" option

<img width="1672" alt="Screenshot 2025-05-12 at 8 18 02 AM" src="https://github.com/user-attachments/assets/88727775-2b71-463f-950d-cbc8a417b8fd" />
<img width="1160" alt="Screenshot 2025-05-12 at 8 18 08 AM" src="https://github.com/user-attachments/assets/a2d0181a-ebb0-4268-9d31-c20b1879ff62" />

