### PR TITLE
Fixed #16241 - menu items not getting class="active" on click.

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -455,8 +455,7 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                     <x-icon type="angle-left" class="pull-right fa-fw"/>
                                 </a>
                                 <ul class="treeview-menu">
-                                    <li {!! (Request::is('hardware') ? ' class="active"' : '') !!}>
-{{--                                        this makes list all ALWAYS active for the dropdown submenu. need this but NOT that--}}
+                                    <li>
                                         <a href="{{ url('hardware') }}">
                                             <x-icon type="circle" class="text-grey fa-fw"/>
                                             {{ trans('general.list_all') }}
@@ -575,7 +574,6 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                             </a>
                                         </li>
                                         <li {!! (Request::is('maintenances') ? ' class="active"' : '') !!}>
-{{--                                            dropdown menu still closes when selecting this--}}
                                             <a href="{{ route('maintenances.index') }}">
                                                 {{ trans('general.asset_maintenances') }}
                                             </a>

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -455,7 +455,8 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                     <x-icon type="angle-left" class="pull-right fa-fw"/>
                                 </a>
                                 <ul class="treeview-menu">
-                                    <li>
+                                    <li {!! (Request::is('hardware') ? ' class="active"' : '') !!}>
+{{--                                        this makes list all ALWAYS active for the dropdown submenu. need this but NOT that--}}
                                         <a href="{{ url('hardware') }}">
                                             <x-icon type="circle" class="text-grey fa-fw"/>
                                             {{ trans('general.list_all') }}
@@ -573,21 +574,22 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                                 {{ trans('general.deleted') }}
                                             </a>
                                         </li>
-                                        <li>
+                                        <li {!! (Request::is('maintenances') ? ' class="active"' : '') !!}>
+{{--                                            dropdown menu still closes when selecting this--}}
                                             <a href="{{ route('maintenances.index') }}">
                                                 {{ trans('general.asset_maintenances') }}
                                             </a>
                                         </li>
                                     @endcan
                                     @can('admin')
-                                        <li id="import-history-sidenav-option">
+                                        <li id="import-history-sidenav-option" {!! (Request::is('hardware/history') ? ' class="active"' : '') !!}>
                                             <a href="{{ url('hardware/history') }}">
                                                 {{ trans('general.import-history') }}
                                             </a>
                                         </li>
                                     @endcan
                                     @can('audit', \App\Models\Asset::class)
-                                        <li id="bulk-audit-sidenav-option">
+                                        <li id="bulk-audit-sidenav-option" {!! (Request::is('hardware/bulkaudit') ? ' class="active"' : '') !!}>
                                             <a href="{{ route('assets.bulkaudit') }}">
                                                 {{ trans('general.bulkaudit') }}
                                             </a>
@@ -646,7 +648,7 @@ dir="{{ Helper::determineLanguageDirection() }}">
                             </li>
                         @endcan
                         @can('import')
-                            <li id="import-sidenav-option"{!! (Request::is('import/*') ? ' class="active"' : '') !!}>
+                            <li id="import-sidenav-option"{!! (Request::is('import*') ? ' class="active"' : '') !!}>
                                 <a href="{{ route('imports.index') }}">
                                     <x-icon type="import" class="fa-fw" />
                                     <span>{{ trans('general.import') }}</span>
@@ -680,64 +682,64 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                     @endcan
 
                                     @can('view', \App\Models\AssetModel::class)
-                                        <li>
-                                            <a href="{{ route('models.index') }}" {{ (Request::is('/assetmodels') ? ' class="active"' : '') }}>
+                                        <li {{!! (Request::is('models') ? ' class="active"' : '') !!}}>
+                                            <a href="{{ route('models.index') }}">
                                                 {{ trans('general.asset_models') }}
                                             </a>
                                         </li>
                                     @endcan
 
                                     @can('view', \App\Models\Category::class)
-                                        <li>
-                                            <a href="{{ route('categories.index') }}" {{ (Request::is('/categories') ? ' class="active"' : '') }}>
+                                        <li {{!! (Request::is('categories') ? ' class="active"' : '') !!}}>
+                                            <a href="{{ route('categories.index') }}">
                                                 {{ trans('general.categories') }}
                                             </a>
                                         </li>
                                     @endcan
 
                                     @can('view', \App\Models\Manufacturer::class)
-                                        <li>
-                                            <a href="{{ route('manufacturers.index') }}" {{ (Request::is('/manufacturers') ? ' class="active"' : '') }}>
+                                        <li {{!! (Request::is('manufacturers') ? ' class="active"' : '') !!}}>
+                                            <a href="{{ route('manufacturers.index') }}">
                                                 {{ trans('general.manufacturers') }}
                                             </a>
                                         </li>
                                     @endcan
 
                                     @can('view', \App\Models\Supplier::class)
-                                        <li>
-                                            <a href="{{ route('suppliers.index') }}" {{ (Request::is('/suppliers') ? ' class="active"' : '') }}>
+                                        <li {{!! (Request::is('suppliers') ? ' class="active"' : '') !!}}>
+                                            <a href="{{ route('suppliers.index') }}">
                                                 {{ trans('general.suppliers') }}
                                             </a>
                                         </li>
                                     @endcan
 
                                     @can('view', \App\Models\Department::class)
-                                        <li>
-                                            <a href="{{ route('departments.index') }}" {{ (Request::is('/departments') ? ' class="active"' : '') }}>
+                                        <li {{!! (Request::is('departments') ? ' class="active"' : '') !!}}>
+                                            <a href="{{ route('departments.index') }}">
                                                 {{ trans('general.departments') }}
                                             </a>
                                         </li>
                                     @endcan
 
                                     @can('view', \App\Models\Location::class)
