### PR TITLE
Fixed category importer silently ignoring the alert_on_response column

### DIFF
--- a/app/Importer/CategoryImporter.php
+++ b/app/Importer/CategoryImporter.php
@@ -45,7 +45,7 @@ class CategoryImporter extends ItemImporter
 
         // Boolean flags. Present-empty maps to 0; present-with-value uses
         // fetchHumanBoolean; absent leaves the DB value alone on update.
-        foreach (['use_default_eula', 'require_acceptance', 'checkin_email'] as $flag) {
+        foreach (['use_default_eula', 'require_acceptance', 'checkin_email', 'alert_on_response'] as $flag) {
             if ($this->csvRowHas($row, $flag)) {
                 $raw = $this->findCsvMatch($row, $flag);
                 $this->item[$flag] = ($this->fetchHumanBoolean($raw) == 1) ? 1 : 0;

--- a/tests/Feature/Importing/Api/ImportCategoriesTest.php
+++ b/tests/Feature/Importing/Api/ImportCategoriesTest.php
@@ -176,6 +176,57 @@ class ImportCategoriesTest extends ImportDataTestCase implements TestsPermission
     }
 
     #[Test]
+    public function import_sets_alert_on_response_flag(): void
+    {
+        $this->actingAsForApi(User::factory()->superuser()->create());
+
+        $importFileBuilder = new ImportFileBuilder([[
+            'name' => 'Alerting Laptops',
+            'category_type' => 'asset',
+            'alert_on_response' => 1,
+        ]]);
+        $import = Import::factory()->categories()->create([
+            'file_path' => $importFileBuilder->saveToImportsDirectory(),
+        ]);
+
+        $this->importFileResponse(['import' => $import->id])->assertOk();
+
+        $newCategory = Category::query()->where('name', 'Alerting Laptops')->sole();
+
+        $this->assertEquals(1, $newCategory->alert_on_response);
+    }
+
+    #[Test]
+    public function update_mode_updates_alert_on_response_flag(): void
+    {
+        $this->actingAsForApi(User::factory()->superuser()->create());
+
+        $category = Category::factory()->assetLaptopCategory()->create([
+            'alert_on_response' => 1,
+        ])->refresh();
+
+        $this->assertEquals(1, $category->alert_on_response);
+
+        $importFileBuilder = new ImportFileBuilder([[
+            'name' => $category->name,
+            'category_type' => $category->category_type,
+            'alert_on_response' => 0,
+        ]]);
+        $import = Import::factory()->categories()->create([
+            'file_path' => $importFileBuilder->saveToImportsDirectory(),
+        ]);
+
+        $this->importFileResponse([
+            'import' => $import->id,
+            'import-update' => true,
+        ])->assertOk();
+
+        $category->refresh();
+
+        $this->assertEquals(0, $category->alert_on_response);
+    }
+
+    #[Test]
     public function update_mode_preserves_fields_when_csv_column_is_absent(): void
     {
         $this->actingAsForApi(User::factory()->superuser()->create());


### PR DESCRIPTION
### Description

The importer UI offers **Alert on Response** as a mappable column for category imports (`$categories_fields` in `app/Livewire/Importer.php`, with its own `import_alert_on_response` translation string), but `CategoryImporter` only ever read `use_default_eula`, `require_acceptance` and `checkin_email`.

The result is that anything a user maps to that column is silently dropped — new categories are always created with the column default, and update-mode imports can never change the value. Because `CheckoutableListener` reads `$category->alert_on_response` to decide whether to notify the person who performed the checkout, imported categories never alert regardless of what the CSV said.

`alert_on_response` was added to the `Category` model in #17116, four days after the category importer landed in #17062. That PR extended the importer's UI field list but not the importer's flag list, so the two have been out of sync since.

The fix adds it to the existing boolean-flag loop, so it gets the same `fetchHumanBoolean` coercion and the same "column present vs absent" update semantics as its three siblings.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added two regression tests to `tests/Feature/Importing/Api/ImportCategoriesTest.php` covering both directions — creating a category with the flag set, and using update mode to clear it. Both fail on `develop` and pass with this change.

`DB_CONNECTION=sqlite php artisan test tests/Feature/Importing tests/Unit/Importer tests/Feature/Livewire/ImporterTest.php` → 232 passed. `vendor/bin/pint --test` clean on the changed files.

---

This change was prepared with the assistance of AI (Claude). The bug was reproduced with a failing test before the fix, and the full importer test suite was run locally to check for regressions.
