### PR TITLE
Fix backup restoration when using a unix socket

### DIFF
--- a/app/Console/Commands/RestoreFromBackup.php
+++ b/app/Console/Commands/RestoreFromBackup.php
@@ -510,7 +510,9 @@ class RestoreFromBackup extends Command
             ' --batch '.
             ' --binary-mode '.
             ' -u '.escapeshellarg($connectionConfig['username']).' '.
-            ' -P '.escapeshellarg($connectionConfig['port']).' '.
+            (empty($connectionConfig['unix_socket'])
+                ? ' -P '.escapeshellarg($connectionConfig['port'])
+                : ' -S '.escapeshellarg($connectionConfig['unix_socket'])). ' '.
             escapeshellarg($connectionConfig['database']), // yanked -p since we pass via ENV
             [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
             $pipes,


### PR DESCRIPTION
The NixOS snipe-it module uses a unix socket in its integration tests, we noticed backup restoration was no longer working when using a unix socket.