### PR TITLE
Fixed #17431: EULA not displaying on asset acceptance page

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -992,9 +992,9 @@ class Asset extends Depreciable
     {
 
         if (($this->model) && ($this->model->category)) {
-            if (($this->model->category->eula_text) && ($this->model->category->use_default_eula === 0)) {
+            if (($this->model->category->eula_text) && ($this->model->category->use_default_eula == 0)) {
                 return Helper::parseEscapedMarkedown($this->model->category->eula_text);
-            } elseif ($this->model->category->use_default_eula === 1) {
+            } elseif ($this->model->category->use_default_eula == 1) {
                 return Helper::parseEscapedMarkedown(Setting::getSettings()->default_eula_text);
             } else {
 


### PR DESCRIPTION
Changed two instances of === to ==, as this was causing a comparison to fail and preventing EULAs from being displayed on asset acceptance pages as expected.

Fixes #17431 