### PR TITLE
Add escaping to user_agent and remote_ip variables for API results

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -198,8 +198,8 @@ class ActionlogsTransformer
             'note'          => ($actionlog->note) ? Helper::parseEscapedMarkedownInline($actionlog->note): null,
             'signature_file'   => ($actionlog->accept_signature) ? route('log.signature.view', ['filename' => $actionlog->accept_signature ]) : null,
             'log_meta'          => ((isset($clean_meta)) && (is_array($clean_meta))) ? $clean_meta: null,
-            'remote_ip'          => ($actionlog->remote_ip) ??  null,
-            'user_agent'          => ($actionlog->user_agent) ??  null,
+            'remote_ip' => e($actionlog->remote_ip) ?? null,
+            'user_agent' => e($actionlog->user_agent) ?? null,
             'action_source'          => ($actionlog->action_source) ??  null,
             'action_date'   => ($actionlog->action_date) ? Helper::getFormattedDateObject($actionlog->action_date, 'datetime'): Helper::getFormattedDateObject($actionlog->created_at, 'datetime'),
         ];


### PR DESCRIPTION
Just to maintain consistency between other API endpoints, we should also escape `user_agent` and `remote_ip` in the `ActionLogsTransformer`