### PR TITLE
Fixed #17067: Allow only sending cc email when acceptance required

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -650,6 +650,7 @@ class SettingsController extends Controller
 
         $setting->alert_email = $alert_email;
         $setting->admin_cc_email = $admin_cc_email;
+        $setting->admin_cc_always = $request->validated('admin_cc_always');
         $setting->alerts_enabled = $request->input('alerts_enabled', '0');
         $setting->alert_interval = $request->input('alert_interval');
         $setting->alert_threshold = $request->input('alert_threshold');

--- a/app/Http/Requests/StoreNotificationSettings.php
+++ b/app/Http/Requests/StoreNotificationSettings.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use App\Models\Accessory;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
 
 class StoreNotificationSettings extends FormRequest
 {
@@ -26,6 +27,9 @@ class StoreNotificationSettings extends FormRequest
         return [
             'alert_email'                         => 'email_array|nullable',
             'admin_cc_email'                      => 'email_array|nullable',
+            'admin_cc_always' => [
+                Rule::in('0', '1'),
+            ],
             'alert_threshold'                     => 'numeric|nullable',
             'alert_interval'                      => 'numeric|nullable|gt:0',
             'audit_warning_days'                  => 'numeric|nullable',

--- a/app/Http/Requests/StoreNotificationSettings.php
+++ b/app/Http/Requests/StoreNotificationSettings.php
@@ -26,7 +26,11 @@ class StoreNotificationSettings extends FormRequest
     {
         return [
             'alert_email'                         => 'email_array|nullable',
-            'admin_cc_email'                      => 'email_array|nullable',
+            'admin_cc_email' => [
+                'email_array',
+                'nullable',
+                'required_if_accepted:admin_cc_always',
+            ],
             'admin_cc_always' => [
                 Rule::in('0', '1'),
             ],

--- a/app/Http/Requests/StoreNotificationSettings.php
+++ b/app/Http/Requests/StoreNotificationSettings.php
@@ -26,11 +26,7 @@ class StoreNotificationSettings extends FormRequest
     {
         return [
             'alert_email'                         => 'email_array|nullable',
-            'admin_cc_email' => [
-                'email_array',
-                'nullable',
-                'required_if_accepted:admin_cc_always',
-            ],
+            'admin_cc_email'                      => 'email_array|nullable',
             'admin_cc_always' => [
                 Rule::in('0', '1'),
             ],

--- a/database/migrations/2025_06_02_233556_add_admin_cc_always_to_settings_table.php
+++ b/database/migrations/2025_06_02_233556_add_admin_cc_always_to_settings_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->boolean('admin_cc_always')->after('admin_cc_email')->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('admin_cc_always');
+        });
+    }
+};

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -9,6 +9,8 @@ return [
     'ad_append_domain_help'     => 'User isn\'t required to write "username@domain.local", they can just type "username".',
     'admin_cc_email'            => 'CC Email',
     'admin_cc_email_help'       => 'Send a copy of checkin/checkout emails to this address.',
+    'admin_cc_always' => 'Always send copy upon checkin/checkout',
+    'admin_cc_when_acceptance_required' => 'Only send copy upon checkout if acceptance is required',
     'admin_settings'            => 'Admin Settings',
     'is_ad'				        => 'This is an Active Directory server',
     'alerts'                	=> 'Alerts',

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -101,11 +101,21 @@
                             <div class="form-group">
                                 <div class="col-md-9 col-md-offset-3">
                                     <label class="form-control">
-                                        <input type="radio" name="admin_cc_always" value="1">
+                                        <input
+                                            type="radio"
+                                            name="admin_cc_always"
+                                            value="1"
+                                            @checked($setting->admin_cc_always == 1)
+                                        >
                                         Always send copy to CC email
                                     </label>
                                     <label class="form-control">
-                                        <input type="radio" name="admin_cc_always" value="0">
+                                        <input
+                                            type="radio"
+                                            name="admin_cc_always"
+                                            value="0"
+                                            @checked($setting->admin_cc_always == 0)
+                                        >
                                         Only send if acceptance required
                                     </label>
                                     <p class="help-block">

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -116,7 +116,7 @@
                                             value="0"
                                             @checked($setting->admin_cc_always == 0)
                                         >
-                                        Only send if acceptance required
+                                        Only send copy if acceptance required
                                     </label>
                                     <p class="help-block">
                                         "Always send copy to CC email" requires valid CC Email to be set.

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -107,7 +107,7 @@
                                             value="1"
                                             @checked($setting->admin_cc_always == 1)
                                         >
-                                        Always send copy upon checkin/checkout
+                                        {{ trans('admin/settings/general.admin_cc_always') }}
                                     </label>
                                     <label class="form-control">
                                         <input
@@ -116,7 +116,7 @@
                                             value="0"
                                             @checked($setting->admin_cc_always == 0)
                                         >
-                                        Only send copy upon checkout if acceptance is required
+                                        {{ trans('admin/settings/general.admin_cc_when_acceptance_required') }}
                                     </label>
                                 </div>
                             </div>

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -107,7 +107,7 @@
                                             value="1"
                                             @checked($setting->admin_cc_always == 1)
                                         >
-                                        Always send copy to CC email
+                                        Always send copy upon checkin/checkout
                                     </label>
                                     <label class="form-control">
                                         <input
@@ -116,11 +116,8 @@
                                             value="0"
                                             @checked($setting->admin_cc_always == 0)
                                         >
-                                        Only send copy if acceptance required
+                                        Only send copy upon checkout if acceptance is required
                                     </label>
-                                    <p class="help-block">
-                                        "Always send copy to CC email" requires valid CC Email to be set.
-                                    </p>
                                 </div>
                             </div>
                         </fieldset>

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -96,8 +96,18 @@
                                     <input type="email" name="admin_cc_email" value="{{ old('admin_cc_email', $setting->admin_cc_email) }}" class="form-control" placeholder="admin@yourcompany.com" maxlength="191">
                                     {!! $errors->first('admin_cc_email', '<span class="alert-msg" aria-hidden="true">:message</span><br>') !!}
                                     <p class="help-block">{{ trans('admin/settings/general.admin_cc_email_help') }}</p>
-
-
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <div class="col-md-9 col-md-offset-3">
+                                    <label class="form-control">
+                                        <input type="radio" name="admin_cc_always" value="1">
+                                        Always send copy to CC email
+                                    </label>
+                                    <label class="form-control">
+                                        <input type="radio" name="admin_cc_always" value="0">
+                                        Only send if acceptance required
+                                    </label>
                                 </div>
                             </div>
                         </fieldset>

--- a/resources/views/settings/alerts.blade.php
+++ b/resources/views/settings/alerts.blade.php
@@ -108,6 +108,9 @@
                                         <input type="radio" name="admin_cc_always" value="0">
                                         Only send if acceptance required
                                     </label>
+                                    <p class="help-block">
+                                        "Always send copy to CC email" requires valid CC Email to be set.
+                                    </p>
                                 </div>
                             </div>
                         </fieldset>

--- a/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
@@ -73,6 +73,16 @@ class EmailNotificationsToAdminAlertEmailUponCheckinTest extends TestCase
         });
     }
 
