### PR TITLE
Fixed #17310 - 500 on redirect when checking in a license seat

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -98,7 +98,9 @@ class LicenseCheckinController extends Controller
         $licenseSeat->notes = $request->input('notes');
 
         session()->put(['redirect_option' => $request->get('redirect_option')]);
-
+        if ($request->get('redirect_option') === 'target'){
+            session()->put(['checkout_to_type' => 'user']);
+        }
 
         // Was the asset updated?
         if ($licenseSeat->save()) {


### PR DESCRIPTION
The `checked_out_to` was not being populated when redirecting back to a user on check in, causing a 500. This adds that value.

Fixes #17310 