### PR TITLE
Fixes #17448: feat(api) - API endpoint for Adding Ad-Hoc Notes to Assets 

### DIFF
--- a/app/Http/Controllers/Api/NotesController.php
+++ b/app/Http/Controllers/Api/NotesController.php
@@ -26,29 +26,16 @@ class NotesController extends Controller
      * Returns JSON responses indicating success or failure with appropriate HTTP status codes.
      *
      * @param  \Illuminate\Http\Request  $request  The incoming HTTP request containing the 'note'.
-     * @param  int|string  $assetId  The ID of the asset to attach the note to.
+     * @param  Asset  $asset  The ID of the asset to attach the note to.
      * @return \Illuminate\Http\JsonResponse
      */
-    public function store(Request $request, $assetId): JsonResponse
+    public function store(Request $request, Asset $asset): JsonResponse
     {
-        $this->authorize('update', Asset::class);
+        $this->authorize('update', $asset);
 
         if ($request->input('note', '') == '') {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('validation.required', ['attribute' => 'note'])), 422);
         }
-
-        try {
-            $asset = Asset::findOrFail($assetId);
-        } catch (ModelNotFoundException $e) {
-            return response()->json(Helper::formatStandardApiResponse('error', null, 'Asset not found'), 404);
-        } catch (\Exception $e) {
-            Log::debug('Error fetching asset: ' . $e->getMessage());
-
-            // Return generic server error response since something unexpected happened
-            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/settings/message.webhook.500')), 500);
-        }
-
-        $this->authorize('update', $asset);
 
         // Create the note
         $logaction = new ActionLog();
@@ -74,22 +61,11 @@ class NotesController extends Controller
      * user information for each note. Returns a JSON response with the notes or errors.
      *
      * @param  \Illuminate\Http\Request  $request  The incoming HTTP request.
-     * @param  int|string  $assetId  The ID of the asset whose notes to retrieve.
+     * @param  Asset  $asset  The ID of the asset whose notes to retrieve.
      * @return \Illuminate\Http\JsonResponse
      */