+    public function test_admin_alert_email_sent_when_always_send_is_true_and_asset_does_not_require_acceptance()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_admin_alert_email_not_sent_when_always_send_is_false_and_asset_does_not_require_acceptance()
+    {
+        $this->markTestIncomplete();
+    }
+
     private function fireCheckInEvent($asset, $user): void
     {
         event(new CheckoutableCheckedIn(

--- a/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
@@ -41,7 +41,6 @@ class EmailNotificationsToAdminAlertEmailUponCheckinTest extends TestCase
             ->for($this->assetModel, 'model')
             ->assignedToUser($this->user)
             ->create();
-
     }
 
     public function test_admin_alert_email_sends()

--- a/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
@@ -86,12 +86,32 @@ class EmailNotificationsToAdminAlertEmailUponCheckinTest extends TestCase
 
     public function test_admin_alert_email_sent_when_always_send_is_true_and_asset_does_not_require_acceptance()
     {
-        $this->markTestIncomplete();
+        $this->settings
+            ->enableAdminCC('cc@example.com')
+            ->enableAdminCCAlways();
+
+        $this->category->update(['checkin_email' => false]);
+
+        $this->fireCheckInEvent($this->asset, $this->user);
+
+        Mail::assertSent(CheckinAssetMail::class, function ($mail) {
+            return $mail->hasTo('cc@example.com') || $mail->hasCc('cc@example.com');
+        });
     }
 
     public function test_admin_alert_email_not_sent_when_always_send_is_false_and_asset_does_not_require_acceptance()
     {
-        $this->markTestIncomplete();
+        $this->settings
+            ->enableAdminCC('cc@example.com')
+            ->disableAdminCCAlways();
+
+        $this->category->update(['checkin_email' => false]);
+
+        $this->fireCheckInEvent($this->asset, $this->user);
+
+        Mail::assertNotSent(CheckinAssetMail::class, function ($mail) {
+            return $mail->hasTo('cc@example.com') || $mail->hasCc('cc@example.com');
+        });
     }
 
     private function fireCheckInEvent($asset, $user): void

--- a/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckinTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature\Notifications\Email;
+
+use App\Events\CheckoutableCheckedIn;
+use App\Mail\CheckinAssetMail;
+use App\Models\Asset;
+use App\Models\AssetModel;
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('notifications')]
+class EmailNotificationsToAdminAlertEmailUponCheckinTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Mail::fake();
+    }
+
+    public function test_admin_alert_email_sends()
+    {
+        $this->settings->enableAdminCC('cc@example.com');
+
+        $user = User::factory()->create();
+        $asset = Asset::factory()->assignedToUser($user)->create();
+
+        $asset->model->category->update(['checkin_email' => true]);
+
+        $this->fireCheckInEvent($asset, $user);
+
+        Mail::assertSent(CheckinAssetMail::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email) && $mail->hasCc('cc@example.com');
+        });
+    }
+
+    public function test_admin_alert_email_still_sent_when_category_email_is_not_set_to_send_email_to_user()
+    {
+        $this->settings->enableAdminCC('cc@example.com');
+
+        $category = Category::factory()->create([
+            'checkin_email' => false,
+            'eula_text' => null,
+            'use_default_eula' => false,
+        ]);
+        $assetModel = AssetModel::factory()->create(['category_id' => $category->id]);
+        $asset = Asset::factory()->create(['model_id' => $assetModel->id]);
+
+        $this->fireCheckInEvent($asset, User::factory()->create());
+
+        Mail::assertSent(CheckinAssetMail::class, function ($mail) {
+            return $mail->hasTo('cc@example.com');
+        });
+    }
+
+    public function test_admin_alert_email_still_sent_when_user_has_no_email_address()
+    {
+        $this->settings->enableAdminCC('cc@example.com');
+
+        $user = User::factory()->create(['email' => null]);
+        $asset = Asset::factory()->assignedToUser($user)->create();
+
+        $asset->model->category->update(['checkin_email' => true]);
+
+        $this->fireCheckInEvent($asset, $user);
+
+        Mail::assertSent(CheckinAssetMail::class, function ($mail) {
+            return $mail->hasTo('cc@example.com');
+        });
+    }
+
+    private function fireCheckInEvent($asset, $user): void
+    {
+        event(new CheckoutableCheckedIn(
+            $asset,
+            $user,
+            User::factory()->checkinAssets()->create(),
+            ''
+        ));
+    }
+}

