### PR TITLE
Cap the calendar backfill to 2000 rows per model source

### DIFF
--- a/database/migrations/2026_08_13_160100_backfill_calendar_events_from_existing_sources.php
+++ b/database/migrations/2026_08_13_160100_backfill_calendar_events_from_existing_sources.php
@@ -17,6 +17,13 @@ use Illuminate\Database\Migrations\Migration;
  * populates the index so those existing records show up on the
  * calendar without waiting for a manual save on each one.
  *
+ * Capped at the most-recent 2000 rows per source (ordered by primary
+ * key desc). Large installs with a decade of audit / maintenance /
+ * checkout history would otherwise grind through every historical
+ * row during upgrade to populate a calendar view most users only use
+ * for recent and upcoming events. Admins who want the full backlog
+ * run snipeit:reconcile-calendar-events after the upgrade completes.
+ *
  * Duplicates snipeit:reconcile-calendar-events's sync logic on
  * purpose - the command is meant to be re-runnable on demand later,
  * this migration is the one-time seed at deploy time. Kept small
@@ -42,15 +49,19 @@ return new class extends Migration
 
     protected function backfillSource(string $sourceClass): void
     {
+        $instance = new $sourceClass;
+        $keyName = $instance->getKeyName();
+
         $sourceClass::query()
             ->when(
                 in_array(SoftDeletes::class, class_uses_recursive($sourceClass), true),
                 fn ($q) => $q->withTrashed(),
             )
-            ->chunkById(500, function ($rows) {
-                foreach ($rows as $row) {
-                    $row->forceSyncCalendarEvents();
-                }
+            ->orderByDesc($keyName)
+            ->limit(2000)
+            ->get()
+            ->each(function ($row) {
+                $row->forceSyncCalendarEvents();
             });
     }
 


### PR DESCRIPTION
I just happened to notice the original migration was really slow on some of our hosted customers when I was manually upgrading them. This caps the migration at the most-recent 2000 rows per source, ordered by primary key desc. 

The one-shot calendar-events backfill migration walks every row on every source model that uses `HasCalendarEvents` and force-syncs each one. On installs with a decade of maintenance, audit, and checkout history that grinds through hundreds of thousands of rows to seed a calendar view most users only browse for recent and upcoming events.

**Admins who want the FULL backlog run `php artisan snipeit:reconcile-calendar-events` after the upgrade is done.** (I can absolutely see a use-case for wanting the entire history, so this is a good balance giving the most "useful" stuff out of the gate via migration, but also offering the whole shebang for the handful of folks who might need it. 

## Rationale

- The reconcile command already exists as the on-demand path for the full backlog. The migration is only meant to seed the common case fast.
- 2000 rows per source is enough for typical retrospective views (month-over-month checkout patterns, recent audits, prior maintenance cycles) without walking the entire table.
- Worst case is ~20K upserts across the current five sources (Maintenance, User, License, CheckoutRequest, Asset), which is a far cry faster than what we had before, but should still give a lot of backfill. 

I skipped adding a test for this since it's hooked into events and observers and so on, and it would be really slow for something that only fires once. 