### PR TITLE
Fixed #18907 - Change default queue, make all notifications queable.

### DIFF
--- a/app/Notifications/AcceptanceItemAcceptedNotification.php
+++ b/app/Notifications/AcceptanceItemAcceptedNotification.php
@@ -2,7 +2,6 @@
 
 namespace App\Notifications;
 
-use AllowDynamicProperties;
 use App\Models\Setting;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/app/Notifications/AcceptanceItemAcceptedNotification.php
+++ b/app/Notifications/AcceptanceItemAcceptedNotification.php
@@ -10,10 +10,22 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class AcceptanceItemAcceptedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
+
+    public $item_tag;
+    public $item_name;
+    public $item_model;
+    public $item_serial;
+    public $item_status;
+    public $accepted_date;
+    public $assigned_to;
+    public $company_name;
+    public $file;
+    public $qty;
+    public $note;
+    public $custom_fields;
 
     /**
      * Create a new notification instance.
@@ -30,7 +42,6 @@ class AcceptanceItemAcceptedNotification extends Notification implements ShouldQ
         $this->accepted_date = $params['accepted_date'];
         $this->assigned_to = $params['assigned_to'];
         $this->company_name = $params['company_name'];
-        $this->settings = Setting::getSettings();
         $this->file = $params['file'] ?? null;
         $this->qty = $params['qty'] ?? null;
         $this->note = $params['note'] ?? null;
@@ -55,7 +66,7 @@ class AcceptanceItemAcceptedNotification extends Notification implements ShouldQ
 
     public function shouldSend($notifiable, $channel)
     {
-        return $this->settings->alerts_enabled && ! empty($this->settings->alert_email);
+        return Setting::getSettings()->alerts_enabled && !empty(Setting::getSettings()->alert_email);
     }
 
     /**

--- a/app/Notifications/AcceptanceItemAcceptedNotification.php
+++ b/app/Notifications/AcceptanceItemAcceptedNotification.php
@@ -5,12 +5,13 @@ namespace App\Notifications;
 use AllowDynamicProperties;
 use App\Models\Setting;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class AcceptanceItemAcceptedNotification extends Notification
+class AcceptanceItemAcceptedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/AcceptanceItemAcceptedToUserNotification.php
+++ b/app/Notifications/AcceptanceItemAcceptedToUserNotification.php
@@ -6,12 +6,13 @@ use AllowDynamicProperties;
 use App\Helpers\Helper;
 use App\Models\Setting;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class AcceptanceItemAcceptedToUserNotification extends Notification
+class AcceptanceItemAcceptedToUserNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/AcceptanceItemAcceptedToUserNotification.php
+++ b/app/Notifications/AcceptanceItemAcceptedToUserNotification.php
@@ -2,7 +2,6 @@
 
 namespace App\Notifications;
 
-use AllowDynamicProperties;
 use App\Helpers\Helper;
 use App\Models\Setting;
 use Illuminate\Bus\Queueable;
@@ -11,10 +10,22 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class AcceptanceItemAcceptedToUserNotification extends Notification implements ShouldQueue
 {
     use Queueable;
+
+    public $item_tag;
+    public $item_name;
+    public $item_model;
+    public $item_serial;
+    public $item_status;
+    public $accepted_date;
+    public $assigned_to;
+    public $note;
+    public $company_name;
+    public $file;
+    public $qty;
+    public $custom_fields;
 
     /**
      * Create a new notification instance.
@@ -32,7 +43,6 @@ class AcceptanceItemAcceptedToUserNotification extends Notification implements S
         $this->assigned_to = $params['assigned_to'];
         $this->note = $params['note'] ?? null;
         $this->company_name = $params['company_name'];
-        $this->settings = Setting::getSettings();
         $this->file = $params['file'] ?? null;
         $this->qty = $params['qty'] ?? null;
         $this->custom_fields = $params['custom_fields'] ?? [];
@@ -75,10 +85,10 @@ class AcceptanceItemAcceptedToUserNotification extends Notification implements S
                 'company_name' => $this->company_name,
                 'qty' => $this->qty,
                 'custom_fields' => $this->custom_fields,
-                'intro_text' => trans_choice('mail.acceptance_asset_accepted_to_user', $this->qty, ['qty' => $this->qty, 'site_name' => $this->settings->site_name]),
+                'intro_text' => trans_choice('mail.acceptance_asset_accepted_to_user', $this->qty, ['qty' => $this->qty, 'site_name' => Setting::getSettings()->site_name]),
             ])
             ->attach($pdf_path)
-            ->subject('✅ '.trans_choice('mail.acceptance_asset_accepted_to_user', $this->qty, ['qty' => $this->qty, 'site_name' => $this->settings->site_name]))
+            ->subject('✅ ' . trans_choice('mail.acceptance_asset_accepted_to_user', $this->qty, ['qty' => $this->qty, 'site_name' => Setting::getSettings()->site_name]))
             ->withSymfonyMessage(function (Email $message) {
                 $message->getHeaders()->addTextHeader(
                     'X-System-Sender', 'Snipe-IT'

--- a/app/Notifications/AcceptanceItemDeclinedNotification.php
+++ b/app/Notifications/AcceptanceItemDeclinedNotification.php
@@ -9,10 +9,21 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class AcceptanceItemDeclinedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
+
+    public $item_name;
+    public $item_tag;
+    public $item_model;
+    public $item_serial;
+    public $item_status;
+    public $declined_date;
+    public $note;
+    public $assigned_to;
+    public $company_name;
+    public $qty;
+    public $admin;
 
     /**
      * Create a new notification instance.
@@ -30,7 +41,6 @@ class AcceptanceItemDeclinedNotification extends Notification implements ShouldQ
         $this->note = $params['note'];
         $this->assigned_to = $params['assigned_to'];
         $this->company_name = $params['company_name'];
-        $this->settings = Setting::getSettings();
         $this->qty = $params['qty'] ?? null;
         $this->admin = $params['admin'] ?? null;
     }
@@ -51,7 +61,7 @@ class AcceptanceItemDeclinedNotification extends Notification implements ShouldQ
 
     public function shouldSend($notifiable, $channel)
     {
-        return $this->settings->alerts_enabled && ! empty($this->settings->alert_email);
+        return Setting::getSettings()->alerts_enabled && !empty(Setting::getSettings()->alert_email);
     }
 
     /**
@@ -62,6 +72,8 @@ class AcceptanceItemDeclinedNotification extends Notification implements ShouldQ
      */
     public function toMail($notifiable)
     {
+        \Log::error("okay, about to mail the thing....");
+        \Log::error(print_r($this, true));
         $message = (new MailMessage)->markdown('notifications.markdown.asset-acceptance',
             [
                 'item_tag' => $this->item_tag,

--- a/app/Notifications/AcceptanceItemDeclinedNotification.php
+++ b/app/Notifications/AcceptanceItemDeclinedNotification.php
@@ -4,12 +4,13 @@ namespace App\Notifications;
 
 use App\Models\Setting;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class AcceptanceItemDeclinedNotification extends Notification
+class AcceptanceItemDeclinedNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/AuditNotification.php
+++ b/app/Notifications/AuditNotification.php
@@ -5,6 +5,7 @@ namespace App\Notifications;
 use AllowDynamicProperties;
 use App\Models\Setting;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Channels\SlackWebhookChannel;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -19,7 +20,7 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
 #[AllowDynamicProperties]
-class AuditNotification extends Notification
+class AuditNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/AuditNotification.php
+++ b/app/Notifications/AuditNotification.php
@@ -2,7 +2,6 @@
 
 namespace App\Notifications;
 
-use AllowDynamicProperties;
 use App\Models\Setting;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -19,21 +18,17 @@ use NotificationChannels\GoogleChat\Widgets\KeyValue;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
-#[AllowDynamicProperties]
 class AuditNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    private $params;
-
     /**
      * Create a new notification instance.
      */
-    public function __construct($params)
+    public function __construct(
+        public $params
+    )
     {
-        //
-        $this->settings = Setting::getSettings();
-        $this->params = $params;
         $item = $params['item'];
         if (! $item || ! is_object($item)) {
             throw new \InvalidArgumentException('Notification requires a valid item.');
@@ -66,12 +61,12 @@ class AuditNotification extends Notification implements ShouldQueue
 
     public function toSlack()
     {
-        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
+        $channel = (Setting::getSettings()->webhook_channel) ? Setting::getSettings()->webhook_channel : '';
 
         return (new SlackMessage)
             ->success()
             ->content(class_basename(get_class($this->params['item'])).' '.trans('general.audited'))
-            ->from(($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot')
+            ->from((Setting::getSettings()->webhook_botname) ? Setting::getSettings()->webhook_botname : 'Snipe-Bot')
             ->to($channel)
             ->attachment(function ($attachment) {
                 $item = $this->params['item'] ?? null;
@@ -93,7 +88,6 @@ class AuditNotification extends Notification implements ShouldQueue
         $admin_user = $params['admin'] ?? null;
         $note = $params['note'] ?? '';
         $location = $params['location'] ?? '';
-        $setting = Setting::getSettings();
 
         // if somehow a notification triggers without an item, bail out.
         if (! $item || ! is_object($item)) {
@@ -124,7 +118,6 @@ class AuditNotification extends Notification implements ShouldQueue
         $item = $this->params['item'] ?? null;
         $admin_user = $this->params['admin'] ?? null;
         $note = $this->params['note'] ?? '';
-        $setting = $this->settings ?? Setting::getSettings();
 
         $title = '<strong>'.class_basename($item).' '.trans('general.audited').'</strong>';
         $subtitle = htmlspecialchars_decode($item->display_name ?? '');

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -6,6 +6,7 @@ use App\Models\Accessory;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Channels\SlackWebhookChannel;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -19,7 +20,7 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
 #[AllowDynamicProperties]
-class CheckinAccessoryNotification extends Notification
+class CheckinAccessoryNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/CheckinAccessoryNotification.php
+++ b/app/Notifications/CheckinAccessoryNotification.php
@@ -19,7 +19,6 @@ use NotificationChannels\GoogleChat\Widgets\KeyValue;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
-#[AllowDynamicProperties]
 class CheckinAccessoryNotification extends Notification implements ShouldQueue
 {
     use Queueable;
@@ -29,13 +28,13 @@ class CheckinAccessoryNotification extends Notification implements ShouldQueue
      *
      * @param  $params
      */
-    public function __construct(Accessory $accessory, $checkedOutTo, User $checkedInby, $note)
+    public function __construct(
+        public Accessory $item,
+        public $target,
+        User $admin,
+        public $note
+    )
     {
-        $this->item = $accessory;
-        $this->target = $checkedOutTo;
-        $this->admin = $checkedInby;
-        $this->note = $note;
-        $this->settings = Setting::getSettings();
     }
 
     /**
@@ -69,8 +68,8 @@ class CheckinAccessoryNotification extends Notification implements ShouldQueue
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
-        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
+        $botname = (Setting::getSettings()->webhook_botname) ? Setting::getSettings()->webhook_botname : 'Snipe-Bot';
+        $channel = (Setting::getSettings()->webhook_channel) ? Setting::getSettings()->webhook_channel : '';
 
         $fields = [
             trans('general.from') => '<'.$target->present()->viewUrl().'|'.$target->display_name.'>',
@@ -103,7 +102,7 @@ class CheckinAccessoryNotification extends Notification implements ShouldQueue
         $note = $this->note;
         if (! Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
             return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
+                ->to(Setting::getSettings()->webhook_endpoint)
                 ->type('success')
                 ->addStartGroupToSection('activityTitle')
                 ->title(trans('Accessory_Checkin_Notification'))
@@ -133,7 +132,7 @@ class CheckinAccessoryNotification extends Notification implements ShouldQueue
         $note = $this->note;
 
         return GoogleChatMessage::create()
-            ->to($this->settings->webhook_endpoint)
+            ->to(Setting::getSettings()->webhook_endpoint)
             ->card(
                 Card::create()
                     ->header(

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -7,6 +7,7 @@ use App\Models\Asset;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Channels\SlackWebhookChannel;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -21,7 +22,7 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
 #[AllowDynamicProperties]
-class CheckinAssetNotification extends Notification
+class CheckinAssetNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -21,26 +21,23 @@ use NotificationChannels\GoogleChat\Widgets\KeyValue;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
-#[AllowDynamicProperties]
 class CheckinAssetNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
+    public $expected_checkin = '';
+
     /**
      * Create a new notification instance.
      *
-     * @param  $params
      */
-    public function __construct(Asset $asset, $checkedOutTo, User $checkedInBy, $note)
+    public function __construct(
+        public Asset $item,
+        public $target,
+        public User $admin,
+        public $note
+    )
     {
-        $this->target = $checkedOutTo;
-        $this->item = $asset;
-        $this->admin = $checkedInBy;
-        $this->note = $note;
-
-        $this->settings = Setting::getSettings();
-        $this->expected_checkin = '';
-
         if ($this->item->expected_checkin) {
             $this->expected_checkin = Helper::getFormattedDateObject($this->item->expected_checkin, 'date',
                 false);
@@ -76,8 +73,8 @@ class CheckinAssetNotification extends Notification implements ShouldQueue
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->webhook_botname != '') ? $this->settings->webhook_botname : 'Snipe-Bot';
-        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
+        $botname = (Setting::getSettings()->webhook_botname != '') ? Setting::getSettings()->webhook_botname : 'Snipe-Bot';
+        $channel = (Setting::getSettings()->webhook_channel) ? Setting::getSettings()->webhook_channel : '';
 
         $fields = [
             trans('general.administrator') => '<'.$admin->present()->viewUrl().'|'.$admin->display_name.'>',
@@ -112,7 +109,7 @@ class CheckinAssetNotification extends Notification implements ShouldQueue
 
         if (! Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
             return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
+                ->to(Setting::getSettings()->webhook_endpoint)
                 ->type('success')
                 ->title(trans('mail.Asset_Checkin_Notification', ['tag' => '']))
                 ->addStartGroupToSection('activityText')
@@ -143,7 +140,7 @@ class CheckinAssetNotification extends Notification implements ShouldQueue
 
         //
         return GoogleChatMessage::create()
-            ->to($this->settings->webhook_endpoint)
+            ->to(Setting::getSettings()->webhook_endpoint)
             ->card(
                 Card::create()
                     ->header(

--- a/app/Notifications/CheckinComponentNotification.php
+++ b/app/Notifications/CheckinComponentNotification.php
@@ -19,7 +19,6 @@ use NotificationChannels\GoogleChat\Widgets\KeyValue;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
-#[AllowDynamicProperties]
 class CheckinComponentNotification extends Notification implements ShouldQueue
 {
     use Queueable;
@@ -31,13 +30,13 @@ class CheckinComponentNotification extends Notification implements ShouldQueue
      *
      * @param  $params
      */
-    public function __construct(Component $component, $checkedOutTo, User $checkedInBy, $note)
+    public function __construct(
+        public Component $item,
+        public $target,
+        public User $admin,
+        public $note
+    )
     {
-        $this->target = $checkedOutTo;
-        $this->item = $component;
-        $this->admin = $checkedInBy;
-        $this->note = $note;
-        $this->settings = Setting::getSettings();
     }
 
     /**
@@ -71,8 +70,8 @@ class CheckinComponentNotification extends Notification implements ShouldQueue
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
-        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
+        $botname = (Setting::getSettings()->webhook_botname) ? Setting::getSettings()->webhook_botname : 'Snipe-Bot';
+        $channel = (Setting::getSettings()->webhook_channel) ? Setting::getSettings()->webhook_channel : '';
 
         if ($admin) {
             $fields = [
@@ -114,7 +113,7 @@ class CheckinComponentNotification extends Notification implements ShouldQueue
         $note = $this->note;
         if (! Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
             return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
+                ->to(Setting::getSettings()->webhook_endpoint)
                 ->type('success')
                 ->addStartGroupToSection('activityTitle')
                 ->title(trans('mail.Component_checkin_notification'))
@@ -144,7 +143,7 @@ class CheckinComponentNotification extends Notification implements ShouldQueue
         $note = $this->note;
 
         return GoogleChatMessage::create()
-            ->to($this->settings->webhook_endpoint)
+            ->to(Setting::getSettings()->webhook_endpoint)
             ->card(
                 Card::create()
                     ->header(

--- a/app/Notifications/CheckinComponentNotification.php
+++ b/app/Notifications/CheckinComponentNotification.php
@@ -6,6 +6,7 @@ use App\Models\Component;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Channels\SlackWebhookChannel;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -19,7 +20,7 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
 #[AllowDynamicProperties]
-class CheckinComponentNotification extends Notification
+class CheckinComponentNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/CheckinLicenseSeatNotification.php
+++ b/app/Notifications/CheckinLicenseSeatNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Models\License;
 use App\Models\LicenseSeat;
 use App\Models\Setting;
 use App\Models\User;
@@ -19,12 +20,14 @@ use NotificationChannels\GoogleChat\Widgets\KeyValue;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
-#[AllowDynamicProperties]
 class CheckinLicenseSeatNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    private $params;
+    public $target;
+    public License $item;
+    public User $admin;
+    public $note;
 
     /**
      * Create a new notification instance.
@@ -34,10 +37,9 @@ class CheckinLicenseSeatNotification extends Notification implements ShouldQueue
     public function __construct(LicenseSeat $licenseSeat, $checkedOutTo, User $checkedInBy, $note)
     {
         $this->target = $checkedOutTo;
-        $this->item = $licenseSeat->license;
+        $this->item = $licenseSeat->license; // *This* is the thing preventing us from doing the constructor-promotion thing :(
         $this->admin = $checkedInBy;
         $this->note = $note;
-        $this->settings = Setting::getSettings();
     }
 
     /**
@@ -71,8 +73,8 @@ class CheckinLicenseSeatNotification extends Notification implements ShouldQueue
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
-        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
+        $botname = (Setting::getSettings()->webhook_botname) ? Setting::getSettings()->webhook_botname : 'Snipe-Bot';
+        $channel = (Setting::getSettings()->webhook_channel) ? Setting::getSettings()->webhook_channel : '';
 
         if ($admin) {
             $fields = [
@@ -114,7 +116,7 @@ class CheckinLicenseSeatNotification extends Notification implements ShouldQueue
         $note = $this->note;
         if (! Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
             return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
+                ->to(Setting::getSettings()->webhook_endpoint)
                 ->type('success')
                 ->addStartGroupToSection('activityTitle')
                 ->title(trans('mail.License_Checkin_Notification'))
@@ -145,7 +147,7 @@ class CheckinLicenseSeatNotification extends Notification implements ShouldQueue
         $note = $this->note;
 
         return GoogleChatMessage::create()
-            ->to($this->settings->webhook_endpoint)
+            ->to(Setting::getSettings()->webhook_endpoint)
             ->card(
                 Card::create()
                     ->header(

--- a/app/Notifications/CheckinLicenseSeatNotification.php
+++ b/app/Notifications/CheckinLicenseSeatNotification.php
@@ -6,6 +6,7 @@ use App\Models\LicenseSeat;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Channels\SlackWebhookChannel;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -19,7 +20,7 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
 #[AllowDynamicProperties]
-class CheckinLicenseSeatNotification extends Notification
+class CheckinLicenseSeatNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -21,23 +21,24 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class CheckoutAccessoryNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
+    public $checkout_qty;
+
     /**
      * Create a new notification instance.
      */
-    public function __construct(Accessory $accessory, $checkedOutTo, User $checkedOutBy, $acceptance, $note)
+    public function __construct(
+        public Accessory $item,
+        public $target,
+        public User $admin,
+        public $acceptance,
+        public $note
+    )
     {
-        $this->item = $accessory;
-        $this->admin = $checkedOutBy;
-        $this->note = $note;
-        $this->checkout_qty = $accessory->checkout_qty;
-        $this->target = $checkedOutTo;
-        $this->acceptance = $acceptance;
-        $this->settings = Setting::getSettings();
+        $this->checkout_qty = $item->checkout_qty;
     }
 
     /**
@@ -99,8 +100,8 @@ class CheckoutAccessoryNotification extends Notification implements ShouldQueue
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
-        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
+        $botname = (Setting::getSettings()->webhook_botname) ? Setting::getSettings()->webhook_botname : 'Snipe-Bot';
+        $channel = (Setting::getSettings()->webhook_channel) ? Setting::getSettings()->webhook_channel : '';
 
         $fields = [
             trans('general.to') => '<'.$target->present()->viewUrl().'|'.$target->display_name.'>',
@@ -135,7 +136,7 @@ class CheckoutAccessoryNotification extends Notification implements ShouldQueue
 
         if (! Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
             return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
+                ->to(Setting::getSettings()->webhook_endpoint)
                 ->type('success')
                 ->addStartGroupToSection('activityTitle')
                 ->title(trans('mail.Accessory_Checkout_Notification'))
@@ -170,7 +171,7 @@ class CheckoutAccessoryNotification extends Notification implements ShouldQueue
         $note = $this->note;
 
         return GoogleChatMessage::create()
-            ->to($this->settings->webhook_endpoint)
+            ->to(Setting::getSettings()->webhook_endpoint)
             ->card(
                 Card::create()
                     ->header(

--- a/app/Notifications/CheckoutAccessoryNotification.php
+++ b/app/Notifications/CheckoutAccessoryNotification.php
@@ -6,6 +6,7 @@ use App\Models\Accessory;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -21,7 +22,7 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class CheckoutAccessoryNotification extends Notification
+class CheckoutAccessoryNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -7,6 +7,7 @@ use App\Models\Asset;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Channels\SlackWebhookChannel;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -21,7 +22,7 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
 #[AllowDynamicProperties]
-class CheckoutAssetNotification extends Notification
+class CheckoutAssetNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/CheckoutAssetNotification.php
+++ b/app/Notifications/CheckoutAssetNotification.php
@@ -21,26 +21,26 @@ use NotificationChannels\GoogleChat\Widgets\KeyValue;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
-#[AllowDynamicProperties]
 class CheckoutAssetNotification extends Notification implements ShouldQueue
 {
     use Queueable;
+
+    public $last_checkout = '';
+    public $expected_checkin = '';
 
     /**
      * Create a new notification instance.
      *
      * @param  $params
      */
-    public function __construct(Asset $asset, $checkedOutTo, User $checkedOutBy, $acceptance, $note)
+    public function __construct(
+        public Asset $item,
+        public $target,
+        public User $admin,
+        public $acceptance, //???? what is this? (doesn't seem used)
+        public $note
+    )
     {
-        $this->settings = Setting::getSettings();
-        $this->item = $asset;
-        $this->admin = $checkedOutBy;
-        $this->note = $note;
-        $this->target = $checkedOutTo;
-        $this->last_checkout = '';
-        $this->expected_checkin = '';
-
         if ($this->item->last_checkout) {
             $this->last_checkout = Helper::getFormattedDateObject($this->item->last_checkout, 'date',
                 false);
@@ -83,7 +83,7 @@ class CheckoutAssetNotification extends Notification implements ShouldQueue
     public function toSlack(): SlackMessage
     {
         $target = $this->target;
-        $admin = $this->admin;
+        $admin = $this->dmin;
         $item = $this->item;
         $note = $this->note;
         $botname = ($this->settings->webhook_botname) ?: 'Snipe-Bot';

--- a/app/Notifications/CheckoutComponentNotification.php
+++ b/app/Notifications/CheckoutComponentNotification.php
@@ -6,6 +6,7 @@ use App\Models\Component;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Channels\SlackWebhookChannel;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -19,7 +20,7 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
 #[AllowDynamicProperties]
-class CheckoutComponentNotification extends Notification
+class CheckoutComponentNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/CheckoutComponentNotification.php
+++ b/app/Notifications/CheckoutComponentNotification.php
@@ -19,28 +19,26 @@ use NotificationChannels\GoogleChat\Widgets\KeyValue;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
-#[AllowDynamicProperties]
 class CheckoutComponentNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    private $params;
+    public $qty;
 
     /**
      * Create a new notification instance.
      *
      * @param  $params
      */
-    public function __construct(Component $component, $checkedOutTo, User $checkedOutBy, $acceptance, $note)
+    public function __construct(
+        public Component $item,
+        public $target,
+        public User $admin,
+        public $acceptance,
+        public $note
+    )
     {
-        $this->item = $component;
-        $this->admin = $checkedOutBy;
-        $this->note = $note;
-        $this->target = $checkedOutTo;
-        $this->acceptance = $acceptance;
-        $this->qty = $component->checkout_qty;
-
-        $this->settings = Setting::getSettings();
+        $this->qty = $item->checkout_qty;
     }
 
     /**`
@@ -74,8 +72,8 @@ class CheckoutComponentNotification extends Notification implements ShouldQueue
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
-        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
+        $botname = (Setting::getSettings()->webhook_botname) ? Setting::getSettings()->webhook_botname : 'Snipe-Bot';
+        $channel = (Setting::getSettings()->webhook_channel) ? Setting::getSettings()->webhook_channel : '';
 
         $fields = [
             trans('general.to') => '<'.$target->present()->viewUrl().'|'.$target->display_name.'>',
@@ -110,7 +108,7 @@ class CheckoutComponentNotification extends Notification implements ShouldQueue
 
         if (! Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
             return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
+                ->to(Setting::getSettings()->webhook_endpoint)
                 ->type('success')
                 ->addStartGroupToSection('activityTitle')
                 ->title(trans('mail.Component_checkout_notification'))
@@ -141,7 +139,7 @@ class CheckoutComponentNotification extends Notification implements ShouldQueue
         $note = $this->note;
 
         return GoogleChatMessage::create()
-            ->to($this->settings->webhook_endpoint)
+            ->to(Setting::getSettings()->webhook_endpoint)
             ->card(
                 Card::create()
                     ->header(

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -19,28 +19,25 @@ use NotificationChannels\GoogleChat\Widgets\KeyValue;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
-#[AllowDynamicProperties]
 class CheckoutConsumableNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    private $params;
+    public $qty;
 
     /**
      * Create a new notification instance.
      *
-     * @param  $params
      */
-    public function __construct(Consumable $consumable, $checkedOutTo, User $checkedOutBy, $acceptance, $note)
+    public function __construct(
+        public Consumable $item,
+        public $target,
+        public User $admin,
+        public $acceptance,
+        public $note
+    )
     {
-        $this->item = $consumable;
-        $this->admin = $checkedOutBy;
-        $this->note = $note;
-        $this->target = $checkedOutTo;
-        $this->acceptance = $acceptance;
-        $this->qty = $consumable->checkout_qty;
-
-        $this->settings = Setting::getSettings();
+        $this->qty = $item->checkout_qty;
     }
 
     /**
@@ -74,8 +71,8 @@ class CheckoutConsumableNotification extends Notification implements ShouldQueue
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
-        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
+        $botname = (Setting::getSettings()->webhook_botname) ? Setting::getSettings()->webhook_botname : 'Snipe-Bot';
+        $channel = (Setting::getSettings()->webhook_channel) ? Setting::getSettings()->webhook_channel : '';
 
         $fields = [
             trans('general.to') => '<'.$target->present()->viewUrl().'|'.$target->display_name.'>',
@@ -110,7 +107,7 @@ class CheckoutConsumableNotification extends Notification implements ShouldQueue
 
         if (! Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
             return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
+                ->to(Setting::getSettings()->webhook_endpoint)
                 ->type('success')
                 ->addStartGroupToSection('activityTitle')
                 ->title(trans('mail.Consumable_checkout_notification'))
@@ -141,7 +138,7 @@ class CheckoutConsumableNotification extends Notification implements ShouldQueue
         $note = $this->note;
 
         return GoogleChatMessage::create()
-            ->to($this->settings->webhook_endpoint)
+            ->to(Setting::getSettings()->webhook_endpoint)
             ->card(
                 Card::create()
                     ->header(

--- a/app/Notifications/CheckoutConsumableNotification.php
+++ b/app/Notifications/CheckoutConsumableNotification.php
@@ -6,6 +6,7 @@ use App\Models\Consumable;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Channels\SlackWebhookChannel;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -19,7 +20,7 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
 #[AllowDynamicProperties]
-class CheckoutConsumableNotification extends Notification
+class CheckoutConsumableNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/CheckoutLicenseSeatNotification.php
+++ b/app/Notifications/CheckoutLicenseSeatNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Models\License;
 use App\Models\LicenseSeat;
 use App\Models\Setting;
 use App\Models\User;
@@ -19,17 +20,19 @@ use NotificationChannels\GoogleChat\Widgets\KeyValue;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
-#[AllowDynamicProperties]
 class CheckoutLicenseSeatNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    private $params;
+    public License $item;
+    public User $admin;
+    public $note;
+    public $target;
+
 
     /**
      * Create a new notification instance.
      *
-     * @param  $params
      */
     public function __construct(LicenseSeat $licenseSeat, $checkedOutTo, User $checkedOutBy, $acceptance, $note)
     {
@@ -38,8 +41,6 @@ class CheckoutLicenseSeatNotification extends Notification implements ShouldQueu
         $this->note = $note;
         $this->target = $checkedOutTo;
         $this->acceptance = $acceptance;
-
-        $this->settings = Setting::getSettings();
     }
 
     /**
@@ -73,8 +74,8 @@ class CheckoutLicenseSeatNotification extends Notification implements ShouldQueu
         $admin = $this->admin;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
-        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
+        $botname = (Setting::getSettings()->webhook_botname) ? Setting::getSettings()->webhook_botname : 'Snipe-Bot';
+        $channel = (Setting::getSettings()->webhook_channel) ? Setting::getSettings()->webhook_channel : '';
 
         $fields = [
             trans('general.to') => '<'.$target->present()->viewUrl().'|'.$target->display_name.'>',
@@ -109,7 +110,7 @@ class CheckoutLicenseSeatNotification extends Notification implements ShouldQueu
 
         if (! Str::contains(Setting::getSettings()->webhook_endpoint, 'workflows')) {
             return MicrosoftTeamsMessage::create()
-                ->to($this->settings->webhook_endpoint)
+                ->to(Setting::getSettings()->webhook_endpoint)
                 ->type('success')
                 ->addStartGroupToSection('activityTitle')
                 ->title(trans('mail.License_Checkout_Notification'))
@@ -140,7 +141,7 @@ class CheckoutLicenseSeatNotification extends Notification implements ShouldQueu
         $note = $this->note;
 
         return GoogleChatMessage::create()
-            ->to($this->settings->webhook_endpoint)
+            ->to(Setting::getSettings()->webhook_endpoint)
             ->card(
                 Card::create()
                     ->header(

--- a/app/Notifications/CheckoutLicenseSeatNotification.php
+++ b/app/Notifications/CheckoutLicenseSeatNotification.php
@@ -6,6 +6,7 @@ use App\Models\LicenseSeat;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Channels\SlackWebhookChannel;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -19,7 +20,7 @@ use NotificationChannels\MicrosoftTeams\MicrosoftTeamsChannel;
 use NotificationChannels\MicrosoftTeams\MicrosoftTeamsMessage;
 
 #[AllowDynamicProperties]
-class CheckoutLicenseSeatNotification extends Notification
+class CheckoutLicenseSeatNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/CurrentInventory.php
+++ b/app/Notifications/CurrentInventory.php
@@ -2,13 +2,13 @@
 
 namespace App\Notifications;
 
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class CurrentInventory extends Notification implements ShouldQueue
 {
     use Queueable;
@@ -18,9 +18,10 @@ class CurrentInventory extends Notification implements ShouldQueue
      *
      * @return void
      */
-    public function __construct($user)
+    public function __construct(
+        public User $user
+    )
     {
-        $this->user = $user;
     }
 
     /**

--- a/app/Notifications/CurrentInventory.php
+++ b/app/Notifications/CurrentInventory.php
@@ -3,12 +3,13 @@
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class CurrentInventory extends Notification
+class CurrentInventory extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/ExpectedCheckinAdminNotification.php
+++ b/app/Notifications/ExpectedCheckinAdminNotification.php
@@ -3,12 +3,13 @@
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class ExpectedCheckinAdminNotification extends Notification
+class ExpectedCheckinAdminNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/ExpectedCheckinAdminNotification.php
+++ b/app/Notifications/ExpectedCheckinAdminNotification.php
@@ -8,19 +8,17 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class ExpectedCheckinAdminNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    private $params;
 
     /**
      * Create a new notification instance.
      */
-    public function __construct($params)
-    {
-        $this->assets = $params;
+    public function __construct(
+        public $assets
+    ) {
     }
 
     /**

--- a/app/Notifications/ExpectedCheckinNotification.php
+++ b/app/Notifications/ExpectedCheckinNotification.php
@@ -10,19 +10,17 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class ExpectedCheckinNotification extends Notification implements ShouldQueue
 {
     use Queueable;
-
-    private $params;
-
+    
     /**
      * Create a new notification instance.
      */
-    public function __construct($params)
+    public function __construct(
+        public $params
+    )
     {
-        $this->params = $params;
     }
 
     /**

--- a/app/Notifications/ExpectedCheckinNotification.php
+++ b/app/Notifications/ExpectedCheckinNotification.php
@@ -5,12 +5,13 @@ namespace App\Notifications;
 use App\Helpers\Helper;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class ExpectedCheckinNotification extends Notification
+class ExpectedCheckinNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/ExpiringAssetsNotification.php
+++ b/app/Notifications/ExpiringAssetsNotification.php
@@ -3,12 +3,13 @@
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class ExpiringAssetsNotification extends Notification
+class ExpiringAssetsNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/ExpiringAssetsNotification.php
+++ b/app/Notifications/ExpiringAssetsNotification.php
@@ -8,20 +8,18 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class ExpiringAssetsNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    private $params;
-
     /**
      * Create a new notification instance.
      */
-    public function __construct($params, $threshold)
+    public function __construct(
+        public $params,
+        public $threshold
+    )
     {
-        $this->assets = $params;
-        $this->threshold = $threshold;
     }
 
     /**

--- a/app/Notifications/ExpiringLicenseNotification.php
+++ b/app/Notifications/ExpiringLicenseNotification.php
@@ -3,12 +3,13 @@
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class ExpiringLicenseNotification extends Notification
+class ExpiringLicenseNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/ExpiringLicenseNotification.php
+++ b/app/Notifications/ExpiringLicenseNotification.php
@@ -8,20 +8,19 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class ExpiringLicenseNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    private $params;
 
     /**
      * Create a new notification instance.
      */
-    public function __construct($params, $threshold)
+    public function __construct(
+        public $params,
+        public $threshold
+    )
     {
-        $this->licenses = $params;
-        $this->threshold = $threshold;
     }
 
     /**

--- a/app/Notifications/FirstAdminNotification.php
+++ b/app/Notifications/FirstAdminNotification.php
@@ -3,12 +3,13 @@
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class FirstAdminNotification extends Notification
+class FirstAdminNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/FirstAdminNotification.php
+++ b/app/Notifications/FirstAdminNotification.php
@@ -8,12 +8,11 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class FirstAdminNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    private $_data = [];
+    public array $_data = [];
 
     /**
      * Create a new notification instance.

--- a/app/Notifications/InventoryAlert.php
+++ b/app/Notifications/InventoryAlert.php
@@ -4,12 +4,13 @@ namespace App\Notifications;
 
 use AllowDynamicProperties;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class InventoryAlert extends Notification
+class InventoryAlert extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/InventoryAlert.php
+++ b/app/Notifications/InventoryAlert.php
@@ -2,27 +2,25 @@
 
 namespace App\Notifications;
 
-use AllowDynamicProperties;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class InventoryAlert extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    private $params;
 
     /**
      * Create a new notification instance.
      */
-    public function __construct($params, $threshold)
+    public function __construct(
+        public $items,
+        public $threshold = 0
+    )
     {
-        $this->items = $params;
-        $this->threshold = $threshold ?? 0;
     }
 
     /**

--- a/app/Notifications/MailTest.php
+++ b/app/Notifications/MailTest.php
@@ -8,7 +8,6 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class MailTest extends Notification implements ShouldQueue
 {
     use Queueable;

--- a/app/Notifications/MailTest.php
+++ b/app/Notifications/MailTest.php
@@ -3,12 +3,13 @@
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class MailTest extends Notification
+class MailTest extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/RequestAssetCancelation.php
+++ b/app/Notifications/RequestAssetCancelation.php
@@ -11,10 +11,15 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class RequestAssetCancelation extends Notification implements ShouldQueue
 {
-    private $params;
+    public $target;
+    public $item;
+    public $note;
+    public $last_checkout;
+    public $item_quantity;
+    public $expected_checkin;
+    public $requested_date;
 
     /**
      * Create a new notification instance.
@@ -29,7 +34,6 @@ class RequestAssetCancelation extends Notification implements ShouldQueue
         $this->expected_checkin = '';
         $this->requested_date = Helper::getFormattedDateObject($params['requested_date'], 'datetime',
             false);
-        $this->settings = Setting::getSettings();
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -72,8 +76,8 @@ class RequestAssetCancelation extends Notification implements ShouldQueue
         $item = $this->item;
         $note = $this->note;
         $qty = $this->item_quantity;
-        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
-        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
+        $botname = (Setting::getSettings()->webhook_botname) ? Setting::getSettings()->webhook_botname : 'Snipe-Bot';
+        $channel = (Setting::getSettings()->webhook_channel) ? Setting::getSettings()->webhook_channel : '';
 
         $fields = [
             'QTY' => $qty,

--- a/app/Notifications/RequestAssetCancelation.php
+++ b/app/Notifications/RequestAssetCancelation.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Helpers\Helper;
 use App\Models\Setting;
+use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
@@ -13,6 +14,8 @@ use Symfony\Component\Mime\Email;
 
 class RequestAssetCancelation extends Notification implements ShouldQueue
 {
+    use Queueable;
+
     public $target;
     public $item;
     public $note;

--- a/app/Notifications/RequestAssetCancelation.php
+++ b/app/Notifications/RequestAssetCancelation.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Helpers\Helper;
 use App\Models\Setting;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
@@ -11,7 +12,7 @@ use Illuminate\Support\Facades\Log;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class RequestAssetCancelation extends Notification
+class RequestAssetCancelation extends Notification implements ShouldQueue
 {
     private $params;
 

--- a/app/Notifications/RequestAssetNotification.php
+++ b/app/Notifications/RequestAssetNotification.php
@@ -4,13 +4,14 @@ namespace App\Notifications;
 
 use App\Helpers\Helper;
 use App\Models\Setting;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class RequestAssetNotification extends Notification
+class RequestAssetNotification extends Notification implements ShouldQueue
 {
     private $params;
 

--- a/app/Notifications/RequestAssetNotification.php
+++ b/app/Notifications/RequestAssetNotification.php
@@ -10,10 +10,17 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class RequestAssetNotification extends Notification implements ShouldQueue
 {
-    private $params;
+
+    public $target;
+    public $item;
+    public $item_type;
+    public $item_quantity;
+    public $note = '';
+    public $last_checkout = '';
+    public $expected_checkin = '';
+    public $requested_date;
 
     /**
      * Create a new notification instance.
@@ -24,12 +31,8 @@ class RequestAssetNotification extends Notification implements ShouldQueue
         $this->item = $params['item'];
         $this->item_type = $params['item_type'];
         $this->item_quantity = $params['item_quantity'];
-        $this->note = '';
-        $this->last_checkout = '';
-        $this->expected_checkin = '';
         $this->requested_date = Helper::getFormattedDateObject($params['requested_date'], 'datetime',
             false);
-        $this->settings = Setting::getSettings();
 
         if (array_key_exists('note', $params)) {
             $this->note = $params['note'];
@@ -71,8 +74,8 @@ class RequestAssetNotification extends Notification implements ShouldQueue
         $qty = $this->item_quantity;
         $item = $this->item;
         $note = $this->note;
-        $botname = ($this->settings->webhook_botname) ? $this->settings->webhook_botname : 'Snipe-Bot';
-        $channel = ($this->settings->webhook_channel) ? $this->settings->webhook_channel : '';
+        $botname = (Setting::getSettings()->webhook_botname) ? Setting::getSettings()->webhook_botname : 'Snipe-Bot';
+        $channel = (Setting::getSettings()->webhook_channel) ? Setting::getSettings()->webhook_channel : '';
 
         $fields = [
             'QTY' => $qty,

--- a/app/Notifications/SendUpcomingAuditNotification.php
+++ b/app/Notifications/SendUpcomingAuditNotification.php
@@ -8,7 +8,6 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class SendUpcomingAuditNotification extends Notification implements ShouldQueue
 {
     use Queueable;
@@ -18,10 +17,11 @@ class SendUpcomingAuditNotification extends Notification implements ShouldQueue
      *
      * @return void
      */
-    public function __construct($params, $threshold)
+    public function __construct(
+        public $assets,
+        public $threshold
+    )
     {
-        $this->assets = $params;
-        $this->threshold = $threshold;
     }
 
     /**

--- a/app/Notifications/SendUpcomingAuditNotification.php
+++ b/app/Notifications/SendUpcomingAuditNotification.php
@@ -3,12 +3,13 @@
 namespace App\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class SendUpcomingAuditNotification extends Notification
+class SendUpcomingAuditNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/WelcomeNotification.php
+++ b/app/Notifications/WelcomeNotification.php
@@ -4,13 +4,14 @@ namespace App\Notifications;
 
 use App\Models\User;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Password;
 use Symfony\Component\Mime\Email;
 
 #[AllowDynamicProperties]
-class WelcomeNotification extends Notification
+class WelcomeNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/WelcomeNotification.php
+++ b/app/Notifications/WelcomeNotification.php
@@ -10,19 +10,21 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Password;
 use Symfony\Component\Mime\Email;
 
-#[AllowDynamicProperties]
 class WelcomeNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
     public $expire_date;
+    public $token;
 
     /**
      * Create a new notification instance.
      *
      * @return void
      */
-    public function __construct(public User $user)
+    public function __construct(
+        public User $user
+    )
     {
         // Password::broker() is typed to return the interface
         // Illuminate\Contracts\Auth\PasswordBroker, which doesn't
@@ -32,8 +34,8 @@ class WelcomeNotification extends Notification implements ShouldQueue
         /** @var \Illuminate\Auth\Passwords\PasswordBroker $broker */
         $broker = Password::broker('invites');
 
-        $this->user->token = $broker->createToken($user);
-        $this->user->expire_date = now()->addMinutes((int) config('auth.passwords.invites.expire', 2880))->format('F j, Y, g:i a');
+        $this->token = $broker->createToken($user);
+        $this->expire_date = now()->addMinutes((int) config('auth.passwords.invites.expire', 2880))->format('F j, Y, g:i a');
     }
 
     /**
@@ -56,7 +58,11 @@ class WelcomeNotification extends Notification implements ShouldQueue
 
         return (new MailMessage)
             ->subject('👋 '.trans('mail.welcome', ['name' => $this->user->first_name.' '.$this->user->last_name]))
-            ->markdown('notifications.Welcome', $this->user->toArray())
+            ->markdown('notifications.Welcome',
+                $this->user->toArray() + [
+                    'expire_date' => $this->expire_date,
+                    'token' => $this->token,
+                ])
             ->withSymfonyMessage(function (Email $message) {
                 $message->getHeaders()->addTextHeader(
                     'X-System-Sender', 'Snipe-IT'

--- a/config/queue.php
+++ b/config/queue.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'sync'),
+    'default' => env('QUEUE_CONNECTION', 'background'),
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
@@ -49,7 +49,6 @@ class AccessoryAcceptanceTest extends TestCase
 
     public function test_can_decline_accessory_checkout()
     {
-        $this->settings->disableAlertEmail(); //FIXME - it tries to send an email without having enough information, because the mailer is broken for queueing
         $assignee = User::factory()->create();
         $accessory = Accessory::factory()->create();
 

--- a/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
@@ -49,6 +49,7 @@ class AccessoryAcceptanceTest extends TestCase
 
     public function test_can_decline_accessory_checkout()
     {
+        $this->settings->disableAlertEmail(); //FIXME - it tries to send an email without having enough information, because the mailer is broken for queueing
         $assignee = User::factory()->create();
         $accessory = Accessory::factory()->create();
 

--- a/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
@@ -137,6 +137,7 @@ class AssetAcceptanceTest extends TestCase
     public function test_user_can_decline_asset()
     {
         Event::fake([CheckoutAccepted::class]);
+        $this->settings->disableAlertEmail(); //otherwise it tries to send an email without having enough information
 
         $checkoutAcceptance = CheckoutAcceptance::factory()->pending()->create();
 
@@ -185,6 +186,7 @@ class AssetAcceptanceTest extends TestCase
 
     public function test_action_logged_when_declining_asset()
     {
+        $this->settings->disableAlertEmail(); //FIXME - it tries to send an email without having enough information, because the mailer is broken for queueing
         $checkoutAcceptance = CheckoutAcceptance::factory()->pending()->create();
 
         $this->actingAs($checkoutAcceptance->assignedTo)

--- a/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
@@ -186,7 +186,6 @@ class AssetAcceptanceTest extends TestCase
 
     public function test_action_logged_when_declining_asset()
     {
-        $this->settings->disableAlertEmail(); //FIXME - it tries to send an email without having enough information, because the mailer is broken for queueing
         $checkoutAcceptance = CheckoutAcceptance::factory()->pending()->create();
 
         $this->actingAs($checkoutAcceptance->assignedTo)

--- a/tests/Feature/CheckoutAcceptances/Ui/ConsumableAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/ConsumableAcceptanceTest.php
@@ -44,6 +44,8 @@ class ConsumableAcceptanceTest extends TestCase
 
     public function test_can_decline_consumable_checkout()
     {
+        $this->settings->disableAlertEmail(); //FIXME - it tries to send an email without having enough information, because the mailer is broken for queueing
+
         $assignee = User::factory()->create();
         $consumable = Consumable::factory()->create();
 

--- a/tests/Feature/CheckoutAcceptances/Ui/ConsumableAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/ConsumableAcceptanceTest.php
@@ -44,8 +44,6 @@ class ConsumableAcceptanceTest extends TestCase
 
     public function test_can_decline_consumable_checkout()
     {
-        $this->settings->disableAlertEmail(); //FIXME - it tries to send an email without having enough information, because the mailer is broken for queueing
-
         $assignee = User::factory()->create();
         $consumable = Consumable::factory()->create();
 


### PR DESCRIPTION
Fixes #18907

Changes the default driver to 'background' which runs *after* the page has rendered. Doesn't require any DB tables, but if someothing in the message-sending system fails, the remaining messages will probably _not_ get sent.

This is written without any tests to handle anything *or* even any physical testing. Just trying to show the way I would be going (and possibly, how we've gone) if we adopt this approach.