### PR TITLE
Added command to remove invalid "upload deleted" entries from the action log

### DIFF
--- a/app/Console/Commands/RemoveInvalidUploadDeleteActionLogItems.php
+++ b/app/Console/Commands/RemoveInvalidUploadDeleteActionLogItems.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Actionlog;
+use Illuminate\Console\Command;
+
+class RemoveInvalidUploadDeleteActionLogItems extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'snipeit:remove-invalid-upload-delete-action-log-items';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $invalidLogs = Actionlog::query()
+            ->where('action_type', 'upload deleted')
+            ->whereNull('filename')
+            ->get();
+
+        
+    }
+}

--- a/app/Console/Commands/RemoveInvalidUploadDeleteActionLogItems.php
+++ b/app/Console/Commands/RemoveInvalidUploadDeleteActionLogItems.php
@@ -19,7 +19,7 @@ class RemoveInvalidUploadDeleteActionLogItems extends Command
      *
      * @var string
      */
-    protected $description = 'Command description';
+    protected $description = 'Permanently remove invalid "upload deleted" action log items that have a null filename. This command can potentially result in deleted files being "resurrected" in the UI.';
 
     /**
      * Execute the console command.

--- a/app/Console/Commands/RemoveInvalidUploadDeleteActionLogItems.php
+++ b/app/Console/Commands/RemoveInvalidUploadDeleteActionLogItems.php
@@ -31,6 +31,13 @@ class RemoveInvalidUploadDeleteActionLogItems extends Command
             ->whereNull('filename')
             ->get();
 
-        
+        $this->info("{$invalidLogs->count()} invalid log items found.");
+
+
+        if ($invalidLogs->count() > 0 && $this->confirm("Do you wish to remove {$invalidLogs->count()} log items?")) {
+            $invalidLogs->each(fn($log) => $log->delete());
+        }
+
+        return 0;
     }
 }


### PR DESCRIPTION
This PR follows up #17967 and adds a command: `snipeit:remove-invalid-upload-delete-action-log-items`.

Consider this scenario prior to # 17967 being implemented: 

1. Two files are added for an asset
1. The asset is checked out
1. An api request is made to delete one of the files and triggers what #17967 fixes: an entry is made to the `action_logs` with `action_type=upload deleted` **but** `filename` is null.

The entry is in an invalid state where `action_type` is correctly `upload deleted` but the filename is missing. This can cause the other file for the asset to not be shown in the UI. If a user experiences that they can run the command provided and permanently remove the "upload deleted" `action_logs` entries that are missing filenames.

Since the filename was not stored originally it is probable that running the command will "resurrect" deleted files for assets that had this issue.