### PR TITLE
Fixed phpstan complaining about `env()` outside of config files

### DIFF
--- a/app/Console/Commands/LdapSync.php
+++ b/app/Console/Commands/LdapSync.php
@@ -51,8 +51,8 @@ class LdapSync extends Command
             exit();
         }
 
-        ini_set('max_execution_time', env('LDAP_TIME_LIM', 600)); // 600 seconds = 10 minutes
-        ini_set('memory_limit', env('LDAP_MEM_LIM', '500M'));
+        ini_set('max_execution_time', config('app.ldap_time_limit')); // 600 seconds = 10 minutes
+        ini_set('memory_limit', config('app.ldap_memory_limit'));
 
         // Single source of truth for internal-key => LDAP-attribute-name
         // lives on the Ldap model so parseAndMapLdapAttributes and this

--- a/app/Console/Commands/MoveUploadsToNewDisk.php
+++ b/app/Console/Commands/MoveUploadsToNewDisk.php
@@ -89,7 +89,7 @@ class MoveUploadsToNewDisk extends Command
             $type_count++;
             $filename = basename($logo);
             Storage::disk('public')->put('uploads/'.$filename, file_get_contents($logo));
-            $this->info($type_count.'. LOGO: '.$filename.' was copied to '.env('PUBLIC_AWS_URL').'/uploads/'.$filename);
+            $this->info($type_count.'. LOGO: '.$filename.' was copied to '.config('filesystems.disks.public_aws.url').'/uploads/'.$filename);
         }
 
         $private_uploads['assets'] = glob('storage/private_uploads/assets'.'/*.*');

