### PR TITLE
Feature: Stock Update added for Consumables

### DIFF
--- a/app/Helpers/IconHelper.php
+++ b/app/Helpers/IconHelper.php
@@ -13,6 +13,8 @@ class IconHelper
                 return 'fa-solid fa-rotate-right';
             case 'edit':
                 return 'fas fa-pencil-alt';
+            case 'update_stock':
+                return 'fas fa-cart-plus';
             case 'clone':
                 return 'far fa-clone';
             case 'delete':

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -272,8 +272,9 @@ class ConsumablesController extends Controller
 
         $delta = $request->input('quantity_changed');
         $note = $request->input('note');
-        // Adding a note to be used by the ConsumableObserver::updated when the log for stock update is stored.
+        // Adding a note and action to be used by the ConsumableObserver::updated when the log for stock update is stored.
         $consumable->log->note = $note;
+        $consumable->log->action = 'stock update';
 
         $consumable->qty = max(0, $consumable->qty + $delta);
         session()->put(['redirect_option' => $request->get('redirect_option')]);

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -271,9 +271,8 @@ class ConsumablesController extends Controller
         ]);
 
         $delta = $request->input('quantity_changed');
-        $note = $request->input('note');
         // Adding a note and action to be used by the ConsumableObserver::updated when the log for stock update is stored.
-        $consumable->log->note = $note;
+        $consumable->log->note = $request->input('note');
         $consumable->log->action = 'stock update';
 
         $consumable->qty = max(0, $consumable->qty + $delta);

--- a/app/Http/Transformers/ConsumablesTransformer.php
+++ b/app/Http/Transformers/ConsumablesTransformer.php
@@ -58,6 +58,7 @@ class ConsumablesTransformer
             'checkout' => Gate::allows('checkout', Consumable::class),
             'checkin' => Gate::allows('checkin', Consumable::class),
             'update' => Gate::allows('update', Consumable::class),
+            'update_stock' => Gate::allows('update_stock', Consumable::class),
             'delete' => Gate::allows('delete', Consumable::class),
             'clone' => (Gate::allows('create', Consumable::class) && ($consumable->deleted_at == '')),
         ];

--- a/app/Observers/ConsumableObserver.php
+++ b/app/Observers/ConsumableObserver.php
@@ -36,6 +36,7 @@ class ConsumableObserver
             $logAction->created_at = date('Y-m-d H:i:s');
             $logAction->created_by = auth()->id();
             $logAction->log_meta = json_encode($changed);
+            $logAction->note = $consumable?->log?->note; // Add note if received from ConsumableController -> postUpdateStock()
             $logAction->logaction('update');
         }
     }

--- a/app/Observers/ConsumableObserver.php
+++ b/app/Observers/ConsumableObserver.php
@@ -36,8 +36,11 @@ class ConsumableObserver
             $logAction->created_at = date('Y-m-d H:i:s');
             $logAction->created_by = auth()->id();
             $logAction->log_meta = json_encode($changed);
-            $logAction->note = $consumable?->log?->note; // Add note if received from ConsumableController -> postUpdateStock()
-            $logAction->logaction('update');
+            // Add note if received from ConsumableController -> postUpdateStock()
+            $logAction->note = $consumable?->log?->note;
+            // Add action type if this update was caused by ConsumableController -> postUpdateStock() else use the update action
+            $actionType = $consumable?->log?->action ?? 'update';
+            $logAction->logaction($actionType);
         }
     }
 

--- a/app/Policies/ConsumablePolicy.php
+++ b/app/Policies/ConsumablePolicy.php
@@ -8,4 +8,9 @@ class ConsumablePolicy extends CheckoutablePermissionsPolicy
     {
         return 'consumables';
     }
+
+    public function update_stock(User $user, $item = null)
+    {
+        return $user->hasAccess($this->columnName().'.update_stock');
+    }
 }

