### PR TITLE
Avoid dividing by zero in DefaultLabel

### DIFF
--- a/app/Http/Requests/StoreLabelSettings.php
+++ b/app/Http/Requests/StoreLabelSettings.php
@@ -37,8 +37,8 @@ class StoreLabelSettings extends FormRequest
 
         return [
             'labels_per_page'                     => 'numeric',
-            'labels_width'                        => 'numeric',
-            'labels_height'                       => 'numeric',
+            'labels_width'                        => 'numeric|min:0.1',
+            'labels_height'                       => 'numeric|min:0.1',
             'labels_pmargin_left'                 => 'numeric|nullable',
             'labels_pmargin_right'                => 'numeric|nullable',
             'labels_pmargin_top'                  => 'numeric|nullable',

--- a/app/Models/Labels/DefaultLabel.php
+++ b/app/Models/Labels/DefaultLabel.php
@@ -43,8 +43,8 @@ class DefaultLabel extends RectangleSheet
 
         $this->textSize = Helper::convertUnit($settings->labels_fontsize, 'pt', 'in');
 
-        $this->labelWidth  = $settings->labels_width;
-        $this->labelHeight = $settings->labels_height;
+        $this->labelWidth = $this->setLabelWidth($settings);
+        $this->labelHeight = $this->setLabelHeight($settings);
 
         $this->labelSpacingH = $settings->labels_display_sgutter;
         $this->labelSpacingV = $settings->labels_display_bgutter;
@@ -181,6 +181,25 @@ class DefaultLabel extends RectangleSheet
         }
     }
 
-}
+    private function setLabelWidth(Setting $settings)
+    {
+        $labelWidth = $settings->labels_width;
 
-?>
+        if ($labelWidth == 0) {
+            $labelWidth = 0.1;
+        }
+
+        return $labelWidth;
+    }
+
+    private function setLabelHeight(?Setting $settings)
+    {
+        $labelHeight = $settings->labels_height;
+
+        if ($labelHeight == 0) {
+            $labelHeight = 0.1;
+        }
+
+        return $labelHeight;
+    }
+}

--- a/resources/views/settings/labels.blade.php
+++ b/resources/views/settings/labels.blade.php
@@ -426,15 +426,13 @@
                                         <input class="form-control" aria-label="labels_width" name="labels_width" type="text" value="{{ old('labels_width', $setting->labels_width) }}" id="labels_width">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.width_w') }}</div>
                                     </div>
