### PR TITLE
Fixed #17518: Adds printer line break after signatures

### DIFF
--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -45,6 +45,12 @@
             margin-top: 20px;
             margin-bottom: 10px;
         }
+
+        @media print {
+            .signature-boxes {
+                page-break-after: always;
+            }
+        }
     </style>
 
 
@@ -399,7 +405,7 @@
         </div>
     @endif
 
-    <table style="margin-top: 80px;">
+    <table style="margin-top: 80px;" class="signature-boxes">
         @if (!empty($eulas))
         <tr class="collapse eula-row">
             <td style="padding-right: 10px; vertical-align: top; font-weight: bold;">EULA</td>

--- a/resources/views/users/print.blade.php
+++ b/resources/views/users/print.blade.php
@@ -57,8 +57,12 @@
 </head>
 <body>
 
+@php
+    $count = 0;
+@endphp
 {{-- If we are rendering multiple users we'll add the ability to show/hide EULAs for all of them at once via this button --}}
 @if (count($users) > 1)
+
     <div class="pull-right hidden-print">
         <span>{{ trans('general.show_or_hide_eulas') }}</span>
         <button class="btn btn-default" type="button" data-toggle="collapse" data-target=".eula-row" aria-expanded="false" aria-controls="eula-row" title="EULAs">
@@ -86,6 +90,9 @@
 @endif
 
 @foreach ($users as $show_user)
+    @php
+        $count++;
+    @endphp
     <div id="start_of_user_section"> {{-- used for page breaks when printing --}}</div>
     <h3>
         @if ($show_user->company)
@@ -405,7 +412,7 @@
         </div>
     @endif
 
-    <table style="margin-top: 80px;" class="signature-boxes">
+    <table style="margin-top: 80px;" class="{{ $users->count() > $count ? 'signature-boxes' : ''  }}">
         @if (!empty($eulas))
         <tr class="collapse eula-row">
             <td style="padding-right: 10px; vertical-align: top; font-weight: bold;">EULA</td>


### PR DESCRIPTION
This adds a line break after the signature box after each user except the last one. 

<img width="1670" height="1115" alt="Screenshot 2025-08-05 at 6 50 25 PM" src="https://github.com/user-attachments/assets/76bee9b9-5901-49e9-9434-1c3d6c5fab2e" />
<img width="773" height="672" alt="Screenshot 2025-08-05 at 6 50 39 PM" src="https://github.com/user-attachments/assets/6be6e5f3-12eb-435b-a3dd-3dd35c1f85b4" />

Fixed #17518