### PR TITLE
Added #17687: Add User Responsible for a maintenances.

### DIFF
--- a/app/Http/Controllers/Api/MaintenancesController.php
+++ b/app/Http/Controllers/Api/MaintenancesController.php
@@ -34,7 +34,7 @@ class MaintenancesController extends Controller
         $this->authorize('view', Asset::class);
 
         $maintenances = Maintenance::select('maintenances.*')
-            ->with('asset', 'asset.model', 'asset.location', 'asset.defaultLoc', 'supplier', 'asset.company',  'asset.assetstatus', 'adminuser');
+            ->with('asset', 'asset.model', 'asset.location', 'asset.defaultLoc', 'supplier', 'asset.company',  'asset.assetstatus', 'adminuser', 'userResponsible');
 
         if ($request->filled('search')) {
             $maintenances = $maintenances->TextSearch($request->input('search'));
@@ -54,6 +54,10 @@ class MaintenancesController extends Controller
 
         if ($request->filled('asset_maintenance_type')) {
             $maintenances->where('asset_maintenance_type', '=', $request->input('asset_maintenance_type'));
+        }
+
+        if ($request->filled('user_responsible_id')) {
+            $maintenances->where('user_responsible_id', '=', $request->input('user_responsible_id'));
         }
 
 
@@ -78,6 +82,7 @@ class MaintenancesController extends Controller
                                 'location',
                                 'is_warranty',
                                 'status_label',
+                                'user_responsible_id'
                             ];
 
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';

--- a/app/Http/Controllers/MaintenancesController.php
+++ b/app/Http/Controllers/MaintenancesController.php
@@ -78,6 +78,7 @@ class MaintenancesController extends Controller
             $maintenance->is_warranty = $request->input('is_warranty');
             $maintenance->cost = $request->input('cost');
             $maintenance->notes = $request->input('notes');
+            $maintenance->user_responsible_id = $request->input('user_responsible_id');
 
             // Save the asset maintenance data
             $maintenance->asset_id = $asset->id;
@@ -152,6 +153,7 @@ class MaintenancesController extends Controller
         $maintenance->name = $request->input('name');
         $maintenance->start_date = $request->input('start_date');
         $maintenance->completion_date = $request->input('completion_date');
+        $maintenance->user_responsible_id = $request->input('user_responsible_id');
 
 
         // Todo - put this in a getter/setter?

--- a/app/Http/Transformers/MaintenancesTransformer.php
+++ b/app/Http/Transformers/MaintenancesTransformer.php
@@ -24,7 +24,7 @@ class MaintenancesTransformer
     public function transformMaintenance(Maintenance $assetmaintenance)
     {
         $array = [
-            'id'            => (int) $assetmaintenance->id,
+            'id'  => (int) $assetmaintenance->id,
             'asset' => ($assetmaintenance->asset) ? [
                 'id' => (int) $assetmaintenance->asset->id,
                 'name'=> ($assetmaintenance->asset->name) ? e($assetmaintenance->asset->name) : null,
@@ -82,6 +82,17 @@ class MaintenancesTransformer
             'created_at' => Helper::getFormattedDateObject($assetmaintenance->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($assetmaintenance->updated_at, 'datetime'),
             'is_warranty'=> $assetmaintenance->is_warranty,
+            'user_responsible' => ($assetmaintenance->userResponsible) ? [
+                'id' => (int) $assetmaintenance->userResponsible->id,
+                'username' => e($assetmaintenance->userResponsible->username),
+                'name' => e($assetmaintenance->userResponsible->getFullNameAttribute()),
+                'first_name'=> e($assetmaintenance->userResponsible->first_name),
+                'last_name'=> ($assetmaintenance->userResponsible->last_name) ? e($assetmaintenance->userResponsible->last_name) : null,
+                'email'=> ($assetmaintenance->userResponsible->email) ? e($assetmaintenance->userResponsible->email) : null,
+                'employee_number' =>  ($assetmaintenance->userResponsible->employee_num) ? e($assetmaintenance->userResponsible->employee_num) : null,
+                'jobtitle' => $assetmaintenance->userResponsible->jobtitle ? e($assetmaintenance->userResponsible->jobtitle) : null,
+                'type' => 'user',
+            ] : null,
 
         ];
 

--- a/app/Models/Maintenance.php
+++ b/app/Models/Maintenance.php
@@ -38,6 +38,7 @@ class Maintenance extends SnipeModel implements ICompanyableChild
         'completion_date'        => 'date_format:Y-m-d|nullable|after_or_equal:start_date',
         'notes'                  => 'string|nullable',
         'cost'                   =>  'numeric|nullable|gte:0|max:99999999999999999.99',
+        'user_responsible_id'    => 'nullable|integer'
     ];
 
 
@@ -57,6 +58,7 @@ class Maintenance extends SnipeModel implements ICompanyableChild
         'asset_maintenance_time',
         'notes',
         'cost',
+        'user_responsible_id',
     ];
 
     use Searchable;
@@ -87,6 +89,7 @@ class Maintenance extends SnipeModel implements ICompanyableChild
         'asset.supplier' => ['name'],
         'asset.assetstatus' => ['name'],
         'supplier' => ['name'],
+        'user_responsible' => ['first_name', 'last_name'],
     ];
 
     public function getCompanyableParents()
