### PR TITLE
Display effective permissions

### DIFF
--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -439,6 +439,7 @@ class UsersController extends Controller
             'accessories',
             'licenses',
             'userloc',
+            'groups',
         ])
             ->withTrashed()
             ->find($user->id);
@@ -449,6 +450,7 @@ class UsersController extends Controller
         return view('users/view', [
             'user' => $user,
             'settings' => Setting::getSettings(),
+            'effectivePermissionsBySection' => $user->getEffectivePermissionsBySection(),
         ]);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -320,7 +320,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     public function getEffectivePermissionsBySection(): array
     {
         $displayablePermissions = collect(config('permissions'))
-            ->map(static fn(array $permissions): array => array_values(array_filter($permissions, static fn(array $permission): bool => ($permission['display'] ?? false) === true)))
+            ->map(static fn (array $permissions): array => array_values(array_filter($permissions, static fn (array $permission): bool => ($permission['display'] ?? false) === true)))
             ->all();
 
         $configuredPermissions = collect($displayablePermissions)
@@ -342,7 +342,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         $groupDenialsByPermission = [];
         foreach ($this->groups as $group) {
             $groupPermissions = $group->decodePermissions();
-            if (!is_array($groupPermissions)) {
+            if (! is_array($groupPermissions)) {
                 continue;
             }
 
@@ -360,9 +360,9 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
             $permissionKey = $permissionConfig['permission'];
             $directPermissionValue = (int) ($directPermissions[$permissionKey] ?? 0);
             $isAllowed = $this->hasAccess($permissionKey);
-            $isDenied = ($directPermissionValue === -1) || ((count($groupDenialsByPermission[$permissionKey] ?? []) > 0) && !$isAllowed);
+            $isDenied = ($directPermissionValue === -1) || ((count($groupDenialsByPermission[$permissionKey] ?? []) > 0) && ! $isAllowed);
 
-            if (!$isAllowed && !$isDenied) {
+            if (! $isAllowed && ! $isDenied) {
                 continue;
             }
 
@@ -378,7 +378,7 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
             } elseif ($this->isSuperUser()) {
                 $source = 'superuser';
                 $sourceGroups = [];
-            } elseif (!$isDenied && $directPermissionValue === 1) {
+            } elseif (! $isDenied && $directPermissionValue === 1) {
                 $source = 'individual';
                 $sourceGroups = [];
             }
@@ -412,10 +412,10 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         };
 
         if ($sourceGroups === []) {
-            return $statusLabel . ' (' . $sourceLabel . ')';
+            return $statusLabel.' ('.$sourceLabel.')';
         }
 
-        return $statusLabel . ' (' . $sourceLabel . '): ' . implode(', ', array_values(array_unique($sourceGroups)));
+        return $statusLabel.' ('.$sourceLabel.'): '.implode(', ', array_values(array_unique($sourceGroups)));
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -305,6 +305,120 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
     }
 
     /**
+     * Build a list of effective user permissions grouped by permission section.
+     *
+     * Includes explicit denials from user or group permissions so the UI can
+     * show both allowed and denied entries.
+     *
+     * This is kind of duplicative from the other permission-checking methods, but it allows us to build a
+     * list of permissions for display purposes without having to do a lot of super-confusing and
+     * redundant checks in the UI layer.
+     *
+     * This will likely go away once we refactor the permissions to be in a database table instead of the
+     * stupiud config file.
+     */
+    public function getEffectivePermissionsBySection(): array
+    {
+        $displayablePermissions = collect(config('permissions'))
+            ->map(static fn(array $permissions): array => array_values(array_filter($permissions, static fn(array $permission): bool => ($permission['display'] ?? false) === true)))
+            ->all();
+
+        $configuredPermissions = collect($displayablePermissions)
+            ->flatMap(static function (array $permissions, string $section) {
+                return collect($permissions)->map(static function (array $permission) use ($section): array {
+                    return [
+                        'section' => $section,
+                        'permission' => $permission['permission'],
+                    ];
+                });
+            })
+            ->unique('permission')
+            ->values();
+
+        $directPermissions = $this->decodePermissions();
+        $directPermissions = is_array($directPermissions) ? $directPermissions : [];
+
+        $groupGrantsByPermission = [];
+        $groupDenialsByPermission = [];
+        foreach ($this->groups as $group) {
+            $groupPermissions = $group->decodePermissions();
+            if (!is_array($groupPermissions)) {
+                continue;
+            }
+
+            foreach ($groupPermissions as $permissionKey => $permissionValue) {
+                if ((int) $permissionValue === 1) {
+                    $groupGrantsByPermission[$permissionKey][] = $group->name;
+                } elseif ((int) $permissionValue === -1) {
+                    $groupDenialsByPermission[$permissionKey][] = $group->name;
+                }
+            }
+        }
+
+        $effectiveBySection = [];
+        foreach ($configuredPermissions as $permissionConfig) {
+            $permissionKey = $permissionConfig['permission'];
+            $directPermissionValue = (int) ($directPermissions[$permissionKey] ?? 0);
+            $isAllowed = $this->hasAccess($permissionKey);
+            $isDenied = ($directPermissionValue === -1) || ((count($groupDenialsByPermission[$permissionKey] ?? []) > 0) && !$isAllowed);
+
+            if (!$isAllowed && !$isDenied) {
+                continue;
+            }
+
+            $status = $isDenied ? 'denied' : 'allowed';
+            $source = 'group';
+            $sourceGroups = $isDenied
+                ? ($groupDenialsByPermission[$permissionKey] ?? [])
+                : ($groupGrantsByPermission[$permissionKey] ?? []);
+
+            if ($isDenied && $directPermissionValue === -1) {
+                $source = 'individual';
+                $sourceGroups = [];
+            } elseif ($this->isSuperUser()) {
+                $source = 'superuser';
+                $sourceGroups = [];
+            } elseif (!$isDenied && $directPermissionValue === 1) {
+                $source = 'individual';
+                $sourceGroups = [];
+            }
+
+            $effectiveBySection[$permissionConfig['section']][] = [
+                'permission' => $permissionKey,
+                'status' => $status,
+                'source' => $source,
+                'groups' => array_values(array_unique($sourceGroups)),
+                'source_label' => $this->buildPermissionSourceLabel(
+                    status: $status,
+                    source: $source,
+                    sourceGroups: $sourceGroups
+                ),
+            ];
+        }
+
+        return $effectiveBySection;
+    }
+
+    /**
+     * Build a compact source label for a permission entry.
+     */
+    private function buildPermissionSourceLabel(string $status, string $source, array $sourceGroups = []): string
+    {
+        $statusLabel = $status === 'denied' ? 'Denied' : 'Allowed';
+        $sourceLabel = match ($source) {
+            'individual' => 'Individual',
+            'superuser' => 'Superuser',
+            default => 'Group',
+        };
+
+        if ($sourceGroups === []) {
+            return $statusLabel . ' (' . $sourceLabel . ')';
+        }
+
+        return $statusLabel . ' (' . $sourceLabel . '): ' . implode(', ', array_values(array_unique($sourceGroups)));
+    }
+
+    /**
      * Internally check the user permission for the given section
      *
      * @return bool

--- a/resources/views/users/view.blade.php
+++ b/resources/views/users/view.blade.php
@@ -147,7 +147,22 @@
                                     @endif
                                 </x-data-row>
 
-                                @if (($user->email!='') && ($user->activated=='1')  && ($user->getAssignedItemsWithPendingAcceptance()->count() > 0))
+                                <x-data-row :label="trans('general.permissions')">
+                                    @if (!empty($effectivePermissionsBySection))
+                                        @foreach ($effectivePermissionsBySection as $section => $permissions)
+                                            @foreach ($permissions as $permission)
+                                                @if (($permission['status'] ?? 'allowed') === 'denied')
+                                                    <span class="label label-danger" data-tooltip="true" title="{{ $permission['source_label'] }}"><x-icon type="x" class="fa-fw"/> {{ $permission['permission'] }}</span>
+                                                @else
+                                                    <span class="label label-success" data-tooltip="true" title="{{ $permission['source_label'] }}"><x-icon type="checkmark" class="fa-fw"/> {{ $permission['permission'] }}</span>
+                                                @endif
+                                            @endforeach
+
+                                        @endforeach
+                                    @endif
+                                </x-data-row>
+
+                            @if (($user->email!='') && ($user->activated=='1')  && ($user->getAssignedItemsWithPendingAcceptance()->count() > 0))
 
                                     <x-data-row :label="trans_choice('admin/users/general.unaccepted_items', $user->getAssignedItemsWithPendingAcceptance()->count())">
                                         <form action="{{ route('users.acceptance_reminder', $user) }}" method="POST" class="form-inline" style="display: inline;">

--- a/tests/Feature/Users/Ui/ViewUserTest.php
+++ b/tests/Feature/Users/Ui/ViewUserTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Users\Ui;
 
 use App\Models\Company;
+use App\Models\Group;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -37,5 +38,46 @@ class ViewUserTest extends TestCase
         $this->actingAs($actor)
             ->get(route('users.show', $user))
             ->assertStatus(302);
+    }
+
+    public function test_shows_effective_permissions_from_groups_and_individual_permissions()
+    {
+        $actor = User::factory()->viewUsers()->create();
+
+        $group = Group::factory()->create([
+            'permissions' => json_encode([
+                'assets.view' => 1,
+            ]),
+        ]);
+
+        $user = User::factory()->create([
+            'permissions' => json_encode([
+                'reports.view' => 1,
+            ]),
+        ]);
+        $user->groups()->attach($group->id);
+
+        $this->actingAs($actor)
+            ->get(route('users.show', $user))
+            ->assertOk()
+            ->assertSee('assets.view')
+            ->assertSee('reports.view');
+    }
+
+    public function test_shows_explicitly_denied_permissions()
+    {
+        $actor = User::factory()->viewUsers()->create();
+
+        $user = User::factory()->create([
+            'permissions' => json_encode([
+                'reports.view' => -1,
+            ]),
+        ]);
+
+        $this->actingAs($actor)
+            ->get(route('users.show', $user))
+            ->assertOk()
+            ->assertSee('reports.view')
+            ->assertSee('label-danger', false);
     }
 }


### PR DESCRIPTION
This adds a section to the user's view that shows the effective permissions the user has, including tooltips that show whether it was allowed/denied by group membership. (I might still fiddle with this a bit more to improve the visuals, and possibly add some translations, but that method was already pretty gross.)

<img width="1910" height="1169" alt="Screenshot 2026-04-17 at 12 37 11 PM" src="https://github.com/user-attachments/assets/106a7dba-b46f-412e-904b-c5c133965e94" />
<img width="725" height="119" alt="Screenshot 2026-04-17 at 12 37 46 PM" src="https://github.com/user-attachments/assets/614903d2-1276-4eba-9162-10c91a5b3fea" />
<img width="726" height="177" alt="Screenshot 2026-04-17 at 12 37 34 PM" src="https://github.com/user-attachments/assets/699f4ff7-330a-4e8b-8b83-cc4422e0d110" />