--- a/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckout.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckout.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
 #[Group('notifications')]
-class EmailNotificationsUponCheckoutTest extends TestCase
+class EmailNotificationsToAdminAlertEmailUponCheckout extends TestCase
 {
     private Asset $asset;
     private AssetModel $assetModel;
@@ -37,54 +37,6 @@ class EmailNotificationsUponCheckoutTest extends TestCase
         $this->asset = Asset::factory()->for($this->assetModel, 'model')->create();
 
         $this->user = User::factory()->create();
-    }
-
-    public function test_email_sent_to_user_when_category_requires_acceptance()
-    {
-        $this->category->update(['require_acceptance' => true]);
-
-        $this->fireCheckoutEvent();
-
-        $this->assertUserSentEmail();
-    }
-
-    public function test_email_sent_to_user_when_category_using_default_eula()
-    {
-        $this->settings->setEula();
-
-        $this->category->update(['use_default_eula' => true]);
-
-        $this->fireCheckoutEvent();
-
-        $this->assertUserSentEmail();
-    }
-
-    public function test_email_sent_to_user_when_category_using_local_eula()
-    {
-        $this->category->update(['eula_text' => 'Some EULA text']);
-
-        $this->fireCheckoutEvent();
-
-        $this->assertUserSentEmail();
-    }
-
-    public function test_email_sent_to_user_when_category_set_to_explicitly_send_email()
-    {
-        $this->category->update(['checkin_email' => true]);
-
-        $this->fireCheckoutEvent();
-
-        $this->assertUserSentEmail();
-    }
-
-    public function test_handles_user_not_having_email_address_set()
-    {
-        $this->category->update(['checkin_email' => true]);
-        $this->user->update(['email' => null]);
-
-        $this->fireCheckoutEvent();
-
-        Mail::assertNothingSent();
     }
 
     public function test_admin_alert_email_sends()
