### PR TITLE
Avoid displaying empty table in `SendAcceptanceReminder` command

### DIFF
--- a/app/Console/Commands/SendAcceptanceReminder.php
+++ b/app/Console/Commands/SendAcceptanceReminder.php
@@ -99,8 +99,11 @@ class SendAcceptanceReminder extends Command
         foreach ($no_email_list as $user) {
             $rows[] = [$user['id'], $user['name']];
         }
-        $this->info("The following users do not have an email address:");
-        $this->table($headers, $rows);
+
+        if (!empty($rows)) {
+            $this->info("The following users do not have an email address:");
+            $this->table($headers, $rows);
+        }
 
         return 0;
     }


### PR DESCRIPTION
Currently the output of `SendAcceptanceReminder` (`snipeit:acceptance-reminder`) displays an empty table if all users had an email address:
```
└─[$]› art snipeit:acceptance-reminder
1 users notified.
The following users do not have an email address:
+----+------+
| ID | Name |
+----+------+
```

This PR just avoids displaying that table if that is the case:
```
└─[$]› art snipeit:acceptance-reminder
1 users notified.
```