### PR TITLE
Improved user create tests

### DIFF
--- a/tests/Feature/Users/Ui/CreateUserTest.php
+++ b/tests/Feature/Users/Ui/CreateUserTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Feature\Users\Ui;
 
 use App\Models\User;
+use App\Notifications\WelcomeNotification;
+use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class CreateUserTest extends TestCase
@@ -25,6 +27,39 @@ class CreateUserTest extends TestCase
 
     public function testCanCreateUser()
     {
+        $response = $this->actingAs(User::factory()->createUsers()->viewUsers()->create())
+            ->from(route('users.index'))
+            ->post(route('users.store'), [
+                'first_name' => 'Test First Name',
+                'last_name' => 'Test Last Name',
+                'username' => 'testuser',
+                'password' => 'testpassword1235!!',
+                'password_confirmation' => 'testpassword1235!!',
+                'send_welcome' => '1',
+                'activated' => '1',
+                'notes' => 'Test Note',
+            ])
+            ->assertSessionHasNoErrors()
+            ->assertStatus(302)
+            ->assertRedirect(route('users.index'));
+
+        $this->assertDatabaseHas('users', [
+            'first_name' => 'Test First Name',
+            'last_name' => 'Test Last Name',
+            'username' => 'testuser',
+            'activated' => '1',
+            'notes' => 'Test Note',
+
+        ]);
+
+        $this->followRedirects($response)->assertSee('Success');
+
+    }
+
+    public function testCanCreateAndNotifyUser()
+    {
+
+        Notification::fake();
 
         $response = $this->actingAs(User::factory()->createUsers()->viewUsers()->create())
             ->from(route('users.index'))
@@ -33,11 +68,27 @@ class CreateUserTest extends TestCase
                 'last_name' => 'Test Last Name',
                 'username' => 'testuser',
                 'password' => 'testpassword1235!!',
-                //'notes' => 'Test Note',
+                'password_confirmation' => 'testpassword1235!!',
+                'send_welcome' => '1',
+                'activated' => '1',
+                'email' => 'foo@example.org',
+                'notes' => 'Test Note',
             ])
+            ->assertSessionHasNoErrors()
             ->assertStatus(302)
             ->assertRedirect(route('users.index'));
 
+        $this->assertDatabaseHas('users', [
+            'first_name' => 'Test First Name',
+            'last_name' => 'Test Last Name',
+            'username' => 'testuser',
+            'activated' => '1',
+            'email' => 'foo@example.org',
+            'notes' => 'Test Note',
+        ]);
+
+        $user = User::where('username', 'testuser')->first();
+        Notification::assertSentTo($user, WelcomeNotification::class);
         $this->followRedirects($response)->assertSee('Success');
 
     }


### PR DESCRIPTION
This fixes the user create tests so that they actually check that there are no errors on trying to create a user, and also adds a notification check to confirm that the user is sent a welcome email if `send_welcome` is passed as `1`. 