### PR TITLE
Fixed excessive api requests on bulk checkout page

### DIFF
--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -147,7 +147,6 @@
             return true; // ensure form still submits
         });
 
-        $('#assigned_assets_select').select2('open');
         setTimeout(function () {
             const $searchField = $('.select2-search__field');
             const $results = $('.select2-results');


### PR DESCRIPTION
This PR addresses an issue on the bulk checkout page.

When the page is loaded, the assets select2 starts loading _all_ assets via paginated requests. This is isn't necessary because starting to type into the select2 will send "search" requests to populate the filtered results.

https://github.com/user-attachments/assets/8f0a484d-c378-4562-9074-6e36619f255d

After this change the input is still focused on page load:

https://github.com/user-attachments/assets/ed8f9b0f-9e9d-4ecc-843a-9ecb623c238c

@Godmartinz I think this change still handles what you were going for in #17291 but can you double-check I didn't break anything?