### PR TITLE
Testing: Allowed tests to be run in parallel

### DIFF
--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
+          # ParaTest spawns a worker per core as a separate PHP process
+          # and forwards ini flags only via --passthru-php, so bump the
+          # memory limit here when setting up PHP rather than
+          # on the test command.
+          ini-values: memory_limit=1G
 
       - uses: actions/checkout@v7
         with:
@@ -81,9 +86,7 @@ jobs:
           DB_USERNAME: root
           LOG_CHANNEL: single
           LOG_LEVEL: debug
-        # -d memory_limit=1G: see comment in tests-sqlite.yml. Same reason,
-        # same headroom.
-        run: php -d memory_limit=1G artisan test
+        run: php artisan test --parallel
 
       - name: Upload Laravel logs as artifacts
         if: always()

--- a/.github/workflows/tests-postgres.yml
+++ b/.github/workflows/tests-postgres.yml
@@ -34,6 +34,11 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
+          # ParaTest spawns a worker per core as a separate PHP process
+          # and forwards ini flags only via --passthru-php, so bump the
+          # memory limit here when setting up PHP rather than
+          # on the test command.
+          ini-values: memory_limit=1G
 
       - uses: actions/checkout@v7
         with:
@@ -80,9 +85,7 @@ jobs:
           DB_PASSWORD: password
           LOG_CHANNEL: single
           LOG_LEVEL: debug
-        # -d memory_limit=1G: see comment in tests-sqlite.yml. Same reason,
-        # same headroom.
-        run: php -d memory_limit=1G artisan test
+        run: php artisan test --parallel
 
       - name: Upload Laravel logs as artifacts
         if: always()

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: none
+          # ParaTest spawns a worker per core as a separate PHP process
+          # and forwards ini flags only via --passthru-php, so bump the
+          # memory limit here when setting up PHP rather than
+          # on the test command.
+          ini-values: memory_limit=1G
 
       - uses: actions/checkout@v7
         with:
@@ -65,12 +70,7 @@ jobs:
           DB_CONNECTION: sqlite
           LOG_CHANNEL: single
           LOG_LEVEL: debug
-        # -d memory_limit=1G: CI runs the entire test suite in a single
-        # PHP process, so memory accumulates from every prior test. Default
-        # 500M was pushing the process into OOM on Blade renders late in
-        # the alphabetical run (e.g. Users/Ui/TwoFactorResetTest). 1G
-        # gives comfortable headroom for suite growth.
-        run: php -d memory_limit=1G artisan test
+        run: php artisan test --parallel
 
       - name: Upload Laravel logs as artifacts
         if: always()

