### PR TITLE
Fixed #17386: set key size for SAML to 3072 bit

### DIFF
--- a/app/Http/Requests/SettingsSamlRequest.php
+++ b/app/Http/Requests/SettingsSamlRequest.php
@@ -109,7 +109,7 @@ class SettingsSamlRequest extends FormRequest
                 ];
 
                 $pkey = openssl_pkey_new([
-                    'private_key_bits' => 2048,
+                    'private_key_bits' => 3072,
                     'private_key_type' => OPENSSL_KEYTYPE_RSA,
                 ]);
 


### PR DESCRIPTION
This PR increases RSA key size for auto-generated SAML certificates from 2048 to 3072 bits.

The minimal key size is now required e.g. by EU regulation: https://ec.europa.eu/digital-building-blocks/sites/download/attachments/467109280/eIDAS%20Cryptographic%20Requirement%20v.1.4.1_final.pdf?version=2&modificationDate=1729176493701&api=v2 (see 3.5.1. Certificates for SAML Metadata)

Fixes #17386