### PR TITLE
Force Manager 'value' to be string (even though it's an integer)

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -813,7 +813,7 @@ class SnipeSCIMConfig
                             }
 
                             return [
-                                'value' => $object->manager->id, // TODO - ID's aren't unique like they're supposed to be :/
+                                'value' => (string) $object->manager->id, // TODO - ID's aren't unique like they're supposed to be :/
                                 '$ref' => route('scim.resource', ['resourceType' => 'User', 'resourceObject' => $object->manager->id]),
                                 'displayName' => $object->manager->display_name,
                             ];


### PR DESCRIPTION
Entra was trying to continually `PATCH` the manager's `value` element because we were returning it as an integer instead of a string. This should (hopefully) stop that.