### PR TITLE
Fixed #14077: Disables checkout button after submitting

### DIFF
--- a/resources/views/blade/redirect_submit_options.blade.php
+++ b/resources/views/blade/redirect_submit_options.blade.php
@@ -4,6 +4,7 @@
     'button_label',
     'disabled_select' => false,
     'options' => [],
+    'id' => 'submit_button',
 ])
 
 <div class="box-footer">
@@ -26,7 +27,7 @@
                 </select>
                 @endif
 
-                <button type="submit" class="btn btn-primary pull-right{{ ($disabled_select ? ' disabled' : '') }}" style="margin-left:5px; border-radius: 3px;"{!! ($disabled_select ? ' data-tooltip="true" title="'.trans('admin/hardware/general.edit').'" disabled' : '') !!}>
+                <button type="submit" id="{{ $id }}" class="btn btn-primary pull-right{{ ($disabled_select ? ' disabled' : '') }}" style="margin-left:5px; border-radius: 3px;"{!! ($disabled_select ? ' data-tooltip="true" title="'.trans('admin/hardware/general.edit').'" disabled' : '') !!}>
                     <x-icon type="checkmark" />
                     {{ $button_label }}
                 </button>


### PR DESCRIPTION
This was a regression that was fixed by adding in the `id` for the submit button in checkout forms, so javascript could hook in again and disable the checkout button.