### PR TITLE
Fixed [FD-50921] - base64-encoded image files for asset creation was broken

### DIFF
--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -26,6 +26,7 @@ class StoreAssetRequest extends ImageUploadRequest
 
     public function prepareForValidation(): void
     {
+        parent::prepareForValidation(); // call ImageUploadRequest thing
         // Guard against users passing in an array for company_id instead of an integer.
         // If the company_id is not an integer then we simply use what was
         // provided to be caught by model level validation later.

--- a/app/Http/Traits/ConvertsBase64ToFiles.php
+++ b/app/Http/Traits/ConvertsBase64ToFiles.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Traits;
 
+use Illuminate\Validation\ValidationException;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -38,20 +39,13 @@ trait ConvertsBase64ToFiles
                 if (!$base64Contents) {
                     return;
                 }
-                
-                // autogenerate filenames
-                if ($filename == 'auto'){
-                    $header = explode(';', $base64Contents, 2)[0];
-                    // Grab the image type from the header while we're at it.
-                    $filename = $key . '.' . substr($header, strpos($header, '/')+1);
-                }
 
                 // Generate a temporary path to store the Base64 contents
                 $tempFilePath = tempnam(sys_get_temp_dir(), $filename);
 
-                // Store the contents using a stream, or by decoding manually
+                // Store the contents using a stream, or throw an Error (which doesn't do anything?)
                 if (Str::startsWith($base64Contents, 'data:') && count(explode(',', $base64Contents)) > 1) {
-                    $source = fopen($base64Contents, 'r');
+                    $source = fopen($base64Contents, 'r'); // PHP has special processing for "data:" URL's
                     $destination = fopen($tempFilePath, 'w');
 
                     stream_copy_to_stream($source, $destination);
@@ -59,7 +53,8 @@ trait ConvertsBase64ToFiles
                     fclose($source);
                     fclose($destination);
                 } else {
-                    file_put_contents($tempFilePath, base64_decode($base64Contents, true));
+                    // TODO - to get a better error message here, can we maybe do something with modifying the errorBag?
+                    throw new ValidationException("Need Base64 URL starting with 'data:'"); // This doesn't actually throw?
                 }
 
                 $uploadedFile = new UploadedFile($tempFilePath, $filename, null, null, true);


### PR DESCRIPTION
The bulk of this fix is just the call to `parent::prepareForValidation()` in the `StoreAssetRequest.php` file.

While I was troubleshooting this I decided to make it so that any base64-encoded data *must* be presented as a `data:` -style URL. Unfortunately, my exception-throwing code doesn't seem to work, but the request still fails correctly if the data is not encoded correctly (i.e. as a data: URL with the base64 option).

While I was in there - and to prevent us from breaking this again in the future - I added a basic test for the functionality.