-    public function getList(Request $request, $assetId): JsonResponse
+    public function getList(Asset $asset): JsonResponse
     {
-        $this->authorize('view', Asset::class);
-
-        try {
-            $asset = Asset::findOrFail($assetId);
-        } catch (ModelNotFoundException $e) {
-            return response()->json(Helper::formatStandardApiResponse('error', null, $e->getMessage()), 404);
-        } catch (\Exception $e) {
-            // Return generic server error response since something unexpected happened
-            return response()->json(Helper::formatStandardApiResponse('error', null, $e->getMessage()), 500);
-        }
-
         $this->authorize('view', $asset);
 
         // Get the manual notes for the asset

--- a/app/Http/Controllers/Api/NotesController.php
+++ b/app/Http/Controllers/Api/NotesController.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Helpers\Helper;
+use App\Http\Controllers\Controller;
+use App\Models\Actionlog;
+use App\Models\Asset;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * This class controls all API actions related to notes for
+ * the Snipe-IT Asset Management application.
+ */
+class NotesController extends Controller
+{
+    /**
+     * Store a manual note on a specified asset and log the action.
+     *
+     * Checks authorization for updating assets, validates the presence of the 'note',
+     * attempts to find the asset by ID, and creates a new ActionLog entry if successful.
+     * Returns JSON responses indicating success or failure with appropriate HTTP status codes.
+     *
+     * @param  \Illuminate\Http\Request  $request  The incoming HTTP request containing the 'note'.
+     * @param  int|string  $asset_id  The ID of the asset to attach the note to.
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(Request $request, $asset_id): JsonResponse
+    {
+        $this->authorize('update', Asset::class);
+
+        if ($request->input('note', '') == '') {
+            return response()->json(Helper::formatStandardApiResponse('error', null, trans('validation.required', ['attribute' => 'note'])), 422);
+        }
+
+        try {
+            $asset = Asset::findOrFail($asset_id);
+        } catch (ModelNotFoundException $e) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, 'Asset not found'), 404);
+        } catch (\Exception $e) {
+            Log::debug('Error fetching asset: ' . $e->getMessage());
+
+            // Return generic server error response since something unexpected happened
+            return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/settings/message.webhook.500')), 500);
+        }
+
+        $this->authorize('update', $asset);
+
+        // Create the note
+        $logaction = new ActionLog();
+        $logaction->item_type = get_class($asset);
+        $logaction->created_by = Auth::id();
+        $logaction->item_id = $asset->id;
+        $logaction->note = $request->input('note', '');
+
+        if($logaction->logaction('note added')) {
+            // Return a success response
+            return response()->json(Helper::formatStandardApiResponse('success', ['note' => $logaction->note, 'item_id' => $asset->id], trans('general.note_added')));
+        }
+
+        // Return an error response if something went wrong
+        return response()->json(Helper::formatStandardApiResponse('error', null, 'Something went wrong'), 500);
+    }
+
+    /**
+     * Retrieve a list of manual notes (action logs) for a given asset.
+     *
+     * Checks authorization to view assets, attempts to find the asset by ID,
+     * and fetches related action log entries of type 'note added', including
+     * user information for each note. Returns a JSON response with the notes or errors.
+     *
+     * @param  \Illuminate\Http\Request  $request  The incoming HTTP request.
+     * @param  int|string  $asset_id  The ID of the asset whose notes to retrieve.
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getList(Request $request, $asset_id): JsonResponse
+    {
+        $this->authorize('view', Asset::class);
+
+        try {
+            $asset = Asset::findOrFail($asset_id);
+        } catch (ModelNotFoundException $e) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, $e->getMessage()), 404);
+        } catch (\Exception $e) {
+            // Return generic server error response since something unexpected happened
+            return response()->json(Helper::formatStandardApiResponse('error', null, $e->getMessage()), 500);
+        }
+
+        $this->authorize('view', $asset);
+
+        // Get the manual notes for the asset
+        $notes = ActionLog::with('user:id,username')
+            ->where('item_type', Asset::class)
+            ->where('item_id', $asset->id)
+            ->where('action_type', 'note added')
+            ->orderBy('created_at', 'desc')
+            ->get(['id', 'created_at', 'note', 'created_by', 'item_id', 'item_type', 'action_type', 'target_id', 'target_type']);
+
+        $notesArray = $notes->map(function ($note) {
+            return [
+                'id' => $note->id,
+                'created_at' => $note->created_at,
+                'note' => $note->note,
+                'created_by' => $note->created_by,
+                'username' => $note->user?->username, // adding the username
+                'item_id' => $note->item_id,
+                'item_type' => $note->item_type,
+                'action_type' => $note->action_type,
+            ];
+        });
+
+        // Return a success response
+        return response()->json(Helper::formatStandardApiResponse('success', ['notes' => $notesArray, 'asset_id' => $asset->id]));
+    }
+}

--- a/app/Http/Controllers/Api/NotesController.php
+++ b/app/Http/Controllers/Api/NotesController.php
@@ -26,10 +26,10 @@ class NotesController extends Controller
      * Returns JSON responses indicating success or failure with appropriate HTTP status codes.
      *
      * @param  \Illuminate\Http\Request  $request  The incoming HTTP request containing the 'note'.
-     * @param  int|string  $asset_id  The ID of the asset to attach the note to.
+     * @param  int|string  $assetId  The ID of the asset to attach the note to.
      * @return \Illuminate\Http\JsonResponse
      */
-    public function store(Request $request, $asset_id): JsonResponse
+    public function store(Request $request, $assetId): JsonResponse
     {
         $this->authorize('update', Asset::class);
 
@@ -38,7 +38,7 @@ class NotesController extends Controller
         }
 
         try {
-            $asset = Asset::findOrFail($asset_id);
+            $asset = Asset::findOrFail($assetId);
         } catch (ModelNotFoundException $e) {
             return response()->json(Helper::formatStandardApiResponse('error', null, 'Asset not found'), 404);
         } catch (\Exception $e) {
@@ -57,7 +57,7 @@ class NotesController extends Controller
         $logaction->item_id = $asset->id;
         $logaction->note = $request->input('note', '');
 
-        if($logaction->logaction('note added')) {
+        if ($logaction->logaction('note added')) {
             // Return a success response
             return response()->json(Helper::formatStandardApiResponse('success', ['note' => $logaction->note, 'item_id' => $asset->id], trans('general.note_added')));
         }
@@ -74,15 +74,15 @@ class NotesController extends Controller
      * user information for each note. Returns a JSON response with the notes or errors.
      *
      * @param  \Illuminate\Http\Request  $request  The incoming HTTP request.
-     * @param  int|string  $asset_id  The ID of the asset whose notes to retrieve.
+     * @param  int|string  $assetId  The ID of the asset whose notes to retrieve.
      * @return \Illuminate\Http\JsonResponse
      */
-    public function getList(Request $request, $asset_id): JsonResponse
+    public function getList(Request $request, $assetId): JsonResponse
     {
         $this->authorize('view', Asset::class);
 
         try {
-            $asset = Asset::findOrFail($asset_id);
+            $asset = Asset::findOrFail($assetId);
         } catch (ModelNotFoundException $e) {
             return response()->json(Helper::formatStandardApiResponse('error', null, $e->getMessage()), 404);
         } catch (\Exception $e) {

--- a/app/Http/Controllers/Api/NotesController.php
+++ b/app/Http/Controllers/Api/NotesController.php
@@ -19,6 +19,46 @@ use Illuminate\Support\Facades\Log;
 class NotesController extends Controller
 {
     /**
+     * Retrieve a list of manual notes (action logs) for a given asset.
+     *
+     * Checks authorization to view assets, attempts to find the asset by ID,
+     * and fetches related action log entries of type 'note added', including
+     * user information for each note. Returns a JSON response with the notes or errors.
+     *
+     * @param  \Illuminate\Http\Request  $request  The incoming HTTP request.
+     * @param  Asset  $asset  The ID of the asset whose notes to retrieve.
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index(Asset $asset): JsonResponse
+    {
+        $this->authorize('view', $asset);
+
+        // Get the manual notes for the asset
+        $notes = ActionLog::with('user:id,username')
+            ->where('item_type', Asset::class)
+            ->where('item_id', $asset->id)
+            ->where('action_type', 'note added')
+            ->orderBy('created_at', 'desc')
+            ->get(['id', 'created_at', 'note', 'created_by', 'item_id', 'item_type', 'action_type', 'target_id', 'target_type']);
+
+        $notesArray = $notes->map(function ($note) {
+            return [
+                'id' => $note->id,
+                'created_at' => $note->created_at,
+                'note' => $note->note,
+                'created_by' => $note->created_by,
+                'username' => $note->user?->username, // adding the username
+                'item_id' => $note->item_id,
+                'item_type' => $note->item_type,
+                'action_type' => $note->action_type,
+            ];
+        });
+
+        // Return a success response
+        return response()->json(Helper::formatStandardApiResponse('success', ['notes' => $notesArray, 'asset_id' => $asset->id]));
+    }
+    
+    /**
      * Store a manual note on a specified asset and log the action.
      *
      * Checks authorization for updating assets, validates the presence of the 'note',
@@ -51,45 +91,5 @@ class NotesController extends Controller
 
         // Return an error response if something went wrong
         return response()->json(Helper::formatStandardApiResponse('error', null, 'Something went wrong'), 500);
-    }
-
-    /**
-     * Retrieve a list of manual notes (action logs) for a given asset.
-     *
-     * Checks authorization to view assets, attempts to find the asset by ID,
-     * and fetches related action log entries of type 'note added', including
-     * user information for each note. Returns a JSON response with the notes or errors.
-     *
-     * @param  \Illuminate\Http\Request  $request  The incoming HTTP request.
-     * @param  Asset  $asset  The ID of the asset whose notes to retrieve.
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function getList(Asset $asset): JsonResponse
-    {
-        $this->authorize('view', $asset);
-
-        // Get the manual notes for the asset
-        $notes = ActionLog::with('user:id,username')
-            ->where('item_type', Asset::class)
-            ->where('item_id', $asset->id)
-            ->where('action_type', 'note added')
-            ->orderBy('created_at', 'desc')
-            ->get(['id', 'created_at', 'note', 'created_by', 'item_id', 'item_type', 'action_type', 'target_id', 'target_type']);
-
-        $notesArray = $notes->map(function ($note) {
-            return [
-                'id' => $note->id,
-                'created_at' => $note->created_at,
-                'note' => $note->note,
-                'created_by' => $note->created_by,
-                'username' => $note->user?->username, // adding the username
-                'item_id' => $note->item_id,
-                'item_type' => $note->item_type,
-                'action_type' => $note->action_type,
-            ];
-        });
-
-        // Return a success response
-        return response()->json(Helper::formatStandardApiResponse('success', ['notes' => $notesArray, 'asset_id' => $asset->id]));
     }
 }

--- a/database/factories/ActionlogFactory.php
+++ b/database/factories/ActionlogFactory.php
@@ -91,10 +91,10 @@ class ActionlogFactory extends Factory
      * @param User|null $user Optional user to associate as the creator of the note.
      * @return \Illuminate\Database\Eloquent\Factories\Factory<ActionLog>
      */
-    public function assetNote(?User $user = null)
+    public function assetNote(?User $user=null)
     {
         return $this
-            ->state(function (array $attributes) use ($user) {
+            ->state(function () use ($user) {
                 return [
                     'action_type' => 'note added',
                     'item_type' => Asset::class,

--- a/database/factories/ActionlogFactory.php
+++ b/database/factories/ActionlogFactory.php
@@ -84,6 +84,28 @@ class ActionlogFactory extends Factory
         });
     }
 
+    /**
+     * This sets up an ActionLog representing a manually added note tied to an Asset,
+     * with an optional User as the creator. If no User is provided, one is generated.
+     *
+     * @param User|null $user Optional user to associate as the creator of the note.
+     * @return \Illuminate\Database\Eloquent\Factories\Factory<ActionLog>
+     */
+    public function assetNote(?User $user = null)
+    {
+        return $this
+            ->state(function (array $attributes) use ($user) {
+                return [
+                    'action_type' => 'note added',
+                    'item_type' => Asset::class,
+                    'target_type' => 'asset',
+                    'note' => 'Factory-generated manual note',
+                    'created_by' => $user?->id ?? User::factory(),
+                ];
+            })
+            ->for($user ?? User::factory(), 'user');
+    }
+
     public function licenseCheckoutToUser()
     {
         return $this->state(function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -847,7 +847,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
         Route::group(['prefix' => 'notes'], function () {
 
             Route::post(
-                '{asset_id}/store',
+                '{asset}/store',
                 [
                     Api\NotesController::class,
                     'store'
@@ -855,7 +855,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
             )->name('api.notes.store');
 
             Route::get(
-                '{asset_id}/getList',
+                '{asset}/getList',
                 [
                     Api\NotesController::class,
                     'getList'

--- a/routes/api.php
+++ b/routes/api.php
@@ -841,6 +841,28 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
         ); // end asset models API routes
 
 
+        /**
+         * Asset notes API routes
+         */
+        Route::group(['prefix' => 'notes'], function () {
+
+            Route::post(
+                '{asset_id}/store',
+                [
+                    Api\NotesController::class,
+                    'store'
+                ]
+            )->name('api.notes.store');
+
+            Route::get(
+                '{asset_id}/getList',
+                [
+                    Api\NotesController::class,
+                    'getList'
+                ]
+            )->name('api.notes.getList');
+        }
+        ); // end asset notes API routes
 
         /**
         * Settings API routes

--- a/routes/api.php
+++ b/routes/api.php
@@ -855,12 +855,12 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
             )->name('api.notes.store');
 
             Route::get(
-                '{asset}/getList',
+                '{asset}/index',
                 [
                     Api\NotesController::class,
-                    'getList'
+                    'index'
                 ]
-            )->name('api.notes.getList');
+            )->name('api.notes.index');
         }
         ); // end asset notes API routes
 

--- a/tests/Feature/Assets/Api/AssetNotesTest.php
+++ b/tests/Feature/Assets/Api/AssetNotesTest.php
@@ -67,7 +67,7 @@ class AssetNotesTest extends TestCase
             ]);
 
         $this->actingAsForApi($user)
-            ->getJson(route('api.notes.getList', $asset))
+            ->getJson(route('api.notes.index', $asset))
             ->assertOk()
             ->assertJson([
                 'messages' => null,

--- a/tests/Feature/Assets/Api/AssetNotesTest.php
+++ b/tests/Feature/Assets/Api/AssetNotesTest.php
@@ -12,7 +12,7 @@ class AssetNotesTest extends TestCase
     public function testThatANonExistentAssetIdReturnsError()
     {   
         $this->actingAsForApi(User::factory()->editAssets()->create())
-            ->postJson(route('api.notes.store', 123456789))
+            ->postJson(route('api.notes.store', ['asset' => 123456789]))
             ->assertStatusMessageIs('error');
     }
 
@@ -21,7 +21,7 @@ class AssetNotesTest extends TestCase
         $asset = Asset::factory()->create();
 
         $this->actingAsForApi(User::factory()->create())
-            ->postJson(route('api.notes.store', $asset->id), [
+            ->postJson(route('api.notes.store', $asset), [
                 'note' => 'test'
             ])
             ->assertForbidden();
@@ -32,7 +32,7 @@ class AssetNotesTest extends TestCase
         $asset = Asset::factory()->create();
 
         $this->actingAsForApi(User::factory()->editAssets()->create())
-            ->postJson(route('api.notes.store', ['asset_id' => $asset->id]), [
+            ->postJson(route('api.notes.store', $asset), [
                 'note' => 'This is a test note.'
             ])
             ->assertStatusMessageIs('success')
@@ -67,7 +67,7 @@ class AssetNotesTest extends TestCase
             ]);
 
         $this->actingAsForApi($user)
-            ->getJson(route('api.notes.getList', ['asset_id' => $asset->id]))
+            ->getJson(route('api.notes.getList', $asset))
             ->assertOk()
             ->assertJson([
                 'messages' => null,

--- a/tests/Feature/Assets/Api/AssetNotesTest.php
+++ b/tests/Feature/Assets/Api/AssetNotesTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\Assets\Api;
+
+use App\Models\Actionlog;
+use App\Models\Asset;
+use App\Models\User;
+use Tests\TestCase;
+
+class AssetNotesTest extends TestCase
+{
+    public function testThatANonExistentAssetIdReturnsError()
+    {   
+        $this->actingAsForApi(User::factory()->editAssets()->create())
+            ->postJson(route('api.notes.store', 123456789))
+            ->assertStatusMessageIs('error');
+    }
+
+    public function testRequiresPermissionToAddNoteToAssetAsset()
+    {
+        $asset = Asset::factory()->create();
+
+        $this->actingAsForApi(User::factory()->create())
+            ->postJson(route('api.notes.store', $asset->id), [
+                'note' => 'test'
+            ])
+            ->assertForbidden();
+    }
+
+    public function testAssetNoteIsSaved()
+    {
+        $asset = Asset::factory()->create();
+
+        $this->actingAsForApi(User::factory()->editAssets()->create())
+            ->postJson(route('api.notes.store', ['asset_id' => $asset->id]), [
+                'note' => 'This is a test note.'
+            ])
+            ->assertStatusMessageIs('success')
+            ->assertJson([
+                'messages' => trans('general.note_added'),
+                'payload' => [
+                    'note' => 'This is a test note.',
+                    'item_id' => e($asset->id),
+                ],
+            ])
+            ->assertStatus(200);
+
+        $note = ActionLog::where('item_id', $asset->id)
+            ->where('action_type', 'note added')
+            ->first();
+
+        $this->assertNotNull($note, 'The note was not saved in the database.');
+        $this->assertEquals('This is a test note.', $note->note, 'The note content does not match.');
+    }
+
+    public function testAssetNotesAreRetrievable()
+    {
+        $asset = Asset::factory()->create();
+
+        $user = User::factory()->viewAssets()->create();
+
+        $assetNote = Actionlog::factory()
+            ->assetNote($user)
+            ->create([
+                'item_id' => $asset->id,
+                'note' => 'This is a test note.',
+            ]);
+
+        $this->actingAsForApi($user)
+            ->getJson(route('api.notes.getList', ['asset_id' => $asset->id]))
+            ->assertOk()
+            ->assertJson([
+                'messages' => null,
+                'payload' => [
+                    'notes' => [
+                        [
+                            'note' => 'This is a test note.',
+                            'created_by' => $assetNote->created_by,
+                            'username' => $user->username,
+                            'item_id' => $assetNote->item_id,
+                            'item_type' => Asset::class,
+                            'action_type' => 'note added',
+                        ]
+                    ]
+                ],
+            ]);
+    }
+}


### PR DESCRIPTION
Fixes #17448

Key changes:
- Added a new NotesController in the API namespace with two endpoints:
  - `POST /api/v1/notes/{asset_id}/store` to create a manual notes on an asset
  - `GET /api/v1/notes/{asset_id}/getList` to retrieve all manual notes on an asset
- Implemented authorization checks, matching UI note access gates
- Created a new ActionLog factory state to simplify testing asset notes
- Added feature tests covering:
  - Permission enforcement on note creation
  - Handling of non-existent asset IDs
  - Successful note creation and retrieval

These additions allow clients to automate ad-hoc/manual notes by programmatically adding and querying asset notes via the API.

Ran full tests. 4 unrelated failures remain, all due to array order differences and environment setup (e.g. missing php-intl). None are caused by this change. Tested via official docker container only.

I did not change API documentation, but I don't think that's expected since it's separate from the repo.