### PR TITLE
Fixed #17756 - Duplicate checkout emails

### DIFF
--- a/app/Listeners/CheckoutableListener.php
+++ b/app/Listeners/CheckoutableListener.php
@@ -96,9 +96,19 @@ class CheckoutableListener
 
             if (!empty($to)) {
                 try {
-                    Mail::to(array_flatten($to))->send($mailable->locale($notifiable->locale));
-                    Mail::to(array_flatten($cc))->send($mailable->locale(Setting::getSettings()->locale));
+                    $toMail = (clone $mailable)->locale($notifiable->locale);
+                    Mail::to(array_flatten($to))->send($toMail);
                     Log::info('Checkout Mail sent to checkout target');
+                } catch (ClientException $e) {
+                    Log::debug("Exception caught during checkout email: " . $e->getMessage());
+                } catch (Exception $e) {
+                    Log::debug("Exception caught during checkout email: " . $e->getMessage());
+                }
+            }
+            if (!empty($cc)) {
+                try {
+                    $ccMail = (clone $mailable)->locale(Setting::getSettings()->locale);
+                    Mail::to(array_flatten($cc))->send($ccMail);
                 } catch (ClientException $e) {
                     Log::debug("Exception caught during checkout email: " . $e->getMessage());
                 } catch (Exception $e) {
@@ -179,16 +189,26 @@ class CheckoutableListener
 
             [$to, $cc] = $this->generateEmailRecipients($shouldSendEmailToUser, $shouldSendEmailToAlertAddress, $notifiable);
 
-            try {
-                if (!empty($to)) {
-                    Mail::to(array_flatten($to))->send($mailable->locale($notifiable->locale));
-                    Mail::to(array_flatten($cc))->send($mailable->locale(Setting::getSettings()->locale));
-                    Log::info('Checkin Mail sent to CC addresses');
+            if (!empty($to)) {
+                try {
+                    $toMail = (clone $mailable)->locale($notifiable->locale);
+                    Mail::to(array_flatten($to))->send($toMail);
+                    Log::info('Checkin Mail sent to checkin target');
+                } catch (ClientException $e) {
+                    Log::debug("Exception caught during checkin email: " . $e->getMessage());
+                } catch (Exception $e) {
+                    Log::debug("Exception caught during checkin email: " . $e->getMessage());
                 }
-            } catch (ClientException $e) {
-                Log::debug("Exception caught during checkin email: " . $e->getMessage());
-            } catch (Exception $e) {
-                Log::debug("Exception caught during checkin email: " . $e->getMessage());
+            }
+            if (!empty($cc)) {
+                try {
+                    $ccMail = (clone $mailable)->locale(Setting::getSettings()->locale);
+                    Mail::to(array_flatten($cc))->send($ccMail);
+                } catch (ClientException $e) {
+                    Log::debug("Exception caught during checkin email: " . $e->getMessage());
+                } catch (Exception $e) {
+                    Log::debug("Exception caught during checkin email: " . $e->getMessage());
+                }
             }
         }
 

--- a/app/Notifications/AuditNotification.php
+++ b/app/Notifications/AuditNotification.php
@@ -61,7 +61,7 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
             ->from(($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot')
             ->to($channel)
             ->attachment(function ($attachment) {
-                $item = $this->params['item'];
+                $item = $this->params['item'] ?? null;
                 $admin_user = $this->params['admin'];
                 $fields = [
                     'By' => '<'.$admin_user->present()->viewUrl().'|'.$admin_user->display_name.'>',

--- a/tests/Feature/Checkouts/Ui/BulkAssetCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/BulkAssetCheckoutTest.php
@@ -58,7 +58,7 @@ class BulkAssetCheckoutTest extends TestCase
             $this->assertHasTheseActionLogs($asset, ['create', 'checkout']); //Note: '$this' gets auto-bound in closures, so this does work.
         });
 
-        Mail::assertSent(CheckoutAssetMail::class, 4);
+        Mail::assertSent(CheckoutAssetMail::class, 2);
         Mail::assertSent(CheckoutAssetMail::class, function (CheckoutAssetMail $mail) {
             return $mail->hasTo('someone@example.com');
         });


### PR DESCRIPTION
This fixes the duplicate emails by cloning the mailable to ensure a clean state before sending off the next one.

Fixes #17756