### PR TITLE
Put LDAP troubleshooter's decrypt in a try/catch to avoid crashing if it cannot decrypt the password

### DIFF
--- a/app/Console/Commands/LdapTroubleshooter.php
+++ b/app/Console/Commands/LdapTroubleshooter.php
@@ -371,7 +371,13 @@ class LdapTroubleshooter extends Command
 
         $this->line("STAGE 4: Test Administrative Bind for LDAP Sync");
         foreach($ldap_urls AS $ldap_url) {
-            $this->test_authed_bind($ldap_url[0], $ldap_url[1], $ldap_url[2], $settings->ldap_uname, Crypt::decrypt($settings->ldap_pword));
+            try {
+                $w = Crypt::Decrypt($settings->ldap_pword);
+            } catch (\Exception $e) {
+                $this->warn("Could not decrypt password. This usually means an LDAP password was not set or the APP_KEY was changed since the LDAP pasword was last saved.  Aborting.");
+                exit(0);
+            }
+            $this->test_authed_bind($ldap_url[0], $ldap_url[1], $ldap_url[2], $settings->ldap_uname, $w);
         }
 
         $this->line("STAGE 5: Test BaseDN");
@@ -457,7 +463,7 @@ class LdapTroubleshooter extends Command
         return $this->timed_boolean_execute(function () use ($ldap_url, $check_cert , $start_tls) {
             try {
                 $lconn = $this->connect_to_ldap($ldap_url, $check_cert, $start_tls);
-                $this->line("gonna try to bind now, this can take a while if we mess it up");
+                $this->line("Attempting to bind now, this can take a while if we mess it up");
                 $bind_results = ldap_bind($lconn);
                 $this->line("Bind results are: " . $bind_results . " which translate into boolean: " . (bool)$bind_results);
                 ldap_close($lconn);

--- a/app/Console/Commands/LdapTroubleshooter.php
+++ b/app/Console/Commands/LdapTroubleshooter.php
@@ -161,7 +161,15 @@ class LdapTroubleshooter extends Command
             $output[] = "-x";
             $output[] = "-b ".escapeshellarg($settings->ldap_basedn);
             $output[] = "-D ".escapeshellarg($settings->ldap_uname);
-            $output[] = "-w ".escapeshellarg(Crypt::Decrypt($settings->ldap_pword));
+
+            try {
+                $w = Crypt::Decrypt($settings->ldap_pword);
+            } catch (\Exception $e) {
+                $this->warn("Could not decrypt password. This usually means an LDAP password was not set or the APP_KEY was changed since the LDAP pasword was last saved.  Aborting.");
+                exit(0);
+            }
+
+            $output[] = "-w ". escapeshellarg($w);
             $output[] = escapeshellarg(parenthesized_filter($settings->ldap_filter));
             if($settings->ldap_tls) {
                 $this->line("# adding STARTTLS option");

--- a/app/Console/Commands/LdapTroubleshooter.php
+++ b/app/Console/Commands/LdapTroubleshooter.php
@@ -392,7 +392,14 @@ class LdapTroubleshooter extends Command
         $this->debugout("LDAP constants are: ".print_r($ldap_constants,true));
 
         foreach($ldap_urls AS $ldap_url) {
-            if($this->test_informational_bind($ldap_url[0],$ldap_url[1],$ldap_url[2],$settings->ldap_uname,Crypt::decrypt($settings->ldap_pword),$settings)) {
+            try {
+                $w = Crypt::Decrypt($settings->ldap_pword);
+            } catch (\Exception $e) {
+                $this->warn("Could not decrypt password. This usually means an LDAP password was not set or the APP_KEY was changed since the LDAP pasword was last saved.  Aborting.");
+                exit(0);
+            }
+
+            if($this->test_informational_bind($ldap_url[0],$ldap_url[1],$ldap_url[2],$settings->ldap_uname,$w,$settings)) {
                 $this->info("Success getting informational bind!");
             } else {
                 $this->error("Unable to get information from bind.");
@@ -615,4 +622,6 @@ class LdapTroubleshooter extends Command
         }
 
     }
+
+
 }


### PR DESCRIPTION
Instead of crashing if the LDAP troubleshooter cannot decrypt the password, this will now return:

```shell
✨snipe@chodeblossom✨ snipe-it  (develop) $ php artisan ldap:troubleshoot --ldap-search

 WARNING: This command will display your LDAP password on your terminal. Are you sure this is ok? (yes/no) [no]:
 > yes

Could not decrypt password. This usually means an LDAP password was not set or the APP_KEY was changed since the LDAP pasword was last saved.  Aborting.
```

Before it would crash with:

```shell
WARNING: This command will display your LDAP password on your terminal. Are you sure this is ok? (yes/no) [no]:
 > yes


   Illuminate\Contracts\Encryption\DecryptException

  The payload is invalid.

  at vendor/laravel/framework/src/Illuminate/Encryption/Encrypter.php:236
    232▕      */
    233▕     protected function getJsonPayload($payload)
    234▕     {
    235▕         if (! is_string($payload)) {
  ➜ 236▕             throw new DecryptException('The payload is invalid.');
    237▕         }
    238▕
    239▕         $payload = json_decode(base64_decode($payload), true);
    240▕

      +2 vendor frames

  3   app/Console/Commands/LdapTroubleshooter.php:165
      Illuminate\Support\Facades\Facade::__callStatic("Decrypt")
      +12 vendor frames

  16  artisan:33
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```