### PR TITLE
Fixed #17194 - Return to bulk edit with errors and inputs

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -125,8 +125,17 @@ class Handler extends ExceptionHandler
         // This is traaaaash but it handles models that are not found while using route model binding :(
         // The only alternative is to set that at *each* route, which is crazypants
         if ($e instanceof \Illuminate\Database\Eloquent\ModelNotFoundException) {
+            $ids = method_exists($e, 'getIds') ? $e->getIds() : [];
 
-            // This gets the MVC model name from the exception and formats in a way that's less fugly
+            if (in_array('bulkedit', $ids, true)) {
+
+                return redirect()
+                    ->route('hardware.bulkedit')
+                    ->with('bulk_asset_errors', session()->pull('bulk_asset_errors'))
+                    ->withInput();
+            }
+
+        // This gets the MVC model name from the exception and formats in a way that's less fugly
             $model_name = strtolower(implode(" ", preg_split('/(?=[A-Z])/', last(explode('\\', $e->getModel())))));
             $route = str_plural(strtolower(last(explode('\\', $e->getModel())))).'.index';
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -128,7 +128,8 @@ class Handler extends ExceptionHandler
             $ids = method_exists($e, 'getIds') ? $e->getIds() : [];
 
             if (in_array('bulkedit', $ids, true)) {
-
+                $oldInput = session()->getOldInput();
+                session()->flashInput($oldInput ?? []);
                 return redirect()
                     ->route('hardware.bulkedit')
                     ->with('bulk_asset_errors', session()->pull('bulk_asset_errors'))

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -128,11 +128,10 @@ class Handler extends ExceptionHandler
             $ids = method_exists($e, 'getIds') ? $e->getIds() : [];
 
             if (in_array('bulkedit', $ids, true)) {
-                $oldInput = session()->getOldInput();
-                session()->flashInput($oldInput ?? []);
+            $error_array = session()->get('bulk_asset_errors');
                 return redirect()
                     ->route('hardware.bulkedit')
-                    ->with('bulk_asset_errors', session()->pull('bulk_asset_errors'))
+                    ->withErrors($error_array, 'bulk_asset_errors')
                     ->withInput();
             }
 

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -125,6 +125,7 @@ class BulkAssetsController extends Controller
 
         $models = $assets->unique('model_id');
         $modelNames = [];
+
         foreach($models as $model) {
             $modelNames[] = $model->model->name;
         }
@@ -160,7 +161,6 @@ class BulkAssetsController extends Controller
 
                 case 'edit':
                     $this->authorize('update', Asset::class);
-
                     return view('hardware/bulk')
                         ->with('assets', $asset_ids)
                         ->with('statuslabel_list', Helper::statusLabelList())
@@ -767,5 +767,4 @@ class BulkAssetsController extends Controller
             ->with('models', $models->pluck(['model']))
             ->with('modelNames', $modelNames);
     }
-
 }

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -739,7 +739,7 @@ class BulkAssetsController extends Controller
         return false;
     }
 
-    public function bulkEditForm(Request $request): View|RedirectResponse
+    public function bulkEditForm(): View|RedirectResponse
     {
         $this->authorize('update', Asset::class);
 
@@ -765,8 +765,7 @@ class BulkAssetsController extends Controller
             ->with('assets', $asset_ids)
             ->with('statuslabel_list', Helper::statusLabelList())
             ->with('models', $models->pluck(['model']))
-            ->with('modelNames', $modelNames)
-            ->with('bulk_asset_errors', session('bulk_asset_errors'));
+            ->with('modelNames', $modelNames);
     }
 
 }

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -540,8 +540,8 @@ class BulkAssetsController extends Controller
                 session()->put('bulkedit_ids', $request->input('ids'));
                 session()->put('bulk_asset_errors',$error_array);
 
-
-                return redirect(url()->previous())
+                return redirect()
+                    ->route('hardware.bulkedit')
                     ->with('bulk_asset_errors', $error_array)
                     ->withInput();
             }

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -223,9 +223,6 @@ class BulkAssetsController extends Controller
         // Get the back url from the session and then destroy the session
 
         $bulk_back_url = $request->session()->pull('bulk_back_url', url()->previous());
