### PR TITLE
Fixes #17023 - added ability to bulk add maintenances

### DIFF
--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -63,17 +63,13 @@ class AssetMaintenancesController extends Controller
         $this->authorize('update', Asset::class);
         $asset = null;
 
-        $assetMaintenanceType =  AssetMaintenance::getImprovementOptions();
-        // Mark the selected asset, if it came in
-
         if ($asset = Asset::find(request('asset_id'))) {
             // We have to set this so that the correct property is set in the select2 ajax dropdown
             $asset->asset_id = $asset->id;
         }
-
-
+        
         return view('asset_maintenances/edit')
-                   ->with('assetMaintenanceType', $assetMaintenanceType)
+                   ->with('assetMaintenanceType', AssetMaintenance::getImprovementOptions())
                    ->with('asset', $asset)
                    ->with('item', new AssetMaintenance);
     }

--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -63,20 +63,20 @@ class AssetMaintenancesController extends Controller
         $this->authorize('update', Asset::class);
         $asset = null;
 
-        if ($asset = Asset::find(request('asset_id'))) {
-            // We have to set this so that the correct property is set in the select2 ajax dropdown
-            $asset->asset_id = $asset->id;
-        }
-
-        // Prepare Asset Maintenance Type List
         $assetMaintenanceType = [
                                     '' => 'Select an asset maintenance type',
                                 ] + AssetMaintenance::getImprovementOptions();
         // Mark the selected asset, if it came in
 
+        if ($asset = Asset::find(request('asset_id'))) {
+            // We have to set this so that the correct property is set in the select2 ajax dropdown
+            $asset->asset_id = $asset->id;
+        }
+
+
         return view('asset_maintenances/edit')
-                   ->with('asset', $asset)
                    ->with('assetMaintenanceType', $assetMaintenanceType)
+                   ->with('asset', $asset)
                    ->with('item', new AssetMaintenance);
     }
 
