### PR TITLE
Add new indexes to category_id and deleted_at

### DIFF
--- a/database/migrations/2025_08_19_122533_add_category_indexes.php
+++ b/database/migrations/2025_08_19_122533_add_category_indexes.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->index(['deleted_at']);
+        });
+        Schema::table('accessories', function (Blueprint $table) {
+            $table->index(['deleted_at','category_id']);
+        });
+        Schema::table('consumables', function (Blueprint $table) {
+            $table->index(['deleted_at','category_id']);
+        });
+        Schema::table('components', function (Blueprint $table) {
+            $table->index(['deleted_at','category_id']);
+        });
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->index(['deleted_at','category_id']);
+        });
+        Schema::table('models', function (Blueprint $table) {
+            $table->index(['deleted_at','category_id']);
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropIndex(['deleted_at']);
+        });
+        Schema::table('accessories', function (Blueprint $table) {
+            $table->dropIndex(['deleted_at','category_id']);
+        });
+        Schema::table('consumables', function (Blueprint $table) {
+            $table->dropIndex(['deleted_at','category_id']);
+        });
+        Schema::table('components', function (Blueprint $table) {
+            $table->dropIndex(['deleted_at','category_id']);
+        });
+        Schema::table('licenses', function (Blueprint $table) {
+            $table->dropIndex(['deleted_at','category_id']);
+        });
+        Schema::table('models', function (Blueprint $table) {
+            $table->dropIndex(['deleted_at','category_id']);
+        });
+    }
+};


### PR DESCRIPTION
This adds some indexes to some queries I've seen popping up as 'slow queries' on some instances. They're all related to grabbing aggregate stats about specific categories.