### PR TITLE
Fixed invalid custom fields being used for filtering

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -117,15 +117,19 @@ class AssetsController extends Controller
             'jobtitle',
         ];
 
+        $all_custom_fields = CustomField::all(); //used as a 'cache' of custom fields throughout this page load
+        foreach ($all_custom_fields as $field) {
+            $allowed_columns[] = $field->db_column_name();
+        }
+
         $filter = [];
 
         if ($request->filled('filter')) {
             $filter = json_decode($request->input('filter'), true);
-        }
 
-        $all_custom_fields = CustomField::all(); //used as a 'cache' of custom fields throughout this page load
-        foreach ($all_custom_fields as $field) {
-            $allowed_columns[] = $field->db_column_name();
+            $filter = array_filter($filter, function ($key) use ($allowed_columns) {
+                return in_array($key, $allowed_columns);
+            }, ARRAY_FILTER_USE_KEY);
         }
 
         $assets = Asset::select('assets.*')

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -119,7 +119,9 @@ class AssetsController extends Controller
 
         $all_custom_fields = CustomField::all(); //used as a 'cache' of custom fields throughout this page load
         foreach ($all_custom_fields as $field) {
-            $allowed_columns[] = $field->db_column_name();
+            // custom fields are prefixed with "custom_fields.".
+            // We'll add them to the allowed columns so they can be searched.
+            $allowed_columns[] = 'custom_fields.' . $field->db_column_name();
         }
 
         $filter = [];


### PR DESCRIPTION
This PR fixes an issue where invalid custom fields were being accepted and used for filtering. Now the `$filter` is run through `array_filter` checked against `$allowed_columns` and valid custom field keys.

[RB-20068]
[RB-20069]