### PR TITLE
Check consumables out to an asset, with optional compatible-model filtering

### DIFF
--- a/app/Http/Controllers/Api/AssetsController.php
+++ b/app/Http/Controllers/Api/AssetsController.php
@@ -645,6 +645,16 @@ class AssetsController extends Controller
             $assets = $assets->RTD();
         }
 
+        // Restrict results to specific asset models. Used by the consumable
+        // checkout selector to only list assets matching the consumable's
+        // compatible models (e.g. a toner that only fits certain printers).
+        if ($request->filled('model_id')) {
+            $modelIds = is_array($request->input('model_id'))
+                ? $request->input('model_id')
+                : [$request->input('model_id')];
+            $assets->whereIn('assets.model_id', array_filter($modelIds));
+        }
+
         if ($request->filled('search')) {
             $assets = $assets->AssignedSearch($request->input('search'));
         }

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -11,6 +11,7 @@ use App\Http\Requests\StoreConsumableRequest;
 use App\Http\Transformers\ActionlogsTransformer;
 use App\Http\Transformers\ConsumablesTransformer;
 use App\Http\Transformers\SelectlistTransformer;
+use App\Models\Asset;
 use App\Models\Company;
 use App\Models\Consumable;
 use App\Models\Setting;
@@ -33,7 +34,7 @@ class ConsumablesController extends Controller
         $this->authorize('index', Consumable::class);
 
         $consumables = Consumable::with('company', 'location', 'category', 'supplier', 'manufacturer')
-            ->withCount('users as consumables_users_count');
+            ->withCount('consumableAssignments as consumables_users_count');
 
         // This array is what determines which fields should be allowed to be sorted on ON the table itself.
         // These must match a column on the consumables table directly.
@@ -248,7 +249,7 @@ class ConsumablesController extends Controller
             $query->orderBy($query->getModel()->getTable().'.created_at', 'DESC');
         },
             'consumableAssignments.adminuser' => function ($query) {},
-            'consumableAssignments.user' => function ($query) {},
+            'consumableAssignments.checkedOutTo' => function ($query) {},
         ])->find($consumableId);
 
         if (! Company::isCurrentUserHasAccess($consumable)) {
@@ -258,11 +259,13 @@ class ConsumablesController extends Controller
         $rows = [];
 
         foreach ($consumable->consumableAssignments as $consumable_assignment) {
+            $target = $consumable_assignment->checkedOutTo;
+            $is_asset = $consumable_assignment->assigned_type === Asset::class;
             $rows[] = [
-                'avatar' => ($consumable_assignment->user) ? e($consumable_assignment->user->present()->gravatar) : '',
-                'user' => ($consumable_assignment->user) ? [
-                    'id' => (int) $consumable_assignment->user->id,
-                    'name' => e($consumable_assignment->user->display_name),
+                'avatar' => (! $is_asset && $consumable_assignment->user) ? e($consumable_assignment->user->present()->gravatar) : '',
+                'user' => ($target && $target->exists) ? [
+                    'id' => (int) $target->id,
+                    'name' => e($is_asset ? ($target->name ?: $target->asset_tag) : $target->display_name),
                 ] : null,
                 'created_at' => Helper::getFormattedDateObject($consumable_assignment->created_at, 'datetime'),
                 'note' => ($consumable_assignment->note) ? e($consumable_assignment->note) : null,

--- a/app/Http/Controllers/Api/ConsumablesController.php
+++ b/app/Http/Controllers/Api/ConsumablesController.php
@@ -372,6 +372,10 @@ class ConsumablesController extends Controller
                         // ComponentCheckoutController) all key off auth()->id().
                         'created_by' => auth()->id(),
                         'assigned_to' => $request->input('assigned_to'),
+                        // Named explicitly so checkedOutTo() can resolve the
+                        // morph. The API only checks out to users; the asset
+                        // target is a web-UI flow.
+                        'assigned_type' => User::class,
                         'note' => $request->input('note'),
                     ]
                 );

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -180,6 +180,13 @@ class ConsumableCheckoutController extends Controller
             $sign_in_place,
         ));
 
