### PR TITLE
Fixed --force not skipping the PHP version prompt in ldap:troubleshoot

### DIFF
--- a/app/Console/Commands/LdapTroubleshooter.php
+++ b/app/Console/Commands/LdapTroubleshooter.php
@@ -198,9 +198,12 @@ class LdapTroubleshooter extends Command
             ($major == 8 && $minor == 4 && $patch < 7)
         ) {
             $this->warn("PHP Version: $php_version WARNING - Versions before 8.3.21 or 8.4.7 will return INCONSISTENT results!");
-            if (! $this->confirm('Are you sure you wish to continue?')) {
-                $this->warn('ABORTING');
-                exit(-1);
+            if (! $this->option('force')) {
+                $confirmation = $this->confirm('Are you sure you wish to continue?');
+                if (! $confirmation) {
+                    $this->warn('ABORTING');
+                    exit(-1);
+                }
             }
         }
 


### PR DESCRIPTION
Reported in #19513.

### Problem

`ldap:troubleshoot` declares `--force` as *"Skip the interactive yes/no prompt for confirmation"* and guards two of its three confirmations with it:

```php
// ~149
if (! $this->option('force')) {
    $confirmation = $this->confirm('WARNING: This command will display your LDAP password on your terminal. ...');

// ~207
if (! $this->option('force')) {
    $confirmation = $this->confirm('WARNING: This command will make several attempts to connect to your LDAP server. ...');
```

The PHP-version confirmation isn't guarded, so it prompts even with `--force`:

```php
// ~200
$this->warn("PHP Version: $php_version WARNING - Versions before 8.3.21 or 8.4.7 will return INCONSISTENT results!");
if (! $this->confirm('Are you sure you wish to continue?')) {
    $this->warn('ABORTING');
    exit(-1);
}
```

The practical effect, from the report:

```
$ docker run --rm snipe/snipe-it:v8.7.1 php artisan ldap:troubleshoot --force
PHP Version: 8.3.6 WARNING - Versions before 8.3.21 or 8.4.7 will return INCONSISTENT results!
 Are you sure you wish to continue? (yes/no) [no]:
 > ABORTING
```

`--no-interaction` isn't a way out either — Laravel's `confirm($question, $default = false)` returns the default under `-n`, which lands on the same `ABORTING` branch.

This isn't an edge case for the official image: the Dockerfile is `FROM ubuntu:24.04` installing distro `php8.3-*` packages, and Ubuntu ships the 8.3.6 line with fixes backported rather than the version string advanced. So the check compares an upstream version number against a distro-patched build and fires on every run of that image, making the command unusable unattended there.

### Fix

Guard that confirmation the same way as the other two, in the same shape the file already uses. The `warn()` is deliberately left outside the guard so the caveat still appears in unattended logs — `--force` suppresses the *prompt*, not the warning.

### Testing

`php -l` clean.

The behavioural change, with `confirm()` stubbed to what a non-interactive run returns:

```
--force=false   old: ABORTED    new: ABORTED
--force=true    old: ABORTED    new: CONTINUED
```

So the un-forced path is untouched and only `--force` changes, which is the documented contract. I don't have an LDAP directory to exercise the rest of the command against, so this is scoped strictly to the guard.

The reporter also raised whether the image should ship a newer PHP (they mentioned trying the Ondřej PPA) — that's a separate packaging decision, so I've left it out of this PR.
