### PR TITLE
Fix the add_link_colors_to_settings migration

### DIFF
--- a/database/migrations/2025_11_28_175733_add_link_colors_to_settings.php
+++ b/database/migrations/2025_11_28_175733_add_link_colors_to_settings.php
@@ -35,42 +35,48 @@ return new class extends Migration
         if ($setting) {
 
             switch ($setting->skin) {
-                case 'green' || 'green-dark':
+                case 'green':
+                case 'green-dark':
                     $header_color = '#00a65a';
                     $link_dark_color = '#9ACD32';
                     $link_light_color = '#00a65a';
                     $nav_color = '#ffffff';
                     break;
 
-                case 'red' || 'red-dark':
+                case 'red':
+                case 'red-dark':
                     $header_color = '#dd4b39';
                     $link_dark_color = '#ed9a9a';
                     $link_light_color = '#dd4b39';
                     $nav_color = '#ffffff';
                     break;
 
-                case 'orange' || 'orange-dark':
+                case 'orange':
+                case 'orange-dark':
                     $header_color = '#FF851B';
                     $link_dark_color = '#FFA500';
                     $link_light_color = '#FF8C00';
                     $nav_color = '#ffffff';
                     break;
 
-                case 'black' || 'black-dark':
+                case 'black':
+                case 'black-dark':
                     $header_color = '#000000';
                     $link_dark_color = '#d4d2d2';
                     $link_light_color = '#454759';
                     $nav_color = '#ffffff';
                     break;
 
-                case 'purple' || 'purple-dark':
+                case 'purple':
+                case 'purple-dark':
                     $header_color = '#605ca8';
                     $link_dark_color = '#AC83FF';
                     $link_light_color = '#605ca8';
                     $nav_color = '#ffffff';
                     break;
 
-                case 'yellow' || 'yellow-dark':
+                case 'yellow':
+                case 'yellow-dark':
                     $header_color = '#FBCC34';
                     $link_dark_color = '#F0E68C';
                     $link_light_color = '#a69f08';


### PR DESCRIPTION
Fixes #18345

A syntax error in the `switch .. case` statement would make it so any truthy value in `$setting->skin` would match the first branch, making the "green" theme's values the new defaults.

This problem could become sticky if users overrides were also set to that value at some point, which was the case initially in this migration, removed in commit 4658bf38c5 .

Fixing this automatically after the fact cannot be done automatically, but is basically a matter of setting the "link_light_color" and "link_dark_color" columns in the "users" table to NULL if they're set to an undesired value.

I'm submitting this PR mostly as a documentation effort, to help people, like me, who encountered this problem while landing on v8.3.7 and could not fix it by updating to v8.4 as suggested in the related issue.

Thanks to the Snipe-IT team for this excellent software, and for making it a digital commons by open-sourcing it!