### PR TITLE
Fixed #16934 and #17068 - update asset by ID in importer

### DIFF
--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -80,7 +80,16 @@ class AssetImporter extends ItemImporter
             $asset_tag = Asset::autoincrement_asset();
         }
 
-        $asset = Asset::where(['asset_tag'=> (string) $asset_tag])->first();
+
+
+        if ($this->findCsvMatch($row, 'id')!='') {
+            // Override location if an ID was given
+            \Log::debug('Finding asset by ID: '.$this->findCsvMatch($row, 'id'));
+            $asset = Asset::find($this->findCsvMatch($row, 'id'));
+        } else {
+            $asset = Asset::where(['asset_tag'=> (string) $asset_tag])->first();
+        }
+        
         if ($asset) {
             if (! $this->updating) {
                 $exists_error = trans('general.import_asset_tag_exists', ['asset_tag' => $asset_tag]);

--- a/app/Importer/AssetImporter.php
+++ b/app/Importer/AssetImporter.php
@@ -83,7 +83,7 @@ class AssetImporter extends ItemImporter
 
 
         if ($this->findCsvMatch($row, 'id')!='') {
-            // Override location if an ID was given
+            // Override asset if an ID was given
             \Log::debug('Finding asset by ID: '.$this->findCsvMatch($row, 'id'));
             $asset = Asset::find($this->findCsvMatch($row, 'id'));
         } else {

--- a/app/Livewire/Importer.php
+++ b/app/Livewire/Importer.php
@@ -203,6 +203,7 @@ class Importer extends Component
         ];
 
         $this->assets_fields = [
+            'id' => trans('general.id'),
             'asset_eol_date' => trans('admin/hardware/form.eol_date'),
             'asset_model' => trans('general.model_name'),
             'asset_notes' => trans('general.item_notes', ['item' => trans('admin/hardware/general.asset')]),

--- a/tests/Support/Importing/AssetsImportFileBuilder.php
+++ b/tests/Support/Importing/AssetsImportFileBuilder.php
@@ -40,6 +40,7 @@ class AssetsImportFileBuilder extends FileBuilder
     protected function getDictionary(): array
     {
         return [
+            'id'                  => 'ID',
             'assigneeFullName'    => 'Full Name',
             'assigneeEmail'       => 'Email',
             'assigneeUsername'    => 'Username',
@@ -69,6 +70,7 @@ class AssetsImportFileBuilder extends FileBuilder
         $faker = fake();
 
         return [
+            'asset_tag'           => Str::random(),
             'assigneeFullName'    => $faker->name,
             'assigneeEmail'       => $faker->email,
             'assigneeUsername'    => $faker->userName,


### PR DESCRIPTION
This should allow the ID column, if present, to override the asset tag lookup so that people can export their list of assets with the ID column, change the asset tags, and update.