### PR TITLE
fix: `PHP_UPLOAD_LIMIT` not set for PHP 8.3

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -100,9 +100,15 @@ chown -R docker:root /var/www/html/storage/framework/cache
 # Fix php settings
 if [ -v "PHP_UPLOAD_LIMIT" ]
 then
-    echo "Changing upload limit to ${PHP_UPLOAD_LIMIT}"
+  echo "Changing upload limit to ${PHP_UPLOAD_LIMIT}"
+  if [ -e /etc/php/*/apache2/php.ini ]
+  then
+    sed -i "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_LIMIT}M/" /etc/php/*/apache2/php.ini
+    sed -i "s/^post_max_size.*/post_max_size = ${PHP_UPLOAD_LIMIT}M/" /etc/php/*/apache2/php.ini
+  else
     sed -i "s/^upload_max_filesize.*/upload_max_filesize = ${PHP_UPLOAD_LIMIT}M/" /etc/php*/php.ini
     sed -i "s/^post_max_size.*/post_max_size = ${PHP_UPLOAD_LIMIT}M/" /etc/php*/php.ini
+  fi
 fi
 
 # If the Oauth DB files are not present copy the vendor files over to the db migrations


### PR DESCRIPTION
Checks if a `php.ini` files exists in the old location, and uses the old path to update.

Resolves #16992
