### PR TITLE
Adds option to disable auto generating action log from acceptance factory

### DIFF
--- a/database/factories/CheckoutAcceptanceFactory.php
+++ b/database/factories/CheckoutAcceptanceFactory.php
@@ -23,23 +23,23 @@ class CheckoutAcceptanceFactory extends Factory
             'assigned_to_id' => User::factory(),
         ];
     }
-    protected static bool $skipAutoAssign = false;
+    protected static bool $skipActionLog = false;
 
     public function withoutActionLog(): static
     {
         // turn off for this create() call
-        static::$skipAutoAssign = true;
+        static::$skipActionLog = true;
 
         // ensure it turns back on AFTER creating
         return $this->afterCreating(function () {
-            static::$skipAutoAssign = false;
+            static::$skipActionLog = false;
         });
     }
 
     public function configure(): static
     {
         return $this->afterCreating(function (CheckoutAcceptance $acceptance) {
-            if (static::$skipAutoAssign) {
+            if (static::$skipActionLog) {
                 return; // short-circuit
             }
             if ($acceptance->checkoutable instanceof Asset) {

--- a/database/factories/CheckoutAcceptanceFactory.php
+++ b/database/factories/CheckoutAcceptanceFactory.php
@@ -25,7 +25,7 @@ class CheckoutAcceptanceFactory extends Factory
     }
     protected static bool $skipAutoAssign = false;
 
-    public function withoutAutoAssign(): static
+    public function withoutActionLog(): static
     {
         // turn off for this create() call
         static::$skipAutoAssign = true;

--- a/database/factories/CheckoutAcceptanceFactory.php
+++ b/database/factories/CheckoutAcceptanceFactory.php
@@ -23,22 +23,38 @@ class CheckoutAcceptanceFactory extends Factory
             'assigned_to_id' => User::factory(),
         ];
     }
+    protected static bool $skipAutoAssign = false;
+
+    public function withoutAutoAssign(): static
+    {
+        // turn off for this create() call
+        static::$skipAutoAssign = true;
+
+        // ensure it turns back on AFTER creating
+        return $this->afterCreating(function () {
+            static::$skipAutoAssign = false;
+        });
+    }
 
     public function configure(): static
     {
         return $this->afterCreating(function (CheckoutAcceptance $acceptance) {
+            if (static::$skipAutoAssign) {
+                return; // short-circuit
+            }
             if ($acceptance->checkoutable instanceof Asset) {
                 $this->createdAssociatedActionLogEntry($acceptance);
             }
 
             if ($acceptance->checkoutable instanceof Asset && $acceptance->assignedTo instanceof User) {
                 $acceptance->checkoutable->update([
-                    'assigned_to' => $acceptance->assigned_to_id,
-                    'assigned_type' => get_class($acceptance->assignedTo),
+                    'assigned_to'  => $acceptance->assigned_to_id,
+                    'assigned_type'=> get_class($acceptance->assignedTo),
                 ]);
             }
         });
     }
+
 
     public function forAccessory()
     {

--- a/tests/Feature/Notifications/Email/AssetAcceptanceReminderTest.php
+++ b/tests/Feature/Notifications/Email/AssetAcceptanceReminderTest.php
@@ -86,38 +86,7 @@ class AssetAcceptanceReminderTest extends TestCase
 
     public function testReminderIsSentToUser()
     {
-<<<<<<< Updated upstream
         $checkoutAcceptance = CheckoutAcceptance::factory()->pending()->create();
-=======
-        $checkedOutBy = User::factory()->canViewReports()->create();
-
-        $checkoutTypes = [
-            Asset::class       => CheckoutAssetMail::class,
-            Accessory::class   => CheckoutAccessoryMail::class,
-            LicenseSeat::class => CheckoutLicenseMail::class,
-            Consumable::class  => CheckoutConsumableMail::class,
-            //for the future its setup for components, but we dont send reminders for components at the moment.
-//            Component::class   => CheckoutComponentMail::class,
-        ];
-
-        $assignee = User::factory()->create(['email' => 'test@example.com']);
-        foreach ($checkoutTypes as $modelClass => $mailable) {
-
-            $item = $modelClass::factory()->create();
-            $acceptance = CheckoutAcceptance::factory()->withoutAutoAssign()->pending()->create([
-                'checkoutable_id' => $item->id,
-                'checkoutable_type' => $modelClass,
-                'assigned_to_id' => $assignee->id,
-            ]);
-
-            if ($modelClass === LicenseSeat::class) {
-                $logType = License::class;
-                $logId   = $item->license->id;
-            } else {
-                $logType = $modelClass;
-                $logId   = $item->id;
-            }
->>>>>>> Stashed changes
 
         $this->actingAs(User::factory()->canViewReports()->create())
             ->post($this->routeFor($checkoutAcceptance))

--- a/tests/Feature/Notifications/Email/AssetAcceptanceReminderTest.php
+++ b/tests/Feature/Notifications/Email/AssetAcceptanceReminderTest.php
@@ -86,7 +86,38 @@ class AssetAcceptanceReminderTest extends TestCase
 
     public function testReminderIsSentToUser()
     {
+<<<<<<< Updated upstream
         $checkoutAcceptance = CheckoutAcceptance::factory()->pending()->create();
+=======
+        $checkedOutBy = User::factory()->canViewReports()->create();
+
+        $checkoutTypes = [
+            Asset::class       => CheckoutAssetMail::class,
+            Accessory::class   => CheckoutAccessoryMail::class,
+            LicenseSeat::class => CheckoutLicenseMail::class,
+            Consumable::class  => CheckoutConsumableMail::class,
+            //for the future its setup for components, but we dont send reminders for components at the moment.
+//            Component::class   => CheckoutComponentMail::class,
+        ];
+
+        $assignee = User::factory()->create(['email' => 'test@example.com']);
+        foreach ($checkoutTypes as $modelClass => $mailable) {
+
+            $item = $modelClass::factory()->create();
+            $acceptance = CheckoutAcceptance::factory()->withoutAutoAssign()->pending()->create([
+                'checkoutable_id' => $item->id,
+                'checkoutable_type' => $modelClass,
+                'assigned_to_id' => $assignee->id,
+            ]);
+
+            if ($modelClass === LicenseSeat::class) {
+                $logType = License::class;
+                $logId   = $item->license->id;
+            } else {
+                $logType = $modelClass;
+                $logId   = $item->id;
+            }
+>>>>>>> Stashed changes
 
         $this->actingAs(User::factory()->canViewReports()->create())
             ->post($this->routeFor($checkoutAcceptance))


### PR DESCRIPTION
This fixes an issue with creating an acceptance auto generating an action log, while 99% of the time this may be useful it can conflict with other tests. This gives the option to  append `->withoutActionLog()` if needed