--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
     "ext-exif": "*"
   },
   "require-dev": {
+    "brianium/paratest": "^7.8",
     "fruitcake/laravel-debugbar": "^4.0",
     "larastan/larastan": "^3.0",
     "laravel/boost": "^2.5",
@@ -90,6 +91,9 @@
     "phpmd/phpmd": "^2.15",
     "phpunit/phpunit": "^11.0",
     "squizlabs/php_codesniffer": "^3.5"
+  },
+  "conflict": {
+    "laravel/prompts": "<0.3.19"
   },
   "extra": {
     "laravel": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "538ed1d90b81cae1b0410ad6debc5d74",
+    "content-hash": "4b7ead353b08dd7bdd6d42e7c459003b",
     "packages": [
         {
             "name": "alek13/slack",
@@ -2891,16 +2891,16 @@
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.17",
+            "version": "v0.3.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818"
+                "reference": "5d3cdef29e93ca3b62b1871359db3078cd99908b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/6a82ac19a28b916ae0885828795dbd4c59d9a818",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/5d3cdef29e93ca3b62b1871359db3078cd99908b",
+                "reference": "5d3cdef29e93ca3b62b1871359db3078cd99908b",
                 "shasum": ""
             },
             "require": {
@@ -2944,9 +2944,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.17"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.24"
             },
-            "time": "2026-04-20T16:07:33+00:00"
+            "time": "2026-08-20T12:55:36+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -12142,6 +12142,99 @@
     ],
     "packages-dev": [
         {
+            "name": "brianium/paratest",
+            "version": "v7.8.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paratestphp/paratest.git",
+                "reference": "9b324c8fc319cf9728b581c7a90e1c8f6361c5e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/9b324c8fc319cf9728b581c7a90e1c8f6361c5e5",
+                "reference": "9b324c8fc319cf9728b581c7a90e1c8f6361c5e5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-simplexml": "*",
+                "fidry/cpu-core-counter": "^1.3.0",
+                "jean85/pretty-package-versions": "^2.1.1",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-timer": "^7.0.1",
+                "phpunit/phpunit": "^11.5.46",
+                "sebastian/environment": "^7.2.1",
+                "symfony/console": "^6.4.22 || ^7.3.4 || ^8.0.3",
+                "symfony/process": "^6.4.20 || ^7.3.4 || ^8.0.3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12.0.0",
+                "ext-pcov": "*",
+                "ext-posix": "*",
+                "phpstan/phpstan": "^2.1.33",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.11",
+                "phpstan/phpstan-strict-rules": "^2.0.7",
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "symfony/filesystem": "^6.4.13 || ^7.3.2 || ^8.0.1"
+            },
+            "bin": [
+                "bin/paratest",
+                "bin/paratest_for_phpstorm"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParaTest\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Scaturro",
+                    "email": "scaturrob@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Filippo Tessarotto",
+                    "email": "zoeslam@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Parallel testing for PHP",
+            "homepage": "https://github.com/paratestphp/paratest",
+            "keywords": [
+                "concurrent",
+                "parallel",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/paratestphp/paratest/issues",
+                "source": "https://github.com/paratestphp/paratest/tree/v7.8.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/Slamdunk",
+                    "type": "github"
+                },
+                {
+                    "url": "https://paypal.me/filippotessarotto",
+                    "type": "paypal"
+                }
+            ],
+            "time": "2026-01-08T08:02:38+00:00"
+        },
+        {
             "name": "clue/ndjson-react",
             "version": "v1.3.0",
             "source": {
@@ -13063,6 +13156,66 @@
                 "source": "https://github.com/iamcal/SQLParser/tree/v0.7"
             },
             "time": "2026-01-28T22:20:33+00:00"
+        },
+        {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
         },
         {
             "name": "larastan/larastan",

--- a/database/.gitignore
+++ b/database/.gitignore
@@ -1,3 +1,5 @@
 *.sqlite
 *.journal
 *.sqlite-journal
+# Per-worker databases created by `artisan test --parallel`:
+*.sqlite_test_*

--- a/tests/Feature/Console/OptimizeTest.php
+++ b/tests/Feature/Console/OptimizeTest.php
@@ -2,18 +2,85 @@
 
 namespace Tests\Feature\Console;
 
+use Illuminate\Support\Facades\File;
 use Tests\TestCase;
 
 class OptimizeTest extends TestCase
 {
-    public function test_optimize_succeeds()
-    {
-        $this->beforeApplicationDestroyed(function () {
-            $this->artisan('config:clear');
-            $this->artisan('route:clear');
-            $this->artisan('view:clear');
-        });
+    private const RELOCATABLE_CACHES = [
+        'APP_CONFIG_CACHE' => 'config.php',
+        'APP_EVENTS_CACHE' => 'events.php',
+        'APP_ROUTES_CACHE' => 'routes-v7.php',
+    ];
 
+    private array $originalCacheEnv = [];
+
+    private string $relocatedCacheDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->relocatedCacheDirectory = storage_path('framework/testing/optimize-'.getmypid());
+
+        $this->snapshotCachePathEnv();
+        $this->relocateFrameworkCaches();
+
+        $this->beforeApplicationDestroyed(function () {
+            File::deleteDirectory($this->relocatedCacheDirectory);
+            $this->restoreCachePathEnv();
+        });
+    }
+
+    public function test_optimize_succeeds(): void
+    {
         $this->artisan('optimize')->assertSuccessful();
+    }
+
+    /**
+     * Record every cache path env var as it stands before this test
+     * relocates it.
+     */
+    private function snapshotCachePathEnv(): void
+    {
+        foreach (array_keys(self::RELOCATABLE_CACHES) as $key) {
+            $this->originalCacheEnv[$key] = [
+                'env' => $_ENV[$key] ?? false,
+                'server' => $_SERVER[$key] ?? false,
+            ];
+        }
+    }
+
+    /**
+     * Point the three relocatable caches at an isolated
+     * directory to avoid workers stepping on each other.
+     */
+    private function relocateFrameworkCaches(): void
+    {
+        File::ensureDirectoryExists($this->relocatedCacheDirectory);
+
+        foreach (self::RELOCATABLE_CACHES as $key => $filename) {
+            $path = $this->relocatedCacheDirectory.'/'.$filename;
+
+            $_ENV[$key] = $_SERVER[$key] = $path;
+        }
+    }
+
+    /**
+     * Put every cache path env var back exactly as it was before this test
+     * ran, so a relocated path can't leak into the next test's config boot.
+     */
+    private function restoreCachePathEnv(): void
+    {
+        foreach ($this->originalCacheEnv as $key => $original) {
+            unset($_ENV[$key], $_SERVER[$key]);
+
+            if ($original['env'] !== false) {
+                $_ENV[$key] = $original['env'];
+            }
+            if ($original['server'] !== false) {
+                $_SERVER[$key] = $original['server'];
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR installs and enables [parallel testing](https://laravel.com/framework/docs/12.x/testing#running-tests-in-parallel) via Paratest. 

Running the entire test suite in parallel gives results a lot faster:

|  | MySQL | sqlite |
|--------|--------|--------|
| Before | ~17 minutes | ~12 minutes |
| After | ~4 minutes | **~40 seconds** |

I also updated the GitHub workflows to use parallel testing so those should run faster as well. 

Tests can be run in parallel using `php artisan test --parallel`.

---

I updated the optimize command test because it touches config stuff and that was messing with other workers in parallel. I solved it with an approach similar to #19522: cache and restore before/after the test runs.

---

As part of this work, I updated the `laravel/prompts` package since there was a bug in an earlier version that was making a console test crash out.

---

AI Disclosure: I used Claude Code to help investigate the console and optimize tests mentioned above.
