### PR TITLE
FIXED: Adding Total to Consumable View Page

### DIFF
--- a/app/Presenters/ConsumablePresenter.php
+++ b/app/Presenters/ConsumablePresenter.php
@@ -72,14 +72,6 @@ class ConsumablePresenter extends Presenter
                 'searchable' => true,
                 'sortable' => true,
                 'title' => trans('admin/consumables/general.item_no'),
-            ],  [
-                'field' => 'min_amt',
-                'searchable' => false,
-                'sortable' => true,
-                'title' => trans('general.min_amt'),
-                'visible' => true,
-                'formatter' => 'minAmtFormatter',
-                'class' => 'text-right text-padding-number-cell',
             ], [
                 'field' => 'qty',
                 'searchable' => false,
@@ -96,6 +88,14 @@ class ConsumablePresenter extends Presenter
                 'visible' => true,
                 'class' => 'text-right text-padding-number-cell',
                 'footerFormatter' => 'qtySumFormatter',
+            ], [
+                'field' => 'min_amt',
+                'searchable' => false,
+                'sortable' => true,
+                'title' => trans('general.min_amt'),
+                'visible' => true,
+                'formatter' => 'minAmtFormatter',
+                'class' => 'text-right text-padding-number-cell',
             ], [
                 'field' => 'location',
                 'searchable' => true,

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -189,6 +189,17 @@
                     </div>
                   @endif
 
+                  <!-- total -->
+                  @if ($consumable->qty)
+                    <div class="row">
+                      <div class="col-md-3">
+                        {{ trans('admin/components/general.total') }}
+                      </div>
+                      <div class="col-md-9">
+                        {{ $consumable->qty }}
+                      </div>
+                    </div>
+                  @endif
 
                   <!-- remaining -->
                   @if ($consumable->numRemaining())


### PR DESCRIPTION
REDO of PR #16537

This adds Total to the Consumable View page

OLD:
<img width="585" alt="Screenshot 2025-03-19 at 3 34 47 PM" src="https://github.com/user-attachments/assets/5d47b0a0-b16e-4f7c-9091-83076a49b320" />

NEW:
<img width="548" alt="Screenshot 2025-03-19 at 3 34 32 PM" src="https://github.com/user-attachments/assets/b3f18fe1-694f-4bac-9887-8e12ba84c557" />
