### PR TITLE
Upload log file in GitHub Action tests

### DIFF
--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -76,4 +76,16 @@ jobs:
           DB_DATABASE: snipeit
           DB_PORT: ${{ job.services.mysql.ports[3306] }}
           DB_USERNAME: root
+          LOG_CHANNEL: single
+          LOG_LEVEL: debug
         run: php artisan test
+
+      - name: Upload Laravel logs as artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: laravel-logs-php-${{ matrix.php-version }}-run-${{ github.run_attempt }}
+          path: |
+            storage/logs/*.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -75,4 +75,16 @@ jobs:
           DB_PORT: ${{ job.services.postgresql.ports[5432] }}
           DB_USERNAME: snipeit
           DB_PASSWORD: password
+          LOG_CHANNEL: single
+          LOG_LEVEL: debug
         run: php artisan test
+
+      - name: Upload Laravel logs as artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: laravel-logs-php-${{ matrix.php-version }}-run-${{ github.run_attempt }}
+          path: |
+            storage/logs/*.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -61,4 +61,16 @@ jobs:
       - name: Execute tests (Unit and Feature tests) via PHPUnit
         env:
           DB_CONNECTION: sqlite
+          LOG_CHANNEL: single
+          LOG_LEVEL: debug
         run: php artisan test
+
+      - name: Upload Laravel logs as artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: laravel-logs-php-${{ matrix.php-version }}-run-${{ github.run_attempt }}
+          path: |
+            storage/logs/*.log
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
This PR updates our Github Actions that run tests to upload Laravel's log file as an artifact before quitting so we have some insight into why tests failed. 

Logs are available by expanding the action step: 
<img width="2530" height="1610" alt="image" src="https://github.com/user-attachments/assets/a99b951e-3c46-43d7-85c1-60cfe08f59dd" />

Or clicking Summary and downloading them from the bottom section:
<img width="1416" height="740" alt="image" src="https://github.com/user-attachments/assets/c9092545-093a-4115-a97b-5e03c667dc8f" />

<img width="2520" height="1554" alt="image" src="https://github.com/user-attachments/assets/af944aa6-2e32-40ba-8367-06abb4713d7b" />
