### PR TITLE
Fixed #17742: don't delete random actionlog when trying to delete a file

### DIFF
--- a/app/Http/Controllers/UploadedFilesController.php
+++ b/app/Http/Controllers/UploadedFilesController.php
@@ -139,7 +139,7 @@ class UploadedFilesController extends Controller
 
 
         // Check for the file
-        $log = Actionlog::find($file_id)->where('item_type', self::$map_object_type[$object_type])
+        $log = Actionlog::where('id',$file_id)->where('item_type', self::$map_object_type[$object_type])
             ->where('item_id', $object->id)->first();
 
         if ($log) {


### PR DESCRIPTION
Fixes #17742

Use ::where() instead of ::find() to make sure the file_id is utilised to find the correct entry.