### PR TITLE
API Transformers: Check individual rows, not just general permissions

### DIFF
--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -103,11 +103,11 @@ class AccessoriesTransformer
         $permissions_array['assigned_to_self'] = $userHasOpenRequest;
 
         $permissions_array['available_actions'] = [
-            'checkout' => Gate::allows('checkout', Accessory::class),
+            'checkout' => Gate::allows('checkout', $accessory),
             'checkin' => false,
-            'update' => Gate::allows('update', Accessory::class),
-            'adjust_quantity' => Gate::allows('update', Accessory::class),
-            'delete' => $accessory->checkouts_count === 0 && Gate::allows('delete', Accessory::class),
+            'update' => Gate::allows('update', $accessory),
+            'adjust_quantity' => Gate::allows('update', $accessory),
+            'delete' => $accessory->checkouts_count === 0 && Gate::allows('delete', $accessory),
             'clone' => Gate::allows('create', Accessory::class),
             // Request / cancel: if the requestable flag is off the row
             // never surfaces on /account/requestable anyway (scoped out
@@ -145,7 +145,7 @@ class AccessoriesTransformer
                     'name' => e($checkout->adminuser->present()->fullName),
                 ] : null,
                 'created_at' => Helper::getFormattedDateObject($checkout->created_at, 'datetime'),
-                'available_actions' => Gate::allows('checkout', Accessory::class) ? ['checkin' => true] : ['checkin' => false],
+                'available_actions' => Gate::allows('checkout', $checkout->accessory) ? ['checkin' => true] : ['checkin' => false],
             ];
         }
 

--- a/app/Http/Transformers/AssetModelsTransformer.php
+++ b/app/Http/Transformers/AssetModelsTransformer.php
@@ -104,8 +104,8 @@ class AssetModelsTransformer
             // render the name as an <a> link or as plain text. Keeps
             // the permission check server-side so the JS doesn't need
             // a compile-time @can inside its Blade-hosted formatter.
-            'view' => Gate::allows('view', AssetModel::class),
-            'update' => (Gate::allows('update', AssetModel::class) && ($assetmodel->deleted_at == '')),
+            'view' => Gate::allows('view', $assetmodel),
+            'update' => (Gate::allows('update', $assetmodel) && ($assetmodel->deleted_at == '')),
             'delete' => $assetmodel->isDeletable(),
             'clone' => (Gate::allows('create', AssetModel::class) && ($assetmodel->deleted_at == '')),
             'restore' => (Gate::allows('create', AssetModel::class) && ($assetmodel->deleted_at != '')),
@@ -116,8 +116,8 @@ class AssetModelsTransformer
             'request' => (bool) $assetmodel->requestable && ! $userHasOpenRequest,
             'cancel' => (bool) $assetmodel->requestable && $userHasOpenRequest,
             'bulk_selectable' => [
-                'edit' => (Gate::allows('update', AssetModel::class) && ($assetmodel->deleted_at == '')),
-                'delete' => (Gate::allows('delete', AssetModel::class) && $assetmodel->isDeletable()),
+                'edit' => (Gate::allows('update', $assetmodel) && ($assetmodel->deleted_at == '')),
+                'delete' => (Gate::allows('delete', $assetmodel) && $assetmodel->isDeletable()),
             ],
         ];
 
@@ -155,7 +155,7 @@ class AssetModelsTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'delete' => (Gate::allows('update', AssetModel::class) && ($assetmodel->deleted_at == '')),
+            'delete' => (Gate::allows('update', $assetmodel) && ($assetmodel->deleted_at == '')),
         ];
 
         $array += $permissions_array;

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -3,7 +3,6 @@
 namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
-use App\Models\Accessory;
 use App\Models\AccessoryCheckout;
 use App\Models\Asset;
 use App\Models\Component;
