### PR TITLE
Small info panel tweaks

### DIFF
--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1267,6 +1267,39 @@ class Asset extends Depreciable
         return (float) $this->components->sum('calculated_purchase_cost');
     }
 
+    /**
+     * Return EOL progress percentage (0-100), based on elapsed months since
+     * purchase date over the configured EOL window.
+     */
+    public function eolProgressPercent(): float
+    {
+        if (! $this->purchase_date || ! $this->asset_eol_date) {
+            return 0.0;
+        }
+
+        return $this->calculateProgressPercent(
+            start: Carbon::parse($this->purchase_date),
+            end: Carbon::parse($this->asset_eol_date),
+        );
+    }
+
+    /**
+     * Return warranty progress percentage (0-100), based on elapsed months
+     * since purchase date over the warranty window.
+     */
+    public function warrantyProgressPercent(): float
+    {
+        if (! $this->purchase_date || ! $this->warranty_expires) {
+            return 0.0;
+        }
+
+        return $this->calculateProgressPercent(
+            start: Carbon::parse($this->purchase_date),
+            end: $this->warranty_expires,
+        );
+    }
+
+
     public function getAccessoryCost()
     {
         return (float) $this->accessories()->sum('purchase_cost');

--- a/app/Models/Depreciable.php
+++ b/app/Models/Depreciable.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
+
 class Depreciable extends SnipeModel
 {
     /**
@@ -185,6 +187,39 @@ class Depreciable extends SnipeModel
 
         return null;
 
+    }
+
+    /**
+     * Return depreciation progress percentage (0-100), based on elapsed months
+     * since purchase date over the depreciation window.
+     */
+    public function depreciationProgressPercent(): float
+    {
+        if (! $this->purchase_date || ! $this->depreciated_date()) {
+            return 0.0;
+        }
+
+        return $this->calculateProgressPercent(
+            start: Carbon::parse($this->purchase_date),
+            end: Carbon::instance($this->depreciated_date()),
+        );
+    }
+
+    /**
+     * Calculate elapsed/total month percentage and clamp to 0-100.
+     */
+    protected function calculateProgressPercent(Carbon $start, Carbon $end): float
+    {
+        $totalMonths = (float) $start->diffInMonths($end);
+
+        if ($totalMonths <= 0) {
+            return 0.0;
+        }
+
+        $elapsedMonths = (float) $start->diffInMonths(Carbon::now());
+        $rawPercent = ($elapsedMonths / $totalMonths) * 100;
+
+        return (float) min(100, max(0, $rawPercent));
     }
 
     // it's necessary for unit tests

--- a/resources/views/blade/info-panel/index.blade.php
+++ b/resources/views/blade/info-panel/index.blade.php
@@ -299,18 +299,36 @@
                 ({{ $infoPanelObj->depreciation->months.' '.trans('general.months')}})
             </x-info-element>
 
-            <x-info-element icon_type="depreciation-calendar" title="{{ trans('admin/hardware/form.fully_depreciated') }}">
+            <x-info-element icon_type="depreciation-calendar" class="{{ $infoPanelObj->depreciationProgressPercent() > 90 ? 'text-danger' : '' }}" title="{{ trans('admin/hardware/form.fully_depreciated') }}">
+                {{ trans('admin/hardware/form.fully_depreciated') }}
                 {{ Helper::getFormattedDateObject($infoPanelObj->depreciated_date(), 'date', false) }}
                 -
                 <span class="text-muted">{{ Carbon::parse($infoPanelObj->depreciated_date())->diffForHumans(['parts' => 2]) }}</span>
+                @if (method_exists($infoPanelObj, 'depreciationProgressPercent'))
+                    <span class="text-muted">
+                        ({{ (int) round($infoPanelObj->depreciationProgressPercent()) }}%)
+                    </span>
+                @endif
             </x-info-element>
         @endif
 
+
         @if ($infoPanelObj->eol)
-            <x-info-element icon_type="eol" title="{{ trans('general.eol') }}">
+            <x-info-element icon_type="eol" title="{{ trans('general.device_eol') }}">
                 {{ $infoPanelObj->eol .' '.trans('general.months') }}
             </x-info-element>
         @endif
+
+        @if ($infoPanelObj->asset_eol_date)
+            <x-info-element icon_type="depreciation-calendar" title="{{ trans('general.device_eol') }}">
+                {{ trans('general.device_eol') }}
+                {{ Helper::getFormattedDateObject($infoPanelObj->asset_eol_date, 'date', false) }}
+                -
+                <span class="text-muted">{{ Carbon::parse($infoPanelObj->asset_eol_date)->diffForHumans(['parts' => 2]) }}</span>
+
+            </x-info-element>
+        @endif
+
 
         @if ($infoPanelObj->email)
             <x-info-element icon_type="email" title="{{ trans('general.email') }}">
@@ -356,14 +374,6 @@
                 {{ $infoPanelObj->url }}
             </x-info-element.url>
         </x-info-element>
-
-        @if ($infoPanelObj->manufacturer)
-            <x-info-element icon_type="external-link" title="{{ trans('admin/manufacturers/table.support_url') }}">
-                <x-info-element.url>
-                    {{ $infoPanelObj->present()->dynamicUrl($infoPanelObj->manufacturer->support_url) }}
-                </x-info-element.url>
-            </x-info-element>
-        @endif
 
 
         @if (($infoPanelObj->present()->displayAddress) && (config('services.google.maps_api_key')))

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -224,8 +224,7 @@
                                 <x-well class="well-sm">
                                     @if($asset->purchase_date && $asset->asset_eol_date)
                                         <x-progressbar use_well="false" columns="12" text="{{ trans('general.device_eol') }}" :percent="$asset->eolProgressPercent()">
-                                            (<strong>{{ (int) Carbon::now()->diffInMonths($asset->asset_eol_date, true) }}</strong>/{{ $asset->model?->eol }} {{ trans('general.months') }}
-                                            )
+                                            (<strong>{{ (int) Carbon::now()->diffInMonths($asset->asset_eol_date, true) }}</strong>/{{ $asset->model?->eol }} {{ trans('general.months') }})
                                         </x-progressbar>
                                     @endif
 

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -220,62 +220,24 @@
 
                         <!-- start side stats column -->
                         <x-page-column class="col-md-4 col-sm-12">
-
-                            @php
-                                // Compute elapsed/total percentage clamped to 0–100
-                                $clampedPercent = fn (float $elapsed, float $total): float =>
-                                    $total > 0 ? min(100, max(0, ($elapsed / $total) * 100)) : 0;
-
-                                $now = Carbon::now();
-                                $purchaseCarbon = $asset->purchase_date ? Carbon::parse($asset->purchase_date) : null;
-
-                                // EOL percentage: elapsed since purchase / total EOL period
-                                $eolPercent = 0;
-                                if ($purchaseCarbon && $asset->asset_eol_date) {
-                                    $eolPercent = $clampedPercent(
-                                        $purchaseCarbon->diffInMonths($now),
-                                        $purchaseCarbon->diffInMonths($asset->asset_eol_date)
-                                    );
-                                }
-
-                                // Depreciation percentage: elapsed since purchase / total depreciation period
-                                $deprPercent = 0;
-                                $deprDate = $asset->depreciated_date();
-                                if ($purchaseCarbon && $deprDate) {
-                                    $deprPercent = $clampedPercent(
-                                        $purchaseCarbon->diffInMonths($now),
-                                        $purchaseCarbon->diffInMonths(Carbon::instance($deprDate))
-                                    );
-                                }
-
-                                // Warranty percentage: elapsed since purchase / total warranty period
-                                $warrantyPercent = 0;
-                                if ($purchaseCarbon && $asset->warranty_expires) {
-                                    $warrantyPercent = $clampedPercent(
-                                        $purchaseCarbon->diffInMonths($now),
-                                        $purchaseCarbon->diffInMonths($asset->warranty_expires)
-                                    );
-                                }
-                            @endphp
-
-
-                            @if($asset->purchase_date || $asset->asset_eol_date || $deprDate || $asset->warranty_expires)
+                            @if($asset->purchase_date || $asset->asset_eol_date || $asset->depreciated_date() || $asset->warranty_expires)
                                 <x-well class="well-sm">
                                     @if($asset->purchase_date && $asset->asset_eol_date)
-                                        <x-progressbar use_well="false" columns="12" text="{{ trans('general.device_eol') }}" :percent="$eolPercent">
-                                        <strong>{{ (int) Carbon::now()->diffInMonths($asset->asset_eol_date, true) }}</strong>
-                                            /{{ $asset->model?->eol }} {{ trans('general.months') }}
+                                        <x-progressbar use_well="false" columns="12" text="{{ trans('general.device_eol') }}" :percent="$asset->eolProgressPercent()">
+                                            {{ Helper::getFormattedDateObject($asset->asset_eol_date, 'date', false) }}
+                                            (<strong>{{ (int) Carbon::now()->diffInMonths($asset->asset_eol_date, true) }}</strong>/{{ $asset->model?->eol }} {{ trans('general.months') }}
+                                            )
                                         </x-progressbar>
                                     @endif
 
-                                    @if($deprDate)
-                                        <x-progressbar use_well="false" columns="12" :text="trans('admin/hardware/form.fully_depreciated')" :percent="$deprPercent">
-                                            {{ Helper::getFormattedDateObject($deprDate->format('Y-m-d'), 'date', false) }}
+                                    @if($asset->depreciated_date())
+                                        <x-progressbar use_well="false" columns="12" :text="trans('admin/hardware/form.fully_depreciated')" :percent="$asset->depreciationProgressPercent()">
+                                            {{ Helper::getFormattedDateObject($asset->depreciated_date()->format('Y-m-d'), 'date', false) }}
                                         </x-progressbar>
                                     @endif
 
                                     @if($asset->warranty_expires)
-                                        <x-progressbar use_well="false" columns="12" :text="trans('admin/hardware/form.warranty_expires')" :percent="$warrantyPercent">
+                                        <x-progressbar use_well="false" columns="12" :text="trans('admin/hardware/form.warranty_expires')" :percent="$asset->warrantyProgressPercent()">
                                         {{ Helper::getFormattedDateObject($asset->warranty_expires, 'date', false) }}
                                         </x-progressbar>
                                     @endif

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -224,7 +224,6 @@
                                 <x-well class="well-sm">
                                     @if($asset->purchase_date && $asset->asset_eol_date)
                                         <x-progressbar use_well="false" columns="12" text="{{ trans('general.device_eol') }}" :percent="$asset->eolProgressPercent()">
-                                            {{ Helper::getFormattedDateObject($asset->asset_eol_date, 'date', false) }}
                                             (<strong>{{ (int) Carbon::now()->diffInMonths($asset->asset_eol_date, true) }}</strong>/{{ $asset->model?->eol }} {{ trans('general.months') }}
                                             )
                                         </x-progressbar>

--- a/tests/Feature/Licenses/Ui/LicenseViewTest.php
+++ b/tests/Feature/Licenses/Ui/LicenseViewTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Licenses\Ui;
 use App\Models\Depreciation;
 use App\Models\License;
 use App\Models\User;
+use Carbon\Carbon;
 use Tests\TestCase;
 
 class LicenseViewTest extends TestCase
@@ -26,13 +27,24 @@ class LicenseViewTest extends TestCase
 
     public function test_license_with_purchase_date_depreciates_correctly()
     {
-        $depreciation = Depreciation::factory()->create(['months' => 12]);
-        $license = License::factory()->create(['depreciation_id' => $depreciation->id, 'purchase_date' => '2020-01-01']);
-        $this->actingAs(User::factory()->superuser()->create())
-            ->get(route('licenses.show', $license))
-            ->assertOk()
-            ->assertSee([
-                '2021-01-01',
-            ], false);
+        Carbon::setTestNow(Carbon::create(2021, 1, 1, 0, 0, 0));
+
+        try {
+            $depreciation = Depreciation::factory()->create(['months' => 24]);
+            $license = License::factory()->create([
+                'depreciation_id' => $depreciation->id,
+                'purchase_date' => '2020-01-01',
+            ]);
+
+            $this->actingAs(User::factory()->superuser()->create())
+                ->get(route('licenses.show', $license))
+                ->assertOk()
+                ->assertSee([
+                    '2022-01-01',
+                    '(50%)',
+                ], false);
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 }

--- a/tests/Unit/AssetTest.php
+++ b/tests/Unit/AssetTest.php
@@ -9,6 +9,7 @@ use App\Models\Asset;
 use App\Models\AssetModel;
 use App\Models\Category;
 use App\Models\Component;
+use App\Models\Depreciation;
 use App\Models\Setting;
 use App\Models\Statuslabel;
 use App\Models\User;
@@ -193,6 +194,55 @@ class AssetTest extends TestCase
         $this->assertEquals(Carbon::createFromDate(2017, 1, 1)->format('Y-m-d'), $asset->purchase_date->format('Y-m-d'));
         $this->assertEquals(Carbon::createFromDate(2019, 1, 1)->format('Y-m-d'), $asset->warranty_expires->format('Y-m-d'));
 
+    }
+
+    public function test_eol_progress_percent_returns_expected_value(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 1, 1, 0, 0, 0));
+
+        try {
+            $asset = Asset::factory()->create([
+                'purchase_date' => '2025-01-01',
+                'eol_explicit' => 1,
+            ]);
+
+            $asset->asset_eol_date = '2027-01-01';
+            $asset->save();
+            $asset->refresh();
+
+            $this->assertSame(50.0, $asset->eolProgressPercent());
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_depreciation_progress_percent_returns_expected_value(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 1, 1, 0, 0, 0));
+
+        try {
+            $depreciation = Depreciation::factory()->create(['months' => 24]);
+            $model = AssetModel::factory()->create(['depreciation_id' => $depreciation->id]);
+
+            $asset = Asset::factory()->create([
+                'model_id' => $model->id,
+                'purchase_date' => '2025-01-01',
+            ]);
+
+            $this->assertSame(50.0, $asset->depreciationProgressPercent());
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_warranty_progress_percent_returns_zero_without_required_dates(): void
+    {
+        $asset = Asset::factory()->create([
+            'purchase_date' => null,
+            'warranty_months' => 24,
+        ]);
+
+        $this->assertSame(0.0, $asset->warrantyProgressPercent());
     }
 
     public function test_assigned_type_without_assign_to()

--- a/tests/Unit/Models/LicenseTest.php
+++ b/tests/Unit/Models/LicenseTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Models;
 use App\Enums\ActionType;
 use App\Models\License;
 use App\Models\User;
+use Carbon\Carbon;
 use Tests\TestCase;
 
 class LicenseTest extends TestCase
@@ -99,5 +100,41 @@ class LicenseTest extends TestCase
 
         $license->remaining = 99;
         $this->assertEquals(100.0, $license->percentRemaining());
+    }
+
+    public function test_depreciation_progress_percent_is_available_for_license(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 1, 1, 0, 0, 0));
+
+        try {
+            $license = new class extends License
+            {
+                public function depreciated_date()
+                {
+                    return date_create('2027-01-01');
+                }
+            };
+
+            $license->purchase_date = '2025-01-01';
+
+            $this->assertSame(50.0, $license->depreciationProgressPercent());
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_depreciation_progress_percent_returns_zero_when_dates_are_missing(): void
+    {
+        $license = new class extends License
+        {
+            public function depreciated_date()
+            {
+                return null;
+            }
+        };
+
+        $license->purchase_date = null;
+
+        $this->assertSame(0.0, $license->depreciationProgressPercent());
     }
 }


### PR DESCRIPTION
This refactor the % math out of the blade (because blech) and adds the device EOL date in the side panel. I also found a duplicated support_url line, so I removed that - and if it's 90% depreciated, the date will be in red

This fixes #18877
