### PR TITLE
Fixed #17084 - Adds Eula table to User account area with download option

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -748,6 +748,8 @@ class UsersController extends Controller
      */
     public function eulas(User $user, ActionlogsTransformer $transformer)
     {
+        $this->authorize('view', Asset::class);
+
         $eulas = $user->eulas;
         return response()->json(
             $transformer->transformActionlogs($eulas, $eulas->count())

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -740,9 +740,9 @@ class UsersController extends Controller
     /**
      * Display the EULAs accepted by the user.
      *
-     * @param \App\Models\User $user
-     * * @param \App\Http\Transformers\ActionlogsTransformer $transformer
-     * * @return \Illuminate\Http\JsonResponse
+     *  @param \App\Models\User $user
+     *  @param \App\Http\Transformers\ActionlogsTransformer $transformer
+     *  @return \Illuminate\Http\JsonResponse
      *@since [v8.1.16]
      * @author [Godfrey Martinez] [<gmartinez@grokability.com>]
      */

--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -6,6 +6,7 @@ use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\SaveUserRequest;
 use App\Http\Transformers\AccessoriesTransformer;
+use App\Http\Transformers\ActionlogsTransformer;
 use App\Http\Transformers\AssetsTransformer;
 use App\Http\Transformers\ConsumablesTransformer;
 use App\Http\Transformers\LicensesTransformer;
@@ -80,7 +81,7 @@ class UsersController extends Controller
             'users.autoassign_licenses',
             'users.website',
 
-        ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables', 'createdBy', 'managesUsers', 'managedLocations')
+        ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables', 'createdBy', 'managesUsers', 'managedLocations', 'eulas')
             ->withCount([
                 'assets as assets_count' => function(Builder $query) {
                     $query->withoutTrashed();
@@ -734,6 +735,23 @@ class UsersController extends Controller
     public function getCurrentUserInfo(Request $request) : array
     {
         return (new UsersTransformer)->transformUser($request->user());
+    }
+
+    /**
+     * Display the EULAs accepted by the user.
+     *
+     * @param \App\Models\User $user
+     * * @param \App\Http\Transformers\ActionlogsTransformer $transformer
+     * * @return \Illuminate\Http\JsonResponse
+     *@since [v8.1.16]
+     * @author [Godfrey Martinez] [<gmartinez@grokability.com>]
+     */
+    public function eulas(User $user, ActionlogsTransformer $transformer)
+    {
+        $eulas = $user->eulas;
+        return response()->json(
+            $transformer->transformActionlogs($eulas, $eulas->count())
+        );
     }
 
     /**

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -39,6 +39,7 @@ class ViewAssetsController extends Controller
             'consumables',
             'accessories',
             'licenses',
+            'eulas',
         )->find(auth()->id());
 
         $field_array = array();

--- a/app/Http/Controllers/ViewAssetsController.php
+++ b/app/Http/Controllers/ViewAssetsController.php
@@ -39,7 +39,6 @@ class ViewAssetsController extends Controller
             'consumables',
             'accessories',
             'licenses',
-            'eulas',
         )->find(auth()->id());
 
         $field_array = array();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -554,10 +554,10 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     /**
      * Establishes the user -> eula relationship
      *
-     * @author A. Gianotto <snipe@snipe.net>
-     * @since [v7.0.7]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
-     */
+     * @since [v8.1.16]
+     * @author [Godfrey Martinez] [<gmartinez@grokability.com>]
+ */
     public function eulas()
     {
         return $this->hasMany(Actionlog::class, 'target_id')

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -562,6 +562,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     {
         return $this->hasMany(Actionlog::class, 'target_id')
             ->with('item')
+            ->select(['id', 'target_id', 'target_type', 'action_type', 'filename', 'accept_signature', 'created_at'])
             ->where('target_type', self::class)
             ->where('action_type', 'accepted')
             ->whereNotNull('filename')

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -552,6 +552,23 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     }
 
     /**
+     * Establishes the user -> eula relationship
+     *
+     * @author A. Gianotto <snipe@snipe.net>
+     * @since [v7.0.7]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function eulas()
+    {
+        return $this->hasMany(Actionlog::class, 'target_id')
+            ->where('target_type', self::class)
+            ->where('action_type', 'accepted')
+            ->whereNotNull('filename')
+            ->whereNotNull('accept_signature')
+            ->orderBy('created_at', 'desc');
+    }
+
+    /**
      * Establishes the user -> requested assets relationship
      *
      * @author A. Gianotto <snipe@snipe.net>

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -561,6 +561,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     public function eulas()
     {
         return $this->hasMany(Actionlog::class, 'target_id')
+            ->with('item')
             ->where('target_type', self::class)
             ->where('action_type', 'accepted')
             ->whereNotNull('filename')

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -288,6 +288,7 @@ return [
     'status'    			=> 'Status',
     'accept_eula'           => 'Acceptance Agreement',
     'eula'                  => 'EULAs',
+    'eula_long'             => 'End-User License Agreements',
     'show_or_hide_eulas' => 'Show/Hide EULAs',
     'supplier'              => 'Supplier',
     'suppliers'  			=> 'Suppliers',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -287,6 +287,7 @@ return [
     'status_label'			=> 'Status Label',
     'status'    			=> 'Status',
     'accept_eula'           => 'Acceptance Agreement',
+    'eula'                  => 'EULAs',
     'show_or_hide_eulas' => 'Show/Hide EULAs',
     'supplier'              => 'Supplier',
     'suppliers'  			=> 'Suppliers',

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -731,41 +731,28 @@
                     data-sort-order="asc"
                     data-sort-name="name"
                     class="table table-striped snipe-table table-hover"
+                    data-url="{{route('api.user.eulas', $user->id)}}"
                     data-export-options='{
                     "fileName": "export-eula-{{ str_slug($user->username) }}-{{ date('Y-m-d') }}",
                     "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","delete","purchasecost", "icon"]
                     }'>
 
-              <caption id="userConsumableToolbar" class="tableCaption">
-                {{ trans('general.consumables') }}
+              <caption id="userEulaToolbar" class="tableCaption">
+                {{ trans('general.eula_long') }}
               </caption>
 
               <thead>
               <tr>
-                <th class="col-md-3">{{ trans('general.name') }}</th>
-                @can('self.view_purchase_cost')
-                  <th class="col-md-2" data-footer-formatter="sumFormatter" data-fieldname="purchase_cost">{{ trans('general.purchase_cost') }}</th>
-                @endcan
-                <th class="col-md-2">{{ trans('general.date') }}</th>
-                <th class="col-md-5">{{ trans('general.notes') }}</th>
+                <th data-visible="true" data-field="icon" style="width: 40px;" class="hidden-xs" data-formatter="iconFormatter">{{ trans('admin/hardware/table.icon') }}</th>
+                <th data-visible="true" data-field="item.name">{{ trans('general.item') }}</th>
+                <th data-visible="true" data-field="created_at" data-sortable="true" data-formatter="dateDisplayFormatter">{{ trans('general.accepted_date') }}</th>
+                <th data-field="note">{{ trans('general.notes') }}</th>
+                <th data-field="signature_file" data-visible="false"  data-formatter="imageFormatter">{{ trans('general.signature') }}</th>
+                <th data-field="file" data-formatter="fileUploadFormatter">{{ trans('general.download') }}</th>
               </tr>
               </thead>
-              <tbody>
-              @foreach ($user->consumables as $consumable)
-                <tr>
-                  <td>{{ $consumable->name }}</td>
-                  @can('self.view_purchase_cost')
-                    <td>
-                      {!! Helper::formatCurrencyOutput($consumable->purchase_cost) !!}
-                    </td>
-                  @endcan
-                  <td>{{ Helper::getFormattedDateObject($consumable->pivot->created_at, 'datetime',  false) }}</td>
-                  <td>{{ $consumable->pivot->note }}</td>
-                </tr>
-              @endforeach
-              </tbody>
             </table>
-          </div><!-- /consumables-tab -->
+          </div><!-- /eulas-tab -->
         </div><!-- /.tab-content -->
       </div><!-- nav-tabs-custom -->
     </div>

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -87,6 +87,17 @@
             </a>
           </li>
 
+          <li>
+            <a href="#eulas" data-toggle="tab">
+            <span class="hidden-lg hidden-md" aria-hidden="true">
+                <x-icon type="files" class="fa-2x" />
+              </span>
+              <span class="hidden-xs hidden-sm">{{ trans('general.eula') }}
+                {!! ($user->eulas->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($user->eulas->count()).'</span>' : '' !!}
+            </span>
+            </a>
+          </li>
+
         </ul>
 
         <div class="tab-content">
@@ -703,7 +714,58 @@
                 </tbody>
               </table>
           </div><!-- /consumables-tab -->
+          <div class="tab-pane" id="eulas">
+            <table
+                    data-toolbar="#userEULAToolbar"
+                    data-cookie-id-table="userEULATable"
+                    data-id-table="userEULATable"
+                    id="userEULATable"
+                    data-search="true"
+                    data-pagination="true"
+                    data-side-pagination="client"
+                    data-show-columns="true"
+                    data-show-fullscreen="true"
+                    data-show-export="true"
+                    data-show-footer="true"
+                    data-show-refresh="false"
+                    data-sort-order="asc"
+                    data-sort-name="name"
+                    class="table table-striped snipe-table table-hover"
+                    data-export-options='{
+                    "fileName": "export-eula-{{ str_slug($user->username) }}-{{ date('Y-m-d') }}",
+                    "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","delete","purchasecost", "icon"]
+                    }'>
 
+              <caption id="userConsumableToolbar" class="tableCaption">
+                {{ trans('general.consumables') }}
+              </caption>
+
+              <thead>
+              <tr>
+                <th class="col-md-3">{{ trans('general.name') }}</th>
+                @can('self.view_purchase_cost')
+                  <th class="col-md-2" data-footer-formatter="sumFormatter" data-fieldname="purchase_cost">{{ trans('general.purchase_cost') }}</th>
+                @endcan
+                <th class="col-md-2">{{ trans('general.date') }}</th>
+                <th class="col-md-5">{{ trans('general.notes') }}</th>
+              </tr>
+              </thead>
+              <tbody>
+              @foreach ($user->consumables as $consumable)
+                <tr>
+                  <td>{{ $consumable->name }}</td>
+                  @can('self.view_purchase_cost')
+                    <td>
+                      {!! Helper::formatCurrencyOutput($consumable->purchase_cost) !!}
+                    </td>
+                  @endcan
+                  <td>{{ Helper::getFormattedDateObject($consumable->pivot->created_at, 'datetime',  false) }}</td>
+                  <td>{{ $consumable->pivot->note }}</td>
+                </tr>
+              @endforeach
+              </tbody>
+            </table>
+          </div><!-- /consumables-tab -->
         </div><!-- /.tab-content -->
       </div><!-- nav-tabs-custom -->
     </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1094,6 +1094,14 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
                 ]
             )->name('api.users.me');
 
+            Route::get('/users/{user}/eulas',
+                [
+                    Api\UsersController::class,
+                    'eulas'
+                ]
+            )->name('api.user.eulas');
+
+
             Route::get('list/{status?}',
             [
                 Api\UsersController::class, 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1094,7 +1094,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
                 ]
             )->name('api.users.me');
 
-            Route::get('/users/{user}/eulas',
+            Route::get('{user}/eulas',
                 [
                     Api\UsersController::class,
                     'eulas'


### PR DESCRIPTION
This adds an api point to get all EULAs a user has signed. the api endpoint is used by a new EULA table added into the account area of a user:
<img width="1586" alt="image" src="https://github.com/user-attachments/assets/59963f0e-d8ab-47c9-b296-f9edabe37506" />

Users are able to download and print associated EULAs if they would like to now.

I've added only the columns in the picture, if more or less are needed let me know
