### PR TITLE
Require assigned_x to be integer on asset model

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -122,9 +122,9 @@ class Asset extends Depreciable
         'assigned_to'   => ['nullable', 'integer', 'required_with:assigned_type'],
         'assigned_type' => ['nullable', 'required_with:assigned_to', 'in:'.User::class.",".Location::class.",".Asset::class],
         'requestable'       => ['nullable', 'boolean'],
-        'assigned_user'     => ['nullable', 'exists:users,id,deleted_at,NULL'],
-        'assigned_location' => ['nullable', 'exists:locations,id,deleted_at,NULL', 'fmcs_location'],
-        'assigned_asset'    => ['nullable', 'exists:assets,id,deleted_at,NULL']
+        'assigned_user'     => ['integer', 'nullable', 'exists:users,id,deleted_at,NULL'],
+        'assigned_location' => ['integer', 'nullable', 'exists:locations,id,deleted_at,NULL', 'fmcs_location'],
+        'assigned_asset'    => ['integer', 'nullable', 'exists:assets,id,deleted_at,NULL']
     ];
 
 


### PR DESCRIPTION
This PR prevents an error where the application did not ensure `assigned_user`, `assigned_location`, or `assigned_asset` was an integer when creating an asset via the api. This caused a hard exception to be thrown.

---

**Note**: I have a vague memory that this caused issues in the past but I didn't run into them while testing via api and ui.