### PR TITLE
Fixed #19442 - Print button not working on Safari

### DIFF
--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -547,6 +547,42 @@
                 this.unsortedData = this.data.slice();
             };
 
+        // Bootstrap-table's "print" extension races Safari's async print
+        // against its own synchronous close(). doPrint calls
+        // newWin.focus(); newWin.print(); newWin.close(); right after
+        // document.write. When the written HTML contains <img> tags,
+        // Safari kicks off fetches for them and treats the popup
+        // document as not-yet-ready-to-print. The queued print() is
+        // waiting on that ready state, but close() fires anyway, tears
+        // down the popup, and the queued print is silently canceled.
+        //
+        // See https://github.com/grokability/snipe-it/issues/19443
+        //
+        // Deferring newWin.close() by 500ms gives Safari enough time
+        // to either finish loading the images or latch the print
+        // dialog against the popup before it disappears.
+        if (BootstrapTable && BootstrapTable.prototype.doPrint) {
+            var origDoPrint = BootstrapTable.prototype.doPrint;
+            BootstrapTable.prototype.doPrint = function (data) {
+                var origOpen = window.open;
+                window.open = function () {
+                    var w = origOpen.apply(window, arguments);
+                    if (w) {
+                        var realClose = w.close.bind(w);
+                        w.close = function () {
+                            setTimeout(realClose, 500);
+                        };
+                    }
+                    return w;
+                };
+                try {
+                    return origDoPrint.call(this, data);
+                } finally {
+                    window.open = origOpen;
+                }
+            };
+        }
+
         var blockedFields = "searchable,sortable,switchable,title,visible,formatter,class".split(",");
 
         var keyBlocked = function(key) {


### PR DESCRIPTION
Safari's print button was silently canceling on bootstrap-table listings that render an image column at small-to-medium row counts (10-20 rows). You'd see a brief popup flash and then nothing. No print dialog, no console error. `/hardware` at the default per-page setting hit this for every user we checked with. I couldn't reproduce this on Chrome.

Turns out, it's a race in bootstrap-table's print extension against Safari's async print pipeline. `doPrint` calls `newWin.focus(); newWin.print(); newWin.close();` synchronously right after `document.write`. When the written HTML contains `<img>` tags, Safari kicks off fetches for them and treats the popup as not-yet-ready-to-print. The queued `print()` waits on that ready state, but `close()` fires anyway, tears down the popup, and the queued print gets silently canceled. (This was showing as a shift in browser tabs when the print button was clicked, as if it were trying to open a tab, but then it instantly shifted back, as if the new tab was closed.)

We nailed the mechanism by flipping the image column visibility as a controlled variable. `/hardware` at per_page=10 fails with the image column on and works with it off. `/users` at per_page=10 works by default and fails once you toggle the avatar column on. No `<img>` tags in the print HTML means no failure regardless of page or page size.

## Fix

Wrap `$.BootstrapTable.prototype.doPrint` to intercept `window.open` for the duration of the call. The intercepted popup gets its `close` method deferred by 500ms via `setTimeout`. That gives Safari enough time to either finish loading the images or latch the print dialog against the popup before it disappears.

The race is in bootstrap-table 1.24.2 as shipped in `public/js/dist/bootstrap-table.js`. Nothing recent on our side broke this. Most likely Safari tightened popup print handling in a recent update and we're seeing the fallout.

## Testing

- Safari, `/hardware` at per_page=10, click Print. Without fix, popup flashes with no dialog. With fix, native print dialog appears.
- Safari, `/hardware` at per_page=20, click Print. Same expectation.
- Safari, `/hardware` at per_page=30, click Print. Was already working, should still work.
- Safari, `/users` with avatar column toggled on at per_page=10, click Print. Without fix, popup flashes with no dialog. With fix, native print dialog appears.
- Safari, `/users` with avatar column hidden at per_page=10, click Print. Was working, should still work.
- Safari, `/consumables`, click Print. Was working, should still work.
- Chrome, `/hardware` at per_page=10, click Print. Was working, should still work. Fix shouldn't regress Chrome.
- Firefox, `/hardware` at per_page=10, click Print. Should work.
- Any bs-table listing anywhere else in the app, confirm print still opens the native print dialog.

Fixes #19442
