### PR TITLE
Fixed #7418 - Ability to toggle requestable on checkin/checkout

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -961,6 +961,11 @@ class AssetsController extends Controller
             $asset->status_id = $request->input('status_id');
         }
 
+        // Preserve existing requestable state unless API caller explicitly includes the field.
+        if ($request->has('requestable')) {
+            $asset->requestable = $request->boolean('requestable');
+        }
+
         if (! isset($target)) {
             return response()->json(Helper::formatStandardApiResponse('error', $error_payload, 'Checkout target for asset '.e($asset->asset_tag).' is invalid - '.$error_payload['target_type'].' does not exist.'));
         }

--- a/app/Http/Controllers/Assets/AssetCheckinController.php
+++ b/app/Http/Controllers/Assets/AssetCheckinController.php
@@ -10,6 +10,7 @@ use App\Http\Traits\MigratesLegacyAssetLocations;
 use App\Models\Asset;
 use App\Models\CheckoutAcceptance;
 use App\Models\LicenseSeat;
+use App\Models\Statuslabel;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
@@ -56,9 +57,16 @@ class AssetCheckinController extends Controller
             default => trans('admin/hardware/form.redirect_to_type', ['type' => trans('general.user')]),
         };
 
+        $deployableStatusIds = array_map('intval', array_keys(Helper::deployableStatusLabelList()));
+        $selectedStatusId = old('status_id');
+        $showRequestableToggle = is_numeric($selectedStatusId)
+            && in_array((int) $selectedStatusId, $deployableStatusIds, true);
+
         return view('hardware/checkin', compact('asset', 'target_option'))
             ->with('item', $asset)
             ->with('statusLabel_list', Helper::statusLabelList())
+            ->with('deployable_status_ids', $deployableStatusIds)
+            ->with('show_requestable_toggle', $showRequestableToggle)
             ->with('backto', $backto)
             ->with('table_name', 'Assets');
     }
@@ -105,6 +113,19 @@ class AssetCheckinController extends Controller
 
         if ($request->filled('status_id')) {
             $asset->status_id = e($request->input('status_id'));
+        }
+
+        $selectedStatusId = $request->filled('status_id')
+            ? (int) $request->input('status_id')
+            : (int) $asset->status_id;
+
+        $isDeployableStatus = Statuslabel::query()
+            ->whereKey($selectedStatusId)
+            ->where('deployable', 1)
+            ->exists();
+
+        if ($request->boolean('set_requestable') && $isDeployableStatus) {
+            $asset->requestable = true;
         }
 
         // Add any custom fields that should be included in the checkout

--- a/app/Http/Controllers/Assets/AssetCheckoutController.php
+++ b/app/Http/Controllers/Assets/AssetCheckoutController.php
@@ -103,6 +103,10 @@ class AssetCheckoutController extends Controller
                 $asset->status_id = $request->input('status_id');
             }
 
