### PR TITLE
[FD-49538] Add video/audio uploads

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -329,9 +329,9 @@ class RestoreFromBackup extends Command
                     }
                 }
             }
-            $good_extensions = ['png', 'gif', 'jpg', 'svg', 'jpeg', 'doc', 'docx', 'pdf', 'txt',
-                                'zip', 'rar', 'xls', 'xlsx', 'lic', 'xml', 'rtf', 'webp', 'key', 'ico', 'avif'
-            ];
+
+            $good_extensions = config('filesystems.allowed_upload_extensions_array');
+
             foreach (array_merge($private_files, $public_files) as $file) {
                 $has_wildcard = (strpos($file, '*') !== false);
                 if ($has_wildcard) {

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -869,7 +869,28 @@ class Helper
         $filetype = @finfo_file($finfo, $file);
         finfo_close($finfo);
 
-        if (($filetype == 'image/jpeg') || ($filetype == 'image/jpg') || ($filetype == 'image/png') || ($filetype == 'image/bmp') || ($filetype == 'image/gif') || ($filetype == 'image/avif') || ($filetype == 'image/webp')) {
+        if (($filetype == 'image/jpeg') || ($filetype == 'image/jpg') || ($filetype == 'image/png') || ($filetype == 'image/bmp') || ($filetype == 'image/gif') || ($filetype == 'image/avif') || ($filetype == 'image/webp') || ($filetype == 'video/mp4') || ($filetype == 'video/quicktime') || ($filetype == 'video/mpeg') || ($filetype == 'video/ogg') || ($filetype == 'video/webm') || ($filetype == 'video/x-msvide')) {
+            return $filetype;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the file is an image, so we can show a preview
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v3.0]
+     * @param File $file
+     * @return string | Boolean
+     */
+    public static function checkUploadIsAudio($file)
+    {
+        $finfo = @finfo_open(FILEINFO_MIME_TYPE); // return mime type ala mimetype extension
+        $filetype = @finfo_file($finfo, $file);
+        finfo_close($finfo);
+
+        if (($filetype == 'audio/mpeg') || ($filetype == 'audio/ogg')) {
             return $filetype;
         }
 
@@ -1170,6 +1191,15 @@ class Helper
             // Misc
             'pdf'   => 'far fa-file-pdf',
             'lic'   => 'far fa-save',
+
+            // video
+            'mov'   => 'fa-solid fa-video',
+            'mp4'   => 'fa-solid fa-video',
+
+            // audio
+            'ogg'   => 'fa-solid fa-file-audio',
+            'mp3'   => 'fa-solid fa-file-audio',
+            'wav'   => 'fa-solid fa-file-audio',
         ];
 
         if ($extension && array_key_exists($extension, $allowedExtensionMap)) {

--- a/app/Helpers/StorageHelper.php
+++ b/app/Helpers/StorageHelper.php
@@ -41,15 +41,21 @@ class StorageHelper
     {
 
         $allowed_inline = [
-            'pdf',
-            'svg',
-            'jpg',
-            'gif',
-            'svg',
             'avif',
-            'webp',
-            'png',
             'gif',
+            'gif',
+            'jpg',
+            'mov',
+            'mp3',
+            'mp4',
+            'ogg',
+            'pdf',
+            'png',
+            'svg',
+            'svg',
+            'wav',
+            'webm',
+            'webp',
         ];
 
 

--- a/app/Http/Requests/UploadFileRequest.php
+++ b/app/Http/Requests/UploadFileRequest.php
@@ -31,7 +31,7 @@ class UploadFileRequest extends Request
         $max_file_size = Helper::file_upload_max_size();
 
         return [
-            'file.*' => 'required|mimes:png,gif,jpg,svg,jpeg,doc,docx,pdf,txt,zip,rar,xls,xlsx,lic,xml,rtf,json,webp,avif|max:'.$max_file_size,
+            'file.*' => 'required|mimes:'.config('filesystems.allowed_upload_extensions_for_validator').'|max:'.$max_file_size,
         ];
     }
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -99,10 +99,67 @@ $config = [
 
     ],
 
+
 ];
 
 // copy the selected PUBLIC_FILESYSTEM_DISK's configuration to the 'public' key for easy use
 // (by default, the PUBLIC_FILESYSTEM DISK is 'local_public', in the public/uploads directory)
 $config['disks']['public'] = $config['disks'][env('PUBLIC_FILESYSTEM_DISK','local_public')];
+
+// This is used to determine which files to accept, and also to populate the language strings for the upload-file blade
+$config['allowed_upload_extensions_array']  = [
+    'avif',
+    'doc',
+    'doc',
+    'docx',
+    'docx',
+    'gif',
+    'ico',
+    'jpeg',
+    'jpg',
+    'json',
+    'key',
+    'lic',
+    'mov',
+    'mp3',
+    'mp4',
+    'ogg',
+    'pdf',
+    'png',
+    'rar',
+    'rtf',
+    'svg',
+    'txt',
+    'wav',
+    'webm',
+    'webp',
+    'xls',
+    'xlsx',
+    'xml',
+    'zip',
+];
+
+
+
+$config['allowed_upload_mimetypes_array'] = [
+    'application/json',
+    'application/msword',
+    'application/pdf',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/x-rar-compressed',
+    'application/zip',
+    'audio/*',
+    'image/*',
+    'text/plain',
+    'text/rtf',
+    'text/xml',
+    'video/*',
+];
+
+$config['allowed_upload_mimetypes'] = implode(',', $config['allowed_upload_mimetypes_array']);
+$config['allowed_upload_extensions_for_validator'] = implode(',', $config['allowed_upload_extensions_array']);
+$config['allowed_upload_extensions'] = '.'.implode(', .', $config['allowed_upload_extensions_array']);
 
 return $config;

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -311,7 +311,7 @@ return [
     'username'              => 'Username',
     'update'                => 'Update',
     'updating_item' => 'Updating :item',
-    'upload_filetypes_help'      => 'Allowed filetypes are png, gif, jpg, jpeg, doc, docx, pdf, xls, xlsx, txt, lic, xml, zip, rtf and rar. Max upload size allowed is :size.',
+    'upload_filetypes_help' => 'Allowed filetypes are: :allowed_filetypes. Max upload size allowed is :size.',
     'uploaded'              => 'Uploaded',
     'user'					=> 'User',
     'accepted'			    => 'accepted',

--- a/resources/views/blade/filestable.blade.php
+++ b/resources/views/blade/filestable.blade.php
@@ -32,7 +32,7 @@
                 {{trans('general.file_type')}}
             </th>
             <th class="col-md-2" data-searchable="true" data-visible="true" data-field="image">
-                {{ trans('general.image') }}
+                {{ trans('general.preview') }}
             </th>
             <th class="col-md-2" data-searchable="true" data-visible="true" data-field="filename" data-sortable="true">
                 {{ trans('general.file_name') }}
@@ -76,6 +76,11 @@
                             <a href="{{ route($showfile_routename, [$object->id, $file->id, 'inline' => 'true']) }}" data-toggle="lightbox" data-type="image">
                                 <img src="{{ route($showfile_routename, [$object->id, $file->id, 'inline' => 'true']) }}" class="img-thumbnail" style="max-width: 50px;">
                             </a>
+                        @elseif (Helper::checkUploadIsAudio($file->get_src(str_plural(strtolower(class_basename(get_class($object)))))))
+                            <audio controls>
+                                <source src="{{ route($showfile_routename, [$object->id, $file->id, 'inline' => 'true']) }}" type="audio/mp3">
+                                Your browser does not support the audio element.
+                            </audio>
                         @else
                             {{ trans('general.preview_not_available') }}
                         @endif

--- a/resources/views/modals/upload-file.blade.php
+++ b/resources/views/modals/upload-file.blade.php
@@ -21,7 +21,7 @@
 
                         <label class="btn btn-default btn-block">
                             {{ trans('button.select_files')  }}
-                            <input type="file" name="file[]" multiple="true" class="js-uploadFile" id="uploadFile" data-maxsize="{{ Helper::file_upload_max_size() }}" accept="image/*,.csv,.zip,.rar,.doc,.docx,.xls,.xlsx,.xml,.lic,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/plain,.pdf,application/rtf,application/json" style="display:none" required>
+                            <input type="file" name="file[]" multiple class="js-uploadFile" id="uploadFile" data-maxsize="{{ Helper::file_upload_max_size() }}" accept="{{ config('filesystems.allowed_upload_mimetypes') }}" style="display:none" required>
                         </label>
 
                     </div>
@@ -29,7 +29,7 @@
                         <span id="uploadFile-info"></span>
                     </div>
                     <div class="col-md-12">
-                        <p class="help-block" id="uploadFile-status">{{ trans('general.upload_filetypes_help', ['size' => Helper::file_upload_max_size_readable()]) }}</p>
+                        <p class="help-block" id="uploadFile-status">{{ trans('general.upload_filetypes_help', ['allowed_filetypes' => config('filesystems.allowed_upload_extensions'), 'size' => Helper::file_upload_max_size_readable()]) }}</p>
                     </div>
 
                     <div class="col-md-12">

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -52,7 +52,6 @@
             // This allows us to override the table defaults set below using the data-dash attributes
             var table = this;
             var data_with_default = function (key,default_value) {
-                console.dir($(table).data());
                 attrib_val = $(table).data(key);
                 if(attrib_val !== undefined) {
                     return attrib_val;
@@ -916,7 +915,6 @@
 
 
     function fileUploadNameFormatter(value) {
-        console.dir(value);
         if ((value) && (value.filename) && (value.url)) {
             return '<a href="' + value.url + '">' + value.filename + '</a>';
         }


### PR DESCRIPTION
A customer wrote in with a use-case that I think makes sense. "We sometimes have scenarios where we have video files of hardware faults with the device that are useful to store against an asset so we know it's history."

This also solves a nagging problem which is that every time we add a new type of file that we accept, the translation string has to get changed, which isn't great. This pulls that list out into the filesystems config.

<img width="631" alt="Screenshot 2025-07-03 at 8 21 06 PM" src="https://github.com/user-attachments/assets/c0b7f39a-0e3a-4fdb-868f-8945ea1e19b1" />
<img width="1522" alt="Screenshot 2025-07-03 at 8 22 09 PM" src="https://github.com/user-attachments/assets/e52cf988-069b-4da9-b139-c8105e0f7d39" />
