### PR TITLE
Fixed #17212 - hide columns from print view

### DIFF
--- a/app/Presenters/AccessoryPresenter.php
+++ b/app/Presenters/AccessoryPresenter.php
@@ -21,6 +21,7 @@ class AccessoryPresenter extends Presenter
                 'switchable' => true,
                 'title' => trans('general.id'),
                 'visible' => false,
+                'printIgnore' => true,
             ], [
                 'field' => 'image',
                 'searchable' => false,
@@ -172,6 +173,7 @@ class AccessoryPresenter extends Presenter
                 'switchable' => false,
                 'title' => trans('table.actions'),
                 'formatter' => 'accessoriesActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 
@@ -240,6 +242,7 @@ class AccessoryPresenter extends Presenter
                 'switchable' => false,
                 'title' => trans('table.actions'),
                 'formatter' => 'accessoriesInOutFormatter',
+                'printIgnore' => true,
             ],
         ];
 

--- a/app/Presenters/AssetAuditPresenter.php
+++ b/app/Presenters/AssetAuditPresenter.php
@@ -21,6 +21,7 @@ class AssetAuditPresenter extends Presenter
                 'field' => 'checkbox',
                 'checkbox' => true,
                 'titleTooltip' => trans('general.select_all_none'),
+                 'printIgnore' => true,
              ],
              [
                 'field' => 'id',
@@ -266,6 +267,7 @@ class AssetAuditPresenter extends Presenter
             'switchable' => false,
             'title' => trans('table.actions'),
             'formatter' => 'hardwareAuditFormatter',
+            'printIgnore' => true,
         ];
 
         return json_encode($layout);

--- a/app/Presenters/AssetMaintenancesPresenter.php
+++ b/app/Presenters/AssetMaintenancesPresenter.php
@@ -150,6 +150,7 @@ class AssetMaintenancesPresenter extends Presenter
                 'title' => trans('table.actions'),
                 'visible' => true,
                 'formatter' => 'maintenancesActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 

--- a/app/Presenters/AssetModelPresenter.php
+++ b/app/Presenters/AssetModelPresenter.php
@@ -16,6 +16,7 @@ class AssetModelPresenter extends Presenter
                 'field' => 'checkbox',
                 'checkbox' => true,
                 'titleTooltip' => trans('general.select_all_none'),
+                'printIgnore' => true,
             ],
             [
                 'field' => 'id',
@@ -185,6 +186,7 @@ class AssetModelPresenter extends Presenter
             'switchable' => false,
             'title' => trans('table.actions'),
             'formatter' => 'modelsActionsFormatter',
+            'printIgnore' => true,
         ];
 
         return json_encode($layout);

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -22,6 +22,7 @@ class AssetPresenter extends Presenter
                 'field' => 'checkbox',
                 'checkbox' => true,
                 'titleTooltip' => trans('general.select_all_none'),
+                'printIgnore' => true,
             ], [
                 'field' => 'id',
                 'searchable' => false,
@@ -346,6 +347,7 @@ class AssetPresenter extends Presenter
             'title' => trans('general.checkin').'/'.trans('general.checkout'),
             'visible' => true,
             'formatter' => 'hardwareInOutFormatter',
+            'printIgnore' => true,
         ];
 
         $layout[] = [
@@ -355,6 +357,7 @@ class AssetPresenter extends Presenter
             'switchable' => false,
             'title' => trans('table.actions'),
             'formatter' => 'hardwareActionsFormatter',
+            'printIgnore' => true,
         ];
 
         return json_encode($layout);
@@ -422,6 +425,7 @@ class AssetPresenter extends Presenter
                 'switchable' => false,
                 'title' => trans('table.actions'),
                 'formatter' => 'accessoriesInOutFormatter',
+                'printIgnore' => true,
             ],
         ];
 

--- a/app/Presenters/CategoryPresenter.php
+++ b/app/Presenters/CategoryPresenter.php
@@ -112,7 +112,8 @@ class CategoryPresenter extends Presenter
                 'sortable' => false,
                 'switchable' => false,
                 'title' => trans('table.actions'),
-		'formatter' => 'categoriesActionsFormatter',
+		        'formatter' => 'categoriesActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 

--- a/app/Presenters/CompanyPresenter.php
+++ b/app/Presenters/CompanyPresenter.php
@@ -142,6 +142,7 @@ class CompanyPresenter extends Presenter
                 'title' => trans('table.actions'),
                 'visible' => true,
                 'formatter' => 'companiesActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 

--- a/app/Presenters/ComponentPresenter.php
+++ b/app/Presenters/ComponentPresenter.php
@@ -169,6 +169,7 @@ class ComponentPresenter extends Presenter
             'title' => trans('general.checkin').'/'.trans('general.checkout'),
             'visible' => true,
             'formatter' => 'componentsInOutFormatter',
+            'printIgnore' => true,
         ];
 
         $layout[] = [
@@ -178,6 +179,7 @@ class ComponentPresenter extends Presenter
             'switchable' => false,
             'title' => trans('table.actions'),
             'formatter' => 'componentsActionsFormatter',
+            'printIgnore' => true,
         ];
 
         return json_encode($layout);

