### PR TITLE
Fixed #10052 - Added api endpoint for retrieving assets checked out to asset

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1290,9 +1290,20 @@ class AssetsController extends Controller
 
     public function assignedAssets(Request $request, Asset $asset) : JsonResponse | array
     {
+        // @todo: authorization
 
-        return [];
-        // to do
+        $query = Asset::where([
+            'assigned_to' => $asset->id,
+            'assigned_type' => Asset::class,
+        ]);
+
+        // @todo: offset
+        // @todo: limit
+
+        $total = $query->count();
+        $assets = $query->get();
+
+        return (new AssetsTransformer)->transformAssets($assets, $total);
     }
 
     public function assignedAccessories(Request $request, Asset $asset) : JsonResponse | array

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1298,11 +1298,12 @@ class AssetsController extends Controller
             'assigned_type' => Asset::class,
         ]);
 
-        // @todo: offset
-        // @todo: limit
-
         $total = $query->count();
-        $assets = $query->get();
+
+        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
+        $limit = app('api_limit_value');
+
+        $assets = $query->skip($offset)->take($limit)->get();
 
         return (new AssetsTransformer)->transformAssets($assets, $total);
     }

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1300,10 +1300,7 @@ class AssetsController extends Controller
 
         $total = $query->count();
 
-        $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
-        $limit = app('api_limit_value');
-
-        $assets = $query->skip($offset)->take($limit)->get();
+        $assets = $query->applyOffsetAndLimit($total)->get();
 
         return (new AssetsTransformer)->transformAssets($assets, $total);
     }

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1290,7 +1290,8 @@ class AssetsController extends Controller
 
     public function assignedAssets(Request $request, Asset $asset) : JsonResponse | array
     {
-        // @todo: authorization
+        $this->authorize('view', Asset::class);
+        $this->authorize('view', $asset);
 
         $query = Asset::where([
             'assigned_to' => $asset->id,

--- a/app/Models/SnipeModel.php
+++ b/app/Models/SnipeModel.php
@@ -3,8 +3,10 @@
 namespace App\Models;
 
 use App\Helpers\Helper;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Request;
 
 class SnipeModel extends Model
 {
@@ -156,6 +158,20 @@ class SnipeModel extends Model
         $this->attributes['status_id'] = $value;
     }
 
+    /**
+     * Applies offset (from request) and limit to query.
+     *
+     * @param  Builder  $query
+     * @param  int  $total
+     * @return void
+     */
+    public function scopeApplyOffsetAndLimit(Builder $query, int $total)
+    {
+        $offset = (Request::input('offset') > $total) ? $total : app('api_offset_value');
+        $limit = app('api_limit_value');
+
+        $query->skip($offset)->take($limit);
+    }
 
     protected function displayName(): Attribute
     {

--- a/tests/Feature/Assets/Api/AssignedAssetsTest.php
+++ b/tests/Feature/Assets/Api/AssignedAssetsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Assets\Api;
+
+use App\Models\Asset;
+use App\Models\User;
+use Tests\TestCase;
+
+class AssignedAssetsTest extends TestCase
+{
+    public function test_requires_permission()
+    {
+        $this->actingAsForApi(User::factory()->create())
+            ->getJson(route('api.assets.assigned_assets' , Asset::factory()->create()))
+            ->assertForbidden();
+    }
+
+    public function test_can_get_assets_assigned_to_specific_asset()
+    {
+        $this->markTestIncomplete();
+
+        // check out asset to an asset
+
+        // make request
+
+        // assert assigned asset included in response
+    }
+}

--- a/tests/Feature/Assets/Api/AssignedAssetsTest.php
+++ b/tests/Feature/Assets/Api/AssignedAssetsTest.php
@@ -16,6 +16,11 @@ class AssignedAssetsTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_adheres_to_company_scoping()
+    {
+        $this->markTestIncomplete();
+    }
+
     public function test_can_get_assets_assigned_to_specific_asset()
     {
         $unassociatedAsset = Asset::factory()->create();

--- a/tests/Feature/Assets/Api/AssignedAssetsTest.php
+++ b/tests/Feature/Assets/Api/AssignedAssetsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Assets\Api;
 use App\Models\Asset;
 use App\Models\Company;
 use App\Models\User;
+use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
 class AssignedAssetsTest extends TestCase
@@ -48,7 +49,12 @@ class AssignedAssetsTest extends TestCase
             ->getJson(route('api.assets.assigned_assets', $asset))
             ->assertOk()
             ->assertResponseContainsInRows($assetsAssignedToAsset, 'serial')
-            ->assertResponseDoesNotContainInRows($unassociatedAsset, 'serial');
+            ->assertResponseDoesNotContainInRows($unassociatedAsset, 'serial')
+            ->assertJson(function (AssertableJson $json) {
+                $json->where('total', 2)
+                    ->count('rows', 2)
+                    ->etc();
+            });
     }
 
     public function test_adheres_to_offset_and_limit()
@@ -68,6 +74,12 @@ class AssignedAssetsTest extends TestCase
             ]))
             ->assertOk()
             ->assertResponseDoesNotContainInRows($assetsAssignedToAsset->first(), 'serial')
-            ->assertResponseContainsInRows($assetsAssignedToAsset->last(), 'serial');
+            ->assertResponseContainsInRows($assetsAssignedToAsset->last(), 'serial')
+            ->dump()
+            ->assertJson(function (AssertableJson $json) {
+                $json->where('total', 2)
+                    ->count('rows', 1)
+                    ->etc();
+            });
     }
 }

