### PR TITLE
Fixed #17490: use numeric for purchase cost

### DIFF
--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1157,6 +1157,7 @@ dir="{{ Helper::determineLanguageDirection() }}">
                     $(inputElement).closest('.help-block').remove();
                 },
                 onfocusout: function(element) {
+                    $(element).parent().removeClass('has-error');
                     return $(element).valid();
                 },
 

--- a/resources/views/partials/forms/edit/purchase_cost.blade.php
+++ b/resources/views/partials/forms/edit/purchase_cost.blade.php
@@ -3,7 +3,7 @@
     <label for="purchase_cost" class="col-md-3 control-label">{{ trans('general.purchase_cost') }}</label>
     <div class="col-md-9">
         <div class="input-group col-md-4" style="padding-left: 0px;">
-            <input class="form-control" type="text" name="purchase_cost" aria-label="purchase_cost" id="purchase_cost" value="{{ old('purchase_cost', Helper::formatCurrencyOutput($item->purchase_cost)) }}" maxlength="24" />
+            <input class="form-control" type="number" name="purchase_cost" min="0.00" max="10000000.000" step="0.001" aria-label="purchase_cost" id="purchase_cost" value="{{ old('purchase_cost', Helper::formatCurrencyOutput($item->purchase_cost)) }}" maxlength="24" />
             <span class="input-group-addon">
                 @if (isset($currency_type))
                     {{ $currency_type }}


### PR DESCRIPTION
This forces the field type of be number so that if you accidentally add a currency symbol, it will fail validation. 

I don't expect most people to use the stepper, as they're generally pretty annoying, however we have to use xx.xxx (vers xx.xx) because some currencies use three numbers after the decimal point. 

Fixes #17490