### PR TITLE
Fixed #17759 - translation used in asset check in/out notifications

### DIFF
--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -93,7 +93,7 @@ class CheckinAssetNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_down: :computer: '.trans('mail.Asset_Checkin_Notification', ['tag' => $item->asset_tag]))
+            ->content(':arrow_down: :computer: '.trans('mail.Asset_Checkin_Notification', ['tag' => '']))
             ->from($botname)
             ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
@@ -144,7 +144,7 @@ class CheckinAssetNotification extends Notification
             ->card(
                 Card::create()
                     ->header(
-                        '<strong>'.trans('mail.Asset_Checkin_Notification', ['tag' => $item->asset_tag]).'</strong>' ?: '',
+                        '<strong>'.trans('mail.Asset_Checkin_Notification', ['tag' =>'']).'</strong>' ?: '',
                         htmlspecialchars_decode($item->display_name) ?: '',
                     )
                     ->section(

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -112,21 +112,21 @@ class CheckinAssetNotification extends Notification
             return MicrosoftTeamsMessage::create()
                 ->to($this->settings->webhook_endpoint)
                 ->type('success')
-                ->title(trans('mail.Asset_Checkin_Notification', ['tag' => $item->asset_tag]))
+                ->title(trans('mail.Asset_Checkin_Notification', ['tag' => '']))
                 ->addStartGroupToSection('activityText')
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'activityText')
                 ->fact(trans('mail.checked_into'), ($item->location) ? $item->location->name : '')
-                ->fact(trans('mail.Asset_Checkin_Notification') . " by ", $admin->display_name)
+                ->fact(trans('general.administrator'), $admin->display_name)
                 ->fact(trans('admin/hardware/form.status'), $item->assetstatus?->name)
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 
 
-        $message = trans('mail.Asset_Checkin_Notification', ['tag' => $item->asset_tag]);
+        $message = trans('mail.Asset_Checkin_Notification', ['tag' => '']);
         $details = [
             trans('mail.asset') => htmlspecialchars_decode($item->display_name),
             trans('mail.checked_into') => ($item->location) ? $item->location->name : '',
-            trans('mail.Asset_Checkin_Notification')." by " => $admin->display_name,
+            trans('general.administrator') => $admin->display_name,
             trans('admin/hardware/form.status') => $item->assetstatus?->name,
             trans('mail.notes') => $note ?: '',
         ];

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -93,7 +93,7 @@ class CheckinAssetNotification extends Notification
 
 
         return (new SlackMessage)
-            ->content(':arrow_down: :computer: '.trans('mail.Asset_Checkin_Notification'))
+            ->content(':arrow_down: :computer: '.trans('mail.Asset_Checkin_Notification', ['tag' => $item->asset_tag]))
             ->from($botname)
             ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
@@ -112,7 +112,7 @@ class CheckinAssetNotification extends Notification
             return MicrosoftTeamsMessage::create()
                 ->to($this->settings->webhook_endpoint)
                 ->type('success')
-                ->title(trans('mail.Asset_Checkin_Notification'))
+                ->title(trans('mail.Asset_Checkin_Notification', ['tag' => $item->asset_tag]))
                 ->addStartGroupToSection('activityText')
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'activityText')
                 ->fact(trans('mail.checked_into'), ($item->location) ? $item->location->name : '')
@@ -122,7 +122,7 @@ class CheckinAssetNotification extends Notification
         }
 
 
-        $message = trans('mail.Asset_Checkin_Notification');
+        $message = trans('mail.Asset_Checkin_Notification', ['tag' => $item->asset_tag]);
         $details = [
             trans('mail.asset') => htmlspecialchars_decode($item->display_name),
             trans('mail.checked_into') => ($item->location) ? $item->location->name : '',
@@ -144,7 +144,7 @@ class CheckinAssetNotification extends Notification
             ->card(
                 Card::create()
                     ->header(
-                        '<strong>'.trans('mail.Asset_Checkin_Notification').'</strong>' ?: '',
+                        '<strong>'.trans('mail.Asset_Checkin_Notification', ['tag' => $item->asset_tag]).'</strong>' ?: '',
                         htmlspecialchars_decode($item->display_name) ?: '',
                     )
                     ->section(

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -110,7 +110,7 @@ class CheckoutAssetNotification extends Notification
         }
 
         return (new SlackMessage)
-            ->content(':arrow_up: :computer: '.trans('mail.Asset_Checkout_Notification'))
+            ->content(':arrow_up: :computer: '.trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]))
             ->from($botname)
             ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
@@ -131,19 +131,19 @@ class CheckoutAssetNotification extends Notification
             return MicrosoftTeamsMessage::create()
                 ->to($this->settings->webhook_endpoint)
                 ->type('success')
