### PR TITLE
Fixed #17932 - incorrect number for remaining assets in asset models

### DIFF
--- a/app/Http/Controllers/Api/AssetModelsController.php
+++ b/app/Http/Controllers/Api/AssetModelsController.php
@@ -73,7 +73,8 @@ class AssetModelsController extends Controller
             'models.require_serial'
          ])
             ->with('category', 'depreciation', 'manufacturer', 'fieldset.fields.defaultValues', 'adminuser')
-            ->withCount('assets as assets_count');
+            ->withCount('assets as assets_count')
+            ->withCount('availableAssets as available_assets_count');
 
         if ($request->input('status')=='deleted') {
             $assetmodels->onlyTrashed();

--- a/app/Http/Transformers/AssetModelsTransformer.php
+++ b/app/Http/Transformers/AssetModelsTransformer.php
@@ -48,7 +48,7 @@ class AssetModelsTransformer
             'image' => ($assetmodel->image != '') ? Storage::disk('public')->url('models/'.e($assetmodel->image)) : null,
             'model_number' => ($assetmodel->model_number ? e($assetmodel->model_number): null),
             'min_amt'   => ($assetmodel->min_amt) ? (int) $assetmodel->min_amt : null,
-            'remaining' => (int) ($assetmodel->assets_count - $assetmodel->min_amt),
+            'remaining' => (int) $assetmodel->available_assets_count,
             'depreciation' => ($assetmodel->depreciation) ? [
                 'id' => (int) $assetmodel->depreciation->id,
                 'name'=> e($assetmodel->depreciation->name),

--- a/app/Models/AssetModel.php
+++ b/app/Models/AssetModel.php
@@ -122,6 +122,12 @@ class AssetModel extends SnipeModel
         return $this->hasMany(\App\Models\Asset::class, 'model_id');
     }
 
+
+    public function availableAssets()
+    {
+        return $this->hasMany(\App\Models\Asset::class, 'model_id')->whereNull('assets.assigned_to')->RTD();
+    }
+
     /**
      * Establishes the model -> category relationship
      *


### PR DESCRIPTION
This fixes #17932 where the remaining number of deployable assets was incorrect in the asset models listing table.