### PR TITLE
[FIX] API AssetController - assigned_type incorect query

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -332,7 +332,7 @@ class AssetsController extends Controller
 
         if (($request->filled('assigned_to')) && ($request->filled('assigned_type'))) {
             $assets->where('assets.assigned_to', '=', $request->input('assigned_to'))
-                ->where('assets.assigned_type', '=', $request->input('assigned_type'));
+                ->where('assets.assigned_type', '=', 'App\\Models\\'.ucwords($request->input('assigned_type')));
         }
 
         if ($request->filled('company_id')) {


### PR DESCRIPTION
It's fix for API query, if is used `assigned_type`, was missing part of reference data.