### PR TITLE
Fixed #17190 and [FD-49375]: Do FMCS testing 'async' to keep from blowing out the whole settings page

### DIFF
--- a/app/Livewire/LocationScopeCheck.php
+++ b/app/Livewire/LocationScopeCheck.php
@@ -10,15 +10,16 @@ class LocationScopeCheck extends Component
 {
     public $mismatched = [];
     public $setting;
+    public $is_tested = false;
 
     public function check_locations()
     {
         $this->mismatched = Helper::test_locations_fmcs(false);
+        $this->is_tested = true;
     }
 
     public function mount() {
         $this->setting = Setting::getSettings();
-        $this->mismatched = Helper::test_locations_fmcs(false);
     }
 
     public function render()

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -157,6 +157,7 @@ return [
     'scope_locations_fmcs_support_text'  => 'Scope Locations with Full Multiple Companies Support',
     'scope_locations_fmcs_support_help_text'  => 'Restrict locations to their selected company.',
     'scope_locations_fmcs_check_button' => 'Check Compatibility',
+    'scope_locations_fmcs_test_needed' => 'Please Check Compatibility to enable this',
     'scope_locations_fmcs_support_disabled_text'  => 'This option is disabled because you have conflicting locations set for :count or more items.',
     'show_in_model_list'   => 'Show in Model Dropdowns',
     'optional'					=> 'optional',

--- a/resources/views/livewire/location-scope-check.blade.php
+++ b/resources/views/livewire/location-scope-check.blade.php
@@ -1,11 +1,15 @@
 <div>
-    <label class="form-control{{ (count($mismatched) > 0) ? ' form-control--disabled' : '' }}">
-        <input type="checkbox" name="scope_locations_fmcs" value="1" @checked(old('scope_locations_fmcs', $setting->scope_locations_fmcs)) aria-label="scope_locations_fmcs" {{ (count($mismatched) > 0) ? ' disabled' : '' }}/>
+    <label class="form-control{{ (!$is_tested || count($mismatched) > 0 ) ? ' form-control--disabled' : '' }}">
+        <input type="checkbox" name="scope_locations_fmcs" value="1"
+               @checked(old('scope_locations_fmcs', $setting->scope_locations_fmcs)) aria-label="scope_locations_fmcs" {{ (!$is_tested || count($mismatched) > 0) ? ' disabled' : '' }}/>
         {{ trans('admin/settings/general.scope_locations_fmcs_support_text') }}
     </label>
     <p class="help-block">
         {{ trans('admin/settings/general.scope_locations_fmcs_support_help_text') }}
-        <strong>{{ (count($mismatched) > 0) ? trans('admin/settings/general.scope_locations_fmcs_support_disabled_text', ['count' => count($mismatched)]) : '' }}</strong>
+        <strong>{{ ($is_tested && count($mismatched) > 0) ? trans('admin/settings/general.scope_locations_fmcs_support_disabled_text', ['count' => count($mismatched)]) : '' }}</strong>
+        @if(!$is_tested)
+            <strong>{{ trans('admin/settings/general.scope_locations_fmcs_test_needed') }}</strong>
+        @endif
     </p>
     <button class="btn btn-sm btn-default" wire:click.prevent="check_locations">{{ trans('admin/settings/general.scope_locations_fmcs_check_button') }}</button>
 </div>


### PR DESCRIPTION
We had a problem where the settings/general page would show up as a 'white page' with nothing in it on instances where there are *tons* of first-class-objects. This was happening because of the "LocationScopeCheck" Livewire controller.

We do a good job of 'short-circuiting' the scope-check in the case where there are _failures_. But when the entire database *is* actually consistent (company-wise), we still need to iterate through _everything_ to ensure that no FCO's are cross-linked, which can take up lots of memory, and time. That was causing the rendering for the entire page to break.

This change makes it so that you have to actually click the "Check Compatibilty" button to enable the "Scope Locations with full Multiple Companies Support" checkbox. Until you do, a warning message tells you that you have to do this. While this may _still_ break on larger instances, at least the entire page won't blow up. If it does end up white-screening your settings page, you can just refresh it and still have access to all of the rest of your settings.

Fixes #17190.