@@ -185,7 +188,15 @@ class Maintenance extends SnipeModel implements ICompanyableChild
             ->orderBy('created_at', 'desc')
             ->withTrashed();
     }
-    
+
+    /**
+     * Get the user responsible for this maintenance.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function userResponsible() {
+        return $this->belongsTo(\App\Models\User::class, 'user_responsible_id')->withTrashed();
+    }
 
     /**
      * Get the admin who created the maintenance

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -434,6 +434,19 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     }
 
     /**
+     * Establishes the user -> maintenances relationship
+     *
+     * This would only be used to return maintenances that this user
+     * is responsible for.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\Relation
+     */
+    public function maintenanceCausedBy()
+    {
+        return $this->hasMany(\App\Models\Maintenance::class, 'user_responsible_id')->withTrashed();
+    }
+
+    /**
      * Establishes the user -> accessories relationship
      *
      * @author A. Gianotto <snipe@snipe.net>

--- a/app/Presenters/MaintenancesPresenter.php
+++ b/app/Presenters/MaintenancesPresenter.php
@@ -95,6 +95,12 @@ class MaintenancesPresenter extends Presenter
                 'title' => trans('general.location'),
                 'formatter' => 'locationsLinkObjFormatter',
             ], [
+                'field' => 'user_responsible',
+                'searchable' => 'true',
+                'sortable' => 'true',
+                'title' => trans('admin/maintenances/table.user_responsible'),
+                'formatter' => 'usersLinkObjFormatter',
+            ], [
                 'field' => 'asset_maintenance_type',
                 'searchable' => true,
                 'sortable' => true,

--- a/database/factories/MaintenanceFactory.php
+++ b/database/factories/MaintenanceFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\Asset;
 use App\Models\Maintenance;
 use App\Models\Supplier;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class MaintenanceFactory extends Factory
@@ -31,6 +32,7 @@ class MaintenanceFactory extends Factory
             'start_date' => $this->faker->date(),
             'is_warranty' => $this->faker->boolean(),
             'notes' => $this->faker->paragraph(),
+            'user_responsible_id' => User::factory(),
         ];
     }
 }

--- a/database/migrations/2025_09_21_003823_add_user_responsible_to_maintenances.php
+++ b/database/migrations/2025_09_21_003823_add_user_responsible_to_maintenances.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('maintenances', function (Blueprint $table) {
+            if (!Schema::hasColumn('maintenances', 'user_responsible_id')) {
+                $table->integer('user_responsible_id')->nullable()->default(null);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('maintenances', function (Blueprint $table) {
+            $table->dropColumn('user_responsible_id');
+        });
+    }
+};

--- a/resources/lang/en-US/admin/maintenances/form.php
+++ b/resources/lang/en-US/admin/maintenances/form.php
@@ -11,5 +11,6 @@
         'asset_maintenance_time' => 'Asset Maintenance Time (in days)',
         'notes'                  => 'Notes',
         'update'                 => 'Update Asset Maintenance',
-        'create'                 => 'Create Asset Maintenance'
+        'create'                 => 'Create Asset Maintenance',
+        'user_responsible'       => 'User responsible',
     ];

--- a/resources/lang/en-US/admin/maintenances/table.php
+++ b/resources/lang/en-US/admin/maintenances/table.php
@@ -5,4 +5,5 @@
         'asset_name'    => 'Asset Name',
         'is_warranty'   => 'Warranty',
         'dl_csv'        => 'Download CSV',
+        'user_responsible' => 'User responsible',
     ];

--- a/resources/lang/en-US/admin/users/general.php
+++ b/resources/lang/en-US/admin/users/general.php
@@ -53,4 +53,5 @@ return [
     'all_assigned_list_generation' => 'Generated on:',
     'email_user_creds_on_create' => 'Email this user their credentials?',
     'department_manager' => 'Department Manager',
+    'maintenance_caused_by_user' => 'Maintenance caused by user',
 ];

--- a/resources/views/maintenances/edit.blade.php
+++ b/resources/views/maintenances/edit.blade.php
@@ -105,7 +105,7 @@
 
 
         @include ('partials.forms.edit.maintenance_type')
-
+        @include ('partials.forms.edit.user-select', ['fieldname' => 'user_responsible_id', 'translated_name' => trans('admin/maintenances/table.user_responsible')] )
         <!-- Start Date -->
         <div class="form-group {{ $errors->has('start_date') ? ' has-error' : '' }}">
           <label for="start_date" class="col-md-3 control-label">

--- a/resources/views/maintenances/view.blade.php
+++ b/resources/views/maintenances/view.blade.php
@@ -115,6 +115,18 @@ use Carbon\Carbon;
                 </div>
               </div> <!-- /row -->
               @endif
+              @if ($maintenance->userResponsible)
+                <div class="row">
+                    <div class="col-md-3">
+                        {{ trans('admin/maintenances/form.user_responsible') }}
+                    </div>
+                    <div class="col-md-9">
+                        <a href="{{ route('users.show', $maintenance->userResponsible->id) }}">
+                            {{ $maintenance->userResponsible->name }}
+                        </a>
+                    </div>
+                </div> <!-- /row -->
+                @endif
 
               <div class="row">
                 <div class="col-md-3">

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -137,7 +137,16 @@
                   </a>
               </li>
           @endif
-
+      <li>
+          <a href="#maintenancecausedby" data-toggle="tab">
+            <span class="hidden-lg hidden-md">
+            <x-icon type="maintenancecausedby" class="fa-2x" />
+            </span>
+                  <span class="hidden-xs hidden-sm">{{ trans('admin/users/general.maintenance_caused_by_user') }}
+              {!! ($user->maintenanceCausedBy->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($user->maintenanceCausedBy->count()).'</span>' : '' !!}
+            </span>
+          </a>
+      </li>
 
       @can('update', $user)
           <li class="dropdown pull-right">
@@ -1110,6 +1119,25 @@
               "fileName": "export-users-{{ date('Y-m-d') }}",
               "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
               }'>
+              </table>
+
+          </div>
+          <div class="tab-pane" id="maintenancecausedby">
+
+              <table
+                      data-columns="{{ \App\Presenters\MaintenancesPresenter::dataTableLayout() }}"
+                      data-cookie-id-table="maintenancesTable"
+                      data-side-pagination="server"
+                      data-show-footer="true"
+                      id="maintenancesTable"
+                      data-buttons="maintenanceButtons"
+                      class="table table-striped snipe-table"
+                      data-url="{{route('api.maintenances.index', ['user_responsible_id' => $user->id]) }}"
+                      data-export-options='{
+                "fileName": "export-maintenances-{{ date('Y-m-d') }}",
+              "ignoreColumn": ["actions","image","change","checkbox","checkincheckout","icon"]
+              }'>
+
               </table>
 
           </div>

--- a/tests/Feature/Maintenances/Api/CreateMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Api/CreateMaintenanceTest.php
@@ -27,6 +27,7 @@ class CreateMaintenanceTest extends TestCase
 
         Storage::fake('public');
         $actor = User::factory()->superuser()->create();
+        $userResponsible = User::factory()->create();
 
         $asset = Asset::factory()->create();
         $supplier = Supplier::factory()->create();
@@ -43,6 +44,7 @@ class CreateMaintenanceTest extends TestCase
                 'cost' => '100.00',
                 'image' => UploadedFile::fake()->image('test_image.png'),
                 'notes' => 'A note',
+                'user_responsible_id' => $userResponsible->id,
             ])
             ->assertOk()
             ->assertStatus(200);
@@ -64,6 +66,7 @@ class CreateMaintenanceTest extends TestCase
             'notes' => 'A note',
             'image' => $maintenance->image,
             'created_by' => $actor->id,
+            'user_responsible_id' => $userResponsible->id,
         ]);
 
         $this->assertHasTheseActionLogs($maintenance, ['create']);

--- a/tests/Feature/Maintenances/Api/EditMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Api/EditMaintenanceTest.php
@@ -24,6 +24,8 @@ class EditMaintenanceTest extends TestCase
     {
         Storage::fake('public');
         $actor = User::factory()->superuser()->create();
+        $userResponsible = User::factory()->create();
+
         $supplier = Supplier::factory()->create();
         $maintenance = Maintenance::factory()->create();
 
@@ -38,6 +40,7 @@ class EditMaintenanceTest extends TestCase
                 'is_warranty' => '1',
                 'image' => UploadedFile::fake()->image('test_image.png'),
                 'notes' => 'A note',
+                'user_responsible_id' => $userResponsible->id,
             ])
             ->assertOk();
 
@@ -58,6 +61,7 @@ class EditMaintenanceTest extends TestCase
             'asset_maintenance_time' => '9',
             'notes' => 'A note',
             'image' => $maintenance->image,
+            'user_responsible_id' => $userResponsible->id,
         ]);
 
         $this->assertHasTheseActionLogs($maintenance, ['create', 'update']);

--- a/tests/Feature/Maintenances/Ui/CreateMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Ui/CreateMaintenanceTest.php
@@ -31,6 +31,7 @@ class CreateMaintenanceTest extends TestCase
     {
         Storage::fake('public');
         $actor = User::factory()->superuser()->create();
+        $userResponsible = User::factory()->create();
         $asset = Asset::factory()->create();
         $supplier = Supplier::factory()->create();
 
@@ -46,6 +47,7 @@ class CreateMaintenanceTest extends TestCase
                 'cost' => '100.00',
                 'image' => UploadedFile::fake()->image('test_image.png'),
                 'notes' => 'A note',
+                'user_responsible_id' => $userResponsible->id,
             ])
             ->assertSessionHasNoErrors()
             ->assertRedirect(route('maintenances.index'));
@@ -70,6 +72,7 @@ class CreateMaintenanceTest extends TestCase
             'cost' => '100.00',
             'image' => $maintenance->image,
             'created_by' => $actor->id,
+            'user_responsible_id' => $userResponsible->id,
         ]);
 
         $this->assertHasTheseActionLogs($maintenance, ['create']);

--- a/tests/Feature/Maintenances/Ui/EditMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Ui/EditMaintenanceTest.php
@@ -22,6 +22,7 @@ class EditMaintenanceTest extends TestCase
     public function testCanUpdateMaintenance()
     {
         $actor = User::factory()->superuser()->create();
+        $userResponsible = User::factory()->create();
         $asset = Asset::factory()->create();
         $maintenance = Maintenance::factory()->create(['asset_id' => $asset]);
         $supplier = Supplier::factory()->create();
@@ -38,6 +39,7 @@ class EditMaintenanceTest extends TestCase
                 'image' => UploadedFile::fake()->image('test_image.png'),
                 'cost' => '100.99',
                 'notes' => 'A note',
+                'user_responsible_id' => $userResponsible->id,
             ])
             ->assertSessionHasNoErrors()
             ->assertRedirect(route('maintenances.index'));
@@ -59,6 +61,7 @@ class EditMaintenanceTest extends TestCase
             'asset_maintenance_time' => '9',
             'notes' => 'A note',
             'cost' => '100.99',
+            'user_responsible_id' => $userResponsible->id,
         ]);
 
         $this->assertHasTheseActionLogs($maintenance, ['create', 'update']);


### PR DESCRIPTION
Add #17687.

This adds a User responsible field to maintenances. That way, we can track who cost a lot to a company.

The information is available both in the Users & the maintenance page.

<img width="2600" height="641" alt="image" src="https://github.com/user-attachments/assets/39b4b43d-b9b9-477c-bb95-6f6a17199615" />
<img width="3449" height="386" alt="image" src="https://github.com/user-attachments/assets/2fead5f8-631c-4d88-9340-14714a858366" />
<img width="3447" height="467" alt="image" src="https://github.com/user-attachments/assets/bb09669d-e8e6-4a14-99b0-32fff9cd3c8c" />
