### PR TITLE
Handle displaying deleted creator of an accessory

### DIFF
--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -324,7 +324,11 @@
                   </strong>
               </div>
               <div class="col-md-9" style="word-wrap: break-word;">
-                  {{ $accessory->adminuser->present()->fullName() }}
+                  @if ($accessory->adminuser)
+                      {{ $accessory->adminuser->present()->fullName() }}
+                  @else
+                      {{ trans('admin/reports/general.deleted_user') }}
+                  @endif
               </div>
           </div>
 

--- a/tests/Feature/Accessories/Ui/ShowAccessoryTest.php
+++ b/tests/Feature/Accessories/Ui/ShowAccessoryTest.php
@@ -47,4 +47,13 @@ class ShowAccessoryTest extends TestCase
             ->assertOk();
 
     }
+
+    public function testHandlesAccessoryCreatorNotExisting()
+    {
+        $accessory = Accessory::factory()->create(['created_by' => 999999]);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->get(route('accessories.show', $accessory))
+            ->assertOk();
+    }
 }


### PR DESCRIPTION
This PR handles an issue where (most likely due to bad data) viewing an accessory where the creator has been deleted caused the page to throw a 500 exception.

Now the page will say "Deleted user":
![image](https://github.com/user-attachments/assets/f85acfc8-53a6-4f68-b1d4-c0ecb01dc088)

---

The translation I'm using is under `reports` but is the only string that says "Deleted user" specifically. It feels like it should be under `general` but I didn't want to create a new string for one that already exists.