### PR TITLE
Better indicate via submit button colors and messaging that something is about to be accepted or declined

### DIFF
--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -55,7 +55,7 @@ return [
     'default_eula_text_placeholder' => 'Add your default EULA text',
     'default_language'			=> 'Default Language',
     'default_eula_help_text'	=> 'You can also associate custom EULAs to specific asset categories.',
-    'acceptance_note'           => 'Add a note for your decision (Optional)',
+    'acceptance_note'           => 'Add a note for your decision (required if declining)',
     'display_asset_name'        => 'Display Asset Name',
     'display_checkout_date'     => 'Display Checkout Date',
     'display_eol'               => 'Display EOL in table view',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -346,6 +346,8 @@ return [
     'audit_overdue'         => 'Overdue for Audit',
     'accept'                => 'Accept :asset',
     'i_accept'              => 'I accept',
+    'i_decline_item'        => 'I decline this item',
+    'i_accept_item'         => 'I accept this item',
     'i_decline'             => 'I decline',
     'accept_decline'        => 'Accept/Decline',
     'sign_tos'              => 'Sign below to indicate that you agree to the terms of service:',

--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -89,7 +89,7 @@
                             </div>
 
                             @if (auth()->user()->email!='')
-                                <div class="col-md-12" style="padding-top: 20px; display: none;" id="toggleShow">
+                                <div class="col-md-12" style="padding-top: 20px; display: none;" id="showEmailBox">
                                     <label class="form-control">
                                         <input type="checkbox" value="1" name="send_copy" id="send_copy" checked="checked" aria-label="send_copy">
                                         {{ trans('mail.send_pdf_copy') }} ({{ auth()->user()->email }})
@@ -99,8 +99,13 @@
                         @endif
 
                     </div> <!-- / box-body -->
-                    <div class="box-footer text-right">
-                        <button type="submit" class="btn btn-success" id="submit-button"><i class="fa fa-check icon-white" aria-hidden="true"></i> {{ trans('general.submit') }}</button>
+                    <div class="box-footer text-right" style="display: none;" id="showSubmit">
+                        <button type="submit" class="btn btn-success" id="submit-button">
+                            <i class="fa fa-check icon-white" aria-hidden="true" id="submitIcon"></i>
+                            <span id="buttonText">
+                                {{ trans('general.i_accept_item') }}
+                            </span>
+                        </button>
                     </div><!-- /.box-footer -->
                 </div> <!-- / box-default -->
             </div> <!-- / col -->
@@ -112,9 +117,6 @@
 @section('moar_scripts')
 
     <script nonce="{{ csrf_token() }}">
-
-
-
 
         var wrapper = document.getElementById("signature-pad"),
             clearButton = wrapper.querySelector("[data-action=clear]"),
@@ -145,21 +147,26 @@
             signaturePad.clear();
         });
 
-        $('#submit-button').on("click", function (event) {
-            if (signaturePad.isEmpty()) {
-                alert("Please provide signature first.");
-                return false;
-            } else {
-                $('#signature_output').val(signaturePad.toDataURL());
-            }
-        });
+        $('[name="asset_acceptance"]').on('change', function() {
 
-        $('[name="asset_acceptance"]').on('change', function(){
-            if ($(this).is(':checked') && $(this).attr('id') == 'accepted' ) {
-                $("#toggleShow").show();
-            }
-            else{
-                $("#toggleShow").hide();
+            if ($(this).is(':checked') && $(this).attr('id') == 'declined') {
+                $("#showEmailBox").hide();
+                $("#showSubmit").show();
+                $("#submit-button").removeClass("btn-success").addClass("btn-danger").show();
+                $("#submitIcon").removeClass("fa-check").addClass("fa-times");
+                $("#buttonText").text('{{ trans('general.i_decline_item') }}');
+                $("#note").prop('required', true);
+
+            } else if ($(this).is(':checked') && $(this).attr('id') == 'accepted') {
+                $("#showEmailBox").show();
+                $("#showSubmit").show();
+                $("#submit-button").removeClass("btn-danger").addClass("btn-success").show();
+                $("#submitIcon").removeClass("fa-check").addClass("fa-check");
+                $("#buttonText").text('{{ trans('general.i_accept_item') }}');
+                $("#note").prop('required', false);
+
+
+
             }
 
         });

--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -147,6 +147,15 @@
             signaturePad.clear();
         });
 
+        $('#submit-button').on("click", function (event) {
+            if (signaturePad.isEmpty()) {
+                alert("Please provide signature first.");
+                return false;
+            } else {
+                $('#signature_output').val(signaturePad.toDataURL());
+            }
+        });
+        
         $('[name="asset_acceptance"]').on('change', function() {
 
             if ($(this).is(':checked') && $(this).attr('id') == 'declined') {


### PR DESCRIPTION
This is some small UI sugar on top of the existing accept/decline behavior, where it removed the submit button altogether of a decision (accept/decline) hasn't been chosen, and also changes the color and test on the button depending on what was selected to make it much more apparent which option the user has chosen. It now also requires a note if they are declining (this was previously optional, but I expect admins would like to know why someone is declining something they have checked out to them.)

This also hides the submit button altogether until the accepting user has made a choice. 

### Before


https://github.com/user-attachments/assets/31f5f889-c6cc-4026-b81e-43975ac7aa80



### After

https://github.com/user-attachments/assets/ccee3839-d149-4361-9c06-019b71304d31


https://github.com/user-attachments/assets/ad16c45d-6ed3-4593-af0a-01ae5762e0bb

