### PR TITLE
Asset Labels, Brother Tape label layout

### DIFF
--- a/app/Models/Labels/Tapes/Brother/TZe_25mm.php
+++ b/app/Models/Labels/Tapes/Brother/TZe_25mm.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models\Labels\Tapes\Brother;
+
+use App\Helpers\Helper;
+use App\Models\Labels\Label;
+
+abstract class TZe_25mm extends Label
+{
+    private const HEIGHT = 36.00;
+
+    private const MARGIN_SIDES = 2.00;
+
+    private const MARGIN_ENDS = 2.00;
+
+    public function getHeight()
+    {
+        return Helper::convertUnit(self::HEIGHT, 'mm', $this->getUnit());
+    }
+
+    public function getMarginTop()
+    {
+        return Helper::convertUnit(self::MARGIN_SIDES, 'mm', $this->getUnit());
+    }
+
+    public function getMarginBottom()
+    {
+        return Helper::convertUnit(self::MARGIN_SIDES, 'mm', $this->getUnit());
+    }
+
+    public function getMarginLeft()
+    {
+        return Helper::convertUnit(self::MARGIN_ENDS, 'mm', $this->getUnit());
+    }
+
+    public function getMarginRight()
+    {
+        return Helper::convertUnit(self::MARGIN_ENDS, 'mm', $this->getUnit());
+    }
+    public function getRotation()
+    {
+        return 90;
+    }
+}

--- a/app/Models/Labels/Tapes/Brother/TZe_25mm_A.php
+++ b/app/Models/Labels/Tapes/Brother/TZe_25mm_A.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Models\Labels\Tapes\Brother;
+
+class TZe_25mm_A extends TZe_25mm
+{
+    private const BARCODE_MARGIN = 1.00;
+
+    private const BARCODE2D_SIZE = 19.00;
+
+    private const BARCODE2D_MARGIN = 1.00;
+
+    private const TAG_SIZE = 0.00;
+
+    private const LOGO_MAX_WIDTH = 10.00;
+
+    private const LOGO_MARGIN = 2.20;
+
+    private const TITLE_SIZE = 2.80;
+
+    private const TITLE_MARGIN = 0.50;
+
+    private const LABEL_SIZE = 2.00;
+
+    private const LABEL_MARGIN = -0.35;
+
+    private const FIELD_SIZE = 3.50;
+
+    private const FIELD_MARGIN = 0.15;
+
+    public function getUnit()
+    {
+        return 'mm';
+    }
+
+    public function getWidth()
+    {
+        return 24.0;
+    }
+
+    public function getSupportAssetTag()
+    {
+        return true;
+    }
+
+    public function getSupport1DBarcode()
+    {
+        return false;
+    }
+
+    public function getSupport2DBarcode()
+    {
+        return true;
+    }
+
+    public function getSupportFields()
+    {
+        return 1;
+    }
+
+    public function getSupportLogo()
+    {
+        return false;
+    }
+
+    public function getSupportTitle()
+    {
+        return false;
+    }
+
+    public function preparePDF($pdf) {}
+
+    public function write($pdf, $record)
+    {
+        $pa = $this->getPrintableArea();
+
+        $currentX = $pa->x1;
+        $currentY = $pa->y1;
+        $usableWidth = $pa->w;
+        $usableHeight = $pa->h;
+        //$barcodeSize = self::BARCODE2D_SIZE;
+        $barcodeSize = $pa->w - self::TAG_SIZE;
+
+        if ($record->has('barcode2d')) {
+            //static::writeText(
+            //    $pdf, $record->get('tag'),
+            //    $pa->x1, $pa->y2 - self::TAG_SIZE,
+            //    'freemono', 'b', self::TAG_SIZE, 'C',
+            //    $barcodeSize, self::TAG_SIZE, true, 0
+            //);
+            static::write2DBarcode(
+                $pdf, $record->get('barcode2d')->content, $record->get('barcode2d')->type,
+                $currentX, $currentY,
+                $barcodeSize, $barcodeSize
+            );
+            $currentX += $barcodeSize + self::BARCODE_MARGIN;
+            $usableWidth -= ($barcodeSize + self::BARCODE_MARGIN);
+        }
+      
+        //$textY = $currentY + ($barcodeSize / 2) - (self::FIELD_SIZE / 2);
+        //foreach ($record->get('fields') as $field) {
+        //    static::writeText(
+        //        $pdf, $field['value'],
+        //         $pa->x1, $pa->y2 - self::FIELD_SIZE,
+        //        'freemono', 'B', self::FIELD_SIZE, 'R',
+        //          $usableWidth, self::FIELD_SIZE, true, 0, 0.3
+        //    );
+        //}
+
+        //} else {
+        // === BELOW barcode ===
+
+        //$textY = $currentX + $barcodeSize + self::FIELD_MARGIN;
+	foreach ($record->get('fields') as $field) {
+		$value = $field['value'] ?? '';
+            	$lines = str_split($value, 10);
+                foreach ($lines as $line) {
+                    static::writeText(
+                    $pdf, $line,
+                    $pa->x1, $pa->y2 - 12,
+                    'freemono','B', self::FIELD_SIZE,'L',
+                    $usableWidth, self::FIELD_SIZE, false, 0, 0
+                    );
+                    $pa->y2 += 2.30 + self::FIELD_MARGIN;
+                }
+        }
+    }
+}
+

