### PR TITLE
Asset Checkin Notiification: [FD-55583] Fix Null location bug

### DIFF
--- a/app/Notifications/CheckinAssetNotification.php
+++ b/app/Notifications/CheckinAssetNotification.php
@@ -153,7 +153,7 @@ class CheckinAssetNotification extends Notification
                         Section::create(
                             KeyValue::create(
                                 trans('mail.checked_into') ?: '',
-                                ($item->location) ? $item->location?->name : '',
+                                $item->location?->name ?? '-',
                                 trans('admin/hardware/form.status').': '.$item->status?->name
                             )->onClick(route('hardware.show', $item->id))
                         )


### PR DESCRIPTION
The google chat notification would fail to send if there is no location or default location selected for an asset. it appears a blank return is not valid.

A blank location now returns:
<img width="506" height="424" alt="CleanShot 2026-08-18 at 12 01 53@2x" src="https://github.com/user-attachments/assets/0ddafce2-1325-4fa7-aad0-951d41a78a49" />

Fixes: [FD-55583]