### PR TITLE
Updated some JS packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "bootstrap-less": "^3.3.8",
                 "bootstrap-table": "1.24.1",
                 "canvas-confetti": "^1.9.3",
-                "chart.js": "^2.9.4",
+                "chart.js": "4.5.0",
                 "clipboard": "^2.0.11",
                 "css-loader": "^5.0.0",
                 "ekko-lightbox": "^5.1.1",
@@ -26,7 +26,7 @@
                 "jquery-ui": "^1.14.1",
                 "jquery-validation": "^1.21.0",
                 "jquery.iframe-transport": "^1.0.0",
-                "jspdf-autotable": "^3.8.4",
+                "jspdf-autotable": "^5.0.2",
                 "less": "^4.2.2",
                 "less-loader": "^6.0",
                 "list.js": "^1.5.0",
@@ -35,18 +35,17 @@
                 "select2": "4.0.13",
                 "sheetjs": "^2.0.0",
                 "signature_pad": "^4.2.0",
-                "tableexport.jquery.plugin": "1.32.0",
-                "tether": "^1.4.0",
-                "webpack": "^5.98.0"
+                "tableexport.jquery.plugin": "^1.9.9",
+                "tether": "^1.4.0"
             },
             "devDependencies": {
                 "all-contributors-cli": "^6.26.1",
                 "axios": "^1.7.2",
-                "babel-preset-latest": "^6.24.1",
                 "jquery": "<3.6.0",
                 "laravel-mix": "^6.0.49",
                 "lodash": "^4.17.20",
-                "postcss": "^8.4.5"
+                "postcss": "^8.4.5",
+                "webpack": "^5.2.2"
             },
             "engines": {
                 "node": ">=0.12"
@@ -65,16 +64,24 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.24.2",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/highlight": "^7.24.2",
-                "picocolors": "^1.0.0"
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
+        },
+        "node_modules/@babel/code-frame/node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
         },
         "node_modules/@babel/compat-data": {
             "version": "7.24.4",
@@ -481,17 +488,19 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.1",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.5",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -518,97 +527,26 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.24.5",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+            "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.24.0",
-                "@babel/traverse": "^7.24.5",
-                "@babel/types": "^7.24.5"
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.28.2"
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight": {
-            "version": "7.24.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.24.5",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/chalk": {
-            "version": "2.4.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-convert": {
-            "version": "1.9.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-name": {
-            "version": "1.1.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@babel/highlight/node_modules/has-flag": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/js-tokens": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@babel/highlight/node_modules/supports-color": {
-            "version": "5.5.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.24.5",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+            "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
             "dev": true,
-            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.0"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -1809,23 +1747,22 @@
             "license": "MIT"
         },
         "node_modules/@babel/runtime": {
-            "version": "7.24.5",
-            "license": "MIT",
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+            "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.24.0",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.23.5",
-                "@babel/parser": "^7.24.0",
-                "@babel/types": "^7.24.0"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.2",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1881,24 +1818,16 @@
             "license": "MIT"
         },
         "node_modules/@babel/types": {
-            "version": "7.24.5",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.1",
-                "@babel/helper-validator-identifier": "^7.24.5",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/types/node_modules/to-fast-properties": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/@colors/colors": {
@@ -1972,6 +1901,11 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@kurkle/color": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
+        },
         "node_modules/@leichtgewicht/ip-codec": {
             "version": "2.0.5",
             "dev": true,
@@ -2008,7 +1942,8 @@
         },
         "node_modules/@swc/helpers": {
             "version": "0.3.17",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+            "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -2124,9 +2059,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
         },
         "node_modules/@types/express": {
             "version": "4.17.21",
@@ -2306,6 +2241,12 @@
             "version": "1.3.6",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "optional": true
         },
         "node_modules/@types/ws": {
             "version": "8.5.10",
@@ -2502,9 +2443,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.14.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-            "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2517,6 +2458,17 @@
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^8"
+            }
+        },
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
             }
         },
         "node_modules/acorn-node": {
@@ -2547,14 +2499,16 @@
         },
         "node_modules/adler-32": {
             "version": "1.3.1",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+            "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
             "engines": {
                 "node": ">=0.8"
             }
         },
         "node_modules/admin-lte": {
-            "version": "v2.4.18",
-            "license": "MIT",
+            "version": "2.4.18",
+            "resolved": "https://registry.npmjs.org/admin-lte/-/admin-lte-2.4.18.tgz",
+            "integrity": "sha512-AfIdoUWdbQA0OmW7PnP8GJ3u6RMKNXefN3DRTBHCQXd7VeyJahUfZWtV62ppDxcdjpx0L08ypPV55ARmdGdOIw==",
             "dependencies": {
                 "bootstrap": "^3.4",
                 "bootstrap-colorpicker": "^2.5.3",
@@ -2729,11 +2683,12 @@
             }
         },
         "node_modules/array-buffer-byte-length": {
-            "version": "1.0.1",
-            "license": "MIT",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+            "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
             "dependencies": {
-                "call-bind": "^1.0.5",
-                "is-array-buffer": "^3.0.4"
+                "call-bound": "^1.0.3",
+                "is-array-buffer": "^3.0.5"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2796,8 +2751,9 @@
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true
         },
         "node_modules/atob": {
             "version": "2.1.2",
@@ -2859,190 +2815,14 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
             "dev": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
+                "form-data": "^4.0.4",
                 "proxy-from-env": "^1.1.0"
-            }
-        },
-        "node_modules/babel-code-frame": {
-            "version": "6.26.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
-            }
-        },
-        "node_modules/babel-code-frame/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/babel-code-frame/node_modules/ansi-styles": {
-            "version": "2.2.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/babel-code-frame/node_modules/chalk": {
-            "version": "1.1.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/babel-code-frame/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/babel-code-frame/node_modules/supports-color": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/babel-helper-builder-binary-assignment-operator-visitor": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-explode-assignable-expression": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-call-delegate": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-define-map": {
-            "version": "6.26.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "node_modules/babel-helper-explode-assignable-expression": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-function-name": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-get-function-arity": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-hoist-variables": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-optimise-call-expression": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-regex": {
-            "version": "6.26.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "node_modules/babel-helper-remap-async-to-generator": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-helper-replace-supers": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
             }
         },
         "node_modules/babel-loader": {
@@ -3078,22 +2858,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/babel-messages": {
-            "version": "6.23.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-check-es2015-constants": {
-            "version": "6.22.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
@@ -3138,389 +2902,6 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-            }
-        },
-        "node_modules/babel-plugin-syntax-async-functions": {
-            "version": "6.13.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/babel-plugin-syntax-exponentiation-operator": {
-            "version": "6.13.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/babel-plugin-syntax-trailing-function-commas": {
-            "version": "6.22.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/babel-plugin-transform-async-to-generator": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-remap-async-to-generator": "^6.24.1",
-                "babel-plugin-syntax-async-functions": "^6.8.0",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-arrow-functions": {
-            "version": "6.22.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-block-scoped-functions": {
-            "version": "6.22.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-block-scoping": {
-            "version": "6.26.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-classes": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-define-map": "^6.24.1",
-                "babel-helper-function-name": "^6.24.1",
-                "babel-helper-optimise-call-expression": "^6.24.1",
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-computed-properties": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-destructuring": {
-            "version": "6.23.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-duplicate-keys": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-for-of": {
-            "version": "6.23.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-function-name": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-function-name": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-literals": {
-            "version": "6.22.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-modules-amd": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-modules-commonjs": {
-            "version": "6.26.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-plugin-transform-strict-mode": "^6.24.1",
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-types": "^6.26.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-modules-systemjs": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-hoist-variables": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-modules-umd": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-object-super": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-replace-supers": "^6.24.1",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-parameters": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-call-delegate": "^6.24.1",
-                "babel-helper-get-function-arity": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1",
-                "babel-traverse": "^6.24.1",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-shorthand-properties": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-spread": {
-            "version": "6.22.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-sticky-regex": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-template-literals": {
-            "version": "6.22.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-typeof-symbol": {
-            "version": "6.23.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-es2015-unicode-regex": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-regex": "^6.24.1",
-                "babel-runtime": "^6.22.0",
-                "regexpu-core": "^2.0.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-exponentiation-operator": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-                "babel-runtime": "^6.22.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-regenerator": {
-            "version": "6.26.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "regenerator-transform": "^0.10.0"
-            }
-        },
-        "node_modules/babel-plugin-transform-strict-mode": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.22.0",
-                "babel-types": "^6.24.1"
-            }
-        },
-        "node_modules/babel-preset-es2015": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-plugin-check-es2015-constants": "^6.22.0",
-                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-                "babel-plugin-transform-es2015-classes": "^6.24.1",
-                "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-                "babel-plugin-transform-es2015-destructuring": "^6.22.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-                "babel-plugin-transform-es2015-for-of": "^6.22.0",
-                "babel-plugin-transform-es2015-function-name": "^6.24.1",
-                "babel-plugin-transform-es2015-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-                "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-                "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-                "babel-plugin-transform-es2015-object-super": "^6.24.1",
-                "babel-plugin-transform-es2015-parameters": "^6.24.1",
-                "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-                "babel-plugin-transform-es2015-spread": "^6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-                "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-                "babel-plugin-transform-regenerator": "^6.24.1"
-            }
-        },
-        "node_modules/babel-preset-es2016": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-plugin-transform-exponentiation-operator": "^6.24.1"
-            }
-        },
-        "node_modules/babel-preset-es2017": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-                "babel-plugin-transform-async-to-generator": "^6.24.1"
-            }
-        },
-        "node_modules/babel-preset-latest": {
-            "version": "6.24.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-preset-es2015": "^6.24.1",
-                "babel-preset-es2016": "^6.24.1",
-                "babel-preset-es2017": "^6.24.1"
-            }
-        },
-        "node_modules/babel-runtime": {
-            "version": "6.26.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
-            }
-        },
-        "node_modules/babel-runtime/node_modules/regenerator-runtime": {
-            "version": "0.11.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/babel-template": {
-            "version": "6.26.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "lodash": "^4.17.4"
-            }
-        },
-        "node_modules/babel-traverse": {
-            "version": "6.26.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-code-frame": "^6.26.0",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "debug": "^2.6.8",
-                "globals": "^9.18.0",
-                "invariant": "^2.2.2",
-                "lodash": "^4.17.4"
-            }
-        },
-        "node_modules/babel-types": {
-            "version": "6.26.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "babel-runtime": "^6.26.0",
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.4",
-                "to-fast-properties": "^1.0.3"
-            }
-        },
-        "node_modules/babylon": {
-            "version": "6.18.0",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "babylon": "bin/babylon.js"
             }
         },
         "node_modules/balanced-match": {
@@ -3607,9 +2988,10 @@
             "license": "MIT"
         },
         "node_modules/body-parser": {
-            "version": "1.20.2",
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.5",
@@ -3619,7 +3001,7 @@
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
@@ -3627,28 +3009,6 @@
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/body-parser/node_modules/bytes": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/body-parser/node_modules/qs": {
-            "version": "6.11.0",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/bonjour-service": {
@@ -3710,18 +3070,20 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "license": "MIT",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "license": "MIT",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -3733,7 +3095,8 @@
         },
         "node_modules/brotli": {
             "version": "1.3.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+            "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
             "dependencies": {
                 "base64-js": "^1.1.2"
             }
@@ -4027,9 +3390,10 @@
             "license": "MIT"
         },
         "node_modules/bytes": {
-            "version": "3.0.0",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -4039,14 +3403,41 @@
             "license": "MIT"
         },
         "node_modules/call-bind": {
-            "version": "1.0.7",
-            "license": "MIT",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+            "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
             "dependencies": {
+                "call-bind-apply-helpers": "^1.0.0",
                 "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
                 "get-intrinsic": "^1.2.4",
-                "set-function-length": "^1.2.1"
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4120,8 +3511,9 @@
             }
         },
         "node_modules/canvg": {
-            "version": "3.0.10",
-            "license": "MIT",
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+            "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
             "optional": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
@@ -4154,7 +3546,8 @@
         },
         "node_modules/cfb": {
             "version": "1.2.2",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+            "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
             "dependencies": {
                 "adler-32": "~1.3.0",
                 "crc-32": "~1.2.0"
@@ -4196,38 +3589,15 @@
             "license": "MIT/X11"
         },
         "node_modules/chart.js": {
-            "version": "2.9.4",
-            "license": "MIT",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+            "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
             "dependencies": {
-                "chartjs-color": "^2.1.0",
-                "moment": "^2.10.2"
+                "@kurkle/color": "^0.3.0"
+            },
+            "engines": {
+                "pnpm": ">=8"
             }
-        },
-        "node_modules/chartjs-color": {
-            "version": "2.4.1",
-            "license": "MIT",
-            "dependencies": {
-                "chartjs-color-string": "^0.6.0",
-                "color-convert": "^1.9.3"
-            }
-        },
-        "node_modules/chartjs-color-string": {
-            "version": "0.6.0",
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "^1.0.0"
-            }
-        },
-        "node_modules/chartjs-color/node_modules/color-convert": {
-            "version": "1.9.3",
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/chartjs-color/node_modules/color-name": {
-            "version": "1.1.3",
-            "license": "MIT"
         },
         "node_modules/chokidar": {
             "version": "3.6.0",
@@ -4363,7 +3733,8 @@
         },
         "node_modules/codepage": {
             "version": "1.15.0",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+            "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
             "engines": {
                 "node": ">=0.8"
             }
@@ -4386,6 +3757,7 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/colord": {
@@ -4425,8 +3797,9 @@
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -4459,26 +3832,31 @@
             }
         },
         "node_modules/compression": {
-            "version": "1.7.4",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+            "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "accepts": "~1.3.5",
-                "bytes": "3.0.0",
-                "compressible": "~2.0.16",
+                "bytes": "3.1.2",
+                "compressible": "~2.0.18",
                 "debug": "2.6.9",
-                "on-headers": "~1.0.2",
-                "safe-buffer": "5.1.2",
+                "negotiator": "~0.6.4",
+                "on-headers": "~1.1.0",
+                "safe-buffer": "5.2.1",
                 "vary": "~1.1.2"
             },
             "engines": {
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/compression/node_modules/safe-buffer": {
-            "version": "5.1.2",
+        "node_modules/compression/node_modules/negotiator": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
             "dev": true,
-            "license": "MIT"
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/concat": {
             "version": "1.0.3",
@@ -4549,8 +3927,9 @@
         },
         "node_modules/content-type": {
             "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4561,9 +3940,10 @@
             "license": "MIT"
         },
         "node_modules/cookie": {
-            "version": "0.6.0",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4582,12 +3962,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/mesqueeb"
             }
