### PR TITLE
Added basic logging for maintenances

### DIFF
--- a/app/Models/Maintenance.php
+++ b/app/Models/Maintenance.php
@@ -169,6 +169,21 @@ class Maintenance extends SnipeModel implements ICompanyableChild
         return $this->belongsTo(\App\Models\Asset::class, 'asset_id')
             ->withTrashed();
     }
+
+    /**
+     * Get the asset's logs
+     *
+     * @author [A. Gianotto] [<snipe@snipe.net>]
+     * @since  [v2.0]
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function assetlog()
+    {
+        return $this->hasMany(\App\Models\Actionlog::class, 'item_id')
+            ->where('item_type', '=', self::class)
+            ->orderBy('created_at', 'desc')
+            ->withTrashed();
+    }
     
 
     /**

--- a/app/Models/Maintenance.php
+++ b/app/Models/Maintenance.php
@@ -171,10 +171,10 @@ class Maintenance extends SnipeModel implements ICompanyableChild
     }
 
     /**
-     * Get the asset's logs
+     * Get the maintenance logs
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since  [v2.0]
+     * @since  [v8.2.2]
      * @return \Illuminate\Database\Eloquent\Relations\Relation
      */
     public function assetlog()

--- a/app/Observers/MaintenanceObserver.php
+++ b/app/Observers/MaintenanceObserver.php
@@ -3,26 +3,28 @@
 namespace App\Observers;
 
 use App\Models\Actionlog;
-use App\Models\Component;
-use Illuminate\Support\Facades\Auth;
+use App\Models\Maintenance;
+use App\Models\Asset;
 
-class ComponentObserver
+class MaintenanceObserver
 {
     /**
      * Listen to the User created event.
      *
-     * @param  Component  $component
+     * @param  Maintenance  $maintenance
      * @return void
      */
-    public function updated(Component $component)
+    public function updated(Maintenance $maintenance)
     {
         $logAction = new Actionlog();
-        $logAction->item_type = Component::class;
-        $logAction->item_id = $component->id;
+        $logAction->item_type = Maintenance::class;
+        $logAction->item_id = $maintenance->id;
+        $logAction->target_type = Asset::class;
+        $logAction->target_id = $maintenance->asset_id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->action_date = date('Y-m-d H:i:s');
         $logAction->created_by = auth()->id();
-        if($component->imported) {
+        if($maintenance->imported) {
             $logAction->setActionSource('importer');
         }
         $logAction->logaction('update');
@@ -32,18 +34,20 @@ class ComponentObserver
      * Listen to the Component created event when
      * a new component is created.
      *
-     * @param  Component  $component
+     * @param  Maintenance  $maintenance
      * @return void
      */
-    public function created(Component $component)
+    public function created(Maintenance $maintenance)
     {
         $logAction = new Actionlog();
-        $logAction->item_type = Component::class;
-        $logAction->item_id = $component->id;
+        $logAction->item_type = Maintenance::class;
+        $logAction->item_id = $maintenance->id;
+        $logAction->target_type = Asset::class;
+        $logAction->target_id = $maintenance->asset_id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->action_date = date('Y-m-d H:i:s');
         $logAction->created_by = auth()->id();
-        if($component->imported) {
+        if($maintenance->imported) {
             $logAction->setActionSource('importer');
         }
         $logAction->logaction('create');
@@ -52,14 +56,16 @@ class ComponentObserver
     /**
      * Listen to the Component deleting event.
      *
-     * @param  Component  $component
+     * @param  Maintenance  $maintenance
      * @return void
      */
-    public function deleting(Component $component)
+    public function deleting(Maintenance $maintenance)
     {
         $logAction = new Actionlog();
-        $logAction->item_type = Component::class;
-        $logAction->item_id = $component->id;
+        $logAction->item_type = Maintenance::class;
+        $logAction->item_id = $maintenance->id;
+        $logAction->target_type = Asset::class;
+        $logAction->target_id = $maintenance->asset_id;
         $logAction->created_at = date('Y-m-d H:i:s');
         $logAction->action_date = date('Y-m-d H:i:s');
         $logAction->created_by = auth()->id();

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use App\Models\Asset;
 use App\Models\Component;
 use App\Models\Consumable;
 use App\Models\License;
+use App\Models\Maintenance;
 use App\Models\User;
 use App\Models\Setting;
 use App\Models\SnipeSCIMConfig;
@@ -17,6 +18,7 @@ use App\Observers\ComponentObserver;
 use App\Observers\ConsumableObserver;
 use App\Observers\LicenseObserver;
 use App\Observers\SettingObserver;
+use App\Observers\MaintenanceObserver;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
@@ -67,6 +69,7 @@ class AppServiceProvider extends ServiceProvider
 
         Schema::defaultStringLength(191);
         Asset::observe(AssetObserver::class);
+        Maintenance::observe(MaintenanceObserver::class);
         User::observe(UserObserver::class);
         Accessory::observe(AccessoryObserver::class);
         Component::observe(ComponentObserver::class);

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -368,12 +368,12 @@
 
                 // Add some overrides for any funny urls we have
                 var dest = destination;
-                var dpolymorphicItemFormatterest = '';
+                var polymorphicItemFormatterDest;
                 if (destination=='fieldsets') {
-                    var dpolymorphicItemFormatterest = 'fields/';
+                    var polymorphicItemFormatterDest = 'fields/';
                 }
 
-                return '<nobr><a href="{{ config('app.url') }}/' + dpolymorphicItemFormatterest + dest + '/' + value.id + '">' + value.name + '</a></span>';
+                return '<nobr><a href="{{ config('app.url') }}/' + polymorphicItemFormatterDest + dest + '/' + value.id + '">' + value.name + '</a></span>';
             }
         };
     }
@@ -438,8 +438,6 @@
 
                 if (row.name) {
                     var name_for_box = row.name
-                } else if (row.title) {
-                    var name_for_box = row.title
                 } else if (row.asset_tag) {
                     var name_for_box = row.asset_tag
                 }
@@ -503,6 +501,9 @@
             } else if (value.type == 'location') {
                 item_destination = 'locations'
                 item_icon = 'fas fa-map-marker-alt';
+            } else if (value.type == 'maintenance') {
+                item_destination = 'maintenances'
+                item_icon = 'fa-solid fa-screwdriver-wrench';
             } else if (value.type == 'model') {
                 item_destination = 'models'
                 item_icon = '';
@@ -618,25 +619,26 @@
 
 
     var formatters = [
-        'hardware',
         'accessories',
-        'consumables',
-        'components',
-        'locations',
-        'users',
-        'manufacturers',
-        'maintenances',
-        'statuslabels',
-        'models',
-        'licenses',
         'categories',
-        'suppliers',
-        'departments',
         'companies',
+        'components',
+        'consumables',
+        'departments',
         'depreciations',
         'fieldsets',
         'groups',
-        'kits'
+        'hardware',
+        'kits',
+        'licenses',
+        'locations',
+        'maintenances',
+        'maintenances',
+        'manufacturers',
+        'models',
+        'statuslabels',
+        'suppliers',
+        'users',
     ];
 
     for (var i in formatters) {

--- a/tests/Feature/Maintenances/Api/CreateMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Api/CreateMaintenanceTest.php
@@ -65,6 +65,8 @@ class CreateMaintenanceTest extends TestCase
             'image' => $maintenance->image,
             'created_by' => $actor->id,
         ]);
+
+        $this->assertHasTheseActionLogs($maintenance, ['create']);
     }
 
 

--- a/tests/Feature/Maintenances/Api/DeleteMaintenancesTest.php
+++ b/tests/Feature/Maintenances/Api/DeleteMaintenancesTest.php
@@ -55,6 +55,7 @@ class DeleteMaintenancesTest extends TestCase implements TestsFullMultipleCompan
         $this->assertNotSoftDeleted($maintenanceA);
         $this->assertNotSoftDeleted($maintenanceB);
         $this->assertSoftDeleted($maintenanceC);
+        $this->assertHasTheseActionLogs($maintenanceC, ['create', 'delete']);
     }
 
     public function testCanDeleteMaintenance()
