### PR TITLE
a11y: Added sr-only on non-tabbed tables

### DIFF
--- a/resources/views/accessories/index.blade.php
+++ b/resources/views/accessories/index.blade.php
@@ -10,7 +10,7 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box name="accessory">
+        <x-box name="accessories" sr_only_title>
             <x-table.accessories name="accessories" :route="route('api.accessories.index')" fixed_right_number="3" />
         </x-box>
         <x-shiftclick/>

--- a/resources/views/blade/box/index.blade.php
+++ b/resources/views/blade/box/index.blade.php
@@ -2,6 +2,7 @@
     'box_style' => 'default',
     'header' => false,
     'top_submit' => false,
+    'sr_only_title' => false,
 ])
 @aware(['name', 'route'])
 
@@ -41,7 +42,9 @@
     <div class="box-body">
 
         @if (isset($table_header))
-            <h3 class="box-title{{ (!isset($bulkactions)) ? ' pull-left' : '' }}">
+            <h3
+                @if ($name) id="{{ $name }}-title" @endif
+                class="{{ $sr_only_title ? 'sr-only' : 'box-title'.((!isset($bulkactions)) ? ' pull-left' : '') }}">
                 {{ $table_header }}
             </h3>
         @endif

--- a/resources/views/blade/table/accessories.blade.php
+++ b/resources/views/blade/table/accessories.blade.php
@@ -5,6 +5,7 @@
     'fixed_right_number' => 2,
     'fixed_number' => 2,
     'table_header' => trans('general.accessories'),
+    'export_name' => null,
 ])
 
 @aware(['name'])
@@ -28,7 +29,7 @@
         show_advanced_search="true"
         buttons="accessoryButtons"
         api_url="{{ $route }}"
-        export_filename="export-{{ str_slug($name) }}-accessories-{{ date('Y-m-d') }}"
+        export_filename="export-{{ $export_name ? str_slug($export_name).'-' : '' }}accessories-{{ date('Y-m-d') }}"
     />
 
 @endcan

--- a/resources/views/blade/table/assets.blade.php
+++ b/resources/views/blade/table/assets.blade.php
@@ -5,6 +5,7 @@
     'fixed_number' => 3,
     'table_header' => trans('general.assets'),
     'status_type' => null,
+    'export_name' => null,
 ])
 
 @aware(['name'])
@@ -29,7 +30,7 @@
         show_advanced_search="true"
         buttons="assetButtons"
         api_url="{{ $route }}"
-        export_filename="export-{{ str_slug($name) }}-assets-{{ date('Y-m-d') }}"
+        export_filename="export-{{ $export_name ? str_slug($export_name).'-' : '' }}assets-{{ date('Y-m-d') }}"
     />
 
 @endcan

--- a/resources/views/blade/table/bulk-accessories.blade.php
+++ b/resources/views/blade/table/bulk-accessories.blade.php
@@ -1,6 +1,6 @@
 @can('delete', \App\Models\Accessory::class)
     <x-table.bulk-actions
-        name="accessory"
+        name="accessories"
         :action_route="route('accessories.bulk.delete')"
         model_name="accessory"
         :actions="[

--- a/resources/views/blade/table/components.blade.php
+++ b/resources/views/blade/table/components.blade.php
@@ -5,7 +5,10 @@
     'fixed_right_number' => 2,
     'fixed_number' => 1,
     'table_header' => trans('general.components'),
+    'export_name' => null,
 ])
+
+@aware(['name'])
 
 <!-- start components tab pane -->
 @can('view', \App\Models\Component::class)
@@ -23,7 +26,7 @@
         show_advanced_search="true"
         buttons="componentButtons"
         api_url="{{ $route }}"
-        export_filename="export-{{ str_slug($name) }}-components-{{ date('Y-m-d') }}"
+        export_filename="export-{{ $export_name ? str_slug($export_name).'-' : '' }}components-{{ date('Y-m-d') }}"
     />
 
 @endcan

--- a/resources/views/blade/table/consumables.blade.php
+++ b/resources/views/blade/table/consumables.blade.php
@@ -5,7 +5,10 @@
     'fixed_right_number' => 2,
     'fixed_number' => 1,
     'table_header' => trans('general.consumables'),
+    'export_name' => null,
 ])
+
+@aware(['name'])
 
 <!-- start consumables tab pane -->
 @can('view', \App\Models\Consumable::class)
