### PR TITLE
Update AssetModelsController docblocks for route model binding

### DIFF
--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -128,7 +128,7 @@ class AssetModelsController extends Controller
      *
      * @since [v1.0]
      *
-     * @param  int  $modelId
+     * @param  AssetModel  $model
      */
     public function edit(AssetModel $model): View|RedirectResponse
     {
@@ -147,7 +147,7 @@ class AssetModelsController extends Controller
      * @since [v1.0]
      *
      * @param  ImageUploadRequest  $request
-     * @param  int  $modelId
+     * @param  AssetModel  $model
      *
      * @throws AuthorizationException
      */
@@ -202,7 +202,7 @@ class AssetModelsController extends Controller
      *
      * @since [v1.0]
      *
-     * @param  int  $modelId
+     * @param  AssetModel  $model
      */
     public function destroy(AssetModel $model): RedirectResponse
     {
@@ -273,7 +273,7 @@ class AssetModelsController extends Controller
      *
      * @since [v1.0]
      *
-     * @param  int  $modelId
+     * @param  AssetModel  $model
      */
     public function show(AssetModel $model): View|RedirectResponse
     {
@@ -289,7 +289,7 @@ class AssetModelsController extends Controller
      *
      * @since [v1.0]
      *
-     * @param  int  $modelId
+     * @param  AssetModel  $model
      */
     public function getClone(AssetModel $model): View|RedirectResponse
     {
@@ -436,7 +436,7 @@ class AssetModelsController extends Controller
      *
      * @since [v1.0]
      *
-     * @param  int  $modelId
+     * @param  Request  $request
      */
     public function postBulkDelete(Request $request): RedirectResponse
     {


### PR DESCRIPTION
These look like leftovers from the switch to route model binding: the methods take an `AssetModel` now, and the private `assignCustomFieldsDefaultValues` in the same file already documents it that way. `postBulkDelete` seems to have picked up `destroy`'s block at some point. `getCustomFields` still takes an id, so I left it alone.
