### PR TITLE
Fixed #17102 - added keywords to admin settings search for notifications

### DIFF
--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -484,6 +484,7 @@ return [
         'php_overview'      => 'phpinfo, system, info',
         'purge'             => 'permanently delete',
         'security'          => 'password, passwords, requirements, two factor, two-factor, common passwords, remote login, logout, authentication',
+        'notifications'     => 'alerts, email, notifications, audit, threshold, email alerts, cc',
     ],
 
 ];

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -149,6 +149,7 @@
                   <x-icon type="bell" class="fa-4x"/>
                   <br><br>
                   <span class="name">{{ trans('admin/settings/general.notifications') }}</span>
+                  <span class="keywords" aria-hidden="true" style="display:none"> {{ trans('admin/settings/general.keywords.notifications') }}</span>
 
                 </a>
               </h5>


### PR DESCRIPTION
This just adds the (visibly) hidden keywords that allow the search filter show the notifications box for searches on "alerts, cc, email", etc.