### PR TITLE
Fixed #17963 - over eager deletion of asset files via api

### DIFF
--- a/app/Http/Controllers/Api/UploadedFilesController.php
+++ b/app/Http/Controllers/Api/UploadedFilesController.php
@@ -193,8 +193,12 @@ class UploadedFilesController extends Controller
 
 
         // Check for the file
-        $log = Actionlog::find($file_id)->where('item_type', self::$map_object_type[$object_type])
-            ->where('item_id', $object->id)->first();
+        $log = Actionlog::query()
+            ->where('id', $file_id)
+            ->where('action_type', 'uploaded')
+            ->where('item_type', self::$map_object_type[$object_type])
+            ->where('item_id', $object->id)
+            ->first();
 
         if ($log) {
             // Check the file actually exists, and delete it


### PR DESCRIPTION
We were calling `find` which triggered the database query but then chaining `where` afterwards which turned it back into a query builder, then calling `first` which triggered another query _without_ using the supplied `$file_id`. This PR fixes that making it one query that includes `file_id`.

Note that the files are not and were not actually deleted from the filesystem.

---

Fixes #17963