### PR TITLE
Improved creator on accessory show page

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -220,7 +220,10 @@ class AccessoriesController extends Controller
      */
     public function show(Accessory $accessory) : View | RedirectResponse
     {
-        $accessory = Accessory::withCount('checkouts as checkouts_count')->find($accessory->id);
+        $accessory->loadCount('checkouts as checkouts_count');
+
+        $accessory->load(['adminuser' => fn($query) => $query->withTrashed()]);
+
         $this->authorize('view', $accessory);
         return view('accessories.view', compact('accessory'));
     }

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -303,7 +303,6 @@ return [
     'type'  				=> 'Type',
     'undeployable'			=> 'Un-deployable',
     'unknown_admin'			=> 'Unknown Admin',
-    'unknown_user' => 'Unknown User',
     'username'              => 'Username',
     'update'                => 'Update',
     'updating_item' => 'Updating :item',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -303,6 +303,7 @@ return [
     'type'  				=> 'Type',
     'undeployable'			=> 'Un-deployable',
     'unknown_admin'			=> 'Unknown Admin',
+    'unknown_user' => 'Unknown User',
     'username'              => 'Username',
     'update'                => 'Update',
     'updating_item' => 'Updating :item',

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -317,16 +317,18 @@
 
           @endif
 
-          <div class="row">
-              <div class="col-md-3" style="padding-bottom: 10px;">
-                  <strong>
-                      {{ trans('general.created_by') }}
-                  </strong>
+          @if ($accessory->adminuser)
+              <div class="row">
+                  <div class="col-md-3" style="padding-bottom: 10px;">
+                      <strong>
+                          {{ trans('general.created_by') }}
+                      </strong>
+                  </div>
+                  <div class="col-md-9" style="word-wrap: break-word;">
+                      <x-full-user-name :user="$accessory->adminuser" />
+                  </div>
               </div>
-              <div class="col-md-9" style="word-wrap: break-word;">
-                  <x-full-user-name :user="$accessory->adminuser" />
-              </div>
-          </div>
+          @endif
 
 </div>
 

--- a/resources/views/accessories/view.blade.php
+++ b/resources/views/accessories/view.blade.php
@@ -324,11 +324,7 @@
                   </strong>
               </div>
               <div class="col-md-9" style="word-wrap: break-word;">
-                  @if ($accessory->adminuser)
-                      {{ $accessory->adminuser->present()->fullName() }}
-                  @else
-                      {{ trans('admin/reports/general.deleted_user') }}
-                  @endif
+                  <x-full-user-name :user="$accessory->adminuser" />
               </div>
           </div>
 

--- a/resources/views/blade/full-user-name.blade.php
+++ b/resources/views/blade/full-user-name.blade.php
@@ -3,21 +3,25 @@
 ])
 
 @if($user)
+    @php
+        $fullName = $user->present()->fullName();
+    @endphp
+
     @can('view', $user)
         @if(! $user->trashed())
             {{-- if the user is in database but soft-deleted --}}
-            <a href="{{ route('users.show', $user->id) }}">{{ $user->present()->fullName() }}</a>
+            <a href="{{ route('users.show', $user->id) }}">{{ $fullName }}</a>
         @else
             {{-- if the user exists --}}
-            <s><a href="{{ route('users.show', $user->id) }}">{{ $user->present()->fullName() }}</a></s>
+            <s><a href="{{ route('users.show', $user->id) }}">{{ $fullName }}</a></s>
         @endif
     @else
         @if(! $user->trashed())
             {{-- if the user is in database but soft-deleted --}}
-            <span>{{ $user->present()->fullName() }}</span>
+            <span>{{ $fullName }}</span>
         @else
             {{-- if the user exists --}}
-            <s><span>{{ $user->present()->fullName() }}</span></s>
+            <s><span>{{ $fullName }}</span></s>
         @endif
     @endcan
 @endif

--- a/resources/views/blade/full-user-name.blade.php
+++ b/resources/views/blade/full-user-name.blade.php
@@ -10,7 +10,4 @@
         {{-- if the user exists --}}
         <s><a href="{{ route('users.show', $user->id) }}">{{ $user->present()->fullName() }}</a></s>
     @endif
