### PR TITLE
Fixed #17193 - perform Orderby before Collection in Bulk Assets Controller

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -112,11 +112,47 @@ class BulkAssetsController extends Controller
         // This handles all of the pivot sorting below (versus the assets.* fields in the allowed_columns array)
         $column_sort = in_array($sort_override, $allowed_columns) ? $sort_override : 'assets.id';
 
-        $assets = Asset::with('assignedTo', 'location', 'model')
+        $query = Asset::with('assignedTo', 'location', 'model')
                 ->whereIn('assets.id', $asset_ids)
                 ->withTrashed();
 
-        $assets = $assets->get();
+
+        switch ($sort_override) {
+            case 'model':
+                $query->OrderModels($order);
+                break;
+            case 'model_number':
+                $query->OrderModelNumber($order);
+                break;
+            case 'category':
+                $query->OrderCategory($order);
+                break;
+            case 'manufacturer':
+                $query->OrderManufacturer($order);
+                break;
+            case 'company':
+                $query->OrderCompany($order);
+                break;
+            case 'location':
+                $query->OrderLocation($order);
+                break;
+            case 'rtd_location':
+                $query->OrderRtdLocation($order);
+                break;
+            case 'status_label':
+                $query->OrderStatus($order);
+                break;
+            case 'supplier':
+                $query->OrderSupplier($order);
+                break;
+            case 'assigned_to':
+                $query->OrderAssigned($order);
+                break;
+            default:
+                $query->orderBy($column_sort, $order);
+                break;
+        }
+        $assets = $query->get();
 
         if ($assets->isEmpty()) {
             Log::debug('No assets were found for the provided IDs', ['ids' => $asset_ids]);
@@ -169,40 +205,7 @@ class BulkAssetsController extends Controller
             }
         }
 
-        switch ($sort_override) {
-            case 'model':
-                $assets->OrderModels($order);
-                break;
-            case 'model_number':
-                $assets->OrderModelNumber($order);
-                break;
-            case 'category':
-                $assets->OrderCategory($order);
-                break;
-            case 'manufacturer':
-                $assets->OrderManufacturer($order);
-                break;
-            case 'company':
-                $assets->OrderCompany($order);
-                break;
-            case 'location':
-                $assets->OrderLocation($order);
-            case 'rtd_location':
-                $assets->OrderRtdLocation($order);
-                break;
-            case 'status_label':
-                $assets->OrderStatus($order);
-                break;
-            case 'supplier':
-                $assets->OrderSupplier($order);
-                break;
-            case 'assigned_to':
-                $assets->OrderAssigned($order);
-                break;
-            default:
-                $assets->orderBy($column_sort, $order);
-                break;
-        }
+
 
         return redirect()->back()->with('error', 'No action selected');
     }


### PR DESCRIPTION
> BadMethodCallException: Method Illuminate\Database\Eloquent\Collection::orderBy does not exist. in /snipe-it/vendor/laravel/framework/src/Illuminate/Macroable/Traits/Macroable.php:115

This error is occurring because the code was trying to perform an `OrderBy()` on a Collection rather than the query.

This rearranges the Orderby switch cases to happen before converting the `$assets`	 variable into a collection.

PS: the locations case was missing a `break`.

Fixes #17193