### PR TITLE
Docker: Ensure permissions on Laravel log file

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -126,4 +126,9 @@ php artisan migrate --force
 php artisan config:clear
 php artisan config:cache
 
+# we do this after the artisan commands to ensure that if the laravel
+# log got created by root, we set the permissions back
+touch /var/www/html/storage/logs/laravel.log
+chown -R docker:root /var/www/html/storage/logs/laravel.log
+
 exec supervisord -c /supervisord.conf

--- a/docker/startup_alpine.sh
+++ b/docker/startup_alpine.sh
@@ -79,6 +79,7 @@ done
 chown -R apache:root /var/lib/snipeit/data/*
 chown -R apache:root /var/lib/snipeit/dumps
 chown -R apache:root /var/lib/snipeit/keys
+chown -R apache:root /var/www/html/storage/framework/cache
 
 # Fix php settings
 if [ ! -z "${PHP_UPLOAD_LIMIT}" ]

--- a/docker/startup_alpine_fpm.sh
+++ b/docker/startup_alpine_fpm.sh
@@ -99,10 +99,7 @@ then
   cp -a /var/www/html/vendor/laravel/passport/database/migrations/* /var/www/html/database/migrations/
 fi
 
-# Create laravel log file
-touch /var/www/html/storage/logs/laravel.log
 # Add correct permissions for files and directories
-chown www-data:www-data /var/www/html/storage/logs/laravel.log
 chown -R www-data:www-data \
   /var/lib/snipeit/data \
   /var/lib/snipeit/dumps \
@@ -114,6 +111,11 @@ php artisan migrate --force
 php artisan config:clear
 php artisan config:cache
 
+# Create laravel log file
+touch /var/www/html/storage/logs/laravel.log
+# ensure it's owned by www:data in case it was created by root
+chown www-data:www-data /var/www/html/storage/logs/laravel.log
+
 echo [INFO docker entrypoint] End script execution
 
-exec "$@" 
+exec "$@"


### PR DESCRIPTION
FIXES: https://github.com/grokability/snipe-it/issues/12725

In some of our Docker startups, it was possible for the Laravel log file
to be created with root permissions, causing future errors when the
non-root webapp tries to write to it.

We'll now always chown (and create, if necessary) the log file to the proper
user after running any artisan commands (as root)

We _could_ run them as the proper user via su, but IMO not doing so keeps the
script easier to read, but I'm not married to the approach. I'd still
want to keep the chown command(s) in, because it will also fix the
permissions for anyone who already has this issue.