### PR TITLE
Replace `two_factor_options` macro

### DIFF
--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -220,24 +220,6 @@ Form::macro('username_format', function ($name = 'username_format', $selected = 
     return $select;
 });
 
-Form::macro('two_factor_options', function ($name = 'two_factor_enabled', $selected = null, $class = null) {
-    $formats = [
-        '' => trans('admin/settings/general.two_factor_disabled'),
-        '1' => trans('admin/settings/general.two_factor_optional'),
-        '2' => trans('admin/settings/general.two_factor_required'),
-
-    ];
-
-    $select = '<select name="'.$name.'" class="'.$class.'" aria-label="'.$name.'">';
-    foreach ($formats as $format => $label) {
-        $select .= '<option value="'.$format.'"'.($selected == $format ? ' selected="selected" role="option" aria-selected="true"' : ' aria-selected="false"').'>'.$label.'</option> '."\n";
-    }
-
-    $select .= '</select>';
-
-    return $select;
-});
-
 Form::macro('customfield_elements', function ($name = 'customfield_elements', $selected = null, $class = null) {
     $formats = [
         'text' => 'Text Box',

--- a/resources/views/settings/security.blade.php
+++ b/resources/views/settings/security.blade.php
@@ -48,8 +48,15 @@
                                     <label for="two_factor_enabled">{{ trans('admin/settings/general.two_factor_enabled_text') }}</label>
                                 </div>
                                 <div class="col-md-9">
-
-                                    {!! Form::two_factor_options('two_factor_enabled', old('two_factor_enabled', $setting->two_factor_enabled), 'select2') !!}
+                                    <x-input.select
+                                        name="two_factor_enabled"
+                                        :selected="old('two_factor_enabled', $setting->two_factor_enabled)"
+                                        :options="[
+                                            '' => trans('admin/settings/general.two_factor_disabled'),
+                                            '1' => trans('admin/settings/general.two_factor_optional'),
+                                            '2' => trans('admin/settings/general.two_factor_required'),
+                                        ]"
+                                    />
                                     <p class="help-block">{{ trans('admin/settings/general.two_factor_enabled_warning') }}</p>
 
                                     @if (config('app.lock_passwords'))


### PR DESCRIPTION
This PR replaces the `two_factor_options` form macro with inline html using the existing select blade component in the one place it is used in the application.

![image](https://github.com/user-attachments/assets/258fde9d-009a-4821-8dc7-a27b3558bf04)
