### PR TITLE
Added api endpoint for retrieving components checked out to asset

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -6,6 +6,7 @@ use App\Events\CheckoutableCheckedIn;
 use App\Http\Requests\StoreAssetRequest;
 use App\Http\Requests\UpdateAssetRequest;
 use App\Http\Traits\MigratesLegacyAssetLocations;
+use App\Http\Transformers\ComponentsTransformer;
 use App\Models\AccessoryCheckout;
 use App\Models\CheckoutAcceptance;
 use App\Models\LicenseSeat;
@@ -1322,9 +1323,17 @@ class AssetsController extends Controller
         return (new AssetsTransformer)->transformCheckedoutAccessories($accessory_checkouts, $total);
     }
 
-    public function assignedComponents(Request $request, Asset $asset): JsonResponse
+    public function assignedComponents(Request $request, Asset $asset): JsonResponse|array
     {
-        //
+        $this->authorize('view', Asset::class);
+        $this->authorize('view', $asset);
+
+        $asset->load('components');
+
+        $components = $asset->components;
+        $total = $asset->components->count();
+
+        return (new ComponentsTransformer)->transformComponents($components, $total);
     }
 
     /**

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1322,6 +1322,10 @@ class AssetsController extends Controller
         return (new AssetsTransformer)->transformCheckedoutAccessories($accessory_checkouts, $total);
     }
 
+    public function assignedComponents(Request $request, Asset $asset): JsonResponse
+    {
+        //
+    }
 
     /**
      * Generate asset labels by tag

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1328,10 +1328,10 @@ class AssetsController extends Controller
         $this->authorize('view', Asset::class);
         $this->authorize('view', $asset);
 
-        $asset->load('components');
+        $asset->loadCount('components');
+        $total = $asset->components_count;
 
-        $components = $asset->components;
-        $total = $asset->components->count();
+        $components = $asset->load(['components' => fn($query) => $query->applyOffsetAndLimit($total)])->components;
 
         return (new ComponentsTransformer)->transformComponents($components, $total);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -571,6 +571,13 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
                   'assignedAccessories'
               ]
           )->name('api.assets.assigned_accessories');
+
+          Route::get('{asset}/assigned/components',
+              [
+                  Api\AssetsController::class,
+                  'assignedComponents'
+              ]
+          )->name('api.assets.assigned_components');
           /** End assigned routes */
 
       });

--- a/tests/Feature/Assets/Api/AssignedComponentsTest.php
+++ b/tests/Feature/Assets/Api/AssignedComponentsTest.php
@@ -54,4 +54,9 @@ class AssignedComponentsTest extends TestCase
                     ->etc();
             });
     }
+
+    public function test_adheres_to_offset_and_limit()
+    {
+        $this->markTestIncomplete();
+    }
 }

--- a/tests/Feature/Assets/Api/AssignedComponentsTest.php
+++ b/tests/Feature/Assets/Api/AssignedComponentsTest.php
@@ -57,6 +57,23 @@ class AssignedComponentsTest extends TestCase
 
     public function test_adheres_to_offset_and_limit()
     {
-        $this->markTestIncomplete();
+        $asset = Asset::factory()->hasComponents(2)->create();
+
+        $componentsAssignedToAsset = $asset->components;
+
+        $this->actingAsForApi(User::factory()->viewAssets()->create())
+            ->getJson(route('api.assets.assigned_components', [
+                'asset' => $asset,
+                'offset' => 1,
+                'limit' => 1,
+            ]))
+            ->assertOk()
+            ->assertResponseDoesNotContainInRows($componentsAssignedToAsset->first())
+            ->assertResponseContainsInRows($componentsAssignedToAsset->last())
+            ->assertJson(function (AssertableJson $json) {
+                $json->where('total', 2)
+                    ->count('rows', 1)
+                    ->etc();
+            });
     }
 }

--- a/tests/Feature/Assets/Api/AssignedComponentsTest.php
+++ b/tests/Feature/Assets/Api/AssignedComponentsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Assets\Api;
+
+use App\Models\Asset;
+use App\Models\Company;
+use App\Models\Component;
+use App\Models\User;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class AssignedComponentsTest extends TestCase
+{
+    public function test_requires_permission()
+    {
+        $this->actingAsForApi(User::factory()->create())
+            ->getJson(route('api.assets.assigned_components', Asset::factory()->create()))
+            ->assertForbidden();
+    }
+
+    public function test_adheres_to_company_scoping()
+    {
+        $this->settings->enableMultipleFullCompanySupport();
+
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $asset = Asset::factory()->for($companyA)->create();
+
+        $user = User::factory()->for($companyB)->viewAssets()->create();
+
+        $this->actingAsForApi($user)
+            ->getJson(route('api.assets.assigned_components', $asset))
+            ->assertOk()
+            ->assertStatusMessageIs('error')
+            ->assertMessagesAre('Asset not found');
+    }
+
+    public function test_can_get_components_assigned_to_specific_asset()
+    {
+        $unassociatedComponent = Component::factory()->create();
+
+        $asset = Asset::factory()->hasComponents(2)->create();
+
+        $componentsAssignedToAsset = $asset->components;
+
+        $this->actingAsForApi(User::factory()->viewAssets()->create())
+            ->getJson(route('api.assets.assigned_components', $asset))
+            ->assertOk()
+            ->assertResponseContainsInRows($componentsAssignedToAsset)
+            ->assertResponseDoesNotContainInRows($unassociatedComponent)
+            ->assertJson(function (AssertableJson $json) {
+                $json->where('total', 2)
+                    ->count('rows', 2)
+                    ->etc();
+            });
+    }
+}


### PR DESCRIPTION
Similar to #17835, this PR adds an api endpoint to get the assigned components for a specific asset: `/api/v1/hardware/{asset}/assigned/components`. 

