### PR TITLE
Fixes #17213:  search by admin (created_by) in activity report

### DIFF
--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -69,8 +69,8 @@ class Actionlog extends SnipeModel
      */
     protected $searchableRelations = [
         'company'     => ['name'],
-        'adminuser'   => ['first_name','last_name','username', 'email'],
-        'user'        => ['first_name','last_name','username', 'email'],
+        'adminuser'   => ['first_name','last_name','username', 'email', 'employee_num'],
+        'user'        => ['first_name','last_name','username', 'email', 'employee_num'],
         'assets'      => ['asset_tag','name', 'serial', 'order_number', 'notes', 'purchase_date'],
         'assets.model'              => ['name', 'model_number', 'eol', 'notes'],
         'assets.model.category'     => ['name', 'notes'],

--- a/app/Models/Traits/Searchable.php
+++ b/app/Models/Traits/Searchable.php
@@ -164,7 +164,7 @@ trait Searchable
                     }
                 }
                 // I put this here because I only want to add the concat one time in the end of the user relation search
-                if($relation == 'user') {
+                if(($relation == 'adminuser') || ($relation == 'user')) {
                     $query->orWhereRaw(
                             $this->buildMultipleColumnSearch([
                                 'users.first_name',

--- a/app/Presenters/HistoryPresenter.php
+++ b/app/Presenters/HistoryPresenter.php
@@ -45,7 +45,7 @@ class HistoryPresenter extends Presenter
             ],
             [
                 'field' => 'created_by',
-                'searchable' => false,
+                'searchable' => true,
                 'sortable' => true,
                 'title' => trans('general.created_by'),
                 'visible' => true,


### PR DESCRIPTION
For some reason we were not allowing users to search on the created_by column (by name) even though we load that relationship. This makes the field searchable, and also adds employee_num as a field you can search on, in the case where you might have many people with the same name. 

<del>This does not currently do the concatenation (to be able to use "first name last name" in the search) so only first name, last name, email, or employee number, but I'll see if I can add that.</del> Added.

<img width="1468" alt="Screenshot 2025-06-17 at 1 02 13 PM" src="https://github.com/user-attachments/assets/39e37ed2-90ba-468c-bb7e-8c2dc147db92" />


Fixes #17213.