### PR TITLE
Fixed display of email setting on category show page

### DIFF
--- a/resources/views/blade/info-panel/index.blade.php
+++ b/resources/views/blade/info-panel/index.blade.php
@@ -504,7 +504,7 @@
 
         @if (isset($infoPanelObj->alert_on_response))
             <x-info-element>
-                @if ($infoPanelObj->require_acceptance == 1)
+                @if ($infoPanelObj->alert_on_response)
                     <x-icon type="checkmark" class="fa-fw text-success"  title="{{ trans('general.yes') }}"/>
                 @else
                     <x-icon type="x" class="fa-fw text-danger"  title="{{ trans('general.no') }}"/>


### PR DESCRIPTION
This PR fixes the green check next to "Send email to you when user accepts or declines checkout" appearing on the category screen when the setting is disabled:

<img width="1700" height="2058" alt="image" src="https://github.com/user-attachments/assets/fa08a294-18d7-4172-b530-5650081f4da8" />

| Before | After |
|--------|--------|
| <img width="508" height="854" alt="image" src="https://github.com/user-attachments/assets/8b463724-d601-471d-b9bf-8a4784a81fee" /> | <img width="508" height="842" alt="image" src="https://github.com/user-attachments/assets/48969c7d-d4f3-4214-a017-f3b2554b7449" /> |

---

Partially addresses [FD-54943]
