### PR TITLE
Allow Custom URL Schemas in OAuth Client Redirect

### DIFF
--- a/app/Livewire/OauthClients.php
+++ b/app/Livewire/OauthClients.php
@@ -31,7 +31,7 @@ class OauthClients extends Component
     {
         $this->validate([
             'name' => 'required|string|max:255',
-            'redirect' => 'required|url|max:255',
+            'redirect' => 'required|string|max:255',
         ]);
 
         app(ClientRepository::class)->create(


### PR DESCRIPTION
Laravel's standard `url` validation rule only deals with the `http,https` schemas. You can define more schemas in it, for instance `url:http,https,com.grokability.snipeitmobile` but then we're only allowing our own custom schema, so I went ahead and just changed it to `string` - I can't think of a way this could bite us, but if you can definitely let me know and I can look into other options. 