--- a/app/Presenters/ActionlogPresenter.php
+++ b/app/Presenters/ActionlogPresenter.php
@@ -81,6 +81,9 @@ class ActionlogPresenter extends Presenter
         if ($this->action_type == 'update') {
             return 'fa-solid fa-pen';
         }
+        if ($this->action_type == 'stock update') {
+            return 'fa-solid fa-cart-plus';
+        }
 
         if ($this->action_type == 'restore') {
             return 'fa-solid fa-trash-arrow-up';

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -193,6 +193,12 @@ return [
             'display'    => true,
         ],
         [
+            'permission' => 'consumables.update_stock',
+            'label'      => 'Update Stock',
+            'note'       => 'This allows the user to update the stock level of a consumable.',
+            'display'    => true,
+        ],
+        [
             'permission' => 'consumables.files',
             'label'      => 'View and Modify Consumable Files',
             'note'       => '',

--- a/resources/lang/en-US/admin/consumables/general.php
+++ b/resources/lang/en-US/admin/consumables/general.php
@@ -2,6 +2,9 @@
 
 return array(
     'checkout'                          => 'Checkout Consumable to User',
+    'update_stock'                      => 'Update Stock',
+    'quantity_change'                   => 'Number of Items',
+    'quantity_change_info'              => 'Write a value to add into stock or write a negative value to remove from the stock.',
     'consumable_name'                   => 'Consumable Name',
     'create'                            => 'Create Consumable',
     'item_no'                           => 'Item No.',

--- a/resources/lang/en-US/admin/consumables/message.php
+++ b/resources/lang/en-US/admin/consumables/message.php
@@ -32,7 +32,12 @@ return array(
         'error'   		=> 'Consumable was not checked in, please try again',
         'success' 		=> 'Consumable checked in successfully.',
         'user_does_not_exist' => 'That user is invalid. Please try again.'
-    )
+    ),
+
+    'stock' => array(
+        'error'   		=> 'Consumable stock was not updated, please try again',
+        'success' 		=> 'Consumable stock updated successfully.',
+    ),
 
 
 );

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -315,6 +315,7 @@ return [
     'unknown_user'          => 'Unknown User',
     'username'              => 'Username',
     'update'                => 'Update',
+    'stock_update'          => 'Stock Update',
     'updating_item' => 'Updating :item',
     'upload_filetypes_help' => 'Allowed filetypes are: :allowed_filetypes. Max upload size allowed is :size.',
     'uploaded'              => 'Uploaded',

--- a/resources/views/consumables/update-stock.blade.php
+++ b/resources/views/consumables/update-stock.blade.php
@@ -1,0 +1,96 @@
+@extends('layouts/default')
+
+{{-- Page title --}}
+@section('title')
+    {{ trans('admin/consumables/general.update_stock') }}
+    @parent
+@stop
+
+{{-- Page content --}}
+@section('content')
+
+    <div class="row">
+        <div class="col-md-9">
+
+            <form class="form-horizontal" id="update_stock_form" method="POST" action="{{ route('consumables.update_stock.post', $consumable->id) }}" autocomplete="off">
+                @csrf
+
+                <div class="box box-default">
+                    @if ($consumable->id)
+                        <div class="box-header with-border">
+                            <div class="box-heading">
+                                <h2 class="box-title">{{ $consumable->name }}</h2>
+                            </div>
+                        </div>
+                    @endif
+
+                    <div class="box-body">
+
+                        <!-- Name -->
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">{{ trans('admin/consumables/general.consumable_name') }}</label>
+                            <div class="col-md-6">
+                                <p class="form-control-static">{{ $consumable->name }}</p>
+                            </div>
+                        </div>
+
+                        <!-- Category -->
+                        @if ($consumable->category)
+                            <div class="form-group">
+                                <label class="col-sm-3 control-label">{{ trans('general.category') }}</label>
+                                <div class="col-md-6">
+                                    <p class="form-control-static">{{ $consumable->category->name }}</p>
+                                </div>
+                            </div>
+                        @endif
+
+                        <!-- Current Total -->
+                        <div class="form-group">
+                            <label class="col-sm-3 control-label">{{ trans('admin/components/general.total') }}</label>
+                            <div class="col-md-6">
+                                <p class="form-control-static">{{ $consumable->qty }}</p>
+                            </div>
+                        </div>
+
+                        <!-- Quantity Change -->
+                        <div class="form-group {{ $errors->has('quantity_changed') ? 'error' : '' }}">
+                            <label for="quantity_changed" class="col-md-3 control-label">
+                                {{ trans('admin/consumables/general.quantity_change') }}
+                            </label>
+                            <div class="col-md-7 col-sm-12 required">
+                                <div class="col-md-3" style="padding-left:0px">
+                                    <input class="form-control" type="number" name="quantity_changed" id="quantity_changed" value="0" required>
+                                </div>
+                                <div class="col-md-9 col-sm-12">
+                                    <p>{{ trans('admin/consumables/general.quantity_change_info') }}</p>
+                                </div>
+                            </div>
+                            {!! $errors->first('quantity_changed', '<div class="col-md-8 col-md-offset-3"><span class="alert-msg"><i class="fas fa-times"></i> :message</span></div>') !!}
+                        </div>
+
+                        <!-- Note -->
+                        <div class="form-group {{ $errors->has('note') ? 'error' : '' }}">
+                            <label for="note" class="col-md-3 control-label">{{ trans('admin/hardware/form.notes') }}</label>
+                            <div class="col-md-7">
+                                <textarea class="form-control" name="note" id="note">{{ old('note') }}</textarea>
+                                {!! $errors->first('note', '<span class="alert-msg"><i class="fas fa-times"></i> :message</span>') !!}
+                            </div>
+                        </div>
+
+                    </div> <!-- /.box-body -->
+
+                    <x-redirect_submit_options
+                            index_route="consumables.index"
+                            :button_label="trans('admin/consumables/general.update_stock')"
+                            :options="[
+                'index' => trans('admin/hardware/form.redirect_to_all', ['type' => trans('general.consumables')]),
+                'item' => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.consumable')]),
+            ]" />
+
+                </div> <!-- /.box -->
+            </form>
+
+        </div>
+    </div>
+
+@stop

--- a/resources/views/consumables/view.blade.php
+++ b/resources/views/consumables/view.blade.php
@@ -94,6 +94,14 @@
                   </div>
                 @endif
 
+                @can('update_stock', $consumable)
+                    <div class="col-md-12">
+                        <a href="{{ route('consumables.update_stock', $consumable->id) }}" style="margin-bottom:5px;"  class="btn btn-sm btn-block btn-social btn-primary hidden-print">
+                            <x-icon type="update_stock" />
+                            {{ trans('admin/consumables/general.update_stock') }}
+                        </a>
+                    </div>
+                @endcan
                 
                 @can('update', $consumable)
                   <div class="col-md-12">

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -416,6 +416,10 @@
                 dest = dest + '/' + row.owner_id + '/' + element_name;
             }
 
