### PR TITLE
Fixed #1909 - Small depreciation tweaks (re-added 0 months as a viable value)

### DIFF
--- a/app/Http/Transformers/DepreciationsTransformer.php
+++ b/app/Http/Transformers/DepreciationsTransformer.php
@@ -26,7 +26,7 @@ class DepreciationsTransformer
         $array = [
             'id' => (int) $depreciation->id,
             'name' => e($depreciation->name),
-            'months' => $depreciation->months.' '.trans('general.months'),
+            'months' => trans_choice('general.depreciation_options.months', $depreciation->months),
             'depreciation_min' => $depreciation->depreciation_type === 'percent' ? $depreciation->depreciation_min.'%' : $depreciation->depreciation_min,
             'assets_count' => $depreciation->assets_count,
             'models_count' => $depreciation->models_count,

--- a/app/Http/Transformers/DepreciationsTransformer.php
+++ b/app/Http/Transformers/DepreciationsTransformer.php
@@ -26,7 +26,7 @@ class DepreciationsTransformer
         $array = [
             'id' => (int) $depreciation->id,
             'name' => e($depreciation->name),
-            'months' => trans_choice('general.depreciation_options.months', $depreciation->months),
+            'months' => trans_choice('general.months_plural', $depreciation->months),
             'depreciation_min' => $depreciation->depreciation_type === 'percent' ? $depreciation->depreciation_min.'%' : $depreciation->depreciation_min,
             'assets_count' => $depreciation->assets_count,
             'models_count' => $depreciation->models_count,

--- a/app/Http/Transformers/DepreciationsTransformer.php
+++ b/app/Http/Transformers/DepreciationsTransformer.php
@@ -28,9 +28,9 @@ class DepreciationsTransformer
             'name' => e($depreciation->name),
             'months' => trans_choice('general.months_plural', $depreciation->months),
             'depreciation_min' => $depreciation->depreciation_type === 'percent' ? $depreciation->depreciation_min.'%' : $depreciation->depreciation_min,
-            'assets_count' => $depreciation->assets_count,
-            'models_count' => $depreciation->models_count,
-            'licenses_count' => $depreciation->licenses_count,
+            'assets_count' => ($depreciation->assets_count > 0) ? (int) $depreciation->assets_count : 0,
+            'models_count' => ($depreciation->models_count > 0) ? (int) $depreciation->models_count : 0,
+            'licenses_count' => ($depreciation->licenses_count > 0) ? (int) $depreciation->licenses_count : 0,
             'created_by' => ($depreciation->adminuser) ? [
                 'id' => (int) $depreciation->adminuser->id,
                 'name'=> e($depreciation->adminuser->present()->fullName()),

--- a/app/Models/Depreciation.php
+++ b/app/Models/Depreciation.php
@@ -16,7 +16,7 @@ class Depreciation extends SnipeModel
     // Declare the rules for the form validation
     protected $rules = [
         'name' => 'required|min:3|max:255|unique:depreciations,name',
-        'months' => 'required|max:3600|integer|gt:0',
+        'months' => 'required|max:3600|integer',
     ];
 
     /**

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -659,5 +659,11 @@ return [
         'confirm_delete' => 'Are you sure you want to delete this file?',
     ],
 
+    'depreciation_options' => [
+        'amount' => 'Amount',
+        'percent' => 'Percentage',
+        'months' => '1 month|:count months',
+    ],
+
 
 ];

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -662,8 +662,9 @@ return [
     'depreciation_options' => [
         'amount' => 'Amount',
         'percent' => 'Percentage',
-        'months' => '1 month|:count months',
     ],
+
+    'months_plural' => '1 month|:count months',
 
 
 ];

--- a/resources/views/depreciations/edit.blade.php
+++ b/resources/views/depreciations/edit.blade.php
@@ -15,11 +15,9 @@
     <label for="months" class="col-md-3 control-label">
         {{ trans('admin/depreciations/general.number_of_months') }}
     </label>
-    <div class="col-md-7 col-sm-12">
-        <div class="col-md-7" style="padding-left:0px">
-            <input class="form-control" type="number" min="0" max="3600" name="months" id="months" value="{{ old('months', $item->months) }}" style="width: 80px;"{!!  (\App\Helpers\Helper::checkIfRequired($item, 'months')) ? ' required' : '' !!} />
-            {!! $errors->first('months', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
-        </div>
+    <div class="col-md-9 col-sm-12">
+        <input class="form-control" type="number" min="0" max="3600" name="months" id="months" value="{{ old('months', $item->months) }}" style="width: 90px;"{!!  (\App\Helpers\Helper::checkIfRequired($item, 'months')) ? ' required' : '' !!} />
+        {!! $errors->first('months', '<span class="alert-msg" aria-hidden="true"><i class="fa fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
 </div>
 
@@ -28,13 +26,14 @@
     <label for="depreciation_min" class="col-md-3 control-label">
         {{ trans('admin/depreciations/general.depreciation_min') }}
     </label>
-    <div class="col-md-2" style="display: flex;">
-        <input class="form-control" name="depreciation_min" id="depreciation_min" required type="number" value="{{ old('depreciation_min', $item->depreciation_min) }}" style="width: 80px; margin-right: 15px; display: inline-block;" />
+    <div class="col-md-9" style="display: flex;">
+        <input class="form-control" name="depreciation_min" id="depreciation_min" required type="number" value="{{ old('depreciation_min', $item->depreciation_min) }}" style="width: 90px; margin-right: 15px; display: inline-block;" />
         <select class="form-control select2" name="depreciation_type" id="depreciation_type" data-minimum-results-for-search="Infinity" style="width: 150px; display: inline-block;">
-            <option value="amount" {{ old('depreciation_type', $item->depreciation_type) == 'amount' ? 'selected' : '' }}>Amount</option>
-            <option value="percent" {{ old('depreciation_type', $item->depreciation_type) == 'percent' ? 'selected' : '' }}>Percentage</option>
+            <option value="amount" {{ old('depreciation_type', $item->depreciation_type) == 'amount' ? 'selected' : '' }}>{{ trans('general.depreciation_options.amount') }}</option>
+            <option value="percent" {{ old('depreciation_type', $item->depreciation_type) == 'percent' ? 'selected' : '' }}>{{ trans('general.depreciation_options.percent') }}</option>
         </select>
+        {!! $errors->first('depreciation_min', '<span class="col-md-7 col-md-offset-3 alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
     </div>
-    {!! $errors->first('depreciation_min', '<span class="col-md-7 col-md-offset-3 alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+
 </div>
 @stop

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -903,9 +903,7 @@
                                                 </strong>
                                             </div>
                                             <div class="col-md-9">
-                                                {{ $asset->warranty_months }}
-                                                {{ trans('admin/hardware/form.months') }}
-
+                                                {{ trans_choice('general.months_plural', $asset->warranty_months) }}
                                                 @if (($asset->model) && ($asset->model->manufacturer) && ($asset->model->manufacturer->warranty_lookup_url!=''))
                                                     <a href="{{ $asset->present()->dynamicUrl($asset->model->manufacturer->warranty_lookup_url) }}" target="_blank">
                                                         <x-icon type="external-link" />
@@ -947,8 +945,7 @@
                                             </div>
                                             <div class="col-md-9">
                                                 {{ $asset->depreciation->name }}
-                                                ({{ $asset->depreciation->months }}
-                                                {{ trans('admin/hardware/form.months') }})
+                                                ({{ trans_choice('general.months_plural', $asset->depreciation->months) }})
                                             </div>
                                         </div>
                                         <div class="row">


### PR DESCRIPTION
This re-adds a 0 month depreciation (it's a weird use-case, but seems harmless) and adds some additional translation strings to better represent languages where adding "months" after the number might not be correct.

(Re) Fixes #1909