### PR TITLE
Removed Blade::render from breadcrumbs

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -852,9 +852,9 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                             <li class="breadcrumb-item">
                                                 <a href="{{ $crumbs->url() }}">
                                                     @if ($loop->first)
-                                                        {!! Blade::render($crumbs->title()) !!}
+                                                        <x-icon type="home" />
                                                     @else
-                                                        {{ Blade::render($crumbs->title()) }}
+                                                        <a href="{{ $crumbs->url() }}">{{ $crumbs->title() }}</a>
                                                     @endif
                                                 </a>
                                                 <x-icon type="angle-right" />


### PR DESCRIPTION
This removes the blade render directive from the breadcrumb loop that can result in crashing in certain circumstances. 