### PR TITLE
Fixed #17910 - added counts to mobile view for assets

### DIFF
--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -55,7 +55,9 @@
                           <span class="hidden-lg hidden-md">
                             <x-icon type="info-circle" class="fa-2x" />
                           </span>
-                            <span class="hidden-xs hidden-sm">{{ trans('admin/users/general.info') }}</span>
+                            <span class="hidden-xs hidden-sm">
+                                {{ trans('admin/users/general.info') }}
+                            </span>
                         </a>
                     </li>
 
@@ -64,9 +66,11 @@
                           <span class="hidden-lg hidden-md">
                            <x-icon type="licenses" class="fa-2x" />
                           </span>
-                            <span class="hidden-xs hidden-sm">{{ trans('general.licenses') }}
-                                {!! ($asset->licenses->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->licenses->count()).'</span>' : '' !!}
-                          </span>
+                            <span class="hidden-xs hidden-sm">
+                                {{ trans('general.licenses') }}
+                            </span>
+                            {!! ($asset->licenses->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->licenses->count()).'</span>' : '' !!}
+
                         </a>
                     </li>
 
@@ -75,9 +79,11 @@
                           <span class="hidden-lg hidden-md">
                             <x-icon type="components" class="fa-2x" />
                           </span>
-                            <span class="hidden-xs hidden-sm">{{ trans('general.components') }}
-                                {!! ($asset->components->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->components->count()).'</span>' : '' !!}
-                          </span>
+                            <span class="hidden-xs hidden-sm">
+                                {{ trans('general.components') }}
+                            </span>
+                            {!! ($asset->components->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->components->count()).'</span>' : '' !!}
+
                         </a>
                     </li>
 
@@ -88,24 +94,22 @@
                           </span>
                             <span class="hidden-xs hidden-sm">
                                 {{ trans('general.assets') }}
-                                {!! ($asset->assignedAssets()->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->assignedAssets()->count()).'</span>' : '' !!}
+                            </span>
+                            {!! ($asset->assignedAssets()->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->assignedAssets()->count()).'</span>' : '' !!}
 
-                          </span>
                         </a>
                     </li>
 
                     @if ($asset->assignedAccessories->count() > 0)
                         <li>
                             <a href="#accessories_assigned" data-toggle="tab" data-tooltip="true">
-
                                 <span class="hidden-lg hidden-md">
                                     <i class="fas fa-keyboard fa-2x"></i>
                                 </span>
                                 <span class="hidden-xs hidden-sm">
                                     {{ trans('general.accessories_assigned') }}
-                                    {!! ($asset->assignedAccessories()->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->assignedAccessories()->count()).'</span>' : '' !!}
-
                                 </span>
+                                {!! ($asset->assignedAccessories()->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->assignedAccessories()->count()).'</span>' : '' !!}
                             </a>
                         </li>
                     @endif
@@ -114,15 +118,13 @@
                     @if ($asset->audits->count() > 0)
                     <li>
                         <a href="#audits" data-toggle="tab" data-tooltip="true">
-
                             <span class="hidden-lg hidden-md">
                                 <i class="fas fa-clipboard-check fa-2x"></i>
                             </span>
                             <span class="hidden-xs hidden-sm">
                                 {{ trans('general.audits') }}
-                                {!! ($asset->audits()->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->audits()->count()).'</span>' : '' !!}
-
                             </span>
+                            {!! ($asset->audits()->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->audits()->count()).'</span>' : '' !!}
                         </a>
                     </li>
                     @endif
@@ -142,9 +144,10 @@
                           <span class="hidden-lg hidden-md">
                               <x-icon type="maintenances" class="fa-2x" />
                           </span>
-                            <span class="hidden-xs hidden-sm">{{ trans('general.maintenances') }}
-                                {!! ($asset->maintenances()->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->maintenances()->count()).'</span>' : '' !!}
-                          </span>
+                            <span class="hidden-xs hidden-sm">
+                                {{ trans('general.maintenances') }}
+                            </span>
+                            {!! ($asset->maintenances()->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->maintenances()->count()).'</span>' : '' !!}
                         </a>
                     </li>
 
@@ -153,9 +156,10 @@
                           <span class="hidden-lg hidden-md">
                             <x-icon type="files" class="fa-2x" />
                           </span>
-                            <span class="hidden-xs hidden-sm">{{ trans('general.files') }}
-                                {!! ($asset->uploads->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->uploads->count()).'</span>' : '' !!}
-                          </span>
+                            <span class="hidden-xs hidden-sm">
+                            {{ trans('general.files') }}
+                            </span>
+                            {!! ($asset->uploads->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->uploads->count()).'</span>' : '' !!}
                         </a>
                     </li>
 
@@ -167,8 +171,8 @@
                           </span>
                             <span class="hidden-xs hidden-sm">
                             {{ trans('general.additional_files') }}
-                                {!! ($asset->model) && ($asset->model->uploads->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->model->uploads->count()).'</span>' : '' !!}
-                          </span>
+                            </span>
+                            {!! ($asset->model) && ($asset->model->uploads->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->model->uploads->count()).'</span>' : '' !!}
                         </a>
                     </li>
                     @endcan


### PR DESCRIPTION
This fixes #17910, adding counts to the mobile view for assets.

<img width="2110" height="1112" alt="Screenshot 2025-10-07 at 10 40 20 AM" src="https://github.com/user-attachments/assets/1c2b9dd4-8809-4f1f-9864-d7e139c72e8a" />
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Plus - 2025-10-07 at 10 39 09" src="https://github.com/user-attachments/assets/5f25b01b-a428-430f-879d-87225b662c4f" />
