### PR TITLE
Fixed [FD-49550] - added a 'created_at' index to the models table

### DIFF
--- a/database/migrations/2025_08_20_190617_add_created_at_index_to_models.php
+++ b/database/migrations/2025_08_20_190617_add_created_at_index_to_models.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('models', function (Blueprint $table) {
+            $table->index(['created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('models', function (Blueprint $table) {
+            $table->dropIndex(['created_at']);
+        });
+    }
+};


### PR DESCRIPTION
In some circumstances - rare ones - if you ended up adding a ton of asset models that were all created at the exact same millisecond, and then tried to sort those models based on the `created_at` attribute (which is the default), you could get models returned in arbitrary orders as you go through the paginated results. This is due to a (somewhat controversial?) decision by MySQL to return the result set in different orderings based upon whether or not the results fit into a specific sorting buffer.

There are several ways to fix the problem - one is to add an 'id' column to the sort clause - making it into `SORT BY created_at, id`. This would add a lot of extra noise to the code if we were to try to do this everywhere where we do a `SORT BY` on a non-unique column. The other is to just add an index to the column in question. If you do this, then the query goes from a table scan into a regular index lookup, which is must faster, and should return the rows in index-order consistently.

Additionally, the new index should also improve performance of the query. So that's what we went with here.

If at some point MySQL (and/or MariaDB) figure out that returning rows in non-deterministic orders is actually "bad" for normal things that people use databases for, the new index will still at least improve performance on those queries, and the resulting ordering should remain unchanged.