@@ -172,20 +171,20 @@ class AssetsTransformer
         }
 
         $permissions_array['available_actions'] = [
-            'checkout' => ($asset->deleted_at == '' && Gate::allows('checkout', Asset::class)) ? true : false,
-            'checkin' => ($asset->deleted_at == '' && Gate::allows('checkin', Asset::class)) ? true : false,
+            'checkout' => ($asset->deleted_at == '' && Gate::allows('checkout', $asset)) ? true : false,
+            'checkin' => ($asset->deleted_at == '' && Gate::allows('checkin', $asset)) ? true : false,
             'clone' => Gate::allows('create', Asset::class) ? true : false,
             'restore' => ($asset->deleted_at != '' && Gate::allows('create', Asset::class)) ? true : false,
-            'update' => ($asset->deleted_at == '' && Gate::allows('update', Asset::class)) ? true : false,
-            'audit' => Gate::allows('audit', Asset::class) ? true : false,
-            'delete' => ($asset->deleted_at == '' && $asset->assigned_to == '' && Gate::allows('delete', Asset::class) && ($asset->deleted_at == '')) ? true : false,
+            'update' => ($asset->deleted_at == '' && Gate::allows('update', $asset)) ? true : false,
+            'audit' => Gate::allows('audit', $asset) ? true : false,
+            'delete' => ($asset->deleted_at == '' && $asset->assigned_to == '' && Gate::allows('delete', $asset) && ($asset->deleted_at == '')) ? true : false,
             'bulk_selectable' => [
-                'edit' => ($asset->deleted_at == '' && Gate::allows('update', Asset::class)),
-                'maintenance' => ($asset->deleted_at == '' && Gate::allows('update', Asset::class)),
-                'checkout' => ($asset->deleted_at == '' && ! $asset->assigned_to && Gate::allows('checkout', Asset::class)),
-                'checkin' => ($asset->deleted_at == '' && $asset->assigned_to && Gate::allows('checkin', Asset::class)),
-                'audit' => ($asset->deleted_at == '' && Gate::allows('audit', Asset::class)),
-                'delete' => ($asset->deleted_at == '' && ! $asset->assigned_to && Gate::allows('delete', Asset::class)),
+                'edit' => ($asset->deleted_at == '' && Gate::allows('update', $asset)),
+                'maintenance' => ($asset->deleted_at == '' && Gate::allows('update', $asset)),
+                'checkout' => ($asset->deleted_at == '' && ! $asset->assigned_to && Gate::allows('checkout', $asset)),
+                'checkin' => ($asset->deleted_at == '' && $asset->assigned_to && Gate::allows('checkin', $asset)),
+                'audit' => ($asset->deleted_at == '' && Gate::allows('audit', $asset)),
+                'delete' => ($asset->deleted_at == '' && ! $asset->assigned_to && Gate::allows('delete', $asset)),
                 'labels' => $asset->deleted_at == '',
                 'restore' => ($asset->deleted_at != '' && Gate::allows('create', Asset::class)),
             ],
@@ -406,7 +405,7 @@ class AssetsTransformer
 
             $permissions_array['available_actions'] = [
                 'checkout' => false,
-                'checkin' => Gate::allows('checkin', Accessory::class),
+                'checkin' => Gate::allows('checkin', $accessory_checkout->accessory),
             ];
 
             $array += $permissions_array;
@@ -451,9 +450,9 @@ class AssetsTransformer
 
         $permissions_array['available_actions'] = [
             'checkout' => false,
-            'checkin' => Gate::allows('checkin', License::class),
+            'checkin' => Gate::allows('checkin', $licenseseat->license),
             'bulk_selectable' => [
-                'checkin' => Gate::allows('checkin', License::class),
+                'checkin' => Gate::allows('checkin', $licenseseat->license),
             ],
         ];
 
@@ -503,8 +502,8 @@ class AssetsTransformer
                     'name' => e($component_checkout->adminuser->display_name),
                 ] : null,
                 'available_actions' => [
-                    'checkin' => (($component->deleted_at == '') && Gate::allows('checkin', Component::class)),
-                    'view' => (($component->deleted_at == '') && Gate::allows('view', Component::class)),
+                    'checkin' => (($component->deleted_at == '') && Gate::allows('checkin', $component)),
+                    'view' => (($component->deleted_at == '') && Gate::allows('view', $component)),
                 ],
             ];
         }

