### PR TITLE
Fixed #17674: added .ods, .odp, and .odt as acceptable upload types

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1197,19 +1197,30 @@ class Helper
             'webp'   => 'far fa-image',
             'avif'   => 'far fa-image',
             'svg' => 'fas fa-vector-square',
+
             // word
             'doc'   => 'far fa-file-word',
             'docx'   => 'far fa-file-word',
+
             // Excel
             'xls'   => 'far fa-file-excel',
             'xlsx'   => 'far fa-file-excel',
+            'ods'   => 'far fa-file-excel',
+
+            // Presentation
+            'ppt'   => 'far fa-file-powerpoint',
+            'odp'   => 'far fa-file-powerpoint',
+
             // archive
             'zip'   => 'fas fa-file-archive',
             'rar'   => 'fas fa-file-archive',
+
             //Text
+            'odt'   => 'far fa-file-alt',
             'txt'   => 'far fa-file-alt',
             'rtf'   => 'far fa-file-alt',
             'xml'   => 'fas fa-code',
+
             // Misc
             'pdf'   => 'far fa-file-pdf',
             'lic'   => 'far fa-save',

--- a/app/Helpers/StorageHelper.php
+++ b/app/Helpers/StorageHelper.php
@@ -96,11 +96,9 @@ class StorageHelper
             'webp',
         ];
 
-        \Log::error(pathinfo($file_with_path, PATHINFO_EXTENSION));
 
         // The file exists and is allowed to be displayed inline
         if (Storage::exists($file_with_path) && (in_array(pathinfo($file_with_path, PATHINFO_EXTENSION), $allowed_inline))) {
-            \Log::error('File is allowed inline: ' . $file_with_path);
             return true;
         }
         return false;

--- a/app/Helpers/StorageHelper.php
+++ b/app/Helpers/StorageHelper.php
@@ -29,7 +29,7 @@ class StorageHelper
 
     public static function getMediaType($file_with_path) {
 
-        // The file exists and is allowed to be displayed inline
+        // Get the file extension and determine the media type
         if (Storage::exists($file_with_path)) {
             $fileinfo = pathinfo($file_with_path);
             $extension = strtolower($fileinfo['extension']);
@@ -51,6 +51,15 @@ class StorageHelper
                 case 'webm':
                 case 'mov':
                     return 'video';
+                case 'doc':
+                case 'docx':
+                    return 'document';
+                case 'txt':
+                    return 'text';
+                case 'xls':
+                case 'xlsx':
+                case 'ods':
+                    return 'spreadsheet';
                 default:
                     return $extension; // Default for unknown types
             }
@@ -87,9 +96,11 @@ class StorageHelper
             'webp',
         ];
 
+        \Log::error(pathinfo($file_with_path, PATHINFO_EXTENSION));
 
         // The file exists and is allowed to be displayed inline
         if (Storage::exists($file_with_path) && (in_array(pathinfo($file_with_path, PATHINFO_EXTENSION), $allowed_inline))) {
+            \Log::error('File is allowed inline: ' . $file_with_path);
             return true;
         }
         return false;

--- a/app/Http/Transformers/UploadedFilesTransformer.php
+++ b/app/Http/Transformers/UploadedFilesTransformer.php
@@ -45,7 +45,7 @@ class UploadedFilesTransformer
             ] : null,
             'created_at' => Helper::getFormattedDateObject($file->created_at, 'datetime'),
             'deleted_at' => Helper::getFormattedDateObject($file->deleted_at, 'datetime'),
-            'inlineable' => StorageHelper::allowSafeInline($file->uploads_file_path()),
+            'inlineable' => StorageHelper::allowSafeInline($file->uploads_file_path()) ?? false,
             'exists_on_disk' => (Storage::exists($file->uploads_file_path()) ? true : false),
         ];
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -123,6 +123,9 @@ $config['allowed_upload_extensions_array']  = [
     'mov',
     'mp3',
     'mp4',
+    'odp',
+    'ods',
+    'odt',
     'ogg',
     'pdf',
     'png',
@@ -140,12 +143,15 @@ $config['allowed_upload_extensions_array']  = [
 ];
 
 
-
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types
 $config['allowed_upload_mimetypes_array'] = [
     'application/json',
     'application/msword',
     'application/pdf',
     'application/vnd.ms-excel',
+    'application/vnd.oasis.opendocument.presentation',
+    'application/vnd.oasis.opendocument.spreadsheet',
+    'application/vnd.oasis.opendocument.text',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     'application/x-rar-compressed',

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -337,6 +337,7 @@ return [
     'zip'  					=> 'Zip',
     'noimage'				=> 'No image uploaded or image not found.',
     'file_does_not_exist'   => 'The requested file does not exist on the server.',
+    'file_not_inlineable'        => 'The requested file cannot be opened inline in your browser. You can download it instead.',
     'open_new_window'       => 'Open this file in a new window',
     'file_upload_success'   => 'File upload success!',
     'no_files_uploaded'     => 'File upload success!',

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -966,10 +966,14 @@
             var download_button = '<a href="' + download_url + '" class="btn btn-sm btn-default" data-tooltip="true" title="{{ trans('general.download') }}"><x-icon type="download" /></a>';
             var download_button_disabled = '<span data-tooltip="true" title="{{ trans('general.file_does_not_exist') }}"><a class="btn btn-sm btn-default disabled"><x-icon type="download" /></a></span>';
             var inline_button = '<a href="'+ download_url +'?inline=true" class="btn btn-sm btn-default" target="_blank" data-tooltip="true" title="{{ trans('general.open_new_window') }}"><x-icon type="external-link" /></a>';
-            var inline_button_disabled = '<span data-tooltip="true" title="{{ trans('general.file_does_not_exist') }}"><a class="btn btn-sm btn-default disabled" target="_blank" data-tooltip="true" title="{{ trans('general.file_does_not_exist') }}"><x-icon type="external-link" /></a></span>';
+            var inline_button_disabled = '<span data-tooltip="true" title="{{ trans('general.file_not_inlineable') }}"><a class="btn btn-sm btn-default disabled" target="_blank" data-tooltip="true" title="{{ trans('general.file_does_not_exist') }}"><x-icon type="external-link" /></a></span>';
 
             if (exists_on_disk === true) {
-                return '<span style="white-space: nowrap;">' + download_button + ' ' + inline_button + '</span>';
+                if (inlinable === true) {
+                    return '<span style="white-space: nowrap;">' + download_button + ' ' + inline_button + '</span>';
+                } else {
+                    return '<span style="white-space: nowrap;">' + download_button + ' ' + inline_button_disabled + '</span>';
+                }
             } else {
                 return '<span style="white-space: nowrap;">' + download_button_disabled + ' ' + inline_button_disabled + '</span>';
             }


### PR DESCRIPTION
This adds the OpenDocument file formats to the accepted files list.

<img width="1492" height="835" alt="Screenshot 2025-08-20 at 2 16 37 PM" src="https://github.com/user-attachments/assets/01bf0967-851e-40ca-a5b7-44246ac5894e" />


<img width="1521" height="839" alt="Screenshot 2025-08-20 at 2 14 08 PM" src="https://github.com/user-attachments/assets/48efabe1-afcb-4525-8389-100ffb4761b4" />


Fixes #17674