### PR TITLE
Enforce order by ID for actionlog tests

### DIFF
--- a/tests/Support/AssertHasActionLogs.php
+++ b/tests/Support/AssertHasActionLogs.php
@@ -11,7 +11,8 @@ trait AssertHasActionLogs
 {
     public function assertHasTheseActionLogs(Model $item, array $statuses)
     {
-        Assert::assertEquals($statuses, $item->assetlog()->orderBy('id')->pluck('action_type')->toArray(), "Failed asserting that action logs match");
+        //note we have to do a 'reorder()' here because there is an implicit "order_by created_at" baked in to the relationship
+        Assert::assertEquals($statuses, $item->assetlog()->reorder('id')->pluck('action_type')->toArray(), "Failed asserting that action logs match");
     }
 
 }


### PR DESCRIPTION
The new action_log tests that we added seem to be a little bit flaky - at least in MySQL. For some weird reason, they're actually pretty consistent when run in SQLite.

It turns out the query we were doing to try to grab them in ID order was appending the `id` *after* the built-in `created_at` ordering - making it do `ORDER BY created_at, id` - which is not what we wanted.

This uses Laravel's built-in `reorder()` method to force the ordering to the way we want.

My suspicion is that MySQL is using a less fine-grained timestamp, whereas SQLite is using microsecond-precision timestamps.

I tested this by running the tests 10 times in a row - and they all passed (well, one had a failure because of the rate-limiting tests, but that's its own problem).