### PR TITLE
Fixed nesting in orWhere

### DIFF
--- a/app/Console/Commands/SendExpirationAlerts.php
+++ b/app/Console/Commands/SendExpirationAlerts.php
@@ -53,7 +53,7 @@ class SendExpirationAlerts extends Command
                 ->filter(fn($item) => !empty($item))
                 ->all();
             // Expiring Assets
-            $assets = Asset::getExpiringWarrantee($alert_interval);
+            $assets = Asset::getExpiringWarranteeOrEol($alert_interval);
 
             if ($assets->count() > 0) {
                 $this->info(trans_choice('mail.assets_warrantee_alert', $assets->count(), ['count' => $assets->count(), 'threshold' => $alert_interval]));


### PR DESCRIPTION
This should fix a nested where query that was returning too many results for the Expiring EOL/Warrantee asset report.