-//        if ($request->session()->has('bulk_back_url')) {
-//            $bulk_back_url = $request->session()->pull('bulk_back_url');
-//        }
 
        $custom_field_columns = CustomField::all()->pluck('db_column')->toArray();
 

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -55,7 +55,7 @@
                 @if(!$field->is_unique)
                     <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>
                 @endif
-              @elseif ($field->element=='checkbox')<pre>{{ var_dump(old()) }}</pre>
+              @elseif ($field->element=='checkbox')
                     <!-- Checkboxes -->
               @php
                   $fieldName = $field->db_column_name();
@@ -63,7 +63,6 @@
                   $defaultValues = array_map('trim', explode(',', $field->defaultValue($model->id)));
                   $currentValues = isset($item) ? array_map('trim', explode(',', $item->{$fieldName})) : $defaultValues;
 
-                  // if old values exist, use them, otherwise fallback
                   $selectedValues = is_array($oldValues) ? $oldValues : $currentValues;
               @endphp
 
@@ -83,7 +82,6 @@
                       $default = trim($field->defaultValue($model->id));
                       $current = isset($item) ? trim($item->{$fieldName}) : $default;
 
-                      // use old input if available, otherwise fallback
                       $selectedValue = $oldValue !== null ? $oldValue : $current;
                   @endphp
                   @foreach ($field->formatFieldValuesAsArray() as $key => $value)

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -59,7 +59,7 @@
                     <!-- Checkboxes -->
               @php
                   $fieldName = $field->db_column_name();
-                  $oldValues = old($fieldName);  log:debug($oldValues);
+                  $oldValues = old($fieldName);
                   $defaultValues = array_map('trim', explode(',', $field->defaultValue($model->id)));
                   $currentValues = isset($item) ? array_map('trim', explode(',', $item->{$fieldName})) : $defaultValues;
 

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -143,7 +143,7 @@
 
         <div class="col-md-8 col-md-offset-3" style="padding-bottom: 10px;">
             <label class="form-control">
-                <input type="checkbox" name="{{ 'null'.$field->db_column_name() }}" value="1">
+                <input type="checkbox" name="{{ 'null'.$field->db_column_name() }}" value="1" {{ old('null'.$field->db_column_name()) ? 'checked' : '' }}>
                 {{ trans_choice('general.set_to_null', count($assets),['selection_count' => count($assets)]) }}
             </label>
         </div>

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -77,14 +77,24 @@
                   </label>
               @endforeach
             @elseif ($field->element=='radio')
-            @foreach ($field->formatFieldValuesAsArray() as $value)
+                  @php
+                      $fieldName = $field->db_column_name();
+                      $oldValue = old($fieldName);
+                      $default = trim($field->defaultValue($model->id));
+                      $current = isset($item) ? trim($item->{$fieldName}) : $default;
 
-                  <label class="form-control">
-                      <input type="radio" value="{{ $value }}" name="{{ $field->db_column_name() }}" {{ isset($item) ? ($item->{$field->db_column_name()} == $value ? ' checked="checked"' : '') : (old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($value, explode(', ', $field->defaultValue($model->id))) ? ' checked="checked"' : '')) }}>
-                      {{ $value }}
-                  </label>
-
-            @endforeach
+                      // use old input if available, otherwise fallback
+                      $selectedValue = $oldValue !== null ? $oldValue : $current;
+                  @endphp
+                  @foreach ($field->formatFieldValuesAsArray() as $key => $value)
+                      <label class="form-control">
+                          <input type="radio"
+                                 name="{{ $fieldName }}"
+                                 value="{{ $key }}"
+                                  {{ $selectedValue == $key ? 'checked' : '' }}>
+                          {{ $value }}
+                      </label>
+                  @endforeach
                 <button type="button"
                         class="btn btn-default btn-xs clear-radio"
                         data-target-name="{{ $field->db_column_name() }}">

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -59,7 +59,7 @@
                     <!-- Checkboxes -->
               @php
                   $fieldName = $field->db_column_name();
