### PR TITLE
Fix double rollbars

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -15,7 +15,6 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Facades\Lang;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
 use Intervention\Image\Exception\NotSupportedException;
 use JsonException;
@@ -60,12 +59,34 @@ class Handler extends ExceptionHandler
     public function report(Throwable $exception)
     {
         if ($this->shouldReport($exception)) {
-            if (class_exists(Log::class)) {
-                Log::error($exception);
-            }
-
             return parent::report($exception);
         }
+    }
+
+    /**
+     * Report a caught exception, and rethrow in dev when the underlying
+     * cause is a programmer-error \Error (TypeError, ArgumentCountError,
+     * etc.) so it fails loud with a stack trace in dev instead of hiding behind
+     * a friendly "something went wrong" flash. Plain \Exception (sub)types
+     * (QueryException, ItemStillHasAssets, etc.) *always* report + return so
+     * bulk operations can keep swallowing runtime-data failures per row.
+     *
+     * We should use this as a drop-in for `report($e)` inside the wide-net
+     * catch (\Throwable $e) blocks in the bulk destroy / import paths.
+     */
+    public static function reportOrRethrow(Throwable $e): void
+    {
+        // Both APP_DEBUG must be on AND the environment must
+        // not be production before the raw \Error is allowed to
+        // escape past the friendly user-facing error.
+        if (
+            config('app.debug')
+            && !app()->environment('production')
+            && $e instanceof \Error
+        ) {
+            throw $e;
+        }
+        report($e);
     }
 
     /**

--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Actions\Categories\DestroyCategoryAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasChildren;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
@@ -240,8 +241,8 @@ class CategoriesController extends Controller
             return response()->json(
                 Helper::formatStandardApiResponse('error', null, trans('general.bulk_delete_associations.general_assoc_warning', ['asset_type' => $category->category_type]))
             );
-        } catch (\Exception $e) {
-            report($e);
+        } catch (\Throwable $e) {
+            Handler::reportOrRethrow($e);
 
             return response()->json(
                 Helper::formatStandardApiResponse('error', null, trans('general.something_went_wrong'))

--- a/app/Http/Controllers/Api/ManufacturersController.php
+++ b/app/Http/Controllers/Api/ManufacturersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Actions\Manufacturers\DestroyManufacturerAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasChildren;
 use App\Helpers\Helper;
 use App\Http\Controllers\Controller;
@@ -216,8 +217,8 @@ class ManufacturersController extends Controller
             DestroyManufacturerAction::run($manufacturer);
         } catch (ItemStillHasChildren $e) {
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.bulk_delete_associations.general_assoc_warning', ['item' => trans('general.manufacturer')])));
-        } catch (\Exception $e) {
-            report($e);
+        } catch (\Throwable $e) {
+            Handler::reportOrRethrow($e);
 
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.something_went_wrong')));
         }

--- a/app/Http/Controllers/Api/SuppliersController.php
+++ b/app/Http/Controllers/Api/SuppliersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Actions\Suppliers\DestroySupplierAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasAccessories;
 use App\Exceptions\ItemStillHasAssets;
 use App\Exceptions\ItemStillHasComponents;
@@ -235,8 +236,8 @@ class SuppliersController extends Controller
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.bulk_delete_associations.assoc_components', [
                 'components_count' => (int) $supplier->components_count, 'item' => trans('general.supplier'),
             ])));
-        } catch (\Exception $e) {
-            report($e);
+        } catch (\Throwable $e) {
+            Handler::reportOrRethrow($e);
 
             return response()->json(Helper::formatStandardApiResponse('error', null, trans('general.something_went_wrong')));
         }

--- a/app/Http/Controllers/BulkCategoriesController.php
+++ b/app/Http/Controllers/BulkCategoriesController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Categories\DestroyCategoryAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasAccessories;
 use App\Exceptions\ItemStillHasAssetModels;
 use App\Exceptions\ItemStillHasAssets;
@@ -43,8 +44,8 @@ class BulkCategoriesController extends Controller
                 $errors[] = trans('general.bulk_delete_associations.assoc_consumables_no_count', ['item_name' => $category->name, 'item' => trans('general.category')]);
             } catch (ItemStillHasLicenses) {
                 $errors[] = trans('general.bulk_delete_associations.assoc_licenses_no_count', ['item_name' => $category->name, 'item' => trans('general.category')]);
-            } catch (\Exception $e) {
-                report($e);
+            } catch (\Throwable $e) {
+                Handler::reportOrRethrow($e);
                 $errors[] = trans('general.something_went_wrong');
             }
         }

--- a/app/Http/Controllers/BulkCompaniesController.php
+++ b/app/Http/Controllers/BulkCompaniesController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Companies\DestroyCompanyAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasAccessories;
 use App\Exceptions\ItemStillHasAssets;
 use App\Exceptions\ItemStillHasChildCompanies;
@@ -46,8 +47,8 @@ class BulkCompaniesController extends Controller
                 $errors[] = trans('general.bulk_delete_associations.assoc_users_no_count', ['item_name' => $company->name, 'item' => trans('general.company')]);
             } catch (ItemStillHasChildCompanies $e) {
                 $errors[] = trans('general.bulk_delete_associations.assoc_child_companies_no_count', ['item_name' => $company->name, 'item' => trans('general.company')]);
-            } catch (\Exception $e) {
-                report($e);
+            } catch (\Throwable $e) {
+                Handler::reportOrRethrow($e);
                 $errors[] = trans('general.something_went_wrong');
             }
         }

--- a/app/Http/Controllers/BulkDepartmentsController.php
+++ b/app/Http/Controllers/BulkDepartmentsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Departments\DestroyDepartmentAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasUsers;
 use App\Models\Department;
 use Illuminate\Http\Request;
@@ -28,8 +29,8 @@ class BulkDepartmentsController extends Controller
                 $success_count++;
             } catch (ItemStillHasUsers $e) {
                 $errors[] = trans('general.bulk_delete_associations.assoc_users_no_count', ['item_name' => $department->name, 'item' => trans('general.department')]);
-            } catch (\Exception $e) {
-                report($e);
+            } catch (\Throwable $e) {
+                Handler::reportOrRethrow($e);
                 $errors[] = trans('general.something_went_wrong');
             }
         }

--- a/app/Http/Controllers/BulkDepreciationsController.php
+++ b/app/Http/Controllers/BulkDepreciationsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Depreciations\DestroyDepreciationAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasAssetModels;
 use App\Exceptions\ItemStillHasAssets;
 use App\Exceptions\ItemStillHasLicenses;
@@ -34,8 +35,8 @@ class BulkDepreciationsController extends Controller
                 $errors[] = trans('general.bulk_delete_associations.asset_models_no_count', ['item_name' => $depreciation->name, 'item' => trans('general.depreciation')]);
             } catch (ItemStillHasLicenses $e) {
                 $errors[] = trans('general.bulk_delete_associations.assoc_licenses_no_count', ['item_name' => $depreciation->name, 'item' => trans('general.depreciation')]);
-            } catch (\Exception $e) {
-                report($e);
+            } catch (\Throwable $e) {
+                Handler::reportOrRethrow($e);
                 $errors[] = trans('general.something_went_wrong');
             }
         }

--- a/app/Http/Controllers/BulkManufacturersController.php
+++ b/app/Http/Controllers/BulkManufacturersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Manufacturers\DestroyManufacturerAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasAccessories;
 use App\Exceptions\ItemStillHasAssets;
 use App\Exceptions\ItemStillHasComponents;
@@ -39,8 +40,8 @@ class BulkManufacturersController extends Controller
                 $errors[] = trans('general.bulk_delete_associations.assoc_components_no_count', ['item_name' => $manufacturer->name, 'item' => trans('general.manufacturer')]);
             } catch (ItemStillHasLicenses $e) {
                 $errors[] = trans('general.bulk_delete_associations.assoc_licenses_no_count', ['item_name' => $manufacturer->name, 'item' => trans('general.manufacturer')]);
-            } catch (\Exception $e) {
-                report($e);
+            } catch (\Throwable $e) {
+                Handler::reportOrRethrow($e);
                 $errors[] = trans('general.something_went_wrong');
             }
         }

--- a/app/Http/Controllers/BulkStatuslabelsController.php
+++ b/app/Http/Controllers/BulkStatuslabelsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\StatusLabels\DestroyStatuslabelAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasAssets;
 use App\Models\Statuslabel;
 use Illuminate\Http\Request;
@@ -28,8 +29,8 @@ class BulkStatuslabelsController extends Controller
                 $success_count++;
             } catch (ItemStillHasAssets $e) {
                 $errors[] = trans('general.bulk_delete_associations.assoc_assets_no_count', ['item_name' => $statuslabel->name, 'item' => trans('admin/statuslabels/table.status_label')]);
-            } catch (\Exception $e) {
-                report($e);
+            } catch (\Throwable $e) {
+                Handler::reportOrRethrow($e);
                 $errors[] = trans('general.something_went_wrong');
             }
         }

--- a/app/Http/Controllers/BulkSuppliersController.php
+++ b/app/Http/Controllers/BulkSuppliersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Suppliers\DestroySupplierAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasAccessories;
 use App\Exceptions\ItemStillHasAssets;
 use App\Exceptions\ItemStillHasComponents;
@@ -43,8 +44,8 @@ class BulkSuppliersController extends Controller
                 $errors[] = trans('general.bulk_delete_associations.assoc_consumables', ['consumables_count' => (int) $supplier->consumables_count, 'item' => trans('general.supplier'), 'item_name' => $supplier->name]);
             } catch (ItemStillHasComponents $e) {
                 $errors[] = trans('general.bulk_delete_associations.assoc_components', ['components_count' => (int) $supplier->components_count, 'item' => trans('general.supplier'), 'item_name' => $supplier->name]);
-            } catch (\Exception $e) {
-                report($e);
+            } catch (\Throwable $e) {
+                Handler::reportOrRethrow($e);
                 $errors[] = trans('general.something_went_wrong');
             }
         }

--- a/app/Http/Controllers/CategoriesController.php
+++ b/app/Http/Controllers/CategoriesController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Categories\DestroyCategoryAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasChildren;
 use App\Helpers\Helper;
 use App\Http\Requests\ImageUploadRequest;
@@ -164,8 +165,8 @@ class CategoriesController extends Controller
             DestroyCategoryAction::run($category);
         } catch (ItemStillHasChildren $e) {
             return redirect()->route('categories.index')->with('error', trans('general.bulk_delete_associations.general_assoc_warning', ['item' => trans('general.category')]));
-        } catch (\Exception $e) {
-            report($e);
+        } catch (\Throwable $e) {
+            Handler::reportOrRethrow($e);
 
             return redirect()->route('categories.index')->with('error', trans('admin/categories/message.delete.error'));
         }

--- a/app/Http/Controllers/ManufacturersController.php
+++ b/app/Http/Controllers/ManufacturersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Manufacturers\DestroyManufacturerAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasChildren;
 use App\Http\Requests\ImageUploadRequest;
 use App\Models\Actionlog;
@@ -179,8 +180,8 @@ class ManufacturersController extends Controller
             DestroyManufacturerAction::run($manufacturer);
         } catch (ItemStillHasChildren $e) {
             return redirect()->route('manufacturers.index')->with('error', trans('general.bulk_delete_associations.general_assoc_warning', ['item' => trans('general.manufacturer')]));
-        } catch (\Exception $e) {
-            report($e);
+        } catch (\Throwable $e) {
+            Handler::reportOrRethrow($e);
 
             return redirect()->route('manufacturers.index')->with('error', trans('general.something_went_wrong'));
         }

--- a/app/Http/Controllers/SuppliersController.php
+++ b/app/Http/Controllers/SuppliersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Suppliers\DestroySupplierAction;
+use App\Exceptions\Handler;
 use App\Exceptions\ItemStillHasAccessories;
 use App\Exceptions\ItemStillHasAssets;
 use App\Exceptions\ItemStillHasComponents;
@@ -156,8 +157,8 @@ class SuppliersController extends Controller
             return redirect()->route('suppliers.index')->with('error', trans('general.bulk_delete_associations.assoc_components', [
                 'components_count' => (int) $supplier->components_count, 'item' => trans('general.supplier'),
             ]));
-        } catch (\Exception $e) {
-            report($e);
+        } catch (\Throwable $e) {
+            Handler::reportOrRethrow($e);
 
             return redirect()->route('suppliers.index')->with('error', trans('admin/suppliers/message.delete.error'));
         }

--- a/app/Http/Controllers/Users/LDAPImportController.php
+++ b/app/Http/Controllers/Users/LDAPImportController.php
@@ -34,11 +34,6 @@ class LDAPImportController extends Controller
         if (! auth()->user()?->isSuperUser()) {
             abort(403);
         }
-        try {
-            // $this->ldap->connect(); I don't think this actually exists in LdapAd.php, and we don't really 'persist' LDAP connections anyways...right?
-        } catch (\Exception $e) {
-            return redirect()->route('users.index')->with('error', $e->getMessage());
-        }
 
         return view('users/ldap');
     }

--- a/app/Models/Labels/FieldOption.php
+++ b/app/Models/Labels/FieldOption.php
@@ -4,7 +4,6 @@ namespace App\Models\Labels;
 
 use App\Models\Asset;
 use App\Models\User;
-use App\Helpers\Helper;
 
 class FieldOption
 {
@@ -32,7 +31,7 @@ class FieldOption
         if (in_array($dataPath[0], ['assignedTo', 'displayName'])) {
             $assigned = $asset->relationLoaded('assignedTo') ? $asset->assigned : $asset->assignedTo;
 
-            if (!$assigned) {
+            if (! $assigned) {
                 return null;
             }
             if ($dataPath[0] === 'displayName') {
@@ -41,6 +40,7 @@ class FieldOption
             if ($assigned instanceof User) {
                 return $assigned->full_name;
             }
+
             return $assigned->name ?? $assigned->display_name ?? null;
         }
 
@@ -50,16 +50,17 @@ class FieldOption
         }
         if ($dataPath[0] === 'warranty_months') {
 
-            return ($asset->warranty_months > 0) ? e($asset->warranty_months . ' ' . trans('admin/hardware/form.months')) : null;
+            return ($asset->warranty_months > 0) ? e($asset->warranty_months.' '.trans('admin/hardware/form.months')) : null;
         }
         if ($dataPath[0] === 'warranty_expires') {
             return ($asset->warranty_months > 0) ? $asset->warranty_expires->toDateString() : null;
         }
+
         return $dataPath->reduce(
             function ($myValue, $path) {
                 try {
                     return $myValue ? $myValue->{$path} : ${$myValue};
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     return $myValue;
                 }
             }, $asset

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1267,12 +1267,6 @@ parameters:
 			path: app/Http/Controllers/Api/CategoriesController.php
 
 		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/Api/CategoriesController.php
-
-		-
 			message: '#^Method Illuminate\\Filesystem\\FilesystemAdapter\:\:url\(\) invoked with 2 parameters, 1 required\.$#'
 			identifier: arguments.count
 			count: 1
@@ -1771,12 +1765,6 @@ parameters:
 			path: app/Http/Controllers/Api/ManufacturersController.php
 
 		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/Api/ManufacturersController.php
-
-		-
 			message: '#^Method Illuminate\\Filesystem\\FilesystemAdapter\:\:url\(\) invoked with 2 parameters, 1 required\.$#'
 			identifier: arguments.count
 			count: 1
@@ -1948,12 +1936,6 @@ parameters:
 			message: '#^Call to an undefined method App\\Models\\SnipeModel\:\:getErrors\(\)\.$#'
 			identifier: method.notFound
 			count: 2
-			path: app/Http/Controllers/Api/SuppliersController.php
-
-		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
 			path: app/Http/Controllers/Api/SuppliersController.php
 
 		-
@@ -2527,46 +2509,10 @@ parameters:
 			path: app/Http/Controllers/Auth/SamlController.php
 
 		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/BulkCategoriesController.php
-
-		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/BulkCompaniesController.php
-
-		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/BulkDepartmentsController.php
-
-		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/BulkDepreciationsController.php
-
-		-
 			message: '#^Access to an undefined property App\\Models\\Actionlog\:\:\$created_by\.$#'
 			identifier: property.notFound
 			count: 1
 			path: app/Http/Controllers/BulkMaintenancesController.php
-
-		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/BulkManufacturersController.php
-
-		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/BulkStatuslabelsController.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Supplier\|Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\Supplier\>\:\:\$accessories_count\.$#'
@@ -2593,12 +2539,6 @@ parameters:
 			path: app/Http/Controllers/BulkSuppliersController.php
 
 		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/BulkSuppliersController.php
-
-		-
 			message: '#^Access to an undefined property App\\Models\\Category\:\:\$created_by\.$#'
 			identifier: property.notFound
 			count: 1
@@ -2608,12 +2548,6 @@ parameters:
 			message: '#^Call to an undefined method App\\Models\\SnipeModel\:\:getErrors\(\)\.$#'
 			identifier: method.notFound
 			count: 2
-			path: app/Http/Controllers/CategoriesController.php
-
-		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
 			path: app/Http/Controllers/CategoriesController.php
 
 		-
@@ -3271,12 +3205,6 @@ parameters:
 			path: app/Http/Controllers/ManufacturersController.php
 
 		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/ManufacturersController.php
-
-		-
 			message: '#^PHPDoc tag @param for parameter \$request with type Illuminate\\Http\\Request is not subtype of native type App\\Http\\Requests\\ImageUploadRequest\.$#'
 			identifier: parameter.phpDocType
 			count: 1
@@ -3649,12 +3577,6 @@ parameters:
 			path: app/Http/Controllers/SuppliersController.php
 
 		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/SuppliersController.php
-
-		-
 			message: '#^PHPDoc tag @param references unknown parameter\: \$supplierId$#'
 			identifier: parameter.notFound
 			count: 4
@@ -3737,12 +3659,6 @@ parameters:
 			identifier: property.notFound
 			count: 2
 			path: app/Http/Controllers/Users/ImpersonateController.php
-
-		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: app/Http/Controllers/Users/LDAPImportController.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\AccessoryCheckout\:\:\$created_by\.$#'
@@ -7483,7 +7399,7 @@ parameters:
 			path: app/Models/Labels/FieldOption.php
 
 		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
+			message: '#^Dead catch \- Throwable is never thrown in the try block\.$#'
 			identifier: catch.neverThrown
 			count: 1
 			path: app/Models/Labels/FieldOption.php


### PR DESCRIPTION
This pass widens the safety-net catches on the bulk destroy and single-record destroy paths from `\Exception` to `\Throwable`, and moves the per-row error reporting through a new `Handler::reportOrRethrow()` static so an accidental `TypeError` (or other `\Error` subtype) fails loud with a stack trace in dev instead of hiding behind a friendly UI flash. Prod behavior is unchanged so we don't accidentally leak stack traces to the public/non-dev installs. 

This also drops the `Log::error($exception)` call from `Handler::report()` because (I *think*) that's what was double-firing Rollbar reports: once via the log channel, once via the exception reporter. Laravel's `parent::report()` already writes to the configured log channels (of which Rollbar is one for us on the hosted platform), so I think that's why for every error triggered, we'd see two reports. 

Now, catches are `catch (\Throwable $e) { Handler::reportOrRethrow($e); ... }`:

```php
} catch (\Throwable $e) {
    Handler::reportOrRethrow($e);
    $errors[] = trans('general.something_went_wrong');
}
```

`Handler::reportOrRethrow($e)` reports the exception, then rethrows only when all three are true:

- `$e instanceof \Error` (programmer-error subtypes: `TypeError`, `ArgumentCountError`, etc.)
- `config('app.debug')` is true
- `app()->environment()` is not `production`

Two gates on the debug check so an accidental `APP_DEBUG=true` on a prod install can't leak stack traces.

Prod is completely unaffected by the rethrow branch (both `APP_DEBUG=false` and `APP_ENV=production` fail the guard). But the `Log::error` removal from `Handler::report()` should cut prod Rollbar volume roughly in half for reported exceptions, since each one was being reported twice with slightly different call stacks. We'll obviously have to keep an eye on that to make sure we didn't actually *break* the Rollbar reporting, but it would sure be nice to not get two of those for every one error. 🤞

This also resolves 14 `catch.neverThrown` entries in the phpstan baseline. 