### PR TITLE
Fixed potential slack webhook setting inconsistencies

### DIFF
--- a/app/Livewire/SlackSettingsForm.php
+++ b/app/Livewire/SlackSettingsForm.php
@@ -71,7 +71,7 @@ class SlackSettingsForm extends Component
 
         $this->setting = Setting::getSettings();
         $this->save_button = trans('general.save');
-        $this->webhook_selected = $this->setting->webhook_selected ?? 'slack';
+        $this->webhook_selected = ($this->setting->webhook_selected !== '') ? $this->setting->webhook_selected : 'slack';
         $this->webhook_name = $this->webhook_text[$this->setting->webhook_selected]["name"] ?? $this->webhook_text['slack']["name"];
         $this->webhook_icon = $this->webhook_text[$this->setting->webhook_selected]["icon"] ?? $this->webhook_text['slack']["icon"];
         $this->webhook_placeholder = $this->webhook_text[$this->setting->webhook_selected]["placeholder"] ?? $this->webhook_text['slack']["placeholder"];

--- a/app/Livewire/SlackSettingsForm.php
+++ b/app/Livewire/SlackSettingsForm.php
@@ -191,7 +191,6 @@ class SlackSettingsForm extends Component
             $this->setting->webhook_endpoint = '';
             $this->setting->webhook_channel = '';
             $this->setting->webhook_botname = '';
-            $this->setting->webhook_selected = '';
 
             $this->setting->save();
 

--- a/database/migrations/2025_05_20_190317_repopulate_webhook_selected_setting.php
+++ b/database/migrations/2025_05_20_190317_repopulate_webhook_selected_setting.php
@@ -11,21 +11,23 @@ return new class extends Migration {
     {
         $settings = DB::table('settings')->first();
 
-        /** If webhook settings were cleared via the integration settings page,
-         * the webhook_selected was cleared as well when it should have reset to "slack".
-         */
-        if (
-            empty($settings->webhook_selected) &&
-            (empty($settings->webhook_botname) && empty($settings->webhook_channel) && empty($settings->webhook_endpoint))
-        ) {
-            DB::table('settings')->update(['webhook_selected' => 'slack']);
-        }
+        if ($settings) {
+            /** If webhook settings were cleared via the integration settings page,
+             * the webhook_selected was cleared as well when it should have reset to "slack".
+             */
+            if (
+                empty($settings->webhook_selected) &&
+                (empty($settings->webhook_botname) && empty($settings->webhook_channel) && empty($settings->webhook_endpoint))
+            ) {
+                DB::table('settings')->update(['webhook_selected' => 'slack']);
+            }
 
-        /** If webhook settings were cleared via the integration settings page,
-         * then slack settings were re-added; then webhook_selected was not being set to "slack" as needed.
-         */
-        if (str_contains($settings->webhook_endpoint, 'slack.com')) {
-            DB::table('settings')->update(['webhook_selected' => 'slack']);
+            /** If webhook settings were cleared via the integration settings page,
+             * then slack settings were re-added; then webhook_selected was not being set to "slack" as needed.
+             */
+            if (str_contains($settings->webhook_endpoint, 'slack.com')) {
+                DB::table('settings')->update(['webhook_selected' => 'slack']);
+            }
         }
     }
 

--- a/database/migrations/2025_05_20_190317_repopulate_webhook_selected_setting.php
+++ b/database/migrations/2025_05_20_190317_repopulate_webhook_selected_setting.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $settings = DB::table('settings')->first();
+
+        /** If webhook settings were cleared via the integration settings page,
+         * the webhook_selected was cleared as well when it should have reset to "slack".
+         */
+        if (
+            empty($settings->webhook_selected) &&
+            (empty($settings->webhook_botname) && empty($settings->webhook_channel) && empty($settings->webhook_endpoint))
+        ) {
+            DB::table('settings')->update(['webhook_selected' => 'slack']);
+        }
+
+        /** If webhook settings were cleared via the integration settings page,
+         * then slack settings were re-added; then webhook_selected was not being set to "slack" as needed.
+         */
+        if (str_contains($settings->webhook_endpoint, 'slack.com')) {
+            DB::table('settings')->update(['webhook_selected' => 'slack']);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/resources/views/livewire/slack-settings-form.blade.php
+++ b/resources/views/livewire/slack-settings-form.blade.php
@@ -72,6 +72,7 @@
                                     :options="['slack' => trans('admin/settings/general.slack'), 'general' => trans('admin/settings/general.general_webhook'),'google' => trans('admin/settings/general.google_workspaces'), 'microsoft' => trans('admin/settings/general.ms_teams')]"
                                     :selected="old('webhook_selected', $webhook_selected)"
                                     :disabled="Helper::isDemoMode()"
+                                    :for-livewire="true"
                                     data-minimum-results-for-search="-1"
                                     class="form-control"
                                     style="width:100%"
@@ -174,22 +175,3 @@
     </div> <!-- /.row -->
 </form>
 </div>  <!-- /livewire div -->
-
-
-
-
-@section('moar_scripts')
-<script>
-    $(document).ready(function () {
-        $('#select2').select2();
-        $('#select2').on('change', function (e) {
-            var data = $('#select2').select2("val");
-            @this.set('webhook_selected', data);
-        });
-    });
-
-
-</script>
-@endsection
-
-


### PR DESCRIPTION
Previously, if a user set their webhook to Slack, then later hit the `Clear & Save` button, then later came back and re-entered their Slack settings, `webhook_selected` would not be saved as `slack`.

This means that checks for which webhook is selected in `CheckoutableListener` would fail since Slack wasn't "selected".

This PR addresses this by
1. Properly resetting an empty `webhook_selected` to `slack` within the `SlackSettingsForm` livewire component so that future updates through that form will work as expected
1. Adds a migration that resets `webhook_selected` to `slack` if the webhook settings are empty (caused by the user clicking `Clear & Save` or if the user had re-added Slack settings (webhook contains `slack.com`) but `webhook_selected` was not properly set to `slack`.

---

fixes #16965