### PR TITLE
Adds an error message bag for connection issues with LDAP

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -302,14 +302,17 @@ class LoginController extends Controller
         if (Setting::getSettings()->ldap_enabled) { // avoid hitting the $this->ldap
             LOG::debug('LDAP is enabled.');
             try {
-                LOG::debug('Attempting to log user in by LDAP authentication.');
                 $user = $this->loginViaLdap($request);
-                Auth::login($user, $request->input('remember'));
-
-                // If the user was unable to login via LDAP, log the error and let them fall through to
-            // local authentication.
+                \Auth::login($user);
             } catch (\Exception $e) {
-                Log::debug('There was an error authenticating the LDAP user: '.$e->getMessage());
+
+                Session::flash('error', $e->getMessage());
+                Log::notice("LDAP bind failed ({$e}");
+                return back()->withInput();
+            } catch (\Throwable $e) {
+                Session::flash('error', 'Login failed. Please try again.');
+                Log::error($e);
+                return back()->withInput();
             }
         }
 

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -163,10 +163,11 @@ class Ldap extends Model
 
             //More codes can be found under Client side result codes at ldap.com
             $friendly = match ($code) {
+                49 => 'Invalid username or password.',
                 81 => 'Cannot reach the LDAP server. Please try again later.',
                 85 => 'LDAP request timed out. Please try again later.',
                 52 => 'LDAP service unavailable. Please try again later.',
-                default => 'Could not contact LDAP server. Please try again. Hello',
+                default => 'Could not contact LDAP server. Please try again.',
             };
 
             throw new Exception(

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -97,7 +97,7 @@ class Ldap extends Model
         ldap_set_option($connection, LDAP_OPT_NETWORK_TIMEOUT, 20);
 
         if ($ldap_use_tls=='1') {
-            //suppresses the error and grabs it.
+            //suppresses the error and throws exception.
             if (! @ldap_start_tls($connection)) {
                 $code = ldap_errno($connection);
                 $err  = ldap_error($connection);
@@ -163,12 +163,10 @@ class Ldap extends Model
 
             //More codes can be found under Client side result codes at ldap.com
             $friendly = match ($code) {
-                49 => 'Invalid username or password.',
-                34 => 'Invalid username format for LDAP.',
                 81 => 'Cannot reach the LDAP server. Please try again later.',
                 85 => 'LDAP request timed out. Please try again later.',
                 52 => 'LDAP service unavailable. Please try again later.',
-                default => 'Could not contact LDAP server. Please try again.',
+                default => 'Could not contact LDAP server. Please try again. Hello',
             };
 
             throw new Exception(

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -97,7 +97,13 @@ class Ldap extends Model
         ldap_set_option($connection, LDAP_OPT_NETWORK_TIMEOUT, 20);
 
         if ($ldap_use_tls=='1') {
-            ldap_start_tls($connection);
+            //suppresses the error and grabs it.
+            if (! @ldap_start_tls($connection)) {
+                $code = ldap_errno($connection);
+                $err  = ldap_error($connection);
+
+                throw new \Exception("Could not start TLS with LDAP (code $code): $err.");
+            }
         }
 
 
@@ -108,14 +114,15 @@ class Ldap extends Model
     /**
      * Binds/authenticates the user to LDAP, and returns their attributes.
      *
-     * @author [A. Gianotto] [<snipe@snipe.net>]
-     * @since  [v3.0]
      * @param  $username
      * @param  $password
-     * @param  bool|false $user
+     * @param bool|false $user
      * @return bool true    if the username and/or password provided are valid
      *              false   if the username and/or password provided are invalid
      *         array of ldap_attributes if $user is true
+     * @throws Exception
+     * @since  [v3.0]
+     * @author [A. Gianotto] [<snipe@snipe.net>]
      */
     public static function findAndBindUserLdap($username, $password)
     {
@@ -147,7 +154,28 @@ class Ldap extends Model
 
         Log::debug('Filter query: '.$filterQuery);
 
+        //Suppressing the error and handling it to be more friendly
         if (! $ldapbind = @ldap_bind($connection, $userDn, $password)) {
+            $code = ldap_errno($connection);
+            $err  = ldap_error($connection);
+
+            Log::warning("LDAP bind FAILED for DN={$userDn} code={$code} error={$err}");
+
+            //More codes can be found under Client side result codes at ldap.com
+            $friendly = match ($code) {
+                49 => 'Invalid username or password.',
+                34 => 'Invalid username format for LDAP.',
+                81 => 'Cannot reach the LDAP server. Please try again later.',
+                85 => 'LDAP request timed out. Please try again later.',
+                52 => 'LDAP service unavailable. Please try again later.',
+                default => 'Could not contact LDAP server. Please try again.',
+            };
+
+            throw new Exception(
+                $friendly,
+                $code,
+            );
+        }
             Log::debug("Status of binding user: $userDn to directory: (directly!) ".($ldapbind ? "success" : "FAILURE"));
             if (! $ldapbind = self::bindAdminToLdap($connection)) {
                 /*
@@ -166,7 +194,6 @@ class Ldap extends Model
                 Log::debug("Status of binding Admin user: $userDn to directory instead: ".($ldapbind ? "success" : "FAILURE"));
                 return false;
             }
-        }
 
         if (! $results = ldap_search($connection, $baseDn, $filterQuery)) {
             throw new Exception('Could not search LDAP: ');


### PR DESCRIPTION
I tried logging in without tailwind active and I received a timeout error. This adds some error message handling for that and a couple other things. 

No Code, cant connect:
<img width="363" height="464" alt="image" src="https://github.com/user-attachments/assets/0eb9330b-057a-42db-866c-fa26ecc2d05c" />
Wrong username (49):
<img width="363" height="464" alt="image" src="https://github.com/user-attachments/assets/249bfa87-9fb1-4111-a589-fdd588c469f8" />
