### PR TITLE
Adds asset tag to subject line of check in check out

### DIFF
--- a/app/Mail/CheckinAssetMail.php
+++ b/app/Mail/CheckinAssetMail.php
@@ -47,7 +47,7 @@ class CheckinAssetMail extends Mailable
 
         return new Envelope(
             from: $from,
-            subject: trans('mail.Asset_Checkin_Notification'),
+            subject: trans('mail.Asset_Checkin_Notification', ['tag' => $this->item->asset_tag]),
         );
     }
 

--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -125,7 +125,7 @@ class CheckoutAssetMail extends Mailable
     private function getSubject(): string
     {
         if ($this->firstTimeSending) {
-            return trans('mail.Asset_Checkout_Notification');
+            return trans('mail.Asset_Checkout_Notification', ['tag' => $this->item->asset_tag]);
         }
 
         return trans('mail.unaccepted_asset_reminder');

--- a/resources/lang/en-US/mail.php
+++ b/resources/lang/en-US/mail.php
@@ -4,8 +4,8 @@ return [
 
     'Accessory_Checkin_Notification' => 'Accessory checked in',
     'Accessory_Checkout_Notification' => 'Accessory checked out',
-    'Asset_Checkin_Notification' => 'Asset checked in',
-    'Asset_Checkout_Notification' => 'Asset checked out',
+    'Asset_Checkin_Notification' => 'Asset checked in: [:tag]',
+    'Asset_Checkout_Notification' => 'Asset checked out: [:tag]',
     'Confirm_Accessory_Checkin' => 'Accessory checkin confirmation',
     'Confirm_Asset_Checkin' => 'Asset checkin confirmation',
     'Confirm_component_checkin' => 'Component checkin confirmation',

--- a/tests/Unit/Mail/CheckoutAssetMailTest.php
+++ b/tests/Unit/Mail/CheckoutAssetMailTest.php
@@ -28,7 +28,7 @@ class CheckoutAssetMailTest extends TestCase
 
         yield 'Asset not requiring acceptance' => [
             function () {
-                $asset = Asset::factory()->create();
+                $asset = Asset::factory()->doesNotRequireAcceptance()->create();
                 return [
                     'asset' => $asset,
                     'acceptance' => null,

--- a/tests/Unit/Mail/CheckoutAssetMailTest.php
+++ b/tests/Unit/Mail/CheckoutAssetMailTest.php
@@ -20,7 +20,7 @@ class CheckoutAssetMailTest extends TestCase
                     'asset' => $asset,
                     'acceptance' => CheckoutAcceptance::factory()->for($asset, 'checkoutable')->create(),
                     'first_time_sending' => true,
-                    'expected_subject' => 'Asset checked out',
+                    'expected_subject' => trans('mail.Asset_Checkout_Notification', ['tag' => $asset->asset_tag]),
                     'expected_opening' => 'A new item has been checked out under your name that requires acceptance, details are below.'
                 ];
             }
@@ -28,11 +28,12 @@ class CheckoutAssetMailTest extends TestCase
 
         yield 'Asset not requiring acceptance' => [
             function () {
+                $asset = Asset::factory()->requiresAcceptance()->create();
                 return [
-                    'asset' => Asset::factory()->doesNotRequireAcceptance()->create(),
+                    'asset' => $asset,
                     'acceptance' => null,
                     'first_time_sending' => true,
-                    'expected_subject' => 'Asset checked out',
+                    'expected_subject' => trans('mail.Asset_Checkout_Notification', ['tag' => $asset->asset_tag]),
                     'expected_opening' => 'A new item has been checked out under your name, details are below.'
                 ];
             }

--- a/tests/Unit/Mail/CheckoutAssetMailTest.php
+++ b/tests/Unit/Mail/CheckoutAssetMailTest.php
@@ -28,7 +28,7 @@ class CheckoutAssetMailTest extends TestCase
 
         yield 'Asset not requiring acceptance' => [
             function () {
-                $asset = Asset::factory()->requiresAcceptance()->create();
+                $asset = Asset::factory()->create();
                 return [
                     'asset' => $asset,
                     'acceptance' => null,

--- a/tests/Unit/NotificationTest.php
+++ b/tests/Unit/NotificationTest.php
@@ -31,8 +31,8 @@ class NotificationTest extends TestCase
 
         Mail::fake();
         $asset->checkOut($user, $admin->id);
-        Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) use ($user) {
-            return $mail->hasTo($user->email) && $mail->hasSubject(trans('mail.Asset_Checkout_Notification'));
+        Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) use ($user, $asset) {
+            return $mail->hasTo($user->email) && $mail->hasSubject(trans('mail.Asset_Checkout_Notification', ['tag' => $asset->asset_tag]));
         });
     }
     public function testDefaultEulaIsSentWhenSetInCategory()


### PR DESCRIPTION
This adds the asset tag to the subject line for easier read and search ability.
<img width="170" height="125" alt="image" src="https://github.com/user-attachments/assets/b9544cca-33c5-4e3e-a9e9-9d38959c1612" />

FD-50227
