### PR TITLE
Fixed #16157 - Added advanced search to users

### DIFF
--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -42,6 +42,7 @@
             @include('partials.users-bulk-actions')
 
             <table
+                    data-advanced-search="true"
                     data-click-to-select="true"
                     data-columns="{{ \App\Presenters\UserPresenter::dataTableLayout() }}"
                     data-cookie-id-table="usersTable"


### PR DESCRIPTION
While we don't love the bootstrap tables advanced search extension (loads of room for improvement there, obviously), some people do find it useful, so I've added it to the People index. 