### PR TITLE
Fixed #17034 - larger header color box on small views

### DIFF
--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -235,7 +235,7 @@
                                 <div class="col-md-3">
                                     <label for="header_color">{{ trans('admin/settings/general.header_color') }}</label>
                                 </div>
-                                <div class="col-md-2">
+                                <div class="col-md-5 col-xs-5 col-sm-3 col-md-4 col-lg-3 col-xl-3">
                                     <div class="input-group header-color">
                                         <input class="form-control" placeholder="#FF0000" aria-label="header_color" name="header_color" type="text" id="header_color" value="{{ old('header_color', ($setting->header_color ?? '#3c8dbc')) }}">
                                         <div class="input-group-addon">


### PR DESCRIPTION
The header color box was too small on smaller ports. This corrects that.

### Before

(I just re-used the image from the issue - ignore the arrows)

![image](https://github.com/user-attachments/assets/68dd2e7b-afb5-40ad-b3c0-14230836a064)

### After 
<img width="601" alt="Screenshot 2025-05-29 at 1 21 53 PM" src="https://github.com/user-attachments/assets/66ebc2a4-b529-4b39-9950-0196fdaef2e2" />

