### PR TITLE
Add more relations to delete console command

### DIFF
--- a/app/Console/Commands/BulkDelete.php
+++ b/app/Console/Commands/BulkDelete.php
@@ -98,6 +98,10 @@ class BulkDelete extends Command
             options: function (string $value): array {
                 $results = [];
 
+                if ($value === '' || str_contains('(all companies)', strtolower($value))) {
+                    $results['__all__'] = '(All Companies + Unassigned)';
+                }
+
                 if ($value === '' || str_contains('(no company / unassigned)', strtolower($value))) {
                     $results['__null__'] = '(No Company / Unassigned)';
                 }
@@ -117,6 +121,17 @@ class BulkDelete extends Command
             required: 'Please select at least one company.',
             hint: 'If you\'re searching on several differently named companies, use the up-arrow to go back to the search box to search again. ',
         );
+
+        // "All Companies + Unassigned" expands to every company plus the
+        // no-company scope, so callers don't have to pick each one by
+        // hand. Any other selections alongside it are redundant, so we
+        // let it win by resetting the key list.
+        if (in_array('__all__', $selectedCompanyKeys, true)) {
+            $selectedCompanyKeys = array_merge(
+                Company::orderBy('name')->pluck('id')->map(fn ($id) => (int) $id)->all(),
+                ['__null__'],
+            );
+        }
 
         $includeNullCompany = in_array('__null__', $selectedCompanyKeys);
         $selectedCompanyIds = array_values(array_filter(

--- a/app/Console/Commands/BulkDelete.php
+++ b/app/Console/Commands/BulkDelete.php
@@ -8,12 +8,17 @@ use App\Models\Accessory;
 use App\Models\AccessoryCheckout;
 use App\Models\Actionlog;
 use App\Models\Asset;
+use App\Models\CalendarEvent;
 use App\Models\CheckoutAcceptance;
+use App\Models\CheckoutRequest;
 use App\Models\Company;
 use App\Models\Component;
 use App\Models\Consumable;
 use App\Models\License;
 use App\Models\LicenseSeat;
+use App\Models\Maintenance;
+use App\Models\Order;
+use App\Models\OrderItem;
 use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Builder;
@@ -482,20 +487,34 @@ class BulkDelete extends Command
                 // asset, and any other assets that were assigned to this one
                 $maintenanceImages = [];
                 if ($deleteType === 'hard') {
+                    $assetId = (int) $asset->getKey();
                     if ($deleteFiles) {
                         $maintenanceImages = $asset->maintenances()
                             ->whereNotNull('image')
                             ->pluck('image')
                             ->toArray();
                     }
+                    // Calendar events published by each maintenance must go with the
+                    // maintenance rows themselves. Nothing else observes maintenances
+                    // for calendar cleanup once the parent asset is gone.
+                    $maintenanceIds = Maintenance::where('item_id', $assetId)
+                        ->where('item_type', Asset::class)
+                        ->pluck('id')
+                        ->toArray();
+                    if (! empty($maintenanceIds)) {
+                        CalendarEvent::where('source_type', Maintenance::class)
+                            ->whereIn('source_id', $maintenanceIds)
+                            ->forceDelete();
+                    }
                     $asset->maintenances()->forceDelete();
-                    AccessoryCheckout::where('assigned_to', $asset->id)
+                    AccessoryCheckout::where('assigned_to', $assetId)
                         ->where('assigned_type', Asset::class)
                         ->delete();
                     DB::table('assets')
-                        ->where('assigned_to', $asset->id)
+                        ->where('assigned_to', $assetId)
                         ->where('assigned_type', Asset::class)
                         ->update(['assigned_to' => null, 'assigned_type' => null]);
+                    $this->purgeItemRelatedRecords(Asset::class, $assetId);
                 }
 
                 match ($deleteType) {
@@ -602,6 +621,7 @@ class BulkDelete extends Command
                         ->forceDelete();
                     $license->licenseseats()->forceDelete();
                     DB::table('kits_licenses')->where('license_id', $license->id)->delete();
+                    $this->purgeItemRelatedRecords(License::class, (int) $license->getKey());
                     $license->forceDelete();
                     $this->reportLines[] = "Hard-deleted license {$license->name}";
                 }
@@ -679,7 +699,18 @@ class BulkDelete extends Command
                 }
 
                 if ($deleteType === 'hard') {
-                    DB::table('kits_accessories')->where('accessory_id', $accessory->id)->delete();
+                    $accessoryId = (int) $accessory->getKey();
+                    if ($deleteFiles) {
+                        CheckoutAcceptance::where('checkoutable_type', Accessory::class)
+                            ->where('checkoutable_id', $accessoryId)
+                            ->get()
+                            ->each(fn (CheckoutAcceptance $ca) => $this->deleteAcceptanceFiles($ca));
+                    }
+                    CheckoutAcceptance::where('checkoutable_type', Accessory::class)
+                        ->where('checkoutable_id', $accessoryId)
+                        ->forceDelete();
+                    DB::table('kits_accessories')->where('accessory_id', $accessoryId)->delete();
+                    $this->purgeItemRelatedRecords(Accessory::class, $accessoryId);
                 }
 
                 match ($deleteType) {
@@ -765,6 +796,10 @@ class BulkDelete extends Command
                     $component->assetlog()->forceDelete();
                 }
 
+                if ($deleteType === 'hard') {
+                    $this->purgeItemRelatedRecords(Component::class, (int) $component->getKey());
+                }
+
                 match ($deleteType) {
                     'soft' => $component->delete(),
                     'hard' => $component->forceDelete(),
@@ -821,7 +856,18 @@ class BulkDelete extends Command
                 }
 
                 if ($deleteType === 'hard') {
-                    DB::table('kits_consumables')->where('consumable_id', $consumable->id)->delete();
+                    $consumableId = (int) $consumable->getKey();
+                    if ($deleteFiles) {
+                        CheckoutAcceptance::where('checkoutable_type', Consumable::class)
+                            ->where('checkoutable_id', $consumableId)
+                            ->get()
+                            ->each(fn (CheckoutAcceptance $ca) => $this->deleteAcceptanceFiles($ca));
+                    }
+                    CheckoutAcceptance::where('checkoutable_type', Consumable::class)
+                        ->where('checkoutable_id', $consumableId)
+                        ->forceDelete();
+                    DB::table('kits_consumables')->where('consumable_id', $consumableId)->delete();
+                    $this->purgeItemRelatedRecords(Consumable::class, $consumableId);
                 }
 
                 match ($deleteType) {
@@ -928,6 +974,17 @@ class BulkDelete extends Command
                 CheckoutAcceptance::where('assigned_to_id', $user->id)->forceDelete();
                 if ($deleteType === 'hard') {
                     DB::table('company_user')->where('user_id', $user->id)->delete();
+                    // User-side related-record purge. Checkout requests carry
+                    // a user_id column (the requester), and User is a
+                    // HasCalendarEvents publisher (end_date lane), so both
+                    // need to be cleaned when the user is hard-deleted.
+                    // Orders reference users via created_by only, which we
+                    // leave nullable rather than deleting the order.
+                    $userId = (int) $user->getKey();
+                    CheckoutRequest::where('user_id', $userId)->forceDelete();
+                    CalendarEvent::where('source_type', User::class)
+                        ->where('source_id', $userId)
+                        ->forceDelete();
                 }
 
                 if ($clearLogs) {
@@ -986,6 +1043,42 @@ class BulkDelete extends Command
         }
         if ($acceptance->stored_eula_file) {
             $this->deleteStorageFile('local', 'private_uploads/eula-pdfs/'.$acceptance->stored_eula_file);
+        }
+    }
+
+    /**
+     * Purge related records that reference a checkoutable (Asset, License,
+     * Accessory, Component, Consumable) via a polymorphic column. Called on
+     * hard-delete only; soft-delete keeps these records so a restore is
+     * meaningful. Covers checkout_requests, calendar_events, order_items,
+     * and empties out orders that lose their last item as a result.
+     */
+    private function purgeItemRelatedRecords(string $modelClass, int $itemId): void
+    {
+        CheckoutRequest::where('requestable_type', $modelClass)
+            ->where('requestable_id', $itemId)
+            ->forceDelete();
+
+        CalendarEvent::where('source_type', $modelClass)
+            ->where('source_id', $itemId)
+            ->forceDelete();
+
+        $affectedOrderIds = OrderItem::where('item_type', $modelClass)
+            ->where('item_id', $itemId)
+            ->pluck('order_id')
+            ->unique();
+
+        OrderItem::where('item_type', $modelClass)
+            ->where('item_id', $itemId)
+            ->forceDelete();
+
+        // An order with no remaining line items is a dangling shell,
+        // purge it so hard-delete leaves no orphans.
+        foreach ($affectedOrderIds as $orderId) {
+            $stillHasItems = OrderItem::where('order_id', $orderId)->exists();
+            if (! $stillHasItems) {
+                Order::where('id', $orderId)->forceDelete();
+            }
         }
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -117,7 +117,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 21
+			count: 17
 			path: app/Console/Commands/BulkDelete.php
 
 		-

--- a/tests/Feature/Console/BulkDeleteAllCompaniesTest.php
+++ b/tests/Feature/Console/BulkDeleteAllCompaniesTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\Asset;
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Testing\PendingCommand;
+use Tests\TestCase;
+
+/**
+ * Covers the '__all__' sentinel in the multisearch company picker:
+ * selecting "All Companies + Unassigned" must expand to every company
+ * id plus the no-company scope, so items across every tenant are
+ * covered without picking each one by hand.
+ */
+class BulkDeleteAllCompaniesTest extends TestCase
+{
+    private function runCommand(User $admin, array $companySelectionKeys, array $types, string $deleteType): PendingCommand
+    {
+        $searchLabel = 'Who are you? Search by username, first or last name.';
+        $companiesLabel = 'Which companies would you like to check in and delete items for?';
+        $typesLabel = 'What item types would you like to check in and delete?';
+        $deleteLabel = 'How should items be deleted?';
+
+        $hasNotifiable = ! empty(array_intersect($types, ['assets', 'licenses', 'accessories', 'components']));
+
+        $cmd = $this->artisan('snipeit:checkin-delete-items')
+            ->expectsConfirmation('Is this a dry run?', 'no')
+            ->expectsQuestion($searchLabel, $admin->username)
+            ->expectsQuestion($searchLabel, (string) $admin->id)
+            ->expectsQuestion($companiesLabel, '')
+            ->expectsQuestion($companiesLabel, $companySelectionKeys)
+            ->expectsQuestion($typesLabel, $types)
+            ->expectsQuestion($deleteLabel, $deleteType);
+
+        if ($hasNotifiable) {
+            $cmd->expectsConfirmation('Should we send checkin notifications?', 'no');
+        }
+
+        $cmd->expectsConfirmation('Should we clear related action logs?', 'no')
+            ->expectsConfirmation('Should we also delete associated image and upload files?', 'no');
+
+        // The company-deletion prompt only appears when real company ids
+        // (not just __null__) end up in scope. __all__ expands to real
+        // company ids, so the prompt does render for that case.
+        $expandsToRealCompanies = in_array('__all__', $companySelectionKeys, true)
+            || count(array_filter($companySelectionKeys, fn ($k) => is_int($k))) > 0;
+        if ($expandsToRealCompanies) {
+            $cmd->expectsQuestion('Should the selected companies also be deleted?', 'keep');
+        }
+
+        $cmd->expectsConfirmation('Should we run a backup before proceeding?', 'no');
+
+        if ($admin->email) {
+            $cmd->expectsConfirmation("Send an email report to {$admin->email}?", 'no');
+        }
+
+        return $cmd->expectsConfirmation('Are you sure you want to proceed? This cannot be undone.', 'yes');
+    }
+
+    public function test_all_companies_sentinel_covers_every_company_plus_unassigned(): void
+    {
+        $admin = User::factory()->superuser()->create();
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $assetA = Asset::factory()->for($companyA)->create();
+        $assetB = Asset::factory()->for($companyB)->create();
+        $orphanAsset = Asset::factory()->create(['company_id' => null]);
+
+        $this->runCommand($admin, ['__all__'], ['assets'], 'soft')->assertExitCode(0);
+
+        $this->assertSoftDeleted($assetA);
+        $this->assertSoftDeleted($assetB);
+        $this->assertSoftDeleted($orphanAsset);
+    }
+
+    public function test_all_companies_sentinel_wins_when_combined_with_specific_picks(): void
+    {
+        // Selecting __all__ alongside a specific company id shouldn't
+        // narrow the scope. The __all__ branch resets the key list to
+        // every company plus __null__, so the specific pick becomes a
+        // no-op rather than a filter.
+        $admin = User::factory()->superuser()->create();
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $assetA = Asset::factory()->for($companyA)->create();
+        $assetB = Asset::factory()->for($companyB)->create();
+        $orphanAsset = Asset::factory()->create(['company_id' => null]);
+
+        $this->runCommand($admin, ['__all__', $companyA->id], ['assets'], 'soft')->assertExitCode(0);
+
+        $this->assertSoftDeleted($assetA);
+        $this->assertSoftDeleted($assetB);
+        $this->assertSoftDeleted($orphanAsset);
+    }
+
+    public function test_specific_company_only_still_scopes_correctly(): void
+    {
+        // Regression guard: __all__ handling must not accidentally
+        // widen a specific-company selection.
+        $admin = User::factory()->superuser()->create();
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $assetA = Asset::factory()->for($companyA)->create();
+        $assetB = Asset::factory()->for($companyB)->create();
+        $orphanAsset = Asset::factory()->create(['company_id' => null]);
+
+        $this->runCommand($admin, [$companyA->id], ['assets'], 'soft')->assertExitCode(0);
+
+        $this->assertSoftDeleted($assetA);
+        $this->assertNotSoftDeleted($assetB);
+        $this->assertNotSoftDeleted($orphanAsset);
+    }
+
+    public function test_null_only_still_scopes_to_unassigned_only(): void
+    {
+        // Regression guard: __null__ alone still means "no-company only".
+        $admin = User::factory()->superuser()->create();
+        [$companyA, $companyB] = Company::factory()->count(2)->create();
+
+        $assetA = Asset::factory()->for($companyA)->create();
+        $assetB = Asset::factory()->for($companyB)->create();
+        $orphanAsset = Asset::factory()->create(['company_id' => null]);
+
+        $this->runCommand($admin, ['__null__'], ['assets'], 'soft')->assertExitCode(0);
+
+        $this->assertSoftDeleted($orphanAsset);
+        $this->assertNotSoftDeleted($assetA);
+        $this->assertNotSoftDeleted($assetB);
+    }
+}

--- a/tests/Feature/Console/BulkDeleteRelatedRecordsCleanupTest.php
+++ b/tests/Feature/Console/BulkDeleteRelatedRecordsCleanupTest.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\Accessory;
+use App\Models\Asset;
+use App\Models\CalendarEvent;
+use App\Models\CheckoutAcceptance;
+use App\Models\CheckoutRequest;
+use App\Models\Company;
+use App\Models\Component;
+use App\Models\Consumable;
+use App\Models\License;
+use App\Models\Maintenance;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\User;
+use Illuminate\Testing\PendingCommand;
+use Tests\TestCase;
+
+/**
+ * Covers the hard-delete cascade cleanup added so bulk-delete does not
+ * leave orphan checkout_requests, calendar_events, order_items, empty
+ * orders, or checkout_acceptances behind.
+ */
+class BulkDeleteRelatedRecordsCleanupTest extends TestCase
+{
+    private function runBulkDelete(User $admin, Company $company, array $types, string $deleteType): PendingCommand
+    {
+        $searchLabel = 'Who are you? Search by username, first or last name.';
+        $companiesLabel = 'Which companies would you like to check in and delete items for?';
+        $typesLabel = 'What item types would you like to check in and delete?';
+        $deleteLabel = 'How should items be deleted?';
+
+        $hasNotifiable = ! empty(array_intersect($types, ['assets', 'licenses', 'accessories', 'components']));
+
+        $cmd = $this->artisan('snipeit:checkin-delete-items')
+            ->expectsConfirmation('Is this a dry run?', 'no')
+            ->expectsQuestion($searchLabel, $admin->username)
+            ->expectsQuestion($searchLabel, (string) $admin->id)
+            ->expectsQuestion($companiesLabel, '')
+            ->expectsQuestion($companiesLabel, [$company->id])
+            ->expectsQuestion($typesLabel, $types)
+            ->expectsQuestion($deleteLabel, $deleteType);
+
+        if ($hasNotifiable) {
+            $cmd->expectsConfirmation('Should we send checkin notifications?', 'no');
+        }
+
+        $cmd->expectsConfirmation('Should we clear related action logs?', 'no')
+            ->expectsConfirmation('Should we also delete associated image and upload files?', 'no')
+            ->expectsQuestion('Should the selected companies also be deleted?', 'keep')
+            ->expectsConfirmation('Should we run a backup before proceeding?', 'no');
+
+        if ($admin->email) {
+            $cmd->expectsConfirmation("Send an email report to {$admin->email}?", 'no');
+        }
+
+        return $cmd->expectsConfirmation('Are you sure you want to proceed? This cannot be undone.', 'yes');
+    }
+
+    private function anyCalendarEventIdFor(string $sourceType, int $sourceId): ?int
+    {
+        $id = CalendarEvent::where('source_type', $sourceType)
+            ->where('source_id', $sourceId)
+            ->value('id');
+
+        return $id === null ? null : (int) $id;
+    }
+
+    public function test_hard_delete_asset_purges_checkout_requests_calendar_events_order_items_and_empty_orders(): void
+    {
+        $admin = User::factory()->superuser()->create();
+        $company = Company::factory()->create();
+        // warranty_months + purchase_date populate the calendar's
+        // warranty.expires lane via the HasCalendarEvents observer,
+        // giving us a real event to assert against without racing the
+        // observer's own writes.
+        $asset = Asset::factory()->for($company)->create([
+            'warranty_months' => 12,
+            'purchase_date' => now()->subMonth()->toDateString(),
+        ]);
+
+        $requester = User::factory()->create();
+        $request = CheckoutRequest::factory()->create([
+            'user_id' => $requester->id,
+            'requestable_type' => Asset::class,
+            'requestable_id' => $asset->id,
+            'quantity' => 1,
+        ]);
+
+        $eventId = $this->anyCalendarEventIdFor(Asset::class, $asset->id);
+        $this->assertNotNull($eventId, 'Expected the observer to have published at least one calendar_event for this asset.');
+
+        // Order that becomes empty after cleanup: gets purged.
+        $emptyableOrder = Order::create(['order_number' => 'EMPTY-'.uniqid()]);
+        $emptyableOrder->created_by = $admin->id;
+        $emptyableOrder->save();
+        $lineOnEmptyOrder = OrderItem::create([
+            'order_id' => $emptyableOrder->id,
+            'item_type' => Asset::class,
+            'item_id' => $asset->id,
+            'qty' => 1,
+        ]);
+
+        // Order that still has another line after cleanup: kept.
+        $mixedOrder = Order::create(['order_number' => 'MIXED-'.uniqid()]);
+        $mixedOrder->created_by = $admin->id;
+        $mixedOrder->save();
+        $lineForThisAsset = OrderItem::create([
+            'order_id' => $mixedOrder->id,
+            'item_type' => Asset::class,
+            'item_id' => $asset->id,
+            'qty' => 1,
+        ]);
+        $unrelatedAsset = Asset::factory()->create();
+        $lineForOtherAsset = OrderItem::create([
+            'order_id' => $mixedOrder->id,
+            'item_type' => Asset::class,
+            'item_id' => $unrelatedAsset->id,
+            'qty' => 1,
+        ]);
+
+        $this->runBulkDelete($admin, $company, ['assets'], 'hard')->assertExitCode(0);
+
+        $this->assertDatabaseMissing('assets', ['id' => $asset->id]);
+        $this->assertNull(CheckoutRequest::withTrashed()->find($request->id));
+        $this->assertNull(CalendarEvent::withTrashed()->find($eventId));
+        $this->assertNull(OrderItem::withTrashed()->find($lineOnEmptyOrder->id));
+        $this->assertNull(OrderItem::withTrashed()->find($lineForThisAsset->id));
+        // Order that lost its only item is purged.
+        $this->assertNull(Order::withTrashed()->find($emptyableOrder->id));
+        // Order that still has another line is kept.
+        $this->assertNotNull(Order::withTrashed()->find($mixedOrder->id));
+        $this->assertNotNull(OrderItem::withTrashed()->find($lineForOtherAsset->id));
+    }
+
+    public function test_hard_delete_asset_purges_maintenance_calendar_events(): void
+    {
+        $admin = User::factory()->superuser()->create();
+        $company = Company::factory()->create();
+        $asset = Asset::factory()->for($company)->create();
+        $maintenance = Maintenance::factory()->for($asset)->create([
+            'start_date' => now()->addDays(7)->toDateString(),
+            'completion_date' => now()->addDays(8)->toDateString(),
+        ]);
+
+        $eventId = $this->anyCalendarEventIdFor(Maintenance::class, $maintenance->id);
+        $this->assertNotNull($eventId, 'Expected the observer to have published a calendar_event for this maintenance.');
+
+        $this->runBulkDelete($admin, $company, ['assets'], 'hard')->assertExitCode(0);
+
+        $this->assertNull(Maintenance::withTrashed()->find($maintenance->id));
+        $this->assertNull(CalendarEvent::withTrashed()->find($eventId));
+    }
+
+    public function test_hard_delete_license_purges_checkout_requests_and_calendar_events(): void
+    {
+        $admin = User::factory()->superuser()->create();
+        $company = Company::factory()->create();
+        // expiration_date drives the license calendar event.
+        $license = License::factory()->create([
+            'company_id' => $company->id,
+            'expiration_date' => now()->addYears(1)->toDateString(),
+        ]);
+
+        $requester = User::factory()->create();
+        $request = CheckoutRequest::factory()->create([
+            'user_id' => $requester->id,
+            'requestable_type' => License::class,
+            'requestable_id' => $license->id,
+            'quantity' => 1,
+        ]);
+
+        $eventId = $this->anyCalendarEventIdFor(License::class, $license->id);
+        $this->assertNotNull($eventId, 'Expected the observer to have published a calendar_event for this license.');
+
+        $this->runBulkDelete($admin, $company, ['licenses'], 'hard')->assertExitCode(0);
+
+        $this->assertNull(License::withTrashed()->find($license->id));
+        $this->assertNull(CheckoutRequest::withTrashed()->find($request->id));
+        $this->assertNull(CalendarEvent::withTrashed()->find($eventId));
+    }
+
+    public function test_hard_delete_accessory_purges_checkout_requests_and_acceptances_and_order_items(): void
+    {
+        $admin = User::factory()->superuser()->create();
+        $company = Company::factory()->create();
+        $accessory = Accessory::factory()->create(['company_id' => $company->id]);
+
+        $requester = User::factory()->create();
+        $request = CheckoutRequest::factory()->create([
+            'user_id' => $requester->id,
+            'requestable_type' => Accessory::class,
+            'requestable_id' => $accessory->id,
+            'quantity' => 1,
+        ]);
+
+        $acceptance = CheckoutAcceptance::factory()->forAccessory()->create([
+            'checkoutable_id' => $accessory->id,
+        ]);
+
+        $order = Order::create(['order_number' => 'ACC-'.uniqid()]);
+        $order->created_by = $admin->id;
+        $order->save();
+        $line = OrderItem::create([
+            'order_id' => $order->id,
+            'item_type' => Accessory::class,
+            'item_id' => $accessory->id,
+            'qty' => 1,
+        ]);
+
+        $this->runBulkDelete($admin, $company, ['accessories'], 'hard')->assertExitCode(0);
+
+        $this->assertDatabaseMissing('accessories', ['id' => $accessory->id]);
+        $this->assertNull(CheckoutRequest::withTrashed()->find($request->id));
+        $this->assertNull(CheckoutAcceptance::withTrashed()->find($acceptance->id));
+        $this->assertNull(OrderItem::withTrashed()->find($line->id));
+        $this->assertNull(Order::withTrashed()->find($order->id));
+    }
+
+    public function test_hard_delete_consumable_purges_checkout_requests_and_acceptances(): void
+    {
+        $admin = User::factory()->superuser()->create();
+        $company = Company::factory()->create();
+        $consumable = Consumable::factory()->create(['company_id' => $company->id]);
+
+        $requester = User::factory()->create();
+        $request = CheckoutRequest::factory()->create([
+            'user_id' => $requester->id,
+            'requestable_type' => Consumable::class,
+            'requestable_id' => $consumable->id,
+            'quantity' => 1,
+        ]);
+
+        $acceptance = CheckoutAcceptance::factory()->create([
+            'checkoutable_type' => Consumable::class,
+            'checkoutable_id' => $consumable->id,
+        ]);
+
+        $this->runBulkDelete($admin, $company, ['consumables'], 'hard')->assertExitCode(0);
+
+        $this->assertDatabaseMissing('consumables', ['id' => $consumable->id]);
+        $this->assertNull(CheckoutRequest::withTrashed()->find($request->id));
+        $this->assertNull(CheckoutAcceptance::withTrashed()->find($acceptance->id));
+    }
+
+    public function test_hard_delete_component_purges_order_items(): void
+    {
+        $admin = User::factory()->superuser()->create();
+        $company = Company::factory()->create();
+        $component = Component::factory()->create(['company_id' => $company->id]);
+
+        $order = Order::create(['order_number' => 'COMP-'.uniqid()]);
+        $order->created_by = $admin->id;
+        $order->save();
+        $line = OrderItem::create([
+            'order_id' => $order->id,
+            'item_type' => Component::class,
+            'item_id' => $component->id,
+            'qty' => 1,
+        ]);
+
+        $this->runBulkDelete($admin, $company, ['components'], 'hard')->assertExitCode(0);
+
+        $this->assertDatabaseMissing('components', ['id' => $component->id]);
+        $this->assertNull(OrderItem::withTrashed()->find($line->id));
+        $this->assertNull(Order::withTrashed()->find($order->id));
+    }
+
+    public function test_hard_delete_user_purges_their_checkout_requests_and_calendar_events(): void
+    {
+        $admin = User::factory()->superuser()->create();
+        $company = Company::factory()->create();
+        // end_date is what publishes the user's calendar event.
+        $user = User::factory()->forCompany($company->id)->create([
+            'end_date' => now()->addYears(1)->toDateString(),
+        ]);
+
+        $asset = Asset::factory()->create();
+        $request = CheckoutRequest::factory()->create([
+            'user_id' => $user->id,
+            'requestable_type' => Asset::class,
+            'requestable_id' => $asset->id,
+            'quantity' => 1,
+        ]);
+
+        $eventId = $this->anyCalendarEventIdFor(User::class, $user->id);
+        $this->assertNotNull($eventId, 'Expected the observer to have published a calendar_event for this user.');
+
+        $this->runBulkDelete($admin, $company, ['users'], 'hard')->assertExitCode(0);
+
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+        $this->assertNull(CheckoutRequest::withTrashed()->find($request->id));
+        $this->assertNull(CalendarEvent::withTrashed()->find($eventId));
+    }
+
+    public function test_soft_delete_does_not_purge_related_records(): void
+    {
+        $admin = User::factory()->superuser()->create();
+        $company = Company::factory()->create();
+        $asset = Asset::factory()->for($company)->create([
+            'warranty_months' => 12,
+            'purchase_date' => now()->subMonth()->toDateString(),
+        ]);
+
+        $requester = User::factory()->create();
+        $request = CheckoutRequest::factory()->create([
+            'user_id' => $requester->id,
+            'requestable_type' => Asset::class,
+            'requestable_id' => $asset->id,
+            'quantity' => 1,
+        ]);
+
+        $eventId = $this->anyCalendarEventIdFor(Asset::class, $asset->id);
+        $this->assertNotNull($eventId);
+
+        $this->runBulkDelete($admin, $company, ['assets'], 'soft')->assertExitCode(0);
+
+        // Asset is soft-deleted, related records still present so restore is meaningful.
+        $this->assertSoftDeleted('assets', ['id' => $asset->id]);
+        $this->assertNotNull(CheckoutRequest::withTrashed()->find($request->id));
+        $this->assertNotNull(CalendarEvent::withTrashed()->find($eventId));
+    }
+}


### PR DESCRIPTION
Since we've added some new stuff since the `php artisan snipeit:checkin-delete-items` console command was added, this PR just adds those other relations (orders, order_items, calendar_events, etc). It also adds an option for ALL companies, to save folks who really want to nuke their assets, etc from orbit but have set up a lot of companies. 

<img width="806" height="390" alt="Screenshot 2026-08-31 at 2 33 13 PM" src="https://github.com/user-attachments/assets/46a1fedd-8d25-4a2b-a348-0ab196eceb39" />
