### PR TITLE
Fixed company name reference in location print

### DIFF
--- a/resources/views/locations/print.blade.php
+++ b/resources/views/locations/print.blade.php
@@ -55,7 +55,7 @@
     @endif
 <br>
 @if ($company)
-    <b>{{ trans('admin/companies/table.name') }}:</b> {{ $company->present()->Name() }}</b>
+    <b>{{ trans('admin/companies/table.name') }}:</b> {{ $company->display_name }}
 <br>
 @endif
 @if ($manager)


### PR DESCRIPTION
This PR fixes an issue when printing assets assigned to and belonging to a location.

[RB-20266]
[RB-20267]