### PR TITLE
Adds #9000 Item type to Account Asset Acceptance index

### DIFF
--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -32,7 +32,7 @@ class CheckoutAcceptance extends Model
 
         return array_filter($recipients);
     }
-    public function getCheckoutableCategoryTypeAttribute(): string
+    public function getCheckoutableItemTypeAttribute(): string
     {
         $type = $this->checkoutable_type;
 

--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -32,7 +32,19 @@ class CheckoutAcceptance extends Model
 
         return array_filter($recipients);
     }
+    public function getCheckoutableCategoryTypeAttribute(): string
+    {
+        $type = $this->checkoutable_type;
 
+        return match ($type) {
+            Asset::class       => trans('general.asset'),
+            LicenseSeat::class => trans('general.license'),
+            Accessory::class   => trans('general.accessory'),
+            Component::class   => trans('general.component'),
+            Consumable::class  => trans('general.consumable'),
+            default            => class_basename($type),
+        };
+    }
     /**
      * The resource that was is out
      *

--- a/resources/views/account/accept/index.blade.php
+++ b/resources/views/account/accept/index.blade.php
@@ -31,7 +31,7 @@
             <thead>
               <tr>
                 <th>{{ trans('general.name')}}</th>
-                  <th>{{ trans('general.category')}}</th>
+                  <th>{{ trans('general.type')}}</th>
                 <th>{{ trans('general.serial_number')}}</th>
                 <th>{{ trans('table.actions')}}</th>
               </tr>

--- a/resources/views/account/accept/index.blade.php
+++ b/resources/views/account/accept/index.blade.php
@@ -31,6 +31,7 @@
             <thead>
               <tr>
                 <th>{{ trans('general.name')}}</th>
+                  <th>{{ trans('general.category')}}</th>
                 <th>{{ trans('general.serial_number')}}</th>
                 <th>{{ trans('table.actions')}}</th>
               </tr>
@@ -40,6 +41,7 @@
               <tr>
                 @if ($acceptance->checkoutable)
                 <td>{{ ($acceptance->checkoutable) ? $acceptance->checkoutable->present()->name : '' }}</td>
+                  <td>{{ $acceptance->checkoutable_category_type }}</td>
                   <td>{{ ($acceptance->checkoutable) ? $acceptance->checkoutable->serial : '' }}</td>
                 <td><a href="{{ route('account.accept.item', $acceptance) }}" class="btn btn-default btn-sm">{{ trans('general.accept_decline') }}</a></td>
                 @else

--- a/resources/views/account/accept/index.blade.php
+++ b/resources/views/account/accept/index.blade.php
@@ -41,7 +41,7 @@
               <tr>
                 @if ($acceptance->checkoutable)
                 <td>{{ ($acceptance->checkoutable) ? $acceptance->checkoutable->present()->name : '' }}</td>
-                  <td>{{ $acceptance->checkoutable_category_type }}</td>
+                  <td>{{ $acceptance->checkoutable_item_type }}</td>
                   <td>{{ ($acceptance->checkoutable) ? $acceptance->checkoutable->serial : '' }}</td>
                 <td><a href="{{ route('account.accept.item', $acceptance) }}" class="btn btn-default btn-sm">{{ trans('general.accept_decline') }}</a></td>
                 @else


### PR DESCRIPTION
This adds the item type to the Asset Acceptance index:

<img width="1351" height="292" alt="image" src="https://github.com/user-attachments/assets/1d27087a-d987-4cb9-9e42-de761267fe31" />

Fixes: #9000