### PR TITLE
Handle missing location when rendering labels

### DIFF
--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -25,6 +25,16 @@ class Label implements View
      */
     protected $data;
 
+
+    /**
+     * TCPDF output destination.
+     * "I" - inline by default.
+     * See TCPDF's Output method for details.
+     *
+     * @var string
+     */
+    private string $destination = 'I';
+
     public function __construct() {
         $this->data = new Collection();
     }
@@ -222,7 +232,7 @@ class Label implements View
         $template->writeAll($pdf, $data);
 
         $filename = $assets->count() > 1 ? 'assets.pdf' : $assets->first()->asset_tag.'.pdf';
-        $pdf->Output($filename, 'I');
+        $pdf->Output($filename, $this->destination);
     }
 
     /**

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -140,7 +140,9 @@ class Label implements View
                                 $barcode2DTarget = $asset->serial; 
                                 break;
                             case 'location':
-                                $barcode2DTarget = route('locations.show', $asset->location_id);
+                                $barcode2DTarget = $asset->location_id
+                                    ? route('locations.show', $asset->location_id)
+                                    : null;
                                 break;
                             case 'hardware_id':
                             default:

--- a/tests/Unit/Labels/LabelTest.php
+++ b/tests/Unit/Labels/LabelTest.php
@@ -7,6 +7,7 @@ use App\Models\Location;
 use App\Models\Setting;
 use App\View\Label;
 use Tests\TestCase;
+use function Livewire\invade;
 
 class LabelTest extends TestCase
 {
@@ -31,6 +32,9 @@ class LabelTest extends TestCase
             ->with('settings', Setting::getSettings())
             ->with('bulkedit', true)
             ->with('count', 0);
+
+        // a simple way to avoid flooding test output with PDF characters.
+        invade($label)->destination = 'S';
 
         $label->render();
 

--- a/tests/Unit/Labels/LabelTest.php
+++ b/tests/Unit/Labels/LabelTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Labels;
 
 use App\Models\Asset;
+use App\Models\Location;
 use App\Models\Setting;
 use App\View\Label;
 use Tests\TestCase;
@@ -20,16 +21,19 @@ class LabelTest extends TestCase
             'label2_2d_target' => 'location',
         ]);
 
-        $asset = Asset::factory()->create(['location_id' => null]);
+        $location = Location::factory()->create();
+        $assets = Asset::factory()->count(2)->create(['location_id' => $location->id]);
+        $assets->first()->update(['location_id' => null]);
 
         // pulled from BulkAssetsController@edit method
         $label = (new Label)
-            // receives eloquent collection in practice
-            ->with('assets', Asset::findMany($asset->id))
+            ->with('assets', $assets)
             ->with('settings', Setting::getSettings())
             ->with('bulkedit', true)
             ->with('count', 0);
 
         $label->render();
+
+        $this->assertTrue(true, 'Label rendering should not throw an error when location is not set on an asset.');
     }
 }

--- a/tests/Unit/Labels/LabelTest.php
+++ b/tests/Unit/Labels/LabelTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit\Labels;
+
+use App\Models\Asset;
+use App\Models\Setting;
+use App\View\Label;
+use Tests\TestCase;
+
+class LabelTest extends TestCase
+{
+    /**
+     * @link https://app.shortcut.com/grokability/story/29302
+     */
+    public function test_handles_location_not_being_set_on_asset_gracefully()
+    {
+        $this->settings->set([
+            'label2_enable' => 1,
+            'label2_2d_type' => 'QRCODE',
+            'label2_2d_target' => 'location',
+        ]);
+
+        $asset = Asset::factory()->create(['location_id' => null]);
+
+        // pulled from BulkAssetsController@edit method
+        $label = (new Label)
+            // receives eloquent collection in practice
+            ->with('assets', Asset::findMany($asset->id))
+            ->with('settings', Setting::getSettings())
+            ->with('bulkedit', true)
+            ->with('count', 0);
+
+        $label->render();
+    }
+}


### PR DESCRIPTION
Currently, using the new label engine and setting `2D Barcode Target` to `/location/{location_id}` throws an exception when attempting to generate a label for an asset that does not have a location set.

This PR fixes that so that the labels are successfully displayed and the QR code is simply skipped:
![image](https://github.com/user-attachments/assets/317e7111-25c8-4d34-85c6-f3b4bb249c7a)




