### PR TITLE
Added PHP 8.5 to Action tests

### DIFF
--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -28,6 +28,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
 
     name: PHP ${{ matrix.php-version }}
 

--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -24,6 +24,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
 
 
     name: PHP ${{ matrix.php-version }}

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "8.3"
+          - "8.5"
 
     name: PHP ${{ matrix.php-version }}
 


### PR DESCRIPTION
This PR adds PHP 8.5 as a target to run tests against in GitHub Actions for our supported database, mysql.

I added it to Postgres in anticipation of us starting to run tests there.
I also updated sqlite from 8.3 to 8.5. We only run against one version there as a smoke test. 
