### PR TITLE
Adds #17440 serial number column to Expiring Assets Report

### DIFF
--- a/resources/views/notifications/markdown/report-expiring-assets.blade.php
+++ b/resources/views/notifications/markdown/report-expiring-assets.blade.php
@@ -3,14 +3,14 @@
 @component('mail::table')
 
 <table width="100%">
-<tr><td>&nbsp;</td><td>{{ trans('mail.name') }}</td><td>{{ trans('mail.Days') }}</td><td>{{ trans('mail.expires') }}</td><td>{{ trans('mail.supplier') }}</td><td>{{ trans('mail.assigned_to') }}</td></tr>
+<tr><td>&nbsp;</td><td>{{ trans('mail.name') }}</td><td>{{ trans('mail.serial') }}</td><td>{{ trans('mail.Days') }}</td><td>{{ trans('mail.expires') }}</td><td>{{ trans('mail.supplier') }}</td><td>{{ trans('mail.assigned_to') }}</td></tr>
 @foreach ($assets as $asset)
 @php
 $expires = Helper::getFormattedDateObject($asset->present()->warranty_expires, 'date');
 $diff = round(abs(strtotime($asset->present()->warranty_expires) - strtotime(date('Y-m-d')))/86400);
 $icon = ($diff <= ($threshold / 2)) ? '🚨' : (($diff <= $threshold) ? '⚠️' : ' ');
 @endphp
-<tr><td>{{ $icon }} </td><td> <a href="{{ route('hardware.show', $asset->id) }}">{{ $asset->present()->name }}</a> </td><td> {{ $diff }} {{ trans('mail.Days') }} </td><td> {{ !is_null($expires) ? $expires['formatted'] : '' }} </td><td> {{ ($asset->supplier ? e($asset->supplier->name) : '') }} </td><td> {{ ($asset->assignedTo ? e($asset->assignedTo->present()->name()) : '') }} </td></tr>
+<tr><td>{{ $icon }} </td><td> <a href="{{ route('hardware.show', $asset->id) }}">{{ $asset->present()->name }}</a> <td>{{$asset->serial}}</td><td> {{ $diff }} {{ trans('mail.Days') }} </td><td> {{ !is_null($expires) ? $expires['formatted'] : '' }} </td><td> {{ ($asset->supplier ? e($asset->supplier->name) : '') }} </td><td> {{ ($asset->assignedTo ? e($asset->assignedTo->present()->name()) : '') }} </td></tr>
 @endforeach
 </table>
 @endcomponent

--- a/resources/views/notifications/markdown/report-expiring-assets.blade.php
+++ b/resources/views/notifications/markdown/report-expiring-assets.blade.php
@@ -3,14 +3,14 @@
 @component('mail::table')
 
 <table width="100%">
-<tr><td>&nbsp;</td><td>{{ trans('mail.name') }}</td><td>{{ trans('mail.serial') }}</td><td>{{ trans('mail.Days') }}</td><td>{{ trans('mail.expires') }}</td><td>{{ trans('mail.supplier') }}</td><td>{{ trans('mail.assigned_to') }}</td></tr>
+<tr><td>&nbsp;</td><td>{{ trans('mail.name') }}</small></td><td>{{ trans('mail.serial') }}</td><td>{{ trans('mail.Days') }}</td><td>{{ trans('mail.expires') }}</td><td>{{ trans('mail.supplier') }}</td><td>{{ trans('mail.assigned_to') }}</td></tr>
 @foreach ($assets as $asset)
 @php
 $expires = Helper::getFormattedDateObject($asset->present()->warranty_expires, 'date');
 $diff = round(abs(strtotime($asset->present()->warranty_expires) - strtotime(date('Y-m-d')))/86400);
 $icon = ($diff <= ($threshold / 2)) ? '🚨' : (($diff <= $threshold) ? '⚠️' : ' ');
 @endphp
-<tr><td>{{ $icon }} </td><td> <a href="{{ route('hardware.show', $asset->id) }}">{{ $asset->present()->name }}</a> <td>{{$asset->serial}}</td><td> {{ $diff }} {{ trans('mail.Days') }} </td><td> {{ !is_null($expires) ? $expires['formatted'] : '' }} </td><td> {{ ($asset->supplier ? e($asset->supplier->name) : '') }} </td><td> {{ ($asset->assignedTo ? e($asset->assignedTo->present()->name()) : '') }} </td></tr>
+        <tr><td>{{ $icon }} </td><td> <a href="{{ route('hardware.show', $asset->id) }}">{{ $asset->present()->name }}</a><br><small>{{trans('mail.serial').': '.$asset->serial}}</small></td><td> {{ $diff }} {{ trans('mail.Days') }} </td><td> {{ !is_null($expires) ? $expires['formatted'] : '' }} </td><td> {{ ($asset->supplier ? e($asset->supplier->name) : '') }} </td><td> {{ ($asset->assignedTo ? e($asset->assignedTo->present()->name()) : '') }} </td></tr>
 @endforeach
 </table>
 @endcomponent


### PR DESCRIPTION
This adds the serial number under the name to the expiring assets report email:
<img width="1192" height="233" alt="image" src="https://github.com/user-attachments/assets/a7c0f264-9c35-4644-bbb8-478b7ccb6a31" />

Fixes: #17440 