### PR TITLE
Fixed #17205 - replace Form:: email_format

### DIFF
--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -168,32 +168,6 @@ Form::macro('barcode_types', function ($name = 'barcode_type', $selected = null,
     return $select;
 });
 
-Form::macro('email_format', function ($name = 'email_format', $selected = null, $class = null) {
-    $formats = [
-        'firstname.lastname' => trans('admin/settings/general.email_formats.firstname_lastname_format'),
-        'firstname' => trans('admin/settings/general.email_formats.first_name_format'),
-        'lastname' => trans('admin/settings/general.email_formats.last_name_format'),
-        'filastname' => trans('admin/settings/general.email_formats.filastname_format'),
-        'lastnamefirstinitial' => trans('admin/settings/general.email_formats.lastnamefirstinitial_format'),
-        'firstname_lastname' => trans('admin/settings/general.email_formats.firstname_lastname_underscore_format'),
-        'firstinitial.lastname' => trans('admin/settings/general.email_formats.firstinitial_lastname'),
-        'lastname_firstinitial' => trans('admin/settings/general.email_formats.lastname_firstinitial'),
-        'lastname.firstinitial' => trans('admin/settings/general.email_formats.lastname_dot_firstinitial_format'),
-        'firstnamelastname' => trans('admin/settings/general.email_formats.firstnamelastname'),
-        'firstnamelastinitial' => trans('admin/settings/general.email_formats.firstnamelastinitial'),
-        'lastname.firstname' => trans('admin/settings/general.email_formats.lastnamefirstname'),
-    ];
-
-    $select = '<select name="'.$name.'" class="'.$class.'" style="width: 100%" aria-label="'.$name.'">';
-    foreach ($formats as $format => $label) {
-        $select .= '<option value="'.$format.'"'.($selected == $format ? ' selected="selected" role="option" aria-selected="true"' : ' aria-selected="false"').'>'.$label.'</option> '."\n";
-    }
-
-    $select .= '</select>';
-
-    return $select;
-});
-
 Form::macro('username_format', function ($name = 'username_format', $selected = null, $class = null) {
     $formats = [
         'firstname.lastname' => trans('admin/settings/general.username_formats.firstname_lastname_format'),

--- a/resources/views/blade/input/email-format-select.blade.php
+++ b/resources/views/blade/input/email-format-select.blade.php
@@ -1,0 +1,27 @@
+@php
+    $formats = [
+        'firstname.lastname' => trans('admin/settings/general.email_formats.firstname_lastname_format'),
+        'firstname' => trans('admin/settings/general.email_formats.first_name_format'),
+        'lastname' => trans('admin/settings/general.email_formats.last_name_format'),
+        'filastname' => trans('admin/settings/general.email_formats.filastname_format'),
+        'lastnamefirstinitial' => trans('admin/settings/general.email_formats.lastnamefirstinitial_format'),
+        'firstname_lastname' => trans('admin/settings/general.email_formats.firstname_lastname_underscore_format'),
+        'firstinitial.lastname' => trans('admin/settings/general.email_formats.firstinitial_lastname'),
+        'lastname_firstinitial' => trans('admin/settings/general.email_formats.lastname_firstinitial'),
+        'lastname.firstinitial' => trans('admin/settings/general.email_formats.lastname_dot_firstinitial_format'),
+        'firstnamelastname' => trans('admin/settings/general.email_formats.firstnamelastname'),
+        'firstnamelastinitial' => trans('admin/settings/general.email_formats.firstnamelastinitial'),
+        'lastname.firstname' => trans('admin/settings/general.email_formats.lastnamefirstname'),
+    ];
+@endphp
+
+<x-input.select {{ $attributes }}>
+    @foreach($formats as $format => $label)
+        <option
+            value="{{ $format }}"
+            @selected($selected == $format)
+        >
+            {{ $label }}
+        </option>
+    @endforeach
+</x-input.select>

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -87,7 +87,12 @@
                                    <label for="email_format">{{ trans('admin/settings/general.email_formats.email_format') }}</label>
                                </div>
                                <div class="col-md-8">
-                                   {!! Form::email_format('email_format', old('email_format', $setting->email_format), 'select2') !!}
+                                   <x-input.email-format-select
+                                       name="email_format"
+                                       :selected="old('email_format', $setting->email_format)"
+                                       style="width: 100%"
+                                       aria-label="email_format"
+                                   />
                                    {!! $errors->first('email_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                                </div>
                            </div>


### PR DESCRIPTION
This PR replaces and removes the `email_format` form macro used here:
<img width="1512" height="496" alt="image" src="https://github.com/user-attachments/assets/e5738577-7b31-4b03-a2c4-a9d0ca41ecfa" />

---

Fixes #17205

