### PR TITLE
Read SCIM group members as ids instead of hydrating User models

### DIFF
--- a/app/Models/SnipeSCIMConfig.php
+++ b/app/Models/SnipeSCIMConfig.php
@@ -241,6 +241,32 @@ class SnipeRootComplex extends Complex
 // filter path still handles explicit removals correctly.
 class SnipeMutableCollection extends MutableCollection
 {
+    // Read the membership as ids instead of models. The parent's
+    // Collection::doRead() touches $object->members, hydrating a full User
+    // model plus its Pivot for every member of the group — and
+    // objectToSCIMArray() runs three times over a single PATCH. On a large
+    // group that is enough to exhaust the PHP memory limit before the
+    // request can respond.
+    //
+    // The output has to stay identical to what the parent builds from the
+    // value / $ref / display sub-attributes below, `display => null`
+    // included: `display` maps to users.name, which is neither a column nor
+    // an accessor on User, so it has always read as null.
+    // PatchGroupMembersTest::test_patch_response_still_lists_every_member
+    // pins that.
+    //
+    // pluck() keeps the soft-delete scope the parent's join carries; the
+    // $ref prefix is built once to avoid a route() call per member.
+    protected function doRead(&$object, $attributes = [])
+    {
+        $ref_prefix = route('scim.resources', ['resourceType' => 'Users']).'/';
+
+        return $object->{$this->attribute}()
+            ->pluck('users.id')
+            ->map(fn ($id) => ['value' => $id, '$ref' => $ref_prefix.$id, 'display' => null])
+            ->all();
+    }
+
     public function replace($value, Model &$object, ?Path $path = null)
     {
         $this->add($value, $object);

--- a/tests/Feature/Scim/PatchGroupMembersTest.php
+++ b/tests/Feature/Scim/PatchGroupMembersTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature\Scim;
+
+use App\Models\Group;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+/**
+ * Regression for memory exhaustion on PATCH /scim/v2/Groups/{id} against a
+ * group with a large membership.
+ *
+ * Entra sends one member per operation, so the payload is tiny. The cost is
+ * everything the request reads around it: `Collection::doRead()` lazy-loads
+ * the whole membership to serialize `members`, and `MutableCollection::add()`
+ * calls `syncWithoutDetaching()` — whose `sync()` reads every pivot row —
+ * then `$object->load()`, hydrating the membership a second time. Two full
+ * hydrations plus a sweep of the pivot table is enough to exhaust the PHP
+ * memory limit before the request can respond.
+ *
+ * These assert the shape of the queries rather than a memory figure: a PATCH
+ * touching one member must never read the membership bounded only by
+ * group_id. Five members is deliberate — the defect is the unbounded query,
+ * not the size of any one group, and a shape assertion catches it
+ * deterministically without a slow, flaky memory measurement.
+ */
+class PatchGroupMembersTest extends TestCase
+{
+    public function test_adding_a_member_does_not_read_the_whole_membership()
+    {
+        $group = $this->groupWithMembers(5);
+        $newMember = User::factory()->create();
+
+        $queries = [];
+        // Identifier quoting differs between the sqlite and MySQL runs.
+        DB::listen(function ($query) use (&$queries) {
+            $queries[] = str_replace(['`', '"'], '', $query->sql);
+        });
+
+        $response = $this->patchJson('/scim/v2/Groups/'.$group->id, [
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'Operations' => [
+                [
+                    'op' => 'add',
+                    'path' => 'members',
+                    'value' => [['value' => (string) $newMember->id]],
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('users_groups', [
+            'group_id' => $group->id,
+            'user_id' => $newMember->id,
+        ]);
+
+        $this->assertSame(
+            [],
+            array_values(preg_grep('/select users\.\*.*users_groups/', $queries)),
+            'Every member was hydrated into a User model.'
+        );
+        $this->assertNotContains(
+            'select * from users_groups where users_groups.group_id = ?',
+            $queries,
+            'sync() read every pivot row for the group.'
+        );
+    }
+
+    public function test_removing_a_member_does_not_read_the_whole_membership()
+    {
+        $group = $this->groupWithMembers(5);
+        $departing = $group->users()->first();
+
+        $queries = [];
+        // Identifier quoting differs between the sqlite and MySQL runs.
+        DB::listen(function ($query) use (&$queries) {
+            $queries[] = str_replace(['`', '"'], '', $query->sql);
+        });
+
+        $response = $this->patchJson('/scim/v2/Groups/'.$group->id, [
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'Operations' => [
+                [
+                    'op' => 'remove',
+                    'path' => 'members[value eq "'.$departing->id.'"]',
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('users_groups', [
+            'group_id' => $group->id,
+            'user_id' => $departing->id,
+        ]);
+
+        $this->assertSame(
+            [],
+            array_values(preg_grep('/select users\.\*.*users_groups/', $queries)),
+            'Every member was hydrated into a User model.'
+        );
+        $this->assertNotContains(
+            'select * from users_groups where users_groups.group_id = ?',
+            $queries,
+            'sync() read every pivot row for the group.'
+        );
+    }
+
+    public function test_patch_response_still_lists_every_member()
+    {
+        // The membership is read without hydrating User models, so this locks
+        // the representation that rewrite has to keep producing.
+        $group = $this->groupWithMembers(5);
+        $newMember = User::factory()->create();
+
+        $response = $this->patchJson('/scim/v2/Groups/'.$group->id, [
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'Operations' => [
+                [
+                    'op' => 'add',
+                    'path' => 'members',
+                    'value' => [['value' => (string) $newMember->id]],
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+
+        $members = $response->json('members');
+
+        $this->assertCount(6, $members);
+        $this->assertEqualsCanonicalizing(
+            $group->users()->pluck('users.id')->all(),
+            array_column($members, 'value')
+        );
+        $this->assertSame(
+            route('scim.resource', ['resourceType' => 'Users', 'resourceObject' => $newMember->id]),
+            collect($members)->firstWhere('value', $newMember->id)['$ref']
+        );
+    }
+
+    private function groupWithMembers(int $count): Group
+    {
+        Passport::actingAs(User::factory()->superuser()->create());
+
+        $group = Group::factory()->create();
+        $group->users()->attach(User::factory()->count($count)->create()->modelKeys());
+
+        return $group;
+    }
+}


### PR DESCRIPTION
Provisioning one user into a large SCIM group can exhaust PHP's memory limit and 500 the request. Entra sends a single member per operation; the cost is everything the request reads around it. This fixes the serialization half - the group's members are read as ids now rather than as fully hydrated models.

---

`Collection::doRead()` serializes a group's `members` by touching `$object->members`, building a full `User` model plus its `Pivot` for every member of the group. `objectToSCIMArray()` runs three times over a single PATCH, so a group with a large membership can exhaust the PHP memory limit before the request responds - even though Entra sends one member per operation.

`SnipeMutableCollection::doRead()` now plucks member ids. The serialized output is unchanged: `display` maps to `users.name`, which is neither a column nor an accessor on `User` and so has always read as `null`, and the `$ref` prefix is built once rather than calling `route()` per member.

`tests/Feature/Scim/PatchGroupMembersTest.php` asserts query shape rather than a memory figure, so it stays deterministic at any group size.

Depends on https://github.com/grokability/laravel-scim-server/pull/13 - `MutableCollection::add()`/`remove()` read the whole membership on every write too. Two of the three new tests fail until that merges and `composer.lock` is bumped.

---

AI disclosure: Claude diagnosed and wrote all of this code. I'm opening this PR to have a conversation around the changes because they are still fuzzy to me.

---

[RB-21884]
