### PR TITLE
[FD-49569 ] - Show only assigned in license tab

### DIFF
--- a/app/Http/Controllers/Api/LicenseSeatsController.php
+++ b/app/Http/Controllers/Api/LicenseSeatsController.php
@@ -29,6 +29,15 @@ class LicenseSeatsController extends Controller
             $seats = LicenseSeat::with('license', 'user', 'asset', 'user.department')
                 ->where('license_seats.license_id', $licenseId);
 
+            if ($request->input('status') == 'available') {
+                $seats->whereNull('license_seats.assigned_to');
+            }
+
+            if ($request->input('status') == 'assigned') {
+                $seats->whereNotNull('license_seats.assigned_to');
+            }
+
+
             $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
 
             if ($request->input('sort') == 'department') {

--- a/resources/views/licenses/view.blade.php
+++ b/resources/views/licenses/view.blade.php
@@ -31,8 +31,8 @@
             <span class="hidden-lg hidden-md">
               <x-icon type="seats" class="fa-2x" />
               </span>
-              <span class="hidden-xs hidden-sm">{{ trans('admin/licenses/form.seats') }}</span>
-              <span class="badge badge-secondary">{{ number_format($license->availCount()->count()) }} / {{ number_format($license->seats) }}</span>
+              <span class="hidden-xs hidden-sm">{{ trans('general.assigned') }}</span>
+              <span class="badge badge-secondary">{{ number_format($license->assignedCount()->count()) }} / {{ number_format($license->seats) }}</span>
 
             </a>
         </li>
@@ -443,7 +443,7 @@
                         data-sort-order="asc"
                         data-sort-name="name"
                         class="table table-striped snipe-table"
-                        data-url="{{ route('api.licenses.seats.index', $license->id) }}"
+                        data-url="{{ route('api.licenses.seats.index', [$license->id, 'status' => 'assigned']) }}"
                         data-export-options='{
                         "fileName": "export-seats-{{ str_slug($license->name) }}-{{ date('Y-m-d') }}",
                         "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]


### PR DESCRIPTION
Since we already allow you to checkout licenses using the button the side, showing only the assigned seats on that license detail view makes more sense. 

<img width="1624" alt="Screenshot 2025-07-07 at 4 58 01 PM" src="https://github.com/user-attachments/assets/86f9b8de-61ea-4fd8-b188-cc50450198b7" />
