### PR TITLE
Wrong format for <img tag in checkin emails

### DIFF
--- a/resources/views/mail/markdown/checkin-asset.blade.php
+++ b/resources/views/mail/markdown/checkin-asset.blade.php
@@ -5,8 +5,8 @@
 
 @if (($snipeSettings->show_images_in_email =='1') && $item->getImageUrl())
     {{-- @formatter:off --}}
-    <img src="{{ $item->getImageUrl() }}" alt="Asset" style="display:block; height:auto; max-width:100%; max-height:400px; margin:0 auto;">
-    {{-- @formatter:on --}}
+<img src="{{ $item->getImageUrl() }}" alt="Asset" style="display:block; height:auto; max-width:100%; max-height:400px; margin:0 auto;">
+{{-- @formatter:on --}}
 @endif
 
 @component('mail::table')


### PR DESCRIPTION
in checkin emails, the image isn't shown and the html tag is shown as plain text

<img width="700" height="215" alt="image" src="https://github.com/user-attachments/assets/00de2902-101e-4d7a-9bca-ab65957ff662" />
