### PR TITLE
Fixed #18002 - use correct path for audit images to determine validity

### DIFF
--- a/app/Models/Actionlog.php
+++ b/app/Models/Actionlog.php
@@ -493,6 +493,10 @@ class Actionlog extends SnipeModel
             return 'private_uploads/eula-pdfs/'.$this->filename;
         }
 
+        if ($this->action_type == 'audit')  {
+            return 'private_uploads/audits/'.$this->filename;
+        }
+
         switch ($this->item_type) {
         case Accessory::class:
             return 'private_uploads/accessories/'.$this->filename;

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1391,7 +1391,7 @@
                                         <th data-visible="true" data-field="icon" style="width: 40px;" class="hidden-xs" data-formatter="iconFormatter">{{ trans('admin/hardware/table.icon') }}</th>
                                         <th data-visible="true" data-field="created_at" data-sortable="true" data-formatter="dateDisplayFormatter">{{ trans('general.date') }}</th>
                                         <th data-visible="true" data-field="admin" data-formatter="usersLinkObjFormatter">{{ trans('general.created_by') }}</th>
-                                        <th class="col-sm-2" data-field="file" data-sortable="true" data-visible="false" data-formatter="fileUploadNameFormatter">{{ trans('general.file_name') }}</th>
+                                        <th class="col-sm-2" data-field="file" data-sortable="true" data-visible="false" data-formatter="fileNameFormatter">{{ trans('general.file_name') }}</th>
                                         <th data-field="note">{{ trans('general.notes') }}</th>
                                         <th data-visible="false" data-field="file" data-visible="false"  data-formatter="fileDownloadButtonsFormatter">{{ trans('general.download') }}</th>
                                         <th data-field="log_meta" data-visible="true" data-formatter="changeLogFormatter">{{ trans('admin/hardware/table.changed')}}</th>


### PR DESCRIPTION
We were previously not making an exception in the file handlers to account for audits, so viewing audit images would erroneously report them as not existing on the server even though they do. This fixes #18002.