### PR TITLE
Enforce basenames on filenames

### DIFF
--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -182,7 +182,7 @@ class AcceptanceController extends Controller
         // This is needed for TCPDF to properly embed the image if it's a png and the cache isn't writable
         $encoded_logo = null;
         if (($settings->acceptance_pdf_logo) && (Storage::disk('public')->exists($settings->acceptance_pdf_logo))) {
-            $encoded_logo = base64_encode(file_get_contents(public_path() . '/uploads/' . basename($settings->acceptance_pdf_logo)));
+            $encoded_logo = base64_encode(file_get_contents(public_path().'/uploads/'.basename($settings->acceptance_pdf_logo)));
         }
 
         // Get the data array ready for the notifications and PDF generation

--- a/app/Http/Controllers/Account/AcceptanceController.php
+++ b/app/Http/Controllers/Account/AcceptanceController.php
@@ -182,7 +182,7 @@ class AcceptanceController extends Controller
         // This is needed for TCPDF to properly embed the image if it's a png and the cache isn't writable
         $encoded_logo = null;
         if (($settings->acceptance_pdf_logo) && (Storage::disk('public')->exists($settings->acceptance_pdf_logo))) {
-            $encoded_logo = base64_encode(file_get_contents(public_path().'/uploads/'.$settings->acceptance_pdf_logo));
+            $encoded_logo = base64_encode(file_get_contents(public_path() . '/uploads/' . basename($settings->acceptance_pdf_logo)));
         }
 
         // Get the data array ready for the notifications and PDF generation