--- a/app/Models/Labels/Tapes/Brother/TZe_62mm_Landscape_B.php
+++ b/app/Models/Labels/Tapes/Brother/TZe_62mm_Landscape_B.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Models\Labels\Tapes\Brother;
+
+use App\Models\Labels\Tapes\Brother\TZe_62mm_Landscape;
+
+class TZe_62mm_Landscape_B extends TZe_62mm_Landscape
+{
+    public function getUnit()
+    {
+        return 'mm';
+    }
+
+    public function getHeight()
+    {
+        return 31.50;
+    }
+
+    public function getSupportAssetTag()
+    {
+        return true;
+    }
+
+    public function getSupport1DBarcode()
+    {
+        return true;
+    }
+
+    public function getSupport2DBarcode()
+    {
+        return true;
+    }
+
+    public function getSupportFields()
+    {
+        return 2;
+    }
+
+    public function getSupportLogo()
+    {
+        return true;
+    }
+
+    public function getSupportTitle()
+    {
+        return true;
+    }
+
+    private const BARCODE1D_HEIGHT = 3.00;
+
+    private const BARCODE1D_MARGIN = 3.00;
+
+    private const BARCODE2D_SIZE = 24.00;
+
+    private const BARCODE2D_MARGIN = 1.50;
+
+    private const TAG_SIZE = 3.00;
+
+    private const LOGO_HEIGHT = 19.00;
+
+    private const LOGO_MARGIN = 1.50;
+
+    private const TITLE_SIZE = 3.00;
+
+    private const TITLE_MARGIN = 0.50;
+
+    private const LABEL_SIZE = 2.00;
+
+    private const LABEL_MARGIN = -0.35;
+
+    private const FIELD_SIZE = 3.00;
+
+    private const FIELD_MARGIN = 0.10;
+
+    public function preparePDF($pdf) {}
+
+    public function write($pdf, $record)
+    {
+        $pa = $this->getPrintableArea();
+
+        $currentX = $pa->x1;
+        $currentY = $pa->y1;
+
+        // Wide 1D barcode on top
+
+        if ($record->has('barcode1d')) {
+            static::write1DBarcode(
+                $pdf, $record->get('barcode1d')->content, $record->get('barcode1d')->type,
+                $currentX, $currentY, $pa->w, self::BARCODE1D_HEIGHT
+            );
+            $currentY = self::BARCODE1D_HEIGHT + self::BARCODE1D_MARGIN;
+        }
+
+        // Left column
+
+        if ($record->has('barcode2d')) {
+            $columnY = $currentY;
+            static::write2DBarcode(
+                $pdf, $record->get('barcode2d')->content, $record->get('barcode2d')->type,
+                $currentX, $columnY,
+                self::BARCODE2D_SIZE, self::BARCODE2D_SIZE
+            );
+            $columnY += self::BARCODE2D_SIZE + self::BARCODE2D_MARGIN;
+            //static::writeText(
+            //    $pdf, $record->get('tag'),
+            //    $currentX, $columnY,
+            //    'freemono', 'b', self::TAG_SIZE, 'C',
+            //    self::BARCODE2D_SIZE, self::TAG_SIZE, true, 0
+            //);
+            $currentX += self::BARCODE2D_SIZE + self::BARCODE2D_MARGIN;
+        }
+
+        // Right column
+        if ($record->get('logo')) {
+            static::writeImage(
+                $pdf, $record->get('logo'),
+                $currentX, $currentY,
+                $pa->w - $currentX, self::LOGO_HEIGHT,
+                'L', 'T', 300, true, false, 0
+            );
+            $currentY += self::LOGO_HEIGHT + self::LOGO_MARGIN;
+        }
+
+        if ($record->has('title')) {
+            static::writeText(
+                $pdf, $record->get('title'),
+                $currentX, $currentY,
+                'freesans', '', self::TITLE_SIZE, 'L',
+                $pa->w - $currentX, self::TITLE_SIZE, true, 0
+            );
+            $currentY += self::TITLE_SIZE + self::TITLE_MARGIN;
+        }
+
+       // foreach ($record->get('fields') as $field) {
+       //     static::writeText(
+       //         $pdf, $field['label'],
+       //         $currentX, $currentY,
+       //         'freesans', '', self::LABEL_SIZE, 'L',
+       //         $pa->w - $currentX, self::LABEL_SIZE, true, 0, 0
+       //     );
+       //     $currentY += self::LABEL_SIZE + self::LABEL_MARGIN;
+
+       //     static::writeText(
+       //         $pdf, $field['value'],
+       //         $currentX, $currentY,
+       //         'freemono', 'B', self::FIELD_SIZE, 'L',
+       //         $pa->w - $currentX, self::FIELD_SIZE, true, 0, 0.3
+       //     );
+       //     $currentY += self::FIELD_SIZE + self::FIELD_MARGIN;
+       // }
+	$currentY = $pa->y1 + 25;
+	$currentX = $pa->x1;
+        foreach ($record->get('fields') as $field) {
+            static::writeText(
+                $pdf, $field['value'],
+                $currentX,$currentY,
+                'freemono','', self::FIELD_SIZE,'L',
+                $pa->w - $currentX, self::FIELD_SIZE, true, 0,0.3
+            );
+            $currentY += self::FIELD_SIZE + 1;
+            
+        }
+    }
+}


### PR DESCRIPTION
Two new brother tape label layout.

Larger 62mm layout formatted for long UUID values length of the label.
Smaller 25mmX36mm with QRCODE and UUID value split on multiple lines for clarity.