### PR TITLE
Fixed #18367 - Added option to audit by serial in quickscan audit

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -39,6 +39,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 /**
  * This class controls all actions related to assets for
@@ -1122,11 +1123,23 @@ class AssetsController extends Controller
             $dt = Carbon::now()->addMonths($settings->audit_interval)->toDateString();
         }
 
-        // Allow the asset tag to be passed in the payload (legacy method)
-        if ($request->filled('asset_tag')) {
+        $audit_by_field = $request->input('audit_by_field', 'asset_tag');
+        $audit_key = $request->input('audit_key', null);
+
+        // If they have selected to scan by serial, use that
+        if (($settings->unique_serial == '1') && ($audit_by_field == 'serial') && ($audit_key)) {
+            $asset = Asset::where('serial', '=', trim($audit_key))->first();
+
+            // If they have selected by asset tag, use that
+        } elseif (($audit_by_field == 'asset_tag') && ($audit_key)) {
+            $asset = Asset::where('asset_tag', '=', trim($audit_key))->first();
+
+            // Allow the asset tag to be passed in the payload (legacy method)
+        } elseif ($request->filled('asset_tag')) {
             $asset = Asset::where('asset_tag', '=', $request->input('asset_tag'))->first();
         }
 
+        // If none of the above were selected, fall back to the route-model-binding
         if ($asset) {
 
             $originalValues = $asset->getRawOriginal();
@@ -1148,7 +1161,9 @@ class AssetsController extends Controller
             // Set up the payload for re-display in the API response
             $payload = [
                 'id' => $asset->id,
-                'asset_tag' => $asset->asset_tag,
+                'asset_tag' => e($asset->asset_tag),
+                'audit_by_field' => e(Str::headline($audit_by_field)),
+                'audit_key' => e($audit_key),
                 'note' => e($request->input('note')),
                 'status_label' => e($asset->status?->display_name),
                 'status_type' => $asset->status?->getStatuslabelType(),
@@ -1223,8 +1238,13 @@ class AssetsController extends Controller
 
         }
 
+        $fail_payload = [
+            'audit_by_field' => e(Str::headline($audit_by_field)),
+            'audit_key' => e($audit_key),
+        ];
+
         // No matching asset for the asset tag that was passed.
-        return response()->json(Helper::formatStandardApiResponse('error', null, trans('admin/hardware/message.does_not_exist')), 200);
+        return response()->json(Helper::formatStandardApiResponse('error', $fail_payload, trans('admin/hardware/message.does_not_exist')), 200);
 
     }
 

--- a/resources/lang/en-US/general.php
+++ b/resources/lang/en-US/general.php
@@ -54,7 +54,7 @@ return [
     'avatar_upload' => 'Upload Avatar',
     'back' => 'Back',
     'bad_data' => 'Nothing found. Maybe bad data?',
-    'bulkaudit' => 'Bulk Audit',
+    'bulkaudit' => 'Scanner Bulk Audit',
     'bulkaudit_status' => 'Audit Status',
     'bulk_checkout' => 'Bulk Checkout',
     'bulk_edit' => 'Bulk Edit',
@@ -670,6 +670,9 @@ return [
     'child_locations' => 'Child Locations',
     'append' => 'Append',
     'optional' => 'OPTIONAL',
+    'audit_by_field' => 'Audit by Field',
+    'audit_by_field_help' => 'Auditing by scanning serial numbers is only an available option if serial numbers are required to be unique in the Admin Settings.',
+    'audit_key' => 'Asset',
 
     // Add form placeholders here
     'placeholders' => [
@@ -698,26 +701,6 @@ return [
     'breadcrumb_button_actions' => [
         'checkout_item' => 'Checkout :name',
         'checkin_item' => 'Checkin :name',
-    ],
-
-    'skins' => [
-        'site_default' => 'Site Default',
-        'default_blue' => 'Default Blue',
-        'blue_dark' => 'Blue (Dark Mode)',
-        'green' => 'Green',
-        'green_dark' => 'Green (Dark Mode)',
-        'red' => 'Red',
-        'red_dark' => 'Red (Dark Mode)',
-        'orange' => 'Orange',
-        'orange_dark' => 'Orange (Dark Mode)',
-        'black' => 'Black',
-        'black_dark' => 'Black (Dark Mode)',
-        'purple' => 'Purple',
-        'purple_dark' => 'Purple (Dark Mode)',
-        'yellow' => 'Yellow',
-        'yellow_dark' => 'Yellow (Dark Mode)',
-        'high_contrast' => 'High Contrast',
-
     ],
 
     'select_all_none' => 'Select/Unselect All',

--- a/resources/views/hardware/quickscan.blade.php
+++ b/resources/views/hardware/quickscan.blade.php
@@ -27,15 +27,29 @@
                     <div class="box-body">
                     {{csrf_field()}}
 
-                    <!-- Next Audit -->
-                        <div class="form-group {{ $errors->has('asset_tag') ? 'error' : '' }}">
-                            <label for="asset_tag" class="col-md-3 control-label" id="audit_tag">{{ trans('general.asset_tag') }}</label>
-                            <div class="col-md-9">
-                                <div class="input-group date col-md-11 required" data-date-format="yyyy-mm-dd">
-                                    <input type="text" class="form-control" name="asset_tag" id="asset_tag" required value="{{ old('asset_tag') }}">
+                        <div class="form-group {{ $errors->has('audit_by_field') ? 'error' : '' }}">
+                            <label for="audit_by_field" class="col-md-3 control-label" id="audit_by_field">{{ trans('general.audit_by_field') }}</label>
+                            <div class="col-md-8">
+                                <select name="audit_by_field" data-minimum-results-for-search="Infinity" id="audit_by_field" class="form-control select2" aria-label="audit_by_field" required>
+                                    <option value="asset_tag">{{ trans('general.asset_tag') }}</option>
+                                    <option value="serial" {{ (($settings->unique_serial != '1') ? 'disabled' : '') }}>{{ trans('general.serial_number') }}</option>
+                                </select>
+                                {!! $errors->first('audit_by_field', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
 
-                                </div>
-                                {!! $errors->first('asset_tag', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
+                                <p class="help-block">
+                                    <x-icon type="tip"/>
+                                    {{ trans('general.audit_by_field_help') }}
+                                </p>
+
+                            </div>
+                        </div>
+
+                        <!-- Tag/Serial -->
+                        <div class="form-group {{ $errors->has('asset_tag') ? 'error' : '' }}">
+                            <label for="audit_key" class="col-md-3 control-label" id="audit_key_label">{{ trans('general.asset_tag') }}</label>
+                            <div class="col-md-8">
+                                <input type="text" class="form-control" name="audit_key" required value="{{ old('audit_key') }}">
+                                {!! $errors->first('audit_key', '<span class="alert-msg" aria-hidden="true"><i class="fas fa-times" aria-hidden="true"></i> :message</span>') !!}
                             </div>
                         </div>
 
@@ -105,7 +119,7 @@
                     <table id="audited" class="table table-striped snipe-table">
                         <thead>
                         <tr>
-                            <th>{{ trans('general.asset_tag') }}</th>
+                            <th>{{ trans('general.audit') }}</th>
                             <th>{{ trans('general.bulkaudit_status') }}</th>
                             <th>{{ trans('general.status') }}</th>
                             <th>{{ trans('general.notes') }}</th>
@@ -134,6 +148,15 @@
 @section('moar_scripts')
     <script nonce="{{ csrf_token() }}">
 
+        $(document.body).on("change", "#audit_by_field", function () {
+            $('label#audit_key_label').text('{{ trans('general.asset_tag') }}');
+
+            if (this.value === 'serial') {
+                $('label#audit_key_label').text('{{ trans('general.serial_number') }}');
+            }
+        });
+
+
         $("#audit-form").submit(function (event) {
             $('#audited-div').show();
             $('#audit-loader').show();
@@ -142,7 +165,7 @@
 
             var form = $("#audit-form").get(0);
             var formData = $('#audit-form').serializeArray();
-            var asset_tag = $('#asset_tag').val();
+            var audit_key = $('#audit_key').val();
 
             $.ajax({
                 url: "{{ route('api.asset.audit.legacy') }}",
@@ -156,7 +179,7 @@
                 success : function (data) {
 
                     if (data.status == 'success') {
-                        $('#audited tbody').prepend("<tr class='success'><td>" + data.payload.asset_tag + "</td><td>" + data.messages + "</td><td>" + data.payload.status_label + " (" + data.payload.status_type + ")</td><td>" + data.payload.note + "</td><td><i class='fas fa-check text-success' style='font-size:18px;'></i></td></tr>");
+                        $('#audited tbody').prepend("<tr class='success'><td>" + data.payload.audit_by_field + ': ' + data.payload.audit_key + "</td><td>" + data.messages + "</td><td>" + data.payload.status_label + " (" + data.payload.status_type + ")</td><td>" + data.payload.note + "</td><td><i class='fas fa-check' style='font-size:18px;'></i></td></tr>");
 
                         @if ($user?->enable_sounds)
                         var audio = new Audio('{{ config('app.url') }}/sounds/success.mp3');
@@ -165,12 +188,12 @@
 
                         incrementOnSuccess();
                     } else {
-                        handleAuditFail(data, asset_tag);
+                        handleAuditFail(data);
                     }
-                    $('input#asset_tag').val('');
+                    $('input#audit_key').val('');
                 },
                 error: function (data) {
-                    handleAuditFail(data, asset_tag);
+                    handleAuditFail(data, audit_key);
                 },
                 complete: function() {
                     $('#audit-loader').hide();
@@ -181,18 +204,12 @@
             return false;
         });
 
-        function handleAuditFail (data, asset_tag) {
+        function handleAuditFail(data) {
             @if ($user?->enable_sounds)
             var audio = new Audio('{{ config('app.url') }}/sounds/error.mp3');
             audio.play()
             @endif
 
-
-            if ((!asset_tag) && (data.payload)  && (data.payload.asset_tag)) {
-                asset_tag = data.payload.asset_tag;
-            }
-
-            asset_tag = jQuery('<span>' + asset_tag + '</span>').text();
 
             let messages = "";
 
@@ -203,7 +220,7 @@
                 }
             }
 
-            $('#audited tbody').prepend("<tr class='danger'><td>" + asset_tag + "</td><td>" + messages + "</td><td></td><td></td><td><i class='fas fa-times text-danger' style='font-size:18px;'></i></td></tr>");
+            $('#audited tbody').prepend("<tr class='danger'><td>" + data.payload.audit_by_field + ': ' + data.payload.audit_key + "</td><td>" + messages + "</td><td></td><td></td><td><i class='fas fa-times' style='font-size:18px;'></i></td></tr>");
         }
 
         function incrementOnSuccess() {
@@ -212,7 +229,7 @@
             $('#audit-counter').html(y);
         }
 
-        $("#audit_tag").focus();
+        $("#audit_key").focus();
 
     </script>
 @stop

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -1610,13 +1610,6 @@
                                             </a>
                                         </li>
                                     @endcan
-                                    @can('admin')
-                                        <li id="import-history-sidenav-option" {!! (request()->is('hardware/history') ? ' class="active"' : '') !!}>
-                                            <a href="{{ url('hardware/history') }}">
-                                                {{ trans('general.import-history') }}
-                                            </a>
-                                        </li>
-                                    @endcan
                                     @can('audit', \App\Models\Asset::class)
                                         <li id="bulk-audit-sidenav-option" {!! (request()->is('hardware/bulkaudit') ? ' class="active"' : '') !!}>
                                             <a href="{{ route('assets.bulkaudit') }}">
@@ -1624,6 +1617,15 @@
                                             </a>
                                         </li>
                                     @endcan
+
+                                    @can('admin')
+                                        <li id="import-history-sidenav-option" {!! (request()->is('hardware/history') ? ' class="active"' : '') !!}>
+                                            <a href="{{ url('hardware/history') }}">
+                                                {{ trans('general.import-history') }}
+                                            </a>
+                                        </li>
+                                    @endcan
+
                                 </ul>
                             </li>
                         @endcan

--- a/tests/Feature/Assets/Api/AuditAssetTest.php
+++ b/tests/Feature/Assets/Api/AuditAssetTest.php
@@ -60,6 +60,53 @@ class AuditAssetTest extends TestCase
         $this->assertEquals($future, $asset->next_audit_date);
     }
 
+    public function test_legacy_asset_audit_defaults_to_asset_tag_when_audit_by_field_is_not_sent()
+    {
+        $asset = Asset::factory()->create();
+        $future = now()->addMonths(2)->toDateString();
+
+        $this->actingAsForApi(User::factory()->auditAssets()->create())
+            ->postJson(route('api.asset.audit.legacy'), [
+                // Simulates the new quickscan form where audit_key is posted
+                // and the dropdown may remain on default.
+                'audit_key' => $asset->asset_tag,
+                'next_audit_date' => $future,
+                'note' => 'default asset tag',
+            ])
+            ->assertStatusMessageIs('success')
+            ->assertJsonPath('payload.id', $asset->id)
+            ->assertJsonPath('payload.audit_by_field', 'Asset Tag')
+            ->assertJsonPath('payload.audit_key', (string) $asset->asset_tag)
+            ->assertStatus(200);
+
+        $asset->refresh();
+        $this->assertEquals($future, $asset->next_audit_date);
+    }
+
+    public function test_legacy_asset_audit_can_find_asset_by_serial_when_selected()
+    {
+        $this->settings->enableUniqueSerialNumbers();
+
+        $asset = Asset::factory()->create(['serial' => 'SERIAL-ABC-123']);
+        $future = now()->addMonths(2)->toDateString();
+
+        $this->actingAsForApi(User::factory()->auditAssets()->create())
+            ->postJson(route('api.asset.audit.legacy'), [
+                'audit_by_field' => 'serial',
+                'audit_key' => $asset->serial,
+                'next_audit_date' => $future,
+                'note' => 'serial lookup',
+            ])
+            ->assertStatusMessageIs('success')
+            ->assertJsonPath('payload.id', $asset->id)
+            ->assertJsonPath('payload.audit_by_field', 'Serial')
+            ->assertJsonPath('payload.audit_key', $asset->serial)
+            ->assertStatus(200);
+
+        $asset->refresh();
+        $this->assertEquals($future, $asset->next_audit_date);
+    }
+
     public function test_asset_audit_is_saved()
     {
         $asset = Asset::factory()->create(['next_audit_date' => now()->subMonth()->toDateString()]);


### PR DESCRIPTION
This adds the ability to switch to using serial number for the Scanner bulk audit

https://github.com/user-attachments/assets/b4cc7648-05f7-4314-9942-b3b158716166
 
Fixes #18367
