### PR TITLE
Fixed #17386 - Added SAML key size to env - possible alternative to #17387 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,10 +193,16 @@ LDAP_TIME_LIM=600
 IMPORT_TIME_LIMIT=600
 IMPORT_MEMORY_LIMIT=500M
 REPORT_TIME_LIMIT=12000
-REQUIRE_SAML=false
 API_THROTTLE_PER_MINUTE=120
 CSV_ESCAPE_FORMULAS=true
 LIVEWIRE_URL_PREFIX=null
+
+
+# --------------------------------------------
+# OPTIONAL: SAML SETTINGS
+# --------------------------------------------
+REQUIRE_SAML=false
+SAML_KEY_SIZE=2048
 
 # --------------------------------------------
 # OPTIONAL: HASHING

--- a/app/Http/Requests/SettingsSamlRequest.php
+++ b/app/Http/Requests/SettingsSamlRequest.php
@@ -109,7 +109,7 @@ class SettingsSamlRequest extends FormRequest
                 ];
 
                 $pkey = openssl_pkey_new([
-                    'private_key_bits' => 2048,
+                    'private_key_bits' => config('app.saml_key_size'),
                     'private_key_type' => OPENSSL_KEYTYPE_RSA,
                 ]);
 

--- a/config/app.php
+++ b/config/app.php
@@ -207,7 +207,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Require SAML Login
+    |  Require SAML Login
     |--------------------------------------------------------------------------
     |
     | Disable the ability to login via form login, and disables the 'nosaml'
@@ -219,6 +219,23 @@ return [
     */
 
     'require_saml' => env('REQUIRE_SAML', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    |  SAML KEYS
+    |--------------------------------------------------------------------------
+    |
+    | This is the size of the keys used by openssl_pkey_new for SAML authentication.
+    | The default is 2048 bits, but this can be changed to 3072 or 4096 bits
+    | for higher security. Note that this will increase the time it takes to
+    | generate the keys, so it is not recommended to set this to a very high value
+    | unless you have a specific need for it.
+    |
+    | The European Commission now requires at least 3072-bit keys for new SAML certificates
+    | @link https://github.com/grokability/snipe-it/issues/17386
+    */
+
+    'saml_key_size' => env('SAML_KEY_SIZE', 2048),
 
 
     /*


### PR DESCRIPTION
This just takes the solution proposed by @strobelm in #17387 and makes it into an environmental variable for better backwards compatibility.

Fixes #17386 and #17387