@@ -91,43 +91,47 @@ class AssetMaintenancesController extends Controller
     public function store(Request $request) : RedirectResponse
     {
         $this->authorize('update', Asset::class);
-        // create a new model instance
-        $assetMaintenance = new AssetMaintenance();
-        $assetMaintenance->supplier_id = $request->input('supplier_id');
-        $assetMaintenance->is_warranty = $request->input('is_warranty');
-        $assetMaintenance->cost = $request->input('cost');
-        $assetMaintenance->notes = $request->input('notes');
-        $asset = Asset::find($request->input('asset_id'));
 
-        if ((! Company::isCurrentUserHasAccess($asset)) && ($asset != null)) {
-            return static::getInsufficientPermissionsRedirect();
+        $assets = Asset::whereIn('id', $request->input('selected_assets'))->get();
+
+        foreach ($assets as $asset) {
+            if ((! Company::isCurrentUserHasAccess($asset)) && ($asset != null)) {
+                return static::getInsufficientPermissionsRedirect();
+            }
+
+            $assetMaintenance = new AssetMaintenance();
+            $assetMaintenance->supplier_id = $request->input('supplier_id');
+            $assetMaintenance->is_warranty = $request->input('is_warranty');
+            $assetMaintenance->cost = $request->input('cost');
+            $assetMaintenance->notes = $request->input('notes');
+
+            // Save the asset maintenance data
+            $assetMaintenance->asset_id = $asset->id;
+            $assetMaintenance->asset_maintenance_type = $request->input('asset_maintenance_type');
+            $assetMaintenance->title = $request->input('title');
+            $assetMaintenance->start_date = $request->input('start_date');
+            $assetMaintenance->completion_date = $request->input('completion_date');
+            $assetMaintenance->created_by = auth()->id();
+
+            if (($assetMaintenance->completion_date !== null)
+                && ($assetMaintenance->start_date !== '')
+                && ($assetMaintenance->start_date !== '0000-00-00')
+            ) {
+                $startDate = Carbon::parse($assetMaintenance->start_date);
+                $completionDate = Carbon::parse($assetMaintenance->completion_date);
+                $assetMaintenance->asset_maintenance_time = (int) $completionDate->diffInDays($startDate, true);
+            }
+
+
+            // Was the asset maintenance created?
+            if (!$assetMaintenance->save()) {
+                return redirect()->back()->withInput()->withErrors($assetMaintenance->getErrors());
+            }
         }
 
-        // Save the asset maintenance data
-        $assetMaintenance->asset_id = $request->input('asset_id');
-        $assetMaintenance->asset_maintenance_type = $request->input('asset_maintenance_type');
-        $assetMaintenance->title = $request->input('title');
-        $assetMaintenance->start_date = $request->input('start_date');
-        $assetMaintenance->completion_date = $request->input('completion_date');
-        $assetMaintenance->created_by = auth()->id();
+        return redirect()->route('maintenances.index')
+            ->with('success', trans('admin/asset_maintenances/message.create.success'));
 
-        if (($assetMaintenance->completion_date !== null)
-            && ($assetMaintenance->start_date !== '')
-            && ($assetMaintenance->start_date !== '0000-00-00')
-        ) {
-            $startDate = Carbon::parse($assetMaintenance->start_date);
-            $completionDate = Carbon::parse($assetMaintenance->completion_date);
-            $assetMaintenance->asset_maintenance_time = (int) $completionDate->diffInDays($startDate, true);
-        }
-
-        // Was the asset maintenance created?
-        if ($assetMaintenance->save()) {
-            // Redirect to the new asset maintenance page
-            return redirect()->route('maintenances.index')
-                           ->with('success', trans('admin/asset_maintenances/message.create.success'));
-        }
-
-        return redirect()->back()->withInput()->withErrors($assetMaintenance->getErrors());
     }
 
     /**

--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -63,9 +63,7 @@ class AssetMaintenancesController extends Controller
         $this->authorize('update', Asset::class);
         $asset = null;
 
-        $assetMaintenanceType = [
-                                    '' => 'Select an asset maintenance type',
-                                ] + AssetMaintenance::getImprovementOptions();
+        $assetMaintenanceType =  AssetMaintenance::getImprovementOptions();
         // Mark the selected asset, if it came in
 
         if ($asset = Asset::find(request('asset_id'))) {
@@ -153,7 +151,7 @@ class AssetMaintenancesController extends Controller
         }
 
         // Prepare Improvement Type List
-        $assetMaintenanceType = ['' => 'Select an improvement type'] + AssetMaintenance::getImprovementOptions();
+        $assetMaintenanceType = ['' => trans('general.select')] + AssetMaintenance::getImprovementOptions();
 
         return view('asset_maintenances/edit')
                    ->with('selectedAsset', null)

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -52,9 +52,15 @@ class BulkAssetsController extends Controller
         }
 
         $asset_ids = $request->input('ids');
+
         if ($request->input('bulk_actions') === 'checkout') {
             $request->session()->flashInput(['selected_assets' => $asset_ids]);
             return redirect()->route('hardware.bulkcheckout.show');
+        }
+
+        if ($request->input('bulk_actions') === 'maintenance') {
+            $request->session()->flashInput(['selected_assets' => $asset_ids]);
+            return redirect()->route('maintenances.create');
         }
 
         // Figure out where we need to send the user after the update is complete, and store that in the session

--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -26,7 +26,7 @@ class AssetMaintenance extends Model implements ICompanyableChild
     protected $table = 'asset_maintenances';
     protected $rules = [
         'asset_id'               => 'required|integer',
-        'supplier_id'            => 'required|integer',
+        'supplier_id'            => 'nullable|integer',
         'asset_maintenance_type' => 'required',
         'title'                  => 'required|max:100',
         'is_warranty'            => 'boolean',

--- a/database/migrations/2025_06_06_155058_make_supplier_id_nullable.php
+++ b/database/migrations/2025_06_06_155058_make_supplier_id_nullable.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('asset_maintenances', function (Blueprint $table) {
+            $table->integer('supplier_id')->nullable()->default(null)->change();
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/resources/lang/en-US/admin/asset_maintenances/form.php
+++ b/resources/lang/en-US/admin/asset_maintenances/form.php
@@ -1,6 +1,7 @@
 <?php
 
     return [
+        'select_type'            => 'Select Maintenance Type',
         'asset_maintenance_type' => 'Asset Maintenance Type',
         'title'                  => 'Title',
         'start_date'             => 'Start Date',

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -19,7 +19,7 @@
 
 {{-- Page content --}}
 @section('content')
-
+  
 <div class="row">
   <div class="col-md-9">
     @if ($item->id)
@@ -54,10 +54,21 @@
         </div>
 
 
-        @include ('partials.forms.edit.asset-select', ['translated_name' => trans('general.asset'), 'fieldname' => 'asset_id', 'required' => 'true'])
-        @include ('partials.forms.edit.supplier-select', ['translated_name' => trans('general.supplier'), 'fieldname' => 'supplier_id', 'required' => 'true'])
-        @include ('partials.forms.edit.maintenance_type')
 
+        @include ('partials.forms.edit.asset-select', [
+          'translated_name' => trans('general.assets'),
+          'fieldname' => 'selected_assets[]',
+          'multiple' => true,
+          'required' => true,
+          'asset_status_type' => 'RTD',
+          'select_id' => 'assigned_assets_select',
+          'asset_selector_div_id' => 'assets_to_checkout_div',
+          'asset_ids' => old('selected_assets')
+        ])
+
+
+        @include ('partials.forms.edit.maintenance_type')
+        @include ('partials.forms.edit.supplier-select', ['translated_name' => trans('general.supplier'), 'fieldname' => 'supplier_id'])
 
 
         <!-- Start Date -->

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -60,7 +60,6 @@
           'fieldname' => 'selected_assets[]',
           'multiple' => true,
           'required' => true,
-          'asset_status_type' => 'RTD',
           'select_id' => 'assigned_assets_select',
           'asset_selector_div_id' => 'assets_to_checkout_div',
           'asset_ids' => old('selected_assets')

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -19,7 +19,7 @@
 
 {{-- Page content --}}
 @section('content')
-  
+
 <div class="row">
   <div class="col-md-9">
     @if ($item->id)

--- a/resources/views/partials/asset-bulk-actions.blade.php
+++ b/resources/views/partials/asset-bulk-actions.blade.php
@@ -24,6 +24,7 @@
         @else
             @can('update', \App\Models\Asset::class)
                 <option value="edit">{{ trans('button.edit') }}</option>
+                <option value="maintenance">{{ trans('button.add_maintenance') }}</option>
             @endcan
             @can('checkout', \App\Models\Asset::class)
                 <option value="checkout">{{ trans('general.bulk_checkout') }}</option>

--- a/resources/views/partials/forms/edit/maintenance_type.blade.php
+++ b/resources/views/partials/forms/edit/maintenance_type.blade.php
@@ -8,6 +8,8 @@
                       :options="$assetMaintenanceType"
                       :selected="old('asset_maintenance_type', $item->asset_maintenance_type)"
                       :required="Helper::checkIfRequired($item, 'asset_maintenance_type')"
+                      data-placeholder="{{ trans('admin/asset_maintenances/form.select_type')}}"
+                      includeEmpty="true"
                       style="width:100%;"
                       aria-label="asset_maintenance_type"
                   />

--- a/tests/Feature/AssetMaintenances/Ui/CreateAssetMaintenanceTest.php
+++ b/tests/Feature/AssetMaintenances/Ui/CreateAssetMaintenanceTest.php
@@ -16,6 +16,7 @@ class CreateAssetMaintenanceTest extends TestCase
             ->assertOk();
     }
 
+
     public function testCanCreateAssetMaintenance()
     {
         $actor = User::factory()->superuser()->create();
@@ -27,7 +28,7 @@ class CreateAssetMaintenanceTest extends TestCase
             ->followingRedirects()
             ->post(route('maintenances.store'), [
                 'title' => 'Test Maintenance',
-                'asset_id' => $asset->id,
+                'selected_assets' => [$asset->id],
                 'supplier_id' => $supplier->id,
                 'asset_maintenance_type' => 'Maintenance',
                 'start_date' => '2021-01-01',


### PR DESCRIPTION
This extends the maintenances feature to be able to add maintenances through the bulk edit menu, and also to allow you to select multiple assets from the creation page. 


### From the asset page
https://github.com/user-attachments/assets/6bd97021-98e5-445a-96ee-eb9edd8da0d7

### From bulk edit menu
https://github.com/user-attachments/assets/eed27b90-c536-44ab-bb55-eb9b17d7c4bc

### From the maintenance page
https://github.com/user-attachments/assets/49c776bf-c92a-4ec7-b047-f2a6d971fdc1

