### PR TITLE
Fixed #17972 - set last_checkin if asset is checked in during an update

### DIFF
--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -398,6 +398,7 @@ class AssetsController extends Controller
             $asset->assigned_to = null;
             $asset->assigned_type = null;
             $asset->accepted = null;
+            $asset->last_checkin = now();
             event(new CheckoutableCheckedIn($asset, $target, auth()->user(), 'Checkin on asset update with '.$status->getStatuslabelType().' status', date('Y-m-d H:i:s'), $originalValues));
         }
 

--- a/tests/Feature/Assets/Ui/EditAssetTest.php
+++ b/tests/Feature/Assets/Ui/EditAssetTest.php
@@ -75,7 +75,10 @@ class EditAssetTest extends TestCase
         $user = User::factory()->create();
         $deployable_status = Statuslabel::factory()->rtd()->create();
         $achived_status = Statuslabel::factory()->archived()->create();
-        $asset = Asset::factory()->assignedToUser($user)->create(['status_id' => $deployable_status->id]);
+        $asset = Asset::factory()->assignedToUser($user)->create([
+            'status_id' => $deployable_status->id,
+            'last_checkin' => null,
+        ]);
         $this->assertTrue($asset->assignedTo->is($user));
 
         $currentTimestamp = now();
@@ -96,6 +99,7 @@ class EditAssetTest extends TestCase
         $this->assertNull($asset->assigned_to);
         $this->assertNull($asset->assigned_type);
         $this->assertEquals($achived_status->id, $asset->status_id);
+        $this->assertNotNull($asset->last_checkin);
 
         Event::assertDispatched(function (CheckoutableCheckedIn $event) use ($currentTimestamp) {
             return (int) Carbon::parse($event->action_date)->diffInSeconds($currentTimestamp, true) < 2;


### PR DESCRIPTION
Currently, if you edit an asset that is checked out via the UI and set the status to something undeployable the asset is checked in but the `last_checkin` property on the model is not updated. This PR fixes that.

---

Fixes #17972