-        },
-        "node_modules/core-js": {
-            "version": "2.6.12",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT"
         },
         "node_modules/core-js-compat": {
             "version": "3.37.0",
@@ -4622,7 +3996,8 @@
         },
         "node_modules/crc-32": {
             "version": "1.2.2",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+            "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
             "bin": {
                 "crc32": "bin/crc32.njs"
             },
@@ -4666,9 +4041,10 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -4708,7 +4084,8 @@
         },
         "node_modules/crypto-js": {
             "version": "4.2.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+            "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
         },
         "node_modules/css-declaration-sorter": {
             "version": "6.4.1",
@@ -4937,7 +4314,8 @@
         },
         "node_modules/deep-equal": {
             "version": "2.2.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.0",
                 "call-bind": "^1.0.5",
@@ -4967,7 +4345,8 @@
         },
         "node_modules/deep-equal/node_modules/isarray": {
             "version": "2.0.5",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         },
         "node_modules/default-gateway": {
             "version": "6.0.3",
@@ -5027,8 +4406,9 @@
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -5039,8 +4419,9 @@
         },
         "node_modules/depd": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -5068,8 +4449,9 @@
         },
         "node_modules/destroy": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
@@ -5097,7 +4479,8 @@
         },
         "node_modules/dfa": {
             "version": "1.2.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+            "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
         },
         "node_modules/didyoumean": {
             "version": "1.2.2",
@@ -5210,9 +4593,13 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "2.5.2",
-            "license": "(MPL-2.0 OR Apache-2.0)",
-            "optional": true
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+            "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+            "optional": true,
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
         },
         "node_modules/domutils": {
             "version": "2.8.0",
@@ -5263,6 +4650,19 @@
             "dev": true,
             "license": "BSD-2-Clause"
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/duplexer2": {
             "version": "0.1.4",
             "license": "BSD-3-Clause",
@@ -5272,8 +4672,9 @@
         },
         "node_modules/ee-first": {
             "version": "1.1.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "dev": true
         },
         "node_modules/ekko-lightbox": {
             "version": "5.3.0",
@@ -5285,8 +4686,9 @@
             "integrity": "sha512-xtoijJTZ+qeucLBDNztDOuQBE1ksqjvNjvqFoST3nGC7fSpqJ+X6BdTBaY5BHG+IhWWmpc6b/KfpeuEDupEPOQ=="
         },
         "node_modules/elliptic": {
-            "version": "6.5.5",
-            "license": "MIT",
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
             "dependencies": {
                 "bn.js": "^4.11.9",
                 "brorand": "^1.1.0",
@@ -5314,17 +4716,18 @@
             }
         },
         "node_modules/encodeurl": {
-            "version": "1.0.2",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.17.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
-            "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+            "version": "5.18.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
+            "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -5372,11 +4775,9 @@
             }
         },
         "node_modules/es-define-property": {
-            "version": "1.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "get-intrinsic": "^1.2.4"
-            },
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -5390,7 +4791,8 @@
         },
         "node_modules/es-get-iterator": {
             "version": "1.1.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.3",
@@ -5408,11 +4810,38 @@
         },
         "node_modules/es-get-iterator/node_modules/isarray": {
             "version": "2.0.5",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         },
         "node_modules/es-module-lexer": {
             "version": "1.5.2",
             "license": "MIT"
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/escalade": {
             "version": "3.2.0",
@@ -5480,8 +4909,9 @@
         },
         "node_modules/etag": {
             "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5532,36 +4962,37 @@
             }
         },
         "node_modules/express": {
-            "version": "4.19.2",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.2",
+                "body-parser": "1.20.3",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.6.0",
+                "cookie": "0.7.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
+                "finalhandler": "1.3.1",
                 "fresh": "0.5.2",
                 "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
+                "merge-descriptors": "1.0.3",
                 "methods": "~1.1.2",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
+                "path-to-regexp": "0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
+                "send": "0.19.0",
+                "serve-static": "1.16.2",
                 "setprototypeof": "1.2.0",
                 "statuses": "2.0.1",
                 "type-is": "~1.6.18",
@@ -5570,20 +5001,10 @@
             },
             "engines": {
                 "node": ">= 0.10.0"
-            }
-        },
-        "node_modules/express/node_modules/qs": {
-            "version": "6.11.0",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">=0.6"
             },
             "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/external-editor": {
@@ -5670,8 +5091,9 @@
             }
         },
         "node_modules/fflate": {
-            "version": "0.4.8",
-            "license": "MIT"
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
         },
         "node_modules/figures": {
             "version": "3.2.0",
@@ -5726,8 +5148,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "license": "MIT",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -5736,12 +5159,13 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "1.2.0",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
@@ -5819,7 +5243,8 @@
         },
         "node_modules/fontkit": {
             "version": "1.9.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
+            "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
             "dependencies": {
                 "@swc/helpers": "^0.3.13",
                 "brotli": "^1.3.2",
@@ -5833,19 +5258,29 @@
             }
         },
         "node_modules/for-each": {
-            "version": "0.3.3",
-            "license": "MIT",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
             "dependencies": {
-                "is-callable": "^1.1.3"
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.0",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
                 "mime-types": "^2.1.12"
             },
             "engines": {
@@ -5862,7 +5297,8 @@
         },
         "node_modules/frac": {
             "version": "1.1.2",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+            "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
             "engines": {
                 "node": ">=0.8"
             }
@@ -5881,8 +5317,9 @@
         },
         "node_modules/fresh": {
             "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -5938,7 +5375,8 @@
         },
         "node_modules/functions-have-names": {
             "version": "1.2.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -5964,20 +5402,38 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.4",
-            "license": "MIT",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
                 "function-bind": "^1.1.2",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0"
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-stream": {
@@ -6023,14 +5479,6 @@
             "version": "0.4.1",
             "license": "BSD-2-Clause"
         },
-        "node_modules/globals": {
-            "version": "9.18.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/globby": {
             "version": "12.2.0",
             "license": "MIT",
@@ -6067,10 +5515,11 @@
             }
         },
         "node_modules/gopd": {
-            "version": "1.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "get-intrinsic": "^1.1.3"
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -6097,28 +5546,13 @@
                 "node": ">= 0.4.0"
             }
         },
