### PR TITLE
Tests: Slightly improve testing speed

### DIFF
--- a/.ai/rules/tests.md
+++ b/.ai/rules/tests.md
@@ -24,3 +24,19 @@ Use `$this->actingAsForApi($user)` in API tests and `$this->actingAs($user)` in 
 
 ## Feature and unit test placement
 Feature tests live in `tests/Feature/`, grouped by the feature or resource under test. A resource with both API and web controllers splits its tests into `Api/` and `Ui/` subfolders matching the layer under test; cross-cutting feature-area suites stay flat in their folder. Unit tests live in `tests/Unit/`, grouped by the type under test (`Models/`, `Presenters/`, `Transformers/`...).
+
+## Avoid calling truncate() in tests — use delete() or forceDelete()
+
+Avoid using `Model::truncate()` or `DB::table(...)->truncate()` in a test. Use `Model::query()->delete()` (soft delete)
+or `Model::query()->forceDelete()` (hard delete) instead — both are DML and roll back normally.
+
+Why: TRUNCATE is DDL, and MySQL implicitly commits on DDL. That destroys the transaction `LazilyRefreshDatabase` wraps
+each test in. Laravel spots the dead transaction at teardown, clears `RefreshDatabaseState::$migrated`, and re-runs
+all migrations before the next test — roughly 10s per occurrence on MySQL. SQLite hides the problem entirely
+because its DDL is transactional, so this only shows up on a MySQL run.
+
+The same trap applies to any runtime DDL, notably `Schema::table()` — which is why creating a `CustomField` (its
+`created` hook does `ALTER TABLE assets`) is expensive on MySQL.
+
+Tell: the test that runs the DDL looks fast; the *next* test pays. A test suddenly reporting ~1,690 queries is paying
+for a re-migration.

--- a/tests/Feature/Assets/Api/AssetPaginationTest.php
+++ b/tests/Feature/Assets/Api/AssetPaginationTest.php
@@ -221,12 +221,22 @@ class AssetPaginationTest extends TestCase
 
     public function test_page_urls_do_not_include_limit_when_not_in_original_request()
     {
-        Asset::factory()->count(600)->create();
+        // Since this test relies on app.max_results,
+        // let's lower it temporarily to avoid having
+        // to create a bunch of models.
+        $newMaxResults = 1;
+
+        config(['app.max_results' => $newMaxResults]);
+
+        Asset::factory()->count($newMaxResults + 1)->create();
 
         $response = $this->actingAsForApi($this->user)
             ->getJson(route('api.assets.index', ['page' => 1]))
             ->assertOk();
 
+        // Guards the thin margin above: without a second page there is no URL to
+        // inspect and the assertion below would pass vacuously.
+        $this->assertNotNull($response->json('next_page_url'));
         $this->assertStringNotContainsString('limit=', $response->json('next_page_url'));
     }
 

--- a/tests/Unit/Importer/AssetImportTest.php
+++ b/tests/Unit/Importer/AssetImportTest.php
@@ -12,7 +12,7 @@ class AssetImportTest extends TestCase
 {
     public function test_uses_first_deployable_status_label_as_default_if_one_exists()
     {
-        Statuslabel::truncate();
+        Statuslabel::query()->forceDelete();
 
         $pendingStatusLabel = Statuslabel::factory()->pending()->create();
         $readyToDeployStatusLabel = Statuslabel::factory()->readyToDeploy()->create();
@@ -27,7 +27,7 @@ class AssetImportTest extends TestCase
 
     public function test_uses_first_status_label_as_default_if_deployable_status_label_does_not_exist()
     {
-        Statuslabel::truncate();
+        Statuslabel::query()->forceDelete();
 
         $statusLabel = Statuslabel::factory()->pending()->create();
 
@@ -41,7 +41,7 @@ class AssetImportTest extends TestCase
 
     public function test_creates_default_status_label_if_one_does_not_exist()
     {
-        Statuslabel::truncate();
+        Statuslabel::query()->forceDelete();
 
         $this->assertEquals(0, Statuslabel::count());
 


### PR DESCRIPTION
I noticed that MySQL tests take a while to run and wanted to see what I could do to speed them up. The biggest issue are tests that create CustomField models because that breaks the quick database refresh that happens between tests and requires a full re-migration from scratch. I haven't figured out how to solve that yet but here are two improvements that reduce the test suite runtime by about 30 seconds. (Not much but it's something)

---

AI Disclosure: I had Claude look at the output of the test suite to know which tests to target. For these two improvements it wrote the core changes as well and I touched them up.
