### PR TITLE
Fixed potential failure in license checkin due to redirect option

### DIFF
--- a/app/Http/Controllers/Licenses/LicenseCheckinController.php
+++ b/app/Http/Controllers/Licenses/LicenseCheckinController.php
@@ -87,7 +87,9 @@ class LicenseCheckinController extends Controller
 
         if($licenseSeat->assigned_to != null){
             $return_to = User::withTrashed()->find($licenseSeat->assigned_to);
-            session()->put('checkedInFrom', $return_to->id);
+            if ($return_to) {
+                session()->put('checkedInFrom', $return_to->id);
+            }
         } else {
             $return_to = Asset::find($licenseSeat->asset_id);
         }


### PR DESCRIPTION
This PR fixes an issue where checking in a license from a force deleted user could cause a 500 on redirect. 

If a user is completely removed from the application the `Checkin` button still appears but 
<img width="1776" height="950" alt="CleanShot 2025-08-05 at 10 55 46@2x" src="https://github.com/user-attachments/assets/179537e4-91e8-4516-ad25-4eee39b3fad1" />


but even opting to `Go to License` below will trigger a 500 [on this line](https://github.com/grokability/snipe-it/blob/2f77f2cb2b676606466fa6c746401c520ed068fe/app/Http/Controllers/Licenses/LicenseCheckinController.php#L90)
<img width="1628" height="772" alt="CleanShot 2025-08-05 at 10 58 49@2x" src="https://github.com/user-attachments/assets/3cba44d4-5c5d-48ed-ae53-0fe4d54fb579" />