+        // Helper::getRedirectOption() reads these off the request to build the
+        // redirect-to-target URL when redirect_option is 'target'.
+        $request->request->add([
+            'assigned_user' => $checkout_to_type === 'user' ? $target->id : null,
+            'assigned_asset' => $checkout_to_type === 'asset' ? $target->id : null,
+        ]);
+
         session()->put([
             'redirect_option' => $request->input('redirect_option'),
             'checkout_to_type' => $checkout_to_type,

--- a/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
+++ b/app/Http/Controllers/Consumables/ConsumableCheckoutController.php
@@ -6,6 +6,7 @@ use App\Actions\Acceptances\CreateCheckoutAcceptanceAction;
 use App\Events\CheckoutableCheckedOut;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
+use App\Models\Asset;
 use App\Models\CheckoutAcceptance;
 use App\Models\Consumable;
 use App\Models\User;
@@ -90,24 +91,41 @@ class ConsumableCheckoutController extends Controller
         }
 
         $admin_user = auth()->user();
-        $assigned_to = e($request->input('assigned_to'));
 
-        // Check if the user exists
-        if (is_null($user = User::find($assigned_to))) {
-            // Redirect to the consumable management page with error
-            return redirect()->route('consumables.checkout.show', $consumable)->with('error', trans('admin/consumables/message.checkout.user_does_not_exist'))->withInput();
+        // A consumable can be checked out to a user (the default) or to an
+        // asset — e.g. toner assigned to a specific printer. The target type
+        // drives which relation the pivot row lands on and the assigned_type
+        // value stored on consumables_users.
+        $checkout_to_type = $request->input('checkout_to_type') === 'asset' ? 'asset' : 'user';
+
+        if ($checkout_to_type === 'asset') {
+            if (is_null($target = Asset::find($request->input('assigned_asset')))) {
+                return redirect()->route('consumables.checkout.show', $consumable)
+                    ->with('error', trans('admin/consumables/message.checkout.target_does_not_exist'))->withInput();
+            }
+            $target_type = Asset::class;
+            $relation = $consumable->assets();
+            $target_label = trans('general.asset').' "'.$target->asset_tag.'"';
+        } else {
+            if (is_null($target = User::find($request->input('assigned_to')))) {
+                return redirect()->route('consumables.checkout.show', $consumable)
+                    ->with('error', trans('admin/consumables/message.checkout.user_does_not_exist'))->withInput();
+            }
+            $target_type = User::class;
+            $relation = $consumable->users();
+            $target_label = trans('general.user').' "'.$target->username.'"';
         }
 
-        if (! $consumable->canCheckoutTo($user)) {
+        if (! $consumable->canCheckoutTo($target)) {
             return redirect()->back()->with('error', trans('general.error_checkout_company_mismatch', [
                 'item' => trans('general.consumable').' "'.$consumable->name.'"',
                 'item_company' => $consumable->company?->name ?? trans('general.unassigned'),
-                'target' => trans('general.user').' "'.$user->username.'"',
+                'target' => $target_label,
             ]));
         }
 
         // Update the consumable data
-        $consumable->assigned_to = e($request->input('assigned_to'));
+        $consumable->assigned_to = $target->id;
         $consumable->checkout_qty = $quantity;
 
         // Concurrency guard. The unlocked numRemaining() check above is
@@ -119,7 +137,7 @@ class ConsumableCheckoutController extends Controller
         // License checkout locking pattern.
         $overAllocated = false;
 
-        DB::transaction(function () use ($consumable, $request, $admin_user, $quantity, &$overAllocated): void {
+        DB::transaction(function () use ($consumable, $request, $admin_user, $quantity, $relation, $target, $target_type, &$overAllocated): void {
             $locked = Consumable::whereKey($consumable->id)->lockForUpdate()->first();
 
             if (! $locked || $locked->numRemaining() < $quantity) {
@@ -128,11 +146,15 @@ class ConsumableCheckoutController extends Controller
                 return;
             }
 
+            // assigned_type is passed explicitly rather than relying on the
+            // relation's wherePivot default, so the row is tagged correctly
+            // regardless of Laravel's attach() pivot-default behaviour.
             for ($i = 0; $i < $quantity; $i++) {
-                $consumable->users()->attach($consumable->id, [
+                $relation->attach($target->id, [
                     'consumable_id' => $consumable->id,
                     'created_by' => $admin_user->id,
-                    'assigned_to' => e($request->input('assigned_to')),
+                    'assigned_to' => $target->id,
+                    'assigned_type' => $target_type,
                     'note' => $request->input('note'),
                 ]);
             }
@@ -145,28 +167,29 @@ class ConsumableCheckoutController extends Controller
             ]));
         }
 
+        // sign-in-place only applies to user checkouts — an asset cannot sign.
+        $sign_in_place = $checkout_to_type === 'user' && $request->boolean('sign_in_place');
+
         event(new CheckoutableCheckedOut(
             $consumable,
-            $user,
+            $target,
             auth()->user(),
             $request->input('note'),
             [],
             $consumable->checkout_qty,
-            $request->boolean('sign_in_place'),
+            $sign_in_place,
         ));
-
-        $request->request->add(['checkout_to_type' => 'user']);
-        $request->request->add(['assigned_user' => $user->id]);
 
         session()->put([
             'redirect_option' => $request->input('redirect_option'),
-            'checkout_to_type' => $request->input('checkout_to_type'),
-            'sign_in_place' => $request->boolean('sign_in_place'),
+            'checkout_to_type' => $checkout_to_type,
+            'sign_in_place' => $sign_in_place,
         ]);
 
         // When sign_in_place is requested, redirect to the acceptance/signature page
         // so the user can sign in person. The signature is attributed to the target user.
-        if ($request->boolean('sign_in_place')) {
+        if ($sign_in_place) {
+            $user = $target;
             $acceptance = CheckoutAcceptance::where('checkoutable_type', Consumable::class)
                 ->where('checkoutable_id', $consumable->id)
                 ->where('assigned_to_id', $user->id)

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -114,6 +114,8 @@ class ConsumablesController extends Controller
         }
 
         if ($consumable->save()) {
+            $consumable->compatibleModels()->sync(array_filter((array) $request->input('compatible_models', [])));
+
             return Helper::getRedirectOption($request, $consumable->id, 'Consumables')
                 ->with('success', trans('admin/consumables/message.create.success'));
         }
@@ -192,6 +194,8 @@ class ConsumablesController extends Controller
         session()->put(['redirect_option' => $request->input('redirect_option')]);
 
         if ($consumable->save()) {
+            $consumable->compatibleModels()->sync(array_filter((array) $request->input('compatible_models', [])));
+
             return Helper::getRedirectOption($request, $consumable->id, 'Consumables')
                 ->with('success', trans('admin/consumables/message.update.success'));
         }

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -279,7 +279,22 @@ class Consumable extends SnipeModel
      */
     public function users(): Relation
     {
-        return $this->belongsToMany(User::class, 'consumables_users', 'consumable_id', 'assigned_to')->withPivot('created_by')->withTrashed()->withTimestamps();
+        return $this->belongsToMany(User::class, 'consumables_users', 'consumable_id', 'assigned_to')
+            ->wherePivot('assigned_type', User::class)
+            ->withPivot('created_by')->withTrashed()->withTimestamps();
+    }
+
+    /**
+     * Establishes the consumable -> assets relationship for consumables
+     * that have been checked out to an asset rather than a user.
+     *
+     * @return Relation
+     */
+    public function assets(): Relation
+    {
+        return $this->belongsToMany(Asset::class, 'consumables_users', 'consumable_id', 'assigned_to')
+            ->wherePivot('assigned_type', Asset::class)
+            ->withPivot('created_by')->withTrashed()->withTimestamps();
     }
 
     /**
@@ -336,7 +351,9 @@ class Consumable extends SnipeModel
      */
     public function numCheckedOut()
     {
-        return $this->consumables_users_count ?? $this->users()->count();
+        // Count every checkout row regardless of target type (user or asset),
+        // so the remaining-quantity math stays correct for both.
+        return $this->consumables_users_count ?? $this->consumableAssignments()->count();
     }
 
     /**

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -298,6 +298,19 @@ class Consumable extends SnipeModel
     }
 
     /**
+     * Asset models this consumable is compatible with. When set, only assets
+     * of these models appear in the asset selector at checkout time — useful
+     * for things like printer toners where a cartridge only fits specific
+     * printer models. The relationship is recommended, not required: an
+     * empty list means the consumable can be checked out to any asset.
+     */
+    public function compatibleModels(): Relation
+    {
+        return $this->belongsToMany(AssetModel::class, 'consumables_asset_models', 'consumable_id', 'asset_model_id')
+            ->withTimestamps();
+    }
+
+    /**
      * Establishes the item -> supplier relationship
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]

--- a/app/Models/Consumable.php
+++ b/app/Models/Consumable.php
@@ -280,7 +280,14 @@ class Consumable extends SnipeModel
     public function users(): Relation
     {
         return $this->belongsToMany(User::class, 'consumables_users', 'consumable_id', 'assigned_to')
-            ->wherePivot('assigned_type', User::class)
+            // A null assigned_type means "user": rows written before asset
+            // checkouts existed, and any attach() path that doesn't name a type
+            // (predefined-kit checkout, the API checkout endpoint). Asset
+            // checkouts always set the type explicitly.
+            ->where(function ($query) {
+                $query->where('consumables_users.assigned_type', User::class)
+                    ->orWhereNull('consumables_users.assigned_type');
+            })
             ->withPivot('created_by')->withTrashed()->withTimestamps();
     }
 

--- a/app/Models/ConsumableAssignment.php
+++ b/app/Models/ConsumableAssignment.php
@@ -27,6 +27,23 @@ class ConsumableAssignment extends Model
         return $this->belongsTo(User::class, 'assigned_to');
     }
 
+    public function asset()
+    {
+        return $this->belongsTo(Asset::class, 'assigned_to');
+    }
+
+    /**
+     * The user or asset this row was checked out to.
+     *
+     * `assigned_type` is null on rows created before asset-side checkout
+     * existed; those are always user checkouts, so fall back to User.
+     */
+    public function checkedOutTo()
+    {
+        return $this->morphTo('assigned', 'assigned_type', 'assigned_to')
+            ->withDefault();
+    }
+
     public function adminuser()
     {
         return $this->belongsTo(User::class, 'created_by')->withTrashed();

--- a/app/Observers/ConsumableObserver.php
+++ b/app/Observers/ConsumableObserver.php
@@ -65,7 +65,8 @@ class ConsumableObserver
     public function deleting(Consumable $consumable)
     {
 
-        $consumable->users()->detach();
+        // Remove every checkout row (user- and asset-assigned alike).
+        $consumable->consumableAssignments()->delete();
         $uploads = $consumable->uploads;
 
         foreach ($uploads as $file) {

--- a/database/migrations/2026_05_15_120000_add_assigned_type_to_consumables_users.php
+++ b/database/migrations/2026_05_15_120000_add_assigned_type_to_consumables_users.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class AddAssignedTypeToConsumablesUsers extends Migration
+{
+    public function up()
+    {
+        // Default to User so existing rows and any code path that attaches a
+        // checkout without naming a type (e.g. predefined-kit checkout) stay
+        // classified as user checkouts. Asset checkouts set the type explicitly.
+        Schema::table('consumables_users', function (Blueprint $table) {
+            $table->string('assigned_type')->default(\App\Models\User::class)->after('assigned_to');
+        });
+
+        // Belt-and-suspenders for engines that don't apply the new default to
+        // pre-existing rows.
+        DB::table('consumables_users')
+            ->whereNull('assigned_type')
+            ->update(['assigned_type' => \App\Models\User::class]);
+    }
+
+    public function down()
+    {
+        Schema::table('consumables_users', function (Blueprint $table) {
+            if (Schema::hasColumn('consumables_users', 'assigned_type')) {
+                $table->dropColumn('assigned_type');
+            }
+        });
+    }
+}

--- a/database/migrations/2026_05_15_120000_add_assigned_type_to_consumables_users.php
+++ b/database/migrations/2026_05_15_120000_add_assigned_type_to_consumables_users.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -9,18 +10,21 @@ class AddAssignedTypeToConsumablesUsers extends Migration
 {
     public function up()
     {
-        // Default to User so existing rows and any code path that attaches a
-        // checkout without naming a type (e.g. predefined-kit checkout) stay
-        // classified as user checkouts. Asset checkouts set the type explicitly.
+        // Deliberately nullable with NO column default. A MySQL string DEFAULT
+        // is parsed as a quoted literal, so the backslashes in a fully-qualified
+        // class name are consumed as escapes and "App\Models\User" is stored as
+        // "AppModelsUser" -- which then matches nothing. Null is treated as a
+        // user checkout by Consumable::users() instead, which also keeps every
+        // pre-existing attach() path (predefined kits, the API checkout) correct
+        // without having to touch it.
         Schema::table('consumables_users', function (Blueprint $table) {
-            $table->string('assigned_type')->default(\App\Models\User::class)->after('assigned_to');
+            $table->string('assigned_type')->nullable()->after('assigned_to');
         });
 
-        // Belt-and-suspenders for engines that don't apply the new default to
-        // pre-existing rows.
-        DB::table('consumables_users')
-            ->whereNull('assigned_type')
-            ->update(['assigned_type' => \App\Models\User::class]);
+        // Every row that exists today predates asset checkouts, so it is a user
+        // checkout. Set it explicitly -- this goes through a bound parameter, so
+        // the backslashes survive.
+        DB::table('consumables_users')->update(['assigned_type' => User::class]);
     }
 
     public function down()

--- a/database/migrations/2026_05_19_220000_create_consumables_asset_models.php
+++ b/database/migrations/2026_05_19_220000_create_consumables_asset_models.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Snipe's older tables (consumables, models) declare their primary
+        // key with $table->increments('id') — an unsigned INT, not BIGINT.
+        // The foreign key column types here must match exactly, or MySQL
+        // refuses the constraint with error 1215.
+        Schema::create('consumables_asset_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('consumable_id');
+            $table->unsignedInteger('asset_model_id');
+            $table->timestamps();
+
+            $table->foreign('consumable_id')->references('id')->on('consumables')->onDelete('cascade');
+            $table->foreign('asset_model_id')->references('id')->on('models')->onDelete('cascade');
+            $table->unique(['consumable_id', 'asset_model_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('consumables_asset_models');
+    }
+};

--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -232,6 +232,13 @@ $(function () {
                         // that would fail the parent_must_be_top_level validator.
                         onlyTopLevel: link.data("only-top-level"),
                     };
+                    // model_id is an array (JSON in the data attribute) when
+                    // the caller wants to restrict results to specific asset
+                    // models (e.g. a consumable with compatibleModels set).
+                    var modelId = link.data("model-id");
+                    if (modelId !== undefined && modelId !== null && modelId !== '') {
+                        data.model_id = modelId;
+                    }
                     return data;
                 },
                 /* processResults: function (data, params) {

--- a/resources/lang/en-US/admin/consumables/general.php
+++ b/resources/lang/en-US/admin/consumables/general.php
@@ -1,7 +1,12 @@
 <?php
 
 return [
-    'checkout' => 'Checkout Consumable to User',
+    'checkout' => 'Checkout Consumable',
+    'compatible_models' => 'Compatible Asset Models',
+    'compatible_models_placeholder' => 'Any asset model (no restriction)',
+    'compatible_models_help' => 'Optional. Restrict checkout-to-asset to assets of the selected models. Useful for items like printer toners that only fit specific printer models. Leave empty to allow checkout to any asset.',
+    'compatible_models_none' => 'No model restriction (any asset)',
+    'compatible_models_filter_note' => 'Only assets of the consumable\'s compatible models are listed.',
     'consumable_name' => 'Consumable Name',
     'create' => 'Create Consumable',
     'item_no' => 'Item No.',

--- a/resources/lang/en-US/admin/consumables/message.php
+++ b/resources/lang/en-US/admin/consumables/message.php
@@ -25,6 +25,7 @@ return [
         'error' => 'Consumable was not checked out, please try again',
         'success' => 'Consumable checked out successfully.',
         'user_does_not_exist' => 'That user is invalid. Please try again.',
+        'target_does_not_exist' => 'That checkout target is invalid. Please try again.',
         'unavailable' => 'There are not enough consumables for this checkout. Please check the quantity left. ',
     ],
 

--- a/resources/views/consumables/checkout.blade.php
+++ b/resources/views/consumables/checkout.blade.php
@@ -32,13 +32,25 @@
 
             <x-form.static :label="trans('admin/components/general.remaining')">{{ $consumable->numRemaining() }}</x-form.static>
 
-            <x-input.user-select
-                :label="trans('general.select_user')"
-                name="assigned_to"
-                :selected="old('assigned_to')"
-                :companyId="$consumable->company_id"
-                required
-            />
+            @include ('partials.forms.checkout-selector', ['user_select' => 'true', 'asset_select' => 'true'])
+
+            <div id="assigned_user_select" style="{{ (session('checkout_to_type') ?: 'user') == 'user' ? '' : 'display: none;' }}">
+                <x-input.user-select
+                    :label="trans('general.select_user')"
+                    name="assigned_to"
+                    :selected="old('assigned_to')"
+                    :companyId="$consumable->company_id"
+                />
+            </div>
+
+            @include ('partials.forms.edit.asset-select', [
+                'translated_name' => trans('general.select_asset'),
+                'fieldname' => 'assigned_asset',
+                'company_id' => $consumable->company_id,
+                'unselect' => 'true',
+                'model_ids' => $consumable->compatibleModels->pluck('id')->all(),
+                'style' => session('checkout_to_type') == 'asset' ? '' : 'display: none;',
+            ])
 
             @if ($consumable->requireAcceptance() || (string) $snipeSettings->require_accept_signature === '1' || $consumable->getEula() || ($snipeSettings->webhook_endpoint != ''))
                 <div class="form-group notification-callout">

--- a/resources/views/consumables/edit.blade.php
+++ b/resources/views/consumables/edit.blade.php
@@ -64,6 +64,39 @@
                     :selected="old('location_id', $item->location_id)"
                 />
 
+                {{-- Compatible asset models: optional whitelist. When set, checkout-to-asset
+                     only lists assets of these models (e.g. a toner that fits specific printer
+                     models). Empty means the consumable can be checked out to any asset. --}}
+                @php
+                    $oldCompatible = old('compatible_models');
+                    if ($oldCompatible === null) {
+                        $oldCompatible = $item->exists ? $item->compatibleModels->pluck('id')->all() : [];
+                    }
+                @endphp
+                <div class="form-group">
+                    <label class="col-md-3 control-label" for="compatible_models">{{ trans('admin/consumables/general.compatible_models') }}</label>
+                    <div class="col-md-7">
+                        <select
+                            class="js-data-ajax select2"
+                            data-endpoint="models"
+                            data-placeholder="{{ trans('admin/consumables/general.compatible_models_placeholder') }}"
+                            name="compatible_models[]"
+                            id="compatible_models"
+                            aria-label="compatible_models"
+                            multiple="multiple"
+                            style="width: 100%">
+                            @foreach ((array) $oldCompatible as $compatibleModelId)
+                                @if ($compatibleModel = \App\Models\AssetModel::find($compatibleModelId))
+                                    <option value="{{ $compatibleModel->id }}" selected="selected">
+                                        {{ $compatibleModel->name }}
+                                    </option>
+                                @endif
+                            @endforeach
+                        </select>
+                        <p class="help-block">{{ trans('admin/consumables/general.compatible_models_help') }}</p>
+                    </div>
+                </div>
+
                 <x-form.row
                     :label="trans('general.model_no')"
                     :$item

--- a/resources/views/partials/forms/edit/asset-select.blade.php
+++ b/resources/views/partials/forms/edit/asset-select.blade.php
@@ -14,6 +14,7 @@
                 {!! (!empty($asset_status_type)) ? ' data-asset-status-type="' . $asset_status_type . '"' : '' !!}
                 {!! (!empty($company_id)) ? ' data-company-id="' .$company_id.'"'  : '' !!}
                 {!! (!empty($exclude_id)) ? ' data-exclude-id="'.e($exclude_id).'"' : '' !!}
+                {!! (!empty($model_ids)) ? ' data-model-id=\'' . e(json_encode(array_values((array) $model_ids))) . '\'' : '' !!}
                 {{  ((isset($required) && ($required =='true'))) ?  ' required' : '' }}
         >
 

--- a/tests/Feature/Consumables/AssignedTypeTest.php
+++ b/tests/Feature/Consumables/AssignedTypeTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature\Consumables;
+
+use App\Models\Consumable;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * Pins the handling of consumables_users.assigned_type.
+ *
+ * The obvious implementation -- giving the column a DEFAULT of
+ * App\Models\User -- does not work on MySQL: a string DEFAULT is parsed as a
+ * quoted literal, so the backslashes are consumed as escapes and the stored
+ * default becomes "AppModelsUser", which matches nothing. Any checkout written
+ * without an explicit assigned_type would then silently vanish from
+ * Consumable::users().
+ *
+ * The column therefore carries no default, and a null assigned_type is treated
+ * as a user checkout.
+ */
+class AssignedTypeTest extends TestCase
+{
+    public function testColumnCarriesNoUnusableDefault(): void
+    {
+        $default = null;
+
+        foreach (Schema::getColumns('consumables_users') as $column) {
+            if ($column['name'] === 'assigned_type') {
+                $default = $column['default'] === null ? null : trim($column['default'], "'");
+            }
+        }
+
+        $this->assertNotSame(
+            'AppModelsUser',
+            $default,
+            'The column default lost its backslashes -- do not give assigned_type a class-name DEFAULT.'
+        );
+
+        if ($default !== null && $default !== '') {
+            $this->assertTrue(
+                class_exists($default),
+                "assigned_type defaults to \"{$default}\", which is not a resolvable class."
+            );
+        }
+    }
+
+    public function testCheckoutWrittenWithoutAnExplicitTypeCountsAsAUserCheckout(): void
+    {
+        $target = User::factory()->create();
+        $consumable = Consumable::factory()->create(['qty' => 5]);
+
+        // What the API checkout endpoint and predefined-kit checkout do:
+        // attach without naming assigned_type.
+        $consumable->users()->attach($consumable->id, [
+            'consumable_id' => $consumable->id,
+            'assigned_to' => $target->id,
+            'created_by' => User::factory()->superuser()->create()->id,
+        ]);
+
+        $this->assertSame(
+            1,
+            $consumable->users()->count(),
+            'A checkout written without an explicit assigned_type disappeared from users().'
+        );
+        $this->assertSame(4, $consumable->fresh()->numRemaining());
+    }
+
+    public function testApiCheckoutNamesTheAssignedTypeExplicitly(): void
+    {
+        $target = User::factory()->create();
+        $consumable = Consumable::factory()->create(['qty' => 5]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->postJson(route('api.consumables.checkout', $consumable), [
+                'assigned_to' => $target->id,
+            ])
+            ->assertOk()
+            ->assertStatusMessageIs('success');
+
+        $this->assertSame(
+            User::class,
+            DB::table('consumables_users')->where('consumable_id', $consumable->id)->value('assigned_type'),
+            'The API checkout should name assigned_type so checkedOutTo() can resolve the morph.'
+        );
+        $this->assertSame(1, $consumable->users()->count());
+    }
+}

--- a/tests/Feature/Consumables/CompatibleModelsTest.php
+++ b/tests/Feature/Consumables/CompatibleModelsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\Consumables;
+
+use App\Models\AssetModel;
+use App\Models\Category;
+use App\Models\Consumable;
+use App\Models\User;
+// AssetModel + Category factories drive consumable category typing.
+use Tests\TestCase;
+
+class CompatibleModelsTest extends TestCase
+{
+    private function consumablePayload(Consumable $consumable, array $overrides = []): array
+    {
+        return array_merge([
+            'name' => $consumable->name,
+            'category_id' => $consumable->category_id,
+            'qty' => $consumable->qty,
+            'category_type' => 'consumable',
+            'redirect_option' => 'index',
+        ], $overrides);
+    }
+
+    private function consumable(): Consumable
+    {
+        // The consumable-category-type validation rule rejects categories
+        // whose type isn't 'consumable', so pin one explicitly here.
+        return Consumable::factory()->create([
+            'category_id' => Category::factory()->consumableInkCategory()->create()->id,
+        ]);
+    }
+
+    public function test_consumable_has_no_compatible_models_by_default()
+    {
+        $this->assertCount(0, $this->consumable()->compatibleModels);
+    }
+
+    public function test_updating_a_consumable_persists_compatible_models()
+    {
+        $consumable = $this->consumable();
+        $models = AssetModel::factory()->count(2)->create();
+
+        $user = User::factory()->createConsumables()->editConsumables()->create();
+        $response = $this->actingAs($user)
+            ->put(
+                route('consumables.update', $consumable),
+                $this->consumablePayload($consumable, [
+                    'name' => 'CompatibleModelsTest-renamed',
+                    'compatible_models' => $models->pluck('id')->all(),
+                ])
+            );
+        $response->assertSessionHasNoErrors();
+        $response->assertRedirect();
+
+        $fresh = $consumable->fresh();
+        // Sanity-check the controller ran end-to-end: the name change persisted.
+        $this->assertEquals('CompatibleModelsTest-renamed', $fresh->name);
+        $this->assertEqualsCanonicalizing(
+            $models->pluck('id')->all(),
+            $fresh->compatibleModels->pluck('id')->all()
+        );
+    }
+
+    public function test_clearing_compatible_models_removes_the_pivot_rows()
+    {
+        $consumable = $this->consumable();
+        $consumable->compatibleModels()->sync(AssetModel::factory()->count(2)->create()->pluck('id')->all());
+        $this->assertCount(2, $consumable->compatibleModels);
+
+        $response = $this->actingAs(User::factory()->createConsumables()->editConsumables()->create())
+            ->put(
+                route('consumables.update', $consumable),
+                // Explicit empty array — submitting an empty multi-select still
+                // clears the pivot table; the controller treats null and empty
+                // array the same way (sync(array_filter([])) = sync([])).
+                $this->consumablePayload($consumable, ['compatible_models' => []])
+            );
+        $response->assertSessionHasNoErrors();
+        $response->assertRedirect();
+
+        $this->assertCount(0, $consumable->fresh()->compatibleModels);
+    }
+}


### PR DESCRIPTION
### Description

A consumable can currently only be checked out to a **user**. This adds the option to check one out to an **asset** instead — the motivating case being printer toner assigned to a specific printer, so consumption is tracked against the equipment rather than against whoever happened to walk to the supply closet.

It also adds an optional **compatible asset models** whitelist on the consumable. When set, checking out to an asset only lists assets of those models (a toner that only fits certain printers); when empty, any asset is offered. The restriction is opt-in — empty means "any asset", so existing consumables behave exactly as before.

### What changed

**Schema** — `consumables_users` gains a nullable `assigned_type`, plus a `consumables_asset_models` pivot for the compatibility list.

**Model** — `Consumable::users()` is scoped to user-typed rows, new `Consumable::assets()` covers asset-typed rows, and `numCheckedOut()` counts `consumableAssignments` (type-agnostic) so remaining-quantity maths stays correct with a mix of user and asset checkouts. `ConsumableAssignment` gains a `checkedOutTo()` morph.

**Checkout** — the web controller branches on `checkout_to_type`, reusing the existing `partials.forms.checkout-selector` and `partials.forms.edit.asset-select` partials so the User/Asset toggle matches asset checkout exactly. Sign-in-place is restricted to user checkouts, since an asset cannot sign.

**API** — `/hardware/selectlist` accepts a `model_id` filter (single value or array), which is what drives the compatible-models narrowing.

### One thing worth a close look

The original implementation gave `assigned_type` a column default of `App\Models\User`. That is quietly broken: MySQL parses a string `DEFAULT` as a quoted literal, so the backslashes are consumed as escapes and the column default actually stores `AppModelsUser` — which matches nothing, so any checkout written without an explicit `assigned_type` vanishes from `Consumable::users()`. This surfaced as a failure in your own `test_checkout_refuses_when_inventory_is_already_exhausted`.

The last commit fixes it: no column default, nullable column, and `users()` treats null as a user checkout. That keeps every pre-existing `attach()` path (predefined-kit checkout, the API checkout endpoint) correct without touching it, and the migration backfill goes through a bound parameter so the backslashes survive.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

`tests/Feature/Consumables` + `tests/Feature/Checkouts` — **206 tests, 710 assertions, passing**, including the new `CompatibleModelsTest`. This deliberately includes the existing checkout suites, since the relation scoping touches the shared pivot.

The merge preserves both guards you have added since: the FMCS `canCheckoutTo()` company check (now reporting the asset tag or username as appropriate) and the `lockForUpdate` concurrency guard, which the asset path goes through identically.

### Note on built assets

The compatible-models filter needs one line in `resources/assets/js/snipeit.js` to forward `data-model-id` to the selectlist endpoint. I have **not** committed rebuilt `public/js/dist/all.js`: building here produces a completely different minification from what is checked in (2.3 MB → 991 KB), which would bury the actual change under a megabyte of unrelated diff. Until assets are rebuilt the asset list is simply unfiltered — checkout still works correctly. Happy to include the rebuild if you would rather have it in the PR.
