### PR TITLE
Fixes #17642 Checkouts to location email for Assets and Accessories

### DIFF
--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -78,16 +78,16 @@ class CheckoutAssetMail extends Mailable
         $eula = method_exists($this->item, 'getEula') ? $this->item->getEula() : '';
         $req_accept = $this->requiresAcceptance();
         $fields = [];
-        $location = [false, ''];
+        $name = null;
+
         if($this->target instanceof User){
-            $this->target = $this->target->display_name;
+            $name = $this->target->display_name;
         }
         else if($this->target instanceof Asset){
-            $this->target = $this->target->assignedto?->display_name;
+            $name  = $this->target->assignedto?->display_name;
         }
         else if($this->target instanceof Location){
-            $location = [true, $this->target->name];
-            $this->target = $this->target->manager->name;
+            $name  = $this->target->manager->name;
         }
 
         // Check if the item has custom fields associated with it
@@ -104,14 +104,14 @@ class CheckoutAssetMail extends Mailable
                 'admin'         => $this->admin,
                 'status'        => $this->item->assetstatus?->name,
                 'note'          => $this->note,
-                'target'        => $this->target,
+                'target'        => $name,
                 'fields'        => $fields,
                 'eula'          => $eula,
                 'req_accept'    => $req_accept,
                 'accept_url'    => $accept_url,
                 'last_checkout' => $this->last_checkout,
                 'expected_checkin'  => $this->expected_checkin,
-                'introduction_line' => $this->introductionLine($location),
+                'introduction_line' => $this->introductionLine(),
             ],
         );
     }
@@ -135,10 +135,10 @@ class CheckoutAssetMail extends Mailable
         return trans('mail.unaccepted_asset_reminder');
     }
 
-    private function introductionLine($location= null): string
+    private function introductionLine(): string
     {
-        if ($this->firstTimeSending && $location[0]) {
-            return trans('mail.new_item_checked_location', ['location' => $location[1] ]);
+        if ($this->firstTimeSending && $this->target instanceof Location) {
+            return trans('mail.new_item_checked_location', ['location' => $this->target->name ]);
         }
         if ($this->firstTimeSending && $this->requiresAcceptance()) {
             return trans('mail.new_item_checked_with_acceptance');

--- a/resources/lang/en-US/mail.php
+++ b/resources/lang/en-US/mail.php
@@ -77,7 +77,7 @@ return [
     'name' => 'Name',
     'new_item_checked' => 'A new item has been checked out under your name, details are below.',
     'new_item_checked_with_acceptance' => 'A new item has been checked out under your name that requires acceptance, details are below.',
-    'new_item_checked_location' => 'A new item has been checked out to :location details are below.',
+    'new_item_checked_location' => 'A new item has been checked out to :location, details are below.',
     'recent_item_checked' => 'An item was recently checked out under your name that requires acceptance, details are below.',
     'notes' => 'Notes',
     'password' => 'Password',

--- a/resources/lang/en-US/mail.php
+++ b/resources/lang/en-US/mail.php
@@ -77,6 +77,7 @@ return [
     'name' => 'Name',
     'new_item_checked' => 'A new item has been checked out under your name, details are below.',
     'new_item_checked_with_acceptance' => 'A new item has been checked out under your name that requires acceptance, details are below.',
+    'new_item_checked_location' => 'A new item has been checked out to :location details are below.',
     'recent_item_checked' => 'An item was recently checked out under your name that requires acceptance, details are below.',
     'notes' => 'Notes',
     'password' => 'Password',

--- a/resources/views/mail/markdown/checkout-accessory.blade.php
+++ b/resources/views/mail/markdown/checkout-accessory.blade.php
@@ -1,7 +1,7 @@
 @component('mail::message')
-# {{ trans('mail.hello') }}{{ $target->assignedto?->display_name ? ' ' . $target->assignedto->display_name . ',' : ',' }}
+# {{ trans('mail.hello').' '.$target.','}}
 
-{{ trans('mail.new_item_checked') }}
+{{ $introduction_line }}
 
 @if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
 <center><img src="{{ $item->getImageUrl() }}" alt="Accessory" style="max-width: 570px;"></center>


### PR DESCRIPTION
This fixes the salutation and intro message when checking out to a location. Locations are suppose to be addressed to the manager of the location. Also the message was misleading, as it sounded like it was being checked out to the manager and not the location.

Before:
<img width="618" height="950" alt="image" src="https://github.com/user-attachments/assets/9f1db268-1be5-4ebf-a8da-c8f18d8a774d" />

After:
There is a new translation for checking out to location as well:
<img width="618" height="950" alt="image" src="https://github.com/user-attachments/assets/039f3585-5ad4-444e-a91f-98161d8142b4" />

This change was also applied to accessories:
<img width="618" height="950" alt="image" src="https://github.com/user-attachments/assets/f30dbd33-9176-41b2-9326-09d40e8bdcab" />

Fixes: #17642
