### PR TITLE
Reference correct translation string

### DIFF
--- a/resources/views/setup/user.blade.php
+++ b/resources/views/setup/user.blade.php
@@ -98,7 +98,7 @@
 
       <!-- email format  -->
       <div class="form-group col-lg-6 {{ $errors->has('email_format') ? 'error' : '' }}">
-        <label for="email_format">{{ trans('general.email_format') }}</label>
+        <label for="email_format">{{ trans('admin/settings/general.email_formats.email_format') }}</label>
         {!! Form::username_format('email_format', old('email_format', 'filastname'), 'select2') !!}
         {!! $errors->first('email_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
       </div>


### PR DESCRIPTION
Within the setup steps, `Email Format` is currently untranslated. This PR fixes that.

Before
![image](https://github.com/user-attachments/assets/d86b750c-fb0d-45e3-9f12-180211abb968)

After
![image](https://github.com/user-attachments/assets/91cd3f10-4c97-4ba7-a64d-c3c65a7775a9)
