### PR TITLE
Annotated Attribute return types on eloquent models

### DIFF
--- a/.ai/rules/models.md
+++ b/.ai/rules/models.md
@@ -20,3 +20,8 @@ Add behavior as a trait rather than pushing it into a base class.
 
 ## Casts go in the $casts property
 Declare casts with `protected $casts = [...]`, not a `casts()` method, even though Laravel 12 supports the method form.
+
+## New-style Attribute accessors need @return Attribute generics for Larastan
+If a model attribute has a new-style accessor (`protected function locationId(): Attribute`), Larastan drops the property entirely unless the method has a generic PHPDoc: `/** @return Attribute<TGet, TSet> */` (e.g. `Attribute<int|null, int|null>`). Without it, the DB-column extension defers to the accessor extension, the accessor extension requires strict generics, and the property reads as "undefined" — that is why `@property` tags crept into model docblocks (e.g. PR #19480). Fix by adding the `@return Attribute<...>` generic instead of `@property` tags; plain columns without accessors are inferred from migrations automatically and need no annotation.
+
+TGet is the readable type; **TSet is the writable one — the setter's argument, i.e. what may be assigned**, not what the setter stores. Reserve `never` for attributes genuinely never written: no `set:` closure **and** nothing assigns to them (computed values like `expiresDiffInDays()`). No `set:` closure alone is not enough — an accessor decorating a real column still gets assigned elsewhere, and `never` turns each assignment into `Property Setting::$header_color (never) does not accept mixed`; use `mixed` there. Same reasoning for a setter that narrows: `requestable()` stores `(int) filter_var(...)` but accepts an untyped `$value`, so it is `Attribute<int, mixed>`.

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -30,13 +30,6 @@ use Watson\Validating\ValidatingTrait;
  * Model for Assets.
  *
  * @version v1.0
- * @property ?int $location_id
- * @property Carbon|string|null $next_audit_date
- * @property Carbon|string|null $last_audit_date
- * @property Carbon|string|null $asset_eol_date
- * @property ?int $company_id
- * @property Carbon|string|null $last_checkin
- * @property bool $requestable
  */
 class Asset extends Depreciable
 {
@@ -125,6 +118,8 @@ class Asset extends Depreciable
      * NULL and 0 as different. `set` normalizes on write, `get`
      * normalizes on read so legacy rows already storing 0 present as
      * null at the model boundary until they're re-saved.
+     *
+     * @return Attribute<int|null, int|null>
      */
     protected function locationId(): Attribute
     {
@@ -134,6 +129,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<int|null, int|null>
+     */
     protected function companyId(): Attribute
     {
         return Attribute::make(
@@ -336,7 +334,7 @@ class Asset extends Depreciable
     /**
      * Returns the warranty expiration date as Carbon object
      *
-     * @return Carbon|null
+     * @return Attribute<Carbon|null, never>
      */
     protected function warrantyExpires(): Attribute
     {
@@ -345,6 +343,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function warrantyExpiresFormattedDate(): Attribute
     {
 
@@ -353,6 +354,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<float|null, never>
+     */
     protected function warrantyExpiresDiff(): Attribute
     {
         return Attribute::make(
@@ -361,6 +365,9 @@ class Asset extends Depreciable
 
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function warrantyExpiresDiffForHumans(): Attribute
     {
         return Attribute::make(
@@ -369,6 +376,9 @@ class Asset extends Depreciable
 
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function lastAuditFormattedDate(): Attribute
     {
 
@@ -377,6 +387,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<float|null, never>
+     */
     protected function lastAuditDiff(): Attribute
     {
         return Attribute::make(
@@ -385,6 +398,9 @@ class Asset extends Depreciable
 
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function lastAuditDiffForHumans(): Attribute
     {
         return Attribute::make(
@@ -393,6 +409,9 @@ class Asset extends Depreciable
 
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function nextAuditFormattedDate(): Attribute
     {
 
@@ -401,6 +420,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<float|null, never>
+     */
     protected function nextAuditDiffInDays(): Attribute
     {
         return Attribute::make(
@@ -408,6 +430,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function nextAuditDiffForHumans(): Attribute
     {
         return Attribute::make(
@@ -416,6 +441,9 @@ class Asset extends Depreciable
 
     }
 
+    /**
+     * @return Attribute<Carbon|null, never>
+     */
     protected function eolDate(): Attribute
     {
 
@@ -433,6 +461,9 @@ class Asset extends Depreciable
 
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function eolFormattedDate(): Attribute
     {
         return Attribute::make(
@@ -440,6 +471,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<float|null, never>
+     */
     protected function eolDiffInDays(): Attribute
     {
         return Attribute::make(
@@ -448,6 +482,9 @@ class Asset extends Depreciable
 
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function eolDiffForHumans(): Attribute
     {
 
@@ -457,6 +494,9 @@ class Asset extends Depreciable
 
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function expectedCheckinFormattedDate(): Attribute
     {
         return Attribute::make(
@@ -464,6 +504,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function expectedCheckinDiffForHumans(): Attribute
     {
         return Attribute::make(
@@ -1366,7 +1409,7 @@ class Asset extends Depreciable
      * in the database, but here we are.
      *
      * @param  $value
-     * @return void
+     * @return Attribute<string|null, string|null>
      */
     protected function nextAuditDate(): Attribute
     {
@@ -1376,6 +1419,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<string|null, string|null>
+     */
     protected function lastAuditDate(): Attribute
     {
         return Attribute::make(
@@ -1384,6 +1430,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<string|null, string|null>
+     */
     protected function lastCheckout(): Attribute
     {
         return Attribute::make(
@@ -1392,6 +1441,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<string|null, string|null>
+     */
     protected function lastCheckin(): Attribute
     {
         return Attribute::make(
@@ -1400,6 +1452,9 @@ class Asset extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<string|null, string|null>
+     */
     protected function assetEolDate(): Attribute
     {
         return Attribute::make(
@@ -1415,7 +1470,7 @@ class Asset extends Depreciable
      * This will also correctly parse a 1/0 if "true"/"false" is passed.
      *
      * @param  $value
-     * @return void
+     * @return Attribute<int, mixed>
      */
     protected function requestable(): Attribute
     {

--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -54,6 +54,8 @@ class CheckoutAcceptance extends Model
 
     /**
      * Accessor for the checkoutable item's category name.
+     *
+     * @return Attribute<string|null, never>
      */
     protected function checkoutableCategoryName(): Attribute
     {
@@ -180,6 +182,9 @@ class CheckoutAcceptance extends Model
         return $query->whereNull('accepted_at')->whereNotNull('declined_at');
     }
 
+    /**
+     * @return Attribute<string, never>
+     */
     protected function displayCheckoutableType(): Attribute
     {
         return Attribute::make(

--- a/app/Models/Component.php
+++ b/app/Models/Component.php
@@ -182,6 +182,8 @@ class Component extends SnipeModel
      * Per-pivot line cost for components-assets. Pulls the per-unit
      * price from the last acquisition (with the same default_* fallback
      * that lastOrderDefaults() applies) and multiplies by pivot qty.
+     *
+     * @return Attribute<float|null, never>
      */
     protected function calculatedPurchaseCost(): Attribute
     {

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -182,6 +182,9 @@ class License extends Depreciable
             && ($this->deleted_at == '');
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function terminatesFormattedDate(): Attribute
     {
         return Attribute::make(
@@ -189,6 +192,9 @@ class License extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<float|null, never>
+     */
     protected function terminatesDiffInDays(): Attribute
     {
         return Attribute::make(
@@ -196,6 +202,9 @@ class License extends Depreciable
         );
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function terminatesDiffForHumans(): Attribute
     {
         return Attribute::make(

--- a/app/Models/LicenseSeat.php
+++ b/app/Models/LicenseSeat.php
@@ -92,6 +92,9 @@ class LicenseSeat extends SnipeModel implements ICompanyableChild
         return $this->license->getEula();
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function name(): Attribute
     {
         return Attribute::make(
@@ -99,6 +102,9 @@ class LicenseSeat extends SnipeModel implements ICompanyableChild
         );
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function displayName(): Attribute
     {
         return Attribute::make(

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -209,9 +209,9 @@ class Setting extends Model
      *
      * Important: Do not remove the e() escaping here, as we output raw in the blade.
      *
-     * @return string escaped CSS
-     *
      * @author A. Gianotto <snipe@snipe.net>
+     *
+     * @return Attribute<string, mixed>
      */
     protected function headerColor(): Attribute
     {
@@ -220,6 +220,9 @@ class Setting extends Model
         );
     }
 
+    /**
+     * @return Attribute<string, mixed>
+     */
     protected function linkLightColor(): Attribute
     {
         return Attribute::make(
@@ -227,6 +230,9 @@ class Setting extends Model
         );
     }
 
+    /**
+     * @return Attribute<string, mixed>
+     */
     protected function linkDarkColor(): Attribute
     {
         return Attribute::make(
@@ -234,6 +240,9 @@ class Setting extends Model
         );
     }
 
+    /**
+     * @return Attribute<string, mixed>
+     */
     protected function navLinkColor(): Attribute
     {
         return Attribute::make(

--- a/app/Models/SnipeModel.php
+++ b/app/Models/SnipeModel.php
@@ -10,9 +10,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Storage;
 
-/**
- * @property-read string $display_name
- */
 class SnipeModel extends Model
 {
     // Setters that are appropriate across multiple models.
@@ -24,6 +21,9 @@ class SnipeModel extends Model
         $this->attributes['purchase_date'] = $value;
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function purchaseDateFormatted(): Attribute
     {
         return Attribute::make(
@@ -31,6 +31,9 @@ class SnipeModel extends Model
         );
     }
 
+    /**
+     * @return Attribute<float|null, never>
+     */
     protected function expiresDiffInDays(): Attribute
     {
         return Attribute::make(
@@ -38,6 +41,9 @@ class SnipeModel extends Model
         );
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function expiresDiffForHumans(): Attribute
     {
         return Attribute::make(
@@ -45,6 +51,9 @@ class SnipeModel extends Model
         );
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function expiresFormattedDate(): Attribute
     {
         return Attribute::make(
@@ -200,6 +209,9 @@ class SnipeModel extends Model
         $query->skip($offset)->take($limit);
     }
 
+    /**
+     * @return Attribute<string|null, never>
+     */
     protected function displayName(): Attribute
     {
         return Attribute::make(

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -32,9 +32,6 @@ use Illuminate\Support\Str;
 use Laravel\Passport\HasApiTokens;
 use Watson\Validating\ValidatingTrait;
 
-/**
- * @property string $display_name
- */
 class User extends SnipeModel implements AuthenticatableContract, AuthorizableContract, CanResetPasswordContract, HasLocalePreference
 {
     use CompanyableTrait;
@@ -328,6 +325,8 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
      * This overrides the SnipeModel displayName accessor to return the full name if display_name is not set
      *
      * @see SnipeModel::displayName()
+     *
+     * @return Attribute<string|null, mixed>
      */
     protected function displayName(): Attribute
     {
@@ -909,6 +908,9 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         return $this->last_name ? $this->first_name.' '.$this->last_name : $this->first_name;
     }
 
+    /**
+     * @return Attribute<string, never>
+     */
     protected function linkLightColor(): Attribute
     {
         return Attribute::make(
@@ -928,6 +930,9 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         );
     }
 
+    /**
+     * @return Attribute<string, never>
+     */
     protected function linkDarkColor(): Attribute
     {
         return Attribute::make(
@@ -947,6 +952,9 @@ class User extends SnipeModel implements AuthenticatableContract, AuthorizableCo
         );
     }
 
+    /**
+     * @return Attribute<string, never>
+     */
     protected function navLinkColor(): Attribute
     {
         return Attribute::make(

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -445,18 +445,6 @@ parameters:
 			path: app/Console/Commands/ObjectImportCommand.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\CheckoutAcceptance\:\:\$checkoutable_category_name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/PurgeEulaPDFs.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\CheckoutAcceptance\:\:\$display_checkoutable_type\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/PurgeEulaPDFs.php
-
-		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$display_name\.$#'
 			identifier: property.notFound
 			count: 1
@@ -497,30 +485,6 @@ parameters:
 			identifier: if.alwaysTrue
 			count: 1
 			path: app/Console/Commands/RegenerateAssetTags.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$header_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/ResetDemoSettings.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$link_dark_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/ResetDemoSettings.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$link_light_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/ResetDemoSettings.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$nav_link_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/ResetDemoSettings.php
 
 		-
 			message: '#^Property App\\Models\\User\:\:\$enable_confetti \(bool\) does not accept int\.$#'
@@ -583,82 +547,16 @@ parameters:
 			path: app/Console/Commands/RotateAppKey.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$expected_checkin_diff_for_humans\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/SendExpectedCheckinAlerts.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$expected_checkin_formattedDate\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/SendExpectedCheckinAlerts.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$purchase_date_formatted\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/SendExpectedCheckinAlerts.php
-
-		-
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
 			count: 2
 			path: app/Console/Commands/SendExpectedCheckinAlerts.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\License\:\:\$expires_diff_for_humans\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/SendExpirationAlerts.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\License\:\:\$expires_formatted_date\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Console/Commands/SendExpirationAlerts.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\License\:\:\$purchase_date_formatted\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/SendExpirationAlerts.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\License\:\:\$terminates_diff_for_humans\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/SendExpirationAlerts.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\License\:\:\$terminates_formatted_date\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/SendExpirationAlerts.php
-
-		-
 			message: '#^Comparison operation "\>" between int\<1, max\> and 0 is always true\.$#'
 			identifier: greater.alwaysTrue
 			count: 1
 			path: app/Console/Commands/SendInventoryAlerts.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$last_audit_formatted_date\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/SendUpcomingAuditReport.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$next_audit_diff_in_days\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/SendUpcomingAuditReport.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$next_audit_formatted_date\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Console/Commands/SendUpcomingAuditReport.php
 
 		-
 			message: '#^Access to an undefined property ArrayObject\:\:\$id\.$#'
@@ -3505,24 +3403,6 @@ parameters:
 			path: app/Http/Controllers/NotesController.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$link_dark_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/ProfileController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$link_light_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/ProfileController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$nav_link_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/ProfileController.php
-
-		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
@@ -3550,12 +3430,6 @@ parameters:
 			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$assigned\.$#'
 			identifier: property.notFound
 			count: 2
-			path: app/Http/Controllers/ReportsController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$last_checkout\.$#'
-			identifier: property.notFound
-			count: 1
 			path: app/Http/Controllers/ReportsController.php
 
 		-
@@ -3703,30 +3577,6 @@ parameters:
 			path: app/Http/Controllers/SettingsController.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$header_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/SettingsController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$link_dark_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/SettingsController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$link_light_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/SettingsController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$nav_link_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/SettingsController.php
-
-		-
 			message: '#^Access to an undefined property App\\Models\\SnipeModel\:\:\$default_avatar\.$#'
 			identifier: property.notFound
 			count: 1
@@ -3788,24 +3638,6 @@ parameters:
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$created_by\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/SetupController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$link_dark_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/SetupController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$link_light_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Controllers/SetupController.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$nav_link_color\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Http/Controllers/SetupController.php
@@ -4099,42 +3931,6 @@ parameters:
 			path: app/Http/Kernel.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$link_dark_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Middleware/CheckColorSettings.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$link_light_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Middleware/CheckColorSettings.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$nav_link_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Middleware/CheckColorSettings.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$link_dark_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Middleware/CheckColorSettings.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$link_light_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Middleware/CheckColorSettings.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\User\:\:\$nav_link_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Middleware/CheckColorSettings.php
-
-		-
 			message: '#^Binary operation "\." between non\-falsy\-string and array\<string\> results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
@@ -4244,18 +4040,6 @@ parameters:
 
 		-
 			message: '#^Access to an undefined property App\\Models\\AccessoryCheckout\:\:\$display_name\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Transformers/AssetsTransformer.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$last_checkout\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Transformers/AssetsTransformer.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$warranty_expires\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Http/Transformers/AssetsTransformer.php
@@ -4388,12 +4172,6 @@ parameters:
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$assigned\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Http/Transformers/DepreciationReportTransformer.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$warranty_expires\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Http/Transformers/DepreciationReportTransformer.php
@@ -5725,12 +5503,6 @@ parameters:
 			path: app/Mail/CheckoutAssetMail.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$last_checkout\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Mail/CheckoutAssetMail.php
-
-		-
 			message: '#^PHPDoc tag @param references unknown parameter\: \$notifiable$#'
 			identifier: parameter.notFound
 			count: 1
@@ -6253,18 +6025,6 @@ parameters:
 			path: app/Models/Asset.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$eolDate\.$#'
-			identifier: property.notFound
-			count: 3
-			path: app/Models/Asset.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$last_checkout\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Asset.php
-
-		-
 			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$license\.$#'
 			identifier: property.notFound
 			count: 1
@@ -6274,18 +6034,6 @@ parameters:
 			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$license_id\.$#'
 			identifier: property.notFound
 			count: 5
-			path: app/Models/Asset.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$warrantyExpires\.$#'
-			identifier: property.notFound
-			count: 4
-			path: app/Models/Asset.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$warranty_expires\.$#'
-			identifier: property.notFound
-			count: 1
 			path: app/Models/Asset.php
 
 		-
@@ -6421,21 +6169,9 @@ parameters:
 			path: app/Models/Asset.php
 
 		-
-			message: '#^PHPDoc tag @return with type Carbon\\Carbon\|null is incompatible with native type Illuminate\\Database\\Eloquent\\Casts\\Attribute\.$#'
-			identifier: return.phpDocType
-			count: 1
-			path: app/Models/Asset.php
-
-		-
 			message: '#^PHPDoc tag @return with type Illuminate\\Database\\Query\\Builder is incompatible with native type Illuminate\\Database\\Eloquent\\Builder\.$#'
 			identifier: return.phpDocType
 			count: 1
-			path: app/Models/Asset.php
-
-		-
-			message: '#^PHPDoc tag @return with type void is incompatible with native type Illuminate\\Database\\Eloquent\\Casts\\Attribute\.$#'
-			identifier: return.phpDocType
-			count: 2
 			path: app/Models/Asset.php
 
 		-
@@ -7831,12 +7567,6 @@ parameters:
 			path: app/Models/Labels/FieldOption.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$warranty_expires\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/Labels/FieldOption.php
-
-		-
 			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
 			identifier: catch.neverThrown
 			count: 1
@@ -8695,12 +8425,6 @@ parameters:
 			path: app/Models/Setting.php
 
 		-
-			message: '#^PHPDoc tag @return with type string is incompatible with native type Illuminate\\Database\\Eloquent\\Casts\\Attribute\.$#'
-			identifier: return.phpDocType
-			count: 1
-			path: app/Models/Setting.php
-
-		-
 			message: '#^PHPDoc tag @var above a method has no effect\.$#'
 			identifier: varTag.misplaced
 			count: 2
@@ -8932,24 +8656,6 @@ parameters:
 			message: '#^Access to an undefined property App\\Models\\Actionlog\:\:\$created_by\.$#'
 			identifier: property.notFound
 			count: 5
-			path: app/Models/User.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$link_dark_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/User.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$link_light_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Models/User.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$nav_link_color\.$#'
-			identifier: property.notFound
-			count: 1
 			path: app/Models/User.php
 
 		-
@@ -9749,12 +9455,6 @@ parameters:
 			identifier: nullsafe.neverNull
 			count: 2
 			path: app/Notifications/CheckoutAccessoryNotification.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Asset\:\:\$last_checkout\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Notifications/CheckoutAssetNotification.php
 
 		-
 			message: '#^Access to an undefined property App\\Notifications\\CheckoutAssetNotification\:\:\$admin\.$#'
@@ -11905,18 +11605,6 @@ parameters:
 			path: database/migrations/2024_09_17_204302_change_user_id_to_created_by.php
 
 		-
-			message: '#^Left side of \|\| is always true\.$#'
-			identifier: booleanOr.leftAlwaysTrue
-			count: 6
-			path: database/migrations/2025_11_28_175733_add_link_colors_to_settings.php
-
-		-
-			message: '#^Right side of \|\| is always true\.$#'
-			identifier: booleanOr.rightAlwaysTrue
-			count: 6
-			path: database/migrations/2025_11_28_175733_add_link_colors_to_settings.php
-
-		-
 			message: '#^Called ''pluck'' on Laravel collection, but could have been retrieved as a query\.$#'
 			identifier: larastan.noUnnecessaryCollectionCall
 			count: 2
@@ -12017,12 +11705,6 @@ parameters:
 			identifier: larastan.noUnnecessaryCollectionCall
 			count: 1
 			path: database/seeders/LicenseSeeder.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Setting\:\:\$header_color\.$#'
-			identifier: property.notFound
-			count: 1
-			path: database/seeders/SettingsSeeder.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\User\:\:\$enable_sound\.$#'


### PR DESCRIPTION
This PR adds the return property in PHPDocs for Eloquent Attributes according to the [Larastan documentation](https://github.com/larastan/larastan/blob/3.x/docs/features.md#laravel-9-attributes). 

- [x] Should I be including a new `composer analyse:phpstan:baseline` with this?

Note: Claude actually made most of the changes in this PR.
