### PR TITLE
[FD-54740] Fixed managing user avatar via API

### DIFF
--- a/app/Http/Requests/ImageUploadRequest.php
+++ b/app/Http/Requests/ImageUploadRequest.php
@@ -57,6 +57,7 @@ class ImageUploadRequest extends Request
          * had it once to allow encoded image uploads.
          */
         return [
+            'avatar' => 'auto',
             'image' => 'auto',
             'image_source' => 'auto',
         ];

--- a/tests/Feature/Users/Api/CreateUserTest.php
+++ b/tests/Feature/Users/Api/CreateUserTest.php
@@ -7,6 +7,7 @@ use App\Models\Department;
 use App\Models\User;
 use App\Notifications\WelcomeNotification;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
@@ -64,7 +65,7 @@ class CreateUserTest extends TestCase
     {
         Notification::fake();
 
-        $this->actingAsForApi(User::factory()->createUsers()->create())
+        $response = $this->actingAsForApi(User::factory()->createUsers()->create())
             ->postJson(route('api.users.store'), [
                 'first_name' => 'Test First Name',
                 'last_name' => 'Test Last Name',
@@ -74,6 +75,7 @@ class CreateUserTest extends TestCase
                 'activated' => '1',
                 'email' => 'foo@example.org',
                 'notes' => 'Test Note',
+                'avatar' => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZAAAAEsAQMAAADXeXeBAAAABlBMVEX+AAD///+KQee0AAAACXBIWXMAAAsSAAALEgHS3X78AAAAB3RJTUUH5QQbCAoNcoiTQAAAACZJREFUaN7twTEBAAAAwqD1T20JT6AAAAAAAAAAAAAAAAAAAICnATvEAAEnf54JAAAAAElFTkSuQmCC',
             ])
             ->assertStatusMessageIs('success')
             ->assertOk();
@@ -85,10 +87,17 @@ class CreateUserTest extends TestCase
             'activated' => '1',
             'email' => 'foo@example.org',
             'notes' => 'Test Note',
-
         ]);
 
         Notification::assertNothingSent();
+
+        $user = User::findOrFail($response['payload']['id']);
+
+        $this->assertEquals(
+            // assert against resized hash
+            'db2e13ba04318c99058ca429d67777322f48566b',
+            sha1(Storage::disk('public')->get(app('users_upload_path').$user->avatar))
+        );
     }
 
     public function test_can_create_and_notify_user()

--- a/tests/Feature/Users/Api/CreateUserTest.php
+++ b/tests/Feature/Users/Api/CreateUserTest.php
@@ -93,8 +93,8 @@ class CreateUserTest extends TestCase
 
         $user = User::findOrFail($response['payload']['id']);
 
+        // assert against resized hash
         $this->assertEquals(
-            // assert against resized hash
             'db2e13ba04318c99058ca429d67777322f48566b',
             sha1(Storage::disk('public')->get(app('users_upload_path').$user->avatar))
         );

--- a/tests/Feature/Users/Api/UpdateUserTest.php
+++ b/tests/Feature/Users/Api/UpdateUserTest.php
@@ -9,6 +9,7 @@ use App\Models\Group;
 use App\Models\Location;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class UpdateUserTest extends TestCase
@@ -51,6 +52,7 @@ class UpdateUserTest extends TestCase
                 'vip' => true,
                 'start_date' => '2021-08-01',
                 'end_date' => '2025-12-31',
+                'avatar' => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZAAAAEsAQMAAADXeXeBAAAABlBMVEX+AAD///+KQee0AAAACXBIWXMAAAsSAAALEgHS3X78AAAAB3RJTUUH5QQbCAoNcoiTQAAAACZJREFUaN7twTEBAAAAwqD1T20JT6AAAAAAAAAAAAAAAAAAAICnATvEAAEnf54JAAAAAElFTkSuQmCC',
             ])
             ->assertOk()
             ->assertStatus(200)
@@ -79,6 +81,12 @@ class UpdateUserTest extends TestCase
         $this->assertEquals(1, $user->vip, 'VIP was not updated');
         $this->assertEquals('2021-08-01', $user->start_date, 'Start date was not updated');
         $this->assertEquals('2025-12-31', $user->end_date, 'End date was not updated');
+
+        $this->assertEquals(
+            // assert against resized hash
+            'db2e13ba04318c99058ca429d67777322f48566b',
+            sha1(Storage::disk('public')->get(app('users_upload_path').$user->avatar))
+        );
 
         // `groups` can be an id or array or ids
         $this->patch(route('api.users.update', $user), ['groups' => [$groupA->id, $groupB->id]]);
@@ -127,6 +135,7 @@ class UpdateUserTest extends TestCase
                 'vip' => true,
                 'start_date' => '2021-08-01',
                 'end_date' => '2025-12-31',
+                'avatar' => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZAAAAEsAQMAAADXeXeBAAAABlBMVEX+AAD///+KQee0AAAACXBIWXMAAAsSAAALEgHS3X78AAAAB3RJTUUH5QQbCAoNcoiTQAAAACZJREFUaN7twTEBAAAAwqD1T20JT6AAAAAAAAAAAAAAAAAAAICnATvEAAEnf54JAAAAAElFTkSuQmCC',
             ])
             ->assertOk()
             ->assertStatus(200)
@@ -155,6 +164,12 @@ class UpdateUserTest extends TestCase
         $this->assertEquals(1, $user->vip, 'VIP was not updated');
         $this->assertEquals('2021-08-01', $user->start_date, 'Start date was not updated');
         $this->assertEquals('2025-12-31', $user->end_date, 'End date was not updated');
+
+        $this->assertEquals(
+            // assert against resized hash
+            'db2e13ba04318c99058ca429d67777322f48566b',
+            sha1(Storage::disk('public')->get(app('users_upload_path').$user->avatar))
+        );
 
         // `groups` can be an id or array or ids
         $this->patch(route('api.users.update', $user), ['groups' => [$groupA->id, $groupB->id]]);

--- a/tests/Feature/Users/Api/UpdateUserTest.php
+++ b/tests/Feature/Users/Api/UpdateUserTest.php
@@ -82,8 +82,8 @@ class UpdateUserTest extends TestCase
         $this->assertEquals('2021-08-01', $user->start_date, 'Start date was not updated');
         $this->assertEquals('2025-12-31', $user->end_date, 'End date was not updated');
 
+        // assert against resized hash
         $this->assertEquals(
-            // assert against resized hash
             'db2e13ba04318c99058ca429d67777322f48566b',
             sha1(Storage::disk('public')->get(app('users_upload_path').$user->avatar))
         );
@@ -165,8 +165,8 @@ class UpdateUserTest extends TestCase
         $this->assertEquals('2021-08-01', $user->start_date, 'Start date was not updated');
         $this->assertEquals('2025-12-31', $user->end_date, 'End date was not updated');
 
+        // assert against resized hash
         $this->assertEquals(
-            // assert against resized hash
             'db2e13ba04318c99058ca429d67777322f48566b',
             sha1(Storage::disk('public')->get(app('users_upload_path').$user->avatar))
         );


### PR DESCRIPTION
This PR allows a base64 encoded image to be uploaded for a user's `avatar` when creating or updating via the api. This was previously silently ignoring the avatar field.

---

[FD-54740]

---

@snipe let me know if I should target develop instead.
