### PR TITLE
Fixed #17127 - added note to EULA info

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -562,7 +562,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     {
         return $this->hasMany(Actionlog::class, 'target_id')
             ->with('item')
-            ->select(['id', 'target_id', 'target_type', 'action_type', 'filename', 'accept_signature', 'created_at'])
+            ->select(['id', 'target_id', 'target_type', 'action_type', 'filename', 'accept_signature', 'created_at', 'note'])
             ->where('target_type', self::class)
             ->where('action_type', 'accepted')
             ->whereNotNull('filename')


### PR DESCRIPTION
This adds the note to the EULAs tab for user's assets. I'm not seeing the item in that list though, so that may be another issue we need to look at. 