### PR TITLE
Adds translation and better error messaging for API labels

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1424,7 +1424,7 @@ class AssetsController extends Controller
                 $label = new Label;
 
                 if (! $label) {
-                    throw new \Exception('Label object could not be created');
+                    throw new \Exception(trans('admin/labels/message.label_not_created'));
                 }
 
                 // Configure label with assets and settings
@@ -1445,7 +1445,7 @@ class AssetsController extends Controller
 
                 // Verify PDF was generated successfully
                 if (empty($pdf_content)) {
-                    throw new \Exception('PDF content is empty');
+                    throw new \Exception(trans('admin/labels/message.use_new_label_engine'));
                 }
 
                 $encoded_content = base64_encode($pdf_content);

--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -1445,7 +1445,7 @@ class AssetsController extends Controller
 
                 // Verify PDF was generated successfully
                 if (empty($pdf_content)) {
-                    throw new \Exception(trans('admin/labels/message.use_new_label_engine'));
+                    throw new \Exception(trans('admin/labels/message.use_new_label_engine_for_api'));
                 }
 
                 $encoded_content = base64_encode($pdf_content);

--- a/resources/lang/en-US/admin/labels/message.php
+++ b/resources/lang/en-US/admin/labels/message.php
@@ -7,5 +7,6 @@ return [
     'invalid_return_value' => 'Invalid value returned from :name. Expected :expected, got :actual.',
 
     'does_not_exist' => 'Label does not exist',
-
+    'use_new_label_engine' => 'Enable the New Label Engine to load labels via the API',
+    'label_not_created' => 'Label object could not be created',
 ];

--- a/resources/lang/en-US/admin/labels/message.php
+++ b/resources/lang/en-US/admin/labels/message.php
@@ -7,6 +7,6 @@ return [
     'invalid_return_value' => 'Invalid value returned from :name. Expected :expected, got :actual.',
 
     'does_not_exist' => 'Label does not exist',
-    'use_new_label_engine' => 'Enable the New Label Engine to load labels via the API',
+    'use_new_label_engine_for_api' => 'Enable the New Label Engine to load labels via the API',
     'label_not_created' => 'Label object could not be created',
 ];


### PR DESCRIPTION
This updates the api label exception messages to translations, and now suggest to use the new label engine as this is a feature only for the new label engine.

<img width="1550" height="1184" alt="image" src="https://github.com/user-attachments/assets/7e9b5773-2b77-4990-a3a7-2a572ead5a1f" />
