### PR TITLE
Replace locales macro

### DIFF
--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -4,27 +4,6 @@
 */
 
 /**
- * Locale macro
- * Generates the dropdown menu of available languages
- */
-Form::macro('locales', function ($name = 'locale', $selected = null, $class = null, $id = null) {
-
-    $idclause = (!is_null($id)) ? $id : '';
-
-    $select = '<select name="'.$name.'" class="'.$class.'" style="width:100%"'.$idclause.' aria-label="'.$name.'" data-placeholder="'.trans('localizations.select_language').'">';
-    $select .= '<option value=""  role="option">'.trans('localizations.select_language').'</option>';
-
-    // Pull the autoglossonym array from the localizations translation file
-    foreach (trans('localizations.languages') as $abbr => $locale) {
-        $select .= '<option value="'.$abbr.'"'.(($selected == $abbr) ? ' selected="selected" role="option" aria-selected="true"' : ' aria-selected="false"').'>'.$locale.'</option> ';
-    }
-
-    $select .= '</select>';
-
-    return $select;
-});
-
-/**
  * Country macro
  * Generates the dropdown menu of countries for the profile form
  */

--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -49,7 +49,7 @@
           <div class="col-md-7">
 
             @if (!config('app.lock_passwords'))
-              <x-input.locale-select name="locales" :selected="old('locale', $user->locale)"/>
+              <x-input.locale-select name="locale" :selected="old('locale', $user->locale)"/>
               {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
             @else
               <p class="help-block">{{ trans('general.feature_disabled') }}</p>

--- a/resources/views/account/profile.blade.php
+++ b/resources/views/account/profile.blade.php
@@ -49,7 +49,7 @@
           <div class="col-md-7">
 
             @if (!config('app.lock_passwords'))
-              {!! Form::locales('locale', old('locale', $user->locale), 'select2') !!}
+              <x-input.locale-select name="locales" :selected="old('locale', $user->locale)"/>
               {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
             @else
               <p class="help-block">{{ trans('general.feature_disabled') }}</p>

--- a/resources/views/blade/input/locale-select.blade.php
+++ b/resources/views/blade/input/locale-select.blade.php
@@ -2,23 +2,21 @@
     'name' => 'locale',
     'selected' => null,
 ])
-<div>
-    <select
-        name="{{ $name }}"
-        {{ $attributes->merge(['class' => 'select2', 'style' => 'width:100%']) }}
-        aria-label="{{ $name }}"
-        data-placeholder="{{ trans('localizations.select_language') }}"
-    >
-        <option value=""  role="option">{{ trans('localizations.select_language') }}</option>'
-        @foreach (trans('localizations.languages') as $abbr => $locale)
-            <option
-                value="{{ $abbr }}"
-                role="option"
-                @selected($abbr == $selected)
-                aria-selected="{{ $abbr == $selected ? 'true' : 'false' }}"
-            >
-                {{ $locale }}
-            </option>
-        @endforeach
-    </select>
-</div>
+<select
+    name="{{ $name }}"
+    {{ $attributes->merge(['class' => 'select2', 'style' => 'width:100%']) }}
+    aria-label="{{ $name }}"
+    data-placeholder="{{ trans('localizations.select_language') }}"
+>
+    <option value=""  role="option">{{ trans('localizations.select_language') }}</option>'
+    @foreach (trans('localizations.languages') as $abbr => $locale)
+        <option
+            value="{{ $abbr }}"
+            role="option"
+            @selected($abbr == $selected)
+            aria-selected="{{ $abbr == $selected ? 'true' : 'false' }}"
+        >
+            {{ $locale }}
+        </option>
+    @endforeach
+</select>

--- a/resources/views/blade/input/locale-select.blade.php
+++ b/resources/views/blade/input/locale-select.blade.php
@@ -1,0 +1,24 @@
+@props([
+    'name' => 'locale',
+    'selected' => null,
+])
+<div>
+    <select
+        name="{{ $name }}"
+        {{ $attributes->merge(['class' => 'select2', 'style' => 'width:100%']) }}
+        aria-label="{{ $name }}"
+        data-placeholder="{{ trans('localizations.select_language') }}"
+    >
+        <option value=""  role="option">{{ trans('localizations.select_language') }}</option>'
+        @foreach (trans('localizations.languages') as $abbr => $locale)
+            <option
+                value="{{ $abbr }}"
+                role="option"
+                @selected($abbr == $selected)
+                aria-selected="{{ $abbr == $selected ? 'true' : 'false' }}"
+            >
+                {{ $locale }}
+            </option>
+        @endforeach
+    </select>
+</div>

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -46,7 +46,7 @@
                                 <label for="site_name">{{ trans('admin/settings/general.default_language') }}</label>
                             </div>
                             <div class="col-md-5 col-xs-12">
-                                {!! Form::locales('locale', old('locale', $setting->locale), 'select2') !!}
+                                <x-input.locale-select name="locale" :selected="old('locale', $setting->locale)" />
 
                                 {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>

--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -34,7 +34,7 @@
       <label for="locale">
         {{ trans('admin/settings/general.default_language') }}
       </label>
-      {!! Form::locales('locale', old('locale', "en-US"), 'select2') !!}
+      <x-input.locale-select name="locale" :selected="old('locale', 'en-US')" />
       {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
     </div>
 

--- a/resources/views/users/bulk-edit.blade.php
+++ b/resources/views/users/bulk-edit.blade.php
@@ -94,7 +94,7 @@
                         <div class="form-group {{ $errors->has('locale') ? 'has-error' : '' }}">
                             <label class="col-md-3 control-label" for="locale">{{ trans('general.language') }}</label>
                             <div class="col-md-8">
-                                {!! Form::locales('locale', old('locale', ''), 'select2') !!}
+                                <x-input.locale-select name="locale" :selected="old('locale', '')"/>
                                 {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
                         </div>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -302,7 +302,7 @@
                               <div class="form-group {{ $errors->has('locale') ? 'has-error' : '' }}">
                                   <label class="col-md-3 control-label" for="locale">{{ trans('general.language') }}</label>
                                   <div class="col-md-6">
-                                      {!! Form::locales('locale', old('locale', $user->locale), 'select2') !!}
+                                      <x-input.locale-select name="locale" :selected="old('locale', $user->locale)" />
                                       {!! $errors->first('locale', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                   </div>
                               </div>


### PR DESCRIPTION
This PR replaces the custom `locales` form macro with a new blade component.

![image](https://github.com/user-attachments/assets/489df326-e0ab-458b-9ebe-464ff28a14d9)