@@ -66,5 +67,7 @@ class DeleteMaintenancesTest extends TestCase implements TestsFullMultipleCompan
             ->assertStatusMessageIs('success');
 
         $this->assertSoftDeleted($maintenance);
+
+        $this->assertHasTheseActionLogs($maintenance, ['create', 'delete']);
     }
 }

--- a/tests/Feature/Maintenances/Api/EditMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Api/EditMaintenanceTest.php
@@ -59,5 +59,7 @@ class EditMaintenanceTest extends TestCase
             'notes' => 'A note',
             'image' => $maintenance->image,
         ]);
+
+        $this->assertHasTheseActionLogs($maintenance, ['create', 'update']);
     }
 }

--- a/tests/Feature/Maintenances/Ui/CreateMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Ui/CreateMaintenanceTest.php
@@ -71,5 +71,7 @@ class CreateMaintenanceTest extends TestCase
             'image' => $maintenance->image,
             'created_by' => $actor->id,
         ]);
+
+        $this->assertHasTheseActionLogs($maintenance, ['create']);
     }
 }

--- a/tests/Feature/Maintenances/Ui/EditMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Ui/EditMaintenanceTest.php
@@ -60,6 +60,8 @@ class EditMaintenanceTest extends TestCase
             'notes' => 'A note',
             'cost' => '100.99',
         ]);
+
+        $this->assertHasTheseActionLogs($maintenance, ['create', 'update']);
     }
 
 }


### PR DESCRIPTION
This doesn't (yet) to the log_meta style where we track what specifically changed,  but we do at least track the creation, editing, and deletion of maintenances.

@uberbrady - I know this is going to conflict with your logging changes, but I at least added tests to check for the log entries, so we can at least test against your changes. 