### PR TITLE
Mobile OAuth Client Endpoint

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api;
 use Illuminate\Support\Facades\Route;
+use Laravel\Passport\Client;
 
 /*
 |--------------------------------------------------------------------------
@@ -23,6 +24,23 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
                 'message' => '404 endpoint not found. This is the base URL for the API and does not return anything itself. Please check the API reference at https://snipe-it.readme.io/reference to find a valid API endpoint.',
                 'payload' => null,
             ], 404);
+    });
+
+    Route::withoutMiddleware(['api'])->get('/client', function () {
+        $client = Client::firstOrCreate(
+            ['redirect' => 'com.grokability.snipeitmobile://home'],
+            [
+                'name'                   => 'Snipe-IT Mobile App',
+                'user_id'                => null,
+                'secret'                 => '',
+                'personal_access_client' => false,
+                'password_client'        => false,
+                'revoked'                => false,
+            ]);
+
+        return response()->json([
+            'client_id' => $client->id,
+        ]);
     });
 
     /**


### PR DESCRIPTION
This adds an endpoint for ensuring that a mobile client is present with the correct redirect (into the upcoming official mobile app) for OAuth-authentication. From what I can tell and everything I have read, an unprotected endpoint that reveals the OAuth Client ID is not a security concern, we've discussed internally and think this is the correct route. 