### PR TITLE
Fixed #14869: changes the depreciation method selected for Assets index table

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -102,7 +102,7 @@ class AssetsTransformer
             'checkout_counter' => (int) $asset->checkout_counter,
             'requests_counter' => (int) $asset->requests_counter,
             'user_can_checkout' => (bool) $asset->availableForCheckout(),
-            'book_value' => Helper::formatCurrencyOutput($asset->getLinearDepreciatedValue()),
+            'book_value' => Helper::formatCurrencyOutput($asset->getDepreciatedValue()),
         ];
 
 


### PR DESCRIPTION
The wrong method was selected for displaying the book value of an asset in the assets index table.
No error in calculation, just wrong method selected. Before pictures can be seen in the linked issue.
After:
<img width="1802" alt="image" src="https://github.com/user-attachments/assets/2208c43a-7389-43d6-8bb2-522a7b9cfff8" />
<img width="885" alt="image" src="https://github.com/user-attachments/assets/f7f1c1c6-fc36-4b01-b460-5a79975d3297" />
