### PR TITLE
Fixed #17163 - insufficient permissions on editing an asset maintenance

### DIFF
--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -133,26 +133,18 @@ class AssetMaintenancesController extends Controller
     *
     * @see AssetMaintenancesController::postEdit() method that stores the data
     * @author  Vincent Sposato <vincent.sposato@gmail.com>
-    * @param int $assetMaintenanceId
     * @version v1.0
     * @since [v1.8]
     */
     public function edit(AssetMaintenance $maintenance) : View | RedirectResponse
     {
         $this->authorize('update', Asset::class);
-        if ((!$maintenance->asset) || ($maintenance->asset->deleted_at!='')) {
-            return redirect()->route('maintenances.index')->with('error', 'asset does not exist');
-        } elseif (! Company::isCurrentUserHasAccess($maintenance->asset)) {
-            return static::getInsufficientPermissionsRedirect();
-        }
-
-        // Prepare Improvement Type List
-        $assetMaintenanceType = ['' => trans('general.select')] + AssetMaintenance::getImprovementOptions();
 
         return view('asset_maintenances/edit')
-                   ->with('selectedAsset', null)
-                   ->with('assetMaintenanceType', $assetMaintenanceType)
-                   ->with('item', $maintenance);
+            ->with('selected_assets', $maintenance->asset->pluck('id')->toArray())
+            ->with('asset_ids', request()->input('asset_ids', []))
+            ->with('assetMaintenanceType', AssetMaintenance::getImprovementOptions())
+            ->with('item', $maintenance);
     }
 
     /**

--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -168,6 +168,20 @@ class AssetMaintenance extends Model implements ICompanyableChild
     }
 
     /**
+     * asset
+     * Get asset for this improvement
+     *
+     * @return mixed
+     * @author  Vincent Sposato <vincent.sposato@gmail.com>
+     * @version v1.0
+     */
+    public function assets()
+    {
+        return $this->hasMany(Asset::class, 'asset_id')
+            ->withTrashed();
+    }
+
+    /**
      * Get the admin who created the maintenance
      *
      * @return mixed

--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -166,20 +166,7 @@ class AssetMaintenance extends Model implements ICompanyableChild
         return $this->belongsTo(\App\Models\Asset::class, 'asset_id')
                     ->withTrashed();
     }
-
-    /**
-     * asset
-     * Get asset for this improvement
-     *
-     * @return mixed
-     * @author  Vincent Sposato <vincent.sposato@gmail.com>
-     * @version v1.0
-     */
-    public function assets()
-    {
-        return $this->hasMany(Asset::class, 'asset_id')
-            ->withTrashed();
-    }
+    
 
     /**
      * Get the admin who created the maintenance

--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -31,7 +31,7 @@ class AssetMaintenance extends Model implements ICompanyableChild
         'title'                  => 'required|max:100',
         'is_warranty'            => 'boolean',
         'start_date'             => 'required|date_format:Y-m-d',
-        'completion_date'        => 'date_format:Y-m-d|nullable',
+        'completion_date'        => 'date_format:Y-m-d|nullable|after_or_equal:start_date',
         'notes'                  => 'string|nullable',
         'cost'                   => 'numeric|nullable',
     ];

--- a/app/Providers/BreadcrumbsServiceProvider.php
+++ b/app/Providers/BreadcrumbsServiceProvider.php
@@ -418,9 +418,9 @@ class BreadcrumbsServiceProvider extends ServiceProvider
             ->push($maintenance->title, route('maintenances.show', $maintenance))
         );
 
-        Breadcrumbs::for('manufacturers.edit', fn (Trail $trail, Manufacturer $manufacturer) =>
-        $trail->parent('manufacturers.index', route('manufacturers.index'))
-            ->push(trans('general.breadcrumb_button_actions.edit_item', ['name' => $manufacturer->name]), route('manufacturers.edit', $manufacturer))
+        Breadcrumbs::for('maintenances.edit', fn (Trail $trail, AssetMaintenance $maintenance) =>
+        $trail->parent('maintenances.index', route('maintenances.index'))
+            ->push(trans('general.breadcrumb_button_actions.edit_item', ['name' => $maintenance->name]), route('maintenances.edit', $maintenance))
         );
 
 

--- a/app/Providers/BreadcrumbsServiceProvider.php
+++ b/app/Providers/BreadcrumbsServiceProvider.php
@@ -414,13 +414,13 @@ class BreadcrumbsServiceProvider extends ServiceProvider
         );
 
         Breadcrumbs::for('maintenances.show', fn (Trail $trail, AssetMaintenance $maintenance) =>
-        $trail->parent('maintenances.index', route('locations.index'))
+        $trail->parent('maintenances.index', route('maintenances.index'))
             ->push($maintenance->title, route('maintenances.show', $maintenance))
         );
 
         Breadcrumbs::for('maintenances.edit', fn (Trail $trail, AssetMaintenance $maintenance) =>
         $trail->parent('maintenances.index', route('maintenances.index'))
-            ->push(trans('general.breadcrumb_button_actions.edit_item', ['name' => $maintenance->name]), route('maintenances.edit', $maintenance))
+            ->push(trans('general.breadcrumb_button_actions.edit_item', ['name' => $maintenance->title]), route('maintenances.edit', $maintenance))
         );
 
 

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -107,7 +107,7 @@
           <div class="input-group col-md-3">
             <x-input.datepicker
                     name="completion_date"
-                    :value="old('start_date', $item->start_date)"
+                    :value="old('start_date', $item->completion_date)"
                     placeholder="{{ trans('general.select_date') }}"
                     required="Helper::checkIfRequired($item, 'completion_date')"
             />

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -78,7 +78,7 @@
 
               <div class="col-md-9">
                 <p class="form-control-static">
-                  {{ ($item->asset && $item->asset->company) ? $item->asset->company->name : '' }}
+                  {{  $item->asset->company->name }}
                 </p>
               </div>
             </div>
@@ -95,6 +95,20 @@
                 </p>
               </div>
             </div>
+
+            @if ($item->asset->location)
+              <div class="form-group">
+                <label for="location" class="control-label col-md-3">
+                  {{ trans('general.location') }}
+                </label>
+
+                <div class="col-md-9">
+                  <p class="form-control-static">
+                    {{ $item->asset->location->name }}
+                  </p>
+                </div>
+              </div>
+            @endif
 
         @endif
 

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -53,17 +53,30 @@
           </div>
         </div>
 
+        <!-- This is an edit -->
+        @if (!$item->id)
+          @include ('partials.forms.edit.asset-select', [
+            'translated_name' => trans('general.assets'),
+            'fieldname' => 'selected_assets[]',
+            'multiple' => true,
+            'required' => true,
+            'select_id' => 'assigned_assets_select',
+            'asset_selector_div_id' => 'assets_for_maintenance_div',
+            'asset_ids' => $item->id ? $item->asset()->pluck('id')->toArray() : old('selected_assets'),
+            'asset_id' => $item->id ? $item->asset()->pluck('id')->toArray() : null
+          ])
+        @else
+            <label for="asset" class="control-label col-md-3">
+              {{ trans('general.asset') }}
+            </label>
 
+          <div class="col-md-9">
+            <p class="form-control-static">
+              {{ $item->asset() ? $item->asset->present()->fullName : '' }}
+            </p>
+          </div>
 
-        @include ('partials.forms.edit.asset-select', [
-          'translated_name' => trans('general.assets'),
-          'fieldname' => 'selected_assets[]',
-          'multiple' => true,
-          'required' => true,
-          'select_id' => 'assigned_assets_select',
-          'asset_selector_div_id' => 'assets_to_checkout_div',
-          'asset_ids' => old('selected_assets')
-        ])
+        @endif
 
 
         @include ('partials.forms.edit.maintenance_type')

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -32,13 +32,14 @@
     {{ csrf_field() }}
 
     <div class="box box-default">
-      <div class="box-header with-border">
-        <h2 class="box-title">
-          @if ($item)
-          {{ $item->name }}
-          @endif
-        </h2>
-      </div><!-- /.box-header -->
+
+        @if ($item->id)
+          <div class="box-header with-border">
+            <h2 class="box-title">
+              {{ $item->title }}
+            </h2>
+          </div><!-- /.box-header -->
+        @endif
 
       <div class="box-body">
 
@@ -53,8 +54,10 @@
           </div>
         </div>
 
-        <!-- This is an edit -->
+        <!-- This is a new maintenance -->
         @if (!$item->id)
+
+
           @include ('partials.forms.edit.asset-select', [
             'translated_name' => trans('general.assets'),
             'fieldname' => 'selected_assets[]',
@@ -66,13 +69,27 @@
             'asset_id' => $item->id ? $item->asset()->pluck('id')->toArray() : null
           ])
         @else
+
+          @if ($item->asset->company)
+            <label for="company" class="control-label col-md-3">
+              {{ trans('general.company') }}
+            </label>
+
+            <div class="col-md-9">
+              <p class="form-control-static">
+                {{ ($item->asset && $item->asset->company) ? $item->asset->company->name : '' }}
+              </p>
+            </div>
+          @endif
+
+
             <label for="asset" class="control-label col-md-3">
               {{ trans('general.asset') }}
             </label>
 
           <div class="col-md-9">
             <p class="form-control-static">
-              {{ $item->asset() ? $item->asset->present()->fullName : '' }}
+              {{ $item->asset ? $item->asset->present()->fullName : '' }}
             </p>
           </div>
 

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -71,27 +71,30 @@
         @else
 
           @if ($item->asset->company)
-            <label for="company" class="control-label col-md-3">
-              {{ trans('general.company') }}
-            </label>
+            <div class="form-group">
+              <label for="company" class="control-label col-md-3">
+                {{ trans('general.company') }}
+              </label>
 
-            <div class="col-md-9">
-              <p class="form-control-static">
-                {{ ($item->asset && $item->asset->company) ? $item->asset->company->name : '' }}
-              </p>
+              <div class="col-md-9">
+                <p class="form-control-static">
+                  {{ ($item->asset && $item->asset->company) ? $item->asset->company->name : '' }}
+                </p>
+              </div>
             </div>
           @endif
 
+            <div class="form-group">
+              <label for="asset" class="control-label col-md-3">
+                {{ trans('general.asset') }}
+              </label>
 
-            <label for="asset" class="control-label col-md-3">
-              {{ trans('general.asset') }}
-            </label>
-
-          <div class="col-md-9">
-            <p class="form-control-static">
-              {{ $item->asset ? $item->asset->present()->fullName : '' }}
-            </p>
-          </div>
+              <div class="col-md-9">
+                <p class="form-control-static">
+                  {{ $item->asset ? $item->asset->present()->fullName : '' }}
+                </p>
+              </div>
+            </div>
 
         @endif
 
@@ -102,9 +105,11 @@
 
         <!-- Start Date -->
         <div class="form-group {{ $errors->has('start_date') ? ' has-error' : '' }}">
-          <label for="start_date" class="col-md-3 control-label">{{ trans('admin/asset_maintenances/form.start_date') }}</label>
+          <label for="start_date" class="col-md-3 control-label">
+            {{ trans('admin/asset_maintenances/form.start_date') }}
+          </label>
 
-          <div class="input-group col-md-3">
+          <div class="col-md-4">
             <x-input.datepicker
                     name="start_date"
                     :value="old('start_date', $item->start_date)"
@@ -121,7 +126,7 @@
         <div class="form-group {{ $errors->has('completion_date') ? ' has-error' : '' }}">
           <label for="start_date" class="col-md-3 control-label">{{ trans('admin/asset_maintenances/form.completion_date') }}</label>
 
-          <div class="input-group col-md-3">
+          <div class="input-group col-md-4">
             <x-input.datepicker
                     name="completion_date"
                     :value="old('start_date', $item->completion_date)"

--- a/resources/views/asset_maintenances/view.blade.php
+++ b/resources/views/asset_maintenances/view.blade.php
@@ -49,6 +49,31 @@ use Carbon\Carbon;
               </div>
             </div> <!-- /row -->
 
+            @if ($assetMaintenance->asset->model)
+              <div class="row">
+                <div class="col-md-3">
+                  {{ trans('general.asset_model') }}
+                </div>
+                <div class="col-md-9">
+                  <a href="{{ route('models.show', $assetMaintenance->asset->model_id) }}">
+                    {{ $assetMaintenance->asset->model->name }}
+                  </a>
+                </div>
+              </div> <!-- /row -->
+            @endif
+
+            @if ($assetMaintenance->asset->company)
+              <div class="row">
+                <div class="col-md-3">
+                  {{ trans('general.company') }}
+                </div>
+                <div class="col-md-9">
+                  <a href="{{ route('companies.show', $assetMaintenance->asset->company_id) }}">
+                    {{ $assetMaintenance->asset->company->name }}
+                  </a>
+                </div>
+              </div> <!-- /row -->
+            @endif
 
 
             @if ($assetMaintenance->supplier)

--- a/resources/views/partials/forms/edit/asset-select.blade.php
+++ b/resources/views/partials/forms/edit/asset-select.blade.php
@@ -10,7 +10,7 @@
                 name="{{ $fieldname }}"
                 style="width: 100%"
                 id="{{ (isset($select_id)) ? $select_id : 'assigned_asset_select' }}"
-                {{ (isset($multiple)) ? ' multiple' : '' }}
+                {{ ((isset($multiple)) && ($multiple === true)) ? ' multiple' : '' }}
                 {!! (!empty($asset_status_type)) ? ' data-asset-status-type="' . $asset_status_type . '"' : '' !!}
                 {!! (!empty($company_id)) ? ' data-company-id="' .$company_id.'"'  : '' !!}
                 {{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}

--- a/tests/Feature/AssetMaintenances/Ui/EditAssetMaintenanceTest.php
+++ b/tests/Feature/AssetMaintenances/Ui/EditAssetMaintenanceTest.php
@@ -20,26 +20,25 @@ class EditAssetMaintenanceTest extends TestCase
     public function testCanUpdateAssetMaintenance()
     {
         $actor = User::factory()->superuser()->create();
-
-        $assetMaintenance = AssetMaintenance::factory()->create();
-
         $asset = Asset::factory()->create();
+        $assetMaintenance = AssetMaintenance::factory()->create(['asset_id' => $asset]);
         $supplier = Supplier::factory()->create();
 
         $this->actingAs($actor)
             ->followingRedirects()
-            ->put(route('maintenances.update', $assetMaintenance->id), [
+            ->put(route('maintenances.update', $assetMaintenance), [
                 'title' => 'Test Maintenance',
                 'asset_id' => $asset->id,
                 'supplier_id' => $supplier->id,
                 'asset_maintenance_type' => 'Maintenance',
                 'start_date' => '2021-01-01',
                 'completion_date' => '2021-01-10',
-                'is_warranty' => '1',
-                'cost' => '100.00',
+                'is_warranty' => 1,
+                'cost' => '100.99',
                 'notes' => 'A note',
             ])
             ->assertOk();
+
 
         $this->assertDatabaseHas('asset_maintenances', [
             'asset_id' => $asset->id,
@@ -51,7 +50,7 @@ class EditAssetMaintenanceTest extends TestCase
             'completion_date' => '2021-01-10',
             'asset_maintenance_time' => '9',
             'notes' => 'A note',
-            'cost' => '100.00',
+            'cost' => '100.99',
         ]);
     }
 


### PR DESCRIPTION
This addresses a regression that was introduced in #17126 where we allowed users to create multiple asset maintenances at once but accidentally broke the ability to edit maintenances, instead returning an "insufficient permissions" error, even as a superuser. 

I believe this is being triggers via this bit:

https://github.com/grokability/snipe-it/blob/ec411fa0db1fe32509d8790190ae6c012ae972fa/app/Http/Controllers/AssetMaintenancesController.php#L172-L176

It's odd to me that it would be tripping on that particular bit of code (which also should be translated), but perhaps more importantly, that entire chunk really doesn't feel like it should be in a controller anyway. 

This is still a WIP, but I think it's pretty close. I still need to do a lot more testing (especially around FMCS), but it's almost ready.

Once this is done, it should fix #17163.