### PR TITLE
Salutation target fix

### DIFF
--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -30,10 +30,18 @@ class CheckoutAssetMail extends Mailable
         $this->item = $asset;
         $this->admin = $checkedOutBy;
         $this->note = $note;
-        $this->target = $checkedOutTo;
         $this->acceptance = $acceptance;
 
         $this->settings = Setting::getSettings();
+        $this->target = $checkedOutTo;
+
+        // Location is a target option, but there are no emails currently associated with locations.
+        if($this->target instanceof User){
+            $this->target = $this->target->present()->fullName();
+        }
+        else if($this->target instanceof Asset){
+            $this->target = $this->target->assignedto->present()->fullName();
+        }
 
         $this->last_checkout = '';
         $this->expected_checkin = '';

--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -24,6 +24,7 @@ class CheckoutAssetMail extends Mailable
 
     /**
      * Create a new message instance.
+     * @throws \Exception
      */
     public function __construct(Asset $asset, $checkedOutTo, User $checkedOutBy, $acceptance, $note, bool $firstTimeSending = true)
     {
@@ -37,10 +38,10 @@ class CheckoutAssetMail extends Mailable
 
         // Location is a target option, but there are no emails currently associated with locations.
         if($this->target instanceof User){
-            $this->target = $this->target->present()->fullName();
+            $this->target = $this->target->present()?->fullName();
         }
         else if($this->target instanceof Asset){
-            $this->target = $this->target->assignedto->present()->fullName();
+            $this->target = $this->target->assignedto?->present()?->fullName();
         }
 
         $this->last_checkout = '';

--- a/app/Mail/CheckoutLicenseMail.php
+++ b/app/Mail/CheckoutLicenseMail.php
@@ -31,10 +31,10 @@ class CheckoutLicenseMail extends Mailable
         $this->target = $checkedOutTo;
 
         if($this->target instanceof User){
-            $this->target = $this->target->present()->fullName();
+            $this->target = $this->target->present()?->fullName();
         }
         elseif($this->target instanceof Asset){
-            $this->target = $this->target->assignedto->present()->fullName();
+            $this->target = $this->target->assignedto?->present()?->fullName();
         }
     }
 

--- a/app/Mail/CheckoutLicenseMail.php
+++ b/app/Mail/CheckoutLicenseMail.php
@@ -2,6 +2,7 @@
 
 namespace App\Mail;
 
+use App\Models\Asset;
 use App\Models\LicenseSeat;
 use App\Models\Setting;
 use App\Models\User;
@@ -25,9 +26,16 @@ class CheckoutLicenseMail extends Mailable
         $this->item = $licenseSeat;
         $this->admin = $checkedOutBy;
         $this->note = $note;
-        $this->target = $checkedOutTo;
         $this->acceptance = $acceptance;
         $this->settings = Setting::getSettings();
+        $this->target = $checkedOutTo;
+
+        if($this->target instanceof User){
+            $this->target = $this->target->present()->fullName();
+        }
+        elseif($this->target instanceof Asset){
+            $this->target = $this->target->assignedto->present()->fullName();
+        }
     }
 
     /**

--- a/resources/views/mail/markdown/checkout-asset.blade.php
+++ b/resources/views/mail/markdown/checkout-asset.blade.php
@@ -1,5 +1,5 @@
 @component('mail::message')
-# {{ trans('mail.hello') }}{{ $target->assignedto?->present()->fullName() ? ' ' . $target->assignedto->present()->fullName() . ',' : ',' }}
+# {{ trans('mail.hello').' '.$target.','}}
 
 {{ $introduction_line }}
 

--- a/resources/views/mail/markdown/checkout-license.blade.php
+++ b/resources/views/mail/markdown/checkout-license.blade.php
@@ -1,5 +1,5 @@
 @component('mail::message')
-# {{ trans('mail.hello') }} {{ $target->present()->fullName() }},
+# {{ trans('mail.hello').' '.$target.','}}
 
 {{ trans('mail.new_item_checked') }}
 


### PR DESCRIPTION
This now applies the correct method chaining for a recipient name based on being checked out to an asset or user.