### PR TITLE
Acceptances: Delete pending acceptances when checking in accessory via API

### DIFF
--- a/app/Http/Controllers/Api/AccessoriesController.php
+++ b/app/Http/Controllers/Api/AccessoriesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Events\CheckoutableCheckedIn;
 use App\Events\CheckoutableCheckedOut;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
@@ -503,13 +504,8 @@ class AccessoriesController extends Controller
         $accessory = Accessory::find($accessory_checkout->accessory_id);
         $this->authorize('checkin', $accessory);
 
-        $accessory->logCheckin(User::find($accessory_checkout->assigned_to), $request->input('note'));
-
-        // Was the accessory updated?
         if ($accessory_checkout->delete()) {
-            if (! is_null($accessory_checkout->assigned_to)) {
-                $user = User::find($accessory_checkout->assigned_to);
-            }
+            event(new CheckoutableCheckedIn($accessory, $accessory_checkout->assignedTo, auth()->user(), $request->input('note')));
 
             $payload = [
                 'accessory_id' => $accessory->id,

--- a/tests/Feature/Checkins/Api/AccessoryCheckinTest.php
+++ b/tests/Feature/Checkins/Api/AccessoryCheckinTest.php
@@ -2,10 +2,13 @@
 
 namespace Tests\Feature\Checkins\Api;
 
+use App\Mail\CheckinAccessoryMail;
 use App\Models\Accessory;
 use App\Models\CheckoutAcceptance;
 use App\Models\Company;
+use App\Models\Location;
 use App\Models\User;
+use Illuminate\Support\Facades\Mail;
 use Tests\Concerns\TestsFullMultipleCompaniesSupport;
 use Tests\Concerns\TestsPermissionsRequirement;
 use Tests\TestCase;
@@ -85,6 +88,52 @@ class AccessoryCheckinTest extends TestCase implements TestsFullMultipleCompanie
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
         ]);
+
+        $this->assertHasTheseActionLogs($accessory, ['create', 'checkin from']);
+    }
+
+    public function test_checkin_of_accessory_checked_out_to_location_is_logged_against_the_location()
+    {
+        $location = Location::factory()->create();
+        $actor = User::factory()->checkinAccessories()->create();
+
+        $accessory = Accessory::factory()->checkedOutToLocation($location)->create();
+        $accessoryCheckout = $accessory->checkouts->first();
+
+        $this->actingAsForApi($actor)
+            ->postJson(route('api.accessories.checkin', $accessoryCheckout))
+            ->assertStatusMessageIs('success');
+
+        $this->assertDatabaseHas('action_logs', [
+            'created_by' => $actor->id,
+            'action_type' => 'checkin from',
+            'target_id' => $location->id,
+            'target_type' => Location::class,
+            'item_id' => $accessory->id,
+            'item_type' => Accessory::class,
+        ]);
+
+        // todo: check action logs count == 1 instead of above
+    }
+
+    public function test_checkin_sends_checkin_email_to_user_when_category_enables_it()
+    {
+        Mail::fake();
+
+        $user = User::factory()->create();
+        $accessory = Accessory::factory()->checkedOutToUser($user)->create();
+        $accessory->category->update(['checkin_email' => true]);
+
+        $accessoryCheckout = $accessory->checkouts->first();
+
+        $this->actingAsForApi(User::factory()->checkinAccessories()->create())
+            ->postJson(route('api.accessories.checkin', $accessoryCheckout))
+            ->assertStatusMessageIs('success');
+
+        Mail::assertSent(
+            CheckinAccessoryMail::class,
+            fn ($mail) => $mail->hasTo($user->email),
+        );
     }
 
     public function test_checkin_clears_pending_acceptance()

--- a/tests/Feature/Checkins/Api/AccessoryCheckinTest.php
+++ b/tests/Feature/Checkins/Api/AccessoryCheckinTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Checkins\Api;
 
 use App\Models\Accessory;
+use App\Models\CheckoutAcceptance;
 use App\Models\Company;
 use App\Models\User;
 use Tests\Concerns\TestsFullMultipleCompaniesSupport;
@@ -84,5 +85,33 @@ class AccessoryCheckinTest extends TestCase implements TestsFullMultipleCompanie
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
         ]);
+    }
+
+    public function test_checkin_clears_pending_acceptance()
+    {
+        $user = User::factory()->create();
+        $accessory = Accessory::factory()->checkedOutToUser($user)->create();
+        $accessory->category->update(['require_acceptance' => true]);
+
+        $checkout = $accessory->checkouts()
+            ->where('assigned_type', User::class)
+            ->where('assigned_to', $user->id)
+            ->firstOrFail();
+
+        $acceptance = CheckoutAcceptance::factory()->forAccessory()->pending()->create([
+            'checkoutable_id' => $accessory->id,
+            'assigned_to_id' => $user->id,
+        ]);
+
+        $this->assertTrue($acceptance->isPending());
+
+        $this->actingAsForApi(User::factory()->checkinAccessories()->create())
+            ->postJson(route('api.accessories.checkin', $checkout))
+            ->assertStatusMessageIs('success');
+
+        $this->assertNotNull(
+            CheckoutAcceptance::withTrashed()->findOrFail($acceptance->id)->deleted_at,
+            'Pending acceptance survived accessory check-in.'
+        );
     }
 }

--- a/tests/Feature/Checkins/Api/AccessoryCheckinTest.php
+++ b/tests/Feature/Checkins/Api/AccessoryCheckinTest.php
@@ -140,7 +140,7 @@ class AccessoryCheckinTest extends TestCase implements TestsFullMultipleCompanie
     {
         $user = User::factory()->create();
         $accessory = Accessory::factory()->checkedOutToUser($user)->create();
-        $accessory->category->update(['require_acceptance' => true]);
+        $accessory->category->update(['require_acceptance' => true, 'checkin_email' => true]);
 
         $checkout = $accessory->checkouts()
             ->where('assigned_type', User::class)

--- a/tests/Feature/Checkins/Api/AccessoryCheckinTest.php
+++ b/tests/Feature/Checkins/Api/AccessoryCheckinTest.php
@@ -112,8 +112,6 @@ class AccessoryCheckinTest extends TestCase implements TestsFullMultipleCompanie
             'item_id' => $accessory->id,
             'item_type' => Accessory::class,
         ]);
-
-        // todo: check action logs count == 1 instead of above
     }
 
     public function test_checkin_sends_checkin_email_to_user_when_category_enables_it()


### PR DESCRIPTION
When checking in an accessory through the API, pending checkout acceptances are not being soft-deleted as they should be in some cases. This PR fixes that.

## Reproduction steps
1. Create an accessory category that requires users to confirm acceptance and sends an email to the user upon check-in or check-out <img width="1354" height="1014" alt="image" src="https://github.com/user-attachments/assets/451250b6-9d22-4335-8b41-de1b6c33b13c" />
1. Create an accessory in that category
1. Check out the accessory to a user and see that checkout acceptances has a new row (a pending CheckoutAcceptance`)
1. Send an API request to check in the accessory and see that the `accessories_checkout` is removed but the row in `checkout_acceptances` does not have `deleted_at` populated.
1. Optionally: log in as the user and see that the pending acceptance is still there.

## The Fix 
The core issue is that `CheckoutableCheckedIn` was not being dispatched like it is in other controllers so the `CheckoutableListener` that handles pending acceptance clean up was not being run.

---

AI Disclosure: I used Claude Code to help investigate the issue and write most of the tests.