+            if ($request->boolean('set_not_requestable')) {
+                $asset->requestable = false;
+            }
+
             if (! empty($asset->licenseseats->all())) {
                 if (request('checkout_to_type') == 'user') {
                     foreach ($asset->licenseseats as $seat) {

--- a/app/Http/Controllers/Assets/BulkAssetsController.php
+++ b/app/Http/Controllers/Assets/BulkAssetsController.php
@@ -716,6 +716,10 @@ class BulkAssetsController extends Controller
                         $asset->status_id = $request->input('status_id');
                     }
 
+                    if ($request->boolean('set_not_requestable')) {
+                        $asset->requestable = false;
+                    }
+
                     $checkout_success = $asset->checkOut($target, $admin, $checkout_at, $expected_checkin, e($request->input('note')), $asset->name, null);
 
                     // TODO - I think this logic is duplicated in the checkOut method?

--- a/app/Http/Requests/AssetCheckinRequest.php
+++ b/app/Http/Requests/AssetCheckinRequest.php
@@ -25,7 +25,9 @@ class AssetCheckinRequest extends Request
     {
         $settings = Setting::getSettings();
 
-        $rules = [];
+        $rules = [
+            'set_requestable' => 'nullable|boolean',
+        ];
 
         if ($settings->require_checkinout_notes) {
             $rules['note'] = 'string|required';

--- a/app/Http/Requests/AssetCheckoutRequest.php
+++ b/app/Http/Requests/AssetCheckoutRequest.php
@@ -39,6 +39,8 @@ class AssetCheckoutRequest extends Request
                 'nullable',
                 'date',
             ],
+            'requestable' => 'nullable|boolean',
+            'set_not_requestable' => 'nullable|boolean',
         ];
 
         if ($settings->require_checkinout_notes) {

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -76,18 +76,23 @@
                 </div>
             </div>
 
-            <div class="form-group">
-                <div class="col-md-7 col-md-offset-3">
-                    <label class="form-control" for="set_not_requestable">
-                        <input
-                            type="checkbox"
-                            value="1"
-                            name="set_not_requestable"
-                            id="set_not_requestable"
-                            @checked((bool) old('set_not_requestable', true))
-                        >
-                        {{ trans('admin/hardware/general.not_requestable') }}
-                    </label>
+            <div class="form-group {{ $errors->has('set_not_requestable') ? 'error' : '' }}">
+                <label for="set_not_requestable" class="col-md-3 control-label">
+                    {{ trans('admin/hardware/form.requestable') }}
+                </label>
+                <div class="col-md-7">
+                    <x-input.select
+                        name="set_not_requestable"
+                        id="set_not_requestable"
+                        :options="[
+                            '' => trans('general.do_not_change'),
+                            '1' => trans('admin/hardware/general.not_requestable'),
+                        ]"
+                        :selected="old('set_not_requestable', '')"
+                        style="width: 100%;"
+                        aria-label="set_not_requestable"
+                    />
+                    {!! $errors->first('set_not_requestable', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                 </div>
             </div>
 

--- a/resources/views/hardware/bulk-checkout.blade.php
+++ b/resources/views/hardware/bulk-checkout.blade.php
@@ -76,6 +76,21 @@
                 </div>
             </div>
 
+            <div class="form-group">
+                <div class="col-md-7 col-md-offset-3">
+                    <label class="form-control" for="set_not_requestable">
+                        <input
+                            type="checkbox"
+                            value="1"
+                            name="set_not_requestable"
+                            id="set_not_requestable"
+                            @checked((bool) old('set_not_requestable', true))
+                        >
+                        {{ trans('admin/hardware/general.not_requestable') }}
+                    </label>
+                </div>
+            </div>
+
 
             <!-- Checkout selector -->
 

--- a/resources/views/hardware/checkin.blade.php
+++ b/resources/views/hardware/checkin.blade.php
@@ -109,10 +109,30 @@
                                                     name="status_id"
                                                     id="modal-statuslabel_types"
                                                     :options="$statusLabel_list"
+                                                    :selected="old('status_id')"
                                                     style="width: 100%"
                                                     aria-label="status_id"
                                                 />
                                                 {!! $errors->first('status_id', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                            </div>
+                                        </div>
+
+                                        <div
+                                            class="form-group"
+                                            id="set-requestable-wrapper"
+                                            @if (! $show_requestable_toggle) style="display: none;" @endif
+                                        >
+                                            <div class="col-md-9 col-md-offset-3">
+                                                <label class="form-control" for="set_requestable">
+                                                    <input
+                                                        type="checkbox"
+                                                        value="1"
+                                                        name="set_requestable"
+                                                        id="set_requestable"
+                                                        @checked((bool) old('set_requestable', false))
+                                                    />
+                                                    {{ trans('admin/hardware/general.requestable') }}
+                                                </label>
                                             </div>
                                         </div>
 
@@ -200,3 +220,48 @@
     </div>
 
 @stop
+
+@section('moar_scripts')
+    <script nonce="{{ csrf_token() }}">
+        const initializeRequestableToggle = function () {
+            const deployableStatusIds = @json($deployable_status_ids);
+            const statusSelect = document.getElementById('modal-statuslabel_types')
+                ?? document.querySelector('select[name="status_id"]');
+            const requestableWrapper = document.getElementById('set-requestable-wrapper');
+            const requestableCheckbox = document.getElementById('set_requestable');
+
+            if (!statusSelect || !requestableWrapper) {
+                return;
+            }
+
+            const toggleRequestable = function () {
+                const selectedStatusValue = statusSelect.value;
+                const selectedStatusId = Number.parseInt(selectedStatusValue, 10);
+                const isDeployable = selectedStatusValue !== ''
+                    && Number.isInteger(selectedStatusId)
+                    && deployableStatusIds.includes(selectedStatusId);
+
+                requestableWrapper.style.display = isDeployable ? '' : 'none';
+
+                if (!isDeployable && requestableCheckbox) {
+                    requestableCheckbox.checked = false;
+                }
+            };
+
+            statusSelect.addEventListener('change', toggleRequestable);
+
+            if (window.jQuery) {
+                window.jQuery(statusSelect).on('select2:select select2:clear', toggleRequestable);
+            }
+
+            toggleRequestable();
+        };
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initializeRequestableToggle);
+        } else {
+            initializeRequestableToggle();
+        }
+    </script>
+@stop
+

--- a/resources/views/hardware/checkout.blade.php
+++ b/resources/views/hardware/checkout.blade.php
@@ -101,6 +101,23 @@
                             </div>
                         </div>
 
+                        @if ($asset->requestable)
+                            <div class="form-group">
+                                <div class="col-md-7 col-md-offset-3">
+                                    <label class="form-control" for="set_not_requestable">
+                                        <input
+                                            type="checkbox"
+                                            value="1"
+                                            name="set_not_requestable"
+                                            id="set_not_requestable"
+                                            @checked((bool) old('set_not_requestable', true))
+                                        >
+                                        {{ trans('admin/hardware/general.not_requestable') }}
+                                    </label>
+                                </div>
+                            </div>
+                        @endif
+
                         @include ('partials.forms.checkout-selector', ['user_select' => 'true','asset_select' => 'true', 'location_select' => 'true'])
                         @include ('partials.forms.edit.user-select', ['translated_name' => trans('general.user'), 'fieldname' => 'assigned_user', 'style' => (session('checkout_to_type') ?: 'user') == 'user' ? '' : 'display: none;'])
                         <!-- We have to pass unselect here so that we don't default to the asset that's being checked out. We want that asset to be pre-selected everywhere else. -->

--- a/tests/Feature/Checkins/Ui/AssetCheckinTest.php
+++ b/tests/Feature/Checkins/Ui/AssetCheckinTest.php
@@ -47,6 +47,79 @@ class AssetCheckinTest extends TestCase
             ->assertOk();
     }
 
+    public function test_requestable_toggle_is_hidden_on_checkin_page_without_old_status_selection()
+    {
+        $deployableStatus = Statuslabel::factory()->readyToDeploy()->create();
+        $asset = Asset::factory()->assignedToUser()->create([
+            'status_id' => $deployableStatus->id,
+        ]);
+
+        $response = $this->actingAs(User::factory()->checkinAssets()->create())
+            ->get(route('hardware.checkin.create', $asset))
+            ->assertOk();
+
+        $content = $response->getContent();
+
+        $this->assertStringContainsString('id="set-requestable-wrapper"', $content);
+        $this->assertMatchesRegularExpression(
+            '/id="set-requestable-wrapper"(?:(?!>).)*style="display:\s*none;"/s',
+            $content
+        );
+    }
+
+    public function test_requestable_toggle_is_hidden_on_checkin_page_for_non_deployable_status()
+    {
+        $nonDeployableStatus = Statuslabel::factory()->create(['deployable' => 0]);
+        $asset = Asset::factory()->assignedToUser()->create([
+            'status_id' => $nonDeployableStatus->id,
+        ]);
+
+        $response = $this->actingAs(User::factory()->checkinAssets()->create())
+            ->get(route('hardware.checkin.create', $asset))
+            ->assertOk();
+
+        $content = $response->getContent();
+
+        $this->assertMatchesRegularExpression(
+            '/id="set-requestable-wrapper"(?:(?!>).)*style="display:\s*none;"/s',
+            $content
+        );
+    }
+
+    public function test_requestable_toggle_visibility_prefers_old_input_status_id_when_present()
+    {
+        $deployableStatus = Statuslabel::factory()->readyToDeploy()->create();
+        $nonDeployableStatus = Statuslabel::factory()->create(['deployable' => 0]);
+
+        $asset = Asset::factory()->assignedToUser()->create([
+            'status_id' => $nonDeployableStatus->id,
+        ]);
+
+        $responseWithDeployableOldInput = $this->actingAs(User::factory()->checkinAssets()->create())
+            ->withSession(['_old_input' => ['status_id' => (string) $deployableStatus->id]])
+            ->get(route('hardware.checkin.create', $asset))
+            ->assertOk();
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/id="set-requestable-wrapper"(?:(?!>).)*style="display:\s*none;"/s',
+            $responseWithDeployableOldInput->getContent()
+        );
+
+        $assetWithDeployableStatus = Asset::factory()->assignedToUser()->create([
+            'status_id' => $deployableStatus->id,
+        ]);
+
+        $responseWithNonDeployableOldInput = $this->actingAs(User::factory()->checkinAssets()->create())
+            ->withSession(['_old_input' => ['status_id' => (string) $nonDeployableStatus->id]])
+            ->get(route('hardware.checkin.create', $assetWithDeployableStatus))
+            ->assertOk();
+
+        $this->assertMatchesRegularExpression(
+            '/id="set-requestable-wrapper"(?:(?!>).)*style="display:\s*none;"/s',
+            $responseWithNonDeployableOldInput->getContent()
+        );
+    }
+
     public function test_asset_can_be_checked_in()
     {
         Event::fake([CheckoutableCheckedIn::class]);
@@ -173,6 +246,38 @@ class AssetCheckinTest extends TestCase
         Event::assertDispatched(function (CheckoutableCheckedIn $event) {
             return $event->action_date === '2023-01-02' && $event->note === 'hello';
         }, 1);
+    }
+
+    public function test_checkin_can_set_asset_to_requestable_when_status_is_deployable()
+    {
+        $deployableStatus = Statuslabel::factory()->readyToDeploy()->create();
+        $asset = Asset::factory()->assignedToUser()->create([
+            'requestable' => 0,
+        ]);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.checkin.store', [$asset]), [
+                'status_id' => $deployableStatus->id,
+                'set_requestable' => 1,
+            ]);
+
+        $this->assertTrue((bool) $asset->fresh()->requestable);
+    }
+
+    public function test_checkin_does_not_set_asset_to_requestable_when_status_is_not_deployable()
+    {
+        $undeployableStatus = Statuslabel::factory()->create(['deployable' => 0]);
+        $asset = Asset::factory()->assignedToUser()->create([
+            'requestable' => 0,
+        ]);
+
+        $this->actingAs(User::factory()->checkinAssets()->create())
+            ->post(route('hardware.checkin.store', [$asset]), [
+                'status_id' => $undeployableStatus->id,
+                'set_requestable' => 1,
+            ]);
+
+        $this->assertFalse((bool) $asset->fresh()->requestable);
     }
 
     public function test_asset_checkin_page_is_redirected_if_model_is_invalid()