--- a/app/Console/Commands/ObjectImportCommand.php
+++ b/app/Console/Commands/ObjectImportCommand.php
@@ -54,8 +54,8 @@ class ObjectImportCommand extends Command
      */
     public function handle()
     {
-        ini_set('max_execution_time', env('IMPORT_TIME_LIMIT', 600)); // 600 seconds = 10 minutes
-        ini_set('memory_limit', env('IMPORT_MEMORY_LIMIT', '500M'));
+        ini_set('max_execution_time', config('importer.time_limit')); // 600 seconds = 10 minutes
+        ini_set('memory_limit', config('importer.memory_limit'));
 
         $this->progressIndicator = new ProgressIndicator($this->output);
 

--- a/app/Console/Commands/SystemBackup.php
+++ b/app/Console/Commands/SystemBackup.php
@@ -41,7 +41,7 @@ class SystemBackup extends Command
      */
     public function handle()
     {
-        ini_set('max_execution_time', env('BACKUP_TIME_LIMIT', 600)); // 600 seconds = 10 minutes
+        ini_set('max_execution_time', config('backup.time_limit')); // 600 seconds = 10 minutes
 
         if ($this->option('filename')) {
             $filename = $this->option('filename');

--- a/app/Http/Controllers/Reports/CustomComponentReportController.php
+++ b/app/Http/Controllers/Reports/CustomComponentReportController.php
@@ -42,7 +42,7 @@ class CustomComponentReportController extends Controller
     {
         $this->authorize('reports.view');
 
-        ini_set('max_execution_time', env('REPORT_TIME_LIMIT', 12000)); // 12000 seconds = 200 minutes
+        ini_set('max_execution_time', config('app.report_time_limit')); // 12000 seconds = 200 minutes
 
         $this->disableDebugbar();
 

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -501,7 +501,7 @@ class ReportsController extends Controller
      */
     public function postCustom(CustomAssetReportRequest $request): StreamedResponse
     {
-        ini_set('max_execution_time', env('REPORT_TIME_LIMIT', 12000)); // 12000 seconds = 200 minutes
+        ini_set('max_execution_time', config('app.report_time_limit')); // 12000 seconds = 200 minutes
         $this->authorize('reports.view');
 
         $this->disableDebugbar();

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -88,7 +88,7 @@ class SecurityHeaders
             $csp_policy[] = "connect-src 'self'";
             $csp_policy[] = "object-src 'none'";
             $csp_policy[] = "font-src 'self' data:";
-            $csp_policy[] = "img-src 'self' data: ".config('app.url').' '.config('app.additional_csp_urls').' '.env('PUBLIC_AWS_URL').' https://secure.gravatar.com http://gravatar.com maps.google.com maps.gstatic.com *.googleapis.com';
+            $csp_policy[] = "img-src 'self' data: ".config('app.url').' '.config('app.additional_csp_urls').' '.config('filesystems.disks.public_aws.url').' https://secure.gravatar.com http://gravatar.com maps.google.com maps.gstatic.com *.googleapis.com';
 
             if (config('filesystems.disks.public.driver') == 's3') {
                 $csp_policy[] = "img-src 'self' data:  ".config('filesystems.disks.public.url');

--- a/app/Http/Requests/ItemImportRequest.php
+++ b/app/Http/Requests/ItemImportRequest.php
@@ -32,8 +32,8 @@ class ItemImportRequest extends FormRequest
 
     public function import(Import $import)
     {
-        ini_set('max_execution_time', env('IMPORT_TIME_LIMIT', 600)); // 600 seconds = 10 minutes
-        ini_set('memory_limit', env('IMPORT_MEMORY_LIMIT', '500M'));
+        ini_set('max_execution_time', config('importer.time_limit')); // 600 seconds = 10 minutes
+        ini_set('memory_limit', config('importer.memory_limit'));
 
         $filename = config('app.private_uploads').'/imports/'.$import->file_path;
         $import->import_type = $this->input('import-type');

--- a/app/Models/Ldap.php
+++ b/app/Models/Ldap.php
@@ -73,8 +73,8 @@ class Ldap extends Model
         self::ignoreCertificates((bool) $ldap_server_cert_ignore);
 
         // If the user specifies where CA Certs are, make sure to use them
-        if (env('LDAPTLS_CACERT')) {
-            putenv('LDAPTLS_CACERT='.env('LDAPTLS_CACERT'));
+        if (config('app.ldap_tls_cacert')) {
+            putenv('LDAPTLS_CACERT='.config('app.ldap_tls_cacert'));
         }
         // You _were_ allowed to do this *after* the ldap_connect() in some versions of PHP, but it's not how they want
         // you to anymore, and it seems to not work at all in later PHP versions.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -62,12 +62,11 @@ class AppServiceProvider extends ServiceProvider
          *
          * We'll force the https scheme if the APP_URL starts with https://, or if APP_FORCE_TLS is set to true.
          */
-        if ((strpos(env('APP_URL'), 'https://') === 0) || (env('APP_FORCE_TLS'))) {
+        if ((str_starts_with(config('app.url'), 'https://')) || config('app.force_tls')) {
             $url->forceScheme('https');
         }
 
-        // TODO - isn't it somehow 'gauche' to check the environment directly; shouldn't we be using config() somehow?
-        if (! env('APP_ALLOW_INSECURE_HOSTS')) {  // unless you set APP_ALLOW_INSECURE_HOSTS, you should PROHIBIT forging domain parts of URL via Host: headers
+        if (! config('app.allow_insecure_hosts')) {  // unless you set APP_ALLOW_INSECURE_HOSTS, you should PROHIBIT forging domain parts of URL via Host: headers
             $url_parts = parse_url(config('app.url'));
             if ($url_parts && array_key_exists('scheme', $url_parts) && array_key_exists('host', $url_parts)) { // check for the *required* parts of a bare-minimum URL
                 URL::forceRootUrl(config('app.url'));

--- a/config/app.php
+++ b/config/app.php
@@ -626,4 +626,37 @@ return [
 
     'report_time_limit' => env('REPORT_TIME_LIMIT', 12000),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Force TLS / Allow Insecure Hosts
+    |--------------------------------------------------------------------------
+    | force_tls: forces the URL generator to emit https:// links regardless
+    | of the incoming request scheme. Snipe-IT already forces https when
+    | APP_URL starts with https, this flag covers reverse-proxy setups where
+    | APP_URL is http but is actually TLS. allow_insecure_hosts skips
+    | the URL::forceRootUrl() lockdown that otherwise rejects requests whose
+    | Host header doesn't match APP_URL.
+    */
+
+    'force_tls' => env('APP_FORCE_TLS', false),
+
+    'allow_insecure_hosts' => env('APP_ALLOW_INSECURE_HOSTS', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | LDAP Execution Limits
+    |--------------------------------------------------------------------------
+    | Seconds and memory ceiling passed to ini_set() at the top of the
+    | LDAP sync command so a large directory sync doesn't get killed by
+    | PHP's shorter defaults. ldap_tls_cacert points at a custom CA
+    | bundle to trust when running LDAPS against a self-signed or
+    | private-CA-signed directory.
+    */
+
+    'ldap_time_limit' => env('LDAP_TIME_LIM', 600),
+
+    'ldap_memory_limit' => env('LDAP_MEM_LIM', '500M'),
+
+    'ldap_tls_cacert' => env('LDAPTLS_CACERT'),
+
 ];

--- a/config/backup.php
+++ b/config/backup.php
@@ -253,4 +253,15 @@ return [
 
     'sanitize_by_default' => env('DB_SANITIZE_BY_DEFAULT', false),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Backup execution time limit
+    |--------------------------------------------------------------------------
+    | Seconds passed to ini_set('max_execution_time') at the top of the
+    | snipeit:backup console command so a large-database dump doesn't get
+    | killed by PHP's shorter default. Default 600 (10 minutes).
+    */
+
+    'time_limit' => env('BACKUP_TIME_LIMIT', 600),
+
 ];

--- a/config/importer.php
+++ b/config/importer.php
@@ -26,4 +26,18 @@ return [
 
     'slice_size' => env('IMPORT_SLICE_SIZE', 500),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Importer execution knobs
+    |--------------------------------------------------------------------------
+    | Seconds and memory ceiling passed to ini_set() at the top of the
+    | import processing path so a large CSV doesn't get killed by PHP's
+    | shorter defaults. Applied both to the console ObjectImportCommand
+    | and the API ItemImportRequest slice handler.
+    */
+
+    'time_limit' => env('IMPORT_TIME_LIMIT', 600),
+
+    'memory_limit' => env('IMPORT_MEMORY_LIMIT', '500M'),
+
 ];

--- a/database/factories/MaintenanceFactory.php
+++ b/database/factories/MaintenanceFactory.php
@@ -72,16 +72,23 @@ class MaintenanceFactory extends Factory
             // Use item_id + item_type (the polymorphic FK) rather than the
             // legacy asset_id so callers can override the target with their
             // own asset instance and skip the default factory-created one.
-            // The legacy asset_id path still routes through the model's
-            // setAssetIdAttribute mutator, but the default path here no
-            // longer spawns an asset when a caller passes item_id, which
-            // was leaking spurious asset rows into cross-cutting counts
-            // (assetsPastEol on the Needs Attention widget hit this).
-            'item_id' => Asset::factory()->laptopZenbook()->afterMaking(function (Asset $asset) {
-                if ($asset->location_id === null) {
-                    $asset->location_id = $asset->rtd_location_id;
+            // A supplied asset_id routes through the model's
+            // setAssetIdAttribute mutator at save time. The closure below
+            // detects that up front and skips the default asset spawn so
+            // we don't leak a spurious asset row for cross-cutting counts
+            // to trip over (assetsPastEol on the Needs Attention widget,
+            // source_id collisions in the calendar events API test, etc.).
+            'item_id' => function (array $attributes) {
+                if (array_key_exists('asset_id', $attributes)) {
+                    return null;
                 }
-            }),
+
+                return Asset::factory()->laptopZenbook()->afterMaking(function (Asset $asset) {
+                    if ($asset->location_id === null) {
+                        $asset->location_id = $asset->rtd_location_id;
+                    }
+                });
+            },
             'item_type' => Asset::class,
             'supplier_id' => Supplier::factory(),
             'maintenance_type_id' => $maintenanceType->id,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -337,12 +337,6 @@ parameters:
 			path: app/Console/Commands/LdapSync.php
 
 		-
-			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
-			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 2
-			path: app/Console/Commands/LdapSync.php
-
-		-
 			message: '#^Property App\\Models\\User\:\:\$activated \(bool\) does not accept int\.$#'
 			identifier: assign.propertyType
 			count: 2
@@ -415,12 +409,6 @@ parameters:
 			path: app/Console/Commands/MergeUsersByUsername.php
 
 		-
-			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
-			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 1
-			path: app/Console/Commands/MoveUploadsToNewDisk.php
-
-		-
 			message: '#^Method Illuminate\\Filesystem\\FilesystemAdapter\:\:url\(\) invoked with 2 parameters, 1 required\.$#'
 			identifier: arguments.count
 			count: 1
@@ -437,12 +425,6 @@ parameters:
 			identifier: return.missing
 			count: 1
 			path: app/Console/Commands/NormalizeUserNames.php
-
-		-
-			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
-			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 2
-			path: app/Console/Commands/ObjectImportCommand.php
 
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$display_name\.$#'
@@ -575,12 +557,6 @@ parameters:
 			identifier: if.alwaysTrue
 			count: 1
 			path: app/Console/Commands/SyncAssetLocations.php
-
-		-
-			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
-			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 1
-			path: app/Console/Commands/SystemBackup.php
 
 		-
 			message: '#^Method App\\Console\\Commands\\ToggleCustomfieldEncryption\:\:handle\(\) should return int but return statement is missing\.$#'
@@ -3259,12 +3235,6 @@ parameters:
 			path: app/Http/Controllers/Reports/CustomComponentReportController.php
 
 		-
-			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
-			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 1
-			path: app/Http/Controllers/Reports/CustomComponentReportController.php
-
-		-
 			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Builder\:\:onlyTrashed\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -3363,12 +3333,6 @@ parameters:
 		-
 			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:checkouts\(\)\.$#'
 			identifier: method.notFound
-			count: 1
-			path: app/Http/Controllers/ReportsController.php
-
-		-
-			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
-			identifier: larastan.noEnvCallsOutsideOfConfig
 			count: 1
 			path: app/Http/Controllers/ReportsController.php
 
@@ -3787,12 +3751,6 @@ parameters:
 			path: app/Http/Middleware/PreventRequestsDuringMaintenance.php
 
 		-
-			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
-			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 1
-			path: app/Http/Middleware/SecurityHeaders.php
-
-		-
 			message: '#^PHPDoc type array of property App\\Http\\Middleware\\TrimStrings\:\:\$except is not covariant with PHPDoc type array\<int, string\> of overridden property Illuminate\\Foundation\\Http\\Middleware\\TrimStrings\:\:\$except\.$#'
 			identifier: property.phpDocType
 			count: 1
@@ -3814,12 +3772,6 @@ parameters:
 			message: '#^Access to an undefined property App\\Models\\Import\:\:\$created_by\.$#'
 			identifier: property.notFound
 			count: 1
-			path: app/Http/Requests/ItemImportRequest.php
-
-		-
-			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
-			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 2
 			path: app/Http/Requests/ItemImportRequest.php
 
 		-
@@ -7543,12 +7495,6 @@ parameters:
 			path: app/Models/Ldap.php
 
 		-
-			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
-			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 2
-			path: app/Models/Ldap.php
-
-		-
 			message: '#^Method App\\Models\\Ldap\:\:bindAdminToLdap\(\) should return bool but return statement is missing\.$#'
 			identifier: return.missing
 			count: 2
@@ -9749,12 +9695,6 @@ parameters:
 			identifier: nullsafe.neverNull
 			count: 1
 			path: app/Presenters/UserPresenter.php
-
-		-
-			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
-			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 3
-			path: app/Providers/AppServiceProvider.php
 
 		-
 			message: '#^PHPDoc type array of property App\\Providers\\AuthServiceProvider\:\:\$policies is not covariant with PHPDoc type array\<class\-string, class\-string\> of overridden property Illuminate\\Foundation\\Support\\Providers\\AuthServiceProvider\:\:\$policies\.$#'

--- a/tests/Feature/CalendarEvents/CalendarEventsApiTest.php
+++ b/tests/Feature/CalendarEvents/CalendarEventsApiTest.php
@@ -79,6 +79,7 @@ class CalendarEventsApiTest extends TestCase implements TestsFullMultipleCompani
             ]))
             ->assertOk()
             ->json('events'))
+            ->filter(fn ($row) => $row['extendedProps']['source_type'] === Maintenance::class)
             ->pluck('extendedProps.source_id')
             ->all();
 
@@ -102,6 +103,7 @@ class CalendarEventsApiTest extends TestCase implements TestsFullMultipleCompani
             ->getJson(route('api.calendar.events', ['event_type' => ['maintenance.start']]))
             ->assertOk()
             ->json('events'))
+            ->filter(fn ($row) => $row['extendedProps']['source_type'] === Maintenance::class)
             ->pluck('extendedProps.source_id')
             ->all();
         $this->assertContains($maintenance->id, $ids);
@@ -111,6 +113,7 @@ class CalendarEventsApiTest extends TestCase implements TestsFullMultipleCompani
             ->getJson(route('api.calendar.events', ['event_type' => ['some.other.type']]))
             ->assertOk()
             ->json('events'))
+            ->filter(fn ($row) => $row['extendedProps']['source_type'] === Maintenance::class)
             ->pluck('extendedProps.source_id')
             ->all();
         $this->assertNotContains($maintenance->id, $ids);
@@ -150,6 +153,7 @@ class CalendarEventsApiTest extends TestCase implements TestsFullMultipleCompani
             ->getJson(route('api.calendar.events'))
             ->assertOk()
             ->json('events'))
+            ->filter(fn ($row) => $row['extendedProps']['source_type'] === Maintenance::class)
             ->pluck('extendedProps.source_id')
             ->all();
 


### PR DESCRIPTION
Again, what it says on the tin. Larastan doesn't like it when you call `env()` directly, so this just moves those calls into the config files. Also fixed an unrelated flappy test. Baseline dropped from 10567 -> 10507 (-60 lines) and cleared `larastan.noEnvCallsOutsideOfConfig` completely (10 -> 0 entries). 💃