-                  $oldValues = old($fieldName);
+                  $oldValues = old($fieldName);  log:debug($oldValues);
                   $defaultValues = array_map('trim', explode(',', $field->defaultValue($model->id)));
                   $currentValues = isset($item) ? array_map('trim', explode(',', $item->{$fieldName})) : $defaultValues;
 

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -55,14 +55,27 @@
                 @if(!$field->is_unique)
                     <textarea class="col-md-6 form-control" id="{{ $field->db_column_name() }}" name="{{ $field->db_column_name() }}">{{ old($field->db_column_name(),(isset($item) ? Helper::gracefulDecrypt($field, $item->{$field->db_column_name()}) : $field->defaultValue($model->id))) }}</textarea>
                 @endif
-              @elseif ($field->element=='checkbox')
+              @elseif ($field->element=='checkbox')<pre>{{ var_dump(old()) }}</pre>
                     <!-- Checkboxes -->
-                  @foreach ($field->formatFieldValuesAsArray() as $key => $value)
-                      <label class="form-control">
-                          <input type="checkbox" value="{{ $value }}" name="{{ $field->db_column_name() }}[]" {{  isset($item) ? (in_array($value, array_map('trim', explode(',', $item->{$field->db_column_name()}))) ? ' checked="checked"' : '') : (old($field->db_column_name()) != '' ? ' checked="checked"' : (in_array($key, array_map('trim', explode(',', $field->defaultValue($model->id)))) ? ' checked="checked"' : '')) }}>
-                          {{ $value }}
-                      </label>
-                  @endforeach
+              @php
+                  $fieldName = $field->db_column_name();
+                  $oldValues = old($fieldName);
+                  $defaultValues = array_map('trim', explode(',', $field->defaultValue($model->id)));
+                  $currentValues = isset($item) ? array_map('trim', explode(',', $item->{$fieldName})) : $defaultValues;
+
+                  // if old values exist, use them, otherwise fallback
+                  $selectedValues = is_array($oldValues) ? $oldValues : $currentValues;
+              @endphp
+
+              @foreach ($field->formatFieldValuesAsArray() as $key => $value)
+                  <label class="form-control">
+                      <input type="checkbox"
+                             name="{{ $fieldName }}[]"
+                             value="{{ $key }}"
+                              {{ in_array($key, $selectedValues) ? 'checked' : '' }}>
+                      {{ $value }}
+                  </label>
+              @endforeach
             @elseif ($field->element=='radio')
             @foreach ($field->formatFieldValuesAsArray() as $value)
 

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -143,7 +143,7 @@
 
         <div class="col-md-8 col-md-offset-3" style="padding-bottom: 10px;">
             <label class="form-control">
-                <input type="checkbox" name="{{ 'null'.$field->db_column_name() }}" value="1" {{ old('null'.$field->db_column_name()) ? 'checked' : '' }}>
+                <input type="checkbox" name="{{ 'null'.$field->db_column_name() }}" value="1">
                 {{ trans_choice('general.set_to_null', count($assets),['selection_count' => count($assets)]) }}
             </label>
         </div>

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -152,6 +152,7 @@ Route::group(
         Route::delete('{asset}/showfile/{fileId}/delete',
             [AssetFilesController::class, 'destroy']
         )->name('delete/assetfile')->withTrashed();
+        Route::get('hardware/bulkedit', [BulkAssetsController::class, 'bulkEditForm'])->name('hardware.bulkedit');
 
         Route::post(
             'bulkedit',


### PR DESCRIPTION
This fixes the failed validation redirect, it now goes back to the form with errors instead of the asset index.

This also returns the old values for custom field radio boxes and checkboxes.

FIXES: #17194 

https://github.com/user-attachments/assets/7a1d81b7-cd9b-4337-ae62-38dd5f600749

