### PR TITLE
Fixed #18260 - informal variants of locales returned wrong plural translations

### DIFF
--- a/app/Services/SnipeTranslator.php
+++ b/app/Services/SnipeTranslator.php
@@ -16,13 +16,13 @@ use Illuminate\Translation\Translator;
  *
  * This method is called by the trans_choice() helper, which we *do* use a lot.
  ***************************************************************/
-class SnipeTranslator extends Translator {
-
-    static $legacy_translation_namespaces = [
-        "backup::" //Spatie backup uses 'legacy' locale names
+class SnipeTranslator extends Translator
+{
+    public static $legacy_translation_namespaces = [
+        'backup::', // Spatie backup uses 'legacy' locale names
     ];
 
-    //This is copied-and-pasted (almost) verbatim from Illuminate\Translation\Translator
+    // This is copied-and-pasted (almost) verbatim from Illuminate\Translation\Translator
     public function choice($key, $number, array $replace = [], $locale = null)
     {
         $line = $this->get(
@@ -40,7 +40,18 @@ class SnipeTranslator extends Translator {
             $replace['count'] = $number;
         }
 
-        $underscored_locale = str_replace("-","_",$locale); // OUR CHANGE.
+        // Snipe-IT uses a `-if` suffix on informal-variant locales (e.g.
+        // `de-if` for informal German alongside `de-DE` for formal).
+        // Laravel's MessageSelector plural-rule table only knows base and
+        // country-scoped codes (`de`, `de_DE`, etc.), so an informal locale
+        // falls through to the `default: return 0` branch, which always
+        // picks the singular form. Strip the informal marker before mapping
+        // dashes to underscores so the base language's plural rule kicks in
+        // for the choice, without disturbing the actual locale used for
+        // file lookup. 
+        $plural_locale = preg_replace('/-if$/', '', $locale);
+        $underscored_locale = str_replace('-', '_', $plural_locale); // OUR CHANGE.
+
         return $this->makeReplacements( // BELOW - that $underscored_locale is the *ONLY* modified part
             $this->getSelector()->choose($line, $number, $underscored_locale), $replace
         );
@@ -57,7 +68,7 @@ class SnipeTranslator extends Translator {
             if (preg_match("/^$namespace/", $key)) {
                 $modified_locale = Helper::mapBackToLegacyLocale($locale);
                 $changed_fallback = true;
-                $this->fallback = 'en'; //TODO - should this be 'env-able'? Or do we just put our foot down and say 'en'?
+                $this->fallback = 'en'; // TODO - should this be 'env-able'? Or do we just put our foot down and say 'en'?
                 break;
             }
         }
@@ -66,8 +77,7 @@ class SnipeTranslator extends Translator {
         if ($changed_fallback) {
             $this->fallback = $previous_fallback;
         }
+
         return $result;
     }
-
-
 }

--- a/resources/views/blade/info-panel/index.blade.php
+++ b/resources/views/blade/info-panel/index.blade.php
@@ -392,7 +392,7 @@
         @if ($infoPanelObj->depreciation && $infoPanelObj->purchase_date)
             <x-info-element icon_type="depreciation" title="{{ trans('general.depreciation') }}">
                 {!!  $infoPanelObj->depreciation->present()->nameUrl !!}
-                ({{ $infoPanelObj->depreciation->months.' '.trans('general.months')}})
+                ({{ trans_choice('general.months_plural', $infoPanelObj->depreciation->months) }})
             </x-info-element>
 
             <x-info-element icon_type="depreciation-calendar" class="{{ $infoPanelObj->depreciationProgressPercent() > 90 ? 'text-danger' : '' }}" title="{{ trans('admin/hardware/form.fully_depreciated') }}">

--- a/resources/views/depreciations/view.blade.php
+++ b/resources/views/depreciations/view.blade.php
@@ -3,7 +3,7 @@
 {{-- Page title --}}
 @section('title')
 
-    {{ trans('general.depreciation') }}: {{ $depreciation->name }} ({{ $depreciation->months }} {{ trans('general.months') }})
+    {{ trans('general.depreciation') }}: {{ $depreciation->name }} ({{ trans_choice('general.months_plural', $depreciation->months) }})
 
     @parent
 @stop

--- a/resources/views/reports/licenses.blade.php
+++ b/resources/views/reports/licenses.blade.php
@@ -67,7 +67,7 @@
                                     {{ $snipeSettings->default_currency }}{{ Helper::formatCurrencyOutput($license->purchase_cost) }}
                                 </td>
                                 <td>
-                                    {{ ($license->depreciation) ? e($license->depreciation->name).' ('.$license->depreciation->months.' '.trans('general.months').')' : ''  }}
+                                    {{ ($license->depreciation) ? e($license->depreciation->name).' ('.trans_choice('general.months_plural', $license->depreciation->months).')' : ''  }}
                                 </td>
                                 <td class="text-right">
                                     {{ $snipeSettings->default_currency }}{{ Helper::formatCurrencyOutput($license->getDepreciatedValue()) }}

--- a/tests/Unit/SnipeTranslatorTest.php
+++ b/tests/Unit/SnipeTranslatorTest.php
@@ -91,4 +91,21 @@ class SnipeTranslatorTest extends TestCase
             trans('backup::notifications.exception_message', ['message' => 'MESSAGE'], 'pt_BR')
         );
     }
+
+    public function test_trans_choice_plural_on_informal_locale()
+    {
+        // Regression coverage for GH #18260: Laravel's MessageSelector doesn't
+        // know the `-if` informal-variant codes, so it used to fall through to
+        // `default: return 0` and always pick the singular form. SnipeTranslator
+        // strips the `-if` suffix before the plural-rule lookup so the base
+        // language's rule kicks in.
+        $this->assertEquals(
+            '1 Monat',
+            trans_choice('general.months_plural', 1, [], 'de-if')
+        );
+        $this->assertEquals(
+            '24 Monate',
+            trans_choice('general.months_plural', 24, [], 'de-if')
+        );
+    }
 }


### PR DESCRIPTION
Happened across this one while going through old issues. I thought we had already fixed in previous incarnations of SnipeTranslator fixes, but we didn't account for the `-if` suffix we use in `de-if` (German informal).

Laravel's built-in MessageSelector plural-rule table only knows base and country-scoped codes (`de`, `de_DE`, etc.), so an informal locale falls through to the `default: return 0` branch, which always picks the singular form. This meant that in english,  or even `de-DE`, 36 months would show corrrectly as "36 months/36 Monate", but in `de-if`, it would _always_ show "1 Monat" regardless of the actual number of months. 

This wasn't as noticeable since we weren't using `trans_choice()` on the months for the info-panel (which this PR also fixes) - it was just a straight concatenation (most likely because I was being lazy at the time.) 

I updated the info-panel and a few other spots to use `trans_choice()` and threw in a regression test to boot. 

Fixes #18260