### PR TITLE
Email Notifications: Made Asset Image size responsive

### DIFF
--- a/resources/views/mail/markdown/checkin-asset.blade.php
+++ b/resources/views/mail/markdown/checkin-asset.blade.php
@@ -4,7 +4,9 @@
 {{ trans('mail.the_following_item') }}
 
 @if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
-<center><img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;"></center>
+    {{-- @formatter:off --}}
+    <img src="{{ $item->getImageUrl() }}" alt="Asset" style="display:block; height:auto; max-width:100%; max-height:400px; margin:0 auto;">
+    {{-- @formatter:on --}}
 @endif
 
 @component('mail::table')

--- a/resources/views/mail/markdown/checkout-asset.blade.php
+++ b/resources/views/mail/markdown/checkout-asset.blade.php
@@ -4,7 +4,9 @@
 {{ $introduction_line }}
 
 @if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
-<center><img src="{{ $item->getImageUrl() }}" alt="Asset" style="max-width: 570px;"></center>
+    {{-- @formatter:off --}}
+<img src="{{ $item->getImageUrl() }}" alt="Asset" style="display:block; height:auto; max-width:100%; max-height:400px; margin:0 auto;">
+{{-- @formatter:on --}}
 @endif
 
 @component('mail::table')


### PR DESCRIPTION
The email logo and area was being resized due to the size of the Asset images. This makes the Asset images responsive and should prevent unintended message and logo scaling for smaller windows/devices.

Before
<img width="800" height="477" alt="CleanShot 2026-08-26 at 12 42 52" src="https://github.com/user-attachments/assets/a998bc96-faca-4059-819e-40e8b1f3639e" />
After
<img width="800" height="477" alt="CleanShot 2026-08-26 at 12 28 20" src="https://github.com/user-attachments/assets/94b33f9c-8dec-41e9-8c67-b6a16644b565" />

Fixes #19540