### PR TITLE
Adds Form Request for Creating Departments

### DIFF
--- a/app/Http/Controllers/Api/DepartmentsController.php
+++ b/app/Http/Controllers/Api/DepartmentsController.php
@@ -97,9 +97,8 @@ class DepartmentsController extends Controller
      */
     public function store(StoreDepartmentRequest $request): JsonResponse
     {
-        $this->authorize('create', Department::class);
         $department = new Department;
-        $department->fill($request->all());
+        $department->fill($request->validated());
         $department = $request->handleImages($department);
 
         $department->created_by = auth()->id();

--- a/app/Http/Controllers/Api/DepartmentsController.php
+++ b/app/Http/Controllers/Api/DepartmentsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StoreDepartmentRequest;
 use App\Http\Transformers\DepartmentsTransformer;
 use App\Http\Transformers\SelectlistTransformer;
 use App\Models\Department;
@@ -94,7 +95,7 @@ class DepartmentsController extends Controller
      * @since [v4.0]
      * @param  \App\Http\Requests\ImageUploadRequest  $request
      */
-    public function store(ImageUploadRequest $request) : JsonResponse
+    public function store(StoreDepartmentRequest $request): JsonResponse
     {
         $this->authorize('create', Department::class);
         $department = new Department;

--- a/app/Http/Requests/StoreDepartmentRequest.php
+++ b/app/Http/Requests/StoreDepartmentRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Department;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class StoreDepartmentRequest extends ImageUploadRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('create', new Department);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $modelRules = (new Department)->getRules();
+
+        return array_merge(
+            $modelRules,
+        );
+    }
+}

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -30,10 +30,13 @@ class Department extends SnipeModel
     ];
 
     protected $rules = [
-        'name'                  => 'required|max:255|is_unique_department',
-        'location_id'           => 'numeric|nullable',
-        'company_id'            => 'numeric|nullable',
-        'manager_id'            => 'numeric|nullable',
+        'name'        => 'required|max:255|is_unique_department',
+        'location_id' => 'numeric|nullable|exists:locations,id',
+        'company_id'  => 'numeric|nullable|exists:companies,id',
+        'manager_id'  => 'numeric|nullable|exists:users,id',
+        'phone'       => 'string|max:255|nullable',
+        'fax'         => 'string|max:255|nullable',
+        'notes'       => 'string|max:255|nullable',
     ];
 
     /**

--- a/tests/Feature/Departments/Api/CreateDepartmentsTest.php
+++ b/tests/Feature/Departments/Api/CreateDepartmentsTest.php
@@ -6,9 +6,9 @@ use App\Models\AssetModel;
 use App\Models\Company;
 use App\Models\Department;
 use App\Models\Category;
+use App\Models\Location;
 use App\Models\User;
 use Illuminate\Testing\Fluent\AssertableJson;
-use phpDocumentor\Reflection\Location;
 use Tests\TestCase;
 
 class CreateDepartmentsTest extends TestCase
@@ -25,13 +25,13 @@ class CreateDepartmentsTest extends TestCase
     public function test_can_create_department_with_all_fields()
     {
         $company = Company::factory()->create();
-        //$location = Location::factory()->create(); ???
+        $location = Location::factory()->create();
         $manager = User::factory()->create();
         $response = $this->actingAsForApi(User::factory()->superuser()->create())
             ->postJson(route('api.departments.store'), [
                 'name'       => 'Test Department',
                 'company_id' => $company->id,
-                //'location_id' => $location->id,
+                'location_id' => $location->id,
                 'manager_id' => $manager->id,
                 'notes'      => 'Test Note',
                 'phone'      => '1234567890',

--- a/tests/Feature/Departments/Api/CreateDepartmentsTest.php
+++ b/tests/Feature/Departments/Api/CreateDepartmentsTest.php
@@ -27,7 +27,8 @@ class CreateDepartmentsTest extends TestCase
         $company = Company::factory()->create();
         $location = Location::factory()->create();
         $manager = User::factory()->create();
-        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+        $user = User::factory()->superuser()->create();
+        $response = $this->actingAsForApi($user)
             ->postJson(route('api.departments.store'), [
                 'name'       => 'Test Department',
                 'company_id' => $company->id,
@@ -46,6 +47,17 @@ class CreateDepartmentsTest extends TestCase
         $department = Department::find($response['payload']['id']);
         $this->assertEquals('Test Department', $department->name);
         $this->assertEquals('Test Note', $department->notes);
+
+        $this->assertDatabaseHas('departments', [
+            'name'        => 'Test Department',
+            'company_id'  => $company->id,
+            'location_id' => $location->id,
+            'manager_id'  => $manager->id,
+            'notes'       => 'Test Note',
+            'phone'       => '1234567890',
+            'fax'         => '1234567890',
+            'created_by'  => $user->id,
+        ]);
     }
 
     public function test_name_required_for_department()

--- a/tests/Feature/Departments/Api/CreateDepartmentsTest.php
+++ b/tests/Feature/Departments/Api/CreateDepartmentsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Departments\Api;
 
 use App\Models\AssetModel;
+use App\Models\Company;
 use App\Models\Department;
 use App\Models\Category;
 use App\Models\User;
@@ -37,6 +38,17 @@ class CreateDepartmentsTest extends TestCase
         $department = Department::find($response['payload']['id']);
         $this->assertEquals('Test Department', $department->name);
         $this->assertEquals('Test Note', $department->notes);
+    }
+
+    public function testNoArraysAllowed()
+    {
+        $response = $this->actingAsForApi(User::factory()->superuser()->create())
+            ->postJson(route('api.departments.store'), [
+                'name'       => 'Test Department',
+                'company_id' => [1, 2],
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('error');
     }
 
 }


### PR DESCRIPTION
This adds a form request for the store department method in the API. For some reason `watson\validating` wasn't picking up that there was an array in a request which resulted in a 500, this ensures that's caught before we do the `->fill(...)`. 

Adds tests for this as well. For testing errors, `->assertOk` (which asserts a 200 status), and `assertStatusMessageIs('error')` in combination more or less assert one of our validation errors. 