-                                        <li>
-                                            <a href="{{ route('locations.index') }}" {{ (Request::is('/locations') ? ' class="active"' : '') }}>
+                                        <li {{!! (Request::is('locations') ? ' class="active"' : '') !!}}>
+                                            <a href="{{ route('locations.index') }}">
                                                 {{ trans('general.locations') }}
                                             </a>
                                         </li>
                                     @endcan
 
                                     @can('view', \App\Models\Company::class)
-                                        <li>
-                                            <a href="{{ route('companies.index') }}" {{ (Request::is('/companies') ? ' class="active"' : '') }}>
+                                        <li {{!! (Request::is('companies') ? ' class="active"' : '') !!}}>
+                                            <a href="{{ route('companies.index') }}">
                                                 {{ trans('general.companies') }}
                                             </a>
                                         </li>
                                     @endcan
 
                                     @can('view', \App\Models\Depreciation::class)
-                                        <li>
-                                            <a href="{{ route('depreciations.index') }}" {{ (Request::is('/depreciations') ? ' class="active"' : '') }}>
+                                        <li  {{!! (Request::is('depreciations') ? ' class="active"' : '') !!}}>
+                                            <a href="{{ route('depreciations.index') }}">
                                                 {{ trans('general.depreciation') }}
                                             </a>
                                         </li>
@@ -755,42 +757,42 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                 </a>
 
                                 <ul class="treeview-menu">
-                                    <li>
-                                        <a href="{{ route('reports.activity') }}" {{ (Request::is('reports/activity') ? ' class="active"' : '') }}>
+                                    <li {{!! (Request::is('reports/activity') ? ' class="active"' : '') !!}}>
+                                        <a href="{{ route('reports.activity') }}">
                                             {{ trans('general.activity_report') }}
                                         </a>
                                     </li>
-                                    <li>
-                                        <a href="{{ url('reports/custom') }}" {{ (Request::is('reports/custom') ? ' class="active"' : '') }}>
+                                    <li {{!! (Request::is('reports/custom') ? ' class="active"' : '') !!}}>
+                                        <a href="{{ url('reports/custom') }}">
                                             {{ trans('general.custom_report') }}
                                         </a>
                                     </li>
-                                    <li>
-                                        <a href="{{ route('reports.audit') }}" {{ (Request::is('reports.audit') ? ' class="active"' : '') }}>
+                                    <li {{!! (Request::is('reports/audit') ? ' class="active"' : '') !!}}>
+                                        <a href="{{ route('reports.audit') }}">
                                             {{ trans('general.audit_report') }}</a>
                                     </li>
-                                    <li>
-                                        <a href="{{ url('reports/depreciation') }}" {{ (Request::is('reports/depreciation') ? ' class="active"' : '') }}>
+                                    <li {{!! (Request::is('reports/depreciation') ? ' class="active"' : '') !!}}>
+                                        <a href="{{ url('reports/depreciation') }}">
                                             {{ trans('general.depreciation_report') }}
                                         </a>
                                     </li>
-                                    <li>
-                                        <a href="{{ url('reports/licenses') }}" {{ (Request::is('reports/licenses') ? ' class="active"' : '') }}>
+                                    <li {{!! (Request::is('reports/licenses') ? ' class="active"' : '') !!}}>
+                                        <a href="{{ url('reports/licenses') }}">
                                             {{ trans('general.license_report') }}
                                         </a>
                                     </li>
-                                    <li>
-                                        <a href="{{ url('reports/asset_maintenances') }}" {{ (Request::is('reports/asset_maintenances') ? ' class="active"' : '') }}>
+                                    <li {{!! (Request::is('reports/asset_maintenances') ? ' class="active"' : '') !!}}>
+                                        <a href="{{ url('reports/asset_maintenances') }}">
                                             {{ trans('general.asset_maintenance_report') }}
                                         </a>
                                     </li>
-                                    <li>
-                                        <a href="{{ url('reports/unaccepted_assets') }}" {{ (Request::is('reports/unaccepted_assets') ? ' class="active"' : '') }}>
+                                    <li {{!! (Request::is('reports/unaccepted_assets') ? ' class="active"' : '') !!}}>
+                                        <a href="{{ url('reports/unaccepted_assets') }}">
                                             {{ trans('general.unaccepted_asset_report') }}
                                         </a>
                                     </li>
-                                    <li>
-                                        <a href="{{ url('reports/accessories') }}" {{ (Request::is('reports/accessories') ? ' class="active"' : '') }}>
+                                    <li  {{!! (Request::is('reports/accessories') ? ' class="active"' : '') !!}}>
+                                        <a href="{{ url('reports/accessories') }}">
                                             {{ trans('general.accessory_report') }}
                                         </a>
                                     </li>


### PR DESCRIPTION
A list of items on the left side bar were not showing active while selected.
The items fixed by this PR are:
**Menus**
      Import

**Sub-menus**
      Assets > Import History
      Assets > Bulk Audit
      Settings > Asset Models
      Settings > Categories
      Settings > Manufacturers
      Settings > Suppliers
      Settings > Departments
      Settings > Locations
      Settings > Companies
      Settings > Depreciation 
      Reports > Activity Report
      Reports > Custom Asset Report
      Reports > Audit Log
      Reports > Depreciation Report
      Reports > License Report
      Reports > Asset Maintenance Report
      Reports > Unaccepted Assets
      Reports > Accessory Report
      

Three items were not fixed due to more complicated bits, but this should get a majority of the reported items to be fixed.
Those items:
**Sub-menus**
      Assets > List All
      Assets > Deleted
      Assets > Maintenances
 