### PR TITLE
Fixed #17914 - Improve UX around attempted bulk checkout of assigned assets

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -630,7 +630,7 @@ class BulkAssetsController extends Controller
                 return !$asset->assigned_to;
             });
 
-            session()->flashInput(['selected_assets' => $assignable->pluck('id')]);
+            session()->flashInput(['selected_assets' => $assignable->pluck('id')->values()->toArray()]);
         }
 
         $do_not_change = ['' => trans('general.do_not_change')];

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -522,6 +522,7 @@ return [
     'error_user_company_multiple' => 'One or more of the checkout target company and asset company do not match',
     'error_user_company_accept_view' => 'An Asset assigned to you belongs to a different company so you can\'t accept nor deny it, please check with your manager',
     'error_assets_already_checked_out' => 'One or more of the assets are already checked out',
+    'assigned_assets_removed' => 'The following were removed from the selected assets because they are already checked out',
     'importer' => [
         'checked_out_to_fullname' => 'Checked Out to: Full Name',
         'checked_out_to_first_name' => 'Checked Out to: First Name',

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -36,7 +36,11 @@
                         <p>The following were removed from the selected assets because they are already checked out:</p>
                         <ul>
                             @foreach($removed_assets as $removed_asset)
-                                <li>{{ $removed_asset->present()->fullName }}</li>
+                                <li>
+                                    <a href="{{ route('hardware.show', $removed_asset->id) }}">
+                                        {{ $removed_asset->present()->fullName }}
+                                    </a>
+                                </li>
                             @endforeach
                         </ul>
                     </div>

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -33,7 +33,7 @@
                         <span class="box-title col-xs-12">Warning</span>
                     </div>
                     <div class="box-body">
-                        <p>The following were removed from the selected assets because they are already checked out:</p>
+                        <p>{{ trans('general.assigned_assets_removed') }}</p>
                         <ul>
                             @foreach($removed_assets as $removed_asset)
                                 <li>

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -27,6 +27,22 @@
         <form class="form-horizontal" method="post" action="" autocomplete="off">
           {{ csrf_field() }}
 
+            @if ($removed_assets->isNotEmpty())
+                <div class="box box-solid box-warning">
+                    <div class="box-header with-border">
+                        <span class="box-title col-xs-12">Warning</span>
+                    </div>
+                    <div class="box-body">
+                        <p>The following were removed from the selected assets because they are already checked out:</p>
+                        <ul>
+                            @foreach($removed_assets as $asset)
+                                <li>{{ $asset->present()->fullName }}</li>
+                          @endforeach
+                        </ul>
+                    </div>
+                </div>
+            @endif
+
             @include ('partials.forms.edit.asset-select', [
            'translated_name' => trans('general.assets'),
            'fieldname' => 'selected_assets[]',

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -35,9 +35,9 @@
                     <div class="box-body">
                         <p>The following were removed from the selected assets because they are already checked out:</p>
                         <ul>
-                            @foreach($removed_assets as $asset)
-                                <li>{{ $asset->present()->fullName }}</li>
-                          @endforeach
+                            @foreach($removed_assets as $removed_asset)
+                                <li>{{ $removed_asset->present()->fullName }}</li>
+                            @endforeach
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
A previous PR, #17897, fixed an issue where including assigned assets in bulk checkout would silently re-assign assets without alerting the previous assignee by declining the entire request _after_ the user submitted the form.

This PR improves the UX by removing the assigned assets and informing the user why they were removed before the user submits the form:

<img width="1282" height="1200" alt="image" src="https://github.com/user-attachments/assets/9b4eb9a4-e2ef-46f6-8b0b-1ef2e7adf37a" />


https://github.com/user-attachments/assets/54b69b7c-9f35-441c-b4c2-443ec8a712b7

---

Fixes #17914