### PR TITLE
Fixed RB-17904 - added validation to asset index api endpoint

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -9,7 +9,7 @@ use App\Http\Traits\MigratesLegacyAssetLocations;
 use App\Models\AccessoryCheckout;
 use App\Models\CheckoutAcceptance;
 use App\Models\LicenseSeat;
-use Closure;
+use App\Rules\FlatArray;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Crypt;
@@ -35,8 +35,6 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use App\View\Label;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Facades\Validator;
-
 
 /**
  * This class controls all actions related to assets for
@@ -58,20 +56,10 @@ class AssetsController extends Controller
      */
     public function index(Request $request, $action = null, $upcoming_status = null) : JsonResponse | array
     {
-        $this->validate($request, [
+        $request->validate([
             'filter' => [
                 'json',
-                function (string $attribute, mixed $value, Closure $fail) {
-                    if (is_string($value)) {
-                        $value = json_decode($value, true);
-                    }
-
-                    foreach ($value as $arrayValue) {
-                        if (is_array($arrayValue)) {
-                            $fail("{$attribute} cannot contain a nested data.");
-                        }
-                    }
-                },
+                new FlatArray,
             ],
         ]);
 

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -9,6 +9,7 @@ use App\Http\Traits\MigratesLegacyAssetLocations;
 use App\Models\AccessoryCheckout;
 use App\Models\CheckoutAcceptance;
 use App\Models\LicenseSeat;
+use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Crypt;
@@ -58,7 +59,20 @@ class AssetsController extends Controller
     public function index(Request $request, $action = null, $upcoming_status = null) : JsonResponse | array
     {
         $this->validate($request, [
-            'filter' => 'json',
+            'filter' => [
+                'json',
+                function (string $attribute, mixed $value, Closure $fail) {
+                    if (is_string($value)) {
+                        $value = json_decode($value, true);
+                    }
+
+                    foreach ($value as $arrayValue) {
+                        if (is_array($arrayValue)) {
+                            $fail("{$attribute} cannot contain a nested data.");
+                        }
+                    }
+                },
+            ],
         ]);
 
         // This handles the legacy audit endpoints :(

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -58,7 +58,7 @@ class AssetsController extends Controller
     public function index(Request $request, $action = null, $upcoming_status = null) : JsonResponse | array
     {
         $this->validate($request, [
-            'filter' => 'string',
+            'filter' => 'json',
         ]);
 
         // This handles the legacy audit endpoints :(

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -57,7 +57,9 @@ class AssetsController extends Controller
      */
     public function index(Request $request, $action = null, $upcoming_status = null) : JsonResponse | array
     {
-
+        $this->validate($request, [
+            'filter' => 'string',
+        ]);
 
         // This handles the legacy audit endpoints :(
         if ($action == 'audit') {

--- a/app/Rules/FlatArray.php
+++ b/app/Rules/FlatArray.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Validates array is only one level deep.
+ * Passes: ['a' => 'b']
+ * Fails: ['a' => ['b', 'c']]
+ */
+class FlatArray implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (is_string($value)) {
+            $value = json_decode($value, true);
+        }
+
+        foreach ($value as $arrayValue) {
+            if (is_array($arrayValue)) {
+                $fail(":attribute cannot contain a nested data.");
+            }
+        }
+    }
+}

--- a/tests/Feature/Assets/Api/AssetIndexTest.php
+++ b/tests/Feature/Assets/Api/AssetIndexTest.php
@@ -127,6 +127,7 @@ class AssetIndexTest extends TestCase
     }
 
     /**
+     * [RB-17904]
      * [RB-19910]
      */
     public function test_handles_non_string_filter()

--- a/tests/Feature/Assets/Api/AssetIndexTest.php
+++ b/tests/Feature/Assets/Api/AssetIndexTest.php
@@ -144,7 +144,6 @@ class AssetIndexTest extends TestCase
     public function test_handles_non_string_filter($filterString)
     {
         $this->actingAsForApi(User::factory()->superuser()->create())
-            // url encode an array: filter=[assigned_to]
             ->getJson(route('api.assets.index') . '?' . $filterString)
             ->assertOk()
             ->assertStatusMessageIs('error')

--- a/tests/Feature/Assets/Api/AssetIndexTest.php
+++ b/tests/Feature/Assets/Api/AssetIndexTest.php
@@ -132,7 +132,8 @@ class AssetIndexTest extends TestCase
         return [
             ['filter%5Bassigned_to%5D'],
             ['filter[assigned_to][not]=null'],
-            ['filter={%22assigned_to%22:{%22$ne%22:null}}']
+            ['filter={%22assigned_to%22:{%22$ne%22:null}}'],
+            ['filter=%5B%22a%22%20%3D%3E%20%22b%22%5D'],
         ];
     }
 


### PR DESCRIPTION
This PR fixes a 500 being thrown when an array is passed for `filter` to the asset index api route.

I simply added some validation at the top of the method to ensure it is a string since the logic in the controller expects it to be a `json_encoded` string.

---

[RB-17904]
[RB-19910]
