### PR TITLE
Rebuild Docker images weekly to pick up security patches

### DIFF
--- a/.github/workflows/docker-alpine.yml
+++ b/.github/workflows/docker-alpine.yml
@@ -10,6 +10,11 @@ on:
       - develop
     tags:
       - 'v**'
+  # Weekly rebuild so the rolling 'v{major}-latest-alpine' tag picks up
+  # base-OS security patches (e.g. Alpine apk package updates) even when no
+  # new Snipe-IT version has been tagged. Does NOT touch immutable vX.Y.Z tags.
+  schedule:
+    - cron: '0 6 * * 1'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -46,6 +51,17 @@ jobs:
         with:
           persist-credentials: false
 
+      # On a scheduled run there's no tag/branch push event to derive the ref
+      # from, so explicitly check out the most recent published release tag
+      # before building - this is what gets rebuilt to refresh v{major}-latest-alpine.
+      - name: Checkout latest release tag (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          git fetch --tags
+          latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+          echo "Rebuilding latest release tag: $latest_tag"
+          git checkout "$latest_tag"
+
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -69,7 +85,9 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: snipe/snipe-it
-          tags: ${{ env.IMAGE_TAGS }}
+          # On schedule, metadata-action can't derive tags from github.ref
+          # (it still points at the default branch) - only emit v{major}-latest-alpine.
+          tags: ${{ github.event_name == 'schedule' && 'type=semver,pattern=v{{major}}-latest-alpine' || env.IMAGE_TAGS }}
           flavor: ${{ env.TAGS_FLAVOR }}
 
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-ubuntu.yml
+++ b/.github/workflows/docker-ubuntu.yml
@@ -10,6 +10,11 @@ on:
       - develop
     tags:
       - 'v**'
+  # Weekly rebuild so the rolling 'v{major}-latest' tag picks up base-OS
+  # security patches (e.g. Ubuntu apt package updates) even when no new
+  # Snipe-IT version has been tagged. Does NOT touch immutable vX.Y.Z tags.
+  schedule:
+    - cron: '0 6 * * 1'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -46,6 +51,17 @@ jobs:
         with:
           persist-credentials: false
 
+      # On a scheduled run there's no tag/branch push event to derive the ref
+      # from, so explicitly check out the most recent published release tag
+      # before building - this is what gets rebuilt to refresh v{major}-latest.
+      - name: Checkout latest release tag (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          git fetch --tags
+          latest_tag=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+          echo "Rebuilding latest release tag: $latest_tag"
+          git checkout "$latest_tag"
+
       # https://github.com/docker/setup-buildx-action
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -69,7 +85,9 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: snipe/snipe-it
-          tags: ${{ env.IMAGE_TAGS }}
+          # On schedule, metadata-action can't derive tags from github.ref
+          # (it still points at the default branch) - only emit v{major}-latest.
+          tags: ${{ github.event_name == 'schedule' && 'type=semver,pattern=v{{major}}-latest' || env.IMAGE_TAGS }}
           flavor: ${{ env.TAGS_FLAVOR }}
 
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
Right now, Docker images only rebuild when a new version is tagged. If nothing gets tagged for a while, the images can end up with old, unpatched system packages (like curl), for example, CVE-2026-8925 is fixed upstream in Ubuntu's curl package, but v8.6.3 predates that fix and won't pick it up until a new release is cut.

This adds a weekly scheduled rebuild for the rolling `v{major}-latest` tag, so it stays patched even between releases. It does not touch or change the fixed version tags (like v8.6.3)