### PR TITLE
Remove logo outline from L7162_B

### DIFF
--- a/app/Models/Labels/Sheets/Avery/L7162_B.php
+++ b/app/Models/Labels/Sheets/Avery/L7162_B.php
@@ -55,7 +55,7 @@ class L7162_B extends L7162
                 $pdf, $record->get('logo'),
                 $pa->x1, $pa->y1,
                 self::LOGO_MAX_WIDTH, $usableHeight,
-                'L', 'T', 300, true, false, 0.1
+                'L', 'T', 300, true, false, 0
             );
             $currentX += $logoSize[0] + self::LOGO_MARGIN;
             $usableWidth -= $logoSize[0] + self::LOGO_MARGIN;


### PR DESCRIPTION
As noted in #16919, when using the L7162_B label an outline is being added around the logo.

All of our other labels that support displaying logos don't have an outline around the logo so I removed it from this one as well.


Before:
![image](https://github.com/user-attachments/assets/05d09f65-7545-43d3-9abd-04b6d344946f)

After:
![image](https://github.com/user-attachments/assets/4be799fc-f1fe-489f-aa77-2995ade14c87)

---

Should fix #16919