### PR TITLE
FIXED: Clear Button actually Clearing Dates on Date Picker

### DIFF
--- a/resources/views/reports/custom.blade.php
+++ b/resources/views/reports/custom.blade.php
@@ -736,52 +736,60 @@
           clearBtn: true,
           todayHighlight: true,
           endDate: '0d',
-          format: 'yyyy-mm-dd'
+          format: 'yyyy-mm-dd',
+          keepEmptyValues: true,
       });
       $('.checkout-range .input-daterange').datepicker({
           clearBtn: true,
           todayHighlight: true,
           endDate: '0d',
-          format: 'yyyy-mm-dd'
+          format: 'yyyy-mm-dd',
+          keepEmptyValues: true,
       });
 
       $('.checkin-range .input-daterange').datepicker({
           clearBtn: true,
           todayHighlight: true,
           endDate: '0d',
-          format: 'yyyy-mm-dd'
+          format: 'yyyy-mm-dd',
+          keepEmptyValues: true,
       });
 
       $('.expected_checkin-range .input-daterange').datepicker({
           clearBtn: true,
           todayHighlight: true,
-          format: 'yyyy-mm-dd'
+          format: 'yyyy-mm-dd',
+          keepEmptyValues: true,
       });
 
       $('.asset_eol_date-range .input-daterange').datepicker({
           clearBtn: true,
           todayHighlight: true,
-          format: 'yyyy-mm-dd'
+          format: 'yyyy-mm-dd',
+          keepEmptyValues: true,
       });
 
       $('.last_audit-range .input-daterange').datepicker({
           clearBtn: true,
           todayHighlight: true,
           endDate:'0d',
-          format: 'yyyy-mm-dd'
+          format: 'yyyy-mm-dd',
+          keepEmptyValues: true,
       });
 
       $('.next_audit-range .input-daterange').datepicker({
           clearBtn: true,
           todayHighlight: true,
-          format: 'yyyy-mm-dd'
+          format: 'yyyy-mm-dd',
+          keepEmptyValues: true,
       });
 
       $('.last_updated-range .input-daterange').datepicker({
           clearBtn: true,
           todayHighlight: true,
           endDate:'0d',
-          format: 'yyyy-mm-dd'
+          format: 'yyyy-mm-dd',
+          keepEmptyValues: true,
       });
 
 


### PR DESCRIPTION
fixes [16888](https://github.com/grokability/snipe-it/issues/16888)

Date picker was not allowing the date to clear. in the issue you can see the date going from one side to the other when choosing to clear.

This adds in lines to allow the clear button to remove the date outright, and not have it hop to the other side of the date range.