### PR TITLE
Adds `hasUndeplyableStatus` check to bulk checkout

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -59,7 +59,7 @@ class BulkAssetsController extends Controller
                 $asset_tags = implode(', ', array_column($status_check['tags'], 'asset_tag'));
                 $asset_ids = $status_check['asset_ids'];
 
-                session()->flash('error', trans('admin/hardware/message.undeployable', ['asset_tags' => $asset_tags]));
+                session()->flash('warning', trans('admin/hardware/message.undeployable', ['asset_tags' => $asset_tags]));
             }
 
             $request->session()->flashInput(['selected_assets' => $asset_ids]);

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -53,9 +53,13 @@ class BulkAssetsController extends Controller
 
         $asset_ids = $request->input('ids');
         if ($request->input('bulk_actions') === 'checkout') {
+            $status_check =$this->hasUndeployableStatus($asset_ids);
+            if($status_check && $status_check['status'] === true){
 
-            if($this->hasUndeployableStatus($asset_ids)){
-                return redirect()->back()->with('error', trans('admin/hardware/message.undeployable'));
+                $asset_tags = implode(', ', array_column($status_check['tags'], 'asset_tag'));
+                $asset_ids = $status_check['asset_ids'];
+
+                session()->flash('error', trans('admin/hardware/message.undeployable', ['asset_tags' => $asset_tags]));
             }
 
             $request->session()->flashInput(['selected_assets' => $asset_ids]);
@@ -665,14 +669,24 @@ class BulkAssetsController extends Controller
             return redirect()->route('hardware.index')->with('success', trans('admin/hardware/message.restore.success'));
         }
     }
