### PR TITLE
Fixed Expected checkin notification erroring on unknown users

### DIFF
--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -307,6 +307,7 @@ return [
     'type'  				=> 'Type',
     'undeployable'			=> 'Un-deployable',
     'unknown_admin'			=> 'Unknown Admin',
+    'unknown_user'          => 'Unknown User',
     'username'              => 'Username',
     'update'                => 'Update',
     'updating_item' => 'Updating :item',

--- a/resources/views/notifications/markdown/report-expected-checkins.blade.php
+++ b/resources/views/notifications/markdown/report-expected-checkins.blade.php
@@ -10,7 +10,7 @@
 @php
 $checkin = Helper::getFormattedDateObject($asset->expected_checkin, 'date');
 
-$assignedToName = $asset->assignedTo ? $asset->assignedTo->present()->fullName : 'Unknown User';
+$assignedToName = $asset->assignedTo ? $asset->assignedTo->present()->fullName : trans('general.unknown_user');
 $assignedToRoute = $asset->assignedTo ? route($asset->targetShowRoute().'.show', [$asset->assignedTo->id]) : '';
 @endphp
 | [{{ $asset->present()->name }}]({{ route('hardware.show', $asset) }}) | @if ($asset->assignedTo) [{{ $assignedToName }}]({{ $assignedToRoute }}) @else {{ $assignedToName }} @endif  | {{ $checkin['formatted'] }}

--- a/resources/views/notifications/markdown/report-expected-checkins.blade.php
+++ b/resources/views/notifications/markdown/report-expected-checkins.blade.php
@@ -9,8 +9,11 @@
 @foreach ($assets as $asset)
 @php
 $checkin = Helper::getFormattedDateObject($asset->expected_checkin, 'date');
+
+$assignedToName = $asset->assignedTo ? $asset->assignedTo->present()->fullName : 'Unknown User';
+$assignedToRoute = $asset->assignedTo ? route($asset->targetShowRoute().'.show', [$asset->assignedTo->id]) : '';
 @endphp
-| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset) }}) | [{{ $asset->assignedTo->present()->fullName }}]({{ route($asset->targetShowRoute().'.show', [$asset->assignedTo->id]) }})  | {{ $checkin['formatted'] }}
+| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset) }}) | [{{ $assignedToName }}]({{ $assignedToRoute }})  | {{ $checkin['formatted'] }}
 @endforeach
 @endcomponent
 

--- a/resources/views/notifications/markdown/report-expected-checkins.blade.php
+++ b/resources/views/notifications/markdown/report-expected-checkins.blade.php
@@ -13,7 +13,7 @@ $checkin = Helper::getFormattedDateObject($asset->expected_checkin, 'date');
 $assignedToName = $asset->assignedTo ? $asset->assignedTo->present()->fullName : 'Unknown User';
 $assignedToRoute = $asset->assignedTo ? route($asset->targetShowRoute().'.show', [$asset->assignedTo->id]) : '';
 @endphp
-| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset) }}) | [{{ $assignedToName }}]({{ $assignedToRoute }})  | {{ $checkin['formatted'] }}
+| [{{ $asset->present()->name }}]({{ route('hardware.show', $asset) }}) | @if ($asset->assignedTo) [{{ $assignedToName }}]({{ $assignedToRoute }}) @else {{ $assignedToName }} @endif  | {{ $checkin['formatted'] }}
 @endforeach
 @endcomponent
 


### PR DESCRIPTION
This PR prevents a 500 from occurring within the `SendExpectedCheckinAlerts` (`snipeit:expected-checkin`) command when an asset that is overdue for checkin is assigned to an unknown user (invalid `id`).

Now the text "Unknown User" is displayed:
![image](https://github.com/user-attachments/assets/f5e1f329-9264-4806-a46d-5fa29b65b278)

---

[RB-18254]
[RB-18419]
[RB-18430]
[RB-18431]
