### PR TITLE
A quick check to make sure that webhooks still fire when email is off

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -388,6 +388,9 @@ class CheckoutableListener
         if(in_array(get_class($checkoutable), $this->skipNotificationsFor)) {
             return true;
         }
+        if ($this->shouldSendWebhookNotification()) {
+            return false;
+        }
         //runs a check if the category wants to send checkin/checkout emails to users
         $category = match (true) {
             $checkoutable instanceof Asset => $checkoutable->model->category,


### PR DESCRIPTION
I think @marcusmoore 's fix #16932 is more likely to be the better fix, going forward, since he includes tests and I think untangles some of the logic a little more cleanly. But this is short, and seems to help for now.

I was able to configure my development workstation to turn *off* global notifications, and turn *off* notifications in the category in question, and then I stopped getting webhooks, even though the UI says that I should get one.

When I applied this fix, then I got the webhook notifications again.

So I think it's a safe interim step until we can get Marcus's more permanent fix.