### PR TITLE
Change the 'default' queue back to 'sync' :/

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'background'),
+    'default' => env('QUEUE_CONNECTION', 'sync'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The 'background' queue doesn't seem to work the way I thought it would in a lot of situations, so let's drop back down to 'sync' as the default until we can come up with something better.