-    public function hasUndeployableStatus (array $asset_ids) : bool
+    public function hasUndeployableStatus (array $asset_ids)
     {
         $undeployable = Asset::whereIn('id', $asset_ids)
             ->undeployable()
-            ->first();
+            ->get();
 
-         if($undeployable) {
-             return true;
+        $undeployableTags = $undeployable->map(function ($asset) {
+            return [
+                'id' => $asset->id,
+                'asset_tag' => $asset->asset_tag,
+            ];
+        })->toArray();
+
+        $undeployableIds = array_column($undeployableTags, 'id');
+        $filtered_ids = array_diff($asset_ids, $undeployableIds);
+
+         if($undeployable->isNotEmpty()) {
+             return ['status' => true, 'tags' => $undeployableTags, 'asset_ids' => $filtered_ids];
          }
         return false;
     }

--- a/resources/lang/en-US/admin/hardware/message.php
+++ b/resources/lang/en-US/admin/hardware/message.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'undeployable' 		 => '<strong>Warning: </strong> This asset has been marked as currently undeployable. If this status has changed, please update the asset status.',
+    'undeployable' 		 => 'An asset in your selection for checkout has been marked as currently undeployable. If this status has changed, please update the asset status before checking it out.',
     'does_not_exist' 	 => 'Asset does not exist.',
     'does_not_exist_var' => 'Asset with tag :asset_tag not found.',
     'no_tag' 	         => 'No asset tag provided.',

--- a/resources/lang/en-US/admin/hardware/message.php
+++ b/resources/lang/en-US/admin/hardware/message.php
@@ -2,7 +2,7 @@
 
 return [
 
-    'undeployable' 		 => 'An asset in your selection for checkout has been marked as currently undeployable. If this status has changed, please update the asset status before checking it out.',
+    'undeployable' 		 => 'The following assets cannot be deployed and have been removed from checkout: :asset_tags',
     'does_not_exist' 	 => 'Asset does not exist.',
     'does_not_exist_var' => 'Asset with tag :asset_tag not found.',
     'no_tag' 	         => 'No asset tag provided.',

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\StatuslabelsController;
 use App\Http\Controllers\SuppliersController;
 use App\Http\Controllers\ViewAssetsController;
 use App\Livewire\Importer;
+use App\Models\Asset;
 use App\Models\ReportTemplate;
 use Illuminate\Support\Facades\Route;
 use Tabuna\Breadcrumbs\Trail;
@@ -698,3 +699,11 @@ Route::middleware(['auth'])->get(
     ->breadcrumbs(fn (Trail $trail) =>
     $trail->push('Home', route('home'))
     );
+
+Route::get( 'blah',
+    function(){
+        Asset::whereIn('id', [1886])
+            ->undeployable()
+            ->get();
+    }
+);

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,6 @@ use App\Http\Controllers\StatuslabelsController;
 use App\Http\Controllers\SuppliersController;
 use App\Http\Controllers\ViewAssetsController;
 use App\Livewire\Importer;
-use App\Models\Asset;
 use App\Models\ReportTemplate;
 use Illuminate\Support\Facades\Route;
 use Tabuna\Breadcrumbs\Trail;
@@ -699,11 +698,3 @@ Route::middleware(['auth'])->get(
     ->breadcrumbs(fn (Trail $trail) =>
     $trail->push('Home', route('home'))
     );
-
-Route::get( 'blah',
-    function(){
-        Asset::whereIn('id', [1886])
-            ->undeployable()
-            ->get();
-    }
-);

--- a/tests/Unit/AssetTest.php
+++ b/tests/Unit/AssetTest.php
@@ -242,7 +242,7 @@ class AssetTest extends TestCase
     }
     public function testUndeployableStatusReturnsFalseifAssetIsDeployable()
     {
-        $assets = Asset::factory()->count(3)->create(); // Assume none match undeployable condition
+        $assets = Asset::factory()->count(3)->create();
         $asset_ids = $assets->pluck('id')->toArray();
 
         $bulk_assets = new BulkAssetsController();

--- a/tests/Unit/AssetTest.php
+++ b/tests/Unit/AssetTest.php
@@ -1,9 +1,11 @@
 <?php
 namespace Tests\Unit;
 
+use App\Http\Controllers\Assets\BulkAssetsController;
 use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Category;
+use App\Models\Statuslabel;
 use App\Models\User;
 use Carbon\Carbon;
 use Tests\TestCase;
@@ -237,5 +239,53 @@ class AssetTest extends TestCase
         $asset->forceSave();
 
         $this->assertFalse($asset->refresh()->getImageUrl());
+    }
+    public function testUndeployableStatusReturnsFalseifAssetIsDeployable()
+    {
+        $assets = Asset::factory()->count(3)->create(); // Assume none match undeployable condition
+        $asset_ids = $assets->pluck('id')->toArray();
+
+        $bulk_assets = new BulkAssetsController();
+
+        $result = $bulk_assets->hasUndeployableStatus($asset_ids);
+
+        $this->assertFalse($result);
+    }
+    public function testUndeployableStatusReturnsTrueandTagsIfAssetIsUnDeployable()
+    {
+        $deployable = Asset::factory()->create();
+        $undeployableStatus = Statuslabel::factory()->create(['deployable' => 0]);
+        $undeployable = Asset::factory()->create(
+            [
+                'status_id' => $undeployableStatus->id
+            ]);
+
+        $bulk_assets = new BulkAssetsController();
+
+        $result = $bulk_assets->hasUndeployableStatus([$deployable->id, $undeployable->id]);
+
+        $this->assertIsArray($result);
+        $this->assertTrue($result['status']);
+        $this->assertEquals($undeployable->id, $result['tags'][0]['id']);
+        $this->assertEquals($undeployable->asset_tag, $result['tags'][0]['asset_tag']);
+    }
+
+    public function testUndeployableStatusCheckFiltersOutUndeployableIds()
+    {
+        $deployable = Asset::factory()->create();
+        $undeployableStatus = Statuslabel::factory()->create(['deployable' => 0]);
+        $undeployable = Asset::factory()->create(
+            [
+                'status_id' => $undeployableStatus->id
+            ]);
+
+        $bulk_assets = new BulkAssetsController();
+
+        $result = $bulk_assets->hasUndeployableStatus([$deployable->id, $undeployable->id]);
+
+        $undeployableIds = array_column($result['tags'], 'id');
+        $filtered = array_diff([$deployable->id, $undeployable->id], $undeployableIds);
+
+        $this->assertEquals([$deployable->id], array_values($filtered));
     }
 }


### PR DESCRIPTION
This adds an undeployable status check when selecting assets to be bulk checked out.

An error message is returned if an undeployable asset is in the user's selection:
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/e6d73c42-b67f-4c4b-b8c9-1fcfba692791" />

#17046 #17075