-        "node_modules/has-ansi": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/has-ansi/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/has-bigints": {
-            "version": "1.0.2",
-            "license": "MIT",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+            "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -6140,19 +5574,10 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/has-proto": {
-            "version": "1.0.3",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/has-symbols": {
-            "version": "1.0.3",
-            "license": "MIT",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -6367,8 +5792,9 @@
         },
         "node_modules/http-errors": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "depd": "2.0.0",
                 "inherits": "2.0.4",
@@ -6399,9 +5825,10 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.6",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/http-proxy": "^1.17.8",
                 "http-proxy": "^1.18.1",
@@ -6650,12 +6077,13 @@
             }
         },
         "node_modules/internal-slot": {
-            "version": "1.0.7",
-            "license": "MIT",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+            "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "hasown": "^2.0.0",
-                "side-channel": "^1.0.4"
+                "hasown": "^2.0.2",
+                "side-channel": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6667,14 +6095,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/invariant": {
-            "version": "2.2.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.0.0"
             }
         },
         "node_modules/ion-rangeslider": {
@@ -6714,11 +6134,13 @@
             }
         },
         "node_modules/is-array-buffer": {
-            "version": "3.0.4",
-            "license": "MIT",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+            "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1"
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "get-intrinsic": "^1.2.6"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6733,10 +6155,14 @@
             "license": "MIT"
         },
         "node_modules/is-bigint": {
-            "version": "1.0.4",
-            "license": "MIT",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+            "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
             "dependencies": {
-                "has-bigints": "^1.0.1"
+                "has-bigints": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -6754,11 +6180,12 @@
             }
         },
         "node_modules/is-boolean-object": {
-            "version": "1.1.2",
-            "license": "MIT",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+            "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.3",
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6773,7 +6200,8 @@
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -6792,10 +6220,12 @@
             }
         },
         "node_modules/is-date-object": {
-            "version": "1.0.5",
-            "license": "MIT",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+            "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
             "dependencies": {
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.2",
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6858,7 +6288,8 @@
         },
         "node_modules/is-map": {
             "version": "2.0.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+            "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -6868,16 +6299,19 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "engines": {
                 "node": ">=0.12.0"
             }
         },
         "node_modules/is-number-object": {
-            "version": "1.0.7",
-            "license": "MIT",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+            "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
             "dependencies": {
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.3",
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6909,11 +6343,14 @@
             }
         },
         "node_modules/is-regex": {
-            "version": "1.1.4",
-            "license": "MIT",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.2",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6924,7 +6361,8 @@
         },
         "node_modules/is-set": {
             "version": "2.0.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+            "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -6933,10 +6371,11 @@
             }
         },
         "node_modules/is-shared-array-buffer": {
-            "version": "1.0.3",
-            "license": "MIT",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+            "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
             "dependencies": {
-                "call-bind": "^1.0.7"
+                "call-bound": "^1.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6957,10 +6396,12 @@
             }
         },
         "node_modules/is-string": {
-            "version": "1.0.7",
-            "license": "MIT",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+            "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
             "dependencies": {
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.3",
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6970,10 +6411,13 @@
             }
         },
         "node_modules/is-symbol": {
-            "version": "1.0.4",
-            "license": "MIT",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+            "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
             "dependencies": {
-                "has-symbols": "^1.0.2"
+                "call-bound": "^1.0.2",
+                "has-symbols": "^1.1.0",
+                "safe-regex-test": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6983,10 +6427,11 @@
             }
         },
         "node_modules/is-typed-array": {
-            "version": "1.1.13",
-            "license": "MIT",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
             "dependencies": {
-                "which-typed-array": "^1.1.14"
+                "which-typed-array": "^1.1.16"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6997,7 +6442,8 @@
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+            "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -7006,11 +6452,12 @@
             }
         },
         "node_modules/is-weakset": {
-            "version": "2.0.3",
-            "license": "MIT",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+            "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
             "dependencies": {
-                "call-bind": "^1.0.7",
-                "get-intrinsic": "^1.2.4"
+                "call-bound": "^1.0.3",
+                "get-intrinsic": "^1.2.6"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7114,11 +6561,6 @@
             "version": "1.0.0",
             "license": "MIT"
         },
-        "node_modules/js-tokens": {
-            "version": "3.0.2",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/jsesc": {
             "version": "2.5.2",
             "dev": true,
@@ -7194,27 +6636,28 @@
             }
         },
         "node_modules/jspdf": {
-            "version": "2.5.1",
-            "license": "MIT",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
+            "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
             "dependencies": {
-                "@babel/runtime": "^7.14.0",
+                "@babel/runtime": "^7.26.7",
                 "atob": "^2.1.2",
                 "btoa": "^1.2.1",
-                "fflate": "^0.4.8"
+                "fflate": "^0.8.1"
             },
             "optionalDependencies": {
-                "canvg": "^3.0.6",
+                "canvg": "^3.0.11",
                 "core-js": "^3.6.0",
-                "dompurify": "^2.2.0",
+                "dompurify": "^3.2.4",
                 "html2canvas": "^1.0.0-rc.5"
             }
         },
         "node_modules/jspdf-autotable": {
-            "version": "3.8.4",
-            "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-3.8.4.tgz",
-            "integrity": "sha512-rSffGoBsJYX83iTRv8Ft7FhqfgEL2nLpGAIiqruEQQ3e4r0qdLFbPUB7N9HAle0I3XgpisvyW751VHCqKUVOgQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.2.tgz",
+            "integrity": "sha512-YNKeB7qmx3pxOLcNeoqAv3qTS7KuvVwkFe5AduCawpop3NOkBUtqDToxNc225MlNecxT4kP2Zy3z/y/yvGdXUQ==",
             "peerDependencies": {
-                "jspdf": "^2.5.1"
+                "jspdf": "^2 || ^3"
             }
         },
         "node_modules/jspdf/node_modules/core-js": {
@@ -7633,7 +7076,8 @@
         },
         "node_modules/linebreak": {
             "version": "1.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+            "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
             "dependencies": {
                 "base64-js": "0.0.8",
                 "unicode-trie": "^2.0.0"
@@ -7641,7 +7085,8 @@
         },
         "node_modules/linebreak/node_modules/base64-js": {
             "version": "0.0.8",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+            "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -7711,17 +7156,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/loose-envify": {
-            "version": "1.4.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-            },
-            "bin": {
-                "loose-envify": "cli.js"
-            }
-        },
         "node_modules/lower-case": {
             "version": "2.0.2",
             "dev": true,
@@ -7760,6 +7194,14 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/md5": {
             "version": "2.3.0",
             "dev": true,
@@ -7786,8 +7228,9 @@
         },
         "node_modules/media-typer": {
             "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -7804,9 +7247,13 @@
             }
         },
         "node_modules/merge-descriptors": {
-            "version": "1.0.1",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
             "dev": true,
-            "license": "MIT"
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -7828,10 +7275,11 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "license": "MIT",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -8003,14 +7451,15 @@
             "license": "ISC"
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -8195,15 +7644,20 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.13.1",
-            "license": "MIT",
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/object-is": {
             "version": "1.1.6",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1"
@@ -8245,8 +7699,9 @@
         },
         "node_modules/on-finished": {
             "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ee-first": "1.1.1"
             },
@@ -8255,9 +7710,10 @@
             }
         },
         "node_modules/on-headers": {
-            "version": "1.0.2",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -8507,9 +7963,10 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.7",
-            "dev": true,
-            "license": "MIT"
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+            "dev": true
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -8519,22 +7976,53 @@
             }
         },
         "node_modules/pbkdf2": {
-            "version": "3.1.2",
-            "license": "MIT",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+            "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
             "dependencies": {
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4",
-                "ripemd160": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "create-hash": "~1.1.3",
+                "create-hmac": "^1.1.7",
+                "ripemd160": "=2.0.1",
+                "safe-buffer": "^5.2.1",
+                "sha.js": "^2.4.11",
+                "to-buffer": "^1.2.0"
             },
             "engines": {
                 "node": ">=0.12"
             }
         },
