### PR TITLE
Fixed potential exception in bulk asset checkout

### DIFF
--- a/app/Listeners/CheckoutablesCheckedOutInBulkListener.php
+++ b/app/Listeners/CheckoutablesCheckedOutInBulkListener.php
@@ -142,7 +142,7 @@ class CheckoutablesCheckedOutInBulkListener
         if ($target instanceof Asset) {
             $target->load('assignedTo');
 
-            return $target->assignedto;
+            return $target->assigned;
         }
 
         if ($target instanceof Location) {

--- a/app/Listeners/CheckoutablesCheckedOutInBulkListener.php
+++ b/app/Listeners/CheckoutablesCheckedOutInBulkListener.php
@@ -135,14 +135,18 @@ class CheckoutablesCheckedOutInBulkListener
         return false;
     }
 
-    private function getNotifiableUser(CheckoutablesCheckedOutInBulk $event): ?Model
+    private function getNotifiableUser(CheckoutablesCheckedOutInBulk $event): ?User
     {
         $target = $event->target;
 
         if ($target instanceof Asset) {
             $target->load('assignedTo');
 
-            return $target->assigned;
+            if ($target->assigned instanceof User) {
+                return $target->assigned;
+            }
+
+            return null;
         }
 
         if ($target instanceof Location) {

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -314,7 +314,7 @@ class AssetFactory extends Factory
     {
         return $this->state(function () {
             return [
-                'model_id' => 1,
+                'model_id' => AssetModel::factory(),
                 'assigned_to' => Asset::factory(),
                 'assigned_type' => Asset::class,
             ];

--- a/tests/Feature/Notifications/Email/BulkCheckoutEmailTest.php
+++ b/tests/Feature/Notifications/Email/BulkCheckoutEmailTest.php
@@ -214,6 +214,20 @@ class BulkCheckoutEmailTest extends TestCase
         Mail::assertNotSent(BulkAssetCheckoutMail::class);
     }
 
+    public function test_handles_assignee_asset_already_being_checked_out_to_asset()
+    {
+        $this->assignee = Asset::factory()->assignedToAsset()->create();
+
+        $this->sendRequest();
+    }
+
+    public function test_handles_assignee_asset_already_being_checked_out_to_location()
+    {
+        $this->assignee = Asset::factory()->assignedToLocation()->create();
+
+        $this->sendRequest();
+    }
+
     private function sendRequest()
     {
         $assigned = match (get_class($this->assignee)) {


### PR DESCRIPTION
This PR fixes an issue that can occur when performing a bulk checkout of assets.

An exception was being thrown when checking out assets _to_ an **asset** that is checked out to another asset or a location.

In this PR, I added a check within the `getNotifiableUser` method to ensure a user object or null is returned.

---

[RB-20840]