### PR TITLE
Bumped container image versions

### DIFF
--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - .env.dev.docker
 
   mariadb:
-    image: mariadb:11.5.2
+    image: mariadb:11.4.7
     volumes:
       - db:/var/lib/mysql
     env_file:
@@ -36,7 +36,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:7.4.0
+    image: redis:7.4.3
 
   mailhog:
     image: mailhog/mailhog:v1.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - .env
 
   db:
-    image: mariadb:11.5.2
+    image: mariadb:11.4.7
     restart: unless-stopped
     volumes:
       - db_data:/var/lib/mysql


### PR DESCRIPTION
Dear Team,

The mariadb `11.5.2` minor tag/version was not LTS and became EOL in the compose files so I changed it to a smaller, but LTS one.
Supported tags, dates, etc:
https://hub.docker.com/_/mariadb
https://endoflife.date/mariadb
https://mariadb.org/mariadb/all-releases/
My server works with 11.4.7 too.

I've also changed the patch version of the redis images to the latest.

But I haven't found an newer version from mailhog (which is a 5 years old build).

Please, check!

And most importantly: Very many thanks for this awesome project! 🥳