+        "node_modules/pbkdf2/node_modules/create-hash": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+            "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+            "dependencies": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/hash-base": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+            "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+            "dependencies": {
+                "inherits": "^2.0.1"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/ripemd160": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+            "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+            "dependencies": {
+                "hash-base": "^2.0.0",
+                "inherits": "^2.0.1"
+            }
+        },
         "node_modules/pdfkit": {
             "version": "0.12.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.12.3.tgz",
+            "integrity": "sha512-+qDLgm2yq6WOKcxTb43lDeo3EtMIDQs0CK1RNqhHC9iT6u0KOmgwAClkYh9xFw2ATbmUZzt4f7KMwDCOfPDluA==",
             "dependencies": {
                 "crypto-js": "^4.0.0",
                 "fontkit": "^1.8.1",
@@ -8544,7 +8032,8 @@
         },
         "node_modules/pdfmake": {
             "version": "0.1.72",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.1.72.tgz",
+            "integrity": "sha512-xZrPS+Safjf1I8ZYtMoXX83E6C6Pd1zFwa168yNTeeJWHclqf1z9DoYajjlY2uviN7gGyxwVZeou39uSk1oh1g==",
             "dependencies": {
                 "iconv-lite": "^0.6.2",
                 "linebreak": "^1.0.2",
@@ -8558,7 +8047,8 @@
         },
         "node_modules/pdfmake/node_modules/iconv-lite": {
             "version": "0.6.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -8631,7 +8121,9 @@
             }
         },
         "node_modules/png-js": {
-            "version": "1.0.0"
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+            "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
@@ -9182,14 +8674,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/private": {
-            "version": "0.1.8",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/process": {
             "version": "0.11.10",
             "license": "MIT",
@@ -9253,8 +8737,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.12.1",
-            "license": "BSD-3-Clause",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
             "dependencies": {
                 "side-channel": "^1.0.6"
             },
@@ -9329,22 +8814,15 @@
         },
         "node_modules/raw-body": {
             "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "bytes": "3.1.2",
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "unpipe": "1.0.0"
             },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/raw-body/node_modules/bytes": {
-            "version": "3.1.2",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -9444,67 +8922,23 @@
                 "node": ">=4"
             }
         },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "license": "MIT"