@@ -133,12 +85,5 @@ class EmailNotificationsUponCheckoutTest extends TestCase
             User::factory()->superuser()->create(),
             '',
         ));
-    }
-
-    private function assertUserSentEmail(): void
-    {
-        Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
-            return $mail->hasTo($this->user->email);
-        });
     }
 }

--- a/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckout.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckout.php
@@ -77,6 +77,21 @@ class EmailNotificationsToAdminAlertEmailUponCheckout extends TestCase
         });
     }
 
+    public function test_admin_alert_email_not_sent_when_always_send_is_false_and_asset_does_not_require_acceptance()
+    {
+        $this->settings
+            ->enableAdminCC('cc@example.com')
+            ->disableAdminCCAlways();
+
+        $this->category->update(['checkin_email' => false]);
+
+        $this->fireCheckoutEvent();
+
+        Mail::assertNotSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
+            return $mail->hasTo('cc@example.com') || $mail->hasCc('cc@example.com');
+        });
+    }
+
     private function fireCheckoutEvent(): void
     {
         event(new CheckoutableCheckedOut(

--- a/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckoutTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToAdminAlertEmailUponCheckoutTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
 #[Group('notifications')]
-class EmailNotificationsToAdminAlertEmailUponCheckout extends TestCase
+class EmailNotificationsToAdminAlertEmailUponCheckoutTest extends TestCase
 {
     private Asset $asset;
     private AssetModel $assetModel;
@@ -74,6 +74,21 @@ class EmailNotificationsToAdminAlertEmailUponCheckout extends TestCase
 
         Mail::assertSent(CheckoutAssetMail::class, function ($mail) {
             return $mail->hasTo('cc@example.com');
+        });
+    }
+
+    public function test_admin_alert_email_sent_when_always_send_is_true_and_asset_does_not_require_acceptance()
+    {
+        $this->settings
+            ->enableAdminCC('cc@example.com')
+            ->enableAdminCCAlways();
+
+        $this->category->update(['checkin_email' => false]);
+
+        $this->fireCheckoutEvent();
+
+        Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
+            return $mail->hasTo('cc@example.com') || $mail->hasCc('cc@example.com');
         });
     }
 

--- a/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckinTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckinTest.php
@@ -4,8 +4,6 @@ namespace Tests\Feature\Notifications\Email;
 
 use App\Mail\CheckinAssetMail;
 use App\Models\Accessory;
-use App\Models\AssetModel;
-use App\Models\Category;
 use App\Models\Consumable;
 use App\Models\LicenseSeat;
 use Illuminate\Support\Facades\Mail;
@@ -16,7 +14,7 @@ use App\Models\User;
 use Tests\TestCase;
 
 #[Group('notifications')]
-class EmailNotificationsUponCheckinTest extends TestCase
+class EmailNotificationsToUserUponCheckinTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -99,57 +97,6 @@ class EmailNotificationsUponCheckinTest extends TestCase
         $this->fireCheckInEvent($asset, $user);
 
         Mail::assertNothingSent();
-    }
-
-    public function test_admin_alert_email_sends()
-    {
-        $this->settings->enableAdminCC('cc@example.com');
-
-        $user = User::factory()->create();
-        $asset = Asset::factory()->assignedToUser($user)->create();
-
-        $asset->model->category->update(['checkin_email' => true]);
-
-        $this->fireCheckInEvent($asset, $user);
-
-        Mail::assertSent(CheckinAssetMail::class, function ($mail) use ($user) {
-            return $mail->hasTo($user->email) && $mail->hasCc('cc@example.com');
-        });
-    }
-
-    public function test_admin_alert_email_still_sent_when_category_email_is_not_set_to_send_email_to_user()
-    {
-        $this->settings->enableAdminCC('cc@example.com');
-
-        $category = Category::factory()->create([
-            'checkin_email' => false,
-            'eula_text' => null,
-            'use_default_eula' => false,
-        ]);
-        $assetModel = AssetModel::factory()->create(['category_id' => $category->id]);
-        $asset = Asset::factory()->create(['model_id' => $assetModel->id]);
-
-        $this->fireCheckInEvent($asset, User::factory()->create());
-
-        Mail::assertSent(CheckinAssetMail::class, function ($mail) {
-            return $mail->hasTo('cc@example.com');
-        });
-    }
-
-    public function test_admin_alert_email_still_sent_when_user_has_no_email_address()
-    {
-        $this->settings->enableAdminCC('cc@example.com');
-
-        $user = User::factory()->create(['email' => null]);
-        $asset = Asset::factory()->assignedToUser($user)->create();
-
-        $asset->model->category->update(['checkin_email' => true]);
-
-        $this->fireCheckInEvent($asset, $user);
-
-        Mail::assertSent(CheckinAssetMail::class, function ($mail) {
-            return $mail->hasTo('cc@example.com');
-        });
     }
 
     private function fireCheckInEvent($asset, $user): void

