### PR TITLE
Fixed #17076 - Disable optional status ID form field if value is blank/Do Not Change

### DIFF
--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -137,6 +137,14 @@
         //if there's already a user selected, make sure their checked-out assets show up
         // (if there isn't one, it won't do anything)
         $('#assigned_user').change();
+
+        // Add the disabled attribute to empty inputs on submit to handle the case where someone does not pick a status ID
+        // and the form is submitted with an empty status ID which will fail validation via the form request
+        $("form").submit(function() {
+            $(this).find(":input").filter(function(){ return !this.value; }).attr("disabled", "disabled");
+            return true; // ensure form still submits
+        });
+
     });
 </script>
 


### PR DESCRIPTION
This fixes an issue introduced in #17019, where we added the optional status_id dropdown to the bulk checkout. The issue was that the AssetCheckoutFormRequest was firing and looking at all of the data submitted. If you selected `Do not change`, the form gets submitted passing `status_id` as `''`, which would hit the validator. By disabling the empty form field on submit, it removes the value from the submitted data, and therefore does not trip the validation - which is good, since if there is nothing submitted there, the status labels stay as they were on each of the assets being checked out. 