### PR TITLE
Replaced Form::checkbox with raw html

### DIFF
--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -295,7 +295,14 @@
 
                           <div class="col-md-8 col-md-offset-3">
                               <label class="form-control form-control--disabled">
-                                  {{ Form::checkbox('send_welcome', '1', old('send_welcome'), ['id' => "email_user_checkbox", 'aria-label'=>'send_welcome']) }}
+                                  <input
+                                      type="checkbox"
+                                      name="send_welcome"
+                                      id="email_user_checkbox"
+                                      value="1"
+                                      aria-label="send_welcome"
+                                      @checked(old('send_welcome'))
+                                  />
                                   {{ trans('general.send_welcome_email_to_users') }}
                               </label>
 


### PR DESCRIPTION
This PR continues the saga of replacing `Form::x` and replaces a lingering `Form::checkbox` on the user create screen.

<img width="1966" height="1270" alt="image" src="https://github.com/user-attachments/assets/19636936-9f10-4429-815d-31f000e6765c" />
