### PR TITLE
Fixed #17498 - added serial to user acceptance

### DIFF
--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -51,7 +51,7 @@
                     <div class="box-body">
                         <div class="col-md-12" style="padding-top: 20px; padding-bottom: 15px;">
                         @if ($acceptance->checkoutable->getEula())
-                            <div id="eula_div" style="padding-bottom: 20px; background-color: rgba(211,211,211,0.25); padding: 10px; border: lightgrey 1px solid;">
+                            <div id="eula_div" style="background-color: rgba(211,211,211,0.25); padding: 10px; border: lightgrey 1px solid;">
                                 {!!  $acceptance->checkoutable->getEula() !!}
                             </div>
                         @endif
@@ -69,12 +69,11 @@
                         </div>
                         <div class="col-md-12">
                             <br>
-                            <div class="col-md-12" style="display:block;">
+
                                 <label id="note_label" for="note" style="text-align:center;" >{{trans('admin/settings/general.acceptance_note')}}</label>
-                            </div>
-                            <div class="col-md-12">
-                                <textarea id="note" name="note" rows="4" value="note" class="form-control" style="width:100%"></textarea>
-                            </div>
+                                <br>
+                                <textarea id="note" name="note" rows="4" class="form-control" style="width:100%">{{ old('note') }}</textarea>
+
                         </div>
 
                         @if ($snipeSettings->require_accept_signature=='1')

--- a/resources/views/account/accept/create.blade.php
+++ b/resources/views/account/accept/create.blade.php
@@ -42,16 +42,19 @@
         <div class="row">
             <div class="col-sm-12 col-sm-offset-1 col-md-10 col-md-offset-1">
                 <div class="panel box box-default">
+                    <div class="box-header with-border">
+                        <h2 class="box-title">
+                            {{$acceptance->checkoutable->present()->name()}}
+                            {{ (($acceptance->checkoutable) && ($acceptance->checkoutable->serial)) ? ' - '.trans('general.serial_number').': '.$acceptance->checkoutable->serial : '' }}
+                        </h2>
+                    </div>
                     <div class="box-body">
-                        <div class="col-md-12" style="padding-top: 20px;">
+                        <div class="col-md-12" style="padding-top: 20px; padding-bottom: 15px;">
                         @if ($acceptance->checkoutable->getEula())
-                            <div id="eula_div" style="padding-bottom: 20px">
+                            <div id="eula_div" style="padding-bottom: 20px; background-color: rgba(211,211,211,0.25); padding: 10px; border: lightgrey 1px solid;">
                                 {!!  $acceptance->checkoutable->getEula() !!}
                             </div>
                         @endif
-                        </div>
-                        <div class="col-md-12">
-                        <h3>{{$acceptance->checkoutable->present()->name()}}</h3>
                         </div>
                         <div class="col-md-12">
                             <label class="form-control">

--- a/resources/views/account/accept/index.blade.php
+++ b/resources/views/account/accept/index.blade.php
@@ -31,6 +31,7 @@
             <thead>
               <tr>
                 <th>{{ trans('general.name')}}</th>
+                <th>{{ trans('general.serial_number')}}</th>
                 <th>{{ trans('table.actions')}}</th>
               </tr>
             </thead>
@@ -39,6 +40,7 @@
               <tr>
                 @if ($acceptance->checkoutable)
                 <td>{{ ($acceptance->checkoutable) ? $acceptance->checkoutable->present()->name : '' }}</td>
+                  <td>{{ ($acceptance->checkoutable) ? $acceptance->checkoutable->serial : '' }}</td>
                 <td><a href="{{ route('account.accept.item', $acceptance) }}" class="btn btn-default btn-sm">{{ trans('general.accept_decline') }}</a></td>
                 @else
                 <td> ----- </td>


### PR DESCRIPTION
This adds the serial number to the user's asset acceptance flow.

<img width="1618" height="1100" alt="Screenshot 2025-08-02 at 2 39 55 PM" src="https://github.com/user-attachments/assets/7c1d359a-c37f-4f4b-aa79-8092d0310786" />

<img width="1620" height="1102" alt="Screenshot 2025-08-02 at 2 39 39 PM" src="https://github.com/user-attachments/assets/3c32c425-dcf0-4713-8626-cd893af8348a" />

Fixes #17498 