### PR TITLE
FIXED: #17136 loads item relation properly in account EULA tab

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -562,7 +562,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     {
         return $this->hasMany(Actionlog::class, 'target_id')
             ->with('item')
-            ->select(['id', 'target_id', 'target_type', 'action_type', 'filename', 'accept_signature', 'created_at', 'note'])
+            ->select(['id', 'target_id', 'target_type', 'action_type', 'filename', 'accept_signature', 'created_at', 'note', 'item_id', 'item_type'])
             ->where('target_type', self::class)
             ->where('action_type', 'accepted')
             ->whereNotNull('filename')


### PR DESCRIPTION
Fixes the select in the eula query to include `item_id` and `item_type`. fixing the `item` relation to load properly now.
<img width="1054" alt="image" src="https://github.com/user-attachments/assets/441af6cd-6d10-4ae2-af8d-ddd3b02a2fdb" />
