### PR TITLE
Fix #18595 checkout acceptance url bug

### DIFF
--- a/app/Mail/CheckoutAssetMail.php
+++ b/app/Mail/CheckoutAssetMail.php
@@ -132,6 +132,9 @@ class CheckoutAssetMail extends BaseMailable
 
     private function introductionLine(): string
     {
+        if (is_null($this->acceptance)) {
+            return trans_choice('mail.new_item_checked', 1);
+        }
         if ($this->firstTimeSending && $this->target instanceof Location) {
             return trans_choice('mail.new_item_checked_location', 1, ['location' => $this->target->name]);
         }
@@ -140,7 +143,7 @@ class CheckoutAssetMail extends BaseMailable
             return trans_choice('mail.new_item_checked_with_acceptance', 1);
         }
 
-        if ($this->firstTimeSending && ! $this->requiresAcceptance()) {
+        if ($this->firstTimeSending && !$this->requiresAcceptance()) {
             return trans_choice('mail.new_item_checked', 1);
         }
 
@@ -149,7 +152,7 @@ class CheckoutAssetMail extends BaseMailable
         }
 
         // we shouldn't get here but let's send a default message just in case
-        return trans('new_item_checked');
+        return trans('mail.new_item_checked');
     }
 
     private function requiresAcceptance(): int|bool

--- a/resources/views/mail/markdown/checkout-asset.blade.php
+++ b/resources/views/mail/markdown/checkout-asset.blade.php
@@ -52,7 +52,7 @@
 | **{{ trans('mail.additional_notes') }}** | {{ $note }} |
 @endif
 @endcomponent
-
+@if($accept_url)
 @if (($req_accept == 1) && ($eula!=''))
 {{ trans('mail.read_the_terms_and_click') }}
 @elseif (($req_accept == 1) && ($eula==''))
@@ -70,7 +70,7 @@
 @if ($req_accept == 1)
 **[✔ {{ trans('mail.i_have_read') }}]({{ $accept_url }})**
 @endif
-
+@endif
 
 {{ trans('mail.best_regards') }}
 

--- a/resources/views/mail/markdown/checkout-asset.blade.php
+++ b/resources/views/mail/markdown/checkout-asset.blade.php
@@ -52,10 +52,10 @@
 | **{{ trans('mail.additional_notes') }}** | {{ $note }} |
 @endif
 @endcomponent
-@if($accept_url)
-@if (($req_accept == 1) && ($eula!=''))
+
+@if (($req_accept == 1) && ($eula!='') && $accept_url)
 {{ trans('mail.read_the_terms_and_click') }}
-@elseif (($req_accept == 1) && ($eula==''))
+@elseif (($req_accept == 1) && ($eula=='') && $accept_url)
 {{ trans('mail.click_on_the_link_asset') }}
 @elseif (($req_accept == 0) && ($eula!=''))
 {{ trans('mail.read_the_terms') }}
@@ -65,9 +65,9 @@
 @component('mail::panel')
 {!! $eula !!}
 @endcomponent
-@endif
 
-@if ($req_accept == 1)
+
+@if ($req_accept == 1 && $accept_url)
 **[✔ {{ trans('mail.i_have_read') }}]({{ $accept_url }})**
 @endif
 @endif


### PR DESCRIPTION
When an item is checked out to an asset thats assigned to a user, a link to a non-existent acceptance request was being created.
Now when an item->asset->user it will send a message to the assigned user but it will be without that link.
Before:
<img width="810" height="1400" alt="image" src="https://github.com/user-attachments/assets/9bd64cad-7a36-44d7-a4ee-6edb33991de1" />
After:
<img width="810" height="1266" alt="image" src="https://github.com/user-attachments/assets/992350ad-7330-4979-b8d3-ecd180fc9bce" />

Fixes: #18595 