### PR TITLE
LDAP Wizard: Fixed #19519 - better handle mTLS

### DIFF
--- a/app/Livewire/LdapSettings.php
+++ b/app/Livewire/LdapSettings.php
@@ -757,7 +757,7 @@ class LdapSettings extends Component
         $bindOk = @ldap_bind($conn, $uname, $pword);
         if (! $bindOk) {
             $errno = ldap_errno($conn);
-            $ldapError = ldap_error($conn);
+            $ldapError = Ldap::bindError($conn);
             @ldap_unbind($conn);
 
             if ($errno === -1) {
@@ -1223,6 +1223,19 @@ class LdapSettings extends Component
             putenv('LDAPTLS_REQCERT=never');
         }
 
+        // Client TLS cert/key MUST be set on the global (null-handle) LDAP
+        // context BEFORE ldap_connect(), the same way Ldap::connectToLdap
+        // does at runtime. Without this, mTLS-required directories (e.g.
+        // Google Secure LDAP) reject the wizard's bind test with a
+        // generic "Invalid credentials" even when everything the admin
+        // entered is correct, and since saveStep2 gates persistence on the
+        // test passing, the wizard becomes impossible to complete against
+        // those servers. See #19519.
+        if ($settings->ldap_client_tls_cert && $settings->ldap_client_tls_key) {
+            ldap_set_option(null, LDAP_OPT_X_TLS_CERTFILE, Setting::get_client_side_cert_path());
+            ldap_set_option(null, LDAP_OPT_X_TLS_KEYFILE, Setting::get_client_side_key_path());
+        }
+
         $conn = @ldap_connect($server);
         if (! $conn) {
             $this->recordTestResult(
@@ -1278,7 +1291,7 @@ class LdapSettings extends Component
 
         $bindOk = $uname !== '' ? @ldap_bind($conn, $uname, $pword) : @ldap_bind($conn);
         if (! $bindOk) {
-            $ldapError = ldap_error($conn);
+            $ldapError = Ldap::bindError($conn);
             @ldap_unbind($conn);
             $this->recordTestResult(
                 'error',

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -282,7 +282,7 @@ class Ldap extends Model
             }
 
             if (! $ldapbind = @ldap_bind($connection, $ldap_username, $ldap_pass)) {
-                throw new Exception('Could not bind to LDAP: '.ldap_error($connection));
+                throw new Exception('Could not bind to LDAP: '.self::bindError($connection));
             }
             // TODO - this just "falls off the end" but the function states that it should return true or false
             // unfortunately, one of the use cases for this function is wrong and *needs* for that failure mode to fire
@@ -292,9 +292,26 @@ class Ldap extends Model
         } else {
             // LDAP should also work with anonymous bind (no dn, no password available)
             if (! $ldapbind = @ldap_bind($connection)) {
-                throw new Exception('Could not bind to LDAP: '.ldap_error($connection));
+                throw new Exception('Could not bind to LDAP: '.self::bindError($connection));
             }
         }
+    }
+
+    /**
+     * Return "<ldap_error message> (<diagnostic message>)" for a failed
+     * operation on the given LDAP connection, or just the ldap_error
+     * message when no diagnostic is available. Servers often put the
+     * real cause (bad DN, missing client cert, expired password, etc.)
+     * in LDAP_OPT_DIAGNOSTIC_MESSAGE while ldap_error stays at the
+     * generic "Invalid credentials", so surfacing both is the difference
+     * between "credentials rejected" and knowing WHY they were rejected.
+     */
+    public static function bindError($connection): string
+    {
+        $diag = '';
+        @ldap_get_option($connection, LDAP_OPT_DIAGNOSTIC_MESSAGE, $diag);
+
+        return ldap_error($connection).($diag !== '' ? ' ('.$diag.')' : '');
     }
 
     /**

--- a/tests/Unit/LdapTest.php
+++ b/tests/Unit/LdapTest.php
@@ -44,9 +44,25 @@ class LdapTest extends TestCase
         $this->settings->enableLdap();
         $this->getFunctionMock('App\\Models', 'ldap_bind')->expects($this->once())->willReturn(false);
         $this->getFunctionMock('App\\Models', 'ldap_error')->expects($this->once())->willReturn('exception');
+        // bindError now also queries LDAP_OPT_DIAGNOSTIC_MESSAGE to surface
+        // the server's real reason (see #19519). Mocked as returning true
+        // without populating the by-ref $diag arg so the composed error
+        // stays just the ldap_error message.
+        $this->getFunctionMock('App\\Models', 'ldap_get_option')->expects($this->once())->willReturn(true);
         $this->expectExceptionMessage('Could not bind to LDAP:');
 
         $this->assertNull(Ldap::bindAdminToLdap('dummy'));
+    }
+
+    public function test_bind_error_returns_just_ldap_error_when_diagnostic_is_empty()
+    {
+        // Regression for #19519 secondary issue: bindError should NEVER
+        // suppress ldap_error; if no diagnostic is present, the composed
+        // string is just the ldap_error text.
+        $this->getFunctionMock('App\\Models', 'ldap_error')->expects($this->once())->willReturn('Server Down');
+        $this->getFunctionMock('App\\Models', 'ldap_get_option')->expects($this->once())->willReturn(true);
+
+        $this->assertSame('Server Down', Ldap::bindError('dummy'));
     }
     // other test cases - test donked password?
 
@@ -63,6 +79,8 @@ class LdapTest extends TestCase
         $this->settings->enableAnonymousLdap();
         $this->getFunctionMock('App\\Models', 'ldap_bind')->expects($this->once())->willReturn(false);
         $this->getFunctionMock('App\\Models', 'ldap_error')->expects($this->once())->willReturn('exception');
+        // bindError now also queries LDAP_OPT_DIAGNOSTIC_MESSAGE; see test_bind_bad.
+        $this->getFunctionMock('App\\Models', 'ldap_get_option')->expects($this->once())->willReturn(true);
         $this->expectExceptionMessage('Could not bind to LDAP:');
 
         $this->assertNull(Ldap::bindAdminToLdap('dummy'));


### PR DESCRIPTION
The LDAP wizard's connection test never set the client TLS cert or key, so mTLS-required directories (Google Secure LDAP, some corporate AD setups) rejected the bind test with a generic "Invalid credentials" message. Because the wizard gates persistence on the test passing, the settings could not be saved at all against those servers. This adds the client cert/key setup to `openLdapConnectionForTest()` in the same shape `Ldap::connectToLdap()` uses at runtime.

Fixes #19519