### PR TITLE
Fixed #17112 - Set location ID to null instead of 0

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -182,7 +182,7 @@ class LdapSync extends Command
             // Inject location information fields
             for ($i = 0; $i < $results['count']; $i++) {
                 $results[$i]['ldap_location_override'] = false;
-                $results[$i]['location_id'] = 0;
+                $results[$i]['location_id'] = null;
             }
 
             // Grab subsets based on location-specific DNs, and overwrite location for these users.


### PR DESCRIPTION
In certain cases,  we would inadvertently set location ID to 0 if a location existed in AD/LDAP but didn't correspond to a location within Snipe-IT. This would disallow user editing, since the location ID was invalid. This should fix that issue. 

Fixes #17112.