### PR TITLE
Fixed #17232 - removed duplicate expected_checkin field on asset edit/create

### DIFF
--- a/resources/views/hardware/edit.blade.php
+++ b/resources/views/hardware/edit.blade.php
@@ -66,9 +66,6 @@
         @include ('partials.forms.edit.user-select', ['translated_name' => trans('admin/hardware/form.checkout_to'), 'fieldname' => 'assigned_user', 'style' => 'display:none;', 'required' => 'false'])
         @include ('partials.forms.edit.asset-select', ['translated_name' => trans('admin/hardware/form.checkout_to'), 'fieldname' => 'assigned_asset', 'style' => 'display:none;', 'required' => 'false'])
         @include ('partials.forms.edit.location-select', ['translated_name' => trans('admin/hardware/form.checkout_to'), 'fieldname' => 'assigned_location', 'style' => 'display:none;', 'required' => 'false'])
-    @elseif (($item->assignedTo) && ($item->deleted_at == ''))
-        <!-- This is an asset and it's currently deployed, so let them edit the expected checkin date -->
-        @include ('partials.forms.edit.datepicker', ['translated_name' => trans('admin/hardware/form.expected_checkin'),'fieldname' => 'expected_checkin'])
     @endif
 
     @include ('partials.forms.edit.notes')


### PR DESCRIPTION
This resolves a bug where we had two `expected_checkin` fields on the hardware edit screen, and therefore if you entered a value in the first one, it would be overwritten by the second one on submit. 

Down the line, I'd like to make this a little smarter - we could remove the `expected_checkin` field if the asset isn't actually checked out (since there wouldn't be an expected checkin) and/or use the JS functionality that we already have in the check that determines if it's deployable, and if it is, it presents you with a select box of users, locations, etc. This would be a nicer UI, but this at least solves the problem for now. 

Fixes #17232.