### PR TITLE
Make checkin emails not send when not configured to be

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -76,8 +76,9 @@ class CheckoutableListener
              * 4. If the admin CC email is set, even if the item being checked out doesn't have an email address (location, etc)
              */
 
-            if ($event->checkoutable->requireAcceptance() || $event->checkoutable->getEula() ||
-                $this->checkoutableShouldSendEmail($event)) {
+            if ($event->checkoutable->requireAcceptance() /* does category require acceptance? (no?) this seems REALLY clear */ ||
+                $event->checkoutable->getEula() /* is there *some* kind of EULA? (no?) I mean, this seems pretty straightforward too? */ ||
+                $this->checkoutableShouldSendEmail($event) /* does the category have 'checkin_email' set? (no?) */) {
 
 
                 // Send a checkout email to the admin CC addresses, even if the target has no email
@@ -171,30 +172,28 @@ class CheckoutableListener
         $notifiable = $this->getNotifiableUsers($event);
 
         // Send email notifications
-        try {
-            /**
-             * Send an email if any of the following conditions are met:
-             * 1. The asset requires acceptance
-             * 2. The item has a EULA
-             * 3. The item should send an email at check-in/check-out
-             * 4. If the admin CC email is set, even if the item being checked in doesn't have an email address (location, etc)
-             */
+        if ($this->checkoutableShouldSendEmail($event)) {
+            try {
+                /**
+                 * Send a check-in n email *only* if the item should send an email at check-in/check-out
+                 */
 
-            // Send a checkout email to the admin's CC addresses, even if the target has no email
-            if (!empty($ccEmails)) {
-                Mail::to($ccEmails)->send($mailable);
-                Log::info('Checkin Mail sent to CC addresses');
-            }
+                // Send a checkout email to the admin's CC addresses, even if the target has no email
+                if (!empty($ccEmails)) {
+                    Mail::to($ccEmails)->send($mailable);
+                    Log::info('Checkin Mail sent to CC addresses');
+                }
 
-            // Send a checkout email to the target if it has an email
-            if (!empty($notifiable->email)) {
-                Mail::to($notifiable)->send($mailable);
-                Log::info('Checkin Mail sent to checkout target');
+                // Send a checkout email to the target if it has an email
+                if (!empty($notifiable->email)) {
+                    Mail::to($notifiable)->send($mailable); //I bet this is it?
+                    Log::info('Checkin Mail sent to checkout target');
+                }
+            } catch (ClientException $e) {
+                Log::debug("Exception caught during checkin email: " . $e->getMessage());
+            } catch (Exception $e) {
+                Log::debug("Exception caught during checkin email: " . $e->getMessage());
             }
-        } catch (ClientException $e) {
-            Log::debug("Exception caught during checkin email: " . $e->getMessage());
-        } catch (Exception $e) {
-            Log::debug("Exception caught during checkin email: " . $e->getMessage());
         }
 
         // Send Webhook notification

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -77,7 +77,7 @@ class CheckoutableListener
              */
 
             if ($event->checkoutable->requireAcceptance() /* does category require acceptance? */ ||
-                $event->checkoutable->getEula() /* is there *some* kind of EULA? (no?) */ ||
+                $event->checkoutable->getEula() /* is there *some* kind of EULA? */ ||
                 $this->checkoutableShouldSendEmail($event) /* does the category have 'checkin_email' [sic] set? */) {
 
 

--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -76,9 +76,9 @@ class CheckoutableListener
              * 4. If the admin CC email is set, even if the item being checked out doesn't have an email address (location, etc)
              */
 
-            if ($event->checkoutable->requireAcceptance() /* does category require acceptance? (no?) this seems REALLY clear */ ||
-                $event->checkoutable->getEula() /* is there *some* kind of EULA? (no?) I mean, this seems pretty straightforward too? */ ||
-                $this->checkoutableShouldSendEmail($event) /* does the category have 'checkin_email' set? (no?) */) {
+            if ($event->checkoutable->requireAcceptance() /* does category require acceptance? */ ||
+                $event->checkoutable->getEula() /* is there *some* kind of EULA? (no?) */ ||
+                $this->checkoutableShouldSendEmail($event) /* does the category have 'checkin_email' [sic] set? */) {
 
 
                 // Send a checkout email to the admin CC addresses, even if the target has no email
@@ -186,7 +186,7 @@ class CheckoutableListener
 
                 // Send a checkout email to the target if it has an email
                 if (!empty($notifiable->email)) {
-                    Mail::to($notifiable)->send($mailable); //I bet this is it?
+                    Mail::to($notifiable)->send($mailable);
                     Log::info('Checkin Mail sent to checkout target');
                 }
             } catch (ClientException $e) {


### PR DESCRIPTION
Unless the send-emails attribute is set on the category, we should not send check-in emails. This is different than the check-out logic - which is based on whether there's a EULA to accept, and whether the asset actually requires acceptance.

Without this logic, a check-in will give a slack-hook (good!) but also send an email (not good!) when the category is not configured to send emails on check-in/check-out.

Once I added this logic, I still got the slack-hook, but no email was sent. I also confirmed that if you *do* turn the checkin-/checkout emails, the emails _are_ sent in addition to the slack-hook.

@marcusmoore 's PR #16932 should be much better and more complete than this one - if this needs backing out to accept that one, that's fine. This is just an interim step.