### PR TITLE
Backup: Accounted for prefix during pre-restore backup

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -1107,15 +1107,18 @@ class SettingsController extends Controller
         // Take a fresh pre-restore backup so we can point the operator at
         // it if the restore fails after we wipe. This is the mitigation
         // the pre-existing
-        $preRestoreBackupName = 'pre-restore-'.date('Y-m-d-H-i-s').'.zip';
-        Log::debug('Running pre-restore backup: '.$preRestoreBackupName);
+        $requestedBackupFilename = 'pre-restore-'.date('Y-m-d-H-i-s').'.zip';
+        // spatie prepends filename_prefix to the filename provided so this is the actual name on disk:
+        $preRestoreBackupFilename = config('backup.backup.destination.filename_prefix').$requestedBackupFilename;
+        $preBackupPath = storage_path($path).'/'.$preRestoreBackupFilename;
+
+        Log::debug('Running pre-restore backup: '.$preRestoreBackupFilename);
         $preBackupExit = Artisan::call('snipeit:backup', [
-            '--filename' => $preRestoreBackupName,
+            '--filename' => $requestedBackupFilename,
             '--force' => true,
         ]);
-        $preBackupPath = storage_path($path).'/'.$preRestoreBackupName;
 
-        if ($preBackupExit !== 0 || ! Storage::exists($path.'/'.$preRestoreBackupName)) {
+        if ($preBackupExit !== 0 || ! (Storage::exists($path.'/'.$preRestoreBackupFilename))) {
             Log::warning('Pre-restore backup failed (exit '.$preBackupExit.'); aborting restore to protect existing data.');
 
             return redirect()->route('settings.backups.index')->with('error', trans('admin/settings/message.restore.pre_backup_failed'));
@@ -1158,7 +1161,7 @@ class SettingsController extends Controller
             Log::error('Restore failed after db:wipe. Pre-restore backup available at '.$preBackupPath);
 
             return redirect()->route('settings.backups.index')->with('error', trans('admin/settings/message.restore.failed_with_backup', [
-                'backup' => $preRestoreBackupName,
+                'backup' => $preRestoreBackupFilename,
             ]));
         }
 
@@ -1172,7 +1175,7 @@ class SettingsController extends Controller
             Log::error('Migrate failed after restore. Pre-restore backup available at '.$preBackupPath);
 
             return redirect()->route('settings.backups.index')->with('error', trans('admin/settings/message.restore.failed_with_backup', [
-                'backup' => $preRestoreBackupName,
+                'backup' => $preRestoreBackupFilename,
             ]));
         }
 


### PR DESCRIPTION
Currently, restoring from a backup is broken and the following error message is displayed to the user:

<img width="900" height="52" alt="image" src="https://github.com/user-attachments/assets/002ec6a0-bd12-4bee-a136-3e206a8f938e" />

> Error: Could not create a pre-restore safety backup. Restore aborted so that the existing database is not destroyed without a recovery path.

In reality, the pre-restore backup _is_ created but not referenced correctly due to the Spatie backup package prefixing the filename within their backup command. 

This PR fixes that by referencing that prefix. 
