### PR TITLE
Fixed #17192 - wonky layout on bulk edit screens

### DIFF
--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -2,6 +2,14 @@
 //set array up before loop so it doesn't get wiped at every iteration
     $fields = [];
 @endphp
+
+@if (isset($models) && count($models) > 0)
+    <fieldset name="custom-fields" class="bottom-padded">
+        <legend class="highlight">
+            {{ trans('admin/custom_fields/general.custom_fields') }}
+        </legend>
+@endif
+
 @foreach($models as $model)
 @if (($model) && ($model->fieldset))
     @foreach($model->fieldset->fields AS $field)
@@ -30,12 +38,6 @@
                       :selected="old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id)))"
                       class="format form-control"
                   />
-                  <div class="col-md-5">
-                      <label class="form-control">
-                          <input type="checkbox" name="null_asset_eol_date" value="1">
-                          {{ trans_choice('general.set_to_null', count($assets),['selection_count' => count($assets)]) }}
-                      </label>
-                  </div>
 
               @elseif ($field->element=='textarea')
                 @if($field->is_unique)
@@ -98,13 +100,19 @@
 
           @endif
 
+          <p class="help-block">
+              <x-icon type="warning" class="text-info" /> {{ trans('admin/hardware/form.bulk_update_model_prefix') }}:
+              @foreach ($field->assetModels()->pluck('name')->intersect($modelNames) as $modelName)
+                  <span class="label label-default">
+                {{ $modelName }}
+            </span>&nbsp;
+              @endforeach
+          </p>
+
         @if ($field->help_text!='')
             <p class="help-block">{{ $field->help_text }}</p>
         @endif
 
-        <p>{{ trans('admin/hardware/form.bulk_update_model_prefix') }}: 
-                    {{$field->assetModels()->pluck('name')->intersect($modelNames)->implode(', ')}} 
-            </p>     
 
               
               
@@ -124,14 +132,16 @@
         </div>
         @endif
 
-        <div class="col-md-5">
+        <div class="col-md-8 col-md-offset-3" style="padding-bottom: 10px;">
             <label class="form-control">
                 <input type="checkbox" name="{{ 'null'.$field->db_column_name() }}" value="1">
                 {{ trans_choice('general.set_to_null', count($assets),['selection_count' => count($assets)]) }}
             </label>
         </div>
     </div>
-
     @endforeach
 @endif
  @endforeach
+@if (isset($models) && count($models) > 0)
+    </fieldset>
+@endif

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -1,9 +1,18 @@
 @php
 //set array up before loop so it doesn't get wiped at every iteration
     $fields = [];
+    $anyModelHasCustomFields = 0;
 @endphp
 
-@if (isset($models) && count($models) > 0)
+@foreach($models as $model)
+    @if ($model->fieldset ? $model->fieldset->count() > 0 : false)
+        @php
+            $anyModelHasCustomFields++;
+        @endphp
+    @endif
+@endforeach
+
+@if ($anyModelHasCustomFields > 0)
     <fieldset name="custom-fields" class="bottom-padded">
         <legend class="highlight">
             {{ trans('admin/custom_fields/general.custom_fields') }}

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -151,6 +151,6 @@
     @endforeach
 @endif
  @endforeach
-@if (isset($models) && count($models) > 0)
+@if ($anyModelHasCustomFields > 0)
     </fieldset>
 @endif


### PR DESCRIPTION
This fixes the wonky layout on bulk asset editing for the new deleting values option and makes the display a bit nicer. Fixes #17192 

### Before
<img width="1262" alt="Screenshot 2025-06-16 at 3 53 49 PM" src="https://github.com/user-attachments/assets/5e1e4fcb-671d-4da6-aca0-31a520760411" />

### After
<img width="1004" alt="Screenshot 2025-06-16 at 4 27 30 PM" src="https://github.com/user-attachments/assets/635c907d-5cf8-4ec7-a7b8-8d6e870414db" />

This also adds a custom fields legend, @bzeus test that:

- mixed assets with no custom fields for any models do not show the custom fields legend
- mixed assets with custom fields for models only show the custom fields legend once
- mixed assets where some models have custom fields and some do not only shows the custom field once. 

It should look like this if none of the assets have models with custom fieldsets:

![FireShot Capture 011 - Asset Update __ Snipe-IT Demo - snipe-it test](https://github.com/user-attachments/assets/71cb951f-7ce9-4e7b-a741-e3338014750e)

And like this if they have mixed models with various custom fields or mixed assets where some have custom fields and some don't:
![FireShot Capture 012 - Asset Update __ Snipe-IT Demo - snipe-it test](https://github.com/user-attachments/assets/65e68722-0202-4003-bfcc-2e7508cd8824)