--- a/tests/Feature/Checkouts/Api/AssetCheckoutTest.php
+++ b/tests/Feature/Checkouts/Api/AssetCheckoutTest.php
@@ -230,4 +230,35 @@ class AssetCheckoutTest extends TestCase
 
         $this->assertTrue((int) Carbon::parse($asset->last_checkout)->diffInSeconds(now(), true) < 2);
     }
+
+    public function test_api_checkout_can_update_requestable_when_field_is_passed()
+    {
+        $asset = Asset::factory()->create(['requestable' => 1]);
+        $targetUser = User::factory()->create();
+
+        $this->actingAsForApi(User::factory()->checkoutAssets()->create())
+            ->postJson(route('api.asset.checkout', $asset), [
+                'checkout_to_type' => 'user',
+                'assigned_user' => $targetUser->id,
+                'requestable' => 0,
+            ])
+            ->assertStatusMessageIs('success');
+
+        $this->assertFalse((bool) $asset->fresh()->requestable);
+    }
+
+    public function test_api_checkout_leaves_requestable_unchanged_when_field_is_omitted()
+    {
+        $asset = Asset::factory()->create(['requestable' => 1]);
+        $targetUser = User::factory()->create();
+
+        $this->actingAsForApi(User::factory()->checkoutAssets()->create())
+            ->postJson(route('api.asset.checkout', $asset), [
+                'checkout_to_type' => 'user',
+                'assigned_user' => $targetUser->id,
+            ])
+            ->assertStatusMessageIs('success');
+
+        $this->assertTrue((bool) $asset->fresh()->requestable);
+    }
 }

