### PR TITLE
Adds #10969 Parent location to Asset Checked out to info

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -378,7 +378,11 @@
                                             @if (isset($asset->location))
                                                 <li>
                                                     <x-icon type="locations" class="fa-fw" />
-                                                     {{ $asset->location->name }}</li>
+                                                     {{ $asset->location->parent?->name }}
+                                                        @if ($asset->location->parent)
+                                                            <i class="fas fa-long-arrow-alt-right" aria-hidden="true"></i>
+                                                        @endif
+                                                        {{ $asset->location->name }}</li>
                                                 <li>{{ $asset->location->address }}
                                                     @if ($asset->location->address2!='')
                                                         {{ $asset->location->address2 }}


### PR DESCRIPTION
This adds the parent location to display when assigned to a User/Asset/Location.

Location:
<img width="242" height="536" alt="image" src="https://github.com/user-attachments/assets/1e02a4ca-2752-41b4-8eec-3d2d0563bdfa" />
User:
<img width="224" height="219" alt="image" src="https://github.com/user-attachments/assets/696e9faf-ba12-4cdb-8958-ac609c8cfe61" />
Asset
<img width="224" height="171" alt="image" src="https://github.com/user-attachments/assets/00f0fcea-996f-4505-91c4-c44df5a78a2f" />

Fixes: #10969
