### PR TITLE
Fix components presenting wrong URLs

### DIFF
--- a/app/Presenters/ComponentPresenter.php
+++ b/app/Presenters/ComponentPresenter.php
@@ -191,7 +191,7 @@ class ComponentPresenter extends Presenter
      */
     public function nameUrl()
     {
-        return (string) link_to_route('consumables.show', e($this->name), $this->id);
+        return (string) link_to_route('components.show', e($this->name), $this->id);
     }
 
     /**
@@ -200,6 +200,6 @@ class ComponentPresenter extends Presenter
      */
     public function viewUrl()
     {
-        return route('accessories.show', $this->id);
+        return route('components.show', $this->id);
     }
 }


### PR DESCRIPTION
My team noticed that webhook notifications for checked out components are wrongly presenting URLs leading to accessories. After a quick search it seems that the Presenter class for components has been partly copy/pasted from other Presenters, and a slight mistake has been made regarding relevant routes.

This small commit aim at fixing this.