### PR TITLE
Fixed #17249 - sort by location in asset maintenances

### DIFF
--- a/app/Http/Controllers/Api/AssetMaintenancesController.php
+++ b/app/Http/Controllers/Api/AssetMaintenancesController.php
@@ -75,6 +75,7 @@ class AssetMaintenancesController extends Controller
                                 'serial',
                                 'created_by',
                                 'supplier',
+                                'location',
                                 'is_warranty',
                                 'status_label',
                             ];
@@ -97,6 +98,9 @@ class AssetMaintenancesController extends Controller
                 break;
             case 'serial':
                 $maintenances = $maintenances->OrderByAssetSerial($order);
+                break;
+            case 'location':
+                $maintenances = $maintenances->OrderLocationName($order);
                 break;
             case 'status_label':
                 $maintenances = $maintenances->OrderStatusName($order);

--- a/app/Models/AssetMaintenance.php
+++ b/app/Models/AssetMaintenance.php
@@ -267,6 +267,21 @@ class AssetMaintenance extends Model implements ICompanyableChild
     }
 
     /**
+     * Query builder scope to order on status label name
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query  Query builder instance
+     * @param  text                              $order         Order
+     *
+     * @return \Illuminate\Database\Query\Builder          Modified query builder
+     */
+    public function scopeOrderLocationName($query, $order)
+    {
+        return $query->join('assets as maintained_asset', 'asset_maintenances.asset_id', '=', 'maintained_asset.id')
+            ->leftjoin('locations as maintained_asset_location', 'maintained_asset_location.id', '=', 'maintained_asset.location_id')
+            ->orderBy('maintained_asset_location.name', $order);
+    }
+
+    /**
      * Query builder scope to order on the user that created it
      */
     public function scopeOrderByCreatedBy($query, $order)


### PR DESCRIPTION
This adds a query scope to order maintenances by location name. Fixes #17249.