+            if ((row.available_actions) && (row.available_actions.update_stock === true)) {
+                actions += '<a href="{{ config('app.url') }}/' + dest + '/' + row.id + '/update-stock" class="actions btn btn-sm btn-primary" data-tooltip="true" title="{{ trans('admin/consumables/general.update_stock') }}"><x-icon type="update_stock" /><span class="sr-only">{{ trans('admin/consumables/general.update_stock') }}</span></a>&nbsp;';
+            }
+
             if ((row.available_actions) && (row.available_actions.clone === true)) {
                 actions += '<a href="{{ config('app.url') }}/' + dest + '/' + row.id + '/clone" class="actions btn btn-sm btn-info" data-tooltip="true" title="{{ trans('general.clone_item') }}"><x-icon type="clone" /><span class="sr-only">{{ trans('general.clone_item') }}</span></a>&nbsp;';
             }

--- a/routes/web/consumables.php
+++ b/routes/web/consumables.php
@@ -20,7 +20,14 @@ Route::group(['prefix' => 'consumables', 'middleware' => ['auth']], function () 
     Route::get('{consumable}/clone',
         [Consumables\ConsumablesController::class, 'clone']
     )->name('consumables.clone.create');
-    
+
+    // Show stock update form
+    Route::get('{consumable}/update-stock', [Consumables\ConsumablesController::class, 'getUpdateStock'])
+        ->name('consumables.update_stock');
+
+    // Submit stock update
+    Route::post('{consumable}/update-stock', [Consumables\ConsumablesController::class, 'postUpdateStock'])
+        ->name('consumables.update_stock.post');
 
 });
     


