### PR TITLE
Manage maintenance types UI

### DIFF
--- a/app/Console/Commands/Purge.php
+++ b/app/Console/Commands/Purge.php
@@ -213,8 +213,16 @@ class Purge extends Command
         // soft-deletable models, but a trashed License with live
         // LicenseSeats or a trashed Asset with live Maintenances would
         // leave orphans behind if we only nuked soft-deleted rows.
+        // Two shapes: a plain FK column name (`license_seats.license_id`)
+        // or a `[column, type_column, expected_type]` triple for
+        // polymorphic child tables (`maintenances.item_id` paired with
+        // `item_type='App\Models\Asset'`). The polymorphic form is needed
+        // now that maintenances live on `item_id`/`item_type` and could
+        // point at non-Asset parents; without the type guard, purging a
+        // trashed Asset would also delete accessory-owned maintenances
+        // that happen to share the same numeric id.
         $childTables = [
-            Asset::class => ['maintenances' => 'asset_id'],
+            Asset::class => ['maintenances' => ['item_id', 'item_type', Asset::class]],
             License::class => ['license_seats' => 'license_id'],
         ];
         $childCounts = [];
@@ -222,7 +230,13 @@ class Purge extends Command
             foreach ($childTables[$modelClass] as $childTable => $foreignKey) {
                 $count = 0;
                 foreach ($ids as $id) {
-                    $q = DB::table($childTable)->where($foreignKey, $id);
+                    $q = DB::table($childTable);
+                    if (is_array($foreignKey)) {
+                        [$idColumn, $typeColumn, $expectedType] = $foreignKey;
+                        $q->where($idColumn, $id)->where($typeColumn, $expectedType);
+                    } else {
+                        $q->where($foreignKey, $id);
+                    }
                     $count += $dryRun ? $q->count() : $q->delete();
                 }
                 if ($count > 0) {

--- a/app/Http/Controllers/Api/MaintenanceTypesController.php
+++ b/app/Http/Controllers/Api/MaintenanceTypesController.php
@@ -16,7 +16,9 @@ class MaintenanceTypesController extends Controller
     {
         $this->authorize('view', MaintenanceType::class);
 
-        $types = MaintenanceType::select(['id', 'name', 'created_at', 'updated_at', 'deleted_at']);
+        $types = MaintenanceType::select(['id', 'name', 'tag_color', 'created_by', 'created_at', 'updated_at', 'deleted_at'])
+            ->with('adminuser')
+            ->withCount('maintenances as maintenances_count');
 
         if ($request->input('deleted') == 'true') {
             $types->onlyTrashed();
@@ -34,7 +36,7 @@ class MaintenanceTypesController extends Controller
         $offset = ($request->input('offset') > $total) ? $total : app('api_offset_value');
         $limit = app('api_limit_value');
         $order = $request->input('order') === 'asc' ? 'asc' : 'desc';
-        $sort = in_array($request->input('sort'), ['id', 'name', 'created_at', 'updated_at']) ? $request->input('sort') : 'name';
+        $sort = in_array($request->input('sort'), ['id', 'name', 'maintenances_count', 'created_by', 'created_at', 'updated_at']) ? $request->input('sort') : 'name';
 
         $types = $types->orderBy($sort, $order)->skip($offset)->take($limit)->get();
 
@@ -54,6 +56,7 @@ class MaintenanceTypesController extends Controller
 
         $type = new MaintenanceType;
         $type->name = $request->input('name');
+        $type->tag_color = $request->input('tag_color');
         $type->created_by = auth()->id();
 
         if ($type->save()) {
@@ -68,6 +71,7 @@ class MaintenanceTypesController extends Controller
         $this->authorize('update', $maintenanceType);
 
         $maintenanceType->name = $request->input('name');
+        $maintenanceType->tag_color = $request->input('tag_color');
 
         if ($maintenanceType->save()) {
             return response()->json(Helper::formatStandardApiResponse('success', (new MaintenanceTypesTransformer)->transformMaintenanceType($maintenanceType), trans('admin/maintenance_types/message.update.success')));
@@ -79,6 +83,23 @@ class MaintenanceTypesController extends Controller
     public function destroy(MaintenanceType $maintenanceType): JsonResponse
     {
         $this->authorize('delete', $maintenanceType);
+
+        // Refuse the delete if any maintenance rows still reference this
+        // type. Enforced here as well as at the UI layer so the API
+        // doesn't strand orphaned maintenance_type_id values pointing
+        // at a soft-deleted row. Message uses the shared
+        // general.bulk_delete_associations.assoc_maintenances key so
+        // the reason surfaces the current in-use count.
+        if (! $maintenanceType->isDeletable()) {
+            return response()->json(
+                Helper::formatStandardApiResponse('error', null, trans('general.bulk_delete_associations.assoc_maintenances', [
+                    'item_name' => $maintenanceType->name,
+                    'maintenance_count' => $maintenanceType->maintenances()->count(),
+                    'item' => trans('admin/maintenance_types/general.maintenance_type'),
+                ])),
+                409,
+            );
+        }
 
         $maintenanceType->delete();
 

--- a/app/Http/Controllers/Api/MaintenancesController.php
+++ b/app/Http/Controllers/Api/MaintenancesController.php
@@ -52,7 +52,13 @@ class MaintenancesController extends Controller
         }
 
         if ($request->filled('asset_id')) {
-            $maintenances->where('asset_id', '=', $request->input('asset_id'));
+            // asset_id request param stays for API back-compat but
+            // filters against the polymorphic (item_id, item_type)
+            // pair now that maintenances can attach to accessories
+            // too. Callers filtering by asset_id are, by definition,
+            // scoping to items of type Asset.
+            $maintenances->where('item_id', '=', $request->input('asset_id'))
+                ->where('item_type', '=', Asset::class);
         }
 
         // Polymorphic filter — used by the user detail Maintenances tab to

--- a/app/Http/Controllers/BulkMaintenanceTypesController.php
+++ b/app/Http/Controllers/BulkMaintenanceTypesController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\MaintenanceType;
+use Illuminate\Http\Request;
+
+/**
+ * Bulk delete for MaintenanceType. Same shape as
+ * BulkManufacturersController / BulkDepreciationsController: authorize
+ * once at the class level via the policy's delete gate, then walk each
+ * requested id and guard per-row on the model's isDeletable() check
+ * (which refuses when the type still has referring maintenances).
+ * Aggregates per-row skips into a multi_error_messages flash so a
+ * partial batch still applies the safe deletes and surfaces the reason
+ * on the ones it couldn't touch.
+ */
+class BulkMaintenanceTypesController extends Controller
+{
+    public function destroy(Request $request)
+    {
+        $this->authorize('delete', MaintenanceType::class);
+
+        $errors = [];
+        $success_count = 0;
+
+        foreach ($request->ids ?? [] as $id) {
+            $type = MaintenanceType::find($id);
+            if (is_null($type)) {
+                $errors[] = trans('admin/maintenance_types/message.not_found');
+
+                continue;
+            }
+
+            if (! $type->isDeletable()) {
+                $errors[] = trans('general.bulk_delete_associations.assoc_maintenances_no_count', [
+                    'item_name' => $type->name,
+                    'item' => trans('admin/maintenance_types/general.maintenance_type'),
+                ]);
+
+                continue;
+            }
+
+            try {
+                $type->delete();
+                $success_count++;
+            } catch (\Exception $e) {
+                report($e);
+                $errors[] = trans('general.something_went_wrong');
+            }
+        }
+
+        if (count($errors) > 0) {
+            if ($success_count > 0) {
+                return redirect()->route('maintenance-types.index')
+                    ->with('success', trans_choice('admin/maintenance_types/message.delete.partial_success', $success_count, ['count' => $success_count]))
+                    ->with('multi_error_messages', $errors);
+            }
+
+            return redirect()->route('maintenance-types.index')->with('multi_error_messages', $errors);
+        }
+
+        return redirect()->route('maintenance-types.index')
+            ->with('success', trans_choice('admin/maintenance_types/message.delete.bulk_success', $success_count, ['count' => $success_count]));
+    }
+}

--- a/app/Http/Controllers/MaintenanceTypesController.php
+++ b/app/Http/Controllers/MaintenanceTypesController.php
@@ -29,6 +29,7 @@ class MaintenanceTypesController extends Controller
 
         $type = new MaintenanceType;
         $type->name = $request->input('name');
+        $type->tag_color = $request->input('tag_color');
         $type->created_by = auth()->id();
 
         if ($type->save()) {
@@ -37,6 +38,13 @@ class MaintenanceTypesController extends Controller
         }
 
         return redirect()->back()->withInput()->withErrors($type->getErrors());
+    }
+
+    public function show(MaintenanceType $maintenanceType): View
+    {
+        $this->authorize('view', $maintenanceType);
+
+        return view('maintenance-types.view')->with('item', $maintenanceType);
     }
 
     public function edit(MaintenanceType $maintenanceType): View
@@ -51,6 +59,7 @@ class MaintenanceTypesController extends Controller
         $this->authorize('update', $maintenanceType);
 
         $maintenanceType->name = $request->input('name');
+        $maintenanceType->tag_color = $request->input('tag_color');
 
         if ($maintenanceType->save()) {
             return redirect()->route('maintenance-types.index')
@@ -63,6 +72,18 @@ class MaintenanceTypesController extends Controller
     public function destroy(MaintenanceType $maintenanceType): RedirectResponse
     {
         $this->authorize('delete', $maintenanceType);
+
+        // Same guard as the API destroy: refuse when any maintenance row
+        // still references this type so we don't strand orphaned
+        // maintenance_type_id values on a soft-deleted parent.
+        if (! $maintenanceType->isDeletable()) {
+            return redirect()->route('maintenance-types.index')
+                ->with('error', trans('general.bulk_delete_associations.assoc_maintenances', [
+                    'item_name' => $maintenanceType->name,
+                    'maintenance_count' => $maintenanceType->maintenances()->count(),
+                    'item' => trans('admin/maintenance_types/general.maintenance_type'),
+                ]));
+        }
 
         $maintenanceType->delete();
 

--- a/app/Http/Transformers/MaintenanceTypesTransformer.php
+++ b/app/Http/Transformers/MaintenanceTypesTransformer.php
@@ -24,13 +24,31 @@ class MaintenanceTypesTransformer
         return [
             'id' => (int) $type->id,
             'name' => e($type->name),
+            'tag_color' => $type->tag_color ? e($type->tag_color) : null,
+            // withCount('maintenances as maintenances_count') on the
+            // index query populates the count column, so the frontend
+            // can display it inline and can tell at a glance which
+            // types are unsafe to delete. show() paths that don't run
+            // withCount fall back to a live count query.
+            'maintenances_count' => (int) ($type->maintenances_count ?? $type->maintenances()->count()),
+            'created_by' => ($type->adminuser) ? [
+                'id' => (int) $type->adminuser->id,
+                'name' => e($type->adminuser->display_name),
+            ] : null,
             'created_at' => Helper::getFormattedDateObject($type->created_at, 'datetime'),
             'updated_at' => Helper::getFormattedDateObject($type->updated_at, 'datetime'),
             'deleted_at' => Helper::getFormattedDateObject($type->deleted_at, 'datetime'),
             'available_actions' => [
                 'update' => Gate::allows('update', $type),
                 'delete' => $type->isDeletable(),
-                'restore' => Gate::allows('delete', $type),
+                // Restore is only meaningful for a soft-deleted row.
+                // Emitting restore=true on active rows made every row
+                // render a restore button (and, in combination with a
+                // false delete flag, made the actions column look like
+                // a live row could be "restored" back to itself).
+                // Match the ManufacturersTransformer / LocationsTransformer
+                // pattern: gate on trashed-and-permitted.
+                'restore' => $type->trashed() && Gate::allows('delete', $type),
             ],
         ];
     }

--- a/app/Http/Transformers/MaintenancesTransformer.php
+++ b/app/Http/Transformers/MaintenancesTransformer.php
@@ -87,8 +87,23 @@ class MaintenancesTransformer
                 'id' => (int) $assetmaintenance->adminuser->id,
                 'name' => e($assetmaintenance->adminuser->display_name),
             ] : null,
+            // DEPRECATED: bare-string maintenance_type. Kept for API
+            // back-compat with callers reading this as a plain type
+            // name. New consumers should read maintenance_type_details
+            // below for id/name/tag_color, which the bootstrap-table
+            // linker formatter uses to render the type as a link to
+            // its Maintenance Types detail page.
             'maintenance_type' => $assetmaintenance->maintenanceType
                 ? e($assetmaintenance->maintenanceType->name)
+                : null,
+            'maintenance_type_details' => $assetmaintenance->maintenanceType
+                ? [
+                    'id' => (int) $assetmaintenance->maintenanceType->id,
+                    'name' => e($assetmaintenance->maintenanceType->name),
+                    'tag_color' => $assetmaintenance->maintenanceType->tag_color
+                        ? e($assetmaintenance->maintenanceType->tag_color)
+                        : null,
+                ]
                 : null,
             'responsible_party' => ($assetmaintenance->responsibleParty) ? [
                 'id' => (int) $assetmaintenance->responsibleParty->id,
@@ -150,8 +165,23 @@ class MaintenancesTransformer
             'supplier' => ($assetmaintenance->supplier) ? e($assetmaintenance->supplier?->name) : null,
             'url' => ($assetmaintenance->url) ? e($assetmaintenance->url) : null,
             'cost' => Helper::formatCurrencyOutput($assetmaintenance->cost),
+            // DEPRECATED: bare-string maintenance_type. Kept for API
+            // back-compat with callers reading this as a plain type
+            // name. New consumers should read maintenance_type_details
+            // below for id/name/tag_color, which the bootstrap-table
+            // linker formatter uses to render the type as a link to
+            // its Maintenance Types detail page.
             'maintenance_type' => $assetmaintenance->maintenanceType
                 ? e($assetmaintenance->maintenanceType->name)
+                : null,
+            'maintenance_type_details' => $assetmaintenance->maintenanceType
+                ? [
+                    'id' => (int) $assetmaintenance->maintenanceType->id,
+                    'name' => e($assetmaintenance->maintenanceType->name),
+                    'tag_color' => $assetmaintenance->maintenanceType->tag_color
+                        ? e($assetmaintenance->maintenanceType->tag_color)
+                        : null,
+                ]
                 : null,
             'asset_maintenance_type' => e($assetmaintenance->asset_maintenance_type),
             'start_date' => Helper::getFormattedDateObject($assetmaintenance->start_date, 'date'),

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -1082,7 +1082,7 @@ class Asset extends Depreciable
      */
     public function maintenances()
     {
-        return $this->hasMany(Maintenance::class, 'asset_id')
+        return $this->morphMany(Maintenance::class, 'item')
             ->orderBy('created_at', 'desc');
     }
 

--- a/app/Models/Builders/MaintenanceQueryBuilder.php
+++ b/app/Models/Builders/MaintenanceQueryBuilder.php
@@ -52,32 +52,32 @@ class MaintenanceQueryBuilder extends Builder
 
     public function orderByTag(string $order): static
     {
-        return $this->leftJoin('assets', 'maintenances.asset_id', '=', 'assets.id')
+        return $this->leftJoin('assets', 'maintenances.item_id', '=', 'assets.id')
             ->orderBy('assets.asset_tag', $order);
     }
 
     public function orderByAssetName(string $order): static
     {
-        return $this->leftJoin('assets', 'maintenances.asset_id', '=', 'assets.id')
+        return $this->leftJoin('assets', 'maintenances.item_id', '=', 'assets.id')
             ->orderBy('assets.name', $order);
     }
 
     public function orderByAssetSerial(string $order): static
     {
-        return $this->leftJoin('assets', 'maintenances.asset_id', '=', 'assets.id')
+        return $this->leftJoin('assets', 'maintenances.item_id', '=', 'assets.id')
             ->orderBy('assets.serial', $order);
     }
 
     public function orderStatusName(string $order): static
     {
-        return $this->join('assets as maintained_asset', 'maintenances.asset_id', '=', 'maintained_asset.id')
+        return $this->join('assets as maintained_asset', 'maintenances.item_id', '=', 'maintained_asset.id')
             ->leftJoin('status_labels as maintained_asset_status', 'maintained_asset_status.id', '=', 'maintained_asset.status_id')
             ->orderBy('maintained_asset_status.name', $order);
     }
 
     public function orderLocationName(string $order): static
     {
-        return $this->join('assets as maintained_asset', 'maintenances.asset_id', '=', 'maintained_asset.id')
+        return $this->join('assets as maintained_asset', 'maintenances.item_id', '=', 'maintained_asset.id')
             ->leftJoin('locations as maintained_asset_location', 'maintained_asset_location.id', '=', 'maintained_asset.location_id')
             ->orderBy('maintained_asset_location.name', $order);
     }
@@ -92,14 +92,14 @@ class MaintenanceQueryBuilder extends Builder
 
     public function orderByAssetModelName(string $order): static
     {
-        return $this->join('assets as maintained_asset', 'maintenances.asset_id', '=', 'maintained_asset.id')
+        return $this->join('assets as maintained_asset', 'maintenances.item_id', '=', 'maintained_asset.id')
             ->leftJoin('models as maintained_asset_model', 'maintained_asset_model.id', '=', 'maintained_asset.model_id')
             ->orderBy('maintained_asset_model.name', $order);
     }
 
     public function orderByAssetModelNumber(string $order): static
     {
-        return $this->join('assets as maintained_asset', 'maintenances.asset_id', '=', 'maintained_asset.id')
+        return $this->join('assets as maintained_asset', 'maintenances.item_id', '=', 'maintained_asset.id')
             ->leftJoin('models as maintained_asset_model', 'maintained_asset_model.id', '=', 'maintained_asset.model_id')
             ->orderBy('maintained_asset_model.model_number', $order);
     }

--- a/app/Models/Maintenance.php
+++ b/app/Models/Maintenance.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Helpers\Helper;
 use App\Models\Builders\MaintenanceQueryBuilder;
 use App\Models\Traits\CompanyableChildTrait;
+use App\Models\Traits\HasCalendarEvents;
 use App\Models\Traits\HasUploads;
 use App\Models\Traits\Loggable;
 use App\Models\Traits\Searchable;
@@ -20,10 +21,19 @@ use Watson\Validating\ValidatingTrait;
  * Model for Asset Maintenances.
  *
  * @version v1.0
+ *
+ * @property-read \App\Models\Asset|null $asset
+ * @property-read \App\Models\Actionlog|null $assetlog
+ * @property-read \App\Models\Supplier|null $supplier
+ * @property-read \App\Models\MaintenanceType|null $maintenanceType
+ * @property-read \App\Models\User|null $adminuser
+ * @property-read \App\Models\User|null $responsibleParty
+ * @property-read \App\Models\User|null $completedByUser
  */
 class Maintenance extends SnipeModel implements ICompanyableChild
 {
     use CompanyableChildTrait;
+    use HasCalendarEvents;
     use HasFactory;
     use HasUploads;
     use Loggable, Presentable;
@@ -37,7 +47,11 @@ class Maintenance extends SnipeModel implements ICompanyableChild
     protected $table = 'maintenances';
 
     protected $rules = [
-        'asset_id' => 'required|integer',
+        // item_id is the polymorphic FK. Legacy asset_id keeps working
+        // via the accessor / mutator pair below; both mutators set
+        // item_id so the validator's item_id rule catches either.
+        'item_id' => 'required|integer',
+        'item_type' => 'required|string',
         'supplier_id' => 'nullable|integer',
         'maintenance_type_id' => 'required|integer|exists:maintenance_types,id',
         'name' => 'required|max:100',
@@ -65,6 +79,13 @@ class Maintenance extends SnipeModel implements ICompanyableChild
      */
     protected $fillable = [
         'name',
+        // Polymorphic item FK. Legacy asset_id is kept fillable so
+        // Maintenance::create(['asset_id' => ...]) still works via the
+        // setAssetIdAttribute mutator that forwards to item_id +
+        // item_type=Asset. New callers should pass item_id + item_type
+        // directly.
+        'item_id',
+        'item_type',
         'asset_id',
         'supplier_id',
         'asset_maintenance_type',
@@ -216,10 +237,57 @@ class Maintenance extends SnipeModel implements ICompanyableChild
      *
      * @version v1.0
      */
+    /**
+     * Polymorphic parent - an Asset (historically), and potentially
+     * an Accessory or other checkoutable model going forward. Every
+     * new caller should use ->item; ->asset() below stays as a
+     * backward-compat alias that returns the parent only when it IS
+     * an Asset (returns null for other item_types).
+     */
+    public function item()
+    {
+        return $this->morphTo()->withTrashed();
+    }
+
+    /**
+     * Legacy alias for ->item kept so existing blades, transformers,
+     * and controllers using $maintenance->asset or ->with('asset')
+     * keep working during the transition to polymorphic items.
+     * No item_type WHERE guard here because it would attach to the
+     * assets-table subquery during eager loading (Eloquent scopes the
+     * belongsTo child query at the parent side) and reference a
+     * non-existent maintenances.item_type column from the assets
+     * table context. Every existing maintenance has item_type = Asset
+     * per the rename migration's backfill, so the plain belongsTo
+     * still returns the right rows today. Once accessories actually
+     * carry maintenances, callers should switch to ->item.
+     */
     public function asset()
     {
-        return $this->belongsTo(Asset::class, 'asset_id')
+        return $this->belongsTo(Asset::class, 'item_id')
             ->withTrashed();
+    }
+
+    /**
+     * Legacy accessor for the old asset_id column. Returns item_id
+     * only when the polymorphic parent is an Asset so it doesn't
+     * misrepresent a maintenance attached to an accessory as an
+     * asset-scoped one.
+     */
+    public function getAssetIdAttribute()
+    {
+        return $this->item_type === Asset::class ? $this->attributes['item_id'] ?? null : null;
+    }
+
+    /**
+     * Legacy mutator - Maintenance::create(['asset_id' => X]) still
+     * works. Sets item_id + pins item_type to Asset since callers
+     * using asset_id are, by definition, targeting an Asset.
+     */
+    public function setAssetIdAttribute($value): void
+    {
+        $this->attributes['item_id'] = $value;
+        $this->attributes['item_type'] = Asset::class;
     }
 
     /**
@@ -265,6 +333,28 @@ class Maintenance extends SnipeModel implements ICompanyableChild
     public function checkedOutTo()
     {
         return $this->morphTo('checked_out_to');
+    }
+
+    /**
+     * Fields published to the calendar_events index table via the
+     * HasCalendarEvents trait. A single range event per maintenance
+     * anchored on start_date -> expected_completion_date. The
+     * completed_at column is intentionally NOT its own event today -
+     * "completed" is a state, not a scheduled item, and the read
+     * path can flip a completed marker via the source model. Add
+     * more entries here if a maintenance ever needs multiple event
+     * markers on the calendar.
+     */
+    public function calendarEventDefinitions(): array
+    {
+        return [
+            [
+                'field' => 'start_date',
+                'event_type' => 'maintenance.start',
+                'end_field' => 'expected_completion_date',
+                'all_day' => true,
+            ],
+        ];
     }
 
     public function journal()

--- a/app/Models/Maintenance.php
+++ b/app/Models/Maintenance.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use App\Helpers\Helper;
 use App\Models\Builders\MaintenanceQueryBuilder;
 use App\Models\Traits\CompanyableChildTrait;
-use App\Models\Traits\HasCalendarEvents;
 use App\Models\Traits\HasUploads;
 use App\Models\Traits\Loggable;
 use App\Models\Traits\Searchable;
@@ -33,7 +32,7 @@ use Watson\Validating\ValidatingTrait;
 class Maintenance extends SnipeModel implements ICompanyableChild
 {
     use CompanyableChildTrait;
-    use HasCalendarEvents;
+
     use HasFactory;
     use HasUploads;
     use Loggable, Presentable;
@@ -48,7 +47,7 @@ class Maintenance extends SnipeModel implements ICompanyableChild
 
     protected $rules = [
         // item_id is the polymorphic FK. Legacy asset_id keeps working
-        // via the accessor / mutator pair below; both mutators set
+        // via the accessor / mutator pair below. Both mutators set
         // item_id so the validator's item_id rule catches either.
         'item_id' => 'required|integer',
         'item_type' => 'required|string',

--- a/app/Models/MaintenanceType.php
+++ b/app/Models/MaintenanceType.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Presenters\MaintenanceTypePresenter;
 use App\Presenters\Presentable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -15,6 +16,8 @@ class MaintenanceType extends SnipeModel
     use SoftDeletes;
     use ValidatingTrait;
 
+    protected $presenter = MaintenanceTypePresenter::class;
+
     protected $table = 'maintenance_types';
 
     protected $rules = [
@@ -23,17 +26,23 @@ class MaintenanceType extends SnipeModel
 
     protected $injectUniqueIdentifier = true;
 
-    protected $fillable = ['name'];
+    protected $fillable = ['name', 'tag_color'];
 
     public function isDeletable(): bool
     {
         return Gate::allows('delete', $this)
-            && ($this->deleted_at == '');
+            && ($this->deleted_at == '')
+            && $this->maintenances()->doesntExist();
     }
 
     public function maintenances()
     {
         return $this->hasMany(Maintenance::class, 'maintenance_type_id');
+    }
+
+    public function adminuser()
+    {
+        return $this->belongsTo(User::class, 'created_by')->withTrashed();
     }
 
     public function getDisplayNameAttribute(): string

--- a/app/Presenters/MaintenanceTypePresenter.php
+++ b/app/Presenters/MaintenanceTypePresenter.php
@@ -8,6 +8,13 @@ class MaintenanceTypePresenter extends Presenter
     {
         $layout = [
             [
+                'field' => 'checkbox',
+                'scope' => 'col',
+                'checkbox' => true,
+                'titleTooltip' => trans('general.select_all_none'),
+                'printIgnore' => true,
+                'class' => 'hidden-print',
+            ], [
                 'field' => 'id',
                 'scope' => 'col',
                 'searchable' => false,
@@ -23,6 +30,30 @@ class MaintenanceTypePresenter extends Presenter
                 'switchable' => false,
                 'title' => trans('general.name'),
                 'visible' => true,
+                // maintenanceTypesLinkFormatter is auto-generated from
+                // the formatters array in bootstrap-table.blade.php and
+                // renders the row's tag_color as a leading colored
+                // square, matching how categories and other tag-colored
+                // entities read on their index tables.
+                'formatter' => 'maintenanceTypesLinkFormatter',
+            ], [
+                'field' => 'maintenances_count',
+                'scope' => 'col',
+                'searchable' => false,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('admin/maintenances/general.maintenances'),
+                'visible' => true,
+                'class' => 'text-right',
+            ], [
+                'field' => 'created_by',
+                'scope' => 'col',
+                'searchable' => false,
+                'sortable' => true,
+                'switchable' => true,
+                'title' => trans('general.created_by'),
+                'visible' => false,
+                'formatter' => 'usersLinkObjFormatter',
             ], [
                 'field' => 'created_at',
                 'scope' => 'col',

--- a/app/Presenters/MaintenancesPresenter.php
+++ b/app/Presenters/MaintenancesPresenter.php
@@ -133,13 +133,14 @@ class MaintenancesPresenter extends Presenter
                 'title' => trans('general.location'),
                 'formatter' => 'locationsLinkObjFormatter',
             ], [
-                'field' => 'maintenance_type',
+                'field' => 'maintenance_type_details',
                 'scope' => 'col',
                 'searchable' => true,
                 'sortable' => true,
                 'switchable' => true,
                 'title' => trans('admin/maintenances/form.asset_maintenance_type'),
                 'visible' => true,
+                'formatter' => 'maintenanceTypesLinkObjFormatter',
             ], [
                 'field' => 'responsible_party',
                 'scope' => 'col',
@@ -356,13 +357,14 @@ class MaintenancesPresenter extends Presenter
                 'sortable' => true,
                 'title' => trans('general.location'),
             ], [
-                'field' => 'maintenance_type',
+                'field' => 'maintenance_type_details',
                 'scope' => 'col',
                 'searchable' => true,
                 'sortable' => true,
                 'switchable' => true,
                 'title' => trans('admin/maintenances/form.asset_maintenance_type'),
                 'visible' => true,
+                'formatter' => 'maintenanceTypesLinkObjFormatter',
             ], [
                 'field' => 'responsible_party',
                 'scope' => 'col',
@@ -475,5 +477,40 @@ class MaintenancesPresenter extends Presenter
         ];
 
         return json_encode($layout);
+    }
+
+    /**
+     * Display name for the unified calendar. Renders as
+     * "<maintenance name> - <asset name or unknown>" so the event
+     * tile carries enough context to identify what and where without
+     * clicking through.
+     */
+    public function name()
+    {
+        $itemLabel = $this->model->item
+            ? ($this->model->item->display_name ?? $this->model->item->name ?? '')
+            : trans('general.unknown');
+
+        return sprintf('%s - %s', $this->model->name, $itemLabel);
+    }
+
+    /**
+     * Deep link used by the calendar event tile. Routes to the
+     * maintenance show page.
+     */
+    public function calendarUrl(): ?string
+    {
+        return route('maintenances.show', $this->model->id);
+    }
+
+    /**
+     * Color precedence for the calendar tile: maintenance type's
+     * tag_color when the admin has set one so tenants can color-code
+     * by "recall vs upgrade vs routine service". Otherwise null and
+     * the frontend paints from a per-event_type CSS palette.
+     */
+    public function calendarColor(): ?string
+    {
+        return $this->model->maintenanceType?->tag_color;
     }
 }

--- a/database/factories/MaintenanceFactory.php
+++ b/database/factories/MaintenanceFactory.php
@@ -23,6 +23,43 @@ class MaintenanceFactory extends Factory
      *
      * @return array
      */
+    /**
+     * Short, realistic maintenance names so seeded / demo rows look
+     * plausible in the list, calendar, and other views instead of the
+     * Faker `sentence(3)` output ("Ipsum quos aut voluptatum.") that
+     * was there before.
+     */
+    private const NAMES = [
+        'Battery replacement',
+        'Screen repair',
+        'Keyboard replacement',
+        'Fan replacement',
+        'Firmware update',
+        'OS reinstall',
+        'Cleaning',
+        'RAM upgrade',
+        'Hard drive replacement',
+        'Warranty repair',
+        'Annual service',
+        'Diagnostic check',
+        'Screen calibration',
+        'Cable replacement',
+        'Charging port repair',
+    ];
+
+    /**
+     * Define the model's default state.
+     *
+     * Default state is a plain-active maintenance (no expected end,
+     * no completion) so existing feature tests that call
+     * ->factory()->create() and rely on that shape still pass. The
+     * ->realistic() state below is what the seeder uses for
+     * demo/dev data — anchored dates, expected end, and sometimes
+     * completed_at populated so the calendar and list views show a
+     * plausible mix.
+     *
+     * @return array
+     */
     public function definition()
     {
         $maintenanceType = MaintenanceType::factory()->create();
@@ -39,14 +76,42 @@ class MaintenanceFactory extends Factory
             'supplier_id' => Supplier::factory(),
             'maintenance_type_id' => $maintenanceType->id,
             'asset_maintenance_type' => $maintenanceType->name,
-            'name' => $this->faker->sentence(3),
+            'name' => $this->faker->randomElement(self::NAMES),
             'start_date' => $this->faker->dateTime()->format('Y-m-d H:i:s'),
             'is_warranty' => $this->faker->boolean(),
             'notes' => $this->faker->paragraph(),
             'url' => $this->faker->url(),
-            'cost' => $this->faker->randomFloat(),
+            'cost' => $this->faker->randomFloat(2, 5, 500),
             'created_by' => User::factory()->superuser(),
             'image' => $this->faker->numberBetween(1, 11).'.png',
         ];
+    }
+
+    /**
+     * Seeder-friendly state that produces a maintenance with
+     * start_date anchored around today, an expected_completion_date
+     * a few days out, and a ~40% chance of already being completed
+     * (for past-start rows only). Produces a plausible mix on the
+     * calendar / list views so demo installs don't render as
+     * "everything from 1974".
+     */
+    public function realistic(): static
+    {
+        return $this->state(function () {
+            $startDate = $this->faker->dateTimeBetween('-6 months', '+3 months');
+            $startCarbon = \Carbon\Carbon::instance($startDate);
+            $expectedEnd = (clone $startCarbon)->addDays($this->faker->numberBetween(1, 21));
+
+            $isCompletable = $startCarbon->isPast() && $this->faker->boolean(40);
+            $completedAt = $isCompletable
+                ? $this->faker->dateTimeBetween($startCarbon, min($expectedEnd, \Carbon\Carbon::now()))
+                : null;
+
+            return [
+                'start_date' => $startCarbon->format('Y-m-d H:i:s'),
+                'expected_completion_date' => $expectedEnd->format('Y-m-d H:i:s'),
+                'completed_at' => $completedAt?->format('Y-m-d H:i:s'),
+            ];
+        });
     }
 }

--- a/database/factories/MaintenanceTypeFactory.php
+++ b/database/factories/MaintenanceTypeFactory.php
@@ -9,10 +9,29 @@ class MaintenanceTypeFactory extends Factory
 {
     protected $model = MaintenanceType::class;
 
+    /**
+     * Palette of hand-picked hex colors that read cleanly against the
+     * AdminLTE box background in both light and dark mode. Used to
+     * seed tag_color on generated maintenance types so the calendar
+     * view's color-coded events don't all render as the site header
+     * fallback (or worse, whatever hex random_int spits out).
+     */
+    private const TAG_COLORS = [
+        '#3c8dbc',
+        '#f39c12',
+        '#00a65a',
+        '#dd4b39',
+        '#605ca8',
+        '#00c0ef',
+        '#39cccc',
+        '#d81b60',
+    ];
+
     public function definition(): array
     {
         return [
             'name' => $this->faker->unique()->words(2, true),
+            'tag_color' => $this->faker->randomElement(self::TAG_COLORS),
         ];
     }
 }

--- a/database/migrations/2026_08_13_140000_add_tag_color_to_maintenance_types_table.php
+++ b/database/migrations/2026_08_13_140000_add_tag_color_to_maintenance_types_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds a nullable `tag_color` column to maintenance_types, matching
+ * the same-name column on other categorizing tables (companies,
+ * models, categories, locations, departments, etc). Used by the new
+ * asset-maintenance calendar view (blade: maintenances/calendar) to
+ * color-code events by maintenance type - the calendar falls back to
+ * a status-based palette (green/orange/blue for
+ * completed/active/upcoming) when no tag_color is set on the type.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('maintenance_types', function (Blueprint $table) {
+            if (! Schema::hasColumn('maintenance_types', 'tag_color')) {
+                $table->string('tag_color')->after('name')->nullable()->default(null);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('maintenance_types', function (Blueprint $table) {
+            if (Schema::hasColumn('maintenance_types', 'tag_color')) {
+                $table->dropColumn('tag_color');
+            }
+        });
+    }
+};

--- a/database/migrations/2026_08_13_150000_add_item_type_and_rename_asset_id_on_maintenances_table.php
+++ b/database/migrations/2026_08_13_150000_add_item_type_and_rename_asset_id_on_maintenances_table.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Turns maintenances into a polymorphic child so it can be attached
+ * to accessories (and any other checkoutable) in future, not just
+ * assets:
+ *
+ *   asset_id (int) -> item_id (int)
+ *   [new] item_type (string, default App\Models\Asset)
+ *
+ * Existing rows all belong to assets, so item_type is backfilled to
+ * the Asset FQCN in the same migration and then indexed together
+ * with item_id for polymorphic lookup speed.
+ *
+ * The Maintenance model keeps ->asset() and $maintenance->asset_id
+ * working as legacy accessors on top of the new columns so callers
+ * (view templates, transformers, controller filters, external API
+ * consumers) don't break. New callers should use ->item() / item_id
+ * / item_type directly.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Rename first, add the type column second, backfill third.
+        // Splitting rename into its own Schema::table() call avoids
+        // MySQL "cannot rename a column that's about to be indexed"
+        // combined-DDL edge cases.
+        Schema::table('maintenances', function (Blueprint $table) {
+            if (Schema::hasColumn('maintenances', 'asset_id') && ! Schema::hasColumn('maintenances', 'item_id')) {
+                $table->renameColumn('asset_id', 'item_id');
+            }
+        });
+
+        Schema::table('maintenances', function (Blueprint $table) {
+            if (! Schema::hasColumn('maintenances', 'item_type')) {
+                $table->string('item_type')->after('item_id')->nullable();
+            }
+        });
+
+        // Backfill: every pre-existing maintenance is against an
+        // asset. Do this before adding the composite index so index
+        // build sees the final values.
+        DB::table('maintenances')
+            ->whereNull('item_type')
+            ->update(['item_type' => \App\Models\Asset::class]);
+
+        Schema::table('maintenances', function (Blueprint $table) {
+            $table->index(['item_type', 'item_id'], 'maintenances_item_type_item_id_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('maintenances', function (Blueprint $table) {
+            $table->dropIndex('maintenances_item_type_item_id_index');
+        });
+
+        Schema::table('maintenances', function (Blueprint $table) {
+            if (Schema::hasColumn('maintenances', 'item_type')) {
+                $table->dropColumn('item_type');
+            }
+        });
+
+        Schema::table('maintenances', function (Blueprint $table) {
+            if (Schema::hasColumn('maintenances', 'item_id') && ! Schema::hasColumn('maintenances', 'asset_id')) {
+                $table->renameColumn('item_id', 'asset_id');
+            }
+        });
+    }
+};

--- a/database/seeders/MaintenanceSeeder.php
+++ b/database/seeders/MaintenanceSeeder.php
@@ -12,17 +12,17 @@ class MaintenanceSeeder extends Seeder
     public function run()
     {
         Maintenance::truncate();
-        Maintenance::factory()->create(['image' => '1.png']);
-        Maintenance::factory()->create(['image' => '2.png']);
-        Maintenance::factory()->create(['image' => '3.png']);
-        Maintenance::factory()->create(['image' => '4.png']);
-        Maintenance::factory()->create(['image' => '5.png']);
-        Maintenance::factory()->create(['image' => '6.png']);
-        Maintenance::factory()->create(['image' => '7.png']);
-        Maintenance::factory()->create(['image' => '8.png']);
-        Maintenance::factory()->create(['image' => '9.png']);
-        Maintenance::factory()->create(['image' => '10.png']);
-        Maintenance::factory()->create(['image' => '11.png']);
+        Maintenance::factory()->realistic()->create(['image' => '1.png']);
+        Maintenance::factory()->realistic()->create(['image' => '2.png']);
+        Maintenance::factory()->realistic()->create(['image' => '3.png']);
+        Maintenance::factory()->realistic()->create(['image' => '4.png']);
+        Maintenance::factory()->realistic()->create(['image' => '5.png']);
+        Maintenance::factory()->realistic()->create(['image' => '6.png']);
+        Maintenance::factory()->realistic()->create(['image' => '7.png']);
+        Maintenance::factory()->realistic()->create(['image' => '8.png']);
+        Maintenance::factory()->realistic()->create(['image' => '9.png']);
+        Maintenance::factory()->realistic()->create(['image' => '10.png']);
+        Maintenance::factory()->realistic()->create(['image' => '11.png']);
 
         $src = public_path('/img/demo/maintenances/');
         $dst = 'maintenances'.'/';

--- a/resources/lang/en-US/admin/maintenance_types/general.php
+++ b/resources/lang/en-US/admin/maintenance_types/general.php
@@ -2,6 +2,7 @@
 
 return [
     'maintenance_types' => 'Maintenance Types',
+    'maintenance_type' => 'maintenance type',
     'create' => 'Create Maintenance Type',
     'update' => 'Update Maintenance Type',
 ];

--- a/resources/lang/en-US/admin/maintenance_types/message.php
+++ b/resources/lang/en-US/admin/maintenance_types/message.php
@@ -14,6 +14,8 @@ return [
         'confirm' => 'Are you sure you wish to delete this maintenance type?',
         'error' => 'There was an issue deleting this maintenance type. Please try again.',
         'success' => 'The maintenance type was deleted successfully.',
+        'bulk_success' => 'Maintenance type deleted successfully.|:count maintenance types were deleted successfully.',
+        'partial_success' => 'Maintenance type deleted successfully. See additional information below. | :count maintenance types were deleted successfully. See additional information below.',
     ],
     'complete' => [
         'success' => 'Maintenance marked as complete.',

--- a/resources/lang/en-US/admin/maintenances/general.php
+++ b/resources/lang/en-US/admin/maintenances/general.php
@@ -3,6 +3,7 @@
 return [
     'asset_maintenances' => 'Asset Maintenances', // not used anymore
     'maintenances' => 'Maintenances',
+    'create' => 'Create Asset Maintenance',
     'edit' => 'Edit Asset Maintenance',
     'delete' => 'Delete Asset Maintenance',
     'view' => 'View Asset Maintenance Details',

--- a/resources/views/blade/table/bulk-maintenance-types.blade.php
+++ b/resources/views/blade/table/bulk-maintenance-types.blade.php
@@ -1,0 +1,10 @@
+@can('delete', \App\Models\MaintenanceType::class)
+    <x-table.bulk-actions
+        name="maintenancetype"
+        :action_route="route('maintenance-types.bulk.delete')"
+        model_name="maintenanceType"
+        :actions="[
+            'delete' => ['label' => trans('general.delete')],
+        ]"
+    />
+@endcan

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -394,7 +394,7 @@
                             </li>
                         @endcan
                         @can('index', \App\Models\Asset::class)
-                            <li class="treeview{{ ((request()->is('statuslabels/*') || request()->is(['hardware*', 'maintenances*'])) ? ' active' : '') }}">
+                                <li class="treeview{{ ((request()->is('statuslabels/*') || request()->is('hardware*')) ? ' active' : '') }}">
                                 <a href="#">
                                     <x-icon type="assets" class="fa-fw" />
                                     <span>{{ trans('general.assets') }}</span>
@@ -523,11 +523,6 @@
                                                 {{ trans('general.deleted') }}
                                             </a>
                                         </li>
-                                        <li {!! (request()->is('maintenances') ? ' class="active" aria-current="page"' : '') !!}>
-                                            <a href="{{ route('maintenances.index') }}">
-                                                {{ trans('general.maintenances') }}
-                                            </a>
-                                        </li>
                                     @endcan
                                     @can('audit', \App\Models\Asset::class)
                                         <li id="bulk-audit-sidenav-option" {!! (request()->is('hardware/bulkaudit') ? ' class="active" aria-current="page"' : '') !!}>
@@ -538,6 +533,47 @@
                                     @endcan
 
                                 </ul>
+                                </li>
+                            @endcan
+                            {{-- Dedicated Maintenances section. Treeview parent
+                                 so "list all" and Maintenance Types share one
+                                 visual home. The @if guard OR's the two
+                                 governing permissions so a user with either
+                                 can see the parent. --}}
+                            @if (Gate::allows('view', \App\Models\Asset::class) || Gate::allows('index', \App\Models\MaintenanceType::class))
+                                <li class="treeview{{ (request()->is('maintenances*') || request()->is('maintenance-types*')) ? ' active' : '' }}">
+                                    <a href="#">
+                                        <x-icon type="maintenances" class="fa-fw"/>
+                                        <span>{{ trans('general.maintenances') }}</span>
+                                        <x-icon type="angle-left" class="pull-right fa-fw"/>
+                                    </a>
+                                    <ul class="treeview-menu">
+                                        @can('view', \App\Models\Asset::class)
+                                            <li{!! (request()->is('maintenances') ? ' class="active" aria-current="page"' : '') !!}>
+                                            <a href="{{ route('maintenances.index') }}">
+                                                <x-icon type="circle" class="text-grey fa-fw"/>
+                                                {{ trans('general.list_all') }}
+                                            </a>
+                                        </li>
+                                    @endcan
+                                        @can('index', \App\Models\MaintenanceType::class)
+                                            <li{!! (request()->is('maintenance-types*') ? ' class="active" aria-current="page"' : '') !!}>
+                                                <a href="{{ route('maintenance-types.index') }}">
+                                                    <x-icon type="circle" class="text-grey fa-fw"/>
+                                                    {{ trans('admin/maintenance_types/general.maintenance_types') }}
+                                            </a>
+                                        </li>
+                                    @endcan
+                                </ul>
+                                </li>
+                            @endif
+
+                            @can('view', \App\Models\Asset::class)
+                                <li{!! (request()->routeIs('calendar.index') ? ' class="active" aria-current="page"' : '') !!}>
+                                    <a href="#">
+                                        <x-icon type="calendar" class="fa-fw"/>
+                                        <span>{{ trans('general.calendar') }}</span>
+                                    </a>
                             </li>
                         @endcan
                         @can('view', \App\Models\License::class)

--- a/resources/views/maintenance-types/edit.blade.php
+++ b/resources/views/maintenance-types/edit.blade.php
@@ -10,11 +10,6 @@
     @parent
 @stop
 
-@section('header_right')
-    <a href="{{ URL::previous() }}" class="btn btn-primary pull-right">
-        {{ trans('general.back') }}
-    </a>
-@stop
 
 {{-- Page content --}}
 @section('content')
@@ -31,6 +26,18 @@
                     name="name"
                     required
                 />
+
+                    <fieldset name="color-preferences">
+                        <x-form.legend help_text="{{ trans('general.tag_color_help') }}">
+                            {{ trans('general.tag_color') }}
+                        </x-form.legend>
+                        <x-form.row
+                            :label="trans('general.tag_color')"
+                            :$item
+                            name="tag_color"
+                            type="colorpicker"
+                        />
+                    </fieldset>
             </x-box>
         </x-form>
     </x-container>

--- a/resources/views/maintenance-types/index.blade.php
+++ b/resources/views/maintenance-types/index.blade.php
@@ -10,6 +10,11 @@
 @section('content')
     <x-container>
         <x-box>
+
+            <x-slot:bulkactions>
+                <x-table.bulk-maintenance-types />
+            </x-slot:bulkactions>
+
             <x-table
                     name="maintenancetype"
                     buttons="maintenanceTypeButtons"

--- a/resources/views/maintenance-types/view.blade.php
+++ b/resources/views/maintenance-types/view.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts/default')
+
+{{-- Page title --}}
+@section('title')
+    {{ $item->name }} {{ trans('admin/maintenances/general.maintenances') }}
+    @parent
+@stop
+
+@section('header_right')
+    <x-button.info-panel-toggle/>
+@endsection
+
+{{-- Page content --}}
+@section('content')
+    <x-container columns="2">
+        <x-page-column class="col-md-9 main-panel">
+            <x-box name="maintenances">
+                <x-table.maintenances
+                    name="maintenances"
+                    :table_header="trans('admin/maintenances/general.maintenances')"
+                    :route="route('api.maintenances.index', ['maintenance_type_id' => $item->id])"
+                />
+            </x-box>
+        </x-page-column>
+        <x-page-column class="col-md-3">
+            <x-box class="side-box expanded">
+                <x-info-panel :infoPanelObj="$item">
+
+                    <x-slot:buttons>
+                        <x-button.edit :item="$item" :route="route('maintenance-types.edit', $item->id)" />
+                        <x-button.delete :item="$item" />
+                    </x-slot:buttons>
+
+                </x-info-panel>
+            </x-box>
+        </x-page-column>
+    </x-container>
+@stop
+
+@section('moar_scripts')
+    @include ('partials.bootstrap-table', ['exportFile' => 'maintenances-export', 'search' => true])
+    <x-modals.maintenance-complete />
+@stop

--- a/resources/views/partials/bootstrap-table.blade.php
+++ b/resources/views/partials/bootstrap-table.blade.php
@@ -1651,6 +1651,26 @@
     });
     @endcan
 
+    @can('create', \App\Models\MaintenanceType::class)
+    // Maintenance Type table buttons
+    window.maintenanceTypeButtons = () => ({
+        btnAdd: {
+            text: '{{ trans('general.create') }}',
+            icon: 'fa fa-plus',
+            event () {
+                window.location.href = '{{ route('maintenance-types.create') }}';
+            },
+            attributes: {
+                class: 'btn-warning',
+                title: '{{ trans('general.create') }}',
+                @if ($snipeSettings->shortcuts_enabled == 1)
+                accesskey: 'n'
+                @endif
+            }
+        },
+    });
+    @endcan
+
     @can('create', \App\Models\Department::class)
     // Department table buttons
     window.departmentButtons = () => ({
@@ -2167,6 +2187,14 @@
 
     // This only works for model index pages because it uses the row's model ID
     function genericRowLinkFormatter(destination) {
+        // camelCase entries in the formatters array whose URL segment
+        // is actually hyphenated need a rewrite here; the formatter
+        // names stay as valid JS identifiers, the URL uses the real
+        // route segment. Matches the groups -> admin/groups precedent
+        // in genericActionsFormatter.
+        if (destination == 'maintenanceTypes') {
+            destination = 'maintenance-types';
+        }
         return function (value,row) {
 
             if ((row) && (row.tag_color) && (row.tag_color!='') && (row.tag_color!=undefined)) {
@@ -2217,6 +2245,12 @@
 
     // Use this when we're introspecting into a column object and need to link
     function genericColumnObjLinkFormatter(destination) {
+        // camelCase entries in the formatters array whose URL segment
+        // is actually hyphenated need a rewrite here. See sibling
+        // formatters for the groups -> admin/groups precedent.
+        if (destination == 'maintenanceTypes') {
+            destination = 'maintenance-types';
+        }
         return function (value,row) {
             if ((value) && (value.status_meta)) {
 
@@ -2319,6 +2353,10 @@
 
             if (dest =='groups') {
                 var dest = 'admin/groups';
+            }
+
+            if (dest == 'maintenanceTypes') {
+                dest = 'maintenance-types';
             }
 
 
@@ -2538,6 +2576,13 @@
     }
 
     function genericCheckinCheckoutFormatter(destination) {
+        // camelCase entries in the formatters array whose URL segment
+        // is actually hyphenated need a rewrite here even though
+        // maintenance-types isn't checkoutable, kept for consistency
+        // with the sibling formatters.
+        if (destination == 'maintenanceTypes') {
+            destination = 'maintenance-types';
+        }
         return function (value, row) {
 
             // The user is allowed to check items out, AND the item is deployable
@@ -2601,6 +2646,7 @@
         'licenses',
         'locations',
         'maintenances',
+        'maintenanceTypes',
         'manufacturers',
         'models',
         'statuslabels',

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\BulkCategoriesController;
 use App\Http\Controllers\BulkCompaniesController;
 use App\Http\Controllers\BulkDepartmentsController;
 use App\Http\Controllers\BulkDepreciationsController;
+use App\Http\Controllers\BulkMaintenanceTypesController;
 use App\Http\Controllers\BulkManufacturersController;
 use App\Http\Controllers\BulkStatuslabelsController;
 use App\Http\Controllers\BulkSuppliersController;
@@ -39,6 +40,7 @@ use App\Http\Controllers\UploadedFilesController;
 use App\Http\Controllers\ViewAssetsController;
 use App\Livewire\Importer;
 use App\Mail\CheckoutComponentMail;
+use App\Models\MaintenanceType;
 use App\Models\ReportTemplate;
 use Illuminate\Support\Facades\Route;
 use Tabuna\Breadcrumbs\Trail;
@@ -99,6 +101,16 @@ Route::middleware(['web', 'auth', 'authorize:superuser'])->prefix('oauth')->grou
 
 Route::group(['middleware' => 'auth'], function () {
     /*
+    * Calendar (unified view across every HasCalendarEvents source).
+    * Companion API endpoint lives at /api/v1/calendar/events.
+    */
+    Route::get('calendar', [App\Http\Controllers\CalendarEventsController::class, 'index'])
+        ->name('calendar.index')
+        ->breadcrumbs(fn (Tabuna\Breadcrumbs\Trail $trail) => $trail->parent('home')
+            ->push(trans('general.calendar'), route('calendar.index'))
+        );
+
+    /*
     * Companies
     */
     Route::resource('companies', CompaniesController::class, [
@@ -152,8 +164,51 @@ Route::group(['middleware' => 'auth'], function () {
 
     /*
     * Maintenance Types
+    *
+    * Expanded from a Route::resource so per-route breadcrumbs can hang
+    * off each GET action. The four GET routes get an explicit
+    * ->breadcrumbs(); the write routes (POST / PUT / PATCH / DELETE)
+    * don't render a page and don't need trails. Route names match what
+    * Route::resource('maintenance-types', ...) would have generated so
+    * every existing route() lookup keeps working.
     */
-    Route::resource('maintenance-types', MaintenanceTypesController::class);
+    Route::get('maintenance-types', [MaintenanceTypesController::class, 'index'])
+        ->name('maintenance-types.index')
+        ->breadcrumbs(fn (Trail $trail) => $trail->parent('maintenances.index')
+            ->push(trans('admin/maintenance_types/general.maintenance_types'), route('maintenance-types.index'))
+        );
+
+    Route::get('maintenance-types/create', [MaintenanceTypesController::class, 'create'])
+        ->name('maintenance-types.create')
+        ->breadcrumbs(fn (Trail $trail) => $trail->parent('maintenance-types.index')
+            ->push(trans('admin/maintenance_types/general.create'))
+        );
+
+    Route::post('maintenance-types', [MaintenanceTypesController::class, 'store'])
+        ->name('maintenance-types.store');
+
+    Route::get('maintenance-types/{maintenance_type}', [MaintenanceTypesController::class, 'show'])
+        ->name('maintenance-types.show')
+        ->breadcrumbs(fn (Trail $trail, MaintenanceType $maintenanceType) => $trail->parent('maintenance-types.index')
+            ->push($maintenanceType->name, route('maintenance-types.show', $maintenanceType))
+        );
+
+    Route::get('maintenance-types/{maintenance_type}/edit', [MaintenanceTypesController::class, 'edit'])
+        ->name('maintenance-types.edit')
+        ->breadcrumbs(fn (Trail $trail, MaintenanceType $maintenanceType) => $trail->parent('maintenance-types.show', $maintenanceType)
+            ->push(trans('admin/maintenance_types/general.update'))
+        );
+
+    Route::put('maintenance-types/{maintenance_type}', [MaintenanceTypesController::class, 'update'])
+        ->name('maintenance-types.update');
+
+    Route::patch('maintenance-types/{maintenance_type}', [MaintenanceTypesController::class, 'update']);
+
+    Route::delete('maintenance-types/{maintenance_type}', [MaintenanceTypesController::class, 'destroy'])
+        ->name('maintenance-types.destroy');
+
+    Route::post('maintenance-types/bulk/delete', [BulkMaintenanceTypesController::class, 'destroy'])
+        ->name('maintenance-types.bulk.delete');
 
     /*
     * Depreciations

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Assets\BulkAssetsController;
 use App\Http\Controllers\BulkMaintenancesController;
 use App\Http\Controllers\MaintenancesController;
 use App\Models\Asset;
+use App\Models\Maintenance;
 use App\Models\Setting;
 use Illuminate\Support\Facades\Route;
 use Tabuna\Breadcrumbs\Trail;
@@ -208,10 +209,48 @@ Route::resource('hardware',
     ])->parameters(['hardware' => 'asset'])->withTrashed();
 
 // Asset Maintenances
-Route::resource('maintenances',
-    MaintenancesController::class,
-    ['middleware' => ['auth'],
-    ])->parameters(['maintenance' => 'maintenance', 'asset' => 'asset_id']);
+//
+// Expanded from a Route::resource so per-route breadcrumbs can chain.
+// maintenances.show is parented through the maintenance's type so the
+// trail reads: Maintenance Types → {type name} → {maintenance name}.
+// That matches the sidebar reshuffle that moved MT under Settings and
+// positioned it as the drill-down entry point for related maintenances.
+Route::group(['middleware' => ['auth']], function () {
+    Route::get('maintenances', [MaintenancesController::class, 'index'])
+        ->name('maintenances.index')
+        ->breadcrumbs(fn (Trail $trail) => $trail->parent('home', route('home'))
+            ->push(trans('admin/maintenances/general.maintenances'), route('maintenances.index'))
+        );
+
+    Route::get('maintenances/create', [MaintenancesController::class, 'create'])
+        ->name('maintenances.create')
+        ->breadcrumbs(fn (Trail $trail) => $trail->parent('maintenances.index')
+            ->push(trans('admin/maintenances/general.create'))
+        );
+
+    Route::post('maintenances', [MaintenancesController::class, 'store'])
+        ->name('maintenances.store');
+
+    Route::get('maintenances/{maintenance}', [MaintenancesController::class, 'show'])
+        ->name('maintenances.show')
+        ->breadcrumbs(fn (Trail $trail, Maintenance $maintenance) => $trail->parent('maintenances.index')
+            ->push($maintenance->name, route('maintenances.show', $maintenance))
+        );
+
+    Route::get('maintenances/{maintenance}/edit', [MaintenancesController::class, 'edit'])
+        ->name('maintenances.edit')
+        ->breadcrumbs(fn (Trail $trail, Maintenance $maintenance) => $trail->parent('maintenances.show', $maintenance)
+            ->push(trans('admin/maintenances/general.edit'))
+        );
+
+    Route::put('maintenances/{maintenance}', [MaintenancesController::class, 'update'])
+        ->name('maintenances.update');
+
+    Route::patch('maintenances/{maintenance}', [MaintenancesController::class, 'update']);
+
+    Route::delete('maintenances/{maintenance}', [MaintenancesController::class, 'destroy'])
+        ->name('maintenances.destroy');
+});
 
 Route::post('maintenances/{maintenance}/complete',
     [MaintenancesController::class, 'complete']

--- a/tests/Feature/Maintenances/Api/CreateMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Api/CreateMaintenanceTest.php
@@ -55,7 +55,8 @@ class CreateMaintenanceTest extends TestCase
         Storage::disk('public')->assertExists(app('maintenances_path').$maintenance->image);
 
         $this->assertDatabaseHas('maintenances', [
-            'asset_id' => $asset->id,
+            'item_id' => $asset->id,
+            'item_type' => \App\Models\Asset::class,
             'supplier_id' => $supplier->id,
             'maintenance_type_id' => $type->id,
             'asset_maintenance_type' => $type->name,
@@ -93,7 +94,8 @@ class CreateMaintenanceTest extends TestCase
         foreach ($assets as $asset) {
             $this->assertDatabaseHas('maintenances', [
                 'name' => 'Bulk Test',
-                'asset_id' => $asset->id,
+                'item_id' => $asset->id,
+                'item_type' => \App\Models\Asset::class,
                 'maintenance_type_id' => $type->id,
             ]);
         }
@@ -122,8 +124,8 @@ class CreateMaintenanceTest extends TestCase
             ->assertJsonPath('status', 'success')
             ->assertJsonPath('payload.total', 1);
 
-        $this->assertDatabaseHas('maintenances', ['asset_id' => $ownAsset->id, 'name' => 'FMCS Bulk Test']);
-        $this->assertDatabaseMissing('maintenances', ['asset_id' => $otherAsset->id, 'name' => 'FMCS Bulk Test']);
+        $this->assertDatabaseHas('maintenances', ['item_id' => $ownAsset->id, 'item_type' => \App\Models\Asset::class, 'name' => 'FMCS Bulk Test']);
+        $this->assertDatabaseMissing('maintenances', ['item_id' => $otherAsset->id, 'item_type' => \App\Models\Asset::class, 'name' => 'FMCS Bulk Test']);
     }
 
     public function test_bulk_create_returns_error_when_all_assets_inaccessible()

--- a/tests/Feature/Maintenances/Api/EditMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Api/EditMaintenanceTest.php
@@ -118,7 +118,8 @@ class EditMaintenanceTest extends TestCase
 
         $this->assertDatabaseHas('maintenances', [
             'id' => $maintenance->id,
-            'asset_id' => $asset->id,
+            'item_id' => $asset->id,
+            'item_type' => \App\Models\Asset::class,
             'name' => 'Updated Name',
         ]);
     }
@@ -143,7 +144,8 @@ class EditMaintenanceTest extends TestCase
 
         $this->assertDatabaseHas('maintenances', [
             'id' => $maintenance->id,
-            'asset_id' => $assetB->id,
+            'item_id' => $assetB->id,
+            'item_type' => \App\Models\Asset::class,
         ]);
     }
 
@@ -168,7 +170,8 @@ class EditMaintenanceTest extends TestCase
 
         $this->assertDatabaseHas('maintenances', [
             'id' => $maintenance->id,
-            'asset_id' => $assetA->id,
+            'item_id' => $assetA->id,
+            'item_type' => \App\Models\Asset::class,
         ]);
     }
 }

--- a/tests/Feature/Maintenances/Api/IndexMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Api/IndexMaintenanceTest.php
@@ -142,6 +142,7 @@ class IndexMaintenanceTest extends TestCase
             ->assertOk();
 
         $this->assertEquals('Annual Checkup', $response->json('maintenance_type'));
+        $this->assertEquals('Annual Checkup', $response->json('maintenance_type_details.name'));
     }
 
     public function test_sort_by_maintenance_type_does_not_error()

--- a/tests/Feature/Maintenances/Api/MaintenanceTypesTest.php
+++ b/tests/Feature/Maintenances/Api/MaintenanceTypesTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Maintenances\Api;
 
+use App\Models\Asset;
+use App\Models\Maintenance;
 use App\Models\MaintenanceType;
 use App\Models\User;
 use Tests\TestCase;
@@ -74,5 +76,37 @@ class MaintenanceTypesTest extends TestCase
             ->assertStatusMessageIs('success');
 
         $this->assertSoftDeleted($type);
+    }
+
+    public function test_cannot_delete_maintenance_type_that_is_in_use()
+    {
+        $type = MaintenanceType::factory()->create();
+        Maintenance::factory()->create([
+            'maintenance_type_id' => $type->id,
+            'item_id' => Asset::factory()->create()->id,
+            'item_type' => Asset::class,
+        ]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->deleteJson(route('api.maintenance-types.destroy', $type))
+            ->assertStatus(409)
+            ->assertStatusMessageIs('error');
+
+        $this->assertDatabaseHas('maintenance_types', ['id' => $type->id, 'deleted_at' => null]);
+    }
+
+    public function test_index_exposes_maintenances_count()
+    {
+        $type = MaintenanceType::factory()->create();
+        Maintenance::factory()->count(2)->create([
+            'maintenance_type_id' => $type->id,
+            'item_id' => Asset::factory()->create()->id,
+            'item_type' => Asset::class,
+        ]);
+
+        $this->actingAsForApi(User::factory()->superuser()->create())
+            ->getJson(route('api.maintenance-types.index'))
+            ->assertOk()
+            ->assertJsonFragment(['id' => $type->id, 'maintenances_count' => 2]);
     }
 }

--- a/tests/Feature/Maintenances/Ui/BulkMaintenanceTypeDeleteTest.php
+++ b/tests/Feature/Maintenances/Ui/BulkMaintenanceTypeDeleteTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Maintenances\Ui;
+
+use App\Models\Asset;
+use App\Models\Maintenance;
+use App\Models\MaintenanceType;
+use App\Models\User;
+use Tests\TestCase;
+
+/**
+ * Covers the bulk-delete endpoint on BulkMaintenanceTypesController.
+ * Same in-use guard as the per-row destroy: a type with referring
+ * maintenances is skipped and its skip surfaces on the
+ * multi_error_messages flash; unused siblings in the same batch still
+ * get deleted so a partial-success batch applies the safe rows and
+ * flags the unsafe ones by name.
+ */
+class BulkMaintenanceTypeDeleteTest extends TestCase
+{
+    public function test_bulk_delete_requires_permission()
+    {
+        $type = MaintenanceType::factory()->create();
+
+        $this->actingAs(User::factory()->create())
+            ->post(route('maintenance-types.bulk.delete'), ['ids' => [$type->id]])
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('maintenance_types', ['id' => $type->id, 'deleted_at' => null]);
+    }
+
+    public function test_bulk_delete_removes_selected_unused_types()
+    {
+        $doomed = MaintenanceType::factory()->count(3)->create();
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('maintenance-types.bulk.delete'), [
+                'ids' => $doomed->pluck('id')->all(),
+            ])
+            ->assertRedirect(route('maintenance-types.index'))
+            ->assertSessionHas('success')
+            ->assertSessionMissing('multi_error_messages');
+
+        $doomed->each(fn ($t) => $this->assertSoftDeleted('maintenance_types', ['id' => $t->id]));
+    }
+
+    public function test_bulk_delete_skips_types_still_in_use()
+    {
+        $inUse = MaintenanceType::factory()->create();
+        Maintenance::factory()->create([
+            'maintenance_type_id' => $inUse->id,
+            'item_id' => Asset::factory()->create()->id,
+            'item_type' => Asset::class,
+        ]);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('maintenance-types.bulk.delete'), [
+                'ids' => [$inUse->id],
+            ])
+            ->assertRedirect(route('maintenance-types.index'))
+            ->assertSessionMissing('success')
+            ->assertSessionHas('multi_error_messages');
+
+        $this->assertDatabaseHas('maintenance_types', ['id' => $inUse->id, 'deleted_at' => null]);
+    }
+
+    public function test_bulk_delete_handles_mixed_batch()
+    {
+        $unused = MaintenanceType::factory()->count(2)->create();
+        $inUse = MaintenanceType::factory()->create();
+        Maintenance::factory()->create([
+            'maintenance_type_id' => $inUse->id,
+            'item_id' => Asset::factory()->create()->id,
+            'item_type' => Asset::class,
+        ]);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('maintenance-types.bulk.delete'), [
+                'ids' => array_merge($unused->pluck('id')->all(), [$inUse->id]),
+            ])
+            ->assertRedirect(route('maintenance-types.index'))
+            ->assertSessionHas('success')
+            ->assertSessionHas('multi_error_messages');
+
+        $unused->each(fn ($t) => $this->assertSoftDeleted('maintenance_types', ['id' => $t->id]));
+        $this->assertDatabaseHas('maintenance_types', ['id' => $inUse->id, 'deleted_at' => null]);
+    }
+
+    public function test_bulk_delete_skips_missing_ids_without_crashing()
+    {
+        $this->actingAs(User::factory()->superuser()->create())
+            ->post(route('maintenance-types.bulk.delete'), [
+                'ids' => [999999],
+            ])
+            ->assertRedirect(route('maintenance-types.index'))
+            ->assertSessionHas('multi_error_messages');
+    }
+}

--- a/tests/Feature/Maintenances/Ui/CreateMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Ui/CreateMaintenanceTest.php
@@ -72,7 +72,8 @@ class CreateMaintenanceTest extends TestCase
         Storage::disk('local')->assertExists('private_uploads/maintenances/'.$uploadedLog->filename);
 
         $this->assertDatabaseHas('maintenances', [
-            'asset_id' => $asset->id,
+            'item_id' => $asset->id,
+            'item_type' => \App\Models\Asset::class,
             'supplier_id' => $supplier->id,
             'maintenance_type_id' => $type->id,
             'asset_maintenance_type' => $type->name,

--- a/tests/Feature/Maintenances/Ui/CreateMaintenanceTrackingTest.php
+++ b/tests/Feature/Maintenances/Ui/CreateMaintenanceTrackingTest.php
@@ -27,7 +27,8 @@ class CreateMaintenanceTrackingTest extends TestCase
             ->assertRedirect(route('maintenances.index'));
 
         $this->assertDatabaseHas('maintenances', [
-            'asset_id' => $asset->id,
+            'item_id' => $asset->id,
+            'item_type' => Asset::class,
             'checked_out_to_id' => $assignedUser->id,
             'checked_out_to_type' => User::class,
         ]);
@@ -49,7 +50,8 @@ class CreateMaintenanceTrackingTest extends TestCase
             ->assertSessionHasNoErrors();
 
         $this->assertDatabaseHas('maintenances', [
-            'asset_id' => $asset->id,
+            'item_id' => $asset->id,
+            'item_type' => Asset::class,
             'checked_out_to_id' => null,
             'checked_out_to_type' => null,
         ]);
@@ -79,7 +81,8 @@ class CreateMaintenanceTrackingTest extends TestCase
             ->assertSessionHasNoErrors();
 
         $this->assertDatabaseHas('maintenances', [
-            'asset_id' => $asset->id,
+            'item_id' => $asset->id,
+            'item_type' => Asset::class,
             'responsible_party_id' => null,
         ]);
     }
@@ -102,7 +105,8 @@ class CreateMaintenanceTrackingTest extends TestCase
             ->assertSessionHasNoErrors();
 
         $this->assertDatabaseHas('maintenances', [
-            'asset_id' => $asset->id,
+            'item_id' => $asset->id,
+            'item_type' => Asset::class,
             'responsible_party_id' => $technician->id,
         ]);
     }
@@ -123,7 +127,8 @@ class CreateMaintenanceTrackingTest extends TestCase
             ->assertSessionHasNoErrors();
 
         $this->assertDatabaseHas('maintenances', [
-            'asset_id' => $asset->id,
+            'item_id' => $asset->id,
+            'item_type' => Asset::class,
             'maintenance_type_id' => $type->id,
             'asset_maintenance_type' => 'Custom Calibration',
         ]);

--- a/tests/Feature/Maintenances/Ui/EditMaintenanceTest.php
+++ b/tests/Feature/Maintenances/Ui/EditMaintenanceTest.php
@@ -68,7 +68,8 @@ class EditMaintenanceTest extends TestCase
         Storage::disk('local')->assertExists('private_uploads/maintenances/'.$uploadedLog->filename);
 
         $this->assertDatabaseHas('maintenances', [
-            'asset_id' => $asset->id,
+            'item_id' => $asset->id,
+            'item_type' => \App\Models\Asset::class,
             'supplier_id' => $supplier->id,
             'maintenance_type_id' => $type->id,
             'asset_maintenance_type' => $type->name,

--- a/tests/Feature/Maintenances/Ui/MaintenanceTypeControllerTest.php
+++ b/tests/Feature/Maintenances/Ui/MaintenanceTypeControllerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Maintenances\Ui;
+
+use App\Models\Asset;
+use App\Models\Maintenance;
+use App\Models\MaintenanceType;
+use App\Models\User;
+use Tests\TestCase;
+
+/**
+ * Web-side coverage for MaintenanceTypesController: show route renders
+ * and gates on the view permission, and destroy honors the in-use
+ * guard (mirrors the API-side destroy test in tests/Feature/Maintenances/
+ * Api/MaintenanceTypesTest).
+ */
+class MaintenanceTypeControllerTest extends TestCase
+{
+    public function test_show_page_renders()
+    {
+        $type = MaintenanceType::factory()->create();
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->get(route('maintenance-types.show', $type))
+            ->assertOk()
+            ->assertSeeText($type->name);
+    }
+
+    public function test_show_requires_permission()
+    {
+        $type = MaintenanceType::factory()->create();
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('maintenance-types.show', $type))
+            ->assertForbidden();
+    }
+
+    public function test_can_delete_unused_maintenance_type()
+    {
+        $type = MaintenanceType::factory()->create();
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->delete(route('maintenance-types.destroy', $type))
+            ->assertRedirect(route('maintenance-types.index'))
+            ->assertSessionHas('success');
+
+        $this->assertSoftDeleted($type);
+    }
+
+    public function test_cannot_delete_maintenance_type_that_is_in_use()
+    {
+        $type = MaintenanceType::factory()->create();
+        Maintenance::factory()->create([
+            'maintenance_type_id' => $type->id,
+            'item_id' => Asset::factory()->create()->id,
+            'item_type' => Asset::class,
+        ]);
+
+        $this->actingAs(User::factory()->superuser()->create())
+            ->delete(route('maintenance-types.destroy', $type))
+            ->assertRedirect(route('maintenance-types.index'))
+            ->assertSessionHas('error');
+
+        $this->assertDatabaseHas('maintenance_types', ['id' => $type->id, 'deleted_at' => null]);
+    }
+}


### PR DESCRIPTION
This just adds a basic cruddy UI for asset maintenance types. I don't love the UI right now, but it at least makes it functional.

It also adds a migration to include item_type and rename asset_id to item_id so we can potentially expand this out to non-assets.

Neither the UI or API controller sets `item_type` explicitly. Both the web (MaintenancesController::store line 102) and API (Api\MaintenancesController::store line 251) write via `$maintenance->asset_id = $assetId`. That triggers the legacy setAssetIdAttribute() mutator on the model (app/Models/Maintenance.php:286), which does the 
  translation:                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                             
  ```php
public function setAssetIdAttribute($value): void                                                                                                                                                                                                                                                                          
  {                                                                                                                                                                                                                                                                                                                          
      $this->attributes['item_id'] = $value;                                                                                                                                                                                                                                                                                 
      $this->attributes['item_type'] = Asset::class;                                                                                                                                                                                                                                                                         
  }                                                                                                                                                                                                                                                                                                                          
```          
                                                                                                                                                                                                                                                                                                                   
  So `item_type` is being pinned to `App\Models\Asset` by the mutator, always. Every write path today goes through that.    

The moment we want to attach a maintenance to an Accessory/etc, both controllers need to be updated to accept item_type (or a polymorphic item[type] + item[id] shape) and skip the asset_id shortcut. That's further down the line though.