### PR TITLE
Adds require serial as Asset Model option

### DIFF
--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -50,6 +50,7 @@ class AssetModelsController extends Controller
                 'fieldset',
                 'deleted_at',
                 'updated_at',
+                'require_serial',
             ];
 
         $assetmodels = AssetModel::select([
@@ -69,6 +70,7 @@ class AssetModelsController extends Controller
             'models.fieldset_id',
             'models.deleted_at',
             'models.updated_at',
+            'models.require_serial'
          ])
             ->with('category', 'depreciation', 'manufacturer', 'fieldset.fields.defaultValues', 'adminuser')
             ->withCount('assets as assets_count');

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -82,7 +82,7 @@ class AssetModelsController extends Controller
         $model->notes = $request->input('notes');
         $model->created_by = auth()->id();
         $model->requestable = $request->has('requestable');
-        $model->require_serial = $request->input('require_serial');
+        $model->require_serial = $request->input('require_serial', 0);
 
         if ($request->input('fieldset_id') != '') {
             $model->fieldset_id = $request->input('fieldset_id');
@@ -143,7 +143,7 @@ class AssetModelsController extends Controller
         $model->category_id = $request->input('category_id');
         $model->notes = $request->input('notes');
         $model->requestable = $request->input('requestable', '0');
-        $model->require_serial = $request->input('require_serial');
+        $model->require_serial = $request->input('require_serial', 0);
         $model->fieldset_id = $request->input('fieldset_id');
 
         if ($model->save()) {

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -82,7 +82,7 @@ class AssetModelsController extends Controller
         $model->notes = $request->input('notes');
         $model->created_by = auth()->id();
         $model->requestable = $request->has('requestable');
-        $model->require_serial = $request->has('require_serial');
+        $model->require_serial = $request->input('require_serial');
 
         if ($request->input('fieldset_id') != '') {
             $model->fieldset_id = $request->input('fieldset_id');
@@ -143,7 +143,7 @@ class AssetModelsController extends Controller
         $model->category_id = $request->input('category_id');
         $model->notes = $request->input('notes');
         $model->requestable = $request->input('requestable', '0');
-        $model->require_serial = $request->has('require_serial');
+        $model->require_serial = $request->input('require_serial');
         $model->fieldset_id = $request->input('fieldset_id');
 
         if ($model->save()) {

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -82,6 +82,7 @@ class AssetModelsController extends Controller
         $model->notes = $request->input('notes');
         $model->created_by = auth()->id();
         $model->requestable = $request->has('requestable');
+        $model->require_serial = $request->has('require_serial');
 
         if ($request->input('fieldset_id') != '') {
             $model->fieldset_id = $request->input('fieldset_id');
@@ -142,7 +143,7 @@ class AssetModelsController extends Controller
         $model->category_id = $request->input('category_id');
         $model->notes = $request->input('notes');
         $model->requestable = $request->input('requestable', '0');
-
+        $model->require_serial = $request->has('require_serial');
         $model->fieldset_id = $request->input('fieldset_id');
 
         if ($model->save()) {

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -110,28 +110,37 @@ class AssetsController extends Controller
         // This is only necessary on create, not update, since bulk editing is handled
         // differently
         $asset_tags = $request->input('asset_tags');
+        $model = AssetModel::find($request->input('model_id'));
+        $serial_errors = [];
+        $serials = $request->input('serials');
 
         $settings = Setting::getSettings();
 
+        //Validate required serial based on model setting
+        for ($a = 1, $aMax = count($asset_tags); $a <= $aMax; $a++) {
+            if ($model && $model->require_serial === 1 && empty($serials[$a])) {
+                $serial_errors["serials.$a"] = trans('admin/hardware/form.serial_required', ['number' => $a]);
+            }
+
+        }
+
+        if (!empty($serial_errors)) {
+            return redirect()->back()
+                ->withInput()
+                ->withErrors($serial_errors);
+        }
+
+        $asset = null;
+        $companyId = Company::getIdForCurrentUser($request->input('company_id'));
         $successes = [];
         $failures = [];
-        $serials = $request->input('serials');
-        $asset = null;
 
-        for ($a = 1; $a <= count($asset_tags); $a++) {
+        for ($a = 1, $aMax = count($asset_tags); $a <= $aMax; $a++) {
             $asset = new Asset();
-            $model = AssetModel::find($request->input('model_id'));
+
             $asset->model()->associate($model);
             $asset->name = $request->input('name');
 
-            //Validate required serial based on model setting
-            if ($model && $model->require_serial === 1 && empty($serials[$a])) {
-                return redirect()->back()
-                    ->withInput()
-                    ->withErrors([
-                        "serials.$a" => trans('admin/hardware/form.serial_required'),
-                    ]);
-            }
             // Check for a corresponding serial
             if (($serials) && (array_key_exists($a, $serials))) {
                 $asset->serial = $serials[$a];
@@ -141,7 +150,7 @@ class AssetsController extends Controller
                 $asset->asset_tag = $asset_tags[$a];
             }
 
-            $asset->company_id              = Company::getIdForCurrentUser($request->input('company_id'));
+            $asset->company_id              = $companyId;
             $asset->model_id                = $request->input('model_id');
             $asset->order_number            = $request->input('order_number');
             $asset->notes                   = $request->input('notes');
@@ -173,7 +182,6 @@ class AssetsController extends Controller
 
             // Update custom fields in the database.
             // Validation for these fields is handled through the AssetRequest form request
-            $model = AssetModel::find($request->get('model_id'));
 
             if (($model) && ($model->fieldset)) {
                 foreach ($model->fieldset->fields as $field) {

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -422,6 +422,13 @@ class AssetsController extends Controller
 
         session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => $request->get('checkout_to_type')]);
 
+        //Validate required serial based on model setting
+        if ($model && $model->require_serial === 1 && empty($serial[1] ?? null)) {
+            return redirect()->to(Helper::getRedirectOption($request, $asset->id, 'Assets'))
+                ->with('warning', trans('admin/hardware/form.serial_required_post_model_update', [
+                    'asset_model' => $model->name
+                ]));
+        }
         if ($asset->save()) {
             return redirect()->to(Helper::getRedirectOption($request, $asset->id, 'Assets'))
                 ->with('success', trans('admin/hardware/message.update.success'));

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -125,7 +125,7 @@ class AssetsController extends Controller
             $asset->name = $request->input('name');
 
             //Validate required serial based on model setting
-            if ($model && $model->require_serial === 1 && empty($serials[$a] ?? null)) {
+            if ($model && $model->require_serial === 1 && empty($serials[$a])) {
                 return redirect()->back()
                     ->withInput()
                     ->withErrors([
@@ -423,7 +423,7 @@ class AssetsController extends Controller
         session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => $request->get('checkout_to_type')]);
 
         //Validate required serial based on model setting
-        if ($model && $model->require_serial === 1 && empty($serial[1] ?? null)) {
+        if ($model && $model->require_serial === 1 && empty($serial[1])) {
             return redirect()->to(Helper::getRedirectOption($request, $asset->id, 'Assets'))
                 ->with('warning', trans('admin/hardware/form.serial_required_post_model_update', [
                     'asset_model' => $model->name

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -120,9 +120,18 @@ class AssetsController extends Controller
 
         for ($a = 1; $a <= count($asset_tags); $a++) {
             $asset = new Asset();
-            $asset->model()->associate(AssetModel::find($request->input('model_id')));
+            $model = AssetModel::find($request->input('model_id'));
+            $asset->model()->associate($model);
             $asset->name = $request->input('name');
 
+            //Validate required serial based on model setting
+            if ($model && $model->require_serial === 1 && empty($serials[$a] ?? null)) {
+                return redirect()->back()
+                    ->withInput()
+                    ->withErrors([
+                        "serials.$a" => trans('admin/hardware/form.serial_required'),
+                    ]);
+            }
             // Check for a corresponding serial
             if (($serials) && (array_key_exists($a, $serials))) {
                 $asset->serial = $serials[$a];

--- a/app/Http/Controllers/BulkAssetModelsController.php
+++ b/app/Http/Controllers/BulkAssetModelsController.php
@@ -92,7 +92,9 @@ class BulkAssetModelsController extends Controller
             $update_array['min_amt'] = $request->input('min_amt');
         }
 
-
+        if ($request->filled('require_serial')) {
+            $update_array['require_serial'] = $request->input('require_serial');
+        }
 
         if (count($update_array) > 0) {
             AssetModel::whereIn('id', $models_raw_array)->update($update_array);

--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -32,7 +32,7 @@ class LabelsController extends Controller
 
         $exampleAsset->id = 999999;
         $exampleAsset->name = 'JEN-867-5309';
-        $exampleAsset->asset_tag = 'Inet Workstation (13th Gen)';
+        $exampleAsset->asset_tag = '100001';
         $exampleAsset->serial = 'SN9876543210';
         $exampleAsset->asset_eol_date = '2025-01-01';
         $exampleAsset->order_number = '12345';

--- a/app/Http/Controllers/LabelsController.php
+++ b/app/Http/Controllers/LabelsController.php
@@ -32,7 +32,7 @@ class LabelsController extends Controller
 
         $exampleAsset->id = 999999;
         $exampleAsset->name = 'JEN-867-5309';
-        $exampleAsset->asset_tag = '100001';
+        $exampleAsset->asset_tag = 'Inet Workstation (13th Gen)';
         $exampleAsset->serial = 'SN9876543210';
         $exampleAsset->asset_eol_date = '2025-01-01';
         $exampleAsset->order_number = '12345';

--- a/app/Http/Transformers/AssetModelsTransformer.php
+++ b/app/Http/Transformers/AssetModelsTransformer.php
@@ -65,6 +65,7 @@ class AssetModelsTransformer
             'default_fieldset_values' => $default_field_values,
             'eol' => ($assetmodel->eol > 0) ? $assetmodel->eol.' months' : 'None',
             'requestable' => ($assetmodel->requestable == '1') ? true : false,
+            'require_serial' => $assetmodel->require_serial,
             'notes' => Helper::parseEscapedMarkedownInline($assetmodel->notes),
             'created_by' => ($assetmodel->adminuser) ? [
                 'id' => (int) $assetmodel->adminuser->id,

--- a/app/Models/AssetModel.php
+++ b/app/Models/AssetModel.php
@@ -69,6 +69,7 @@ class AssetModel extends SnipeModel
         'name',
         'notes',
         'requestable',
+        'req_serial'
     ];
 
     use Searchable;

--- a/app/Models/AssetModel.php
+++ b/app/Models/AssetModel.php
@@ -69,7 +69,7 @@ class AssetModel extends SnipeModel
         'name',
         'notes',
         'requestable',
-        'req_serial'
+        'require_serial'
     ];
 
     use Searchable;

--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -143,6 +143,14 @@ class AssetModelPresenter extends Presenter
                 'formatter' => 'trueFalseFormatter',
             ],
             [
+                'field' => 'require_serial',
+                'searchable' => false,
+                'sortable' => true,
+                'visible' => false,
+                'title' => trans('admin/hardware/general.require_serial'),
+                'formatter' => 'trueFalseFormatter',
+            ],
+            [
                 'field' => 'notes',
                 'searchable' => true,
                 'sortable' => true,

--- a/database/factories/AssetModelFactory.php
+++ b/database/factories/AssetModelFactory.php
@@ -33,6 +33,7 @@ class AssetModelFactory extends Factory
             'category_id' => Category::factory(),
             'model_number' => $this->faker->creditCardNumber(),
             'notes' => 'Created by demo seeder',
+            'require_serial' => 0,
 
         ];
     }

--- a/database/migrations/2025_05_12_183803_add_req_serial_bool_to_models_table.php
+++ b/database/migrations/2025_05_12_183803_add_req_serial_bool_to_models_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('models', function (Blueprint $table) {
+            $table->boolean( 'require_serial')->after('category_id')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('models', function (Blueprint $table) {
+            $table->dropColumn('require_serial');
+        });
+    }
+};

--- a/database/migrations/2025_05_12_183803_add_req_serial_bool_to_models_table.php
+++ b/database/migrations/2025_05_12_183803_add_req_serial_bool_to_models_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('models', function (Blueprint $table) {
-            $table->boolean( 'require_serial')->after('category_id')->default(false);
+            $table->boolean( 'require_serial')->after('category_id')->default(0)->nullable();
         });
     }
 

--- a/database/migrations/2025_05_12_183803_add_req_serial_bool_to_models_table.php
+++ b/database/migrations/2025_05_12_183803_add_req_serial_bool_to_models_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('models', function (Blueprint $table) {
-            $table->boolean( 'require_serial')->after('category_id')->default(0)->nullable();
+            $table->boolean( 'require_serial')->after('category_id')->default(0);
         });
     }
 

--- a/resources/lang/en-US/admin/hardware/form.php
+++ b/resources/lang/en-US/admin/hardware/form.php
@@ -44,6 +44,7 @@ return [
     'redirect_to_checked_out_to'   => 'Go to Checked Out to',
     'select_statustype'	=> 'Select Status Type',
     'serial'			=> 'Serial',
+    'serial_required'	=> 'This asset model requires a serial number',
     'status'			=> 'Status',
     'tag'				=> 'Asset Tag',
     'update'			=> 'Asset Update',

--- a/resources/lang/en-US/admin/hardware/form.php
+++ b/resources/lang/en-US/admin/hardware/form.php
@@ -44,7 +44,7 @@ return [
     'redirect_to_checked_out_to'   => 'Go to Checked Out to',
     'select_statustype'	=> 'Select Status Type',
     'serial'			=> 'Serial',
-    'serial_required'	=> 'This asset model requires a serial number',
+    'serial_required'	=> 'Asset :number requires a serial number',
     'serial_required_post_model_update'	=> ':asset_model have been updated to require a serial number. Please add a serial number for this asset.',
     'status'			=> 'Status',
     'tag'				=> 'Asset Tag',

--- a/resources/lang/en-US/admin/hardware/form.php
+++ b/resources/lang/en-US/admin/hardware/form.php
@@ -45,6 +45,7 @@ return [
     'select_statustype'	=> 'Select Status Type',
     'serial'			=> 'Serial',
     'serial_required'	=> 'This asset model requires a serial number',
+    'serial_required_post_model_update'	=> ':asset_model have been updated to require a serial number. Please add a serial number for this asset.',
     'status'			=> 'Status',
     'tag'				=> 'Asset Tag',
     'update'			=> 'Asset Update',

--- a/resources/lang/en-US/admin/hardware/general.php
+++ b/resources/lang/en-US/admin/hardware/general.php
@@ -21,6 +21,8 @@ return [
     'requested'				    => 'Requested',
     'not_requestable'           => 'Not Requestable',
     'requestable_status_warning' => 'Do not change requestable status',
+    'require_serial'       => 'Require Serial Number',
+    'require_serial_help'       => 'A serial number will be required when creating an asset of this model.',
     'restore'  					=> 'Restore Asset',
     'pending'  					=> 'Pending',
     'undeployable'  			=> 'Undeployable',

--- a/resources/lang/en-US/admin/hardware/general.php
+++ b/resources/lang/en-US/admin/hardware/general.php
@@ -22,7 +22,7 @@ return [
     'not_requestable'           => 'Not Requestable',
     'requestable_status_warning' => 'Do not change requestable status',
     'require_serial'       => 'Require Serial Number',
-    'require_serial_help'       => 'A serial number will be required when creating an asset of this model.',
+    'require_serial_help'       => 'A serial number will be required when creating a new asset of this model.',
     'restore'  					=> 'Restore Asset',
     'pending'  					=> 'Pending',
     'undeployable'  			=> 'Undeployable',

--- a/resources/views/models/bulk-edit.blade.php
+++ b/resources/views/models/bulk-edit.blade.php
@@ -91,7 +91,27 @@
                             </div>
 
                             @include ('partials.forms.edit.minimum_quantity')
+                            <!-- require serial boolean -->
+                            <div class="form-group">
+                                <label for="require_serial" class="col-md-3 control-label">
+                                    {{ trans('admin/hardware/general.require_serial') }}
+                                </label>
 
+                                <div class="col-md-9">
+                                    <div class="form-inline" style="display: flex; align-items: center; gap: 8px;">
+                                        <input type="checkbox" name="require_serial" value="1" id="require_serial" aria-label="require_serial" />
+                                        <a
+                                                href="#"
+                                                data-tooltip="true"
+                                                title="{{ trans('admin/hardware/general.require_serial_help') }}"
+                                                style="display: inline-flex; align-items: center;"
+                                        >
+                                            <x-icon type="info-circle" />
+                                            <span class="sr-only">{{ trans('admin/hardware/general.require_serial_help') }}</span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
 
                             <!-- requestable -->
                                 <div class="form-group{{ $errors->has('requestable') ? ' has-error' : '' }}">

--- a/resources/views/models/edit.blade.php
+++ b/resources/views/models/edit.blade.php
@@ -17,6 +17,27 @@
 @include ('partials.forms.edit.depreciation')
 @include ('partials.forms.edit.minimum_quantity')
 
+<!-- require serial boolean -->
+<div class="form-group">
+    <label for="require_serial" class="col-md-3 control-label">
+        {{ trans('admin/hardware/general.require_serial') }}
+    </label>
+
+    <div class="col-md-9">
+        <div class="form-inline" style="display: flex; align-items: center; gap: 8px;">
+            <input type="checkbox" name="require_serial" value="1" @checked(old('require_serial', $item->require_serial)) id="require_serial" aria-label="require_serial" />
+            <a
+                    href="#"
+                    data-tooltip="true"
+                    title="{{ trans('admin/hardware/general.require_serial_help') }}"
+                    style="display: inline-flex; align-items: center;"
+            >
+                <x-icon type="info-circle" />
+                <span class="sr-only">{{ trans('admin/hardware/general.require_serial_help') }}</span>
+            </a>
+        </div>
+    </div>
+</div>
 <!-- EOL -->
 
 <div class="form-group {{ $errors->has('eol') ? ' has-error' : '' }}">

--- a/resources/views/partials/forms/edit/serial.blade.php
+++ b/resources/views/partials/forms/edit/serial.blade.php
@@ -3,6 +3,10 @@
     <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ trans('admin/hardware/form.serial') }} </label>
     <div class="col-md-7 col-sm-12">
         <input class="form-control" type="text" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old((isset($old_val_name) ? $old_val_name : $fieldname), $item->serial) }}"{{  (Helper::checkIfRequired($item, 'serial')) ? ' required' : '' }} maxlength="191" />
-        {!! $errors->first('serial', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+        @error($old_val_name ?? $fieldname)
+        <span class="alert-msg" aria-hidden="true">
+                <i class="fas fa-times" aria-hidden="true"></i> {{ $message }}
+            </span>
+        @enderror
     </div>
 </div>

--- a/resources/views/partials/forms/edit/serial.blade.php
+++ b/resources/views/partials/forms/edit/serial.blade.php
@@ -2,7 +2,7 @@
 <div class="form-group {{ $errors->has('serial') ? ' has-error' : '' }}">
     <label for="{{ $fieldname }}" class="col-md-3 control-label">{{ trans('admin/hardware/form.serial') }} </label>
     <div class="col-md-7 col-sm-12">
-        <input class="form-control" type="text" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old((isset($old_val_name) ? $old_val_name : $fieldname), $item->serial) }}"{{  (Helper::checkIfRequired($item, 'serial')) ? ' required' : '' }} maxlength="191" />
+        <input class="form-control" type="text" name="{{ $fieldname }}" id="{{ $fieldname }}" value="{{ old((isset($old_val_name) ? $old_val_name : $fieldname), $item->serial) }}" {{  (Helper::checkIfRequired($item, 'serial') || ($item->model && $item->model->require_serial)) ? ' required' : '' }} maxlength="191" />
         @error($old_val_name ?? $fieldname)
         <span class="alert-msg" aria-hidden="true">
                 <i class="fas fa-times" aria-hidden="true"></i> {{ $message }}

--- a/tests/Feature/Assets/Ui/StoreAssetsTest.php
+++ b/tests/Feature/Assets/Ui/StoreAssetsTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Assets\Ui;
 
+use App\Models\Asset;
+use App\Models\AssetModel;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -12,5 +14,64 @@ class StoreAssetsTest extends TestCase
         $this->actingAs(User::factory()->superuser()->create())
             ->get(route('hardware.create'))
             ->assertOk();
+    }
+
+    public function testAssetCanBeStoredWithSerialRequiredAndSerialProvided()
+    {
+        $user = User::factory()->superuser()->create();
+        $this->actingAs($user);
+
+        $model = AssetModel::factory()->create([
+            'require_serial' => 1,
+        ]);
+
+        $response = $this->post(route('hardware.store'), [
+            'model_id' => $model->id,
+            'serials' => [1 => 'ABC123'],
+            'asset_tags' =>[1 => '1234'],
+            'status_id' => 1,
+            // other required fields...
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success-unescaped');
+        $this->assertNotEquals(
+            trans('admin/hardware/form.serial_required'),
+            session('error')
+        );
+        $this->assertDatabaseHas('assets', [
+            'model_id' => $model->id,
+            'serial' => 'ABC123',
+            'asset_tag' => '1234',
+        ]);
+
+
+    }
+
+    public function testAssetCannotBeStoredIfSerialRequiredAndMissing()
+    {
+        $user = User::factory()->superuser()->create();
+        $this->actingAs($user);
+
+        $model = AssetModel::factory()->create([
+            'require_serial' => 1,
+        ]);
+
+        $response = $this->post(route('hardware.store'), [
+            'model_id' => $model->id,
+            'serials' => [], // ← serial missing
+            'asset_tags' => [1 => '1234'],
+            'status_id' => 1,
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHasErrors(['serials.1']);
+
+        $this->assertDatabaseMissing('assets', [
+            'model_id' => $model->id,
+            'asset_tag' => '1234',
+        ]);
+
+        $response->assertSessionMissing('success-unescaped');
     }
 }


### PR DESCRIPTION
This gives users the option to require serials by asset model. 
This can be done via each model individually, or through bulk editing models
Model edit:
<img width="2051" alt="image" src="https://github.com/user-attachments/assets/ef4a3a53-c973-4f62-b635-e69f861c4ddb" />
Bulk Model edit:
<img width="2051" alt="image" src="https://github.com/user-attachments/assets/151e4a46-3bcf-402a-a953-613a27479ab2" />

I was concerned with "What if you update an asset model to require serials, how do we deal with that retroactively?" My solution is not to make validation fail if you update an asset w/o a serial, but to provide a 'warning' message that that asset needs a serial appended. it is an undertaking that a user should be prepared to fill.

Asset Update:
<img width="1819" alt="image" src="https://github.com/user-attachments/assets/aed60331-7ee0-445f-8ef4-bc69c3f986f9" />
(If a bad user deletes the serial, that info is readily available in the history log of the asset.)

Moving forward with asset creation, if the Asset model selected requires a serial, a form validation will fire:
<img width="2083" alt="image" src="https://github.com/user-attachments/assets/d95fd37c-af5a-4a15-8bb1-009c86143ab1" />

Require Serial Number is also a sortable field in the Asset Models index:
<img width="2083" alt="image" src="https://github.com/user-attachments/assets/7e1b7b47-4a8f-4a20-b7ed-43e9658bd30b" />

Tests have been included.





