### PR TITLE
Fix redirecting users to their intended URL's when logging in via SAML

### DIFF
--- a/app/Http/Controllers/Auth/SamlController.php
+++ b/app/Http/Controllers/Auth/SamlController.php
@@ -74,8 +74,7 @@ class SamlController extends Controller
     public function login(Request $request)
     {
         $auth = $this->saml->getAuth();
-        $ssoUrl = $auth->login(null, [], false, false, false, false);
-
+        $ssoUrl = $auth->login(session()->get('url.intended'), [], false, false, false, false);
         return redirect()->away($ssoUrl);
     }
 
@@ -96,6 +95,7 @@ class SamlController extends Controller
         $saml = $this->saml;
         $auth = $saml->getAuth();
         $saml_exception = false;
+        session()->put('url.intended', $request->post('RelayState'));
         try {
             $auth->processResponse();
         } catch (\Exception $e) {


### PR DESCRIPTION
When you try to log in via SAML, once succesful, you end up getting redirected to /home - regardless of where you were _trying_ to go.

This, hopefully, fixes that.