### PR TITLE
Fixed [FD-49538 ] - use a Video tag for video files for non-Safari usage

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -870,7 +870,7 @@ class Helper
         $filetype = @finfo_file($finfo, $file);
         finfo_close($finfo);
 
-        if (($filetype == 'image/jpeg') || ($filetype == 'image/jpg') || ($filetype == 'image/png') || ($filetype == 'image/bmp') || ($filetype == 'image/gif') || ($filetype == 'image/avif') || ($filetype == 'image/webp') || ($filetype == 'video/mp4') || ($filetype == 'video/quicktime') || ($filetype == 'video/mpeg') || ($filetype == 'video/ogg') || ($filetype == 'video/webm') || ($filetype == 'video/x-msvide')) {
+        if (($filetype == 'image/jpeg') || ($filetype == 'image/jpg') || ($filetype == 'image/png') || ($filetype == 'image/bmp') || ($filetype == 'image/gif') || ($filetype == 'image/avif') || ($filetype == 'image/webp')) {
             return $filetype;
         }
 
@@ -878,12 +878,33 @@ class Helper
     }
 
     /**
-     * Check if the file is an image, so we can show a preview
+     * Check if the file is a video, so we can show a preview
      *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since [v3.0]
      * @param File $file
      * @return string | Boolean
+     * @author [B. Wetherington] [<bwetherington@grokability.com>]
+     * @since [v8.1.18]
+     */
+    public static function checkUploadIsVideo($file)
+    {
+        $finfo = @finfo_open(FILEINFO_MIME_TYPE); // return mime type ala mimetype extension
+        $filetype = @finfo_file($finfo, $file);
+        finfo_close($finfo);
+
+        if (($filetype == 'video/mp4') || ($filetype == 'video/quicktime') || ($filetype == 'video/mpeg') || ($filetype == 'video/ogg') || ($filetype == 'video/webm') || ($filetype == 'video/x-msvide')) {
+            return $filetype;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the file is audio, so we can show a preview
+     *
+     * @param File $file
+     * @return string | Boolean
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since [v3.0]
      */
     public static function checkUploadIsAudio($file)
     {

--- a/resources/views/blade/filestable.blade.php
+++ b/resources/views/blade/filestable.blade.php
@@ -73,8 +73,17 @@
 
                     @if (($file->filename) && (Storage::exists($filepath.$file->filename)))
                         @if (Helper::checkUploadIsImage($file->get_src(str_plural(strtolower(class_basename(get_class($object)))))))
-                            <a href="{{ route($showfile_routename, [$object->id, $file->id, 'inline' => 'true']) }}" data-toggle="lightbox" data-type="image">
-                                <img src="{{ route($showfile_routename, [$object->id, $file->id, 'inline' => 'true']) }}" class="img-thumbnail" style="max-width: 50px;">
+                            <a href="{{ route($showfile_routename, [$object->id, $file->id, 'inline' => 'true']) }}"
+                               data-toggle="lightbox" data-type="image">
+                                <img src="{{ route($showfile_routename, [$object->id, $file->id, 'inline' => 'true']) }}"
+                                     class="img-thumbnail" style="max-width: 50px;">
+                            </a>
+                        @elseif (Helper::checkUploadIsVideo($file->get_src(str_plural(strtolower(class_basename(get_class($object)))))))
+                            <a href="{{ route($showfile_routename, [$object->id, $file->id, 'inline' => 'true']) }}"
+                               data-toggle="lightbox" data-type="video">
+                                <video style="max-width: 50px;">
+                                    <source src="{{ route($showfile_routename, [$object->id, $file->id, 'inline' => 'true']) }}">
+                                </video>
                             </a>
                         @elseif (Helper::checkUploadIsAudio($file->get_src(str_plural(strtolower(class_basename(get_class($object)))))))
                             <audio controls>


### PR DESCRIPTION
Our new Video functionality for file uploads turns out to only be usable on Safari - neither Chrome nor Firefox support that method of showing video files. So this change splits out detection of video files _separately_ from image files, and uses our default Ekko Lightbox display methods to show it. The way to do that isn't very well-documented, unfortunately, so this took a little fiddling around until I could get it to work.

Fixes [FD-49538]