-@else
-    {{-- if the user does not exist --}}
-    <span>{{ trans('general.unknown_user') }}</span>
 @endif

--- a/resources/views/blade/full-user-name.blade.php
+++ b/resources/views/blade/full-user-name.blade.php
@@ -1,0 +1,16 @@
+@props([
+    'user'
+])
+
+@if ($user)
+    @if (! $user->trashed())
+        {{-- if the user is in database but soft-deleted --}}
+        <a href="{{ route('users.show', $user->id) }}">{{ $user->present()->fullName() }}</a>
+    @else
+        {{-- if the user exists --}}
+        <s><a href="{{ route('users.show', $user->id) }}">{{ $user->present()->fullName() }}</a></s>
+    @endif
+@else
+    {{-- if the user does not exist --}}
+    <span>Unknown User</span>
+@endif

--- a/resources/views/blade/full-user-name.blade.php
+++ b/resources/views/blade/full-user-name.blade.php
@@ -2,12 +2,22 @@
     'user'
 ])
 
-@if ($user)
-    @if (! $user->trashed())
-        {{-- if the user is in database but soft-deleted --}}
-        <a href="{{ route('users.show', $user->id) }}">{{ $user->present()->fullName() }}</a>
+@if($user)
+    @can('view', $user)
+        @if(! $user->trashed())
+            {{-- if the user is in database but soft-deleted --}}
+            <a href="{{ route('users.show', $user->id) }}">{{ $user->present()->fullName() }}</a>
+        @else
+            {{-- if the user exists --}}
+            <s><a href="{{ route('users.show', $user->id) }}">{{ $user->present()->fullName() }}</a></s>
+        @endif
     @else
-        {{-- if the user exists --}}
-        <s><a href="{{ route('users.show', $user->id) }}">{{ $user->present()->fullName() }}</a></s>
-    @endif
+        @if(! $user->trashed())
+            {{-- if the user is in database but soft-deleted --}}
+            <span>{{ $user->present()->fullName() }}</span>
+        @else
+            {{-- if the user exists --}}
+            <s><span>{{ $user->present()->fullName() }}</span></s>
+        @endif
+    @endcan
 @endif

--- a/resources/views/blade/full-user-name.blade.php
+++ b/resources/views/blade/full-user-name.blade.php
@@ -12,5 +12,5 @@
     @endif
 @else
     {{-- if the user does not exist --}}
-    <span>Unknown User</span>
+    <span>{{ trans('general.unknown_user') }}</span>
 @endif

--- a/tests/Unit/BladeComponents/UserFullNameTest.php
+++ b/tests/Unit/BladeComponents/UserFullNameTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit\BladeComponents;
+
+use App\Models\User;
+use Illuminate\Support\Facades\View;
+use Tests\TestCase;
+
+class UserFullNameTest extends TestCase
+{
+    public function testComponent()
+    {
+        $this->actingAs(User::factory()->viewUsers()->create());
+
+        $user = User::factory()->create(['first_name' => 'Jim', 'last_name' => 'Bagg']);
+
+        $renderedTemplateString = View::make('blade.full-user-name', ['user' => $user])->render();
+
+        $this->assertStringContainsString('<a', $renderedTemplateString);
+        $this->assertStringContainsString('Jim Bagg', $renderedTemplateString);
+    }
+}

--- a/tests/Unit/BladeComponents/UserFullNameTest.php
+++ b/tests/Unit/BladeComponents/UserFullNameTest.php
@@ -3,20 +3,89 @@
 namespace Tests\Unit\BladeComponents;
 
 use App\Models\User;
