### PR TITLE
Handle potential hard exception in Asset@getImageUrl method

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -656,7 +656,7 @@ class Asset extends Depreciable
             return Storage::disk('public')->url(app('assets_upload_path').e($this->image));
         } elseif ($this->model && ! empty($this->model->image)) {
             return Storage::disk('public')->url(app('models_upload_path').e($this->model->image));
-        } elseif ($this->model->category && ! empty($this->model->category->image)) {
+        } elseif ($this->model?->category && ! empty($this->model->category->image)) {
             return Storage::disk('public')->url(app('categories_upload_path').e($this->model->category->image));
         }
 

--- a/tests/Unit/AssetTest.php
+++ b/tests/Unit/AssetTest.php
@@ -204,17 +204,9 @@ class AssetTest extends TestCase
     {
         $urlBase = config('filesystems.disks.public.url');
 
-        $category = Category::factory()->create([
-            'image' => 'category-image.jpg',
-        ]);
-
-        $model = AssetModel::factory()->for($category)->create([
-            'image' => 'asset-model-image.jpg',
-        ]);
-
-        $asset = Asset::factory()->for($model, 'model')->create([
-            'image' => 'asset-image.jpg',
-        ]);
+        $category = Category::factory()->create(['image' => 'category-image.jpg']);
+        $model = AssetModel::factory()->for($category)->create(['image' => 'asset-model-image.jpg']);
+        $asset = Asset::factory()->for($model, 'model')->create(['image' => 'asset-image.jpg']);
 
         $this->assertEquals(
             "{$urlBase}/assets/asset-image.jpg",

--- a/tests/Unit/AssetTest.php
+++ b/tests/Unit/AssetTest.php
@@ -239,5 +239,11 @@ class AssetTest extends TestCase
         $category->save();
 
         $this->assertFalse($asset->refresh()->getImageUrl());
+
+        // handles case where model does not exist
+        $asset->model_id = 9999999;
+        $asset->forceSave();
+
+        $this->assertFalse($asset->refresh()->getImageUrl());
     }
 }

--- a/tests/Unit/AssetTest.php
+++ b/tests/Unit/AssetTest.php
@@ -199,4 +199,45 @@ class AssetTest extends TestCase
         ]);
         $this->assertModelMissing($asset);
     }
+
+    public function testGetImageUrlMethod()
+    {
+        $urlBase = config('filesystems.disks.public.url');
+
+        $category = Category::factory()->create([
+            'image' => 'category-image.jpg',
+        ]);
+
+        $model = AssetModel::factory()->for($category)->create([
+            'image' => 'asset-model-image.jpg',
+        ]);
+
+        $asset = Asset::factory()->for($model, 'model')->create([
+            'image' => 'asset-image.jpg',
+        ]);
+
+        $this->assertEquals(
+            "{$urlBase}/assets/asset-image.jpg",
+            $asset->getImageUrl()
+        );
+
+        $asset->update(['image' => null]);
+
+        $this->assertEquals(
+            "{$urlBase}/models/asset-model-image.jpg",
+            $asset->refresh()->getImageUrl()
+        );
+
+        $model->update(['image' => null]);
+
+        $this->assertEquals(
+            "{$urlBase}/categories/category-image.jpg",
+            $asset->refresh()->getImageUrl()
+        );
+
+        $category->image = null;
+        $category->save();
+
+        $this->assertFalse($asset->refresh()->getImageUrl());
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where bad data (an asset not having a model) can cause a 500 when accessing the asset's image.

I also backfilled the tests for the `getImageUrl` method