### PR TITLE
Fix missing company creation modal

### DIFF
--- a/app/Http/Controllers/ModalController.php
+++ b/app/Http/Controllers/ModalController.php
@@ -25,6 +25,7 @@ class ModalController extends Controller
         // These values should correspond to a file in resources/views/modals/
         $allowed_types = [
             'category',
+            'company',
             'kit-model',
             'kit-license',
             'kit-consumable',

--- a/resources/views/modals/company.blade.php
+++ b/resources/views/modals/company.blade.php
@@ -1,0 +1,19 @@
+{{-- See snipeit_modals.js for what powers this --}}
+<div class="modal-dialog">
+    <div class="modal-content">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            <h2 class="modal-title">{{ trans('admin/companies/table.create') }}</h2>
+        </div>
+        <div class="modal-body">
+            <form action="{{ route('api.companies.store') }}" onsubmit="return false">
+                <x-alert type="danger" id="modal_error_msg" style="display:none">
+                </x-alert>
+                @include('modals.partials.name', ['required' => 'true'])
+            </form>
+        </div>
+        @include('modals.partials.footer')
+    </div>
+</div>

--- a/tests/Feature/Modals/Ui/ShowModalsTest.php
+++ b/tests/Feature/Modals/Ui/ShowModalsTest.php
@@ -59,6 +59,15 @@ class ShowModalsTest extends TestCase
             ->assertOk();
     }
 
+    public function test_company_modal_renders()
+    {
+        $this->actingAs(User::factory()->superuser()->create())
+            ->get('modals/company')
+            ->assertOk()
+            ->assertSee(route('api.companies.store'))
+            ->assertSee(trans('admin/companies/table.create'));
+    }
+
     public function test_manufacturer_modal_renders()
     {
         $this->actingAs(User::factory()->superuser()->create())


### PR DESCRIPTION
The button already existed, but there was no modal for it. I added the company modal and a test to ensure that the modal exists.

This PR adds the company modal, allows the company modal type in ModalController.