+                                    {!! $errors->first('labels_width', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 </div>
                                 <div class="col-md-3">
                                     <div class="input-group">
                                         <input class="form-control" aria-label="labels_height" name="labels_height" type="text" value="{{ old('labels_height', $setting->labels_height) }}">
                                         <div class="input-group-addon">{{ trans('admin/settings/general.height_h') }}</div>
                                     </div>
-                                </div>
-                                <div class="col-md-9 col-md-offset-3">
-                                    {!! $errors->first('labels_width', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                     {!! $errors->first('labels_height', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 </div>
                             </div>
@@ -485,10 +483,6 @@
                                         <div class="input-group-addon">{{ trans('admin/settings/general.left') }}</div>
                                     </div>
 
-                                </div>
-                                <div class="col-md-9 col-md-offset-3">
-                                    {!! $errors->first('labels_width', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
-                                    {!! $errors->first('labels_height', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                 </div>
                             </div>
 

--- a/tests/Unit/Models/Labels/DefaultLabelTest.php
+++ b/tests/Unit/Models/Labels/DefaultLabelTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Models\Labels;
+
+use App\Models\Labels\DefaultLabel;
+use Tests\TestCase;
+
+class DefaultLabelTest extends TestCase
+{
+    /**
+     * @link https://app.shortcut.com/grokability/story/29281
+     */
+    public function test_handles_zero_values_for_columns_gracefully()
+    {
+        // Defaults
+        // labels_pagewidth = 8.50000
+        // labels_pmargin_left = 0.21975
+        // labels_pmargin_right = 0.21975
+        // labels_display_sgutter = 0.05000
+        // labels_width = 2.62500
+
+        // $this->settings->set([
+        //     'labels_width' => 0.00000,
+        //     'labels_display_sgutter' => 0.00000,
+        // ]);
+
+        $label = new DefaultLabel();
+
+        // $label->getColumns();
+    }
+
+    /**
+     * @link https://app.shortcut.com/grokability/story/29281
+     */
+    public function test_handles_zero_values_for_rows_gracefully()
+    {
+        $this->markTestIncomplete();
+
+        // $this->settings->set([
+        //     'labels_height' => 0.00000,
+        //     'labels_display_bgutter' => 0.00000,
+        // ]);
+
+        $label = new DefaultLabel();
+
+        // $label->getRows()
+    }
+}

--- a/tests/Unit/Models/Labels/DefaultLabelTest.php
+++ b/tests/Unit/Models/Labels/DefaultLabelTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Models\Labels;
 
 use App\Models\Labels\DefaultLabel;
+use Exception;
 use Tests\TestCase;
 
 class DefaultLabelTest extends TestCase
@@ -12,21 +13,13 @@ class DefaultLabelTest extends TestCase
      */
     public function test_handles_zero_values_for_columns_gracefully()
     {
-        // Defaults
-        // labels_pagewidth = 8.50000
-        // labels_pmargin_left = 0.21975
-        // labels_pmargin_right = 0.21975
-        // labels_display_sgutter = 0.05000
-        // labels_width = 2.62500
+        $this->settings->set([
+            'labels_width' => 0.00000,
+            'labels_display_sgutter' => 0.00000,
+        ]);
 
-        // $this->settings->set([
-        //     'labels_width' => 0.00000,
-        //     'labels_display_sgutter' => 0.00000,
-        // ]);
-
-        $label = new DefaultLabel();
-
-        // $label->getColumns();
+        // simply ensuring constructor didn't throw exception...
+        $this->assertInstanceOf(DefaultLabel::class, new DefaultLabel());
     }
 
     /**
@@ -34,15 +27,12 @@ class DefaultLabelTest extends TestCase
      */
     public function test_handles_zero_values_for_rows_gracefully()
     {
-        $this->markTestIncomplete();
+        $this->settings->set([
+            'labels_height' => 0.00000,
+            'labels_display_bgutter' => 0.00000,
+        ]);
 
-        // $this->settings->set([
-        //     'labels_height' => 0.00000,
-        //     'labels_display_bgutter' => 0.00000,
-        // ]);
-
-        $label = new DefaultLabel();
-
-        // $label->getRows()
+        // simply ensuring constructor didn't throw exception...
+        $this->assertInstanceOf(DefaultLabel::class, new DefaultLabel());
     }
 }


### PR DESCRIPTION
It is currently possible to set label width and height to `0`
![image](https://github.com/user-attachments/assets/de10731c-8fac-448a-b256-464fb4d7aa17)

Setting either of these values to `0` along with setting `Label spacing` to `0` will end up causing an exception (`DivisionByZeroError`) to be thrown when the `DefaultLabel` class is constructed. Since the `DefaultLabel` constructor is called when printing labels, loading the label settings page, or attempting to save new settings, this means the user can enter a state where they cannot update the `0` values to prevent the exception.

---

This PR addresses this by adding validation to ensure the `labels_width` and `labels_height` to at least `0.1`. These seem to be impractical values but they solve the issue of making sure the value is not `0`.

![image](https://github.com/user-attachments/assets/c050f684-c29d-46a2-aa6b-c454ada3c3c3)

For the users that may have already set values to `0` and thus `DefaultLabel` will not construct for them, the constructor has been updated to set the label width and height to `0.1`. This will make their labels illegible (they aren't able to view labels without throwing an exception now) but also prompt the user to update their label settings.