-                ->title(trans('mail.Asset_Checkout_Notification'))
+                ->title(trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]))
                 ->addStartGroupToSection('activityText')
                 ->fact(trans('mail.assigned_to'), $target->display_name)
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'activityText')
-                ->fact(trans('mail.Asset_Checkout_Notification') . " by ", $admin->display_name)
+                ->fact(trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]) . " by ", $admin->display_name)
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 
-        $message = trans('mail.Asset_Checkout_Notification');
+        $message = trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]);
         $details = [
             trans('mail.assigned_to') => $target->present()->name,
             trans('mail.asset') => htmlspecialchars_decode($item->display_name),
-            trans('mail.Asset_Checkout_Notification'). ' by' => $admin->display_name,
+            trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]). ' by' => $admin->display_name,
             trans('mail.notes') => $note ?: '',
         ];
        return  array($message, $details);
@@ -159,7 +159,7 @@ public function toGoogleChat()
             ->card(
                 Card::create()
                     ->header(
-                        '<strong>'.trans('mail.Asset_Checkout_Notification').'</strong>' ?: '',
+                        '<strong>'.trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]).'</strong>' ?: '',
                         htmlspecialchars_decode($item->display_name) ?: '',
                     )
                     ->section(

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -131,19 +131,19 @@ class CheckoutAssetNotification extends Notification
             return MicrosoftTeamsMessage::create()
                 ->to($this->settings->webhook_endpoint)
                 ->type('success')
-                ->title(trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]))
+                ->title(trans('mail.Asset_Checkout_Notification', ['tag' => '']))
                 ->addStartGroupToSection('activityText')
                 ->fact(trans('mail.assigned_to'), $target->display_name)
                 ->fact(htmlspecialchars_decode($item->display_name), '', 'activityText')
-                ->fact(trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]) . " by ", $admin->display_name)
+                ->fact(trans('general.administrator'), $admin->display_name)
                 ->fact(trans('mail.notes'), $note ?: '');
         }
 
-        $message = trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]);
+        $message = trans('mail.Asset_Checkout_Notification', ['tag' => '']);
         $details = [
             trans('mail.assigned_to') => $target->present()->name,
             trans('mail.asset') => htmlspecialchars_decode($item->display_name),
-            trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]). ' by' => $admin->display_name,
+            trans('general.administrator') => $admin->display_name,
             trans('mail.notes') => $note ?: '',
         ];
        return  array($message, $details);

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -110,7 +110,7 @@ class CheckoutAssetNotification extends Notification
         }
 
         return (new SlackMessage)
-            ->content(':arrow_up: :computer: '.trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]))
+            ->content(':arrow_up: :computer: '.trans('mail.Asset_Checkout_Notification', ['tag' => '']))
             ->from($botname)
             ->to($channel)
             ->attachment(function ($attachment) use ($item, $note, $admin, $fields) {
@@ -159,7 +159,7 @@ public function toGoogleChat()
             ->card(
                 Card::create()
                     ->header(
-                        '<strong>'.trans('mail.Asset_Checkout_Notification', ['tag' => $item->asset_tag]).'</strong>' ?: '',
+                        '<strong>'.trans('mail.Asset_Checkout_Notification', ['tag' => '']).'</strong>' ?: '',
                         htmlspecialchars_decode($item->display_name) ?: '',
                     )
                     ->section(

--- a/resources/lang/en-US/mail.php
+++ b/resources/lang/en-US/mail.php
@@ -4,8 +4,8 @@ return [
 
     'Accessory_Checkin_Notification' => 'Accessory checked in',
     'Accessory_Checkout_Notification' => 'Accessory checked out',
-    'Asset_Checkin_Notification' => 'Asset checked in: [:tag]',
-    'Asset_Checkout_Notification' => 'Asset checked out: [:tag]',
+    'Asset_Checkin_Notification' => 'Asset checked in: :tag',
+    'Asset_Checkout_Notification' => 'Asset checked out: :tag',
     'Confirm_Accessory_Checkin' => 'Accessory checkin confirmation',
     'Confirm_Asset_Checkin' => 'Asset checkin confirmation',
     'Confirm_component_checkin' => 'Component checkin confirmation',


### PR DESCRIPTION
Fixes the translations used for check in/out notifications to ignore the :tag 
<img width="295" height="255" alt="image" src="https://github.com/user-attachments/assets/842f571b-9c1c-48bf-b0f4-cee2f7dc671d" />
MS Teams:
<img width="656" height="849" alt="image" src="https://github.com/user-attachments/assets/e427d6aa-3cfe-44ca-acdf-93a70e0b0449" />

<img width="527" height="318" alt="image" src="https://github.com/user-attachments/assets/87b8a3e3-5ba4-44e8-8045-929d2e68c763" />

#17759 
