### PR TITLE
This test was flaky, probably due to the PHP statcache.

### DIFF
--- a/tests/Unit/LdapTest.php
+++ b/tests/Unit/LdapTest.php
@@ -228,6 +228,7 @@ class LdapTest extends TestCase
         $this->settings->enableLdap()->set(['ldap_client_tls_cert' => 'SAMPLE CERT TEXT']);
         $client_side_cert_path = Setting::get_client_side_cert_path();
         file_put_contents($client_side_cert_path, 'WEIRDLY UPDATED CERT FILE');
+        clearstatcache();
         //the system should respect our cache-file, since the settings haven't been updated
         $possibly_recached_cert_file = Setting::get_client_side_cert_path(); //this should *NOT* re-cache from the Settings
         $this->assertStringEqualsFile($possibly_recached_cert_file, 'WEIRDLY UPDATED CERT FILE');


### PR DESCRIPTION
I keep forgetting that PHP has a "stat-cache" which caches the stat() values for flies. That was (probably) making this test a little bit flaky. Now we manually clear it, and the test seems to be a little bit more consistent.