--- a/app/Presenters/ConsumablePresenter.php
+++ b/app/Presenters/ConsumablePresenter.php
@@ -173,6 +173,7 @@ class ConsumablePresenter extends Presenter
                 'title' => trans('table.actions'),
                 'visible' => true,
                 'formatter' => 'consumablesActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 

--- a/app/Presenters/DepreciationPresenter.php
+++ b/app/Presenters/DepreciationPresenter.php
@@ -96,6 +96,7 @@ class DepreciationPresenter extends Presenter
                 'title' => trans('table.actions'),
                 'visible' => true,
                 'formatter' => 'depreciationsActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 

--- a/app/Presenters/LicensePresenter.php
+++ b/app/Presenters/LicensePresenter.php
@@ -202,6 +202,7 @@ class LicensePresenter extends Presenter
             'title' => trans('general.checkin').'/'.trans('general.checkout'),
             'visible' => true,
             'formatter' => 'licensesInOutFormatter',
+            'printIgnore' => true,
         ];
 
         $layout[] = [
@@ -211,6 +212,7 @@ class LicensePresenter extends Presenter
             'switchable' => false,
             'title' => trans('table.actions'),
             'formatter' => 'licensesActionsFormatter',
+            'printIgnore' => true,
         ];
 
         return json_encode($layout);

--- a/app/Presenters/LocationPresenter.php
+++ b/app/Presenters/LocationPresenter.php
@@ -18,6 +18,8 @@ class LocationPresenter extends Presenter
                 'field' => 'bulk_selectable',
                 'checkbox' => true,
                 'formatter' => 'checkboxEnabledFormatter',
+                'titleTooltip' => trans('general.select_all_none'),
+                'printIgnore' => true,
             ], [
                 'field' => 'id',
                 'searchable' => false,

--- a/app/Presenters/ManufacturerPresenter.php
+++ b/app/Presenters/ManufacturerPresenter.php
@@ -163,6 +163,7 @@ class ManufacturerPresenter extends Presenter
                 'title' => trans('table.actions'),
                 'visible' => true,
                 'formatter' => 'manufacturersActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 

--- a/app/Presenters/PredefinedKitPresenter.php
+++ b/app/Presenters/PredefinedKitPresenter.php
@@ -61,6 +61,7 @@ class PredefinedKitPresenter extends Presenter
             'title' => trans('general.checkin').'/'.trans('general.checkout'),
             'visible' => true,
             'formatter' => 'kitsInOutFormatter',
+            'printIgnore' => true,
         ];
 
         $layout[] = [
@@ -70,6 +71,7 @@ class PredefinedKitPresenter extends Presenter
             'switchable' => false,
             'title' => trans('table.actions'),
             'formatter' => 'kitsActionsFormatter',
+            'printIgnore' => true,
         ];
 
         return json_encode($layout);
@@ -121,6 +123,7 @@ class PredefinedKitPresenter extends Presenter
                 'switchable' => false,
                 'title' => trans('table.actions'),
                 'formatter' => 'kits_modelsActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 
@@ -173,6 +176,7 @@ class PredefinedKitPresenter extends Presenter
                 'switchable' => false,
                 'title' => trans('table.actions'),
                 'formatter' => 'kits_licensesActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 
@@ -225,6 +229,7 @@ class PredefinedKitPresenter extends Presenter
                 'switchable' => false,
                 'title' => trans('table.actions'),
                 'formatter' => 'kits_accessoriesActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 
@@ -277,6 +282,7 @@ class PredefinedKitPresenter extends Presenter
                 'switchable' => false,
                 'title' => trans('table.actions'),
                 'formatter' => 'kits_consumablesActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 

--- a/app/Presenters/StatusLabelPresenter.php
+++ b/app/Presenters/StatusLabelPresenter.php
@@ -105,6 +105,7 @@ class StatusLabelPresenter extends Presenter
                 'switchable' => false,
                 'title' => trans('table.actions'),
                 'formatter' => 'statuslabelsActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 

--- a/app/Presenters/SupplierPresenter.php
+++ b/app/Presenters/SupplierPresenter.php
@@ -180,6 +180,7 @@ class SupplierPresenter extends Presenter
                 'title' => trans('table.actions'),
                 'visible' => true,
                 'formatter' => 'suppliersActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 

--- a/app/Presenters/UserPresenter.php
+++ b/app/Presenters/UserPresenter.php
@@ -25,6 +25,7 @@ class UserPresenter extends Presenter
                 'field' => 'checkbox',
                 'checkbox' => true,
                 'titleTooltip' => trans('general.select_all_none'),
+                'printIgnore' => true,
             ],
             [
                 'field' => 'id',
@@ -415,6 +416,7 @@ class UserPresenter extends Presenter
                 'title' => trans('table.actions'),
                 'visible' => true,
                 'formatter' => 'usersActionsFormatter',
+                'printIgnore' => true,
             ],
         ];
 


### PR DESCRIPTION
This adds `'printIgnore' => true,` to the presenters on columns where it doesn't really make sense to print them and they cannot be hidden through the toggle selector. Specifically, the checkbox column for selecting all items on a page, the checkin/checkout column, and the available actions (edit, delete, etc) columns.

Fixes #17212 