### PR TITLE
Fixed #17500 [FD-50045] - Make Manufacturer Seeder button work

### DIFF
--- a/app/Http/Controllers/ManufacturersController.php
+++ b/app/Http/Controllers/ManufacturersController.php
@@ -51,7 +51,7 @@ class ManufacturersController extends Controller
         $manufacturers_count = Manufacturer::withTrashed()->count();
 
         if ($manufacturers_count == 0) {
-            Artisan::call('db:seed', ['--class' => 'ManufacturerSeeder']);
+            Artisan::call('db:seed', ['--class' => 'Database\\Seeders\\ManufacturerSeeder', '--force' => true]);
             return redirect()->route('manufacturers.index')->with('success', trans('general.seeding.manufacturers.success'));
         }
 


### PR DESCRIPTION
Needed to add the full path to the manufacturer seeder, and add `--force` to allow it to run in production.

I blanked out my manufacturers on my local, and clicked the button and it didn't do anything. I put in this fix and clicked it again and then it did populate correctly.

Fixes #17500 