--- a/tests/Feature/Checkouts/Ui/AssetCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/AssetCheckoutTest.php
@@ -239,6 +239,21 @@ class AssetCheckoutTest extends TestCase
         $this->assertTrue($user->fresh()->licenses->contains($seat->license));
     }
 
+    public function test_checkout_can_set_asset_to_not_requestable()
+    {
+        $asset = Asset::factory()->create(['requestable' => 1]);
+        $targetUser = User::factory()->create();
+
+        $this->actingAs(User::factory()->checkoutAssets()->create())
+            ->post(route('hardware.checkout.store', $asset), [
+                'checkout_to_type' => 'user',
+                'assigned_user' => $targetUser->id,
+                'set_not_requestable' => 1,
+            ]);
+
+        $this->assertFalse((bool) $asset->fresh()->requestable);
+    }
+
     public function test_last_checkout_uses_current_date_if_not_provided()
     {
         $asset = Asset::factory()->create(['last_checkout' => now()->subMonth()]);

--- a/tests/Feature/Checkouts/Ui/BulkAssetCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/BulkAssetCheckoutTest.php
@@ -118,6 +118,24 @@ class BulkAssetCheckoutTest extends TestCase
         });
     }
 
+    public function test_bulk_checkout_leaves_requestable_unchanged_when_not_selected()
+    {
+        $requestableAsset = Asset::factory()->create(['requestable' => 1]);
+        $nonRequestableAsset = Asset::factory()->create(['requestable' => 0]);
+        $targetUser = User::factory()->create();
+
+        $this->actingAs(User::factory()->checkoutAssets()->create())
+            ->post(route('hardware.bulkcheckout.store'), [
+                'selected_assets' => [$requestableAsset->id, $nonRequestableAsset->id],
+                'checkout_to_type' => 'user',
+                'assigned_user' => $targetUser->id,
+                // Intentionally omitted: set_not_requestable
+            ]);
+
+        $this->assertTrue((bool) $requestableAsset->fresh()->requestable);
+        $this->assertFalse((bool) $nonRequestableAsset->fresh()->requestable);
+    }
+
     public static function checkoutTargets()
     {
         yield 'Checkout to user' => [

--- a/tests/Feature/Checkouts/Ui/BulkAssetCheckoutTest.php
+++ b/tests/Feature/Checkouts/Ui/BulkAssetCheckoutTest.php
@@ -100,6 +100,24 @@ class BulkAssetCheckoutTest extends TestCase
         }
     }
 
+    public function test_bulk_checkout_can_set_assets_to_not_requestable()
+    {
+        $assets = Asset::factory()->count(2)->create(['requestable' => 1]);
+        $targetUser = User::factory()->create();
+
+        $this->actingAs(User::factory()->checkoutAssets()->create())
+            ->post(route('hardware.bulkcheckout.store'), [
+                'selected_assets' => $assets->pluck('id')->toArray(),
+                'checkout_to_type' => 'user',
+                'assigned_user' => $targetUser->id,
+                'set_not_requestable' => 1,
+            ]);
+
+        $assets->each(function (Asset $asset) {
+            $this->assertFalse((bool) $asset->fresh()->requestable);
+        });
+    }
+
     public static function checkoutTargets()
     {
         yield 'Checkout to user' => [


### PR DESCRIPTION
This adds the ability to toggle the request ability of an asset on checkin/checkout. 

https://github.com/user-attachments/assets/4583b421-df01-485f-9012-33d800ba2f87

Since bulk checkout could affect assets with different request ability statuses, we allow you to not change it on bulk checkout. 

https://github.com/user-attachments/assets/4ec378ef-e101-48ae-ba78-45c847151b50



Fixes #7418