+use Generator;
 use Illuminate\Support\Facades\View;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class UserFullNameTest extends TestCase
 {
-    public function testComponent()
+    public static function provider(): Generator
     {
-        $this->actingAs(User::factory()->viewUsers()->create());
+        yield 'Renders link to user if they exist and the authenticated user can view them' => [
+            function () {
+                return [
+                    'actor' => User::factory()->viewUsers()->create(),
+                    'user' => User::factory()->create(['first_name' => 'Jim', 'last_name' => 'Bagg']),
+                    'assertions' => function ($rendered) {
+                        Assert::assertStringContainsString('<a ', $rendered);
+                        Assert::assertStringContainsString('Jim Bagg', $rendered);
+                    },
+                ];
+            }
+        ];
 
-        $user = User::factory()->create(['first_name' => 'Jim', 'last_name' => 'Bagg']);
+        yield 'Renders struck-through link to user if they are deleted and the authenticated user can view them' => [
+            function () {
+                return [
+                    'actor' => User::factory()->viewUsers()->create(),
+                    'user' => User::factory()->deleted()->create(['first_name' => 'Jim', 'last_name' => 'Bagg']),
+                    'assertions' => function ($rendered) {
+                        Assert::assertStringContainsString('<s><a ', $rendered);
+                        Assert::assertStringContainsString('Jim Bagg', $rendered);
+                    },
+                ];
+            }
+        ];
+
+        yield 'Renders name without link if the authenticated user cannot view them' => [
+            function () {
+                return [
+                    'actor' => User::factory()->create(),
+                    'user' => User::factory()->create(['first_name' => 'Jim', 'last_name' => 'Bagg']),
+                    'assertions' => function ($rendered) {
+                        Assert::assertStringContainsString('<span>Jim Bagg', $rendered);
+                        Assert::assertStringNotContainsString('<a ', $rendered);
+                    },
+                ];
+            }
+        ];
+
+        yield 'Renders struck-through name without link if the user is deleted and the authenticated user cannot view them' => [
+            function () {
+                return [
+                    'actor' => User::factory()->create(),
+                    'user' => User::factory()->deleted()->create(['first_name' => 'Jim', 'last_name' => 'Bagg']),
+                    'assertions' => function ($rendered) {
+                        Assert::assertStringContainsString('<s><span>Jim Bagg', $rendered);
+                    },
+                ];
+            }
+        ];
+
+        yield 'Renders nothing if the provided user is null' => [
+            function () {
+                return [
+                    'actor' => User::factory()->create(),
+                    'user' => null,
+                    'assertions' => function ($rendered) {
+                        Assert::assertEmpty($rendered);
+                    },
+                ];
+            }
+        ];
+    }
+
+    #[DataProvider('provider')]
+    public function testComponent($provided)
+    {
+        ['actor' => $actor, 'user' => $user, 'assertions' => $assertions] = $provided();
+
+        $this->actingAs($actor);
 
         $renderedTemplateString = View::make('blade.full-user-name', ['user' => $user])->render();
 
-        $this->assertStringContainsString('<a', $renderedTemplateString);
-        $this->assertStringContainsString('Jim Bagg', $renderedTemplateString);
+        $assertions($renderedTemplateString);
     }
 }


### PR DESCRIPTION
This PR follows up #16918 by improving how the creator of an accessory is displayed on the accessory show page. Now users are linked to the user show page if they have access to that user and if the user cannot be linked, due to the id being null or linking to an non-existent user, then the section is not rendered at all

---

| Scenario                                         | Can view user                                               | Cannot view user                                            |
| ------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
| Creator in database                              | ![image](https://github.com/user-attachments/assets/8c439ee8-049a-4897-80d9-1265db067498) | ![image](https://github.com/user-attachments/assets/86025860-f465-4607-8fc9-7d90f238aa2a) |
| Creator in database but soft deleted             | ![image](https://github.com/user-attachments/assets/0337de2d-62a0-4969-b39d-602b90f8c66e) | ![image](https://github.com/user-attachments/assets/f95dcfd4-e758-4c22-868e-7ae5ca61f919) |
| `created_by` is an id not in database or is null | ![image](https://github.com/user-attachments/assets/4114861c-23c8-476c-8845-f08b0efe859d) | same as on the left                                          |

---

The code in the blade component could have been inlined in the view but I can see this code being repeated elsewhere so I extracted and tested a component up front.