### PR TITLE
Fixes #12094 - Adds focus to select2 in bulk checkout

### DIFF
--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -146,6 +146,21 @@
         });
 
         $('#assigned_assets_select').select2('open');
+        setTimeout(function () {
+            const $searchField = $('.select2-search__field');
+            const $results = $('.select2-results');
+
+            // Focus the search input
+            $searchField.focus();
+
+            // Hide results initially
+            $results.hide();
+
+            // Show results when a user starts typing
+            $searchField.on('input', function () {
+                $results.show();
+            });
+        }, 0);
     });
 </script>
 

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -145,6 +145,7 @@
             return true; // ensure form still submits
         });
 
+        $('#assigned_assets_select').select2('open');
     });
 </script>
 


### PR DESCRIPTION
This puts the cursor focus on the select 2 for bulk checkout hiding the results initially, but showing once a user starts typing:


https://github.com/user-attachments/assets/d5a6dc8e-249f-4438-bc88-e4ee0369e6c1

Fixes #12094. 