--- a/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckoutTest.php
+++ b/tests/Feature/Notifications/Email/EmailNotificationsToUserUponCheckoutTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\Notifications\Email;
+
+use App\Events\CheckoutableCheckedOut;
+use App\Mail\CheckoutAssetMail;
+use App\Models\Asset;
+use App\Models\AssetModel;
+use App\Models\Category;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
+
+#[Group('notifications')]
+class EmailNotificationsToUserUponCheckoutTest extends TestCase
+{
+    private Asset $asset;
+    private AssetModel $assetModel;
+    private Category $category;
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Mail::fake();
+
+        $this->category = Category::factory()->create([
+            'checkin_email' => false,
+            'eula_text' => null,
+            'require_acceptance' => false,
+            'use_default_eula' => false,
+        ]);
+
+        $this->assetModel = AssetModel::factory()->for($this->category)->create();
+        $this->asset = Asset::factory()->for($this->assetModel, 'model')->create();
+
+        $this->user = User::factory()->create();
+    }
+
+    public function test_email_sent_to_user_when_category_requires_acceptance()
+    {
+        $this->category->update(['require_acceptance' => true]);
+
+        $this->fireCheckoutEvent();
+
+        $this->assertUserSentEmail();
+    }
+
+    public function test_email_sent_to_user_when_category_using_default_eula()
+    {
+        $this->settings->setEula();
+
+        $this->category->update(['use_default_eula' => true]);
+
+        $this->fireCheckoutEvent();
+
+        $this->assertUserSentEmail();
+    }
+
+    public function test_email_sent_to_user_when_category_using_local_eula()
+    {
+        $this->category->update(['eula_text' => 'Some EULA text']);
+
+        $this->fireCheckoutEvent();
+
+        $this->assertUserSentEmail();
+    }
+
+    public function test_email_sent_to_user_when_category_set_to_explicitly_send_email()
+    {
+        $this->category->update(['checkin_email' => true]);
+
+        $this->fireCheckoutEvent();
+
+        $this->assertUserSentEmail();
+    }
+
+    public function test_handles_user_not_having_email_address_set()
+    {
+        $this->category->update(['checkin_email' => true]);
+        $this->user->update(['email' => null]);
+
+        $this->fireCheckoutEvent();
+
+        Mail::assertNothingSent();
+    }
+
+    private function fireCheckoutEvent(): void
+    {
+        event(new CheckoutableCheckedOut(
+            $this->asset,
+            $this->user,
+            User::factory()->superuser()->create(),
+            '',
+        ));
+    }
+
+    private function assertUserSentEmail(): void
+    {
+        Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
+            return $mail->hasTo($this->user->email);
+        });
+    }
+}

