### PR TITLE
Logging Audit on Checkin and Checkout

### DIFF
--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Log;
 use \Illuminate\Contracts\View\View;
 use \Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Validator;
+use Gate;
 
 class AssetCheckinController extends Controller
 {
@@ -151,6 +152,12 @@ class AssetCheckinController extends Controller
         $asset->customFieldsForCheckinCheckout('display_checkin');
 
         if ($asset->save()) {
+
+            if(Gate::allows('audit',$asset)) {
+                if ($request->filled('log_audit') == "1") {
+                    $asset->logAudit($request->input('note'), $request->input('location_id'));
+                }
+            }
 
             event(new CheckoutableCheckedIn($asset, $target, auth()->user(), $request->input('note'), $checkin_at, $originalValues));
             return Helper::getRedirectOption($request, $asset->id, 'Assets')

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -153,13 +153,13 @@ class AssetCheckinController extends Controller
 
         if ($asset->save()) {
 
-            event(new CheckoutableCheckedIn($asset, $target, auth()->user(), $request->input('note'), $checkin_at, $originalValues));
-
-            if(Gate::allows('audit',$asset)) {
+            if(Gate::allows('audit',Asset::class)) {
                 if ($request->filled('log_audit') == "1") {
                     $asset->logAudit($request->input('note'), $request->input('location_id'));
                 }
             }
+
+            event(new CheckoutableCheckedIn($asset, $target, auth()->user(), $request->input('note'), $checkin_at, $originalValues));
 
             return Helper::getRedirectOption($request, $asset->id, 'Assets')
                 ->with('success', trans('admin/hardware/message.checkin.success'));

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -153,13 +153,14 @@ class AssetCheckinController extends Controller
 
         if ($asset->save()) {
 
+            event(new CheckoutableCheckedIn($asset, $target, auth()->user(), $request->input('note'), $checkin_at, $originalValues));
+
             if(Gate::allows('audit',$asset)) {
                 if ($request->filled('log_audit') == "1") {
                     $asset->logAudit($request->input('note'), $request->input('location_id'));
                 }
             }
 
-            event(new CheckoutableCheckedIn($asset, $target, auth()->user(), $request->input('note'), $checkin_at, $originalValues));
             return Helper::getRedirectOption($request, $asset->id, 'Assets')
                 ->with('success', trans('admin/hardware/message.checkin.success'));
         }

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -126,7 +126,7 @@ class AssetCheckoutController extends Controller
 
             if ($asset->checkOut($target, $admin, $checkout_at, $expected_checkin, $request->get('note'), $request->get('name'))) {
 
-                if(Gate::allows('audit',$asset)) {
+                if(Gate::allows('audit',Asset::class)) {
                     if ($request->filled('log_audit') == "1") {
                         $asset->logAudit($request->input('note'), $request->input('location_id'));
                     }

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -8,11 +8,13 @@ use App\Http\Controllers\CheckInOutRequest;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AssetCheckoutRequest;
 use App\Models\Asset;
+use App\Http\Controllers\Assets\AssetsController;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Session;
 use \Illuminate\Contracts\View\View;
 use \Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Validator;
+use Gate;
 
 class AssetCheckoutController extends Controller
 {
@@ -123,6 +125,13 @@ class AssetCheckoutController extends Controller
             session()->put(['redirect_option' => $request->get('redirect_option'), 'checkout_to_type' => $request->get('checkout_to_type')]);
 
             if ($asset->checkOut($target, $admin, $checkout_at, $expected_checkin, $request->get('note'), $request->get('name'))) {
+
+                if(Gate::allows('audit',$asset)) {
+                    if ($request->filled('log_audit') == "1") {
+                        $asset->logAudit($request->input('note'), $request->input('location_id'));
+                    }
+                }
+
                 return Helper::getRedirectOption($request, $asset->id, 'Assets')
                     ->with('success', trans('admin/hardware/message.checkout.success'));
             }

--- a/resources/lang/en-US/admin/settings/general.php
+++ b/resources/lang/en-US/admin/settings/general.php
@@ -291,6 +291,8 @@ return [
     'require_accept_signature_help_text'      => 'Enabling this feature will require users to physically sign off on accepting an asset.',
     'require_checkinout_notes'  => 'Require Notes on Checkin/Checkout',
     'require_checkinout_notes_help_text'    => 'Enabling this feature will require the note fields to be populated when checking in or checking out an asset.',
+    'log_audit' => 'Log an audit',
+    'log_audit_help_text' => 'Enabling this feature will also log an audit in addition to this',
     'left'        => 'left',
     'right'        => 'right',
     'top'        => 'top',

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -176,8 +176,6 @@
                                                 'model' => $asset->model,
                                                 'show_custom_fields_type' => 'checkin'
                                         ])
-
-
                     </div> <!--/.box-body-->
                 </div> <!--/.box-body-->
 
@@ -194,7 +192,6 @@
                 </form>
 
             </div>
-        </div>
     </div>
 
 @stop

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -151,6 +151,25 @@
                                             </div>
                                         </div>
 
+                                        <!-- Log an audit checkbox -->
+                                        @can('audit', \App\Models\Asset::class)
+                                        <div class="form-group">
+                                            <div class="col-sm-3 control-label" >
+                                                <label>
+                                                    {{ trans('admin/settings/general.log_audit') }}
+                                                </label>
+                                            </div>
+                                            <div class="col-md-8">
+                                                <label class="form-control">
+                                                    <input type="checkbox" value="1" name="log_audit" {{ (old('log_audit')) == '1' ? ' checked="checked"' : '' }} aria-label="log_audit">
+                                                    {{ trans('general.yes') }}
+                                                </label>
+                                                <p class="help-block">{{ trans('admin/settings/general.log_audit_help_text')  . " " .  trans('general.checkin') . "." }}</p>
+                                            </div>
+                                        </div>
+                                        @endcan
+
+
 
                                         <!-- Custom fields -->
                                         @include("models/custom_fields_form", [

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -152,7 +152,25 @@
                                 {!! $errors->first('note', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
-                        
+
+                        <!-- Log an audit checkbox -->
+                        @can('audit', \App\Models\Asset::class)
+                        <div class="form-group">
+                            <div class="col-sm-3 control-label" >
+                                <label>
+                                    {{ trans('admin/settings/general.log_audit') }}
+                                </label>
+                            </div>
+                            <div class="col-md-8">
+                                <label class="form-control">
+                                    <input type="checkbox" value="1" name="log_audit" {{ (old('log_audit')) == '1' ? ' checked="checked"' : '' }} aria-label="log_audit">
+                                    {{ trans('general.yes') }}
+                                </label>
+                                <p class="help-block">{{ trans('admin/settings/general.log_audit_help_text')  . " " .  trans('general.checkout') . "." }}</p>
+                            </div>
+                        </div>
+                        @endcan
+
                         <!-- Custom fields -->
                         @include("models/custom_fields_form", [
                                 'model' => $asset->model,
@@ -222,4 +240,53 @@
 
 @section('moar_scripts')
     @include('partials/assets-assigned')
+
+    <script> //testing script
+        function auditCheckbox() {
+            // Get the checkbox
+            var checkBox = document.getElementById("auditcheckbox");
+            // Get the output text
+            var text = document.getElementById("audittext");
+            // If the checkbox is checked, display the fields
+            if (checkBox.checked == true) {
+                text.style.display = "block";
+            } else {
+                text.style.display = "none";
+            }
+        }
+    </script>
+
+    <script>
+        // Only display the audit fields if the checkbox is selected
+        $(".format").change(function(){
+            $(this).find("option:selected").each(function(){
+                if ($('.format').prop("selectedIndex") == 1) {
+                    $("#custom_regex").show();
+                } else{
+                    $("#custom_regex").hide();
+                }
+            });
+        }).change();
+    </script>
+
+    <script>
+        $(document).ready(function() {
+            $("#optional_info").on("click", function () {
+                $('#optional_details').fadeToggle(100);
+                $('#optional_info_icon').toggleClass('checkbox);
+                var optional_info_open = $('#optional_info_icon').hasClass('checkbox');
+                document.cookie = "optional_info_open=" + optional_info_open + '; path=/';
+            });
+            var all_cookies = document.cookie.split(';')
+            for (var i in all_cookies) {
+                var trimmed_cookie = all_cookies[i].trim(' ')
+                if (trimmed_cookie.startsWith('optional_info_open=')) {
+                    elems = all_cookies[i].split('=', 2)
+                    if (elems[1] == 'true') {
+                        $('#optional_info').trigger('click');
+                    }
+                }
+            }
+        });
+        </script>
 @stop


### PR DESCRIPTION
Adding in an option to log an audit when you check in or out an asset.
<img width="726" alt="Screenshot 2025-04-09 at 7 29 22 PM" src="https://github.com/user-attachments/assets/f1b606a3-52ec-4130-b1c1-5b2266b4816c" />

<img width="908" alt="Screenshot 2025-04-09 at 7 30 02 PM" src="https://github.com/user-attachments/assets/5b3ca21f-d921-4eb5-a7ba-8ae4ce7d1c78" />

There is less information on the audit itself, but all changes to an asset will be logged on the checkin or out.

NOTE: **This action does not allow a user to manually set a next audit date OR upload a picture as these are not options on checkin or checkout**

Update of https://github.com/grokability/snipe-it/pull/16679 after a bad merge.