### PR TITLE
Fixed #17919 - correct the behavior of the checkout type selector

### DIFF
--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -94,7 +94,7 @@
                         </div>
 
                         @include ('partials.forms.checkout-selector', ['user_select' => 'true','asset_select' => 'true', 'location_select' => 'true'])
-                        @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.user'), 'fieldname' => 'assigned_user', 'style' => session('checkout_to_type') == 'user' ? '' : 'display: none;'])
+                        @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.user'), 'fieldname' => 'assigned_user', 'style' => (session('checkout_to_type') ?? 'user') == 'user' ? '' : 'display: none;'])
                         <!-- We have to pass unselect here so that we don't default to the asset that's being checked out. We want that asset to be pre-selected everywhere else. -->
                         @include ('partials.forms.edit.asset-select', ['translated_name' => trans('general.select_asset'), 'fieldname' => 'assigned_asset', 'company_id' => $asset->company_id, 'unselect' => 'true', 'style' => session('checkout_to_type') == 'asset' ? '' : 'display: none;'])
                         @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'assigned_location', 'style' => session('checkout_to_type') == 'location' ? '' : 'display: none;'])

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -94,7 +94,7 @@
                         </div>
 
                         @include ('partials.forms.checkout-selector', ['user_select' => 'true','asset_select' => 'true', 'location_select' => 'true'])
-                        @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.user'), 'fieldname' => 'assigned_user', 'style' => (session('checkout_to_type') ?? 'user') == 'user' ? '' : 'display: none;'])
+                        @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.user'), 'fieldname' => 'assigned_user', 'style' => (session('checkout_to_type') ?: 'user') == 'user' ? '' : 'display: none;'])
                         <!-- We have to pass unselect here so that we don't default to the asset that's being checked out. We want that asset to be pre-selected everywhere else. -->
                         @include ('partials.forms.edit.asset-select', ['translated_name' => trans('general.select_asset'), 'fieldname' => 'assigned_asset', 'company_id' => $asset->company_id, 'unselect' => 'true', 'style' => session('checkout_to_type') == 'asset' ? '' : 'display: none;'])
                         @include ('partials.forms.edit.location-select', ['translated_name' => trans('general.location'), 'fieldname' => 'assigned_location', 'style' => session('checkout_to_type') == 'location' ? '' : 'display: none;'])

--- a/resources/views/partials/forms/checkout-selector.blade.php
+++ b/resources/views/partials/forms/checkout-selector.blade.php
@@ -4,9 +4,9 @@
 
         <div class="btn-group" data-toggle="buttons">
             @if ((isset($user_select)) && ($user_select!='false'))
-                <label class="btn btn-default{{ (session('checkout_to_type') ?? 'user') == 'user' ? ' active' : '' }}">
+                <label class="btn btn-default{{ (session('checkout_to_type') ?: 'user') == 'user' ? ' active' : '' }}">
                     <input name="checkout_to_type" value="user" aria-label="checkout_to_type"
-                           type="radio" {{ (session('checkout_to_type') ?? 'user') == 'user' ? 'checked' : '' }}>
+                           type="radio" {{ (session('checkout_to_type') ?: 'user') == 'user' ? 'checked' : '' }}>
                 <x-icon type="user" />
                 {{ trans('general.user') }}
             </label>

--- a/resources/views/partials/forms/checkout-selector.blade.php
+++ b/resources/views/partials/forms/checkout-selector.blade.php
@@ -21,7 +21,7 @@
             @endif
             @if ((isset($location_select)) && ($location_select!='false'))
                 <label class="btn btn-default{{ session('checkout_to_type') == 'location' ? ' active' : '' }}">
-                    <input name="checkout_to_type" value="location" aria-label="checkout_to_type" class="active"
+                    <input name="checkout_to_type" value="location" aria-label="checkout_to_type"
                            type="radio" {{ session('checkout_to_type') == 'location' ? 'checked' : '' }}>
                 <i class="fas fa-map-marker-alt" aria-hidden="true"></i>
                 {{ trans('general.location') }}

--- a/resources/views/partials/forms/checkout-selector.blade.php
+++ b/resources/views/partials/forms/checkout-selector.blade.php
@@ -4,22 +4,25 @@
 
         <div class="btn-group" data-toggle="buttons">
             @if ((isset($user_select)) && ($user_select!='false'))
-            <label class="btn btn-default{{ session('checkout_to_type') == 'user' ? ' active' : '' }}">
-                <input name="checkout_to_type" value="user" aria-label="checkout_to_type" type="radio" checked="checked">
+                <label class="btn btn-default{{ (session('checkout_to_type') ?? 'user') == 'user' ? ' active' : '' }}">
+                    <input name="checkout_to_type" value="user" aria-label="checkout_to_type"
+                           type="radio" {{ (session('checkout_to_type') ?? 'user') == 'user' ? 'checked' : '' }}>
                 <x-icon type="user" />
                 {{ trans('general.user') }}
             </label>
             @endif
             @if ((isset($asset_select)) && ($asset_select!='false'))
-            <label class="btn btn-default{{ session('checkout_to_type') == 'asset' ? ' active' : '' }}">
-                <input name="checkout_to_type" value="asset" aria-label="checkout_to_type" type="radio">
+                <label class="btn btn-default{{ session('checkout_to_type') == 'asset' ? ' active' : '' }}">
+                    <input name="checkout_to_type" value="asset" aria-label="checkout_to_type"
+                           type="radio" {{ session('checkout_to_type') == 'asset' ? 'checked': '' }}>
                 <i class="fas fa-barcode" aria-hidden="true"></i>
                 {{ trans('general.asset') }}
             </label>
             @endif
             @if ((isset($location_select)) && ($location_select!='false'))
-            <label class="btn btn-default{{ session('checkout_to_type') == 'location' ? ' active' : '' }}">
-                <input name="checkout_to_type" value="location" aria-label="checkout_to_type" class="active" type="radio">
+                <label class="btn btn-default{{ session('checkout_to_type') == 'location' ? ' active' : '' }}">
+                    <input name="checkout_to_type" value="location" aria-label="checkout_to_type" class="active"
+                           type="radio" {{ session('checkout_to_type') == 'location' ? 'checked' : '' }}>
                 <i class="fas fa-map-marker-alt" aria-hidden="true"></i>
                 {{ trans('general.location') }}
             </label>


### PR DESCRIPTION
We had a problem where, if you had checked an asset out to a non-User, when you would go *back* to checking out another asset, it would correctly highlight the last 'type' of thing you checked out *and* would actually show the correct drop-down menu, but it would *not* select the correct invisible radio button to state what the correct `checkout_to_type` was.

Additionally, when you would go to the checkout screen on a fresh session, no type of checkout target was selected. Whereas we had used to default to showing the User dropdown.

This fixes both of those issues.

It was *really* tempting (and I wrote it at first this way) to do some kind of `@php...@endphp` thing to determine `$active_checkout_type` and then take action on _that_ to prevent us from repeating `session('checkout_to_type')` or `session('checkout_to_type') ?? 'user'` as often as we do, but that seemed like just extra noise and we tend to actively avoid `@php` sections, so I went with this simpler approach.

Fixes #17919