### PR TITLE
Fixed 500 when sending non-string for serial property

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -112,7 +112,7 @@ class Asset extends Depreciable
         'location_id'       => ['nullable', 'exists:locations,id', 'fmcs_location'],
         'rtd_location_id'   => ['nullable', 'exists:locations,id', 'fmcs_location'],
         'purchase_date'     => ['nullable', 'date', 'date_format:Y-m-d'],
-        'serial'            => ['nullable', 'unique_undeleted:assets,serial'],
+        'serial'            => ['nullable', 'string', 'unique_undeleted:assets,serial'],
         'purchase_cost'     => ['nullable', 'numeric', 'gte:0', 'max:9999999999999'],
         'supplier_id'       => ['nullable', 'exists:suppliers,id'],
         'asset_eol_date'    => ['nullable', 'date'],

--- a/tests/Feature/Assets/Api/StoreAssetTest.php
+++ b/tests/Feature/Assets/Api/StoreAssetTest.php
@@ -707,6 +707,22 @@ class StoreAssetTest extends TestCase
             });
     }
 
+    public function test_serial_validation()
+    {
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->postJson(route('api.assets.store'), [
+                'asset_tag' => '1234',
+                'model_id' => AssetModel::factory()->create()->id,
+                'status_id' => Statuslabel::factory()->readyToDeploy()->create()->id,
+                'serial' => [
+                    // this should not be an array
+                ],
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('error')
+            ->assertMessagesContains('serial');
+    }
+
     public function testEncryptedCustomFieldCanBeStored()
     {
         $this->markIncompleteIfMySQL('Custom Fields tests do not work on MySQL');


### PR DESCRIPTION
This PR adds `string` to the `Asset` model's validation rules to prevent hard-500s when users attempt to send arrays (`Array to string conversion`).

[RB-18571]
[RB-19812]