-        },
-        "node_modules/regenerator-transform": {
-            "version": "0.10.1",
-            "dev": true,
-            "license": "BSD",
-            "dependencies": {
-                "babel-runtime": "^6.18.0",
-                "babel-types": "^6.19.0",
-                "private": "^0.1.6"
-            }
-        },
         "node_modules/regexp.prototype.flags": {
-            "version": "1.5.2",
-            "license": "MIT",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+            "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
             "dependencies": {
-                "call-bind": "^1.0.6",
+                "call-bind": "^1.0.8",
                 "define-properties": "^1.2.1",
                 "es-errors": "^1.3.0",
-                "set-function-name": "^2.0.1"
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "set-function-name": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/regexpu-core": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "regenerate": "^1.2.1",
-                "regjsgen": "^0.2.0",
-                "regjsparser": "^0.1.4"
-            }
-        },
-        "node_modules/regjsgen": {
-            "version": "0.2.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/regjsparser": {
-            "version": "0.1.5",
-            "dev": true,
-            "license": "BSD",
-            "dependencies": {
-                "jsesc": "~0.5.0"
-            },
-            "bin": {
-                "regjsparser": "bin/parser"
-            }
-        },
-        "node_modules/regjsparser/node_modules/jsesc": {
-            "version": "0.5.0",
-            "dev": true,
-            "bin": {
-                "jsesc": "bin/jsesc"
             }
         },
         "node_modules/relateurl": {
@@ -9603,7 +9037,8 @@
         },
         "node_modules/restructure": {
             "version": "2.0.1",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
+            "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg=="
         },
         "node_modules/retry": {
             "version": "0.13.1",
@@ -9714,6 +9149,22 @@
             ],
             "license": "MIT"
         },