--- a/tests/Feature/Assets/Api/AssignedAssetsTest.php
+++ b/tests/Feature/Assets/Api/AssignedAssetsTest.php
@@ -12,7 +12,7 @@ class AssignedAssetsTest extends TestCase
     public function test_requires_permission()
     {
         $this->actingAsForApi(User::factory()->create())
-            ->getJson(route('api.assets.assigned_assets' , Asset::factory()->create()))
+            ->getJson(route('api.assets.assigned_assets', Asset::factory()->create()))
             ->assertForbidden();
     }
 
@@ -49,5 +49,25 @@ class AssignedAssetsTest extends TestCase
             ->assertOk()
             ->assertResponseContainsInRows($assetsAssignedToAsset, 'serial')
             ->assertResponseDoesNotContainInRows($unassociatedAsset, 'serial');
+    }
+
+    public function test_adheres_to_offset_and_limit()
+    {
+        $asset = Asset::factory()->hasAssignedAssets(2)->create();
+
+        $assetsAssignedToAsset = Asset::where([
+            'assigned_to' => $asset->id,
+            'assigned_type' => Asset::class,
+        ])->get();
+
+        $this->actingAsForApi(User::factory()->viewAssets()->create())
+            ->getJson(route('api.assets.assigned_assets', [
+                'asset' => $asset,
+                'offset' => 1,
+                'limit' => 1,
+            ]))
+            ->assertOk()
+            ->assertResponseDoesNotContainInRows($assetsAssignedToAsset->first(), 'serial')
+            ->assertResponseContainsInRows($assetsAssignedToAsset->last(), 'serial');
     }
 }

--- a/tests/Feature/Assets/Api/AssignedAssetsTest.php
+++ b/tests/Feature/Assets/Api/AssignedAssetsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Assets\Api;
 
 use App\Models\Asset;
 use App\Models\User;
+use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
 class AssignedAssetsTest extends TestCase
@@ -17,12 +18,24 @@ class AssignedAssetsTest extends TestCase
 
     public function test_can_get_assets_assigned_to_specific_asset()
     {
-        $this->markTestIncomplete();
+        $unassociatedAsset = Asset::factory()->create();
 
-        // check out asset to an asset
+        $asset = Asset::factory()->hasAssignedAssets(2)->create();
 
-        // make request
+        $assetsAssignedToAsset = Asset::where([
+            'assigned_to' => $asset->id,
+            'assigned_type' => Asset::class,
+        ])->get();
+
+        $this->actingAsForApi(User::factory()->viewAssets()->create())
+            ->getJson(route('api.assets.assigned_assets', $asset))
+            ->assertOk()
+            ->dump()
+            ->assertJson(function (AssertableJson $json) {
+                $json->etc();
+            });
 
         // assert assigned asset included in response
+        // assert unassociated asset not in response
     }
 }

