### PR TITLE
Fixed #16218 - added centos to the switch case

### DIFF
--- a/snipeit.sh
+++ b/snipeit.sh
@@ -381,7 +381,7 @@ case $distro in
     apache_group=www-data
     apachefile=/etc/apache2/sites-available/$APP_NAME.conf
     ;;
-  *amzn*|*redhat*|*alma*|*rhel*|*rocky*)
+  *amzn*|*redhat*|*alma*|*rhel*|*rocky*|*centos*)
     echo "  The installer has detected $distro version $version."
     distro=Centos
     apache_group=apache


### PR DESCRIPTION
We've only heard about this from one user I think, but adding this should take care of their use case. Fixes [16218](https://github.com/grokability/snipe-it/issues/16218)