+        "node_modules/safe-regex-test": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "is-regex": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "license": "MIT"
@@ -9791,9 +9242,10 @@
             "license": "ISC"
         },
         "node_modules/send": {
-            "version": "0.18.0",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -9813,10 +9265,20 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/send/node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/send/node_modules/ms": {
             "version": "2.1.3",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true
         },
         "node_modules/serialize-javascript": {
             "version": "6.0.2",
@@ -9883,14 +9345,15 @@
             }
         },
         "node_modules/serve-static": {
-            "version": "1.15.0",
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
-                "send": "0.18.0"
+                "send": "0.19.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -9918,7 +9381,8 @@
         },
         "node_modules/set-function-name": {
             "version": "2.0.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+            "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",
@@ -9936,8 +9400,9 @@
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "dev": true
         },
         "node_modules/sha.js": {
             "version": "2.4.11",
@@ -10007,13 +9472,65 @@
             "license": "MIT"
         },
         "node_modules/side-channel": {
-            "version": "1.0.6",
-            "license": "MIT",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "dependencies": {
-                "call-bind": "^1.0.7",
                 "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.4",
-                "object-inspect": "^1.13.1"
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10190,7 +9707,8 @@
         },
         "node_modules/ssf": {
             "version": "0.11.2",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+            "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
             "dependencies": {
                 "frac": "~1.1.2"
             },
@@ -10213,8 +9731,9 @@
         },
         "node_modules/statuses": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -10225,10 +9744,12 @@
             "license": "MIT"
         },
         "node_modules/stop-iteration-iterator": {
-            "version": "1.0.0",
-            "license": "MIT",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
             "dependencies": {
-                "internal-slot": "^1.0.4"
+                "es-errors": "^1.3.0",
+                "internal-slot": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10401,7 +9922,8 @@
         },
         "node_modules/svg-to-pdfkit": {
             "version": "0.1.8",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/svg-to-pdfkit/-/svg-to-pdfkit-0.1.8.tgz",
+            "integrity": "sha512-QItiGZBy5TstGy+q8mjQTMGRlDDOARXLxH+sgVm1n/LYeo0zFcQlcCh8m4zi8QxctrxB9Kue/lStc/RD5iLadQ==",
             "dependencies": {
                 "pdfkit": ">=0.8.1"
             }
@@ -10434,9 +9956,9 @@
             }
         },
         "node_modules/tableexport.jquery.plugin": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/tableexport.jquery.plugin/-/tableexport.jquery.plugin-1.32.0.tgz",
