### PR TITLE
Fixed #17445 - move jobtitle under assigned_to in AssetTransformer

### DIFF
--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -80,7 +80,6 @@ class AssetsTransformer
             'qr' => ($setting->qr_code=='1') ? config('app.url').'/uploads/barcodes/qr-'.str_slug($asset->asset_tag).'-'.str_slug($asset->id).'.png' : null,
             'alt_barcode' => ($setting->alt_barcode_enabled=='1') ? config('app.url').'/uploads/barcodes/'.str_slug($setting->alt_barcode).'-'.str_slug($asset->asset_tag).'.png' : null,
             'assigned_to' => $this->transformAssignedTo($asset),
-            'jobtitle' => $asset->assigned ? e($asset->assigned->jobtitle) : null,
             'warranty_months' =>  ($asset->warranty_months > 0) ? e($asset->warranty_months.' '.trans('admin/hardware/form.months')) : null,
             'warranty_expires' => ($asset->warranty_months > 0) ? Helper::getFormattedDateObject($asset->warranty_expires, 'date') : null,
             'created_by' => ($asset->adminuser) ? [
@@ -204,6 +203,7 @@ class AssetsTransformer
                     'last_name'=> ($asset->assigned->last_name) ? e($asset->assigned->last_name) : null,
                     'email'=> ($asset->assigned->email) ? e($asset->assigned->email) : null,
                     'employee_number' =>  ($asset->assigned->employee_num) ? e($asset->assigned->employee_num) : null,
+                    'jobtitle' => $asset->assigned->jobtitle ? e($asset->assigned->jobtitle) : null,
                     'type' => 'user',
                 ] : null;
         }

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -110,7 +110,7 @@ class AssetPresenter extends Presenter
                 'visible' => false,
                 'formatter' => 'employeeNumFormatter',
             ],[
-                'field' => 'jobtitle',
+                'field' => 'assigned_to.jobtitle',
                 'searchable' => true,
                 'sortable' => true,
                 'title' => trans('admin/users/table.title'),

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -110,11 +110,12 @@ class AssetPresenter extends Presenter
                 'visible' => false,
                 'formatter' => 'employeeNumFormatter',
             ],[
-                'field' => 'assigned_to.jobtitle',
+                'field' => 'jobtitle',
                 'searchable' => true,
-                'sortable' => true,
+                'sortable' => false,
                 'title' => trans('admin/users/table.title'),
                 'visible' => false,
+                'formatter' => 'jobtitleFormatter',
             ], [
                 'field' => 'location',
                 'searchable' => true,

--- a/app/Presenters/AssetPresenter.php
+++ b/app/Presenters/AssetPresenter.php
@@ -112,7 +112,7 @@ class AssetPresenter extends Presenter
             ],[
                 'field' => 'jobtitle',
                 'searchable' => true,
-                'sortable' => false,
+                'sortable' => true,
                 'title' => trans('admin/users/table.title'),
                 'visible' => false,
                 'formatter' => 'jobtitleFormatter',

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -869,6 +869,12 @@
         }
     }
 
+    function jobtitleFormatter(value, row) {
+        if ((row) && (row.assigned_to) && ((row.assigned_to.jobtitle))) {
+            return '<a href="{{ config('app.url') }}/users/' + row.assigned_to.id + '">' + row.assigned_to.jobtitle + '</a>';
+        }
+    }
+
     function orderNumberObjFilterFormatter(value, row) {
         if (value) {
             return '<a href="{{ config('app.url') }}/hardware/?order_number=' + row.order_number + '">' + row.order_number + '</a>';


### PR DESCRIPTION
This PR moves `jobtitle` from the top level under `assigned_to` in the AssetsTransformer.

Fixes #17445
Follow up for https://github.com/grokability/snipe-it/commit/ff01078b608d109bfeb1c6091f294f710e5213d3