### PR TITLE
Fixed [FD-45786] - Limit changing of asset seat count to no more than 10k at a time

### DIFF
--- a/tests/Feature/Licenses/Ui/CreateLicenseTest.php
+++ b/tests/Feature/Licenses/Ui/CreateLicenseTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Licenses\Ui;
 
-use App\Models\AssetModel;
 use App\Models\Category;
 use App\Models\License;
 use App\Models\Depreciation;
@@ -41,7 +40,48 @@ class CreateLicenseTest extends TestCase
         $response->assertInvalid(['purchase_date']);
         $response->assertSessionHasErrors(['purchase_date']);
         $this->followRedirects($response)->assertSee(trans('general.error'));
-        $this->assertFalse(AssetModel::where('name', 'Test Invalid License')->exists());
+        $this->assertFalse(License::where('name', 'Test Invalid License')->exists());
 
     }
+
+    public function testLicenseCreate()
+    {
+        $response = $this->actingAs(User::factory()->superuser()->create())
+            ->from(route('licenses.create'))
+            ->post(route('licenses.store'), [
+                'name' => 'Test Valid License',
+                'seats' => '10',
+                'category_id' => Category::factory()->forLicenses()->create()->id,
+            ]);
+        $response->assertStatus(302);
+        $license = License::where('name', 'Test Valid License')->sole();
+        $this->assertNotNull($license);
+        //$license->assetlog()->has_one_of_();
+        $this->assertDatabaseHas('action_logs', ['action_type' => 'create', 'item_id' => $license->id, 'item_type' => License::class]);
+        $this->assertDatabaseHas('action_logs', ['action_type' => 'add seats', 'item_id' => $license->id, 'item_type' => License::class]);
+        $this->assertEquals($license->licenseseats()->count(), 10);
+        //test log entries? Sure.
+
+    }
+
+    public function testTooManySeatsLicenseCreate()
+    {
+        $response = $this->actingAs(User::factory()->superuser()->create())
+            ->from(route('licenses.create'))
+            ->post(route('licenses.store'), [
+                'name' => 'Test Valid License',
+                'seats' => '100000',
+                'category_id' => Category::factory()->forLicenses()->create()->id,
+            ]);
+        $response->assertStatus(302);
+        $license = License::where('name', 'Test Valid License')->first();
+        $this->assertNull($license);
+        //$license->assetlog()->has_one_of_();
+//        $this->assertDatabaseMissing('action_logs', ['action_type' => 'create', 'item_id' => $license->id, 'item_type' => License::class]);
+//        $this->assertDatabaseMissing('action_logs', ['action_type' => 'add seats', 'item_id' => $license->id, 'item_type' => License::class]);
+        //test log entries? Sure.
+
+    }
+
+
 }

--- a/tests/Feature/Licenses/Ui/UpdateLicenseTest.php
+++ b/tests/Feature/Licenses/Ui/UpdateLicenseTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Licenses\Ui;
 
+use App\Models\Category;
 use App\Models\License;
 use App\Models\User;
 use Tests\TestCase;
@@ -14,4 +15,90 @@ class UpdateLicenseTest extends TestCase
             ->get(route('licenses.edit', License::factory()->create()->id))
             ->assertOk();
     }
