### PR TITLE
Docker: Allow for overriding of specific apache limits

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -117,6 +117,13 @@ BACKUP_ENV=true
 #PHP_UPLOAD_MAX_FILESIZE=10
 #PHP_MEMORY_LIMIT=10
 
+# --------------------------------------------
+# OPTIONAL: CHANGE APACHE REQUEST HEADER LIMITS (UNCOMMENT WHEN NEEDING TO BE CHANGED)
+# Defaults: 8190 / 8190 / 100
+# --------------------------------------------
+#APACHE_LIMIT_REQUEST_FIELD_SIZE=8190
+#APACHE_LIMIT_REQUEST_LINE=8190
+#APACHE_LIMIT_REQUEST_FIELDS=100
 
 # --------------------------------------------
 # OPTIONAL: SESSION SETTINGS

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,10 @@ COPY . /var/www/html
 
 RUN a2enmod rewrite
 
+# Apache Limits Defaults
+COPY docker/apache-limits.conf /etc/apache2/conf-available/limits.conf
+RUN a2enconf limits
+
 COPY docker/column-statistics.cnf /etc/mysql/conf.d/column-statistics.cnf
 
 ############ INITIAL APPLICATION SETUP #####################

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -44,6 +44,9 @@ RUN mkdir -p /run/apache2 && chown apache:apache /run/apache2
 
 RUN sed -i 's/variables_order = .*/variables_order = "EGPCS"/' /etc/php84/php.ini
 COPY  docker/000-default-2.4.conf /etc/apache2/conf.d/default.conf
+# Apache Limits Defaults
+COPY  docker/apache-limits.conf /etc/apache2/conf.d/limits.conf
+
 
 # Enable mod_rewrite
 RUN sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf

--- a/docker/apache-limits.conf
+++ b/docker/apache-limits.conf
@@ -1,0 +1,10 @@
+# Apache request header limits.
+# Some environments (large SAML/SSO assertions, long Referer/Cookie headers,
+# corporate proxies, etc.) can exceed Apache's conservative defaults and
+# trigger "Bad Request: size of request header exceeds server limit".
+#
+# Override at runtime with the APACHE_LIMIT_REQUEST_* environment variables
+# (see docker/startup.sh).
+LimitRequestFieldSize 8190
+LimitRequestLine 8190
+LimitRequestFields 100

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -110,6 +110,26 @@ then
     done
 fi
 
+# Fix Apache request header limits
+# (defaults live in /etc/apache2/conf-available/limits.conf; override here)
+if [ -v "APACHE_LIMIT_REQUEST_FIELD_SIZE" ]
+then
+    echo "Changing LimitRequestFieldSize to ${APACHE_LIMIT_REQUEST_FIELD_SIZE}"
+    sed -i "s/^LimitRequestFieldSize.*/LimitRequestFieldSize ${APACHE_LIMIT_REQUEST_FIELD_SIZE}/" /etc/apache2/conf-available/limits.conf
+fi
+
+if [ -v "APACHE_LIMIT_REQUEST_LINE" ]
+then
+    echo "Changing LimitRequestLine to ${APACHE_LIMIT_REQUEST_LINE}"
+    sed -i "s/^LimitRequestLine.*/LimitRequestLine ${APACHE_LIMIT_REQUEST_LINE}/" /etc/apache2/conf-available/limits.conf
+fi
+
+if [ -v "APACHE_LIMIT_REQUEST_FIELDS" ]
+then
+    echo "Changing LimitRequestFields to ${APACHE_LIMIT_REQUEST_FIELDS}"
+    sed -i "s/^LimitRequestFields.*/LimitRequestFields ${APACHE_LIMIT_REQUEST_FIELDS}/" /etc/apache2/conf-available/limits.conf
+fi
+
 # If the Oauth DB files are not present copy the vendor files over to the db migrations
 if [ ! -f "/var/www/html/database/migrations/*create_oauth*" ]
 then

--- a/docker/startup_alpine.sh
+++ b/docker/startup_alpine.sh
@@ -94,6 +94,26 @@ then
     done
 fi
 
+# Fix Apache request header limits
+# (defaults live in /etc/apache2/conf.d/limits.conf; override here)
+if [ -v "APACHE_LIMIT_REQUEST_FIELD_SIZE" ]
+then
+    echo "Changing LimitRequestFieldSize to ${APACHE_LIMIT_REQUEST_FIELD_SIZE}"
+    sed -i "s/^LimitRequestFieldSize.*/LimitRequestFieldSize ${APACHE_LIMIT_REQUEST_FIELD_SIZE}/" /etc/apache2/conf.d/limits.conf
+fi
+
+if [ -v "APACHE_LIMIT_REQUEST_LINE" ]
+then
+    echo "Changing LimitRequestLine to ${APACHE_LIMIT_REQUEST_LINE}"
+    sed -i "s/^LimitRequestLine.*/LimitRequestLine ${APACHE_LIMIT_REQUEST_LINE}/" /etc/apache2/conf.d/limits.conf
+fi
+
+if [ -v "APACHE_LIMIT_REQUEST_FIELDS" ]
+then
+    echo "Changing LimitRequestFields to ${APACHE_LIMIT_REQUEST_FIELDS}"
+    sed -i "s/^LimitRequestFields.*/LimitRequestFields ${APACHE_LIMIT_REQUEST_FIELDS}/" /etc/apache2/conf.d/limits.conf
+fi
+
 # If the Oauth DB files are not present copy the vendor files over to the db migrations
 if [ ! -f "/var/www/html/database/migrations/*create_oauth*" ]
 then


### PR DESCRIPTION
## Summary

Adds a configurable Apache `LimitRequestFieldSize` / `LimitRequestLine` / `LimitRequestFields` setup, along with environment variable overrides, following the same pattern already used for `PHP_UPLOAD_LIMIT`.

## Motivation

Apache's default request header/line/field limits are conservative enough that they can be exceeded by legitimate traffic — most commonly large SAML/SSO assertions, long `Cookie` headers, or requests routed through corporate proxies that append extra headers. When this happens, Apache rejects the request before it ever reaches the app, with:

Bad Request
Your browser sent a request that this server could not understand.
Size of a request header field exceeds server limit.


Since this comes from Apache itself, there was previously no supported way to raise these limits without maintaining a custom image or manually patching the container after the fact.

