### PR TITLE
Fixed #17089: SAML metadata now updating with new XML uploads

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -923,7 +923,7 @@ class SettingsController extends Controller
      * @since v5.0.0
      */
     public function postSamlSettings(SettingsSamlRequest $request) : RedirectResponse
-    {
+    {       
         if (is_null($setting = Setting::getSettings())) {
             return redirect()->to('admin')->with('error', trans('admin/settings/message.update.error'));
         }

--- a/app/Http/Requests/SettingsSamlRequest.php
+++ b/app/Http/Requests/SettingsSamlRequest.php
@@ -130,6 +130,10 @@ class SettingsSamlRequest extends FormRequest
                             'saml_sp_x509cert' => $x509cert,
                             'saml_sp_privatekey' => $privateKey,
                         ]);
+                        $setting = Setting::getSettings();
+                        $setting->saml_sp_x509cert = $x509cert;
+                        $setting->saml_sp_privatekey = $privateKey;
+                        $setting->save();
                     }
                 } else {
                     $validator->errors()->add('saml_integration', 'openssl.cnf is missing/invalid');

--- a/app/Http/Requests/SettingsSamlRequest.php
+++ b/app/Http/Requests/SettingsSamlRequest.php
@@ -41,6 +41,7 @@ class SettingsSamlRequest extends FormRequest
     public function withValidator($validator)
     {
         $validator->after(function ($validator) {
+            $setting = Setting::getSettings();
             if ($this->input('saml_enabled') == '1') {
                 $idpMetadata = $this->input('saml_idp_metadata');
                 if (! empty($idpMetadata)) {
@@ -56,7 +57,7 @@ class SettingsSamlRequest extends FormRequest
                 }
             }
 
-            $was_custom_x509cert = strpos(Setting::getSettings()->saml_custom_settings, 'sp_x509cert') !== false;
+            $was_custom_x509cert = strpos($setting->saml_custom_settings, 'sp_x509cert') !== false;
 
             $custom_x509cert = '';
             $custom_privateKey = '';
@@ -126,14 +127,14 @@ class SettingsSamlRequest extends FormRequest
                     }
 
                     if (! (empty($x509cert) && empty($privateKey))) {
-                        $this->merge([
-                            'saml_sp_x509cert' => $x509cert,
-                            'saml_sp_privatekey' => $privateKey,
-                        ]);
-                        $setting = Setting::getSettings();
+//                        $this->merge([
+//                            'saml_sp_x509cert' => $x509cert,
+//                            'saml_sp_privatekey' => $privateKey,
+//                        ]);
                         $setting->saml_sp_x509cert = $x509cert;
                         $setting->saml_sp_privatekey = $privateKey;
                         $setting->save();
+
                     }
                 } else {
                     $validator->errors()->add('saml_integration', 'openssl.cnf is missing/invalid');
@@ -149,15 +150,21 @@ class SettingsSamlRequest extends FormRequest
                 }
 
                 if (! empty($x509certNew)) {
-                    $this->merge([
-                        'saml_sp_x509certNew' => $x509certNew,
-                    ]);
+//                    $this->merge([
+//                        'saml_sp_x509certNew' => $x509certNew,
+//                    ]);
+                    $setting->saml_sp_x509certNew = $x509certNew;
+                    $setting->save();
                 }
             } else {
-                $this->merge([
-                    'saml_sp_x509certNew' => '',
-                ]);
+//                $this->merge([
+//                    'saml_sp_x509certNew' => '',
+//                ]);
+                $setting->saml_sp_x509certNew = '';
+                $setting->save();
             }
+
+
         });
     }
 }

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -113,6 +113,7 @@
                         <div class="col-md-9">
                             <x-input.textarea
                                 name="saml_idp_metadata"
+                                id="saml_idp_metadata"
                                 :value="old('saml_idp_metadata', $setting->saml_idp_metadata)"
                                 placeholder="https://example.com/idp/metadata"
                                 wrap="off"
@@ -218,7 +219,7 @@
             var fr = new FileReader();
 
             fr.onload = function(e) {
-                $('#saml_idp_metadata').text(e.target.result);
+                $('#saml_idp_metadata').val(e.target.result);
             } 
 
             fr.readAsText(this.files[0]);

--- a/resources/views/settings/saml.blade.php
+++ b/resources/views/settings/saml.blade.php
@@ -85,6 +85,7 @@
                                          <label for="saml_sp_x509cert">{{ trans('admin/settings/general.saml_sp_x509cert') }}</label>
                                             <x-input.textarea
                                                 name="saml_sp_x509cert"
+                                                id="saml_sp_x509cert"
                                                 :value="$setting->saml_sp_x509cert"
                                                 wrap="off"
                                                 readonly


### PR DESCRIPTION
This updates the cert and private key sooner in the request stack. also some input ids were missing.

This is a good candidate for a refactor in the future.

Fixes #17089