### PR TITLE
Fixed #17239 - Add `withTrashed` User Search On License Checkin

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -86,7 +86,7 @@ class LicenseCheckinController extends Controller
         }
 
         if($licenseSeat->assigned_to != null){
-            $return_to = User::find($licenseSeat->assigned_to);
+            $return_to = User::withTrashed()->find($licenseSeat->assigned_to);
             session()->put('checkedInFrom', $return_to->id);
         } else {
             $return_to = Asset::find($licenseSeat->asset_id);


### PR DESCRIPTION
On the tin, adds withTrashed to License Checkin User search to prevent a 500

Fixes #17239 