### PR TITLE
Fixed #17896 - Prevent assigned assets from being bulk checked out

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -647,6 +647,14 @@ class BulkAssetsController extends Controller
 
             $assets = Asset::findOrFail($asset_ids);
 
+            if ($assets->pluck('assigned_to')->unique()->filter()->isNotEmpty()) {
+                // re-add the asset ids so the assets select is re-populated
+                $request->session()->flashInput(['selected_assets' => $asset_ids]);
+
+                return redirect(route('hardware.bulkcheckout.show'))
+                    ->with('error', trans('general.error_assets_already_checked_out'));
+            }
+
             if (request('checkout_to_type') == 'asset') {
                 foreach ($asset_ids as $asset_id) {
                     if ($target->id == $asset_id) {

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -647,6 +647,7 @@ class BulkAssetsController extends Controller
 
             $assets = Asset::findOrFail($asset_ids);
 
+            // Prevent checking out assets that are already checked out
             if ($assets->pluck('assigned_to')->unique()->filter()->isNotEmpty()) {
                 // re-add the asset ids so the assets select is re-populated
                 $request->session()->flashInput(['selected_assets' => $asset_ids]);

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -520,6 +520,7 @@ return [
     'item_name_var' => ':item Name',
     'error_user_company' => 'Checkout target company and asset company do not match',
     'error_user_company_accept_view' => 'An Asset assigned to you belongs to a different company so you can\'t accept nor deny it, please check with your manager',
+    'error_assets_already_checked_out' => 'One or more of the assets are already checked out',
     'importer' => [
         'checked_out_to_fullname' => 'Checked Out to: Full Name',
         'checked_out_to_first_name' => 'Checked Out to: First Name',

--- a/tests/Feature/Checkouts/Ui/BulkAssetCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/BulkAssetCheckoutTest.php
@@ -123,7 +123,7 @@ class BulkAssetCheckoutTest extends TestCase
     }
 
     #[DataProvider('checkoutTargets')]
-    public function test_prevents_checkouts_checked_out_items($data)
+    public function test_prevents_checkouts_of_checked_out_items($data)
     {
         ['type' => $type, 'target' => $target] = $data();
 


### PR DESCRIPTION
This PR fixes an issue where assigned assets can be silently re-assigned when checked out via the bulk checkout feature:

https://github.com/user-attachments/assets/8754e836-b273-4c15-9d25-2a83487fc161


Now the action is prevented and the user is presented with "Error: One or more of the assets are already checked out":

https://github.com/user-attachments/assets/7af55f30-c483-426b-9ed2-88655897aac7

---

I anticipate this having merge conflicts with #17887 and will fix them when it comes up.

---

Fixes #17896