### PR TITLE
Notifications: Fixes #19532 Accepted and Declined notifications are sent to CC emails only

### DIFF
--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -34,20 +34,13 @@ class CheckoutAcceptance extends Model
 
         $recipients = [];
 
-        if (!empty($settings->alert_email)) {
-            $recipients = array_merge(
-                $recipients,
-                array_map('trim', explode(',', $settings->alert_email))
-            );
-        }
-
         if (!empty($settings->admin_cc_email)) {
             $recipients = array_merge(
                 $recipients,
                 array_map('trim', explode(',', $settings->admin_cc_email))
             );
         }
-     
+
         return array_values(array_unique(array_filter($recipients)));
     }
 

--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -12,7 +12,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Notifications\Notifiable;
 use TCPDF;
-use Illuminate\Support\Facades\Log;
 class CheckoutAcceptance extends Model
 {
     use HasFactory, Notifiable, SoftDeletes;
@@ -32,14 +31,7 @@ class CheckoutAcceptance extends Model
     {
         $settings = Setting::getSettings();
 
-        $recipients = [];
-
-        if (!empty($settings->admin_cc_email)) {
-            $recipients = array_merge(
-                $recipients,
-                array_map('trim', explode(',', $settings->admin_cc_email))
-            );
-        }
+        $recipients = array_map('trim', explode(',', $settings->admin_cc_email ?? ''));
 
         return array_values(array_unique(array_filter($recipients)));
     }

--- a/app/Models/CheckoutAcceptance.php
+++ b/app/Models/CheckoutAcceptance.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Notifications\Notifiable;
 use TCPDF;
-
+use Illuminate\Support\Facades\Log;
 class CheckoutAcceptance extends Model
 {
     use HasFactory, Notifiable, SoftDeletes;
@@ -30,12 +30,25 @@ class CheckoutAcceptance extends Model
      */
     public function routeNotificationForMail()
     {
-        // At this point the endpoint is the same for everything.
-        //  In the future this may want to be adapted for individual notifications.
-        $recipients_string = explode(',', Setting::getSettings()->alert_email);
-        $recipients = array_map('trim', $recipients_string);
+        $settings = Setting::getSettings();
 
-        return array_filter($recipients);
+        $recipients = [];
+
+        if (!empty($settings->alert_email)) {
+            $recipients = array_merge(
+                $recipients,
+                array_map('trim', explode(',', $settings->alert_email))
+            );
+        }
+
+        if (!empty($settings->admin_cc_email)) {
+            $recipients = array_merge(
+                $recipients,
+                array_map('trim', explode(',', $settings->admin_cc_email))
+            );
+        }
+     
+        return array_values(array_unique(array_filter($recipients)));
     }
 
     public function getCheckoutableItemTypeAttribute(): string

--- a/app/Notifications/AcceptanceItemAcceptedNotification.php
+++ b/app/Notifications/AcceptanceItemAcceptedNotification.php
@@ -65,7 +65,9 @@ class AcceptanceItemAcceptedNotification extends Notification implements ShouldQ
 
     public function shouldSend($notifiable, $channel)
     {
-        return Setting::getSettings()->alerts_enabled && !empty(Setting::getSettings()->alert_email);
+        $settings = Setting::getSettings();
+
+        return $settings->alerts_enabled && (!empty($settings->alert_email) || !empty($settings->cc_email));
     }
 
     /**

--- a/app/Notifications/AcceptanceItemAcceptedNotification.php
+++ b/app/Notifications/AcceptanceItemAcceptedNotification.php
@@ -67,7 +67,7 @@ class AcceptanceItemAcceptedNotification extends Notification implements ShouldQ
     {
         $settings = Setting::getSettings();
 
-        return $settings->alerts_enabled && (!empty($settings->alert_email) || !empty($settings->cc_email));
+        return $settings->alerts_enabled && (!empty($settings->alert_email) || !empty($settings->admin_cc_email));
     }
 
     /**

--- a/app/Notifications/AcceptanceItemAcceptedNotification.php
+++ b/app/Notifications/AcceptanceItemAcceptedNotification.php
@@ -67,7 +67,7 @@ class AcceptanceItemAcceptedNotification extends Notification implements ShouldQ
     {
         $settings = Setting::getSettings();
 
-        return $settings->alerts_enabled && (!empty($settings->alert_email) || !empty($settings->admin_cc_email));
+        return ($settings->alerts_enabled && !empty($settings->admin_cc_email));
     }
 
     /**

--- a/app/Notifications/AcceptanceItemDeclinedNotification.php
+++ b/app/Notifications/AcceptanceItemDeclinedNotification.php
@@ -61,7 +61,9 @@ class AcceptanceItemDeclinedNotification extends Notification implements ShouldQ
 
     public function shouldSend($notifiable, $channel)
     {
-        return Setting::getSettings()->alerts_enabled && !empty(Setting::getSettings()->alert_email);
+        $settings = Setting::getSettings();
+
+        return $settings->alerts_enabled && (!empty($settings->alert_email) || !empty($settings->admin_cc_email));
     }
 
     /**

--- a/app/Notifications/AcceptanceItemDeclinedNotification.php
+++ b/app/Notifications/AcceptanceItemDeclinedNotification.php
@@ -63,7 +63,7 @@ class AcceptanceItemDeclinedNotification extends Notification implements ShouldQ
     {
         $settings = Setting::getSettings();
 
-        return $settings->alerts_enabled && (!empty($settings->alert_email) || !empty($settings->admin_cc_email));
+        return ($settings->alerts_enabled && !empty($settings->admin_cc_email));
     }
 
     /**

--- a/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AccessoryAcceptanceTest.php
@@ -87,7 +87,7 @@ class AccessoryAcceptanceTest extends TestCase
     {
         Notification::fake();
 
-        $this->settings->enableAlertEmail();
+        $this->settings->enableAdminCC();
 
         $acceptance = CheckoutAcceptance::factory()
             ->pending()
@@ -120,7 +120,7 @@ class AccessoryAcceptanceTest extends TestCase
     {
         Notification::fake();
 
-        $this->settings->enableAlertEmail();
+        $this->settings->enableAdminCC();
 
         $acceptance = CheckoutAcceptance::factory()
             ->pending()

--- a/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
+++ b/tests/Feature/CheckoutAcceptances/Ui/AssetAcceptanceTest.php
@@ -212,7 +212,7 @@ class AssetAcceptanceTest extends TestCase
     {
         Event::fake([CheckoutAccepted::class]);
         Notification::fake();
-        $this->settings->enableAlertEmail();
+        $this->settings->enableAdminCC();
 
         $customField = CustomField::factory()->create([
             'name' => 'Cost Center',
@@ -260,7 +260,7 @@ class AssetAcceptanceTest extends TestCase
         // <img> tag survives markdown parsing.
         Event::fake([CheckoutAccepted::class]);
         Notification::fake();
-
+        $this->settings->enableAdminCC();
         $checkoutAcceptance = CheckoutAcceptance::factory()->pending()->create();
 
         $lfrPayload = '![x](/etc/hostname)';


### PR DESCRIPTION
This removes Asset Accepted/Declined notifications from being sent to the Alert email and is sent instead to the listed CC emails.

Before:
<img width="1436" height="640" alt="CleanShot 2026-09-10 at 13 49 48@2x" src="https://github.com/user-attachments/assets/ca83d01d-65b9-4b32-a9c5-953184cdfe6e" />

After:
<img width="1436" height="640" alt="CleanShot 2026-09-10 at 13 50 03@2x" src="https://github.com/user-attachments/assets/d35c09ae-1ad9-4ff0-9d8c-aa5294ff760e" />
<img width="1436" height="640" alt="CleanShot 2026-09-10 at 13 50 13@2x" src="https://github.com/user-attachments/assets/212c673b-dfaf-4ac2-9f09-61a7700a59a8" />

Fixes: #19532 