### PR TITLE
Fixed #17441 - hardware listings "remembered" page numbers between statuses

### DIFF
--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -67,8 +67,8 @@
                    
               <table
                 data-columns="{{ \App\Presenters\AssetPresenter::dataTableLayout() }}"
-                data-cookie-id-table="assetsListingTable"
-                data-id-table="assetsListingTable"
+                data-cookie-id-table="{{ request()->has('status') ? e(request()->input('status')) : ''  }}assetsListingTable"
+                data-id-table="{{ request()->has('status') ? e(request()->input('status')) : ''  }}assetsListingTable"
                 data-search-text="{{ e(Session::get('search')) }}"
                 data-side-pagination="server"
                 data-show-footer="true"
@@ -77,7 +77,7 @@
                 data-toolbar="#assetsBulkEditToolbar"
                 data-bulk-button-id="#bulkAssetEditButton"
                 data-bulk-form-id="#assetsBulkForm"
-                id="assetsListingTable"
+                id="{{ request()->has('status') ? e(request()->input('status')) : ''  }}assetsListingTable"
                 class="table table-striped snipe-table"
                 data-url="{{ route('api.assets.index',
                     array('status' => e(Request::get('status')),


### PR DESCRIPTION
This checks to see if the request has a status passed and prepends that to the table IDs so that the page number are stored specifically for those statuses. 

Fixes #17441