### PR TITLE
Fixed #17620 - `DELETE` method on custom fields causing method not allowed error

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -143,7 +143,7 @@ class Handler extends ExceptionHandler
                     ->withInput();
             }
 
-        // This gets the MVC model name from the exception and formats in a way that's less fugly
+            // This gets the MVC model name from the exception and formats in a way that's less fugly
             $model_name = trim(strtolower(implode(" ", preg_split('/(?=[A-Z])/', last(explode('\\', $e->getModel()))))));
             $route = str_plural(strtolower(last(explode('\\', $e->getModel())))).'.index';
 
@@ -160,9 +160,7 @@ class Handler extends ExceptionHandler
                 $route = 'maintenances.index';
             } elseif ($route === 'licenseseats.index') {
                 $route = 'licenses.index';
-            } elseif ($route === 'customfields.index') {
-                $route = 'fields.index';
-            } elseif ($route === 'customfieldsets.index') {
+            } elseif (($route === 'customfieldsets.index') || ($route === 'customfields.index')) {
                 $route = 'fields.index';
             }
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -144,7 +144,7 @@ class Handler extends ExceptionHandler
             }
 
         // This gets the MVC model name from the exception and formats in a way that's less fugly
-            $model_name = strtolower(implode(" ", preg_split('/(?=[A-Z])/', last(explode('\\', $e->getModel())))));
+            $model_name = trim(strtolower(implode(" ", preg_split('/(?=[A-Z])/', last(explode('\\', $e->getModel()))))));
             $route = str_plural(strtolower(last(explode('\\', $e->getModel())))).'.index';
 
             // Sigh.

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Models\Company;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * SnipePermissionsPolicy provides methods for handling the granular permissions used throughout Snipe-IT.
@@ -85,7 +86,7 @@ abstract class SnipePermissionsPolicy
     }
 
     /**
-     * Determine whether the user can view the accessory.
+     * Determine whether the user can view the model.
      *
      * @param  \App\Models\User  $user
      * @return mixed
@@ -101,7 +102,7 @@ abstract class SnipePermissionsPolicy
     }
 
     /**
-     * Determine whether the user can create accessories.
+     * Determine whether the user can create model.
      *
      * @param  \App\Models\User  $user
      * @return mixed
@@ -112,7 +113,7 @@ abstract class SnipePermissionsPolicy
     }
 
     /**
-     * Determine whether the user can update the accessory.
+     * Determine whether the user can update the model.
      *
      * @param  \App\Models\User  $user
      * @return mixed
@@ -124,7 +125,7 @@ abstract class SnipePermissionsPolicy
 
 
     /**
-     * Determine whether the user can update the accessory.
+     * Determine whether the user can update the model.
      *
      * @param  \App\Models\User  $user
      * @return mixed
@@ -135,7 +136,7 @@ abstract class SnipePermissionsPolicy
     }
 
     /**
-     * Determine whether the user can delete the accessory.
+     * Determine whether the user can delete the model.
      *
      * @param  \App\Models\User  $user
      * @return mixed
@@ -151,7 +152,7 @@ abstract class SnipePermissionsPolicy
     }
 
     /**
-     * Determine whether the user can manage the accessory.
+     * Determine whether the user can manage the model.
      *
      * @param  \App\Models\User  $user
      * @return mixed

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -5,7 +5,6 @@ namespace App\Policies;
 use App\Models\Company;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
-use Illuminate\Database\Eloquent\Model;
 
 /**
  * SnipePermissionsPolicy provides methods for handling the granular permissions used throughout Snipe-IT.

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -351,6 +351,17 @@ class UserFactory extends Factory
         return $this->appendPermission(['import' => '1']);
     }
 
+    public function createCustomFields()
+    {
+        return $this->appendPermission(['customfields.create' => '1']);
+    }
+
+    public function viewCustomFields()
+    {
+        return $this->appendPermission(['customfields.view' => '1']);
+    }
+
+
     public function deleteCustomFields()
     {
         return $this->appendPermission(['customfields.delete' => '1']);

--- a/resources/views/custom_fields/index.blade.php
+++ b/resources/views/custom_fields/index.blade.php
@@ -84,15 +84,12 @@
                 @endcan
 
                 @can('delete', $fieldset)
-                <form method="POST" action="{{ route('fieldsets.destroy', $fieldset->id) }}" accept-charset="UTF-8" style="display:inline-block">
-                  {{ method_field('DELETE') }}
-                  @csrf
+
                   @if($fieldset->models->count() > 0)
                   <button type="submit" class="btn btn-danger btn-sm disabled" data-tooltip="true" title="{{ trans('general.cannot_be_deleted') }}" disabled><i class="fas fa-trash"></i></button>
                   @else
-                  <button type="submit" class="btn btn-danger btn-sm delete-asset" data-tooltip="true" title="{{ trans('general.delete') }}" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $fieldset->name]) }}" data-icon="fa fa-trash" data-target="#dataConfirmModal" onClick="return false;"><i class="fas fa-trash"></i></button>
+                  <a type="submit" href="{{ route('fieldsets.destroy', $fieldset) }}" class="btn btn-danger btn-sm delete-asset" data-tooltip="true" title="{{ trans('general.delete') }}" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $fieldset->name]) }}" data-icon="fa fa-trash" data-target="#dataConfirmModal" onClick="return false;"><i class="fas fa-trash"></i></a>
                   @endif
-                </form>
                 @endcan
                   </nobr>
               </td>
@@ -237,9 +234,6 @@
               </td>
               <td>
                 <nobr>
-                  <form method="POST" action="{{ route('fields.destroy', $field->id) }}" accept-charset="UTF-8" style="display:inline-block">
-                    {{ method_field('DELETE') }}
-                    @csrf
                   @can('update', $field)
                     <a href="{{ route('fields.edit', $field->id) }}" class="btn btn-warning btn-sm" data-tooltip="true" title="{{ trans('general.update') }}">
                       <i class="fas fa-pencil-alt" aria-hidden="true"></i>
@@ -249,19 +243,19 @@
 
                 @can('delete', $field)
 
-                  @if($field->fieldset->count()>0)
+                  @if ($field->fieldset->count() > 0)
                     <button type="submit" class="btn btn-danger btn-sm disabled" data-tooltip="true" title="{{ trans('general.cannot_be_deleted') }}" disabled>
-                      <i class="fas fa-trash" aria-hidden="true"></i>
-                      <span class="sr-only">{{ trans('button.delete') }}</span></button>
-                  @else
-                    <button type="submit" class="btn btn-danger btn-sm delete-asset" data-tooltip="true" title="{{ trans('general.delete') }}" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $field->name]) }}" data-target="#dataConfirmModal" data-icon="fa fa-trash" onClick="return false;">
                       <i class="fas fa-trash" aria-hidden="true"></i>
                       <span class="sr-only">{{ trans('button.delete') }}</span>
                     </button>
+                  @else
+                    <a href="{{ route('fields.destroy', $field) }}" class="btn btn-danger btn-sm delete-asset" data-tooltip="true" title="{{ trans('general.delete') }}" data-toggle="modal" data-title="{{ trans('general.delete') }}" data-content="{{ trans('general.sure_to_delete_var', ['item' => $field->name]) }}" data-target="#dataConfirmModal" data-icon="fa fa-trash" onClick="return false;">
+                      <i class="fas fa-trash" aria-hidden="true"></i>
+                      <span class="sr-only">{{ trans('button.delete') }}</span>
+                    </a>
                   @endif
 
                 @endcan
-                  </form>
                 </nobr>
               </td>
             </tr>

--- a/tests/Feature/CustomFields/Ui/DeleteCustomFieldsTest.php
+++ b/tests/Feature/CustomFields/Ui/DeleteCustomFieldsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\CustomFields\Ui;
+
+use App\Models\CustomField;
+use App\Models\CustomFieldset;
+use App\Models\User;
+use Tests\TestCase;
+
+class DeleteCustomFieldsTest extends TestCase
+{
+    public function testPermissionNeededToDeleteField()
+    {
+        $this->actingAs(User::factory()->create())
+            ->delete(route('fields.destroy', CustomField::factory()->create()))
+            ->assertForbidden();
+    }
+
+
+    public function testCanDeleteCustomField()
+    {
+        $field = CustomField::factory()->create();
+        $this->assertDatabaseHas('custom_fields', ['id' => $field->id]);
+
+        $this->actingAs(User::factory()->deleteCustomFields()->create())
+            ->delete(route('fields.destroy', $field))
+            ->assertRedirectToRoute('fields.index')
+            ->assertStatus(302)
+            ->assertSessionHas('success');
+
+        $this->assertDatabaseMissing('custom_fields', ['id' => $field->id]);
+    }
+
+    public function testCannotDeleteCustomFieldThatDoesNotExist()
+    {
+
+        $response = $this->actingAs(User::factory()->viewCustomFields()->deleteCustomFields()->create())
+            ->delete(route('fields.destroy', '49857589'))
+            ->assertRedirect(route('fields.index'))
+            ->assertSessionHas('error');
+
+        $temp = $this->followRedirects($response);
+        $temp->assertSee(trans('general.error'))->assertSee(trans('general.generic_model_not_found', ['model' => 'custom field']));
+
+    }
+
+    public function testCannotDeleteFieldThatIsAssociatedWithFieldsets()
+    {
+        $field = CustomField::factory()->create();
+        $fieldset = CustomFieldset::factory()->create();
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('fieldsets.associate', $fieldset), [
+                'field_id' => $field->id,
+            ]);
+
+        $response = $this->actingAs(User::factory()->viewCustomFields()->deleteCustomFields()->create())
+            ->from(route('fields.index'))
+            ->delete(route('fields.destroy', $field))
+            ->assertStatus(302)
+            ->assertRedirect(route('fields.index'))
+            ->assertSessionHas('error');
+
+        $this->followRedirects($response)->assertSee(trans('general.error'))->assertSee(trans('admin/custom_fields/message.field.delete.in_use'));
+
+        // Ensure the field is still in the database
+        $this->assertDatabaseHas('custom_fields', ['id' => $field->id]);
+    }
+}


### PR DESCRIPTION
Recent changes to the modals in the `snipeit.js` file caused a slightly different behavior for older screens that aren't using the server-side bootstrap tables formatters. Eventually these should just be converted into API calls, but for now, this uses the correct modal that passes the `href` and replaces the form action via the modal script in `snipeit.js`.

Fixes #17620