### PR DESCRIPTION
### Summary

This update introduces a dedicated **stock update workflow for consumables**, allowing authorized users to increase or decrease quantity without needing full edit access. It simplifies the process by removing the need for manual quantity calculations and adds proper permission control, logging, and UI elements to improve usability and auditability. This addresses key feature requests from the community in issues [[#5881](https://github.com/snipe/snipe-it/issues/5881)](https://github.com/snipe/snipe-it/issues/5881) and [[#5606](https://github.com/snipe/snipe-it/issues/5606)](https://github.com/snipe/snipe-it/issues/5606).

### Background

In Snipe-IT, updating the **stock quantity** of a consumable requires editing the entire item. This poses several challenges:

* Users had to have full **edit** privileges, even if they only needed to adjust stock.
* There was **no dedicated workflow** for restocking or deducting quantity.
* Users had to **manually calculate**:

  > *current quantity + added or removed quantity*
  > which was error-prone and time-consuming.
* Stock changes were logged as generic `update` actions, making it difficult to trace inventory-specific adjustments.

These limitations were brought up by the community, particularly in:

* **[[#5881](https://github.com/snipe/snipe-it/issues/5881)](https://github.com/snipe/snipe-it/issues/5881)** — Requested a proper increase/decrease stock interface for consumables (and similar assets).
* **[[#5606](https://github.com/snipe/snipe-it/issues/5606)](https://github.com/snipe/snipe-it/issues/5606)** — Related discussion on permission-limited quantity updates and clearer logging.

---

## Changes

This PR introduces a **dedicated stock update feature** for consumables, solving the issues raised above.

### 🔐 Permissions & Policy

* **New permission**: `consumables.update_stock`
* Allows stock quantity to be adjusted without giving users full edit rights
* Protected via policy gates

### 🖼️ UI Enhancements

* Added a new **“Update Stock”** button in:

  * Consumables **list view**
  * Consumables **detail view**
* Button opens a form that:

  * Accepts a **quantity change** (positive or negative)
  * Optionally includes a **note**
* Quantity is automatically updated with:
  `new_quantity = current_quantity + change`

### 🧾 Logging & Auditing

* Introduced a **new action type**: `stock update`
* Logged through `ConsumableObserver` when stock is adjusted via the new form
* Captures:

  * Quantity change and other properties are logged by default. 
  * Optional note of stock update is being added in Action Log note and visible in consumable's history.
* **Icon**: Uses `fa-cart-plus` for quick visual identification in logs

## 🧪 Testing Checklist

* [x] Users **without** `consumables.update_stock` cannot access the update form or trigger the action
* [x] Quantity updates apply correctly and increment or decrement the quantity.
* [x] Logs show `stock update` entries with correct metadata
* [x] UI elements are conditionally rendered based on permissions

---

## 📌 Related Issues Addressed

This PR addresses long-standing community feature requests:

* [[#5881](https://github.com/snipe/snipe-it/issues/5881)](https://github.com/snipe/snipe-it/issues/5881): Introduced a dedicated stock increment/decrement interface
* [[#5606](https://github.com/snipe/snipe-it/issues/5606)](https://github.com/snipe/snipe-it/issues/5606): Implemented separate permissions and clearer logging for stock adjustments

By removing the need to manually edit consumables and calculate stock, this feature reduces errors, improves usability, and enhances audit trails.