### PR TITLE
Fixed #9511 - Validation For Encrypted Custom Fields

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -224,7 +224,11 @@ class Asset extends Depreciable
 
             foreach ($this->model->fieldset->fields as $field) {
 
-                if ($field->format == 'BOOLEAN') {
+                // this just casts booleans that may come through as strings to an actual boolean type
+                // adding !$field->field_encrypted because when the encrypted value comes through it
+                // screws things up for the encrypted validation rules (and the encrypted string
+                // is not a valid boolean type)
+                if ($field->format == 'BOOLEAN' && !$field->field_encrypted) {
                     $this->{$field->db_column} = filter_var($this->{$field->db_column}, FILTER_VALIDATE_BOOLEAN);
                 }
             }

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -16,6 +16,7 @@ class CustomField extends Model
         UniqueUndeletedTrait;
 
     /**
+     *
      * Custom field predfined formats
      *
      * @var array

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -128,54 +128,83 @@ class CustomFieldset extends Model
 
             $rules[$field->db_column_name()] = $rule;
 
+            // this is to switch the rules to rules specially made for encrypted custom fields that decrypt the value before validating
+            if ($field->field_encrypted) {
+                $numericKey = array_search('numeric', $rules[$field->db_column_name()]);
+                $alphaKey = array_search('alpha', $rules[$field->db_column_name()]);
+                $emailKey = array_search('email', $rules[$field->db_column_name()]);
+                $dateKey = array_search('date', $rules[$field->db_column_name()]);
+                $urlKey = array_search('url', $rules[$field->db_column_name()]);
+                $ipKey = array_search('ip', $rules[$field->db_column_name()]);
+                $ipv4Key = array_search('ipv4', $rules[$field->db_column_name()]);
+                $ipv6Key = array_search('ipv6', $rules[$field->db_column_name()]);
+                $macKey = array_search('regex', $rules[$field->db_column_name()]);
+                match ($field->format) {
+                    'NUMERIC' => $rules[$field->db_column_name()][$numericKey] = new NumericEncrypted,
+                    'ALPHA' => $rules[$field->db_column_name()][$alphaKey] = new AlphaEncrypted,
+                    'EMAIL' => $rules[$field->db_column_name()][$emailKey] = new EmailEncrypted,
+                    'DATE' => $rules[$field->db_column_name()][$dateKey] = new DateEncrypted,
+                    'URL' => $rules[$field->db_column_name()][$urlKey] = new UrlEncrypted,
+                    'IP' => $rules[$field->db_column_name()][$ipKey] = new IPEncrypted,
+                    'IPV4' => $rules[$field->db_column_name()][$ipv4Key] = new IPv4Encrypted,
+                    'IPV6' => $rules[$field->db_column_name()][$ipv6Key] = new IPv6Encrypted,
+                    'MAC' => $rules[$field->db_column_name()][$macKey] = new MACEncrypted,
+                    default => null,
+                };
+            }
+
 
             // these are to replace the standard 'numeric' and 'alpha' rules if the custom field is also encrypted.
             // the values need to be decrypted first, because encrypted strings are alphanumeric
-            if ($field->format === 'NUMERIC' && $field->field_encrypted) {
-                $numericKey = array_search('numeric', $rules[$field->db_column_name()]);
-                $rules[$field->db_column_name()][$numericKey] = new NumericEncrypted;
-            }
+            //if ($field->format === 'NUMERIC' && $field->field_encrypted) {
+            //    $numericKey = array_search('numeric', $rules[$field->db_column_name()]);
+            //    $rules[$field->db_column_name()][$numericKey] = new NumericEncrypted;
+            //}
+            //
+            //if ($field->format === 'ALPHA' && $field->field_encrypted) {
+            //    $alphaKey = array_search('alpha', $rules[$field->db_column_name()]);
+            //    $rules[$field->db_column_name()][$alphaKey] = new AlphaEncrypted;
+            //}
+            //
+            //if ($field->format === 'EMAIL' && $field->field_encrypted) {
+            //    $emailKey = array_search('email', $rules[$field->db_column_name()]);
+            //    $rules[$field->db_column_name()][$emailKey] = new EmailEncrypted;
+            //}
+            //
+            //if ($field->format === 'DATE' && $field->field_encrypted) {
+            //    $dateKey = array_search('date', $rules[$field->db_column_name()]);
+            //    $rules[$field->db_column_name()][$dateKey] = new DateEncrypted;
+            //}
+            //
+            //if ($field->format === 'URL' && $field->field_encrypted) {
+            //    $urlKey = array_search('url', $rules[$field->db_column_name()]);
+            //    $rules[$field->db_column_name()][$urlKey] = new UrlEncrypted;
+            //}
+            //
+            //if ($field->format === 'IP' && $field->field_encrypted) {
+            //    $ipKey = array_search('ip', $rules[$field->db_column_name()]);
+            //    $rules[$field->db_column_name()][$ipKey] = new IpEncrypted;
+            //}
+            //
+            //if ($field->format === 'IPV4' && $field->field_encrypted) {
+            //    $ipKey = array_search('ipv4', $rules[$field->db_column_name()]);
+            //    $rules[$field->db_column_name()][$ipKey] = new IPv4Encrypted;
+            //}
+            //
+            //if ($field->format === 'IPV6' && $field->field_encrypted) {
+            //    $ipKey = array_search('ipv6', $rules[$field->db_column_name()]);
+            //    $rules[$field->db_column_name()][$ipKey] = new IPv6Encrypted;
+            //}
 
-            if ($field->format === 'ALPHA' && $field->field_encrypted) {
-                $alphaKey = array_search('alpha', $rules[$field->db_column_name()]);
-                $rules[$field->db_column_name()][$alphaKey] = new AlphaEncrypted;
-            }
-
-            if ($field->format === 'EMAIL' && $field->field_encrypted) {
-                $emailKey = array_search('email', $rules[$field->db_column_name()]);
-                $rules[$field->db_column_name()][$emailKey] = new EmailEncrypted;
-            }
-
-            if ($field->format === 'DATE' && $field->field_encrypted) {
-                $dateKey = array_search('date', $rules[$field->db_column_name()]);
-                $rules[$field->db_column_name()][$dateKey] = new DateEncrypted;
-            }
-
-            if ($field->format === 'URL' && $field->field_encrypted) {
-                $urlKey = array_search('url', $rules[$field->db_column_name()]);
-                $rules[$field->db_column_name()][$urlKey] = new UrlEncrypted;
-            }
-
-            if ($field->format === 'IP' && $field->field_encrypted) {
-                $ipKey = array_search('ip', $rules[$field->db_column_name()]);
-                $rules[$field->db_column_name()][$ipKey] = new IpEncrypted;
-            }
-
-            if ($field->format === 'IPV4' && $field->field_encrypted) {
-                $ipKey = array_search('ipv4', $rules[$field->db_column_name()]);
-                $rules[$field->db_column_name()][$ipKey] = new IPv4Encrypted;
-            }
-
-            if ($field->format === 'IPV6' && $field->field_encrypted) {
-                $ipKey = array_search('ipv6', $rules[$field->db_column_name()]);
-                $rules[$field->db_column_name()][$ipKey] = new IPv6Encrypted;
-            }
-
-            // hm, the format on these is just the regex string, so gonna have to figure out how to filter to get it...
-            if ($field->format === 'MAC' && $field->field_encrypted) {
-                $macKey = array_search('mac', $rules[$field->db_column_name()]);
-                $rules[$field->db_column_name()][$macKey] = new MacEncrypted;
-            }
+            // hm, the 'format' on these is just the regex string, so gonna have to figure out how to filter to get it...
+            // hrmph, the string doesn't work. maybe a generic RegexEncrypted rule that takes the regex input and feeds it into
+            // laravel's regex validation rule? yeah, maybe.
+            // hm, dumping $field->format says that the format actually is 'MAC', which doesn't make sense because it's not that in the DB...
+            //if ($field->format == 'MAC' && $field->field_encrypted) {
+            //    //dd($rules);
+            //    $macKey = array_search(CustomField::PREDEFINED_FORMATS['MAC'], $rules[$field->db_column_name()]);
+            //    $rules[$field->db_column_name()][$macKey] = new MacEncrypted;
+            //}
 
 
             // add not_array to rules for all fields but checkboxes

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Rules\AlphaEncrypted;
+use App\Rules\EmailEncrypted;
 use App\Rules\NumericEncrypted;
 use Gate;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -132,6 +133,11 @@ class CustomFieldset extends Model
             if ($field->format === 'ALPHA' && $field->field_encrypted) {
                 $alphaKey = array_search('alpha', $rules[$field->db_column_name()]);
                 $rules[$field->db_column_name()][$alphaKey] = new AlphaEncrypted;
+            }
+
+            if ($field->format === 'EMAIL' && $field->field_encrypted) {
+                $emailKey = array_search('email', $rules[$field->db_column_name()]);
+                $rules[$field->db_column_name()][$emailKey] = new EmailEncrypted;
             }
 
             // add not_array to rules for all fields but checkboxes

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -3,12 +3,13 @@
 namespace App\Models;
 
 use App\Rules\AlphaEncrypted;
+use App\Rules\BooleanEncrypted;
 use App\Rules\DateEncrypted;
 use App\Rules\EmailEncrypted;
 use App\Rules\IPEncrypted;
 use App\Rules\IPv4Encrypted;
 use App\Rules\IPv6Encrypted;
-use App\Rules\MACEncrypted;
+use App\Rules\MacEncrypted;
 use App\Rules\NumericEncrypted;
 use App\Rules\UrlEncrypted;
 use Gate;
@@ -138,7 +139,8 @@ class CustomFieldset extends Model
                 $ipKey = array_search('ip', $rules[$field->db_column_name()]);
                 $ipv4Key = array_search('ipv4', $rules[$field->db_column_name()]);
                 $ipv6Key = array_search('ipv6', $rules[$field->db_column_name()]);
-                $macKey = array_search('regex', $rules[$field->db_column_name()]);
+                $macKey = array_search('regex:/^[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}$/', $rules[$field->db_column_name()]);
+                $booleanKey = array_search('boolean', $rules[$field->db_column_name()]);
                 match ($field->format) {
                     'NUMERIC' => $rules[$field->db_column_name()][$numericKey] = new NumericEncrypted,
                     'ALPHA' => $rules[$field->db_column_name()][$alphaKey] = new AlphaEncrypted,
@@ -148,7 +150,8 @@ class CustomFieldset extends Model
                     'IP' => $rules[$field->db_column_name()][$ipKey] = new IPEncrypted,
                     'IPV4' => $rules[$field->db_column_name()][$ipv4Key] = new IPv4Encrypted,
                     'IPV6' => $rules[$field->db_column_name()][$ipv6Key] = new IPv6Encrypted,
-                    'MAC' => $rules[$field->db_column_name()][$macKey] = new MACEncrypted,
+                    'MAC' => $rules[$field->db_column_name()][$macKey] = new MacEncrypted,
+                    'BOOLEAN' => $rules[$field->db_column_name()][$booleanKey] = new BooleanEncrypted,
                     default => null,
                 };
             }

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -5,6 +5,10 @@ namespace App\Models;
 use App\Rules\AlphaEncrypted;
 use App\Rules\DateEncrypted;
 use App\Rules\EmailEncrypted;
+use App\Rules\IPEncrypted;
+use App\Rules\IPv4Encrypted;
+use App\Rules\IPv6Encrypted;
+use App\Rules\MACEncrypted;
 use App\Rules\NumericEncrypted;
 use App\Rules\UrlEncrypted;
 use Gate;
@@ -151,6 +155,28 @@ class CustomFieldset extends Model
                 $urlKey = array_search('url', $rules[$field->db_column_name()]);
                 $rules[$field->db_column_name()][$urlKey] = new UrlEncrypted;
             }
+
+            if ($field->format === 'IP' && $field->field_encrypted) {
+                $ipKey = array_search('ip', $rules[$field->db_column_name()]);
+                $rules[$field->db_column_name()][$ipKey] = new IpEncrypted;
+            }
+
+            if ($field->format === 'IPV4' && $field->field_encrypted) {
+                $ipKey = array_search('ipv4', $rules[$field->db_column_name()]);
+                $rules[$field->db_column_name()][$ipKey] = new IPv4Encrypted;
+            }
+
+            if ($field->format === 'IPV6' && $field->field_encrypted) {
+                $ipKey = array_search('ipv6', $rules[$field->db_column_name()]);
+                $rules[$field->db_column_name()][$ipKey] = new IPv6Encrypted;
+            }
+
+            // hm, the format on these is just the regex string, so gonna have to figure out how to filter to get it...
+            if ($field->format === 'MAC' && $field->field_encrypted) {
+                $macKey = array_search('mac', $rules[$field->db_column_name()]);
+                $rules[$field->db_column_name()][$macKey] = new MacEncrypted;
+            }
+
 
             // add not_array to rules for all fields but checkboxes
             if ($field->element != 'checkbox') {

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -11,12 +11,11 @@ use App\Rules\IPv4Encrypted;
 use App\Rules\IPv6Encrypted;
 use App\Rules\MacEncrypted;
 use App\Rules\NumericEncrypted;
+use App\Rules\RegexEncrypted;
 use App\Rules\UrlEncrypted;
 use Gate;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Validation\Rule;
 use Watson\Validating\ValidatingTrait;
 
 class CustomFieldset extends Model
@@ -141,73 +140,52 @@ class CustomFieldset extends Model
                 $ipv6Key = array_search('ipv6', $rules[$field->db_column_name()]);
                 $macKey = array_search('regex:/^[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}$/', $rules[$field->db_column_name()]);
                 $booleanKey = array_search('boolean', $rules[$field->db_column_name()]);
-                match ($field->format) {
-                    'NUMERIC' => $rules[$field->db_column_name()][$numericKey] = new NumericEncrypted,
-                    'ALPHA' => $rules[$field->db_column_name()][$alphaKey] = new AlphaEncrypted,
-                    'EMAIL' => $rules[$field->db_column_name()][$emailKey] = new EmailEncrypted,
-                    'DATE' => $rules[$field->db_column_name()][$dateKey] = new DateEncrypted,
-                    'URL' => $rules[$field->db_column_name()][$urlKey] = new UrlEncrypted,
-                    'IP' => $rules[$field->db_column_name()][$ipKey] = new IPEncrypted,
-                    'IPV4' => $rules[$field->db_column_name()][$ipv4Key] = new IPv4Encrypted,
-                    'IPV6' => $rules[$field->db_column_name()][$ipv6Key] = new IPv6Encrypted,
-                    'MAC' => $rules[$field->db_column_name()][$macKey] = new MacEncrypted,
-                    'BOOLEAN' => $rules[$field->db_column_name()][$booleanKey] = new BooleanEncrypted,
-                    default => null,
-                };
+                // find objects in array that start with "regex:"
+                // collect because i couldn't figure how to do this
+                // with array filter and get keys out of it
+                $regexCollect = collect($rules[$field->db_column_name()]);
+                $regexKeys = $regexCollect->filter(function ($value, $key) {
+                    return starts_with($value, 'regex:');
+                })->keys()->values()->toArray();
+
+                switch ($field->format) {
+                    case 'NUMERIC':
+                        $rules[$field->db_column_name()][$numericKey] = new NumericEncrypted;
+                        break;
+                    case 'ALPHA':
+                        $rules[$field->db_column_name()][$alphaKey] = new AlphaEncrypted;
+                        break;
+                    case 'EMAIL':
+                        $rules[$field->db_column_name()][$emailKey] = new EmailEncrypted;
+                        break;
+                    case 'DATE':
+                        $rules[$field->db_column_name()][$dateKey] = new DateEncrypted;
+                        break;
+                    case 'URL':
+                        $rules[$field->db_column_name()][$urlKey] = new UrlEncrypted;
+                        break;
+                    case 'IP':
+                        $rules[$field->db_column_name()][$ipKey] = new IPEncrypted;
+                        break;
+                    case 'IPV4':
+                        $rules[$field->db_column_name()][$ipv4Key] = new IPv4Encrypted;
+                        break;
+                    case 'IPV6':
+                        $rules[$field->db_column_name()][$ipv6Key] = new IPv6Encrypted;
+                        break;
+                    case 'MAC':
+                        $rules[$field->db_column_name()][$macKey] = new MacEncrypted;
+                        break;
+                    case 'BOOLEAN':
+                        $rules[$field->db_column_name()][$booleanKey] = new BooleanEncrypted;
+                        break;
+                    case starts_with($field->format, 'regex'):
+                        foreach ($regexKeys as $regexKey) {
+                            $rules[$field->db_column_name()][$regexKey] = new RegexEncrypted;
+                        }
+                        break;
+                }
             }
-
-
-            // these are to replace the standard 'numeric' and 'alpha' rules if the custom field is also encrypted.
-            // the values need to be decrypted first, because encrypted strings are alphanumeric
-            //if ($field->format === 'NUMERIC' && $field->field_encrypted) {
-            //    $numericKey = array_search('numeric', $rules[$field->db_column_name()]);
-            //    $rules[$field->db_column_name()][$numericKey] = new NumericEncrypted;
-            //}
-            //
-            //if ($field->format === 'ALPHA' && $field->field_encrypted) {
-            //    $alphaKey = array_search('alpha', $rules[$field->db_column_name()]);
-            //    $rules[$field->db_column_name()][$alphaKey] = new AlphaEncrypted;
-            //}
-            //
-            //if ($field->format === 'EMAIL' && $field->field_encrypted) {
-            //    $emailKey = array_search('email', $rules[$field->db_column_name()]);
-            //    $rules[$field->db_column_name()][$emailKey] = new EmailEncrypted;
-            //}
-            //
-            //if ($field->format === 'DATE' && $field->field_encrypted) {
-            //    $dateKey = array_search('date', $rules[$field->db_column_name()]);
-            //    $rules[$field->db_column_name()][$dateKey] = new DateEncrypted;
-            //}
-            //
-            //if ($field->format === 'URL' && $field->field_encrypted) {
-            //    $urlKey = array_search('url', $rules[$field->db_column_name()]);
-            //    $rules[$field->db_column_name()][$urlKey] = new UrlEncrypted;
-            //}
-            //
-            //if ($field->format === 'IP' && $field->field_encrypted) {
-            //    $ipKey = array_search('ip', $rules[$field->db_column_name()]);
-            //    $rules[$field->db_column_name()][$ipKey] = new IpEncrypted;
-            //}
-            //
-            //if ($field->format === 'IPV4' && $field->field_encrypted) {
-            //    $ipKey = array_search('ipv4', $rules[$field->db_column_name()]);
-            //    $rules[$field->db_column_name()][$ipKey] = new IPv4Encrypted;
-            //}
-            //
-            //if ($field->format === 'IPV6' && $field->field_encrypted) {
-            //    $ipKey = array_search('ipv6', $rules[$field->db_column_name()]);
-            //    $rules[$field->db_column_name()][$ipKey] = new IPv6Encrypted;
-            //}
-
-            // hm, the 'format' on these is just the regex string, so gonna have to figure out how to filter to get it...
-            // hrmph, the string doesn't work. maybe a generic RegexEncrypted rule that takes the regex input and feeds it into
-            // laravel's regex validation rule? yeah, maybe.
-            // hm, dumping $field->format says that the format actually is 'MAC', which doesn't make sense because it's not that in the DB...
-            //if ($field->format == 'MAC' && $field->field_encrypted) {
-            //    //dd($rules);
-            //    $macKey = array_search(CustomField::PREDEFINED_FORMATS['MAC'], $rules[$field->db_column_name()]);
-            //    $rules[$field->db_column_name()][$macKey] = new MacEncrypted;
-            //}
 
 
             // add not_array to rules for all fields but checkboxes

--- a/app/Models/CustomFieldset.php
+++ b/app/Models/CustomFieldset.php
@@ -3,8 +3,10 @@
 namespace App\Models;
 
 use App\Rules\AlphaEncrypted;
+use App\Rules\DateEncrypted;
 use App\Rules\EmailEncrypted;
 use App\Rules\NumericEncrypted;
+use App\Rules\UrlEncrypted;
 use Gate;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -100,7 +102,7 @@ class CustomFieldset extends Model
      * @since  [v3.0]
      * @return array
      */
-    public function validation_rules()
+    public function validation_rules(): array
     {
         $rules = [];
         foreach ($this->fields as $field) {
@@ -138,6 +140,16 @@ class CustomFieldset extends Model
             if ($field->format === 'EMAIL' && $field->field_encrypted) {
                 $emailKey = array_search('email', $rules[$field->db_column_name()]);
                 $rules[$field->db_column_name()][$emailKey] = new EmailEncrypted;
+            }
+
+            if ($field->format === 'DATE' && $field->field_encrypted) {
+                $dateKey = array_search('date', $rules[$field->db_column_name()]);
+                $rules[$field->db_column_name()][$dateKey] = new DateEncrypted;
+            }
+
+            if ($field->format === 'URL' && $field->field_encrypted) {
+                $urlKey = array_search('url', $rules[$field->db_column_name()]);
+                $rules[$field->db_column_name()][$urlKey] = new UrlEncrypted;
             }
 
             // add not_array to rules for all fields but checkboxes

--- a/app/Rules/BooleanEncrypted.php
+++ b/app/Rules/BooleanEncrypted.php
@@ -2,28 +2,28 @@
 
 namespace App\Rules;
 
-use App\Models\CustomField;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Validation\Concerns\ValidatesAttributes;
 
-class MACEncrypted implements ValidationRule
+class BooleanEncrypted implements ValidationRule
 {
     use ValidatesAttributes;
 
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         try {
             $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
             $decrypted = Crypt::decrypt($value);
-            if (!$this->validateRegex($attributeName, $decrypted, ['/^[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}$/']) && !is_null($decrypted)) {
-                $fail(trans('validation.mac_address', ['attribute' => $attributeName]));
+
+            if (!$this->validateBoolean($attributeName, $decrypted) && !is_null($decrypted)) {
+                $fail(trans('validation.ipv6', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {
             report($e);

--- a/app/Rules/DateEncrypted.php
+++ b/app/Rules/DateEncrypted.php
@@ -7,9 +7,10 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Validation\Concerns\ValidatesAttributes;
 
-class AlphaEncrypted implements ValidationRule
+class DateEncrypted implements ValidationRule
 {
     use ValidatesAttributes;
+
     /**
      * Run the validation rule.
      *
@@ -20,8 +21,8 @@ class AlphaEncrypted implements ValidationRule
         try {
             $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
             $decrypted = Crypt::decrypt($value);
-            if (!$this->validateAlpha($attributeName, $decrypted, 'ascii') && !is_null($decrypted)) {
-                $fail(trans('validation.alpha', ['attribute' => $attributeName]));
+            if (!$this->validateDate($attributeName, $decrypted) && !is_null($decrypted)) {
+                $fail(trans('validation.date', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {
             report($e);

--- a/app/Rules/EmailEncrypted.php
+++ b/app/Rules/EmailEncrypted.php
@@ -7,21 +7,22 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Validation\Concerns\ValidatesAttributes;
 
-class AlphaEncrypted implements ValidationRule
+class EmailEncrypted implements ValidationRule
 {
     use ValidatesAttributes;
+
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         try {
             $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
             $decrypted = Crypt::decrypt($value);
-            if ($this->validateAlpha($attributeName, $decrypted, 'ascii') && !is_null($decrypted)) {
-                $fail(trans('validation.alpha', ['attribute' => $attributeName]));
+            if (!$this->validateEmail($attribute, $decrypted, []) && !is_null($decrypted)) {
+                $fail(trans('validation.email', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {
             report($e);

--- a/app/Rules/IPEncrypted.php
+++ b/app/Rules/IPEncrypted.php
@@ -7,9 +7,10 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Validation\Concerns\ValidatesAttributes;
 
-class AlphaEncrypted implements ValidationRule
+class IPEncrypted implements ValidationRule
 {
     use ValidatesAttributes;
+
     /**
      * Run the validation rule.
      *
@@ -20,8 +21,8 @@ class AlphaEncrypted implements ValidationRule
         try {
             $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
             $decrypted = Crypt::decrypt($value);
-            if (!$this->validateAlpha($attributeName, $decrypted, 'ascii') && !is_null($decrypted)) {
-                $fail(trans('validation.alpha', ['attribute' => $attributeName]));
+            if (!$this->validateIp($attributeName, $decrypted) && !is_null($decrypted)) {
+                $fail(trans('validation.ip', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {
             report($e);

--- a/app/Rules/IPv4Encrypted.php
+++ b/app/Rules/IPv4Encrypted.php
@@ -7,9 +7,10 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Validation\Concerns\ValidatesAttributes;
 
-class AlphaEncrypted implements ValidationRule
+class IPv4Encrypted implements ValidationRule
 {
     use ValidatesAttributes;
+
     /**
      * Run the validation rule.
      *
@@ -20,8 +21,8 @@ class AlphaEncrypted implements ValidationRule
         try {
             $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
             $decrypted = Crypt::decrypt($value);
-            if (!$this->validateAlpha($attributeName, $decrypted, 'ascii') && !is_null($decrypted)) {
-                $fail(trans('validation.alpha', ['attribute' => $attributeName]));
+            if (!$this->validateIpv4($attributeName, $decrypted) && !is_null($decrypted)) {
+                $fail(trans('validation.ipv4', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {
             report($e);

--- a/app/Rules/IPv6Encrypted.php
+++ b/app/Rules/IPv6Encrypted.php
@@ -7,9 +7,10 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Validation\Concerns\ValidatesAttributes;
 
-class AlphaEncrypted implements ValidationRule
+class IPv6Encrypted implements ValidationRule
 {
     use ValidatesAttributes;
+
     /**
      * Run the validation rule.
      *
@@ -20,8 +21,8 @@ class AlphaEncrypted implements ValidationRule
         try {
             $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
             $decrypted = Crypt::decrypt($value);
-            if (!$this->validateAlpha($attributeName, $decrypted, 'ascii') && !is_null($decrypted)) {
-                $fail(trans('validation.alpha', ['attribute' => $attributeName]));
+            if (!$this->validateIpv6($attributeName, $decrypted) && !is_null($decrypted)) {
+                $fail(trans('validation.ipv6', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {
             report($e);

--- a/app/Rules/MACEncrypted.php
+++ b/app/Rules/MACEncrypted.php
@@ -2,6 +2,7 @@
 
 namespace App\Rules;
 
+use App\Models\CustomField;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Crypt;
@@ -21,7 +22,7 @@ class MACEncrypted implements ValidationRule
         try {
             $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
             $decrypted = Crypt::decrypt($value);
-            if (!$this->validateMacAddress($attributeName, $decrypted, 'ascii') && !is_null($decrypted)) {
+            if (!$this->validateRegex($attributeName, $decrypted, ['/^[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}$/']) && !is_null($decrypted)) {
                 $fail(trans('validation.mac_address', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {

--- a/app/Rules/MACEncrypted.php
+++ b/app/Rules/MACEncrypted.php
@@ -7,9 +7,10 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Validation\Concerns\ValidatesAttributes;
 
-class AlphaEncrypted implements ValidationRule
+class MACEncrypted implements ValidationRule
 {
     use ValidatesAttributes;
+
     /**
      * Run the validation rule.
      *
@@ -20,8 +21,8 @@ class AlphaEncrypted implements ValidationRule
         try {
             $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
             $decrypted = Crypt::decrypt($value);
-            if (!$this->validateAlpha($attributeName, $decrypted, 'ascii') && !is_null($decrypted)) {
-                $fail(trans('validation.alpha', ['attribute' => $attributeName]));
+            if (!$this->validateMacAddress($attributeName, $decrypted, 'ascii') && !is_null($decrypted)) {
+                $fail(trans('validation.mac_address', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {
             report($e);

--- a/app/Rules/MacEncrypted.php
+++ b/app/Rules/MacEncrypted.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\CustomField;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Validation\Concerns\ValidatesAttributes;
+
+class MacEncrypted implements ValidationRule
+{
+    use ValidatesAttributes;
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        try {
+            $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
+            $decrypted = Crypt::decrypt($value);
+            if (!$this->validateRegex($attributeName, $decrypted, ['/^[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}$/']) && !is_null($decrypted)) {
+                $fail(trans('validation.mac_address', ['attribute' => $attributeName]));
+            }
+        } catch (\Exception $e) {
+            report($e);
+            $fail(trans('general.something_went_wrong'));
+        }
+    }
+}

--- a/app/Rules/NumericEncrypted.php
+++ b/app/Rules/NumericEncrypted.php
@@ -3,12 +3,17 @@
 namespace App\Rules;
 
 use Closure;
+use Egulias\EmailValidator\Validation\RFCValidation;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Validation\Concerns\ValidatesAttributes;
 
 class NumericEncrypted implements ValidationRule
 {
+    use ValidatesAttributes;
+
+    //$this->validateEmail($attribute, $decrypted);
     /**
      * Run the validation rule.
      *
@@ -16,13 +21,15 @@ class NumericEncrypted implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-
         try {
             $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
             $decrypted = Crypt::decrypt($value);
-            if (!is_numeric($decrypted) && !is_null($decrypted)) {
+            if (!$this->validateNumeric($attributeName, $decrypted) && !is_null($decrypted)) {
                 $fail(trans('validation.numeric', ['attribute' => $attributeName]));
             }
+            //if (!is_numeric($decrypted) && !is_null($decrypted)) {
+            //    $fail(trans('validation.numeric', ['attribute' => $attributeName]));
+            //}
         } catch (\Exception $e) {
             report($e->getMessage());
             $fail(trans('general.something_went_wrong'));

--- a/app/Rules/NumericEncrypted.php
+++ b/app/Rules/NumericEncrypted.php
@@ -13,7 +13,6 @@ class NumericEncrypted implements ValidationRule
 {
     use ValidatesAttributes;
 
-    //$this->validateEmail($attribute, $decrypted);
     /**
      * Run the validation rule.
      *
@@ -27,9 +26,6 @@ class NumericEncrypted implements ValidationRule
             if (!$this->validateNumeric($attributeName, $decrypted) && !is_null($decrypted)) {
                 $fail(trans('validation.numeric', ['attribute' => $attributeName]));
             }
-            //if (!is_numeric($decrypted) && !is_null($decrypted)) {
-            //    $fail(trans('validation.numeric', ['attribute' => $attributeName]));
-            //}
         } catch (\Exception $e) {
             report($e->getMessage());
             $fail(trans('general.something_went_wrong'));

--- a/app/Rules/RegexEncrypted.php
+++ b/app/Rules/RegexEncrypted.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\CustomField;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Validation\Concerns\ValidatesAttributes;
+
+class RegexEncrypted implements ValidationRule
+{
+    use ValidatesAttributes;
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $field = CustomField::where('db_column', $attribute)->first();
+        $regex = $field->format;
+        $regex = str_replace('regex:', '', $regex);
+        try {
+            $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
+            $decrypted = Crypt::decrypt($value);
+            if (!$this->validateRegex($attributeName, $decrypted, [$regex]) && !is_null($decrypted)) {
+                $fail(trans('validation.regex', ['attribute' => $attributeName]));
+            }
+        } catch (\Exception $e) {
+            report($e->getMessage());
+            $fail(trans('general.something_went_wrong'));
+        }
+    }
+}

--- a/app/Rules/UrlEncrypted.php
+++ b/app/Rules/UrlEncrypted.php
@@ -7,9 +7,10 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Validation\Concerns\ValidatesAttributes;
 
-class AlphaEncrypted implements ValidationRule
+class UrlEncrypted implements ValidationRule
 {
     use ValidatesAttributes;
+
     /**
      * Run the validation rule.
      *
@@ -20,8 +21,8 @@ class AlphaEncrypted implements ValidationRule
         try {
             $attributeName = trim(preg_replace('/_+|snipeit|\d+/', ' ', $attribute));
             $decrypted = Crypt::decrypt($value);
-            if (!$this->validateAlpha($attributeName, $decrypted, 'ascii') && !is_null($decrypted)) {
-                $fail(trans('validation.alpha', ['attribute' => $attributeName]));
+            if (!$this->validateUrl($attributeName, $decrypted, []) && !is_null($decrypted)) {
+                $fail(trans('validation.url', ['attribute' => $attributeName]));
             }
         } catch (\Exception $e) {
             report($e);

--- a/database/factories/CustomFieldFactory.php
+++ b/database/factories/CustomFieldFactory.php
@@ -93,6 +93,54 @@ class CustomFieldFactory extends Factory
         });
     }
 
+    public function encrypt()
+    {
+        return $this->state(function () {
+            return [
+                'field_encrypted' => '1',
+            ];
+        });
+    }
+
+    public function alpha()
+    {
+        return $this->state(function () {
+            return [
+                'format' => 'alpha',
+            ];
+        });
+    }
+
+    public function numeric()
+    {
+        return $this->state(function () {
+            return [
+                'format' => 'numeric',
+            ];
+        });
+    }
+
+    public function email()
+    {
+        return $this->state(function () {
+            return [
+                'format' => 'email',
+            ];
+        });
+    }
+
+    //public function testEncryptedAlpha()
+    //{
+    //    return $this->state(function () {
+    //        return [
+    //            'name'            => 'Test Encrypted',
+    //            'field_encrypted' => '1',
+    //            'help_text'       => 'This is a sample encrypted field.',
+    //            'format'          => 'alpha'
+    //        ];
+    //    });
+    //}
+
     public function testCheckbox()
     {
         return $this->state(function () {

--- a/database/factories/CustomFieldFactory.php
+++ b/database/factories/CustomFieldFactory.php
@@ -129,18 +129,6 @@ class CustomFieldFactory extends Factory
         });
     }
 
-    //public function testEncryptedAlpha()
-    //{
-    //    return $this->state(function () {
-    //        return [
-    //            'name'            => 'Test Encrypted',
-    //            'field_encrypted' => '1',
-    //            'help_text'       => 'This is a sample encrypted field.',
-    //            'format'          => 'alpha'
-    //        ];
-    //    });
-    //}
-
     public function testCheckbox()
     {
         return $this->state(function () {

--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -723,6 +723,65 @@ class StoreAssetTest extends TestCase
         $this->assertEquals('This is encrypted field', Crypt::decrypt($asset->{$field->db_column_name()}));
     }
 
+    public function test_encrypted_custom_field_validation_passes()
+    {
+        $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');
+
+        $status = Statuslabel::factory()->readyToDeploy()->create();
+        $alphaField = CustomField::factory()->encrypt()->alpha()->create();
+        $numericField = CustomField::factory()->encrypt()->numeric()->create();
+        $emailField = CustomField::factory()->encrypt()->email()->create();
+        $fields = [$alphaField, $numericField, $emailField];
+        $superuser = User::factory()->superuser()->create();
+        $assetData = Asset::factory()->hasMultipleCustomFields($fields)->make();
+
+        $response = $this->actingAsForApi($superuser)
+            ->postJson(route('api.assets.store'), [
+                $alphaField->db_column_name()   => 'Thisisencryptedfield',
+                $numericField->db_column_name() => '1234567890',
+                $emailField->db_column_name()   => 'poop@poop.com',
+                'model_id'                      => $assetData->model->id,
+                'status_id'                     => $status->id,
+                'asset_tag'                     => '1234',
+            ])
+            ->assertStatusMessageIs('success')
+            ->assertOk()
+            ->json();
+
+        $asset = Asset::findOrFail($response['payload']['id']);
+        $this->assertEquals('Thisisencryptedfield', Crypt::decrypt($asset->{$alphaField->db_column_name()}));
+        $this->assertEquals('1234567890', Crypt::decrypt($asset->{$numericField->db_column_name()}));
+        $this->assertEquals('poop@poop.com', Crypt::decrypt($asset->{$emailField->db_column_name()}));
+    }
+
+    public function test_encrypted_custom_field_validation_fails()
+    {
+        $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');
+
+        $status = Statuslabel::factory()->readyToDeploy()->create();
+        $alphaField = CustomField::factory()->encrypt()->alpha()->create();
+        $numericField = CustomField::factory()->encrypt()->numeric()->create();
+        $emailField = CustomField::factory()->encrypt()->email()->create();
+        $fields = [$alphaField, $numericField, $emailField];
+        $superuser = User::factory()->superuser()->create();
+        $assetData = Asset::factory()->hasMultipleCustomFields($fields)->make();
+        $cleaned_name = trim(preg_replace('/_+|snipeit|\d+/', ' ', $alphaField->db_column_name()));
+
+        $response = $this->actingAsForApi($superuser)
+            ->postJson(route('api.assets.store'), [
+                $alphaField->db_column_name() => 'Thisisencryptedfield123',
+                'model_id'                    => $assetData->model->id,
+                'status_id'                   => $status->id,
+                'asset_tag'                   => '1234',
+            ])
+            ->dump()
+            ->assertStatusMessageIs('error')
+            ->assertJsonPath('messages.'.$alphaField->db_column_name(), [trans('validation.alpha', ['attribute' => $cleaned_name])])
+            ->assertOk()
+            ->json();
+    }
+
+
     public function testPermissionNeededToStoreEncryptedField()
     {
         // @todo:

--- a/tests/Feature/Assets/Ui/BulkEditAssetsTest.php
+++ b/tests/Feature/Assets/Ui/BulkEditAssetsTest.php
@@ -29,7 +29,7 @@ class BulkEditAssetsTest extends TestCase
         ])->assertStatus(200);
     }
 
-    public function testStandardUserCannotAccessPage()
+    public function test_standard_user_cannot_access_page()
     {
         $user = User::factory()->create();
         $assets = Asset::factory()->count(2)->create();
@@ -44,7 +44,7 @@ class BulkEditAssetsTest extends TestCase
         ])->assertStatus(403);
     }
 
-    public function testBulkEditAssetsAcceptsAllPossibleAttributes()
+    public function test_bulk_edit_assets_accepts_all_possible_attributes()
     {
         // sets up all needed models and attributes on the assets
         // this test does not deal with custom fields - will be dealt with in separate cases
@@ -112,7 +112,7 @@ class BulkEditAssetsTest extends TestCase
         });
     }
 
-    public function testBulkEditAssetsNullsOutFieldsIfSelected()
+    public function test_bulk_edit_assets_nulls_out_fields_if_selected()
     {
         // sets up all needed models and attributes on the assets
         // this test does not deal with custom fields - will be dealt with in separate cases
@@ -165,7 +165,7 @@ class BulkEditAssetsTest extends TestCase
         });
     }
 
-    public function testBulkEditAssetsAcceptsAndUpdatesUnencryptedCustomFields()
+    public function test_bulk_edit_assets_accepts_and_updates_unencrypted_custom_fields()
     {
         $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');
 
@@ -197,7 +197,7 @@ class BulkEditAssetsTest extends TestCase
         });
     }
 
-    public function testBulkEditAssetsNullsCustomFieldsIfSelected()
+    public function test_bulk_edit_assets_nulls_custom_fields_if_selected()
     {
         $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');
 
@@ -238,7 +238,7 @@ class BulkEditAssetsTest extends TestCase
         });
     }
 
-    public function testBulkEditAssetsAcceptsAndUpdatesEncryptedCustomFields()
+    public function test_bulk_edit_assets_accepts_and_updates_encrypted_custom_fields()
     {
         $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');
 
@@ -262,7 +262,7 @@ class BulkEditAssetsTest extends TestCase
         });
     }
 
-    public function testBulkEditAssetsRequiresadminToUpdateEncryptedCustomFields()
+    public function test_bulk_edit_assets_requires_admin_to_update_encrypted_custom_fields()
     {
         $this->markIncompleteIfMySQL('Custom Fields tests do not work on mysql');
         $edit_user = User::factory()->editAssets()->create();


### PR DESCRIPTION
Validation now works on all available formats for encrypted custom fields. I had written a couple of these rules a while back and did the validation manually using PHP native methods, but I switched to using the Laravel methods for this and expanded it to all of the available formats. Doesn't look like much, but took some time to get everything working, especially the custom regex format. 

Fixes #9511 