### PR TITLE
FIXED: Column persist on User's Self View of Assigned Assets

### DIFF
--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -379,6 +379,7 @@
             <!-- checked out assets table -->
 
             <table
+                  data-cookie-id-table="userAssignedAssets"
                   data-toolbar="#userAssetToolbar"
                   data-pagination="true"
                   data-id-table="userAssets"


### PR DESCRIPTION
FIxes Issue [17008](https://github.com/grokability/snipe-it/issues/17008)

Added a cookie to the table view for a user's assigned assets.
This should allow a user to select their columns to view, and those columns will persist if the user navigates away from their assigned assets view, and then navigates back.


https://github.com/user-attachments/assets/1c9e9245-d8ba-49a3-80ad-beacb7bb5ec1

