### PR TITLE
Add new index to users over deleted_at and location_id

### DIFF
--- a/database/migrations/2025_09_16_104604_create_users_deleted_at_location_id_index.php
+++ b/database/migrations/2025_09_16_104604_create_users_deleted_at_location_id_index.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // We are doing 'deleted_at' *first* here because that way this index can do double-duty -
+            // handling queries for 'all undeleted users' as well as 'users who are deleted in this location'
+            // and 'users who are not-deleted in this location'
+            $table->index(['deleted_at','location_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex(['deleted_at','location_id']);
+        });
+    }
+};


### PR DESCRIPTION
Some location-based queries that join to Users, when there are lots of users, can be slower than they need to be, so this adds an index.

One thing we're doing that's a little weirder than usual is that we're indexing `deleted_at` *first*, then doing `location_id`. This is because we could probably use an index over users `deleted_at ` at some point, and this index will cover that. But we're never going to ask for "all users from this location regardless of whether they're deleted or not" - we *always* ask for either `deleted_at IS NULL` or `deleted_at IS NOT NULL`.