--- a/tests/Feature/Settings/AlertsSettingTest.php
+++ b/tests/Feature/Settings/AlertsSettingTest.php
@@ -26,18 +26,32 @@ class AlertsSettingTest extends TestCase
         $this->followRedirects($response)->assertSee('alert-success');
     }
 
-    public function testCannotUpdateAdminCcAwaysWithoutAdminCcEmail()
-    {
-        $this->markTestIncomplete();
-    }
-
     public function test_can_update_admin_cc_always_to_true()
     {
-        $this->markTestIncomplete();
+        $this->settings->disableAdminCCAlways();
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('settings.alerts.save', ['admin_cc_always' => '1']));
+
+        $this->assertDatabaseHas('settings', ['admin_cc_always' => '1']);
+    }
+
+    public function test_cannot_update_admin_cc_always_without_admin_cc_email()
+    {
+        $this->settings->disableAdminCCAlways();
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('settings.alerts.save', ['admin_cc_always' => '1']))
+            ->assertSessionHasErrors('admin_cc_always');
     }
 
     public function test_can_update_admin_cc_always_to_false()
     {
-        $this->markTestIncomplete();
+        $this->settings->enableAdminCCAlways();
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('settings.alerts.save', ['admin_cc_always' => '0']));
+
+        $this->assertDatabaseHas('settings', ['admin_cc_always' => '0']);
     }
 }

--- a/tests/Feature/Settings/AlertsSettingTest.php
+++ b/tests/Feature/Settings/AlertsSettingTest.php
@@ -18,7 +18,10 @@ class AlertsSettingTest extends TestCase
     public function testAdminCCEmailArrayCanBeSaved()
     {
         $response = $this->actingAs(User::factory()->superuser()->create())
-            ->post(route('settings.alerts.save', ['alert_email' => 'me@example.com,you@example.com']))
+            ->post(route('settings.alerts.save', [
+                'alert_email' => 'me@example.com,you@example.com',
+                'admin_cc_always' => '1',
+            ]))
             ->assertStatus(302)
             ->assertValid('alert_email')
             ->assertRedirect(route('settings.index'))

--- a/tests/Feature/Settings/AlertsSettingTest.php
+++ b/tests/Feature/Settings/AlertsSettingTest.php
@@ -39,15 +39,6 @@ class AlertsSettingTest extends TestCase
         $this->assertDatabaseHas('settings', ['admin_cc_always' => '1']);
     }
 
