### PR TITLE
Added #10606: support shift-click checkbox range selection

### DIFF
--- a/resources/assets/js/snipeit.js
+++ b/resources/assets/js/snipeit.js
@@ -1332,6 +1332,56 @@ $(function () {
         $container.find('input[type="checkbox"]').not($master).not(':disabled').prop('checked', $master.prop('checked'));
     });
 
+    // Shift-click a row checkbox to apply its new state to every visible,
+    // enabled checkbox between it and the last checkbox clicked in the same
+    // table and checkbox group.
+    var lastListCheckbox = null;
+    var updatingCheckboxRange = false;
+
+    document.addEventListener('click', function (event) {
+        var $checkbox = $(event.target);
+
+        if (updatingCheckboxRange
+            || !$checkbox.is('table tbody input[type="checkbox"]')
+            || $checkbox.is('[data-toggle="check-all"]')) {
+            return;
+        }
+
+        var checkbox = $checkbox[0];
+        var $table = $checkbox.closest('table');
+        var $checkboxes = $table.find('tbody input[type="checkbox"]')
+            .not(':disabled')
+            .not('[data-toggle="check-all"]')
+            .filter(':visible')
+            .filter(function () {
+                return !checkbox.name || this.name === checkbox.name;
+            });
+        var start = $checkboxes.index(lastListCheckbox);
+        var end = $checkboxes.index(checkbox);
+
+        if (event.shiftKey && start !== -1 && end !== -1 && start !== end) {
+            updatingCheckboxRange = true;
+
+            try {
+                $checkboxes.slice(Math.min(start, end), Math.max(start, end) + 1).each(function () {
+                    if (this !== checkbox && this.checked !== checkbox.checked) {
+                        var rowIndex = $(this).data('index');
+
+                        if ($table.data('bootstrap.table') && rowIndex !== undefined) {
+                            $table.bootstrapTable(checkbox.checked ? 'check' : 'uncheck', rowIndex);
+                        } else {
+                            $(this).trigger('click');
+                        }
+                    }
+                });
+            } finally {
+                updatingCheckboxRange = false;
+            }
+        }
+
+        lastListCheckbox = checkbox;
+    }, true);
+
     // Custom-report "save template" flow. The three custom reports
     // (asset / component / consumable) each have a small side-panel
     // form that captures a template name and posts to the templates


### PR DESCRIPTION
Adds shift-click range selection to checkbox lists throughout Snipe-IT.

After selecting or clearing a row checkbox, users can hold Shift and click another checkbox in the same table to apply that state to every visible, enabled checkbox between them.

The implementation:

- Limits each range to the same table and checkbox group.
- Skips disabled and hidden checkboxes.
- Uses Bootstrap Table's `check` and `uncheck` APIs so bulk actions and selection events remain synchronized.
- Triggers normal clicks for checkboxes in ordinary HTML tables, preserving their existing handlers.

A capture-phase listener is required because Bootstrap Table stops row-checkbox click propagation before a delegated jQuery document handler can receive it.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Production assets built successfully with `npm run prod`.
- [x] JavaScript syntax checked with `node --check resources/assets/js/snipeit.js`.
- [x] Manually tested against seeded data in a local browser.

## Demo

<img width="2403" height="1295" alt="brave_uS6snJDUgL" src="https://github.com/user-attachments/assets/4ffaff7a-7888-4c7b-abbe-800078c91d37" />


Fixes #10606

---

This change was prepared with assistance from an LLM. I've reviewed and tested the implementation before submission.