### PR TITLE
Fixed #15320 - added status label to bulk checkout

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -562,7 +562,10 @@ class BulkAssetsController extends Controller
     public function showCheckout() : View
     {
         $this->authorize('checkout', Asset::class);
-        return view('hardware/bulk-checkout');
+
+        $do_not_change = ['' => trans('general.do_not_change')];
+        $status_label_list = $do_not_change + Helper::deployableStatusLabelList();
+        return view('hardware/bulk-checkout')->with('statusLabel_list', $status_label_list);
     }
 
     /**
@@ -594,19 +597,25 @@ class BulkAssetsController extends Controller
             }
             $checkout_at = date('Y-m-d H:i:s');
             if (($request->filled('checkout_at')) && ($request->get('checkout_at') != date('Y-m-d'))) {
-                $checkout_at = e($request->get('checkout_at'));
+                $checkout_at = $request->get('checkout_at');
             }
 
             $expected_checkin = '';
 
             if ($request->filled('expected_checkin')) {
-                $expected_checkin = e($request->get('expected_checkin'));
+                $expected_checkin = $request->get('expected_checkin');
             }
 
             $errors = [];
             DB::transaction(function () use ($target, $admin, $checkout_at, $expected_checkin, &$errors, $assets, $request) { //NOTE: $errors is passsed by reference!
                 foreach ($assets as $asset) {
                     $this->authorize('checkout', $asset);
+
+                    // See if there is a status label passed
+                    if ($request->filled('status_id')) {
+                        \Log::error('status id: ' . $request->get('status_id'));
+                        $asset->status_id = $request->get('status_id');
+                    }
 
                     $checkout_success = $asset->checkOut($target, $admin, $checkout_at, $expected_checkin, e($request->get('note')), $asset->name, null);
 

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -39,6 +39,23 @@
          ])
 
 
+            <!-- Status -->
+            <div class="form-group {{ $errors->has('status_id') ? 'error' : '' }}">
+                <label for="status_id" class="col-md-3 control-label">
+                    {{ trans('admin/hardware/form.status') }}
+                </label>
+                <div class="col-md-7 required">
+                    <x-input.select
+                            name="status_id"
+                            :options="$statusLabel_list"
+                            :selected="old('status_id', $status_id ?? null)"
+                            style="width: 100%;"
+                            aria-label="status_id"
+                    />
+                    {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                </div>
+            </div>
+
 
             <!-- Checkout selector -->
           @include ('partials.forms.checkout-selector', ['user_select' => 'true','asset_select' => 'true', 'location_select' => 'true'])


### PR DESCRIPTION
This adds an optional status label dropdown to the bulk checkout view.

Fixes #15320.

@bzeus - can you also please manually test this branch when you get a moment? Thanks!