+
+    public function testCanUpdateLicenseSeats()
+    {
+        $admin = User::factory()->superuser()->create();
+        $license_category = Category::factory()->forLicenses()->create()->id;
+        $response = $this->actingAs($admin)
+            ->from(route('licenses.create'))
+            ->post(route('licenses.store'), [
+                'name' => 'Test Update License',
+                'seats' => '9999',
+                'category_id' => $license_category,
+            ]);
+        $response->assertStatus(302);
+        $license = License::where('name', 'Test Update License')->sole();
+        $this->assertNotNull($license);
+
+        $this->actingAs($admin)
+            ->put(route('licenses.update', $license->id), [
+                'name' => 'Test Update License',
+                'seats' => '19999',
+                'category_id' => $license_category,
+            ])
+            ->assertStatus(302);
+
+        $license->refresh();
+        $this->assertEquals($license->licenseseats()->count(), $license->seats);
+        $this->assertEquals($license->licenseseats()->count(), 19999);
+    }
+
+    public function testCannotUpdateLicenseSeatsTooMuch()
+    {
+        $admin = User::factory()->superuser()->create();
+        $license_category = Category::factory()->forLicenses()->create()->id;
+        $response = $this->actingAs($admin)
+            ->from(route('licenses.create'))
+            ->post(route('licenses.store'), [
+                'name' => 'Test Update License',
+                'seats' => '9999',
+                'category_id' => $license_category,
+            ]);
+        $response->assertStatus(302);
+        $license = License::where('name', 'Test Update License')->sole();
+        $this->assertNotNull($license);
+
+        $this->actingAs($admin)
+            ->put(route('licenses.update', $license->id), [
+                'name' => 'Test Update License',
+                'seats' => '29999',
+                'category_id' => $license_category,
+            ])
+            ->assertStatus(302);
+
+        $license->refresh();
+        $this->assertEquals($license->licenseseats()->count(), $license->seats);
+        $this->assertEquals($license->licenseseats()->count(), 9999);
+    }
+
+    public function testCanRemoveLicenseSeats()
+    {
+        $admin = User::factory()->superuser()->create();
+        $license_category = Category::factory()->forLicenses()->create()->id;
+        $response = $this->actingAs($admin)
+            ->from(route('licenses.create'))
+            ->post(route('licenses.store'), [
+                'name' => 'Test Remove License Seats',
+                'seats' => '9999',
+                'category_id' => $license_category,
+            ]);
+        $response->assertStatus(302);
+        $license = License::where('name', 'Test Remove License Seats')->sole();
+        $this->assertNotNull($license);
+
+        $this->actingAs($admin)
+            ->put(route('licenses.update', $license->id), [
+                'name' => 'Test Remove License Seats',
+                'seats' => '5000',
+                'category_id' => $license_category,
+            ])
+            ->assertStatus(302);
+
+        $license->refresh();
+        $this->assertEquals($license->licenseseats()->count(), $license->seats);
+        $this->assertEquals($license->licenseseats()->count(), 5000);
+    }
+
+
 }


### PR DESCRIPTION
We used to have a limit on the maximum number of seats for a license. For some reason, we lifted that limit. And it turns out, if you try to create a license with 99,999 seats, you will get a 500 error. Now, you may say "Well, don't do that then!" which is a fair thing to ask. But, still, we should either prevent it, or fix it.

Due to an implementation choice we made at the time, we require empty `license_seat` records for each seat within a license. We're pretty much all agreed that that was a bad move, and needs fixing, but that's how things work today.

So for some reason I cannot fathom, we can't seem to be able to add more than 30,000 `license_seat` records at a time - I've tried inside a transaction, outside a transaction, in chunks, in huge chunks, in tiny chunks, one-by-one, even using near-raw PDO queries - it doesn't matter what I do, it always hitches up around 30,000 (on my laptop, at least).

And it does seem that some people *do* have uses cases for many, many License Seats - which is probably why we decided to lift the 9,999 cap in the first place.

So this is a kinda 'gross' solution to the problem - I created a "pseudo-rule" that limits the number of seats you can change at a time to +/- 10000. This means you can create a license with 10k seats, and then update it a few times to bump it up, 10k at a time. That's a pretty awful solution, of course, but at least it's not 500'ing, and at least we aren't reintroducing the cap.

In the process of testing this, I found that when deleting chunks of empty seats, it could hitch up when the total seat count was high. I converted those "fluent collection" statements into regular query-builder statements which seem to work much better.

Another implementation note that's subtle - I do math based on the *actual* count of `license_seat` records in the database, not necessarily the `seats` variable within the license. This is because, especially during my testing, it _can_ happen that the seat-count can be different than the `seats` attribute - and we want to be able to let the user 'fixup' a wonky license (where the count of `license_seats` doesn't match the `seats`).