-            "integrity": "sha512-TiZpNFzazMv+gipe9u2JHgBL0guh/kloZDBA0vayWZp35nOSZkIq9XrqjxLc8oX57r7JP58QcM6qEfAgI3xEqw==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/tableexport.jquery.plugin/-/tableexport.jquery.plugin-1.33.0.tgz",
+            "integrity": "sha512-GAN0fOL5+6hqowPgklnqCTjzQ53Lyh6QEQmOKwHsF6Cg87QS+fU5syajpL3Ztfr8F3MtpZDaR1b0anlMHzQbgg==",
             "dependencies": {
                 "file-saver": ">=2.0.4",
                 "html2canvas": ">=1.0.0",
@@ -10447,9 +9969,9 @@
             }
         },
         "node_modules/tapable": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+            "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
             "engines": {
                 "node": ">=6"
             }
@@ -10602,7 +10124,8 @@
         },
         "node_modules/tiny-inflate": {
             "version": "1.0.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
         },
         "node_modules/tmp": {
             "version": "0.0.33",
@@ -10620,17 +10143,28 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/to-fast-properties": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT",
+        "node_modules/to-buffer": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+            "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+            "dependencies": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">= 0.4"
             }
+        },
+        "node_modules/to-buffer/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -10640,8 +10174,9 @@
         },
         "node_modules/toidentifier": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.6"
             }
