### PR TITLE
Fixed #17206 - replace Form::name_display_format macro

### DIFF
--- a/resources/macros/macros.php
+++ b/resources/macros/macros.php
@@ -104,23 +104,6 @@ Form::macro('digit_separator', function ($name = 'digit_separator', $selected = 
     return $select;
 });
 
-
-Form::macro('name_display_format', function ($name = 'name_display_format', $selected = null, $class = null) {
-    $formats = [
-        'first_last' => trans('general.firstname_lastname_display'),
-        'last_first' => trans('general.lastname_firstname_display'),
-    ];
-
-    $select = '<select name="'.$name.'" class="'.$class.'" style="width: 100%" aria-label="'.$name.'">';
-    foreach ($formats as $format => $label) {
-        $select .= '<option value="'.$format.'"'.($selected == $format ? ' selected="selected" role="option" aria-selected="true"' : ' aria-selected="false"').'>'.$label.'</option> '."\n";
-    }
-
-    $select .= '</select>';
-
-    return $select;
-});
-
 /**
  * Barcode macro
  * Generates the dropdown menu of available 1D barcodes

--- a/resources/views/settings/localization.blade.php
+++ b/resources/views/settings/localization.blade.php
@@ -58,8 +58,12 @@
                                 <label for="name_display_format">{{ trans('general.name_display_format') }}</label>
                             </div>
                             <div class="col-md-5 col-xs-12">
-                                {!! Form::name_display_format('name_display_format', old('name_display_format', $setting->name_display_format), 'select2') !!}
-
+                                <x-input.select
+                                    name="name_display_format"
+                                    :options="['first_last' => trans('general.firstname_lastname_display'), 'last_first' => trans('general.lastname_firstname_display')]"
+                                    :selected="old('name_display_format', $setting->name_display_format)"
+                                    style="width: 100%"
+                                />
                                 {!! $errors->first('name_display_format', '<span class="alert-msg" aria-hidden="true">:message</span>') !!}
                             </div>
                         </div>


### PR DESCRIPTION
This PR replaces and removes the `name_display_format` form macro used here:

<img width="1972" height="702" alt="image" src="https://github.com/user-attachments/assets/4277b2b4-13c5-427b-842d-b73db0e84f56" />

---

Fixes #17206