### PR TITLE
Labels: Fixes #19515 the way the QR text is handled from legacy to New Label Engine

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -639,45 +639,48 @@ class SettingsController extends Controller
             $setting->labels_pagewidth = $request->input('labels_pagewidth');
             $setting->labels_pageheight = $request->input('labels_pageheight');
             $setting->labels_display_company_name = $request->input('labels_display_company_name', '0');
+            // Barcodes
+            $setting->qr_code = $request->input('qr_code', '0');
+            // 1D-Barcode
+            $setting->alt_barcode_enabled = $request->input('alt_barcode_enabled', '0');
+            // QR-Code
+            $setting->qr_text = $request->input('qr_text');
+
+            if ($request->filled('labels_display_name')) {
+                $setting->labels_display_name = 1;
+            } else {
+                $setting->labels_display_name = 0;
+            }
+
+            if ($request->filled('labels_display_serial')) {
+                $setting->labels_display_serial = 1;
+            } else {
+                $setting->labels_display_serial = 0;
+            }
+
+            if ($request->filled('labels_display_tag')) {
+                $setting->labels_display_tag = 1;
+            } else {
+                $setting->labels_display_tag = 0;
+            }
+
+            if ($request->filled('labels_display_tag')) {
+                $setting->labels_display_tag = 1;
+            } else {
+                $setting->labels_display_tag = 0;
+            }
+
+            if ($request->filled('labels_display_model')) {
+                $setting->labels_display_model = 1;
+            } else {
+                $setting->labels_display_model = 0;
+            }
         }
 
-        // Barcodes
-        $setting->qr_code = $request->input('qr_code', '0');
-        // 1D-Barcode
-        $setting->alt_barcode_enabled = $request->input('alt_barcode_enabled', '0');
-        // QR-Code
-        $setting->qr_text = $request->input('qr_text');
-
-        if ($request->filled('labels_display_name')) {
-            $setting->labels_display_name = 1;
-        } else {
-            $setting->labels_display_name = 0;
+        if (!$wasLabel2Enabled && $request->boolean('label2_enable')) {
+            $setting->label2_title = $setting->qr_text;
         }
-
-        if ($request->filled('labels_display_serial')) {
-            $setting->labels_display_serial = 1;
-        } else {
-            $setting->labels_display_serial = 0;
-        }
-
-        if ($request->filled('labels_display_tag')) {
-            $setting->labels_display_tag = 1;
-        } else {
-            $setting->labels_display_tag = 0;
-        }
-
-        if ($request->filled('labels_display_tag')) {
-            $setting->labels_display_tag = 1;
-        } else {
-            $setting->labels_display_tag = 0;
-        }
-
-        if ($request->filled('labels_display_model')) {
-            $setting->labels_display_model = 1;
-        } else {
-            $setting->labels_display_model = 0;
-        }
-
+        
         if ($setting->save()) {
 
             return redirect()->route('settings.labels.index')

--- a/resources/views/partials/labels-new-engine.blade.php
+++ b/resources/views/partials/labels-new-engine.blade.php
@@ -61,11 +61,6 @@
             <p class="help-block">
                 {!! trans('admin/settings/general.label2_title_help_phold') !!}.<br />
                 {!! trans('admin/settings/general.help_asterisk_bold') !!}.<br />
-                {!!
-                    trans('admin/settings/general.help_blank_to_use', [
-                        'setting_name' => trans('admin/settings/general.barcodes').' &gt; '.trans('admin/settings/general.qr_text'),
-                    ])
-                !!}
             </p>
         </div>
     </div>


### PR DESCRIPTION
When enabling the new label engine, the `qr_code_text` is suppose to replace the title input if 'left blank'.

I reworked this to copy the `qr_code_text` into the `label2_title` upon switching from the legacy to new label engine. 

Before:
<img width="1436" height="382" alt="CleanShot 2026-09-09 at 12 03 40@2x" src="https://github.com/user-attachments/assets/7c03181e-a3f7-472e-a265-e7b27305c40f" />

After, the help text in red has been removed, and the `qr_code_text` will be copied over one time.

Fixes #19515