@@ -10688,14 +10223,28 @@
         },
         "node_modules/type-is": {
             "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "media-typer": "0.3.0",
                 "mime-types": "~2.1.24"
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/typedarray": {
@@ -10757,7 +10306,8 @@
         },
         "node_modules/unicode-properties": {
             "version": "1.4.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+            "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
             "dependencies": {
                 "base64-js": "^1.3.0",
                 "unicode-trie": "^2.0.0"
@@ -10773,7 +10323,8 @@
         },
         "node_modules/unicode-trie": {
             "version": "2.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+            "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
             "dependencies": {
                 "pako": "^0.2.5",
                 "tiny-inflate": "^1.0.0"
@@ -10781,7 +10332,8 @@
         },
         "node_modules/unicode-trie/node_modules/pako": {
             "version": "0.2.9",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+            "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
         },
         "node_modules/universalify": {
             "version": "2.0.1",
@@ -10793,8 +10345,9 @@
         },
         "node_modules/unpipe": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -10964,19 +10517,21 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/webpack": {
-            "version": "5.98.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
-            "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
+            "version": "5.100.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
+            "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.6",
+                "@types/estree": "^1.0.8",
+                "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.14.0",
+                "acorn": "^8.15.0",
+                "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.24.0",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
+                "enhanced-resolve": "^5.17.2",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -10986,11 +10541,11 @@
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.0",
+                "schema-utils": "^4.3.2",
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.3.11",
                 "watchpack": "^2.4.1",
-                "webpack-sources": "^3.2.3"
+                "webpack-sources": "^3.3.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -11303,9 +10858,9 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node_modules/webpack/node_modules/schema-utils": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-            "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
+            "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
                 "ajv": "^8.9.0",
@@ -11321,8 +10876,9 @@
             }
         },
         "node_modules/webpack/node_modules/webpack-sources": {
-            "version": "3.2.3",
-            "license": "MIT",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+            "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
             "engines": {
                 "node": ">=10.13.0"
             }
@@ -11389,14 +10945,18 @@
             }
         },
         "node_modules/which-boxed-primitive": {
-            "version": "1.0.2",
-            "license": "MIT",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+            "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
             "dependencies": {
-                "is-bigint": "^1.0.1",
-                "is-boolean-object": "^1.1.0",
-                "is-number-object": "^1.0.4",
-                "is-string": "^1.0.5",
-                "is-symbol": "^1.0.3"
+                "is-bigint": "^1.1.0",
+                "is-boolean-object": "^1.2.1",
+                "is-number-object": "^1.1.1",
+                "is-string": "^1.1.1",
+                "is-symbol": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -11404,7 +10964,8 @@
         },
         "node_modules/which-collection": {
             "version": "1.0.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+            "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
             "dependencies": {
                 "is-map": "^2.0.3",
                 "is-set": "^2.0.3",
@@ -11424,13 +10985,16 @@
             "license": "ISC"
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.15",
-            "license": "MIT",
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+            "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
                 "has-tostringtag": "^1.0.2"
             },
             "engines": {
@@ -11447,14 +11011,16 @@
         },
         "node_modules/wmf": {
             "version": "1.0.2",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+            "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
             "engines": {
                 "node": ">=0.8"
             }
         },
         "node_modules/word": {
             "version": "0.3.0",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+            "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
             "engines": {
                 "node": ">=0.8"
             }
@@ -11477,9 +11043,10 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.17.0",
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -11498,7 +11065,8 @@
         },
         "node_modules/xlsx": {
             "version": "0.18.5",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+            "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
             "dependencies": {
                 "adler-32": "~1.3.0",
                 "cfb": "~1.2.1",
@@ -11517,7 +11085,8 @@
         },
         "node_modules/xmldoc": {
             "version": "1.3.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-1.3.0.tgz",
+            "integrity": "sha512-y7IRWW6PvEnYQZNZFMRLNJw+p3pezM4nKYPfr15g4OOW9i8VpeydycFuipE2297OvZnh3jSb2pxOt9QpkZUVng==",
             "dependencies": {
                 "sax": "^1.2.4"
             }

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "devDependencies": {
         "all-contributors-cli": "^6.26.1",
         "axios": "^1.7.2",
-        "babel-preset-latest": "^6.24.1",
         "jquery": "<3.6.0",
         "laravel-mix": "^6.0.49",
         "lodash": "^4.17.20",
-        "postcss": "^8.4.5"
+        "postcss": "^8.4.5",
+        "webpack": "^5.2.2"
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.7.2",
@@ -37,7 +37,7 @@
         "bootstrap-less": "^3.3.8",
         "bootstrap-table": "1.24.1",
         "canvas-confetti": "^1.9.3",
-        "chart.js": "^2.9.4",
+        "chart.js": "4.5.0",
         "clipboard": "^2.0.11",
         "css-loader": "^5.0.0",
         "ekko-lightbox": "^5.1.1",
@@ -46,7 +46,7 @@
         "jquery-ui": "^1.14.1",
         "jquery-validation": "^1.21.0",
         "jquery.iframe-transport": "^1.0.0",
-        "jspdf-autotable": "^3.8.4",
+        "jspdf-autotable": "^5.0.2",
         "less": "^4.2.2",
         "less-loader": "^6.0",
         "list.js": "^1.5.0",
@@ -55,8 +55,7 @@
         "select2": "4.0.13",
         "sheetjs": "^2.0.0",
         "signature_pad": "^4.2.0",
-        "tableexport.jquery.plugin": "1.32.0",
-        "tether": "^1.4.0",
-        "webpack": "^5.98.0"
+        "tableexport.jquery.plugin": "^1.9.9",
+        "tether": "^1.4.0"
     }
 }


### PR DESCRIPTION
This just bumps up a few JS package versions we use. Interestingly, it's still showing some vulnerabilities, but I think that's because AdminLTE requires a vulnerable version of Chart.js, and we're on an older version of AdminLTE:

```bash
✨snipe@chodeblossom✨ snipe-it  (update-js-packages) $ npm audit
# npm audit report

bootstrap  3.1.1 - 3.4.1
Severity: moderate
Bootstrap Cross-Site Scripting (XSS) vulnerability - https://github.com/advisories/GHSA-9mvj-f7w8-pvh2
fix available via `npm audit fix --force`
Will install bootstrap@5.3.7, which is a breaking change
node_modules/bootstrap

chart.js  <2.9.4
Severity: high
Prototype pollution in chart.js - https://github.com/advisories/GHSA-h68q-55jf-x68w
fix available via `npm audit fix --force`
Will install admin-lte@4.0.0-rc3, which is a breaking change
node_modules/admin-lte/node_modules/chart.js
  admin-lte  2.4.0 - 2.4.18
  Depends on vulnerable versions of bootstrap
  Depends on vulnerable versions of chart.js
  node_modules/admin-lte

webpack-dev-server  <=5.2.0
Severity: moderate
webpack-dev-server users' source code may be stolen when they access a malicious web site with non-Chromium based browser - https://github.com/advisories/GHSA-9jgg-88mc-972h
webpack-dev-server users' source code may be stolen when they access a malicious web site - https://github.com/advisories/GHSA-4v9v-hfq4-rm2v
No fix available
node_modules/webpack-dev-server
  laravel-mix  *
  Depends on vulnerable versions of webpack-dev-server
  node_modules/laravel-mix

xlsx  *
Severity: high
Prototype Pollution in sheetJS - https://github.com/advisories/GHSA-4r6h-8v6p-xvw6
SheetJS Regular Expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-5pgg-2g8v-p4x9
fix available via `npm audit fix`
node_modules/xlsx
  tableexport.jquery.plugin  >=1.9.11
  Depends on vulnerable versions of xlsx
  node_modules/tableexport.jquery.plugin

7 vulnerabilities (3 moderate, 4 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.
```

I don't think most of these actually affect us, since either we've mitigated those issues elsewhere or they're dev tooling which wouldn't affect the front-end JS.