### PR TITLE
Use standard model transformer for asset model API response

### DIFF
--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -154,7 +154,7 @@ class AssetModelsController extends Controller
         $assetmodel = $request->handleImages($assetmodel);
 
         if ($assetmodel->save()) {
-            return response()->json(Helper::formatStandardApiResponse('success', $assetmodel, trans('admin/models/message.create.success')));
+            return response()->json(Helper::formatStandardApiResponse('success', (new AssetModelsTransformer)->transformAssetModel($assetmodel), trans('admin/models/message.create.success')));
         }
         return response()->json(Helper::formatStandardApiResponse('error', null, $assetmodel->getErrors()));
 
@@ -207,7 +207,7 @@ class AssetModelsController extends Controller
         $assetmodel = AssetModel::findOrFail($id);
         $assetmodel->fill($request->all());
         $assetmodel = $request->handleImages($assetmodel);
-        
+
         /**
          * Allow custom_fieldset_id to override and populate fieldset_id.
          * This is stupid, but required for legacy API support.
@@ -222,7 +222,7 @@ class AssetModelsController extends Controller
 
 
         if ($assetmodel->save()) {
-            return response()->json(Helper::formatStandardApiResponse('success', $assetmodel, trans('admin/models/message.update.success')));
+            return response()->json(Helper::formatStandardApiResponse('success', (new AssetModelsTransformer)->transformAssetModel($assetmodel), trans('admin/models/message.update.success')));
         }
 
         return response()->json(Helper::formatStandardApiResponse('error', null, $assetmodel->getErrors()));


### PR DESCRIPTION
This might be a fix for https://github.com/grokability/kandji2snipe/issues/23 - I think because the payload wasn't returning a `model_number` value, it would break in those circumstances where a newly created or updated model didn't have one.

This should standardize that payload to use the same transformers we use everywhere else, which will include a `model_number` in the payload, even if it's null.

### Before
```json
{
    "status": "success",
    "messages": "Model created successfully.",
    "payload": {
        "name": "Test 5",
        "category_id": "1",
        "updated_at": "2025-07-10T14:37:15.000000Z",
        "created_at": "2025-07-10T14:37:15.000000Z",
        "id": 24
    }
}
```

### After 

```json
{
    "status": "success",
    "messages": "Model created successfully.",
    "payload": {
        "id": 25,
        "name": "Test 6",
        "manufacturer": null,
        "image": null,
        "model_number": null,
        "min_amt": null,
        "remaining": 0,
        "depreciation": null,
        "assets_count": 0,
        "category": {
            "id": 1,
            "name": "Laptops"
        },
        "fieldset": null,
        "default_fieldset_values": [],
        "eol": "None",
        "requestable": false,
        "notes": null,
        "created_by": null,
        "created_at": {
            "datetime": "2025-07-10 15:37:32",
            "formatted": "Thu Jul 10, 2025 3:37PM"
        },
        "updated_at": {
            "datetime": "2025-07-10 15:37:32",
            "formatted": "Thu Jul 10, 2025 3:37PM"
        },
        "deleted_at": null,
        "available_actions": {
            "update": true,
            "delete": true,
            "clone": true,
            "restore": false
        }
    }
}
```