### PR TITLE
AssetPolicy class import 

### DIFF
--- a/app/Policies/AssetPolicy.php
+++ b/app/Policies/AssetPolicy.php
@@ -3,6 +3,7 @@
 namespace App\Policies;
 
 use App\Models\User;
+use App\Models\Asset;
 
 class AssetPolicy extends CheckoutablePermissionsPolicy
 {


### PR DESCRIPTION
Unsure if this is the fix, but, noticed this while working on another branch.

We did not import the Asset class in the AssetPolicy.

However, in pretty much every case I have seen in the codebase we use `Asset::class` when passing to the policy, so this probably has never worked correctly.