--- a/app/Http/Controllers/ActionlogController.php
+++ b/app/Http/Controllers/ActionlogController.php
@@ -24,14 +24,13 @@ class ActionlogController extends Controller
         $disk = config('filesystems.default');
         switch (config("filesystems.disks.$disk.driver")) {
 
-
             case 's3':
-                $file = 'private_uploads/signatures/' . $filename;
+                $file = 'private_uploads/signatures/'.$filename;
 
                 return redirect()->away(Storage::disk($disk)->temporaryUrl($file, now()->addMinutes(5)));
             default:
                 $this->authorize('view', Asset::class);
-                $file = config('app.private_uploads') . '/signatures/' . $filename;
+                $file = config('app.private_uploads').'/signatures/'.$filename;
                 $filetype = Helper::checkUploadIsImage($file);
 
                 $contents = file_get_contents($file, false, stream_context_create(['http' => ['ignore_errors' => true]]));

--- a/app/Http/Controllers/ActionlogController.php
+++ b/app/Http/Controllers/ActionlogController.php
@@ -15,6 +15,8 @@ class ActionlogController extends Controller
 {
     public function displaySig($filename): RedirectResponse|Response|bool
     {
+        $filename = basename((string) $filename);
+
         // PHP doesn't let you handle file not found errors well with
         // file_get_contents, so we set the error reporting for just this class
         error_reporting(0);
@@ -22,13 +24,14 @@ class ActionlogController extends Controller
         $disk = config('filesystems.default');
         switch (config("filesystems.disks.$disk.driver")) {
 
+
             case 's3':
-                $file = 'private_uploads/signatures/'.$filename;
+                $file = 'private_uploads/signatures/' . $filename;
 
                 return redirect()->away(Storage::disk($disk)->temporaryUrl($file, now()->addMinutes(5)));
             default:
                 $this->authorize('view', Asset::class);
-                $file = config('app.private_uploads').'/signatures/'.$filename;
+                $file = config('app.private_uploads') . '/signatures/' . $filename;
                 $filetype = Helper::checkUploadIsImage($file);
 
                 $contents = file_get_contents($file, false, stream_context_create(['http' => ['ignore_errors' => true]]));
@@ -44,6 +47,7 @@ class ActionlogController extends Controller
 
     public function getStoredEula($filename): Response|BinaryFileResponse|RedirectResponse
     {
+        $filename = basename((string) $filename);
 
         if ($actionlog = Actionlog::where('filename', $filename)->with('user')->with('target')->firstOrFail()) {
 

--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -165,6 +165,7 @@ class SettingsController extends Controller
 
             if (config('mail.reply_to.address') == '') {
                 Log::debug('MAIL_REPLYTO_ADDR not set in env. Skipping mail test.');
+
                 return response()->json(['message' => trans('admin/settings/general.mail_test_no_email')], 403);
             }
 

--- a/app/Http/Controllers/Api/SettingsController.php
+++ b/app/Http/Controllers/Api/SettingsController.php
@@ -292,6 +292,11 @@ class SettingsController extends Controller
      */
     public function downloadBackup($file): JsonResponse|BinaryFileResponse
     {
+        $file = $this->sanitizeBackupFilename($file);
+
+        if ($file === null) {
+            return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.file_not_found')), 404);
+        }
 
         $path = storage_path('app/backups');
 
@@ -334,5 +339,22 @@ class SettingsController extends Controller
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.file_not_found')), 404);
         }
 
+    }
+
+    private function sanitizeBackupFilename(mixed $filename): ?string
+    {
+        $filename = trim((string) $filename);
+
+        if ($filename === '' || str_contains($filename, "\0")) {
+            return null;
+        }
+
+        $sanitized = basename($filename);
+
+        if (($sanitized === '') || ($sanitized === '.') || ($sanitized === '..')) {
+            return null;
+        }
+
+        return ($sanitized === $filename) ? $sanitized : null;
     }
 }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -251,6 +251,7 @@ class ProfileController extends Controller
 
     public function getStoredEula($filename): Response|BinaryFileResponse|RedirectResponse
     {
+        $filename = basename((string) $filename);
 
         $logentry = Actionlog::where('filename', $filename)->first();
 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -872,6 +872,11 @@ class SettingsController extends Controller
     public function downloadFile($filename = null): RedirectResponse|BinaryFileResponse
     {
         $path = 'app/backups';
+        $filename = basename((string) $filename);
+
+        if ($this->hasInvalidBackupFilename($filename)) {
+            return redirect()->route('settings.backups.index')->with('error', trans('admin/settings/message.backup.file_not_found'));
+        }
 
         if (! config('app.lock_passwords')) {
             if (Storage::exists($path.'/'.$filename)) {
@@ -897,6 +902,12 @@ class SettingsController extends Controller
      */
     public function deleteFile($filename = null): RedirectResponse
     {
+        $filename = basename((string) $filename);
+
+        if ($this->hasInvalidBackupFilename($filename)) {
+            return redirect()->route('settings.backups.index')->with('error', trans('admin/settings/message.backup.file_not_found'));
+        }
+
         if (config('app.allow_backup_delete') == 'true') {
 
             if (! config('app.lock_passwords')) {
@@ -971,6 +982,11 @@ class SettingsController extends Controller
      */
     public function postRestore(Request $request, $filename = null): RedirectResponse
     {
+        $filename = basename((string) $filename);
+
+        if ($this->hasInvalidBackupFilename($filename)) {
+            return redirect()->route('settings.backups.index')->with('error', trans('admin/settings/message.backup.file_not_found'));
+        }
 
         if (! config('app.lock_passwords')) {
             $path = 'app/backups';
@@ -1283,5 +1299,15 @@ class SettingsController extends Controller
         return redirect()
             ->to(route('settings.oauth.index').'#oauth-clients')
             ->with('success', trans('admin/settings/message.oauth.client_unrevoked'));
+    }
+
+    private function hasInvalidBackupFilename(string $filename): bool
+    {
+        if ($filename === '' || $filename === '.' || $filename === '..') {
+            return true;
+        }
+
+        // Reject path separators in case a crafted value survives route decoding.
+        return str_contains($filename, '/') || str_contains($filename, '\\');
     }
 }

--- a/app/Http/Controllers/StorageProxyController.php
+++ b/app/Http/Controllers/StorageProxyController.php
@@ -17,6 +17,10 @@ class StorageProxyController extends Controller
      */
     public function show(string $path): Response|StreamedResponse
     {
+        if ($this->hasPathTraversalSegments($path)) {
+            abort(404);
+        }
+
         $disk = Storage::disk('public');
 
         // The S3 adapter includes the disk's root prefix in generated URLs,
@@ -70,5 +74,17 @@ class StorageProxyController extends Controller
         }
 
         return false;
+    }
+
+    private function hasPathTraversalSegments(string $path): bool
+    {
+        $normalizedPath = str_replace('\\', '/', $path);
+
+        return str_contains($normalizedPath, "\0")
+            || str_starts_with($normalizedPath, '/')
+            || str_contains($normalizedPath, '../')
+            || str_contains($normalizedPath, '/..')
+            || str_ends_with($normalizedPath, '/..')
+            || $normalizedPath === '..';
     }
 }

--- a/app/Http/Controllers/StorageProxyController.php
+++ b/app/Http/Controllers/StorageProxyController.php
@@ -27,7 +27,7 @@ class StorageProxyController extends Controller
         // but Flysystem also prepends it internally on every operation.
         // Strip it here to avoid double-prefixing.
         $root = trim(config('filesystems.disks.public.root', ''), '/');
-        if ($root !== '' && str_starts_with($path, $root . '/')) {
+        if ($root !== '' && str_starts_with($path, $root.'/')) {
             $path = substr($path, strlen($root) + 1);
         }
 
@@ -37,12 +37,12 @@ class StorageProxyController extends Controller
 
         $mimeType = $disk->mimeType($path) ?: 'application/octet-stream';
         $lastModified = $disk->lastModified($path);
-        $etag = md5($path . $lastModified);
+        $etag = md5($path.$lastModified);
         $size = $disk->size($path);
 
         if ($this->isNotModified($etag, $lastModified)) {
             return response('', 304)
-                ->header('ETag', '"' . $etag . '"')
+                ->header('ETag', '"'.$etag.'"')
                 ->header('Cache-Control', 'public, max-age=86400');
         }
 
@@ -55,8 +55,8 @@ class StorageProxyController extends Controller
         }, 200, [
             'Content-Type' => $mimeType,
             'Content-Length' => $size,
-            'ETag' => '"' . $etag . '"',
-            'Last-Modified' => gmdate('D, d M Y H:i:s', $lastModified) . ' GMT',
+            'ETag' => '"'.$etag.'"',
+            'Last-Modified' => gmdate('D, d M Y H:i:s', $lastModified).' GMT',
             'Cache-Control' => 'public, max-age=86400',
         ]);
     }
@@ -64,7 +64,7 @@ class StorageProxyController extends Controller
     private function isNotModified(string $etag, int $lastModified): bool
     {
         $requestEtag = request()->header('If-None-Match');
-        if ($requestEtag && $requestEtag === '"' . $etag . '"') {
+        if ($requestEtag && $requestEtag === '"'.$etag.'"') {
             return true;
         }
 

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -110,7 +110,7 @@ class Label implements View
                         $logo = Storage::disk('public')->path('companies/'.e($asset->company->image));
                     } elseif (! empty($settings->label_logo)) {
                         // Use the general site label logo, if available
-                        $logo = Storage::disk('public')->path('/'.e($settings->label_logo));
+                        $logo = Storage::disk('public')->path('/' . e(basename($settings->label_logo)));
                     } elseif (! empty($asset->is_label_preview)) {
                         $logo = public_path('img/label-preview-logo.png');
                     }

--- a/app/View/Label.php
+++ b/app/View/Label.php
@@ -110,7 +110,7 @@ class Label implements View
                         $logo = Storage::disk('public')->path('companies/'.e($asset->company->image));
                     } elseif (! empty($settings->label_logo)) {
                         // Use the general site label logo, if available
-                        $logo = Storage::disk('public')->path('/' . e(basename($settings->label_logo)));
+                        $logo = Storage::disk('public')->path('/'.e(basename($settings->label_logo)));
                     } elseif (! empty($asset->is_label_preview)) {
                         $logo = public_path('img/label-preview-logo.png');
                     }

--- a/tests/Feature/Security/FilenameTraversalMitigationTest.php
+++ b/tests/Feature/Security/FilenameTraversalMitigationTest.php
@@ -61,4 +61,3 @@ class FilenameTraversalMitigationTest extends TestCase
         $this->assertStringContainsString('ok', $response->streamedContent());
     }
 }
-

--- a/tests/Feature/Security/FilenameTraversalMitigationTest.php
+++ b/tests/Feature/Security/FilenameTraversalMitigationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Security;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class FilenameTraversalMitigationTest extends TestCase
+{
+    public function test_settings_backup_download_rejects_nested_filename_input(): void
+    {
+        config(['app.lock_passwords' => false]);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->get('/admin/backups/download/..')
+            ->assertRedirect(route('settings.backups.index'))
+            ->assertSessionHas('error', trans('admin/settings/message.backup.file_not_found'));
+    }
+
+    public function test_settings_backup_delete_rejects_nested_filename_input(): void
+    {
+        config(['app.lock_passwords' => false]);
+        config(['app.allow_backup_delete' => 'true']);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->delete('/admin/backups/delete/..')
+            ->assertRedirect(route('settings.backups.index'))
+            ->assertSessionHas('error', trans('admin/settings/message.backup.file_not_found'));
+    }
+
+    public function test_settings_backup_restore_rejects_nested_filename_input(): void
+    {
+        config(['app.lock_passwords' => false]);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post('/admin/backups/restore/..')
+            ->assertRedirect(route('settings.backups.index'))
+            ->assertSessionHas('error', trans('admin/settings/message.backup.file_not_found'));
+    }
+
+    public function test_storage_proxy_blocks_path_traversal_segments(): void
+    {
+        $this->withoutMiddleware();
+
+        Storage::disk('public')->put('proxy-safe/example.txt', 'ok');
+
+        $this->get('/storage-proxy/..%2Fproxy-safe%2Fexample.txt')
+            ->assertNotFound();
+    }
+
+    public function test_storage_proxy_serves_valid_public_path(): void
+    {
+        $this->withoutMiddleware();
+
+        Storage::disk('public')->put('proxy-safe/example-valid.txt', 'ok');
+
+        $response = $this->get('/storage-proxy/proxy-safe/example-valid.txt')
+            ->assertOk();
+
+        $this->assertStringContainsString('ok', $response->streamedContent());
+    }
+}
+


### PR DESCRIPTION
This enforces base names on the times when we pass an actual filename via request (versus a filename returns via DB lookup.)