### PR TITLE
Adds #13997 - API endpoint to sync users via LDAP

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1031,6 +1031,13 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
                 ]
             )->name('api.users.selectlist');
 
+            Route::post('ldapsync',
+                [
+                    Api\UsersController::class,
+                    'syncLdapUsers'
+                ]
+            )->name('api.users.ldapsync');
+
             Route::post('two_factor_reset',
                 [
                     Api\UsersController::class, 


### PR DESCRIPTION
This adds an API endpoint to LDAP sync users via API. While I don't imagine most folks will use this, it could come in handy (via the OPs use case.) I don't have a super easy way to test this though, so if anyone who uses LDAP wants to give it a shot, I'd appreciate it!

Fixes #13997