### PR TITLE
Fixes #17653 changes translation to administrator

### DIFF
--- a/resources/views/notifications/markdown/asset-acceptance.blade.php
+++ b/resources/views/notifications/markdown/asset-acceptance.blade.php
@@ -38,7 +38,7 @@
 | **{{ trans('mail.serial') }}** | {{ $item_serial }} |
 @endif
 @if (isset($admin))
-| **{{ trans('general.checked_out').' '.trans('general.by')}}** | {{ $admin }} |
+| **{{ trans('general.administrator') }}** | {{ $admin }} |
 @endif
 @endcomponent
 


### PR DESCRIPTION
Changed 'Checked out By' to Administrator for uniformity amongst notifications. This was an oversight by me.

<img width="1192" height="416" alt="image" src="https://github.com/user-attachments/assets/6fd66f6c-db61-4b1f-be52-37453024d3c6" />

Fixes #17653 