### PR TITLE
Fixed #17215: Check for acceptance logo vs regular logo in print views

### DIFF
--- a/resources/views/locations/print.blade.php
+++ b/resources/views/locations/print.blade.php
@@ -35,13 +35,13 @@
     @if ($snipeSettings->brand == '3')
 
         <h3>
-        @if ($snipeSettings->logo!='')
+        @if ($snipeSettings->acceptance_pdf_logo!='')
             <img class="print-logo" src="{{ config('app.url') }}/uploads/{{ $snipeSettings->acceptance_pdf_logo }}">
         @endif
         {{ $snipeSettings->site_name }}
         </h3>
     @elseif ($snipeSettings->brand == '2')
-        @if ($snipeSettings->logo!='')
+        @if ($snipeSettings->acceptance_pdf_logo!='')
             <img class="print-logo" src="{{ config('app.url') }}/uploads/{{ $snipeSettings->acceptance_pdf_logo }}">
         @endif
     @else

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -65,13 +65,13 @@
     @if ($snipeSettings->brand == '3')
 
         <h2>
-            @if ($snipeSettings->logo!='')
+            @if ($snipeSettings->acceptance_pdf_logo!='')
                 <img class="print-logo" src="{{ config('app.url') }}/uploads/{{ $snipeSettings->acceptance_pdf_logo }}">
             @endif
             {{ $snipeSettings->site_name }}
         </h2>
     @elseif ($snipeSettings->brand == '2')
-        @if ($snipeSettings->logo!='')
+        @if ($snipeSettings->acceptance_pdf_logo!='')
             <img class="print-logo" src="{{ config('app.url') }}/uploads/{{ $snipeSettings->acceptance_pdf_logo }}">
         @endif
     @else


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/grokability/snipe-it/pull/17155 and https://github.com/grokability/snipe-it/pull/17154 where we were checking for the wrong logo in print views. Fixes #17215.