### PR TITLE
Added “clone” permission gate

### DIFF
--- a/app/Http/Controllers/Accessories/AccessoriesController.php
+++ b/app/Http/Controllers/Accessories/AccessoriesController.php
@@ -145,7 +145,7 @@ class AccessoriesController extends Controller
     public function getClone(Accessory $accessory): View|RedirectResponse
     {
 
-        $this->authorize('create', $accessory);
+        $this->authorize('clone', $accessory);
         $cloned = clone $accessory;
         $accessory_to_clone = $accessory;
         $cloned->id = null;

--- a/app/Http/Controllers/AssetModelsController.php
+++ b/app/Http/Controllers/AssetModelsController.php
@@ -127,8 +127,6 @@ class AssetModelsController extends Controller
      * @author [A. Gianotto] [<snipe@snipe.net>]
      *
      * @since [v1.0]
-     *
-     * @param  AssetModel  $model
      */
     public function edit(AssetModel $model): View|RedirectResponse
     {
@@ -147,7 +145,6 @@ class AssetModelsController extends Controller
      * @since [v1.0]
      *
      * @param  ImageUploadRequest  $request
-     * @param  AssetModel  $model
      *
      * @throws AuthorizationException
      */
@@ -201,8 +198,6 @@ class AssetModelsController extends Controller
      * @author [A. Gianotto] [<snipe@snipe.net>]
      *
      * @since [v1.0]
-     *
-     * @param  AssetModel  $model
      */
     public function destroy(AssetModel $model): RedirectResponse
     {
@@ -272,8 +267,6 @@ class AssetModelsController extends Controller
      * @author [A. Gianotto] [<snipe@snipe.net>]
      *
      * @since [v1.0]
-     *
-     * @param  AssetModel  $model
      */
     public function show(AssetModel $model): View|RedirectResponse
     {
@@ -288,12 +281,10 @@ class AssetModelsController extends Controller
      * @author [A. Gianotto] [<snipe@snipe.net>]
      *
      * @since [v1.0]
-     *
-     * @param  AssetModel  $model
      */
     public function getClone(AssetModel $model): View|RedirectResponse
     {
-        $this->authorize('create', AssetModel::class);
+        $this->authorize('clone', $model);
 
         $cloned_model = clone $model;
         // Preserve the source model's id BEFORE we blank the working copy — the
@@ -435,8 +426,6 @@ class AssetModelsController extends Controller
      * @author [A. Gianotto] [<snipe@snipe.net>]
      *
      * @since [v1.0]
-     *
-     * @param  Request  $request
      */
     public function postBulkDelete(Request $request): RedirectResponse
     {

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -793,7 +793,7 @@ class AssetsController extends Controller
      */
     public function getClone(Asset $asset)
     {
-        $this->authorize('create', Asset::class);
+        $this->authorize('clone', $asset);
         $cloned = clone $asset;
         $cloned_model = $asset;
         $cloned->id = null;

--- a/app/Http/Controllers/Components/ComponentsController.php
+++ b/app/Http/Controllers/Components/ComponentsController.php
@@ -253,7 +253,7 @@ class ComponentsController extends Controller
 
     public function getClone(Component $component): View|RedirectResponse
     {
-        $this->authorize('create', Component::class);
+        $this->authorize('clone', $component);
 
         $cloned_component = clone $component;
         $cloned_component->id = null;

--- a/app/Http/Controllers/Consumables/ConsumablesController.php
+++ b/app/Http/Controllers/Consumables/ConsumablesController.php
@@ -256,7 +256,7 @@ class ConsumablesController extends Controller
 
     public function clone(Consumable $consumable): View
     {
-        $this->authorize('create', $consumable);
+        $this->authorize('clone', $consumable);
         $consumable_to_close = $consumable;
         $consumable = clone $consumable_to_close;
         $consumable->id = null;

--- a/app/Http/Controllers/Licenses/LicensesController.php
+++ b/app/Http/Controllers/Licenses/LicensesController.php
@@ -316,7 +316,7 @@ class LicensesController extends Controller
             return redirect()->route('licenses.index')->with('error', trans('admin/licenses/message.does_not_exist'));
         }
 
-        $this->authorize('create', License::class);
+        $this->authorize('clone', $license_to_clone);
 
         $maintained_list = [
             '' => 'Maintained',

--- a/app/Http/Controllers/LocationsController.php
+++ b/app/Http/Controllers/LocationsController.php
@@ -359,13 +359,13 @@ class LocationsController extends Controller
      */
     public function getClone($locationId = null): View|RedirectResponse
     {
-        $this->authorize('create', Location::class);
-
         // Check if the asset exists
         if (is_null($location_to_clone = Location::find($locationId))) {
             // Redirect to the asset management page
             return redirect()->route('licenses.index')->with('error', trans('admin/locations/message.does_not_exist'));
         }
+
+        $this->authorize('clone', $location_to_clone);
 
         $location = clone $location_to_clone;
 

--- a/app/Http/Controllers/Users/UsersController.php
+++ b/app/Http/Controllers/Users/UsersController.php
@@ -485,16 +485,13 @@ class UsersController extends Controller
      */
     public function getClone(Request $request, User $user)
     {
-        $this->authorize('create', $user);
-
         // We need to reverse the UI specific logic for our
         // permissions here before we update the user.
         $permissions = $request->input('permissions', []);
         app('request')->request->set('permissions', $permissions);
 
         $user_to_clone = User::with('userloc', 'companies')->withTrashed()->find($user->id);
-        // Make sure they can view this particular user
-        $this->authorize('view', $user_to_clone);
+        $this->authorize('clone', $user_to_clone);
 
         if ($user_to_clone) {
 

--- a/app/Http/Transformers/AccessoriesTransformer.php
+++ b/app/Http/Transformers/AccessoriesTransformer.php
@@ -108,7 +108,7 @@ class AccessoriesTransformer
             'update' => Gate::allows('update', $accessory),
             'adjust_quantity' => Gate::allows('update', $accessory),
             'delete' => $accessory->checkouts_count === 0 && Gate::allows('delete', $accessory),
-            'clone' => Gate::allows('create', Accessory::class),
+            'clone' => Gate::allows('clone', $accessory),
             // Request / cancel: if the requestable flag is off the row
             // never surfaces on /account/requestable anyway (scoped out
             // by Requestable()), but honor it here too for

--- a/app/Http/Transformers/AssetModelsTransformer.php
+++ b/app/Http/Transformers/AssetModelsTransformer.php
@@ -107,7 +107,7 @@ class AssetModelsTransformer
             'view' => Gate::allows('view', $assetmodel),
             'update' => (Gate::allows('update', $assetmodel) && ($assetmodel->deleted_at == '')),
             'delete' => $assetmodel->isDeletable(),
-            'clone' => (Gate::allows('create', AssetModel::class) && ($assetmodel->deleted_at == '')),
+            'clone' => (Gate::allows('clone', $assetmodel) && ($assetmodel->deleted_at == '')),
             'restore' => (Gate::allows('create', AssetModel::class) && ($assetmodel->deleted_at != '')),
             // Request / cancel: if the requestable flag is off the row
             // never surfaces on /account/requestable anyway (scoped

--- a/app/Http/Transformers/AssetsTransformer.php
+++ b/app/Http/Transformers/AssetsTransformer.php
@@ -173,7 +173,7 @@ class AssetsTransformer
         $permissions_array['available_actions'] = [
             'checkout' => ($asset->deleted_at == '' && Gate::allows('checkout', $asset)) ? true : false,
             'checkin' => ($asset->deleted_at == '' && Gate::allows('checkin', $asset)) ? true : false,
-            'clone' => Gate::allows('create', Asset::class) ? true : false,
+            'clone' => Gate::allows('clone', $asset) ? true : false,
             'restore' => ($asset->deleted_at != '' && Gate::allows('create', Asset::class)) ? true : false,
             'update' => ($asset->deleted_at == '' && Gate::allows('update', $asset)) ? true : false,
             'audit' => Gate::allows('audit', $asset) ? true : false,

--- a/app/Http/Transformers/ComponentsTransformer.php
+++ b/app/Http/Transformers/ComponentsTransformer.php
@@ -100,7 +100,7 @@ class ComponentsTransformer
             'checkin' => Gate::allows('checkin', $component),
             'update' => Gate::allows('update', $component),
             'adjust_quantity' => Gate::allows('update', $component),
-            'clone' => Gate::allows('create', Component::class),
+            'clone' => Gate::allows('clone', $component),
             'delete' => $component->isDeletable(),
             'request' => (bool) $component->requestable && ! $userHasOpenRequest,
             'cancel' => (bool) $component->requestable && $userHasOpenRequest,

--- a/app/Http/Transformers/ConsumablesTransformer.php
+++ b/app/Http/Transformers/ConsumablesTransformer.php
@@ -105,7 +105,7 @@ class ConsumablesTransformer
             'update' => Gate::allows('update', $consumable),
             'adjust_quantity' => Gate::allows('update', $consumable),
             'delete' => Gate::allows('delete', $consumable),
-            'clone' => (Gate::allows('create', Consumable::class) && ($consumable->deleted_at == '')),
+            'clone' => (Gate::allows('clone', $consumable) && ($consumable->deleted_at == '')),
             'request' => (bool) $consumable->requestable && ! $userHasOpenRequest,
             'cancel' => (bool) $consumable->requestable && $userHasOpenRequest,
         ];

--- a/app/Http/Transformers/LicenseSeatsTransformer.php
+++ b/app/Http/Transformers/LicenseSeatsTransformer.php
@@ -3,7 +3,6 @@
 namespace App\Http\Transformers;
 
 use App\Helpers\Helper;
-use App\Models\License;
 use App\Models\LicenseSeat;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Gate;
@@ -48,7 +47,7 @@ class LicenseSeatsTransformer
         $permissions_array['available_actions'] = [
             'checkout' => Gate::allows('checkout', $seat->license),
             'checkin' => Gate::allows('checkin', $seat->license),
-            'clone' => Gate::allows('create', License::class),
+            'clone' => Gate::allows('clone', $seat->license),
             'update' => Gate::allows('update', $seat->license),
             'delete' => Gate::allows('delete', $seat->license),
             'bulk_selectable' => [

--- a/app/Http/Transformers/LicensesTransformer.php
+++ b/app/Http/Transformers/LicensesTransformer.php
@@ -88,7 +88,7 @@ class LicensesTransformer
         $permissions_array['available_actions'] = [
             'checkout' => Gate::allows('checkout', $license),
             'checkin' => Gate::allows('checkin', $license),
-            'clone' => Gate::allows('create', License::class),
+            'clone' => Gate::allows('clone', $license),
             'update' => Gate::allows('update', $license),
             'delete' => $license->isDeletable(),
             'user_can_checkout' => (bool) (($license->free_seats_count - $unreassignable) > 0),

--- a/app/Http/Transformers/LocationsTransformer.php
+++ b/app/Http/Transformers/LocationsTransformer.php
@@ -89,7 +89,7 @@ class LocationsTransformer
                     'edit' => (Gate::allows('update', $location) && ($location->deleted_at == '')),
                     'delete' => $location->isDeletable(),
                 ],
-                'clone' => (Gate::allows('create', Location::class) && ($location->deleted_at == '')),
+                'clone' => (Gate::allows('clone', $location) && ($location->deleted_at == '')),
                 'restore' => (Gate::allows('create', Location::class) && ($location->deleted_at != '')),
             ];
 

--- a/app/Http/Transformers/UsersTransformer.php
+++ b/app/Http/Transformers/UsersTransformer.php
@@ -138,7 +138,7 @@ class UsersTransformer
         $permissions_array['available_actions'] = [
             'update' => (Gate::allows('update', $user) && ($user->deleted_at == '')),
             'delete' => ($user->isDeletable() && (auth()->user()->can('canEditAuthFields', $user) && auth()->user()->can('editableOnDemo'))),
-            'clone' => (Gate::allows('create', User::class) && ($user->deleted_at == '')),
+            'clone' => (Gate::allows('clone', $user) && ($user->deleted_at == '')),
             'restore' => (Gate::allows('create', User::class) && ($user->deleted_at != '')),
             'bulk_selectable' => [
                 'edit' => (Gate::allows('update', $user) && $user->deleted_at == ''),

--- a/app/Policies/SnipePermissionsPolicy.php
+++ b/app/Policies/SnipePermissionsPolicy.php
@@ -133,6 +133,18 @@ abstract class SnipePermissionsPolicy
     }
 
     /**
+     * Determine whether the user can clone the given instance to a new
+     * record. Composes view + create so a user can only pre-populate the
+     * create form from a source they already have read access to. Not a
+     * standalone permission, so admins configure it via the existing
+     * view + create toggles on each role.
+     */
+    public function clone(User $user, $item = null)
+    {
+        return $this->view($user, $item) && $this->create($user);
+    }
+
+    /**
      * Determine whether the user can update the model.
      *
      * @return mixed

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -235,6 +235,21 @@ class UserFactory extends Factory
         return $this->appendPermission(['locations.view' => '1']);
     }
 
+    public function viewLocations()
+    {
+        return $this->appendPermission(['locations.view' => '1']);
+    }
+
+    public function createLocations()
+    {
+        return $this->appendPermission(['locations.create' => '1']);
+    }
+
+    public function cloneLocations()
+    {
+        return $this->viewLocations()->createLocations();
+    }
+
     public function viewAccessoryHistory()
     {
         return $this->appendPermission(['accessories.view' => '1']);
@@ -258,6 +273,19 @@ class UserFactory extends Factory
     public function createAssets()
     {
         return $this->appendPermission(['assets.create' => '1']);
+    }
+
+    /**
+     * Grants the permission set the `clone` policy composes for assets
+     * (view + create). Tests exercising the clone happy-path go through
+     * here so any future change to what `AssetPolicy::clone` requires
+     * gets picked up in one place rather than every test file. Negative
+     * tests still call `createAssets()` / `viewAssets()` directly to
+     * exercise a specific subset.
+     */
+    public function cloneAssets()
+    {
+        return $this->viewAssets()->createAssets();
     }
 
     public function editAssets()
@@ -295,6 +323,11 @@ class UserFactory extends Factory
         return $this->appendPermission(['models.create' => '1']);
     }
 
+    public function cloneAssetModels()
+    {
+        return $this->viewAssetModels()->createAssetModels();
+    }
+
     public function deleteAssetModels()
     {
         return $this->appendPermission(['models.delete' => '1']);
@@ -318,6 +351,11 @@ class UserFactory extends Factory
     public function createAccessories()
     {
         return $this->appendPermission(['accessories.create' => '1']);
+    }
+
+    public function cloneAccessories()
+    {
+        return $this->viewAccessories()->createAccessories();
     }
 
     public function editAccessories()
@@ -348,6 +386,11 @@ class UserFactory extends Factory
     public function createConsumables()
     {
         return $this->appendPermission(['consumables.create' => '1']);
+    }
+
+    public function cloneConsumables()
+    {
+        return $this->viewConsumables()->createConsumables();
     }
 
     public function editConsumables()
@@ -390,6 +433,11 @@ class UserFactory extends Factory
         return $this->appendPermission(['licenses.create' => '1']);
     }
 
+    public function cloneLicenses()
+    {
+        return $this->viewLicenses()->createLicenses();
+    }
+
     public function editLicenses()
     {
         return $this->appendPermission(['licenses.edit' => '1']);
@@ -423,6 +471,11 @@ class UserFactory extends Factory
     public function createComponents()
     {
         return $this->appendPermission(['components.create' => '1']);
+    }
+
+    public function cloneComponents()
+    {
+        return $this->viewComponents()->createComponents();
     }
 
     public function editComponents()
@@ -473,6 +526,11 @@ class UserFactory extends Factory
     public function createUsers()
     {
         return $this->appendPermission(['users.create' => '1']);
+    }
+
+    public function cloneUsers()
+    {
+        return $this->viewUsers()->createUsers();
     }
 
     public function editUsers()

--- a/tests/Feature/Accessories/Ui/CloneAccessoryTest.php
+++ b/tests/Feature/Accessories/Ui/CloneAccessoryTest.php
@@ -28,11 +28,23 @@ class CloneAccessoryTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_create_permission_alone_is_not_enough_to_clone_accessory(): void
+    {
+        // Cloning renders the source accessory's data into the create form,
+        // so a user with only accessories.create (no accessories.view)
+        // must be blocked.
+        $accessory = Accessory::factory()->create();
+
+        $this->actingAs(User::factory()->createAccessories()->create())
+            ->get(route('clone/accessories', $accessory))
+            ->assertForbidden();
+    }
+
     public function test_clone_page_renders(): void
     {
         $accessory = Accessory::factory()->create();
 
-        $this->actingAs(User::factory()->createAccessories()->create())
+        $this->actingAs(User::factory()->cloneAccessories()->create())
             ->get(route('clone/accessories', $accessory))
             ->assertOk();
     }
@@ -48,7 +60,7 @@ class CloneAccessoryTest extends TestCase
             'order_number' => 'PO-CLONE-PREFILL-42',
         ]);
 
-        $response = $this->actingAs(User::factory()->createAccessories()->create())
+        $response = $this->actingAs(User::factory()->cloneAccessories()->create())
             ->get(route('clone/accessories', $source))
             ->assertOk();
 
@@ -71,7 +83,7 @@ class CloneAccessoryTest extends TestCase
             'Expected qty=0 accessory to have no observer-written order (baseline for the no-history case).',
         );
 
-        $response = $this->actingAs(User::factory()->createAccessories()->create())
+        $response = $this->actingAs(User::factory()->cloneAccessories()->create())
             ->get(route('clone/accessories', $source))
             ->assertOk();
 

--- a/tests/Feature/AssetModels/Ui/CloneAssetModelTest.php
+++ b/tests/Feature/AssetModels/Ui/CloneAssetModelTest.php
@@ -50,4 +50,16 @@ class CloneAssetModelTest extends TestCase
             ->assertSet('model_id', null)
             ->assertSet('fieldset_id', null);
     }
+
+    public function test_create_permission_alone_is_not_enough_to_clone_asset_model()
+    {
+        // Cloning renders the source asset model's data (model_number,
+        // notes, fieldset, image) into the create form, so a user with
+        // only models.create (no models.view) must be blocked.
+        $model = AssetModel::factory()->create();
+
+        $this->actingAs(User::factory()->createAssetModels()->create())
+            ->get(route('models.clone.create', $model))
+            ->assertForbidden();
+    }
 }

--- a/tests/Feature/Assets/Ui/CloneAssetTest.php
+++ b/tests/Feature/Assets/Ui/CloneAssetTest.php
@@ -19,7 +19,7 @@ class CloneAssetTest extends TestCase
     public function test_page_can_be_accessed(): void
     {
         $asset = Asset::factory()->create();
-        $response = $this->actingAs(User::factory()->createAssets()->create())
+        $response = $this->actingAs(User::factory()->cloneAssets()->create())
             ->get(route('clone/hardware', $asset));
         $response->assertStatus(200);
     }
@@ -27,11 +27,22 @@ class CloneAssetTest extends TestCase
     public function test_asset_can_be_cloned()
     {
         $asset_to_clone = Asset::factory()->create(['name' => 'Asset to clone']);
-        $this->actingAs(User::factory()->createAssets()->create())
+        $this->actingAs(User::factory()->cloneAssets()->create())
             ->get(route('clone/hardware', $asset_to_clone))
             ->assertOk()
             ->assertSee([
                 'Asset to clone',
             ], false);
+    }
+
+    public function test_create_permission_alone_is_not_enough_to_clone_asset()
+    {
+        // Cloning renders the source asset's data into the create form, so
+        // a user with only assets.create (no assets.view) must be blocked.
+        $asset = Asset::factory()->create();
+
+        $this->actingAs(User::factory()->createAssets()->create())
+            ->get(route('clone/hardware', $asset))
+            ->assertForbidden();
     }
 }

--- a/tests/Feature/Components/Ui/CloneComponentTest.php
+++ b/tests/Feature/Components/Ui/CloneComponentTest.php
@@ -17,10 +17,19 @@ class CloneComponentTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_create_permission_alone_is_not_enough_to_clone_component()
+    {
+        $component = Component::factory()->create();
+
+        $this->actingAs(User::factory()->createComponents()->create())
+            ->get(route('components.clone.create', $component))
+            ->assertForbidden();
+    }
+
     public function test_page_can_be_accessed(): void
     {
         $component = Component::factory()->create();
-        $response = $this->actingAs(User::factory()->createComponents()->create())
+        $response = $this->actingAs(User::factory()->cloneComponents()->create())
             ->get(route('components.clone.create', $component));
         $response->assertStatus(200);
     }
@@ -28,7 +37,7 @@ class CloneComponentTest extends TestCase
     public function test_component_can_be_cloned()
     {
         $component_to_clone = Component::factory()->create(['name' => 'Component to clone']);
-        $this->actingAs(User::factory()->createComponents()->create())
+        $this->actingAs(User::factory()->cloneComponents()->create())
             ->get(route('components.clone.create', $component_to_clone))
             ->assertOk()
             ->assertSee([
@@ -51,7 +60,7 @@ class CloneComponentTest extends TestCase
             'order_number' => 'PO-COMP-CLONE-9',
         ]);
 
-        $response = $this->actingAs(User::factory()->createComponents()->create())
+        $response = $this->actingAs(User::factory()->cloneComponents()->create())
             ->get(route('components.clone.create', $source))
             ->assertOk();
 

--- a/tests/Feature/Consumables/Ui/CloneConsumableTest.php
+++ b/tests/Feature/Consumables/Ui/CloneConsumableTest.php
@@ -22,11 +22,20 @@ class CloneConsumableTest extends TestCase
             ->assertForbidden();
     }
 
-    public function test_clone_page_renders(): void
+    public function test_create_permission_alone_is_not_enough_to_clone_consumable(): void
     {
         $consumable = Consumable::factory()->create();
 
         $this->actingAs(User::factory()->createConsumables()->create())
+            ->get(route('consumables.clone.create', $consumable))
+            ->assertForbidden();
+    }
+
+    public function test_clone_page_renders(): void
+    {
+        $consumable = Consumable::factory()->create();
+
+        $this->actingAs(User::factory()->cloneConsumables()->create())
             ->get(route('consumables.clone.create', $consumable))
             ->assertOk();
     }
@@ -42,7 +51,7 @@ class CloneConsumableTest extends TestCase
             'order_number' => 'PO-CONS-CLONE-1',
         ]);
 
-        $response = $this->actingAs(User::factory()->createConsumables()->create())
+        $response = $this->actingAs(User::factory()->cloneConsumables()->create())
             ->get(route('consumables.clone.create', $source))
             ->assertOk();
 

--- a/tests/Feature/Licenses/Ui/CloneLicenseTest.php
+++ b/tests/Feature/Licenses/Ui/CloneLicenseTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Licenses\Ui;
+
+use App\Models\License;
+use App\Models\User;
+use Tests\TestCase;
+
+class CloneLicenseTest extends TestCase
+{
+    public function test_permission_required_to_clone_license(): void
+    {
+        $license = License::factory()->create();
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('clone/license', $license))
+            ->assertForbidden();
+    }
+
+    public function test_create_permission_alone_is_not_enough_to_clone_license(): void
+    {
+        // Cloning renders the source license's data (name, seats, order
+        // number, purchase cost, notes, purchase date, supplier, category)
+        // into the create form, so a user with only licenses.create (no
+        // licenses.view) must be blocked.
+        $license = License::factory()->create();
+
+        $this->actingAs(User::factory()->createLicenses()->create())
+            ->get(route('clone/license', $license))
+            ->assertForbidden();
+    }
+
+    public function test_clone_page_renders_for_a_user_with_clone_permission_set(): void
+    {
+        $license = License::factory()->create();
+
+        $this->actingAs(User::factory()->cloneLicenses()->create())
+            ->get(route('clone/license', $license))
+            ->assertOk();
+    }
+}

--- a/tests/Feature/Locations/Ui/CloneLocationTest.php
+++ b/tests/Feature/Locations/Ui/CloneLocationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Locations\Ui;
+
+use App\Models\Location;
+use App\Models\User;
+use Tests\TestCase;
+
+class CloneLocationTest extends TestCase
+{
+    public function test_permission_required_to_clone_location(): void
+    {
+        $location = Location::factory()->create();
+
+        $this->actingAs(User::factory()->create())
+            ->get(route('clone/location', $location))
+            ->assertForbidden();
+    }
+
+    public function test_create_permission_alone_is_not_enough_to_clone_location(): void
+    {
+        // Cloning renders the source location's data (name, address, city,
+        // state, phone, manager) into the create form, so a user with only
+        // locations.create (no locations.view) must be blocked.
+        $location = Location::factory()->create();
+
+        $this->actingAs(User::factory()->createLocations()->create())
+            ->get(route('clone/location', $location))
+            ->assertForbidden();
+    }
+
+    public function test_clone_page_renders_for_a_user_with_clone_permission_set(): void
+    {
+        $location = Location::factory()->create();
+
+        $this->actingAs(User::factory()->cloneLocations()->create())
+            ->get(route('clone/location', $location))
+            ->assertOk();
+    }
+}

--- a/tests/Feature/Users/Ui/CloneUserTest.php
+++ b/tests/Feature/Users/Ui/CloneUserTest.php
@@ -30,4 +30,16 @@ class CloneUserTest extends TestCase
         $response->assertSee('value="'.$companyA->id.'"', false);
         $response->assertSee('value="'.$companyB->id.'"', false);
     }
+
+    public function test_create_permission_alone_is_not_enough_to_clone_user()
+    {
+        // Cloning renders the source user's data (email domain, groups,
+        // permissions bitmap) into the create form, so a user with only
+        // users.create (no users.view) must be blocked.
+        $source = User::factory()->create();
+
+        $this->actingAs(User::factory()->createUsers()->create())
+            ->get(route('users.clone.show', $source))
+            ->assertForbidden();
+    }
 }


### PR DESCRIPTION
Nothing too sexy here. This just adds a `clone` gate and updates the transformers/tests (versus confirming view and create permissions each time.)