### PR TITLE
Log authed user ID header

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -11,6 +11,7 @@ use App\Http\Middleware\CheckLocale;
 use App\Http\Middleware\CheckPermissions;
 use App\Http\Middleware\CheckUserIsActivated;
 use App\Http\Middleware\EncryptCookies;
+use App\Http\Middleware\LogAuthedUserHeader;
 use App\Http\Middleware\NoSessionStore;
 use App\Http\Middleware\PreventBackHistory;
 use App\Http\Middleware\RedirectIfAuthenticated;
@@ -82,6 +83,7 @@ class Kernel extends HttpKernel
         'api' => [
             'auth:api',
             CheckLocale::class,
+            LogAuthedUserHeader::class,
             SubstituteBindings::class,
         ],
 

--- a/app/Http/Middleware/LogAuthedUserHeader.php
+++ b/app/Http/Middleware/LogAuthedUserHeader.php
@@ -20,6 +20,8 @@ class LogAuthedUserHeader
 
         if ((config('app.authorized_user_header') === true) && ($request->bearerToken() != '')) {
             $response->headers->set('X-API-User-ID', auth()?->id());
+            $response->headers->set('X-API-Token-Name', $request->user()?->token()?->name);
+            $response->headers->set('X-API-Token-ID', $request->user()?->token()?->id);
         }
 
         return $response;

--- a/app/Http/Middleware/LogAuthedUserHeader.php
+++ b/app/Http/Middleware/LogAuthedUserHeader.php
@@ -20,7 +20,7 @@ class LogAuthedUserHeader
 
         if ((config('app.authorized_user_header') === true) && ($request->bearerToken() != '')) {
             $response->headers->set('X-Authorized-User-ID', auth()?->id());
-        } 
+        }
 
         return $response;
     }

--- a/app/Http/Middleware/LogAuthedUserHeader.php
+++ b/app/Http/Middleware/LogAuthedUserHeader.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class LogAuthedUserHeader
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Request  $request
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+
+        $response = $next($request);
+
+        if (config('app.authorized_user_header') === true) {
+            $response->headers->set('X-Authorized-User-ID', auth()?->id());
+        }
+        
+        return $response;
+    }
+}

--- a/app/Http/Middleware/LogAuthedUserHeader.php
+++ b/app/Http/Middleware/LogAuthedUserHeader.php
@@ -21,7 +21,7 @@ class LogAuthedUserHeader
         if (config('app.authorized_user_header') === true) {
             $response->headers->set('X-Authorized-User-ID', auth()?->id());
         }
-        
+
         return $response;
     }
 }

--- a/app/Http/Middleware/LogAuthedUserHeader.php
+++ b/app/Http/Middleware/LogAuthedUserHeader.php
@@ -19,7 +19,7 @@ class LogAuthedUserHeader
         $response = $next($request);
 
         if ((config('app.authorized_user_header') === true) && ($request->bearerToken() != '')) {
-            $response->headers->set('X-Authorized-User-ID', auth()?->id());
+            $response->headers->set('X-API-User-ID', auth()?->id());
         }
 
         return $response;

--- a/app/Http/Middleware/LogAuthedUserHeader.php
+++ b/app/Http/Middleware/LogAuthedUserHeader.php
@@ -18,9 +18,9 @@ class LogAuthedUserHeader
 
         $response = $next($request);
 
-        if (config('app.authorized_user_header') === true) {
+        if ((config('app.authorized_user_header') === true) && ($request->bearerToken() != '')) {
             $response->headers->set('X-Authorized-User-ID', auth()?->id());
-        }
+        } 
 
         return $response;
     }

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -73,7 +73,6 @@ class SecurityHeaders
             $response->headers->set('X-Authorized-User-ID', auth()?->id());
         }
 
-
         // This defaults to false to maintain backwards compatibility for
         // people who are not running Snipe-IT over TLS (shame, shame, shame!)
         // Seriously though, please run Snipe-IT over TLS. Let's Encrypt is free.

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -69,6 +69,11 @@ class SecurityHeaders
             $response->headers->set('X-Frame-Options', 'DENY');
         }
 
+        if (config('app.authorized_user_header') === true) {
+            $response->headers->set('X-Authorized-User-ID', auth()?->id());
+        }
+
+
         // This defaults to false to maintain backwards compatibility for
         // people who are not running Snipe-IT over TLS (shame, shame, shame!)
         // Seriously though, please run Snipe-IT over TLS. Let's Encrypt is free.

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -68,7 +68,7 @@ class SecurityHeaders
         if (config('app.allow_iframing') == false) {
             $response->headers->set('X-Frame-Options', 'DENY');
         }
-        
+
         // This defaults to false to maintain backwards compatibility for
         // people who are not running Snipe-IT over TLS (shame, shame, shame!)
         // Seriously though, please run Snipe-IT over TLS. Let's Encrypt is free.

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -68,11 +68,7 @@ class SecurityHeaders
         if (config('app.allow_iframing') == false) {
             $response->headers->set('X-Frame-Options', 'DENY');
         }
-
-        if (config('app.authorized_user_header') === true) {
-            $response->headers->set('X-Authorized-User-ID', auth()?->id());
-        }
-
+        
         // This defaults to false to maintain backwards compatibility for
         // people who are not running Snipe-IT over TLS (shame, shame, shame!)
         // Seriously though, please run Snipe-IT over TLS. Let's Encrypt is free.

--- a/config/app.php
+++ b/config/app.php
@@ -233,7 +233,6 @@ return [
 
     'allow_iframing' => env('ALLOW_IFRAMING', false),
 
-
     /*
    |--------------------------------------------------------------------------
    | LOG AUTHED USER HEADER

--- a/config/app.php
+++ b/config/app.php
@@ -233,6 +233,22 @@ return [
 
     'allow_iframing' => env('ALLOW_IFRAMING', false),
 
+
+    /*
+   |--------------------------------------------------------------------------
+   | LOG AUTHED USER HEADER
+   |--------------------------------------------------------------------------
+   |
+   | This is an additional header that can be enabled to include the authenticated user's ID
+   | in the response headers of each request. This can be useful for debugging and auditing purposes,
+   | but it may also expose sensitive information if not used carefully.
+   | It should normally be set to false unless you have a specific need for it and
+   | understand the security implications.
+   |
+   */
+
+    'authorized_user_header' => env('INCLUDE_AUTHED_USER_HEADER', false),
+
     /*
     |--------------------------------------------------------------------------
     | ENABLE HTTP Strict Transport Security (HSTS)


### PR DESCRIPTION
This optionally adds a header to the API requests that includes the ID of the authenticated user making the request. This is set to false by default, but can be helpful if there's an integration that might be running wild and nobody can figure out who is responsible. 

IF this is enabled, it will include an additional header in the response that includes the authenticated API user's ID number. 

<img width="854" height="101" alt="Screenshot 2026-04-09 at 7 35 43 PM" src="https://github.com/user-attachments/assets/e72e034b-8272-45aa-ab2f-1403b4cd196b" />


This only fires on API requests, and ONLY if the request has a bearer token, so regular web UI API requests won't have those headers.

Context: We have a customer whose instance is very, very slow and we're seeing a ton of requests come through the API, but we didn't previously have a way to figure out who was doing them. This gets us a little closer. 