### PR TITLE
Fix backup disk driver configuration for S3 support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,7 +90,16 @@ IMAGE_LIB=gd
 
 # --------------------------------------------
 # OPTIONAL: BACKUP SETTINGS
-# --------------------------------------------
+# Backup filesystem configuration
+# - BACKUP_FILESYSTEM_DRIVER: Driver to use (local, s3, etc.)
+#   Default: local (backward compatible)
+#   Set to s3 to use S3 for backups (requires PRIVATE_AWS_* credentials)
+# - BACKUP_FILESYSTEM_ROOT: Root path/prefix
+#   For local driver: leave commented for default to storage_path("app")
+#   For S3 driver: empty string = bucket root, or specify prefix like "backups/"
+#--------------------------------------------
+BACKUP_FILESYSTEM_DRIVER=local
+#BACKUP_FILESYSTEM_ROOT=
 MAIL_BACKUP_NOTIFICATION_DRIVER=null
 MAIL_BACKUP_NOTIFICATION_ADDRESS=null
 BACKUP_ENV=true

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -97,8 +97,13 @@ $config = [
         ],
 
         'backup' => [
-            'driver' => env('PRIVATE_FILESYSTEM_DISK', 'local'),
-            'root' => storage_path('app'),
+            'driver' => env('BACKUP_FILESYSTEM_DRIVER', 'local'),
+            'key' => env('PRIVATE_AWS_ACCESS_KEY_ID'),
+            'secret' => env('PRIVATE_AWS_SECRET_ACCESS_KEY'),
+            'region' => env('PRIVATE_AWS_DEFAULT_REGION'),
+            'bucket' => env('PRIVATE_AWS_BUCKET'),
+            'root'   => env('BACKUP_FILESYSTEM_ROOT', storage_path('app')),
+            'visibility' => 'private',
         ],
 
     ],


### PR DESCRIPTION
Fixes #14057 


## Summary
- Fix the `backup` disk in `config/filesystems.php` to use a dedicated `BACKUP_FILESYSTEM_DRIVER` env var instead of `PRIVATE_FILESYSTEM_DISK`
- Add AWS credential fields to the backup disk config so S3 backups work
- Use `BACKUP_FILESYSTEM_ROOT` with safe default (`storage_path('app')`) for backward compatibility
- Document `BACKUP_FILESYSTEM_DRIVER` and `BACKUP_FILESYSTEM_ROOT` in `.env.example`

## Problem
The current `backup` disk config uses `PRIVATE_FILESYSTEM_DISK` as its driver value:

'backup' => [
    'driver' => env('PRIVATE_FILESYSTEM_DISK', 'local'),
    'root' => storage_path('app'),
],

This can lead to "s3_private" as the driver which is not valid (should be "s3")