### PR TITLE
Allowed setting `id` on location-select component

### DIFF
--- a/resources/views/blade/input/location-select.blade.php
+++ b/resources/views/blade/input/location-select.blade.php
@@ -11,6 +11,15 @@
     'hideNewButton' => false,
 ])
 
+@php
+    $id = $name . '_location_select';
+
+    // User provided id, overwrite the default
+    if ($attributes->has('id')) {
+        $id = $attributes->get('id');
+    }
+@endphp
+
 <div
     @class([
        'form-group',
@@ -26,7 +35,7 @@
             data-placeholder="{{ trans('general.select_location') }}"
             name="{{ $name }}"
             style="width: 100%"
-            id="{{ $name }}_location_select"
+            id="{{ $id }}"
             aria-label="{{ $name }}"
             @required($required)
             @if ($multiple)

--- a/resources/views/blade/input/location-select.blade.php
+++ b/resources/views/blade/input/location-select.blade.php
@@ -34,9 +34,9 @@
             @endif
         >
             @if ($selected)
-                @foreach(Arr::wrap($selected) as $id)
-                    <option value="{{ $id }}" selected="selected" role="option" aria-selected="true"  role="option">
-                        {{ optional(Location::find($id))->name }}
+                @foreach(Arr::wrap($selected) as $value)
+                    <option value="{{ $value }}" selected="selected" role="option" aria-selected="true"  role="option">
+                        {{ optional(Location::find($value))->name }}
                     </option>
                 @endforeach
             @endif


### PR DESCRIPTION
This PR allows customizing the `id` for the `location-select` component.

So far it is only used on the asset check in page and, since the name is set to `location_id`, the id is rendered as `location_id_location_select`. This behavior is still present but now passing something like `id="here"` would render `id="here"` within the component.