### PR TITLE
Fixed #10357: Add maintenance image upload

### DIFF
--- a/app/Http/Controllers/Api/AssetMaintenancesController.php
+++ b/app/Http/Controllers/Api/AssetMaintenancesController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\ImageUploadRequest;
 use App\Http\Transformers\AssetMaintenancesTransformer;
 use App\Models\Asset;
 use App\Models\AssetMaintenance;
@@ -126,14 +127,15 @@ class AssetMaintenancesController extends Controller
      * @version v1.0
      * @since [v1.8]
      */
-    public function store(Request $request) : JsonResponse | array
+    public function store(ImageUploadRequest $request) : JsonResponse | array
     {
         $this->authorize('update', Asset::class);
+
         // create a new model instance
         $maintenance = new AssetMaintenance();
         $maintenance->fill($request->all());
         $maintenance->created_by = auth()->id();
-
+        $maintenance = $request->handleImages($maintenance);
         // Was the asset maintenance created?
         if ($maintenance->save()) {
             return response()->json(Helper::formatStandardApiResponse('success', $maintenance, trans('admin/asset_maintenances/message.create.success')));

--- a/app/Http/Controllers/AssetMaintenancesController.php
+++ b/app/Http/Controllers/AssetMaintenancesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\ImageUploadRequest;
 use App\Models\Asset;
 use App\Models\AssetMaintenance;
 use App\Models\Company;
@@ -69,7 +70,7 @@ class AssetMaintenancesController extends Controller
     * @version v1.0
     * @since [v1.8]
     */
-    public function store(Request $request) : RedirectResponse
+    public function store(ImageUploadRequest $request) : RedirectResponse
     {
         $this->authorize('update', Asset::class);
 
@@ -101,6 +102,7 @@ class AssetMaintenancesController extends Controller
                 $assetMaintenance->asset_maintenance_time = (int) $completionDate->diffInDays($startDate, true);
             }
 
+            $assetMaintenance = $request->handleImages($assetMaintenance);
 
             // Was the asset maintenance created?
             if (!$assetMaintenance->save()) {
@@ -143,7 +145,7 @@ class AssetMaintenancesController extends Controller
      * @version v1.0
      * @since [v1.8]
      */
-    public function update(Request $request, AssetMaintenance $maintenance) : View | RedirectResponse
+    public function update(ImageUploadRequest $request, AssetMaintenance $maintenance) : View | RedirectResponse
     {
         $this->authorize('update', Asset::class);
         $this->authorize('update', $maintenance->asset);
@@ -176,6 +178,7 @@ class AssetMaintenancesController extends Controller
             $completionDate = Carbon::parse($maintenance->completion_date);
             $maintenance->asset_maintenance_time = (int) $completionDate->diffInDays($startDate, true);
         }
+        $maintenance = $request->handleImages($maintenance);
 
         if ($maintenance->save()) {
             return redirect()->route('maintenances.index')

--- a/app/Http/Transformers/AssetMaintenancesTransformer.php
+++ b/app/Http/Transformers/AssetMaintenancesTransformer.php
@@ -7,6 +7,7 @@ use App\Models\Asset;
 use App\Models\AssetMaintenance;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Storage;
 
 class AssetMaintenancesTransformer
 {
@@ -33,6 +34,7 @@ class AssetMaintenancesTransformer
                 'created_at' => Helper::getFormattedDateObject($assetmaintenance->asset->created_at, 'datetime'),
                 'updated_at' => Helper::getFormattedDateObject($assetmaintenance->asset->updated_at, 'datetime'),
             ] : null,
+            'image' => ($assetmaintenance->image != '') ? Storage::disk('public')->url('asset_maintenances/'.e($assetmaintenance->image)) : null,
             'model' => (($assetmaintenance->asset) && ($assetmaintenance->asset->model)) ? [
                 'id' => (int) $assetmaintenance->asset->model->id,
                 'name'=> ($assetmaintenance->asset->model->name) ? e($assetmaintenance->asset->model->name).' '.e($assetmaintenance->asset->model->model_number) : null,

--- a/app/Presenters/AssetMaintenancesPresenter.php
+++ b/app/Presenters/AssetMaintenancesPresenter.php
@@ -31,6 +31,15 @@ class AssetMaintenancesPresenter extends Presenter
                 'formatter' => 'maintenancesLinkFormatter',
             ],
             [
+                'field' => 'image',
+                'searchable' => false,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('general.image'),
+                'visible' => true,
+                'formatter' => 'imageFormatter',
+            ],
+            [
                 'field' => 'company',
                 'searchable' => true,
                 'sortable' => true,

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -31,7 +31,7 @@ class SettingsServiceProvider extends ServiceProvider
 
 
         // Make sure the limit is actually set, is an integer and does not exceed system limits
-        \App::singleton('api_limit_value', function () {
+        app()->singleton('api_limit_value', function () {
             $limit = config('app.max_results');
             $int_limit = intval(request('limit'));
 
@@ -43,7 +43,7 @@ class SettingsServiceProvider extends ServiceProvider
         });
 
         // Make sure the offset is actually set and is an integer
-        \App::singleton('api_offset_value', function () {
+        app()->singleton('api_offset_value', function () {
             $offset = intval(request('offset'));
             return $offset;
         });
@@ -57,117 +57,121 @@ class SettingsServiceProvider extends ServiceProvider
         // Model paths and URLs
 
 
-        \App::singleton('eula_pdf_path', function () {
+        app()->singleton('eula_pdf_path', function () {
             return 'eula_pdf_path/';
         });
 
-        \App::singleton('assets_upload_path', function () {
+        app()->singleton('assets_upload_path', function () {
             return 'assets/';
         });
 
-        \App::singleton('audits_upload_path', function () {
+        app()->singleton('asset_maintenances_path', function () {
+            return 'asset_maintenances/';
+        });
+
+        app()->singleton('audits_upload_path', function () {
             return 'audits/';
         });
 
-        \App::singleton('accessories_upload_path', function () {
+        app()->singleton('accessories_upload_path', function () {
             return 'public/uploads/accessories/';
         });
 
-        \App::singleton('models_upload_path', function () {
+        app()->singleton('models_upload_path', function () {
             return 'models/';
         });
 
-        \App::singleton('models_upload_url', function () {
+        app()->singleton('models_upload_url', function () {
             return 'models/';
         });
 
         // Categories
-        \App::singleton('categories_upload_path', function () {
+        app()->singleton('categories_upload_path', function () {
             return 'categories/';
         });
 
-        \App::singleton('categories_upload_url', function () {
+        app()->singleton('categories_upload_url', function () {
             return 'categories/';
         });
 
         // Locations
-        \App::singleton('locations_upload_path', function () {
+        app()->singleton('locations_upload_path', function () {
             return 'locations/';
         });
 
-        \App::singleton('locations_upload_url', function () {
+        app()->singleton('locations_upload_url', function () {
             return 'locations/';
         });
 
         // Users
-        \App::singleton('users_upload_path', function () {
+        app()->singleton('users_upload_path', function () {
             return 'avatars/';
         });
 
-        \App::singleton('users_upload_url', function () {
+        app()->singleton('users_upload_url', function () {
             return 'users/';
         });
 
         // Manufacturers
-        \App::singleton('manufacturers_upload_path', function () {
+        app()->singleton('manufacturers_upload_path', function () {
             return 'manufacturers/';
         });
 
-        \App::singleton('manufacturers_upload_url', function () {
+        app()->singleton('manufacturers_upload_url', function () {
             return 'manufacturers/';
         });
 
         // Suppliers
-        \App::singleton('suppliers_upload_path', function () {
+        app()->singleton('suppliers_upload_path', function () {
             return 'suppliers/';
         });
 
-        \App::singleton('suppliers_upload_url', function () {
+        app()->singleton('suppliers_upload_url', function () {
             return 'suppliers/';
         });
 
         // Departments
-        \App::singleton('departments_upload_path', function () {
+        app()->singleton('departments_upload_path', function () {
             return 'departments/';
         });
 
-        \App::singleton('departments_upload_url', function () {
+        app()->singleton('departments_upload_url', function () {
             return 'departments/';
         });
 
         // Company paths and URLs
-        \App::singleton('companies_upload_path', function () {
+        app()->singleton('companies_upload_path', function () {
             return 'companies/';
         });
 
-        \App::singleton('companies_upload_url', function () {
+        app()->singleton('companies_upload_url', function () {
             return 'companies/';
         });
 
         // Accessories paths and URLs
-        \App::singleton('accessories_upload_path', function () {
+        app()->singleton('accessories_upload_path', function () {
             return 'accessories/';
         });
 
-        \App::singleton('accessories_upload_url', function () {
+        app()->singleton('accessories_upload_url', function () {
             return 'accessories/';
         });
 
         // Consumables paths and URLs
-        \App::singleton('consumables_upload_path', function () {
+        app()->singleton('consumables_upload_path', function () {
             return 'consumables/';
         });
 
-        \App::singleton('consumables_upload_url', function () {
+        app()->singleton('consumables_upload_url', function () {
             return 'consumables/';
         });
 
         // Components paths and URLs
-        \App::singleton('components_upload_path', function () {
+        app()->singleton('components_upload_path', function () {
             return 'components/';
         });
 
-        \App::singleton('components_upload_url', function () {
+        app()->singleton('components_upload_url', function () {
             return 'components/';
         });
 

--- a/database/migrations/2025_08_06_192954_add_image_to_maintenances.php
+++ b/database/migrations/2025_08_06_192954_add_image_to_maintenances.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('asset_maintenances', function (Blueprint $table) {
+            if (!Schema::hasColumn('asset_maintenances', 'image')) {
+                $table->text('image')->after('notes')->nullable()->default(null);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('asset_maintenances', function (Blueprint $table) {
+            $table->dropColumn('image');
+        });
+    }
+};

--- a/resources/views/asset_maintenances/edit.blade.php
+++ b/resources/views/asset_maintenances/edit.blade.php
@@ -23,10 +23,10 @@
 <div class="row">
   <div class="col-md-9">
     @if ($item->id)
-      <form class="form-horizontal" method="post" action="{{ route('maintenances.update', $item->id) }}" autocomplete="off">
+      <form class="form-horizontal" method="post" action="{{ route('maintenances.update', $item->id) }}" autocomplete="off" enctype="multipart/form-data">
       {{ method_field('PUT') }}
     @else
-      <form class="form-horizontal" method="post" action="{{ route('maintenances.store') }}" autocomplete="off">
+      <form class="form-horizontal" method="post" action="{{ route('maintenances.store') }}" autocomplete="off" enctype="multipart/form-data">
     @endif
     <!-- CSRF Token -->
     {{ csrf_field() }}
@@ -178,6 +178,9 @@
             </div>
           </div>
         </div>
+
+        @include ('partials.forms.edit.image-upload', ['image_path' => app('asset_maintenances_path')])
+
 
         <!-- Notes -->
         <div class="form-group {{ $errors->has('notes') ? ' has-error' : '' }}">

--- a/resources/views/asset_maintenances/view.blade.php
+++ b/resources/views/asset_maintenances/view.blade.php
@@ -9,16 +9,6 @@ use Carbon\Carbon;
 @parent
 @stop
 
-@section('header_right')
-  <div class="pull-right">
-    <a href="{{ route('maintenances.edit', $assetMaintenance) }}" class="btn btn-default pull-right">
-      {{ trans('general.update') }}</a>
-
-    <a href="{{ route('maintenances.index') }}" class="btn btn-primary text-right" style="margin-right: 10px;">{{ trans('general.back') }}</a>
-  </div>
-@stop
-
-
 {{-- Page content --}}
 @section('content')
   <div class="row">
@@ -157,6 +147,75 @@ use Carbon\Carbon;
     </div><!-- /box -->
 
     </div> <!-- col-md-9  end -->
-  </div> <!-- row  end -->
+    <div class="col-md-3">
+
+      @if ($assetMaintenance->image!='')
+        <div class="col-md-12 text-center" style="padding-bottom: 17px;">
+          <img src="{{ Storage::disk('public')->url(app('asset_maintenances_path').e($assetMaintenance->image)) }}" class="img-responsive img-thumbnail" style="width:100%" alt="{{ $assetMaintenance->name }}">
+        </div>
+      @endif
+
+      <div class="col-md-12">
+
+        <ul class="list-unstyled" style="line-height: 22px; padding-bottom: 20px;">
+
+          @if ($assetMaintenance->notes)
+            <li>
+              <strong>{{ trans('general.notes') }}</strong>:
+              {!! nl2br(Helper::parseEscapedMarkedownInline($assetMaintenance->notes)) !!}
+            </li>
+          @endif
+
+          @if ($assetMaintenance->address!='')
+            <li>{{ $assetMaintenance->address }}</li>
+          @endif
+          @if ($assetMaintenance->address2!='')
+            <li>{{ $assetMaintenance->address2 }}</li>
+          @endif
+          @if (($assetMaintenance->city!='') || ($assetMaintenance->state!='') || ($assetMaintenance->zip!=''))
+            <li>{{ $assetMaintenance->city }} {{ $assetMaintenance->state }} {{ $assetMaintenance->zip }}</li>
+          @endif
+          @if ($assetMaintenance->manager)
+            <li>{{ trans('admin/users/table.manager') }}: {!! $assetMaintenance->manager->present()->nameUrl() !!}</li>
+          @endif
+          @if ($assetMaintenance->company)
+            <li>{{ trans('admin/companies/table.name') }}: {!! $assetMaintenance->company->present()->nameUrl() !!}</li>
+          @endif
+          @if ($assetMaintenance->parent)
+            <li>{{ trans('admin/locations/table.parent') }}: {!! $assetMaintenance->parent->present()->nameUrl() !!}</li>
+          @endif
+          @if ($assetMaintenance->ldap_ou)
+            <li>{{ trans('admin/locations/table.ldap_ou') }}: {{ $assetMaintenance->ldap_ou }}</li>
+          @endif
+
+
+          @if ((($assetMaintenance->address!='') && ($assetMaintenance->city!='')) || ($assetMaintenance->state!='') || ($assetMaintenance->country!=''))
+            <li>
+              <a href="https://maps.google.com/?q={{ urlencode($assetMaintenance->address.','. $assetMaintenance->city.','.$assetMaintenance->state.','.$assetMaintenance->country.','.$assetMaintenance->zip) }}" target="_blank">
+                {!! trans('admin/locations/message.open_map', ['map_provider_icon' => '<i class="fa-brands fa-google" aria-hidden="true"></i>']) !!}
+                <x-icon type="external-link"/>
+              </a>
+            </li>
+            <li>
+              <a href="https://maps.apple.com/?q={{ urlencode($assetMaintenance->address.','. $assetMaintenance->city.','.$assetMaintenance->state.','.$assetMaintenance->country.','.$assetMaintenance->zip) }}" target="_blank">
+                {!! trans('admin/locations/message.open_map', ['map_provider_icon' => '<i class="fa-brands fa-apple" aria-hidden="true" style="font-size: 18px"></i>']) !!}
+                <x-icon type="external-link"/></a>
+            </li>
+          @endif
+
+        </ul>
+      </div>
+
+      @can('update', $assetMaintenance)
+        <div class="col-md-12">
+          <a href="{{ route('maintenances.edit', [$assetMaintenance->id]) }}" style="width: 100%;" class="btn btn-sm btn-warning btn-social">
+            <x-icon type="edit" />
+            {{ trans('general.update') }}
+          </a>
+        </div>
+      @endcan
+    </div>
+
+    </div> <!-- row  end -->
 
 @stop

--- a/tests/Feature/AssetMaintenances/Api/CreateAssetMaintenanceTest.php
+++ b/tests/Feature/AssetMaintenances/Api/CreateAssetMaintenanceTest.php
@@ -1,38 +1,40 @@
 <?php
 
-namespace Tests\Feature\AssetMaintenances\Ui;
+namespace Tests\Feature\AssetMaintenances\Api;
 
 use App\Models\Asset;
 use App\Models\AssetMaintenance;
+use App\Models\Category;
 use App\Models\Supplier;
 use App\Models\User;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
 class CreateAssetMaintenanceTest extends TestCase
 {
-    public function testPageRenders()
+
+
+    public function testRequiresPermissionToCreateAssetMaintenance()
     {
-        $this->actingAs(User::factory()->superuser()->create())
-            ->get(route('maintenances.create'))
-            ->assertOk();
+        $this->actingAsForApi(User::factory()->create())
+            ->postJson(route('api.maintenances.store'))
+            ->assertForbidden();
     }
-
-
     public function testCanCreateAssetMaintenance()
     {
+
         Storage::fake('public');
         $actor = User::factory()->superuser()->create();
 
         $asset = Asset::factory()->create();
         $supplier = Supplier::factory()->create();
 
-        $this->actingAs($actor)
-            ->followingRedirects()
-            ->post(route('maintenances.store'), [
+        $response = $this->actingAsForApi($actor)
+            ->postJson(route('api.maintenances.store'), [
                 'title' => 'Test Maintenance',
-                'selected_assets' => [$asset->id],
+                'asset_id' => $asset->id,
                 'supplier_id' => $supplier->id,
                 'asset_maintenance_type' => 'Maintenance',
                 'start_date' => '2021-01-01',
@@ -42,14 +44,15 @@ class CreateAssetMaintenanceTest extends TestCase
                 'image' => UploadedFile::fake()->image('test_image.png'),
                 'notes' => 'A note',
             ])
-            ->assertOk();
+            ->assertOk()
+            ->assertStatus(200);
 
+        \Log::error($response->json());
         // Since we rename the file in the ImageUploadRequest, we have to fetch the record from the database
         $assetMaintenance = AssetMaintenance::where('title', 'Test Maintenance')->first();
 
         // Assert file was stored...
         Storage::disk('public')->assertExists(app('asset_maintenances_path').$assetMaintenance->image);
-
 
         $this->assertDatabaseHas('asset_maintenances', [
             'asset_id' => $asset->id,
@@ -59,11 +62,12 @@ class CreateAssetMaintenanceTest extends TestCase
             'is_warranty' => 1,
             'start_date' => '2021-01-01',
             'completion_date' => '2021-01-10',
-            'asset_maintenance_time' => '9',
             'notes' => 'A note',
-            'cost' => '100.00',
             'image' => $assetMaintenance->image,
             'created_by' => $actor->id,
         ]);
     }
+
+
+
 }

--- a/tests/Feature/AssetMaintenances/Api/EditAssetMaintenanceTest.php
+++ b/tests/Feature/AssetMaintenances/Api/EditAssetMaintenanceTest.php
@@ -20,41 +20,36 @@ class EditAssetMaintenanceTest extends TestCase
     }
 
 
-    public function testCanCreateAssetMaintenance()
+    public function testCanEditAssetMaintenance()
     {
         Storage::fake('public');
         $actor = User::factory()->superuser()->create();
-
         $asset = Asset::factory()->create();
         $supplier = Supplier::factory()->create();
-
         $maintenance = AssetMaintenance::factory()->create();
 
-        $this->actingAs($actor)
+        $response = $this->actingAs($actor)
             ->followingRedirects()
-            ->post(route('maintenances.update',  $maintenance), [
+            ->patch(route('maintenances.update',  $maintenance), [
                 'title' => 'Test Maintenance',
-                'selected_assets' => [$asset->id],
                 'supplier_id' => $supplier->id,
                 'asset_maintenance_type' => 'Maintenance',
                 'start_date' => '2021-01-01',
                 'completion_date' => '2021-01-10',
                 'is_warranty' => '1',
-                'cost' => '100.00',
                 'image' => UploadedFile::fake()->image('test_image.png'),
                 'notes' => 'A note',
             ])
             ->assertOk();
 
-        // Since we rename the file in the ImageUploadRequest, we have to fetch the record from the database
-        $assetMaintenance = AssetMaintenance::where('title', 'Test Maintenance')->first();
+        $this->followRedirects($response)->assertSee('alert-success');
 
+        $maintenance->refresh();
         // Assert file was stored...
-        Storage::disk('public')->assertExists(app('asset_maintenances_path').$assetMaintenance->image);
+        Storage::disk('public')->assertExists(app('asset_maintenances_path').$maintenance->image);
 
 
         $this->assertDatabaseHas('asset_maintenances', [
-            'asset_id' => $asset->id,
             'supplier_id' => $supplier->id,
             'asset_maintenance_type' => 'Maintenance',
             'title' => 'Test Maintenance',
@@ -63,9 +58,7 @@ class EditAssetMaintenanceTest extends TestCase
             'completion_date' => '2021-01-10',
             'asset_maintenance_time' => '9',
             'notes' => 'A note',
-            'cost' => '100.00',
-            'image' => $assetMaintenance->image,
-            'created_by' => $actor->id,
+            'image' => $maintenance->image,
         ]);
     }
 }

--- a/tests/Feature/AssetMaintenances/Api/EditAssetMaintenanceTest.php
+++ b/tests/Feature/AssetMaintenances/Api/EditAssetMaintenanceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\AssetMaintenances\Ui;
+namespace Tests\Feature\AssetMaintenances\Api;
 
 use App\Models\Asset;
 use App\Models\AssetMaintenance;
@@ -10,12 +10,12 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
-class CreateAssetMaintenanceTest extends TestCase
+class EditAssetMaintenanceTest extends TestCase
 {
     public function testPageRenders()
     {
         $this->actingAs(User::factory()->superuser()->create())
-            ->get(route('maintenances.create'))
+            ->get(route('maintenances.update', AssetMaintenance::factory()->create()->id))
             ->assertOk();
     }
 
@@ -28,9 +28,11 @@ class CreateAssetMaintenanceTest extends TestCase
         $asset = Asset::factory()->create();
         $supplier = Supplier::factory()->create();
 
+        $maintenance = AssetMaintenance::factory()->create();
+
         $this->actingAs($actor)
             ->followingRedirects()
-            ->post(route('maintenances.store'), [
+            ->post(route('maintenances.update',  $maintenance), [
                 'title' => 'Test Maintenance',
                 'selected_assets' => [$asset->id],
                 'supplier_id' => $supplier->id,

--- a/tests/Feature/AssetMaintenances/Ui/EditAssetMaintenanceTest.php
+++ b/tests/Feature/AssetMaintenances/Ui/EditAssetMaintenanceTest.php
@@ -6,6 +6,8 @@ use App\Models\Asset;
 use App\Models\AssetMaintenance;
 use App\Models\Supplier;
 use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class EditAssetMaintenanceTest extends TestCase
@@ -34,11 +36,17 @@ class EditAssetMaintenanceTest extends TestCase
                 'start_date' => '2021-01-01',
                 'completion_date' => '2021-01-10',
                 'is_warranty' => 1,
+                'image' => UploadedFile::fake()->image('test_image.png'),
                 'cost' => '100.99',
                 'notes' => 'A note',
             ])
             ->assertOk();
 
+        // Since we rename the file in the ImageUploadRequest, we have to fetch the record from the database
+        $assetMaintenance = AssetMaintenance::where('title', 'Test Maintenance')->first();
+
+        // Assert file was stored...
+        Storage::disk('public')->assertExists(app('asset_maintenances_path').$assetMaintenance->image);
 
         $this->assertDatabaseHas('asset_maintenances', [
             'asset_id' => $asset->id,

--- a/tests/Feature/Settings/BrandingSettingsTest.php
+++ b/tests/Feature/Settings/BrandingSettingsTest.php
@@ -44,7 +44,7 @@ class BrandingSettingsTest extends TestCase
 
         $response = $this->actingAs(User::factory()->superuser()->create())
             ->post(route('settings.branding.save',
-                ['logo' => UploadedFile::fake()->image('test_logo.png')->storeAs('', 'test_logo.png', 'public')]
+                ['logo' => UploadedFile::fake()->image('test_logo.png')]
             ))
             ->assertValid('logo')
             ->assertStatus(302)
@@ -52,21 +52,21 @@ class BrandingSettingsTest extends TestCase
             ->assertSessionHasNoErrors();
 
         // Assert files was stored...
-        Storage::disk('public')->assertExists('test_logo.jpg');
+        Storage::disk('public')->assertExists( $setting->logo);
 
         $this->followRedirects($response)->assertSee('alert-success');
 
         $setting->refresh();
-        Storage::disk('public')->assertExists($setting->logo);
     }
+
 
     public function testLogoCanBeDeleted()
     {
         Storage::fake('public');
 
+        UploadedFile::fake()->image('new_test_logo.png')->storeAs('uploads', 'new_test_logo.png', 'public');
         $setting = Setting::factory()->create(['logo' => 'new_test_logo.png']);
-        $original_file = UploadedFile::fake()->image('new_test_logo.png')->storeAs('uploads', 'new_test_logo.png', 'public');
-        Storage::disk('public')->assertExists($original_file);
+        Storage::disk('public')->assertExists('uploads/'.$setting->logo);
 
         $this->assertNotNull($setting->logo);
 
@@ -81,17 +81,13 @@ class BrandingSettingsTest extends TestCase
 
         $this->followRedirects($response)->assertSee(trans('alert-success'));
         $this->assertDatabaseHas('settings', ['logo' => null]);
-        //Storage::disk('public')->assertMissing($original_file);
+        Storage::disk('public')->assertMissing($setting->logo);
     }
 
     public function testEmailLogoCanBeUploaded()
     {
         Storage::fake('public');
-
-        $original_file = UploadedFile::fake()->image('before_test_email_logo.png')->storeAs('', 'before_test_email_logo.png', 'public');
-
-        Storage::disk('public')->assertExists($original_file);
-        Setting::factory()->create(['email_logo' => $original_file]);
+        Setting::factory()->create(['email_logo' => null]);
 
         $response = $this->actingAs(User::factory()->superuser()->create())
             ->from(route('settings.branding.index'))
@@ -107,16 +103,14 @@ class BrandingSettingsTest extends TestCase
         $this->followRedirects($response)->assertSee(trans('alert-success'));
 
         Storage::disk('public')->assertExists('new_test_email_logo.png');
-        // Storage::disk('public')->assertMissing($original_file);
     }
 
     public function testEmailLogoCanBeDeleted()
     {
         Storage::fake('public');
-
-        $setting = Setting::factory()->create(['email_logo' => 'new_test_email_logo.png']);
-        $original_file = UploadedFile::fake()->image('new_test_email_logo.png')->storeAs('', 'new_test_email_logo.png', 'public');
-        Storage::disk('public')->assertExists($original_file);
+        UploadedFile::fake()->image('new_test_logo.png')->storeAs('uploads', 'new_test_logo.png', 'public');
+        $setting = Setting::factory()->create(['email_logo' => 'new_test_logo.png']);
+        Storage::disk('public')->assertExists('uploads/'.$setting->email_logo);
 
         $this->assertNotNull($setting->email_logo);
 
@@ -128,11 +122,12 @@ class BrandingSettingsTest extends TestCase
             ->assertValid('email_logo')
             ->assertStatus(302)
             ->assertRedirect(route('settings.index'));
+
         $setting->refresh();
         $this->followRedirects($response)->assertSee(trans('alert-success'));
         $this->assertDatabaseHas('settings', ['email_logo' => null]);
 
-        //Storage::disk('public')->assertMissing('new_test_email_logo.png');
+        Storage::disk('public')->assertMissing('new_test_email_logo.png');
 
     }
 

--- a/tests/Feature/Settings/BrandingSettingsTest.php
+++ b/tests/Feature/Settings/BrandingSettingsTest.php
@@ -166,9 +166,9 @@ class BrandingSettingsTest extends TestCase
 
         Storage::fake('public');
 
+        UploadedFile::fake()->image('new_test_label_logo.png')->storeAs('uploads', 'new_test_label_logo.png', 'public');
         $setting = Setting::factory()->create(['label_logo' => 'new_test_label_logo.png']);
-        $original_file = UploadedFile::fake()->image('new_test_label_logo.png')->storeAs('', 'new_test_label_logo.png', 'public');
-        Storage::disk('public')->assertExists($original_file);
+        Storage::disk('public')->assertExists('uploads/'.$setting->label_logo);
 
         $this->assertNotNull($setting->label_logo);
 
@@ -183,8 +183,7 @@ class BrandingSettingsTest extends TestCase
 
         $setting->refresh();
         $this->followRedirects($response)->assertSee(trans('alert-success'));
-        // $this->assertNull($setting->refresh()->logo);
-        // Storage::disk('public')->assertMissing($original_file);
+        Storage::disk('public')->assertMissing('new_test_label_logo.png');
 
     }
 

--- a/tests/Feature/Settings/BrandingSettingsTest.php
+++ b/tests/Feature/Settings/BrandingSettingsTest.php
@@ -51,6 +51,9 @@ class BrandingSettingsTest extends TestCase
             ->assertRedirect(route('settings.index'))
             ->assertSessionHasNoErrors();
 
+        // Assert files was stored...
+        Storage::disk('public')->assertExists('test_logo.jpg');
+
         $this->followRedirects($response)->assertSee('alert-success');
 
         $setting->refresh();


### PR DESCRIPTION
This adds an image upload to the asset maintenances. 

I'll be adding regular file uploads as well.

Unfortunately, somehow my sqlite database has gotten corrupted just now, so I have to fix that before I can update some of the other `Storage::fake()` options.

Fixes #10357