### PR TITLE
Gracefully handle error when editing of soft deleted users

### DIFF
--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -178,7 +178,7 @@ class UsersController extends Controller
      * @author [A. Gianotto] [<snipe@snipe.net>]
      * @since [v1.0]
      * @param $permissions
-     * @return \Illuminate\Contracts\View\View
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Http\RedirectResponse
      * @internal param int $id
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
@@ -189,6 +189,10 @@ class UsersController extends Controller
         $user = User::with(['assets', 'assets.model', 'consumables', 'accessories', 'licenses', 'userloc'])->withTrashed()->find($user->id);
 
         if ($user) {
+
+            if ($user->trashed()) {
+                return redirect()->route('users.show', $user->id);
+            }
 
             $permissions = config('permissions');
             $groups = Group::pluck('name', 'id');

--- a/app/Rules/UserCannotSwitchCompaniesIfItemsAssigned.php
+++ b/app/Rules/UserCannotSwitchCompaniesIfItemsAssigned.php
@@ -15,7 +15,7 @@ class UserCannotSwitchCompaniesIfItemsAssigned implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $user = User::find(request()->route('user')->id);
+        $user = request()->route('user');
 
         if (($value) && ($user->allAssignedCount() > 0) && (Setting::getSettings()->full_multiple_companies_support=='1')) {
 

--- a/tests/Feature/Users/Ui/UpdateUserTest.php
+++ b/tests/Feature/Users/Ui/UpdateUserTest.php
@@ -17,6 +17,15 @@ class UpdateUserTest extends TestCase
             ->assertOk();
     }
 
+    public function testCannotViewEditPageForSoftDeletedUser()
+    {
+        $user = User::factory()->trashed()->create();
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->get(route('users.edit', $user->id))
+            ->assertRedirectToRoute('users.show', $user->id);
+    }
+
     public function testUsersCanBeActivatedWithNumber()
     {
         $admin = User::factory()->superuser()->create();

--- a/tests/Feature/Users/Ui/UpdateUserTest.php
+++ b/tests/Feature/Users/Ui/UpdateUserTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Users\Ui;
 use App\Models\Asset;
 use App\Models\Company;
 use App\Models\User;
+use Error;
 use Tests\TestCase;
 
 class UpdateUserTest extends TestCase
@@ -160,5 +161,33 @@ class UpdateUserTest extends TestCase
         ]);
 
         $this->followRedirects($response)->assertSee('success');
+    }
+
+    /**
+     * This can occur if the user edit screen is open in one tab and
+     * the user is deleted in another before the edit form is submitted.
+     * @link https://app.shortcut.com/grokability/story/29166
+     */
+    public function testAttemptingToUpdateDeletedUserIsHandledGracefully()
+    {
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+        $user = User::factory()->for($companyA)->create();
+        Asset::factory()->assignedToUser($user)->create();
+
+        $id = $user->id;
+
+        $user->delete();
+
+        $response = $this->actingAs(User::factory()->editUsers()->create())
+            ->put(route('users.update', $id), [
+                'first_name' => 'test',
+                'username' => 'test',
+                'company_id' => $companyB->id,
+            ]);
+
+        $this->assertFalse($response->exceptions->contains(function ($exception) {
+            // Avoid hard 500
+            return $exception instanceof Error;
+        }));
     }
 }

--- a/tests/Feature/Users/Ui/UpdateUserTest.php
+++ b/tests/Feature/Users/Ui/UpdateUserTest.php
@@ -190,6 +190,7 @@ class UpdateUserTest extends TestCase
             return $exception instanceof Error;
         }));
 
+        // As of now, the user will be updated but not be restored
         $this->assertDatabaseHas('users', [
             'id' => $id,
             'first_name' => 'test',

--- a/tests/Feature/Users/Ui/UpdateUserTest.php
+++ b/tests/Feature/Users/Ui/UpdateUserTest.php
@@ -189,5 +189,12 @@ class UpdateUserTest extends TestCase
             // Avoid hard 500
             return $exception instanceof Error;
         }));
+
+        $this->assertDatabaseHas('users', [
+            'id' => $id,
+            'first_name' => 'test',
+            'username' => 'test',
+            'company_id' => $companyB->id,
+        ]);
     }
 }


### PR DESCRIPTION
This PR fixes an issue where a 500 would be thrown if a soft-deleted user is edited via the UI.

@snipe I noticed the API doesn't allow modifying users that are soft deleted and the UI shows the edit button disabled but you can manually get to the route.

![image](https://github.com/user-attachments/assets/d778eeaa-d102-4524-b750-f41f53d25851)

✅  Should I include not allowing the edit page to show for soft deleted users?
This is added so attempting to manually view the route redirects back to the user show page with the existing helpful message at the top: 
![image](https://github.com/user-attachments/assets/e7142d37-ec95-4ce8-82c2-9f68687a3b1a)
