### PR TITLE
Fixed FD-49886 - Optimize user queries

### DIFF
--- a/app/Http/Controllers/Api/UsersController.php
+++ b/app/Http/Controllers/Api/UsersController.php
@@ -81,7 +81,12 @@ class UsersController extends Controller
             'users.autoassign_licenses',
             'users.website',
 
-        ])->with('manager', 'groups', 'userloc', 'company', 'department', 'assets', 'licenses', 'accessories', 'consumables', 'createdBy', 'managesUsers', 'managedLocations', 'eulas')
+        ])->with('manager')
+            ->with('groups')
+            ->with('userloc')
+            ->with('company')
+            ->with('department')
+            ->with('createdBy')
             ->withCount([
                 'assets as assets_count' => function(Builder $query) {
                     $query->withoutTrashed();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -288,13 +288,15 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      */
     public function isDeletable()
     {
+
         return Gate::allows('delete', $this)
-            && ($this->assets->count() === 0)
-            && ($this->licenses->count() === 0)
-            && ($this->consumables->count() === 0)
-            && ($this->accessories->count() === 0)
-            && ($this->managedLocations->count() === 0)
-            && ($this->managesUsers->count() === 0)
+            && (($this->assets_count ?? $this->assets()->count()) === 0)
+            && (($this->accessories_count ?? $this->accessories()->count()) === 0)
+            && (($this->licenses_count ?? $this->licenses()->count()) === 0)
+            && (($this->consumables_count ?? $this->consumables()->count()) === 0)
+            && (($this->accessories_count ?? $this->accessories()->count()) === 0)
+            && (($this->manages_users_count ?? $this->managesUsers()->count()) === 0)
+            && (($this->manages_locations_count ?? $this->managedLocations()->count()) === 0)
             && ($this->deleted_at == '');
     }
 


### PR DESCRIPTION
This change does a few small things - first, we don't need some of the things we were loading previously which was causing the query to fail at an eloquent level.  We only need counts for those, so no need to load the whole thing. And second, we're checking to see if we already have the counts for the relations so we don't need to load those.