### PR TITLE
Fixed #17394 - Changes the acceptance letter salutation to target

### DIFF
--- a/resources/views/mail/markdown/checkout-accessory.blade.php
+++ b/resources/views/mail/markdown/checkout-accessory.blade.php
@@ -1,5 +1,5 @@
 @component('mail::message')
-# {{ trans('mail.hello') }} {{ $target->assignedto?->present()->fullName() }},
+# {{ trans('mail.hello') }}{{ $target->assignedto?->present()->fullName() ? ' ' . $target->assignedto->present()->fullName() . ',' : ',' }}
 
 {{ trans('mail.new_item_checked') }}
 

--- a/resources/views/mail/markdown/checkout-accessory.blade.php
+++ b/resources/views/mail/markdown/checkout-accessory.blade.php
@@ -1,5 +1,5 @@
 @component('mail::message')
-# {{ trans('mail.hello') }} {{ $target->assignedto->present()->fullName() }},
+# {{ trans('mail.hello') }} {{ $target->assignedto?->present()->fullName() }},
 
 {{ trans('mail.new_item_checked') }}
 

--- a/resources/views/mail/markdown/checkout-accessory.blade.php
+++ b/resources/views/mail/markdown/checkout-accessory.blade.php
@@ -1,5 +1,5 @@
 @component('mail::message')
-# {{ trans('mail.hello') }} {{ $target->present()->fullName() }},
+# {{ trans('mail.hello') }} {{ $target->assignedto->present()->fullName() }},
 
 {{ trans('mail.new_item_checked') }}
 

--- a/resources/views/mail/markdown/checkout-asset.blade.php
+++ b/resources/views/mail/markdown/checkout-asset.blade.php
@@ -1,5 +1,5 @@
 @component('mail::message')
-# {{ trans('mail.hello') }} {{ $target->assignedto->present()->fullName() }},
+# {{ trans('mail.hello') }} {{ $target->assignedto?->present()->fullName() }},
 
 {{ $introduction_line }}
 

--- a/resources/views/mail/markdown/checkout-asset.blade.php
+++ b/resources/views/mail/markdown/checkout-asset.blade.php
@@ -1,5 +1,5 @@
 @component('mail::message')
-# {{ trans('mail.hello') }} {{ $target->present()->fullName() }},
+# {{ trans('mail.hello') }} {{ $target->assignedto->present()->fullName() }},
 
 {{ $introduction_line }}
 

--- a/resources/views/mail/markdown/checkout-asset.blade.php
+++ b/resources/views/mail/markdown/checkout-asset.blade.php
@@ -1,7 +1,8 @@
 @component('mail::message')
-# {{ trans('mail.hello') }} {{ $target->assignedto?->present()->fullName() }},
-
-{{ $introduction_line }}
+    @php
+    $target->assignedto =  null;
+    @endphp
+# {{ trans('mail.hello') }}{{ $target->assignedto?->present()->fullName() ? ' ' . $target->assignedto->present()->fullName() . ',' : ',' }}
 
 @if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
 <center><img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;"></center>

--- a/resources/views/mail/markdown/checkout-asset.blade.php
+++ b/resources/views/mail/markdown/checkout-asset.blade.php
@@ -4,6 +4,8 @@
     @endphp
 # {{ trans('mail.hello') }}{{ $target->assignedto?->present()->fullName() ? ' ' . $target->assignedto->present()->fullName() . ',' : ',' }}
 
+    {{ $introduction_line }}
+
 @if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
 <center><img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;"></center>
 @endif


### PR DESCRIPTION
Changes the salutation target to `$target->assignedto` in the accessories and asset checkout mail markdowns.
<img width="654" height="369" alt="image" src="https://github.com/user-attachments/assets/7d984973-5097-4970-8990-1e925bc1ca86" />
<img width="654" height="611" alt="image" src="https://github.com/user-attachments/assets/d9fe227c-a5e2-4629-82ba-c9fc0a33507d" />

Fixes: #17394 