### PR TITLE
Clearer text on status label types

### DIFF
--- a/resources/lang/en-US/admin/statuslabels/table.php
+++ b/resources/lang/en-US/admin/statuslabels/table.php
@@ -1,14 +1,14 @@
 <?php
 
 return array(
-    'about'      	=> 'About Status Labels',
+    'about'      	=> 'About Status Types',
     'archived'      	=> 'Archived',
     'create'      	=> 'Create Status Label',
     'color'      	=> 'Chart Color',
     'default_label' => 'Default Label',
     'default_label_help' => 'This is used to ensure your most commonly used status labels appear at the top of the select box when creating/editing assets.',
     'deployable'      	=> 'Deployable',
-    'info'      	=> 'Status labels are used to describe the various states your assets could be in. They may be out for repair, lost/stolen, etc. You can create new status labels for deployable, pending and archived assets.',
+    'info'      	=> 'Status label types are used to describe the various states your assets could be in. They may be out for repair, lost/stolen, etc. You can create new status labels for your deployable, pending and archived assets according to your own workflow. For more information, <a href="https://snipe-it.readme.io/docs/overview#status-labels" target="_blank">see the documentation <i class="fa fa-external-link"></i></a>.',
     'name'      	=> 'Status Name',
     'pending'      	=> 'Pending',
     'status_type'   => 'Status Type',

--- a/resources/views/statuslabels/index.blade.php
+++ b/resources/views/statuslabels/index.blade.php
@@ -1,7 +1,4 @@
-@extends('layouts/default', [
-    'helpText' => trans('admin/statuslabels/table.info') ,
-    'helpPosition' => 'right',
-])
+@extends('layouts/default')
 
 {{-- Page title --}}
 @section('title')
@@ -50,6 +47,13 @@
   <!-- side address column -->
   <div class="col-md-3">
     <h2>{{ trans('admin/statuslabels/table.about') }}</h2>
+
+      <div class="box">
+          <div class="box-body">
+              <p>{!!  trans('admin/statuslabels/table.info') !!}</p>
+          </div>
+      </div>
+
 
       <div class="box box-success">
           <div class="box-body">
@@ -125,7 +129,7 @@
 
           var typename_lower = trans;
           var typename = typename_lower.charAt(0).toUpperCase() + typename_lower.slice(1);
-          return '<i class="fa ' + icon_style + ' text-' + text_color + '"></i> ' + typename;
+          return '<nobr><i class="fa ' + icon_style + ' text-' + text_color + '"></i> ' + typename + '</nobr>';
 
 
       }


### PR DESCRIPTION
This just clarifies the status label *type* information a little better to help folks understand the difference between the label and the type.