@@ -22,7 +25,7 @@
         show_advanced_search="true"
         buttons="consumableButtons"
         api_url="{{ $route }}"
-        export_filename="export-{{ str_slug($name) }}-consumables-{{ date('Y-m-d') }}"
+        export_filename="export-{{ $export_name ? str_slug($export_name).'-' : '' }}consumables-{{ date('Y-m-d') }}"
     />
 
 @endcan

--- a/resources/views/blade/table/index.blade.php
+++ b/resources/views/blade/table/index.blade.php
@@ -10,9 +10,18 @@
     'fixed_right_number' => null,
     'sort_order' => 'asc',
     'sort_field' => 'name',
+    'aria_labelledby' => null,
 ])
 
 @aware(['name'])
+
+{{-- Automatically determine aria-labelledby from the enclosing box or tab-pane's
+     box-title h3 id. Both containers output id="{name}-title" when name is
+     set, so any table underneath can programmatically pair with it without
+     us having to remember to add it. --}}
+@php
+    $aria_labelledby ??= ($name && $name !== 'default') ? $name.'-title' : null;
+@endphp
 
 {{-- fixed_number / fixed_right_number pin the first / last N columns
      via CSS position:sticky (snipe-table--sticky-*-N in overrides.less).
@@ -22,6 +31,7 @@
      height with long-content rows. --}}
 <table
     role="table"
+    @if ($aria_labelledby) aria-labelledby="{{ $aria_labelledby }}" @endif
     @class([
         'table', 'table-striped', 'snipe-table',
         'snipe-table--sticky-right-' . $fixed_right_number => (bool) $fixed_right_number,

--- a/resources/views/blade/table/licenses.blade.php
+++ b/resources/views/blade/table/licenses.blade.php
@@ -11,6 +11,8 @@
     'table_header' => trans('general.licenses'),
 ])
 
+@aware(['name'])
+
 <!-- start licenses tab pane -->
 @can('view', \App\Models\License::class)
 
@@ -28,7 +30,7 @@
         :$show_advanced_search
         buttons="licenseButtons"
         api_url="{{ $route }}"
-        export_filename="export-{{ str_slug($export_name ?? $name) }}-licenses-{{ date('Y-m-d') }}"
+        export_filename="export-{{ $export_name ? str_slug($export_name).'-' : '' }}licenses-{{ date('Y-m-d') }}"
     />
 
 

--- a/resources/views/blade/table/locations.blade.php
+++ b/resources/views/blade/table/locations.blade.php
@@ -4,16 +4,22 @@
     'presenter' => \App\Presenters\LocationPresenter::dataTableLayout(),
     'fixed_right_number' => 1,
     'table_header' => trans('general.locations'),
+    'export_name' => null,
 ])
+
+@aware(['name'])
 
 <!-- start locations tab pane -->
 @can('view', \App\Models\Location::class)
 
+    <x-slot:table_header>
+        {{ $table_header }}
+    </x-slot:table_header>
 
     <x-slot:bulkactions>
         <x-table.bulk-locations />
     </x-slot:bulkactions>
-    
+
     <x-table
         :$presenter
         :$fixed_right_number
@@ -21,7 +27,7 @@
         show_advanced_search="false"
         buttons="locationButtons"
         api_url="{{ $route }}"
-        export_filename="export-{{ str_slug($name) }}-locations-{{ date('Y-m-d') }}"
+        export_filename="export-{{ $export_name ? str_slug($export_name).'-' : '' }}locations-{{ date('Y-m-d') }}"
     />
 
 

--- a/resources/views/blade/table/models.blade.php
+++ b/resources/views/blade/table/models.blade.php
@@ -7,6 +7,8 @@
     'table_header' => trans('general.asset_models'),
 ])
 
+@aware(['name'])
+
 <!-- start assets tab pane -->
 @can('view', \App\Models\AssetModel::class)
     <x-slot:table_header>

--- a/resources/views/blade/table/users.blade.php
+++ b/resources/views/blade/table/users.blade.php
@@ -7,6 +7,8 @@
     'table_header' => trans('general.users'),
 ])
 
+@aware(['name'])
+
 <!-- start assets tab pane -->
 @can('view', \App\Models\User::class)
     <x-slot:table_header>

--- a/resources/views/blade/tabs/pane.blade.php
+++ b/resources/views/blade/tabs/pane.blade.php
@@ -9,7 +9,9 @@
     <div class="row">
         <div class="col-md-12">
             @if (isset($table_header))
