### PR TITLE
Fixed user display name in expiring asset notification

### DIFF
--- a/resources/views/notifications/markdown/report-expiring-assets.blade.php
+++ b/resources/views/notifications/markdown/report-expiring-assets.blade.php
@@ -10,7 +10,7 @@ $expires = Helper::getFormattedDateObject($asset->present()->warranty_expires, '
 $diff = round(abs(strtotime($asset->present()->warranty_expires) - strtotime(date('Y-m-d')))/86400);
 $icon = ($diff <= ($threshold / 2)) ? '🚨' : (($diff <= $threshold) ? '⚠️' : ' ');
 @endphp
-        <tr><td>{{ $icon }} </td><td> <a href="{{ route('hardware.show', $asset->id) }}">{{ $asset->present()->name }}</a><br><small>{{trans('mail.serial').': '.$asset->serial}}</small></td><td> {{ $diff }} {{ trans('mail.Days') }} </td><td> {{ !is_null($expires) ? $expires['formatted'] : '' }} </td><td> {{ ($asset->supplier ? e($asset->supplier->name) : '') }} </td><td> {{ ($asset->assignedTo ? e($asset->assignedTo->present()->name()) : '') }} </td></tr>
+        <tr><td>{{ $icon }} </td><td> <a href="{{ route('hardware.show', $asset->id) }}">{{ $asset->present()->name }}</a><br><small>{{trans('mail.serial').': '.$asset->serial}}</small></td><td> {{ $diff }} {{ trans('mail.Days') }} </td><td> {{ !is_null($expires) ? $expires['formatted'] : '' }} </td><td> {{ ($asset->supplier ? e($asset->supplier->name) : '') }} </td><td> {{ ($asset->assignedTo ? e($asset->assignedTo->present()->display_name) : '') }} </td></tr>
 @endforeach
 </table>
 @endcomponent


### PR DESCRIPTION
This PR fixes a bug by using the `display_name` attribute instead of the non-existent `name()` method in an email.