### PR TITLE
Fixed #17586 - Display accurate quantity in banner

### DIFF
--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -9,7 +9,7 @@
 {{-- Account page content --}}
 @section('content')
 
-@if ($acceptanceCount = \App\Models\CheckoutAcceptance::forUser(Auth::user())->pending()->sum('qty'))
+@if ($acceptanceQuantity = \App\Models\CheckoutAcceptance::forUser(Auth::user())->pending()->sum('qty'))
   <div class="row">
     <div class="col-md-12">
       <div class="alert alert alert-warning fade in">
@@ -17,7 +17,7 @@
 
         <strong>
           <a href="{{ route('account.accept') }}" style="color: white;">
-            {{ trans_choice('general.unaccepted_profile_warning', $acceptanceCount, ['count' => $acceptanceCount]) }}
+            {{ trans_choice('general.unaccepted_profile_warning', $acceptanceQuantity, ['count' => $acceptanceQuantity]) }}
           </a>
           </strong>
       </div>

--- a/resources/views/account/view-assets.blade.php
+++ b/resources/views/account/view-assets.blade.php
@@ -9,7 +9,7 @@
 {{-- Account page content --}}
 @section('content')
 
-@if ($acceptances = \App\Models\CheckoutAcceptance::forUser(Auth::user())->pending()->count())
+@if ($acceptanceCount = \App\Models\CheckoutAcceptance::forUser(Auth::user())->pending()->sum('qty'))
   <div class="row">
     <div class="col-md-12">
       <div class="alert alert alert-warning fade in">
@@ -17,7 +17,7 @@
 
         <strong>
           <a href="{{ route('account.accept') }}" style="color: white;">
-            {{ trans_choice('general.unaccepted_profile_warning', $acceptances, ['count' => $acceptances]) }}
+            {{ trans_choice('general.unaccepted_profile_warning', $acceptanceCount, ['count' => $acceptanceCount]) }}
           </a>
           </strong>
       </div>


### PR DESCRIPTION
This PR updates the "You have items requiring acceptance. Click here to accept or decline them" banner to reflect accessory checkout quantity.

For example, if a user is checked out an accessory with a `qty` of more than one the banner will reflect "2 items" requiring acceptance:

<img width="1224" height="804" alt="CleanShot 2025-09-08 at 14 47 33@2x" src="https://github.com/user-attachments/assets/b4f16246-5194-4250-8e2d-aedf0f377e52" />

<img width="2042" height="578" alt="CleanShot 2025-09-08 at 14 47 43@2x" src="https://github.com/user-attachments/assets/b71b2041-63f6-473e-bea8-bb1af4bc72be" />

> the "4" in this case is just from accepting previous accessories.

---
Fixes #17586 