-            <h3 class="box-title{{ (!isset($bulkactions)) ? ' pull-left' : '' }}">
+            <h3
+                @if ($name) id="{{ $name }}-title" @endif
+                class="box-title{{ (!isset($bulkactions)) ? ' pull-left' : '' }}">
                 {{ $table_header }}
             </h3>
         @endif

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -10,7 +10,9 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box>
+        <x-box name="category" sr_only_title>
+
+            <x-slot:table_header>{{ trans('general.categories') }}</x-slot:table_header>
 
             <x-slot:bulkactions>
                 <x-table.bulk-categories />

--- a/resources/views/companies/index.blade.php
+++ b/resources/views/companies/index.blade.php
@@ -9,7 +9,9 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-            <x-box>
+            <x-box name="company" sr_only_title>
+
+                <x-slot:table_header>{{ trans('general.companies') }}</x-slot:table_header>
 
                 <x-slot:bulkactions>
                     <x-table.bulk-companies />

--- a/resources/views/components/index.blade.php
+++ b/resources/views/components/index.blade.php
@@ -10,7 +10,7 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box>
+        <x-box name="components" sr_only_title>
             <x-table.components :route="route('api.components.index')" />
         </x-box>
     </x-container>

--- a/resources/views/consumables/index.blade.php
+++ b/resources/views/consumables/index.blade.php
@@ -9,7 +9,7 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box>
+        <x-box name="consumables" sr_only_title>
             <x-table.consumables :route="route('api.consumables.index')" />
         </x-box>
     </x-container>

--- a/resources/views/departments/index.blade.php
+++ b/resources/views/departments/index.blade.php
@@ -9,7 +9,9 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box name="department">
+        <x-box name="department" sr_only_title>
+
+            <x-slot:table_header>{{ trans('general.departments') }}</x-slot:table_header>
 
             <x-slot:bulkactions>
                 <x-table.bulk-departments />

--- a/resources/views/depreciations/index.blade.php
+++ b/resources/views/depreciations/index.blade.php
@@ -10,7 +10,9 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box name="depreciation">
+        <x-box name="depreciation" sr_only_title>
+
+            <x-slot:table_header>{{ trans('general.depreciations') }}</x-slot:table_header>
 
             <x-slot:bulkactions>
                 <x-table.bulk-depreciations />

--- a/resources/views/groups/index.blade.php
+++ b/resources/views/groups/index.blade.php
@@ -12,7 +12,9 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box>
+        <x-box name="groups" sr_only_title>
+
+            <x-slot:table_header>{{ trans('general.groups') }}</x-slot:table_header>
 
             <x-table
                     name="groups"

--- a/resources/views/hardware/index.blade.php
+++ b/resources/views/hardware/index.blade.php
@@ -54,7 +54,7 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box name="assets">
+        <x-box name="assets" sr_only_title>
             <x-table.assets
                 :route="route('api.assets.index', array(
                     'status_type' => is_scalar($requestStatusType) ? $requestStatusType : null,

--- a/resources/views/hardware/requested.blade.php
+++ b/resources/views/hardware/requested.blade.php
@@ -13,7 +13,7 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box name="checkoutRequests">
+        <x-box name="checkoutRequests" sr_only_title>
             <x-slot:table_header>
                 {{ trans('admin/hardware/general.requested') }}
             </x-slot:table_header>

--- a/resources/views/kits/index.blade.php
+++ b/resources/views/kits/index.blade.php
@@ -11,7 +11,10 @@
 {{-- Content --}}
 @section('content')
     <x-container>
-        <x-box name="kits">
+        <x-box name="kits" sr_only_title>
+
+            <x-slot:table_header>{{ trans('general.kits') }}</x-slot:table_header>
+
             <x-table
                 :presenter="\App\Presenters\PredefinedKitPresenter::dataTableLayout()"
                 :fixed_number="1"

--- a/resources/views/licenses/index.blade.php
+++ b/resources/views/licenses/index.blade.php
@@ -10,7 +10,7 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box>
+        <x-box name="licenses" sr_only_title>
 
             <x-slot:bulkactions>
                 <x-table.bulk-licenses />

--- a/resources/views/locations/index.blade.php
+++ b/resources/views/locations/index.blade.php
@@ -9,7 +9,7 @@
 
 @section('content')
     <x-container>
