### PR TITLE
Fix to rate-limiter on higher rate-limits

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -52,7 +52,6 @@ class Kernel extends HttpKernel
             'auth:api',
             \App\Http\Middleware\CheckLocale::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
-            \App\Http\Middleware\SetAPIResponseHeaders::class,
         ],
 
         'health' => [
@@ -74,6 +73,7 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'api-throttle' => \App\Http\Middleware\SetAPIResponseHeaders::class,
         'health' => null,
     ];
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::group(['prefix' => 'v1', 'middleware' => ['api', 'throttle:api']], function () {
+Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], function () {
 
 
     Route::get('/', function () {


### PR DESCRIPTION
This pulls our new middleware into its own named routeMiddleware, and makes sure to explicitly invoke it in the API route-group.