--- a/app/Http/Transformers/CategoriesTransformer.php
+++ b/app/Http/Transformers/CategoriesTransformer.php
@@ -73,7 +73,7 @@ class CategoriesTransformer
             ];
 
             $permissions_array['available_actions'] = [
-                'update' => Gate::allows('update', Category::class),
+                'update' => Gate::allows('update', $category),
                 'delete' => $category->isDeletable(),
                 'bulk_selectable' => [
                     'delete' => $category->isDeletable(),

--- a/app/Http/Transformers/CompaniesTransformer.php
+++ b/app/Http/Transformers/CompaniesTransformer.php
@@ -53,7 +53,7 @@ class CompaniesTransformer
             ];
 
             $permissions_array['available_actions'] = [
-                'update' => Gate::allows('update', Company::class),
+                'update' => Gate::allows('update', $company),
                 'delete' => $company->isDeletable(),
                 'bulk_selectable' => [
                     'delete' => $company->isDeletable(),

--- a/app/Http/Transformers/ComponentsAssetsTransformer.php
+++ b/app/Http/Transformers/ComponentsAssetsTransformer.php
@@ -30,10 +30,10 @@ class ComponentsAssetsTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'checkout' => Gate::allows('checkout', Asset::class),
-            'checkin' => Gate::allows('checkin', Asset::class),
-            'update' => Gate::allows('update', Asset::class),
-            'delete' => Gate::allows('delete', Asset::class),
+            'checkout' => Gate::allows('checkout', $asset),
+            'checkin' => Gate::allows('checkin', $asset),
+            'update' => Gate::allows('update', $asset),
+            'delete' => Gate::allows('delete', $asset),
         ];
 
         $array += $permissions_array;

--- a/app/Http/Transformers/ComponentsTransformer.php
+++ b/app/Http/Transformers/ComponentsTransformer.php
@@ -96,10 +96,10 @@ class ComponentsTransformer
         $permissions_array['assigned_to_self'] = $userHasOpenRequest;
 
         $permissions_array['available_actions'] = [
-            'checkout' => Gate::allows('checkout', Component::class),
-            'checkin' => Gate::allows('checkin', Component::class),
-            'update' => Gate::allows('update', Component::class),
-            'adjust_quantity' => Gate::allows('update', Component::class),
+            'checkout' => Gate::allows('checkout', $component),
+            'checkin' => Gate::allows('checkin', $component),
+            'update' => Gate::allows('update', $component),
+            'adjust_quantity' => Gate::allows('update', $component),
             'clone' => Gate::allows('create', Component::class),
             'delete' => $component->isDeletable(),
             'request' => (bool) $component->requestable && ! $userHasOpenRequest,

--- a/app/Http/Transformers/ConsumablesTransformer.php
+++ b/app/Http/Transformers/ConsumablesTransformer.php
@@ -100,11 +100,11 @@ class ConsumablesTransformer
         $permissions_array['assigned_to_self'] = $userHasOpenRequest;
 
         $permissions_array['available_actions'] = [
-            'checkout' => Gate::allows('checkout', Consumable::class),
-            'checkin' => Gate::allows('checkin', Consumable::class),
-            'update' => Gate::allows('update', Consumable::class),
-            'adjust_quantity' => Gate::allows('update', Consumable::class),
-            'delete' => Gate::allows('delete', Consumable::class),
+            'checkout' => Gate::allows('checkout', $consumable),
+            'checkin' => Gate::allows('checkin', $consumable),
+            'update' => Gate::allows('update', $consumable),
+            'adjust_quantity' => Gate::allows('update', $consumable),
+            'delete' => Gate::allows('delete', $consumable),
             'clone' => (Gate::allows('create', Consumable::class) && ($consumable->deleted_at == '')),
             'request' => (bool) $consumable->requestable && ! $userHasOpenRequest,
             'cancel' => (bool) $consumable->requestable && $userHasOpenRequest,

--- a/app/Http/Transformers/DepartmentsTransformer.php
+++ b/app/Http/Transformers/DepartmentsTransformer.php
@@ -53,8 +53,8 @@ class DepartmentsTransformer
             ];
 
             $permissions_array['available_actions'] = [
-                'update' => Gate::allows('update', Department::class),
-                'delete' => (Gate::allows('delete', Department::class) && ($department->users_count == 0)),
+                'update' => Gate::allows('update', $department),
+                'delete' => (Gate::allows('delete', $department) && ($department->users_count == 0)),
                 'bulk_selectable' => [
                     'delete' => $department->users_count == 0,
                 ],

--- a/app/Http/Transformers/DepreciationsTransformer.php
+++ b/app/Http/Transformers/DepreciationsTransformer.php
@@ -38,8 +38,8 @@ class DepreciationsTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'update' => Gate::allows('update', Depreciation::class),
-            'delete' => Gate::allows('delete', Depreciation::class) && $depreciation->isDeletable(),
+            'update' => Gate::allows('update', $depreciation),
+            'delete' => Gate::allows('delete', $depreciation) && $depreciation->isDeletable(),
             'bulk_selectable' => [
                 'delete' => $depreciation->isDeletable(),
             ],

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -46,13 +46,13 @@ class LicenseSeatsTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'checkout' => Gate::allows('checkout', License::class),
-            'checkin' => Gate::allows('checkin', License::class),
+            'checkout' => Gate::allows('checkout', $seat->license),
+            'checkin' => Gate::allows('checkin', $seat->license),
             'clone' => Gate::allows('create', License::class),
-            'update' => Gate::allows('update', License::class),
-            'delete' => Gate::allows('delete', License::class),
+            'update' => Gate::allows('update', $seat->license),
+            'delete' => Gate::allows('delete', $seat->license),
             'bulk_selectable' => [
-                'checkin' => Gate::allows('checkin', License::class) && ($seat->assigned_to || $seat->asset_id),
+                'checkin' => Gate::allows('checkin', $seat->license) && ($seat->assigned_to || $seat->asset_id),
             ],
         ];
 

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -86,10 +86,10 @@ class LicensesTransformer
         $permissions_array['assigned_to_self'] = $userHasOpenRequest;
 
         $permissions_array['available_actions'] = [
-            'checkout' => Gate::allows('checkout', License::class),
-            'checkin' => Gate::allows('checkin', License::class),
+            'checkout' => Gate::allows('checkout', $license),
+            'checkin' => Gate::allows('checkin', $license),
             'clone' => Gate::allows('create', License::class),
-            'update' => Gate::allows('update', License::class),
+            'update' => Gate::allows('update', $license),
             'delete' => $license->isDeletable(),
             'user_can_checkout' => (bool) (($license->free_seats_count - $unreassignable) > 0),
             'request' => (bool) $license->requestable && ! $userHasOpenRequest,

--- a/app/Http/Transformers/LocationsTransformer.php
+++ b/app/Http/Transformers/LocationsTransformer.php
@@ -132,7 +132,7 @@ class LocationsTransformer
 
         $permissions_array['available_actions'] = [
             'checkout' => false,
-            'checkin' => Gate::allows('checkin', Accessory::class),
+            'checkin' => Gate::allows('checkin', $accessory_checkout->accessory),
         ];
 
         $array += $permissions_array;

--- a/app/Http/Transformers/MaintenancesTransformer.php
+++ b/app/Http/Transformers/MaintenancesTransformer.php
@@ -3,7 +3,6 @@
 namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
-use App\Models\Asset;
 use App\Models\Maintenance;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Gate;
@@ -125,9 +124,9 @@ class MaintenancesTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'update' => (Gate::allows('update', Asset::class) && ((($assetmaintenance->asset) && $assetmaintenance->asset->deleted_at == ''))) ? true : false,
-            'delete' => Gate::allows('delete', Asset::class),
-            'complete' => Gate::allows('update', Asset::class) && ! $assetmaintenance->completed_at,
+            'update' => (Gate::allows('update', $assetmaintenance->asset) && ((($assetmaintenance->asset) && $assetmaintenance->asset->deleted_at == ''))) ? true : false,
+            'delete' => Gate::allows('delete', $assetmaintenance->asset),
+            'complete' => Gate::allows('update', $assetmaintenance->asset) && ! $assetmaintenance->completed_at,
         ];
 
         $array += $permissions_array;

--- a/app/Http/Transformers/ManufacturersTransformer.php
+++ b/app/Http/Transformers/ManufacturersTransformer.php
@@ -49,7 +49,7 @@ class ManufacturersTransformer
             ];
 
             $permissions_array['available_actions'] = [
-                'update' => (($manufacturer->deleted_at == '') && (Gate::allows('update', Manufacturer::class))),
+                'update' => (($manufacturer->deleted_at == '') && (Gate::allows('update', $manufacturer))),
                 'restore' => (($manufacturer->deleted_at != '') && (Gate::allows('create', Manufacturer::class))),
                 'delete' => $manufacturer->isDeletable(),
                 'bulk_selectable' => [

--- a/app/Http/Transformers/PredefinedKitsTransformer.php
+++ b/app/Http/Transformers/PredefinedKitsTransformer.php
@@ -42,8 +42,8 @@ class PredefinedKitsTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'update' => Gate::allows('update', PredefinedKit::class),
-            'delete' => Gate::allows('delete', PredefinedKit::class),
+            'update' => Gate::allows('update', $kit),
+            'delete' => Gate::allows('delete', $kit),
             'checkout' => Gate::allows('checkout', Asset::class),
             // 'clone' => Gate::allows('create', PredefinedKit::class),
             // 'restore' => Gate::allows('create', PredefinedKit::class),

--- a/app/Http/Transformers/StatuslabelsTransformer.php
+++ b/app/Http/Transformers/StatuslabelsTransformer.php
@@ -39,8 +39,8 @@ class StatuslabelsTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'update' => Gate::allows('update', Statuslabel::class) ? true : false,
-            'delete' => (Gate::allows('delete', Statuslabel::class) && ($statuslabel->isDeletable())) ? true : false,
+            'update' => Gate::allows('update', $statuslabel) ? true : false,
+            'delete' => (Gate::allows('delete', $statuslabel) && ($statuslabel->isDeletable())) ? true : false,
             'bulk_selectable' => [
                 'delete' => $statuslabel->isDeletable(),
             ],

--- a/app/Http/Transformers/SuppliersTransformer.php
+++ b/app/Http/Transformers/SuppliersTransformer.php
@@ -55,10 +55,10 @@ class SuppliersTransformer
             ];
 
             $permissions_array['available_actions'] = [
-                'update' => Gate::allows('update', Supplier::class),
-                'delete' => (Gate::allows('delete', Supplier::class) && ($supplier->isDeletable())),
+                'update' => Gate::allows('update', $supplier),
+                'delete' => (Gate::allows('delete', $supplier) && ($supplier->isDeletable())),
                 'bulk_selectable' => [
-                    'delete' => (Gate::allows('delete', Supplier::class) && ($supplier->isDeletable())),
+                    'delete' => (Gate::allows('delete', $supplier) && ($supplier->isDeletable())),
                 ],
             ];
 

--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -136,15 +136,15 @@ class UsersTransformer
         ];
 
         $permissions_array['available_actions'] = [
-            'update' => (Gate::allows('update', User::class) && ($user->deleted_at == '')),
+            'update' => (Gate::allows('update', $user) && ($user->deleted_at == '')),
             'delete' => ($user->isDeletable() && (auth()->user()->can('canEditAuthFields', $user) && auth()->user()->can('editableOnDemo'))),
             'clone' => (Gate::allows('create', User::class) && ($user->deleted_at == '')),
             'restore' => (Gate::allows('create', User::class) && ($user->deleted_at != '')),
             'bulk_selectable' => [
-                'edit' => (Gate::allows('update', User::class) && $user->deleted_at == ''),
-                'send_assigned' => (Gate::allows('update', User::class) && $user->deleted_at == '' && ! empty($user->email)),
-                'delete' => (Gate::allows('delete', User::class) && $user->deleted_at == ''),
-                'merge' => (Gate::allows('delete', User::class) && $user->deleted_at == ''),
+                'edit' => (Gate::allows('update', $user) && $user->deleted_at == ''),
+                'send_assigned' => (Gate::allows('update', $user) && $user->deleted_at == '' && ! empty($user->email)),
+                'delete' => (Gate::allows('delete', $user) && $user->deleted_at == ''),
+                'merge' => (Gate::allows('delete', $user) && $user->deleted_at == ''),
                 'bulkpasswordreset' => ($user->deleted_at == '' && $user->activated == '1' && ! empty($user->email) && $user->ldap_import != '1'),
                 'print' => $user->deleted_at == '',
             ],


### PR DESCRIPTION
This isn't that important, since we check any actual actions against the corresponding controllers, but this just updates the transformers so that we're checking the permission on the specific object, not just the general object (`$user` vs `User::class`)