### PR TITLE
Removes double scrollbar from groups

### DIFF
--- a/resources/views/groups/view.blade.php
+++ b/resources/views/groups/view.blade.php
@@ -22,7 +22,7 @@
                 <div class="box-body">
                     <div class="row">
                         <div class="col-md-12">
-                            <div class="table table-responsive">
+
 
                                 <table
                                     data-columns="{{  \App\Presenters\UserPresenter::dataTableLayout() }}"
@@ -41,7 +41,7 @@
                                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
                                         }'>
                                 </table>
-                            </div>
+
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
removes the double scrollbar by removing an extra table div.
Fixed:
<img width="828" alt="image" src="https://github.com/user-attachments/assets/5507c083-ab9d-484a-a14e-01f309556f30" />
[sc-29158]
