### PR TITLE
Fixed #17485: nicer alert menu if no items are below qty

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -279,48 +279,62 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                         @endif
                                     </a>
                                     <ul class="dropdown-menu">
-                                        @can('superadmin')
-                                            @if($deprecations)
-                                                @foreach ($deprecations as $key => $deprecation)
-                                                    @if ($deprecation['check'])
-                                                        <li class="header alert-warning">{!! $deprecation['message'] !!}</li>
-                                                    @endif
-                                                @endforeach
-                                            @endif
-                                        @endcan
-                                        @if($alert_items)
-                                        <li class="header">{{ trans_choice('general.quantity_minimum', count($alert_items)) }}</li>
-                                            <li>
-                                            <!-- inner menu: contains the actual data -->
-                                                <ul class="menu">
-                                                    @for($i = 0; count($alert_items) > $i; $i++)
 
-                                                        <li><!-- Task item -->
-                                                            <a href="{{ route($alert_items[$i]['type'].'.show', $alert_items[$i]['id'])}}">
-                                                                <h2 class="task_menu">{{ $alert_items[$i]['name'] }}
-                                                                    <small class="pull-right">
-                                                                        {{ $alert_items[$i]['remaining'] }} {{ trans('general.remaining') }}
-                                                                    </small>
-                                                                </h2>
-                                                                <div class="progress xs">
-                                                                    <div class="progress-bar progress-bar-yellow"
-                                                                         style="width: {{ $alert_items[$i]['percent'] }}%"
-                                                                         role="progressbar"
-                                                                         aria-valuenow="{{ $alert_items[$i]['percent'] }}"
-                                                                         aria-valuemin="0" aria-valuemax="100">
-                                                                        <span class="sr-only">{{ $alert_items[$i]['percent'] }}% Complete</span>
+                                        @if ((count($alert_items) + count($deprecations)) > 0)
+
+                                            @can('superadmin')
+                                                @if($deprecations)
+                                                    @foreach ($deprecations as $key => $deprecation)
+                                                        @if ($deprecation['check'])
+                                                            <li class="header alert-warning">{!! $deprecation['message'] !!}</li>
+                                                        @endif
+                                                    @endforeach
+                                                @endif
+                                            @endcan
+
+                                            @if($alert_items)
+                                                <li class="header">
+                                                    {{ trans_choice('general.quantity_minimum', count($alert_items)) }}
+                                                </li>
+                                                <li>
+                                                <!-- inner menu: contains the actual data -->
+                                                    <ul class="menu">
+                                                        @for($i = 0; count($alert_items) > $i; $i++)
+                                                            <!-- Task item -->
+                                                            <li>
+                                                                <a href="{{ route($alert_items[$i]['type'].'.show', $alert_items[$i]['id'])}}">
+                                                                    <h2 class="task_menu">{{ $alert_items[$i]['name'] }}
+                                                                        <small class="pull-right">
+                                                                            {{ $alert_items[$i]['remaining'] }} {{ trans('general.remaining') }}
+                                                                        </small>
+                                                                    </h2>
+                                                                    <div class="progress xs">
+                                                                        <div class="progress-bar progress-bar-yellow"
+                                                                             style="width: {{ $alert_items[$i]['percent'] }}%"
+                                                                             role="progressbar"
+                                                                             aria-valuenow="{{ $alert_items[$i]['percent'] }}"
+                                                                             aria-valuemin="0" aria-valuemax="100">
+                                                                            <span class="sr-only">
+                                                                                {{ $alert_items[$i]['percent'] }}%
+                                                                            </span>
+                                                                        </div>
                                                                     </div>
-                                                                </div>
-                                                            </a>
-                                                        </li>
-                                                        <!-- end task item -->
-                                                    @endfor
-                                                </ul>
+                                                                </a>
+                                                            </li>
+                                                            <!-- end task item -->
+                                                        @endfor
+                                                    </ul>
+                                                </li>
+                                            @endif
+                                        @else
+                                            <li class="header">
+                                                {{ trans_choice('general.quantity_minimum', 0) }}
                                             </li>
+
                                         @endif
-                                        {{-- <li class="footer">
-                                          <a href="#">{{ trans('general.tasks_view_all') }}</a>
-                                        </li> --}}
+{{--                                        <li class="footer">--}}
+{{--                                          <a href="#">{{ trans('general.tasks_view_all') }}</a>--}}
+{{--                                        </li>--}}
                                     </ul>
                                 </li>
                             @endcan


### PR DESCRIPTION
### Issue: Weird visual glitch when the alert menu had no items

https://github.com/user-attachments/assets/9993c51c-e313-4865-b8c3-d4f7fe424c1a


### Now: No items
https://github.com/user-attachments/assets/8af63409-37fc-4dd2-bba1-c8e85b86089c

### Now: One item
https://github.com/user-attachments/assets/c4da8922-c942-4d93-8377-b0a052b4d1c1

### Now: Multiple items

https://github.com/user-attachments/assets/34352c62-bda6-4665-a4d0-2ebeb182c111

(That "you have `x` items" message is translatable, it just hasn't been translated into Portuguese (`pt-PT`) yet.)

Fixes #17485


