### PR TITLE
Fixed display of acceptance button if signature is not required

### DIFF
--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -118,6 +118,8 @@
 
     <script nonce="{{ csrf_token() }}">
 
+        @if ($snipeSettings->require_accept_signature=='1')
+
         var wrapper = document.getElementById("signature-pad"),
             clearButton = wrapper.querySelector("[data-action=clear]"),
             saveButton = wrapper.querySelector("[data-action=save]"),
@@ -155,6 +157,7 @@
                 $('#signature_output').val(signaturePad.toDataURL());
             }
         });
+        @endif
         
         $('[name="asset_acceptance"]').on('change', function() {
 


### PR DESCRIPTION
This fixes a regression where the submit button would not always display in Chrome if signatures are not required. (The issue was occurring because the signaturePad object didn't exist if that option was not selected in the Admin Settings, which was throwing a javascript error.)