-        <x-box name="locations">
+        <x-box name="locations" sr_only_title>
             {{-- Convert hand-rolled <table> to the shared x-table.locations
                  component so sticky-column CSS (snipe-table--sticky-right-1)
                  is wired the same way as every other list page. Preserves

--- a/resources/views/maintenance-types/index.blade.php
+++ b/resources/views/maintenance-types/index.blade.php
@@ -9,7 +9,9 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box>
+        <x-box name="maintenancetype" sr_only_title>
+
+            <x-slot:table_header>{{ trans('admin/maintenance_types/general.maintenance_types') }}</x-slot:table_header>
 
             <x-slot:bulkactions>
                 <x-table.bulk-maintenance-types />

--- a/resources/views/maintenances/index.blade.php
+++ b/resources/views/maintenances/index.blade.php
@@ -10,7 +10,7 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box name="maintenance">
+        <x-box name="maintenance" sr_only_title>
 
             <x-slot:bulkactions>
                 <x-table.bulk-maintenances

--- a/resources/views/manufacturers/index.blade.php
+++ b/resources/views/manufacturers/index.blade.php
@@ -9,7 +9,7 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box>
+        <x-box name="manufacturer" sr_only_title>
 
             @if ($manufacturer_count == 0)
 
@@ -24,6 +24,8 @@
                     </form>
 
               @else
+                <x-slot:table_header>{{ trans('admin/manufacturers/table.asset_manufacturers') }}</x-slot:table_header>
+
                 <x-slot:bulkactions>
                     <x-table.bulk-manufacturers />
                 </x-slot:bulkactions>

--- a/resources/views/models/index.blade.php
+++ b/resources/views/models/index.blade.php
@@ -15,8 +15,9 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box name="models">
+        <x-box name="models" sr_only_title>
 
+            <x-slot:table_header>{{ trans('general.asset_models') }}</x-slot:table_header>
 
             <x-slot:bulkactions>
                 <x-table.bulk-models />

--- a/resources/views/statuslabels/index.blade.php
+++ b/resources/views/statuslabels/index.blade.php
@@ -11,7 +11,9 @@
     <x-container columns="2">
 
         <x-page-column class="col-md-9">
-            <x-box>
+            <x-box name="statuslabel" sr_only_title>
+
+                <x-slot:table_header>{{ trans('admin/statuslabels/table.title') }}</x-slot:table_header>
 
                 <x-slot:bulkactions>
                     <x-table.bulk-statuslabels />

--- a/resources/views/suppliers/index.blade.php
+++ b/resources/views/suppliers/index.blade.php
@@ -9,7 +9,9 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box>
+        <x-box name="supplier" sr_only_title>
+
+            <x-slot:table_header>{{ trans('admin/suppliers/table.suppliers') }}</x-slot:table_header>
 
             <x-slot:bulkactions>
                 <x-table.bulk-suppliers />

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -29,7 +29,7 @@
 {{-- Page content --}}
 @section('content')
     <x-container>
-        <x-box>
+        <x-box name="users" sr_only_title>
             <x-table.users :route="route('api.users.index',
                 [
                     'status' => is_scalar(request('status')) ? request('status') : null,


### PR DESCRIPTION
This PR adds an `sr_only_title` attribute to the the box blade component. In index listings, the breadcrumb showed (for example): `Home > Locations` and then the table also showed "Locations", which was visually redundant for users not using a screenreader (especially since they're visually so close together). The new `sr_only_title` allows us to keep the a11y accessibility of having a label above the table without the visual duplication. 


```blade
<x-box name="widgets" sr_only_title>
    <x-slot:table_header>{{ trans('general.widgets') }}</x-slot:table_header>
    <x-table name="widgets" ... />
</x-box>
```

will now pull in the table and also add the `sr-only` class to the title so we can skip the duplication. This give us the best of both worlds, freeing up some space in those table boxes while keeping the accessibility parts. (We should probably eventually change that to `<caption></caption>` instead of an `<h3></h3>`, but that's a little more involved.)

Box blade components that don't specify `sr_only_title` will still display on the page normally. (This is important because on *view* pages where there are tabs, the breadcrumbs don't know what tab the user has clicked on, so the visual feedback isn't there other than the highlighted tab, which can sometimes be just an icon.)

I also caught a few other small bugs in testing this, so those were fixed too. 

One I didn't fix in this is a weird behavior on the locations *view* page on the assets tabs, but I'll get to that next.