### PR TITLE
FIXED #17380 Adds Admin name to acceptance emails

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -232,6 +232,7 @@ class AcceptanceController extends Controller
                 'signature' => ($sig_filename) ? storage_path() . '/private_uploads/signatures/' . $sig_filename : null,
                 'logo' => $path_logo,
                 'date_settings' => $branding_settings->date_display_format,
+                'admin' => auth()->user()->present()?->fullName,
             ];
 
             if ($pdf_view_route!='') {

--- a/app/Notifications/AcceptanceAssetAcceptedNotification.php
+++ b/app/Notifications/AcceptanceAssetAcceptedNotification.php
@@ -29,7 +29,7 @@ class AcceptanceAssetAcceptedNotification extends Notification
         $this->assigned_to = $params['assigned_to'];
         $this->note = $params['note'];
         $this->company_name = $params['company_name'];
-        $this->admin = $params['admin'];
+        $this->admin = $params['admin'] ?? null;
         $this->settings = Setting::getSettings();
 
     }

--- a/app/Notifications/AcceptanceAssetAcceptedNotification.php
+++ b/app/Notifications/AcceptanceAssetAcceptedNotification.php
@@ -29,6 +29,7 @@ class AcceptanceAssetAcceptedNotification extends Notification
         $this->assigned_to = $params['assigned_to'];
         $this->note = $params['note'];
         $this->company_name = $params['company_name'];
+        $this->admin = $params['admin'];
         $this->settings = Setting::getSettings();
 
     }
@@ -72,6 +73,7 @@ class AcceptanceAssetAcceptedNotification extends Notification
                 'assigned_to'   => $this->assigned_to,
                 'company_name'  => $this->company_name,
                 'intro_text'    => trans('mail.acceptance_asset_accepted'),
+                'admin'         => $this->admin,
             ])
             ->subject(trans('mail.acceptance_asset_accepted'));
 

--- a/resources/views/notifications/markdown/asset-acceptance.blade.php
+++ b/resources/views/notifications/markdown/asset-acceptance.blade.php
@@ -37,6 +37,7 @@
 @if (isset($item_serial))
 | **{{ trans('mail.serial') }}** | {{ $item_serial }} |
 @endif
+| **{{ trans('general.checked_out').' '.trans('general.by')}}** | {{ $admin }} |
 @endcomponent
 
 {{ trans('mail.best_regards') }}

--- a/resources/views/notifications/markdown/asset-acceptance.blade.php
+++ b/resources/views/notifications/markdown/asset-acceptance.blade.php
@@ -37,7 +37,9 @@
 @if (isset($item_serial))
 | **{{ trans('mail.serial') }}** | {{ $item_serial }} |
 @endif
+@if (isset($admin))
 | **{{ trans('general.checked_out').' '.trans('general.by')}}** | {{ $admin }} |
+@endif
 @endcomponent
 
 {{ trans('mail.best_regards') }}


### PR DESCRIPTION
This adds Administrator's full name to the acceptance email for an asset:

<img width="672" height="660" alt="image" src="https://github.com/user-attachments/assets/aea8fb88-f7f9-4b81-82f5-a7134f56b6db" />

Fixes: #17380 
