### PR TITLE
Fix RB-20958 company display name in custom reports

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -917,7 +917,7 @@ class ReportsController extends Controller
 
                     if ($request->filled('user_company')) {
                         if ($asset->checkedOutToUser()) {
-                            $row[] = ($asset->assignedto?->company) ? $asset->assignedto->company->display_name : '';
+                            $row[] = ($asset->assignedto?->company) ? $asset->assignedto?->company?->display_name : '';
                         } else {
                             $row[] = ''; // Empty string if unassigned
                         }


### PR DESCRIPTION
This adds ternaries all the way through `$asset->assignedto?->company?->display_name`  in the custom asset report

Fixes RB-20958