-    public function test_cannot_update_admin_cc_always_without_admin_cc_email()
-    {
-        $this->settings->disableAdminCCAlways();
-
-        $this->actingAs(User::factory()->superuser()->create())
-            ->post(route('settings.alerts.save', ['admin_cc_always' => '1']))
-            ->assertSessionHasErrors('admin_cc_always');
-    }
-
     public function test_can_update_admin_cc_always_to_false()
     {
         $this->settings->enableAdminCC()->enableAdminCCAlways();

--- a/tests/Feature/Settings/AlertsSettingTest.php
+++ b/tests/Feature/Settings/AlertsSettingTest.php
@@ -47,7 +47,7 @@ class AlertsSettingTest extends TestCase
 
     public function test_can_update_admin_cc_always_to_false()
     {
-        $this->settings->enableAdminCCAlways();
+        $this->settings->enableAdminCC()->enableAdminCCAlways();
 
         $this->actingAs(User::factory()->superuser()->create())
             ->post(route('settings.alerts.save', ['admin_cc_always' => '0']));

--- a/tests/Feature/Settings/AlertsSettingTest.php
+++ b/tests/Feature/Settings/AlertsSettingTest.php
@@ -26,4 +26,18 @@ class AlertsSettingTest extends TestCase
         $this->followRedirects($response)->assertSee('alert-success');
     }
 
+    public function testCannotUpdateAdminCcAwaysWithoutAdminCcEmail()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_can_update_admin_cc_always_to_true()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function test_can_update_admin_cc_always_to_false()
+    {
+        $this->markTestIncomplete();
+    }
 }

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -4,6 +4,7 @@ namespace Tests\Support;
 
 use App\Models\Setting;
 use Illuminate\Support\Facades\Crypt;
+use RuntimeException;
 
 class Settings
 {
@@ -57,6 +58,24 @@ class Settings
     {
         return $this->update([
             'admin_cc_email' => null,
+        ]);
+    }
+
+    public function enableAdminCCAlways(): Settings
+    {
+        if (is_null($this->setting->admin_cc_email) || $this->setting->admin_cc_email == 0) {
+            throw new RuntimeException('admin_cc_email requires admin_cc_email to be set.');
+        }
+
+        return $this->update([
+            'admin_cc_always' => 1,
+        ]);
+    }
+
+    public function disableAdminCCAlways(): Settings
+    {
+        return $this->update([
+            'admin_cc_always' => 0,
         ]);
     }
 

--- a/tests/Support/Settings.php
+++ b/tests/Support/Settings.php
@@ -4,7 +4,6 @@ namespace Tests\Support;
 
 use App\Models\Setting;
 use Illuminate\Support\Facades\Crypt;
-use RuntimeException;
 
 class Settings
 {
@@ -63,10 +62,6 @@ class Settings
 
     public function enableAdminCCAlways(): Settings
     {
-        if (is_null($this->setting->admin_cc_email) || $this->setting->admin_cc_email == 0) {
-            throw new RuntimeException('admin_cc_email requires admin_cc_email to be set.');
-        }
-
         return $this->update([
             'admin_cc_always' => 1,
         ]);


### PR DESCRIPTION
> Description valid as of 088e6af0b5cd696966f889066c4cb18a3f17ab51

This PR adds a new setting to go along with CC Email:
- Always send copy upon checkin/checkout
	- Is default and matches existing behavior
- Only send copy upon checkout if acceptance is required
	- New option described in detail below

![image](https://github.com/user-attachments/assets/d6918fce-7f7b-4ab2-a680-54b11b719b93)

Using the "Only send copy upon checkout if acceptance is required" option, the checkout email will **only** be sent for the checkout if the item being checked out requires acceptance:

![image](https://github.com/user-attachments/assets/0a9c7a57-a84b-47e4-beec-53c0892e4955)

---

Potential UX improvement: as of now, removing the cc email address does not disable the selection of the radio buttons below

![gif](https://github.com/user-attachments/assets/583b5149-4b09-4c17-93e6-bbad8bd9103c)

 I was about to go down the path of extracting a livewire component for this but didn't know if it was unnecessary for this bit of work. @snipe let me know if you'd like it included and I'll add it.

---

Note: A large amount of the diff is due to splitting the test suite.

---

Remaining:

- [x] Translations


---

# Fixes #17067