### PR TITLE
Fixed #9965 - fallback to category images (if there are any) when no c…

### DIFF
--- a/app/Http/Transformers/ConsumablesTransformer.php
+++ b/app/Http/Transformers/ConsumablesTransformer.php
@@ -25,7 +25,7 @@ class ConsumablesTransformer
         $array = [
             'id'            => (int) $consumable->id,
             'name'          => e($consumable->name),
-            'image' =>   ($consumable->image) ? Storage::disk('public')->url('consumables/'.e($consumable->image)) : null,
+            'image' =>   ($consumable->getImageUrl()) ? ($consumable->getImageUrl()) : null,
             'category'      => ($consumable->category) ? ['id' => $consumable->category->id, 'name' => e($consumable->category->name)] : null,
             'company'   => ($consumable->company) ? ['id' => (int) $consumable->company->id, 'name' => e($consumable->company->name)] : null,
             'item_no'       => e($consumable->item_no),

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -230,11 +230,16 @@ class Consumable extends SnipeModel
      */
     public function getImageUrl()
     {
+        // If there is a consumable image, use that
         if ($this->image) {
             return Storage::disk('public')->url(app('consumables_upload_path').$this->image);
-        }
-        return false;
 
+        // Otherwise check for a category image
+        }   elseif (($this->category) && ($this->category->image)) {
+            return Storage::disk('public')->url(app('categories_upload_path').e($this->category->image));
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
I probably want to make this a trait or an inherited SnipeModel method, but this lets you fall back to the category image for consumables if no consumable image is given. 

Fixes #9965