### PR TITLE
Fixes #17958 - handle accessing deleted model during bulk asset update

### DIFF
--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -470,7 +470,7 @@ class BulkAssetsController extends Controller
                  */
 
                 // Does the model have a fieldset?
-                if ($asset->model->fieldset) {
+                if ($asset->model?->fieldset) {
                     foreach ($asset->model->fieldset->fields as $field) {
 
                         // null custom fields

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -163,7 +163,7 @@ class BulkAssetsController extends Controller
         $modelNames = [];
 
         foreach($models as $model) {
-            $modelNames[] = $model->model->name;
+            $modelNames[] = $model->model?->name;
         }
 
         if ($request->filled('bulk_actions')) {

--- a/app/Observers/AssetObserver.php
+++ b/app/Observers/AssetObserver.php
@@ -175,7 +175,7 @@ class AssetObserver
 
        // determine if explicit and set eol_explicit to true
        if (!is_null($asset->asset_eol_date) && !is_null($asset->purchase_date)) {
-            if($asset->model->eol > 0) {
+           if ($asset->model?->eol > 0) {
                 $months = (int) Carbon::parse($asset->asset_eol_date)->diffInMonths($asset->purchase_date, true);
                 if($months != $asset->model->eol) {
                     $asset->eol_explicit = true;
@@ -184,7 +184,7 @@ class AssetObserver
        } elseif (!is_null($asset->asset_eol_date) && is_null($asset->purchase_date)) {
            $asset->eol_explicit = true;
        }
-       if ((!is_null($asset->asset_eol_date)) && (!is_null($asset->purchase_date)) && (is_null($asset->model->eol) || ($asset->model->eol == 0))) {
+        if ((!is_null($asset->asset_eol_date)) && (!is_null($asset->purchase_date)) && (is_null($asset->model?->eol) || ($asset->model?->eol == 0))) {
            $asset->eol_explicit = true;
        }
 

--- a/resources/views/models/custom_fields_form_bulk_edit.blade.php
+++ b/resources/views/models/custom_fields_form_bulk_edit.blade.php
@@ -5,7 +5,7 @@
 @endphp
 
 @foreach($models as $model)
-    @if ($model->fieldset ? $model->fieldset->count() > 0 : false)
+    @if (($model) && ($model->fieldset ? $model->fieldset->count() > 0 : false))
         @php
             $anyModelHasCustomFields++;
         @endphp

--- a/tests/Feature/Assets/Ui/BulkEditAssetsTest.php
+++ b/tests/Feature/Assets/Ui/BulkEditAssetsTest.php
@@ -29,6 +29,25 @@ class BulkEditAssetsTest extends TestCase
         ])->assertStatus(200);
     }
 
+    public function test_handles_model_being_deleted()
+    {
+        $this->withoutExceptionHandling();
+
+        $user = User::factory()->viewAssets()->editAssets()->create();
+        $assets = Asset::factory()->count(2)->create();
+
+        $assets->first()->model->forceDelete();
+
+        $id_array = $assets->pluck('id')->toArray();
+
+        $this->actingAs($user)->post('/hardware/bulkedit', [
+            'ids' => $id_array,
+            'order' => 'asc',
+            'bulk_actions' => 'edit',
+            'sort' => 'id'
+        ])->assertStatus(200);
+    }
+
     public function test_standard_user_cannot_access_page()
     {
         $user = User::factory()->create();


### PR DESCRIPTION
Bulk updating an asset which has a model that has been forced deleted throws an exception via a couple code paths in the controller, observer, and template. This PR handles those cases.

[RB-19337]
[RB-20311]

Similar to #17957.

Fixes #17958