### PR TITLE
Fixed exception when rolling back migrations

### DIFF
--- a/database/migrations/2025_06_04_101736_add_deleted_at_index_to_action_logs.php
+++ b/database/migrations/2025_06_04_101736_add_deleted_at_index_to_action_logs.php
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('action_logs', function (Blueprint $table) {
-            $table->dropIndex('deleted_at');
+            $table->dropIndex(['deleted_at']);
         });
     }
 };


### PR DESCRIPTION
In this, the smallest of PRs, I added `[` and `]` to allow rolling back migrations. We rarely rollback migrations but this is the only thing preventing it so why not include it.

---

Previously, this `down` method would throw an exception, `Can't DROP 'deleted_at'; check that column/key exists`, which is accurate because the key is actually `action_logs_deleted_at_index`. According to the [docs](https://laravel.com/docs/11.x/migrations#dropping-indexes), passing in an array to `dropIndex` will calculate the full index name.

