### PR TITLE
Use safer deserialization defaults

### DIFF
--- a/app/Http/Transformers/ActionlogsTransformer.php
+++ b/app/Http/Transformers/ActionlogsTransformer.php
@@ -113,8 +113,8 @@ class ActionlogsTransformer
 
                                         // Display the changes if the user is an admin or superadmin
                                         if (Gate::allows('admin')) {
-                                            $clean_meta[$fieldname]['old'] = ($enc_old) ? unserialize($enc_old): '';
-                                            $clean_meta[$fieldname]['new'] = ($enc_new) ? unserialize($enc_new): '';
+                                            $clean_meta[$fieldname]['old'] = ($enc_old) ? unserialize($enc_old, ['allowed_classes' => false]) : '';
+                                            $clean_meta[$fieldname]['new'] = ($enc_new) ? unserialize($enc_new, ['allowed_classes' => false]) : '';
                                         }
 
                                     }


### PR DESCRIPTION
It turns out that `Crypt::encrypt()` by default actually takes an object and _serializes_ it. So we have to `unserialize()` it on the way out. This is a little bit annoying, but it is what it is. 

This change just adds a little bit of extra safety on the deserialization-side to ensure that we're only deserializing simple scalar values.