--- a/tests/Feature/Assets/Api/AssignedAssetsTest.php
+++ b/tests/Feature/Assets/Api/AssignedAssetsTest.php
@@ -75,7 +75,6 @@ class AssignedAssetsTest extends TestCase
             ->assertOk()
             ->assertResponseDoesNotContainInRows($assetsAssignedToAsset->first(), 'serial')
             ->assertResponseContainsInRows($assetsAssignedToAsset->last(), 'serial')
-            ->dump()
             ->assertJson(function (AssertableJson $json) {
                 $json->where('total', 2)
                     ->count('rows', 1)

--- a/tests/Feature/Assets/Api/AssignedAssetsTest.php
+++ b/tests/Feature/Assets/Api/AssignedAssetsTest.php
@@ -36,11 +36,10 @@ class AssignedAssetsTest extends TestCase
             ->getJson(route('api.assets.assigned_assets', $asset))
             ->assertOk()
             ->dump()
+            ->assertResponseContainsInRows($assetsAssignedToAsset, 'serial')
+            ->assertResponseDoesNotContainInRows($unassociatedAsset, 'serial')
             ->assertJson(function (AssertableJson $json) {
                 $json->etc();
             });
-
-        // assert assigned asset included in response
-        // assert unassociated asset not in response
     }
 }

--- a/tests/Support/CustomTestMacros.php
+++ b/tests/Support/CustomTestMacros.php
@@ -27,14 +27,12 @@ trait CustomTestMacros
                 }
 
                 foreach ($models as $model) {
-
                     $guardAgainstNullProperty($model, $property);
 
                     Assert::assertTrue(
                         collect($this['rows'])->pluck($property)->contains(e($model->{$property})),
                         "Response did not contain the expected value: {$model->{$property}}"
                     );
-
                 }
 
                 return $this;

--- a/tests/Support/CustomTestMacros.php
+++ b/tests/Support/CustomTestMacros.php
@@ -21,13 +21,21 @@ trait CustomTestMacros
 
         TestResponse::macro(
             'assertResponseContainsInRows',
-            function (Model $model, string $property = 'name') use ($guardAgainstNullProperty) {
-                $guardAgainstNullProperty($model, $property);
+            function (iterable|Model $models, string $property = 'name') use ($guardAgainstNullProperty) {
+                if ($models instanceof Model) {
+                    $models = [$models];
+                }
 
-                Assert::assertTrue(
-                    collect($this['rows'])->pluck($property)->contains(e($model->{$property})),
-                    "Response did not contain the expected value: {$model->{$property}}"
-                );
+                foreach ($models as $model) {
+
+                    $guardAgainstNullProperty($model, $property);
+
+                    Assert::assertTrue(
+                        collect($this['rows'])->pluck($property)->contains(e($model->{$property})),
+                        "Response did not contain the expected value: {$model->{$property}}"
+                    );
+
+                }
 
                 return $this;
             }


### PR DESCRIPTION
This PR populates a stubbed out API endpoint, `/api/v1/hardware/{asset}/assigned/assets`, allowing for retrieving assets assigned to a specific asset.

---

In the process, I added a new query scope, `applyOffsetAndLimit()` on the base `SnipeModel` that allows the following snippet that appears at the end of a lot (most/all?) of our "index" api controller methods:
```php
$total = $query->count();  
  
$offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');  
$limit = app('api_limit_value');  
  
$assets = $query->skip($offset)->take($limit)->get();
```

to be simplified to:
```php
$total = $query->count();  
  
$assets = $query->applyOffsetAndLimit($total)->get();
```

---

Fixes #10052