### PR TITLE
Acceptances - Fixed #19080 - Allow resending accepted checkout acceptances

### DIFF
--- a/app/Actions/Acceptances/RegenerateAcceptancesAction.php
+++ b/app/Actions/Acceptances/RegenerateAcceptancesAction.php
@@ -1,0 +1,568 @@
+<?php
+
+namespace App\Actions\Acceptances;
+
+use App\Mail\AcceptanceReRequestMail;
+use App\Models\Accessory;
+use App\Models\AccessoryCheckout;
+use App\Models\Asset;
+use App\Models\Category;
+use App\Models\CheckoutAcceptance;
+use App\Models\Component;
+use App\Models\Consumable;
+use App\Models\LicenseSeat;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Re-requests EULA acceptance from users who currently hold items.
+ *
+ * Three phases: find the currently-held in-scope items, classify each (item, user) pair
+ * against its acceptance history, and create one pending row per pair in the send set.
+ * Nothing here prints — the caller renders whatever it wants from the returned run.
+ *
+ * @phpstan-type Checkoutable Accessory|Asset|Component|Consumable|LicenseSeat
+ * @phpstan-type Candidate array{item: Checkoutable, user: User, units: int}
+ * @phpstan-type ClassifiedCandidate array{item: Checkoutable, user: User, units: int, qty: int, outcome: string, declined: bool}
+ */
+class RegenerateAcceptancesAction
+{
+    /**
+     * How many items to load per builder query. Each chunk of items costs one
+     * acceptance-history query, however many holders those items turn out to have.
+     */
+    private const CHUNK_SIZE = 500;
+
+    private const OUTCOME_SEND = 'send';
+
+    private const OUTCOME_COVERED = 'covered';
+
+    private const OUTCOME_DECLINED_EXCLUDED = 'declined_excluded';
+
+    /**
+     * @param  array<int, int|string>  $categoryIds  Empty means every category requiring acceptance.
+     * @param  array<int, int|string>  $companyIds  Empty means every company.
+     */
+    public static function run(
+        array $categoryIds = [],
+        array $companyIds = [],
+        bool $excludeDeclined = false,
+        bool $dryRun = false,
+        bool $notify = false,
+    ): RegenerateAcceptancesResult {
+        $result = new RegenerateAcceptancesResult(
+            categoryIds: $categoryIds,
+            companyIds: $companyIds,
+            excludeDeclined: $excludeDeclined,
+            dryRun: $dryRun,
+            notify: $notify,
+        );
+
+        self::findAssetCandidates($result);
+        self::findLicenseSeatCandidates($result);
+        self::findAccessoryCandidates($result);
+        self::findConsumableCandidates($result);
+        self::findComponentCandidates($result);
+
+        self::notifyHolders($result);
+
+        return $result;
+    }
+
+    /**
+     * Assets assigned directly to a user, plus assets assigned to another asset
+     * that is itself assigned to a user.
+     *
+     * The category is reached through `model.category` rather than the tidier
+     * `Asset::category()` relation because `Asset::category()` is a `hasOneThrough`,
+     * so Laravel adds a `SoftDeletableHasManyThrough` global scope that excludes
+     * assets whose AssetModel is soft-deleted.
+     * A live checkout of such an asset asks `requireAcceptance()`
+     * instead, which reads `$this->model->category` where `model()` is
+     * `belongsTo(...)->withTrashed()` — so it says yes and creates an acceptance row.
+     * Going through the relation would make this command regenerate a smaller set than
+     * a live checkout creates, which is the divergence it exists to remove.
+     */
+    private static function findAssetCandidates(RegenerateAcceptancesResult $result): void
+    {
+        Asset::query()
+            ->whereHas('model.category', fn (Builder $q) => self::scopeToRequestedCategories($q, $result))
+            ->when($result->companyIds, fn (Builder $q) => $q->whereIn('assets.company_id', $result->companyIds))
+            ->whereIn('assets.assigned_type', [User::class, Asset::class])
+            ->with('assignedTo')
+            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $assets) use ($result): void {
+                $candidates = [];
+
+                foreach ($assets as $asset) {
+                    if ($user = self::resolveHolder(self::assignedTarget($asset))) {
+                        $candidates[] = ['item' => $asset, 'user' => $user, 'units' => 1];
+                    }
+                }
+
+                self::classifyChunk($candidates, $result);
+            });
+    }
+
+    /**
+     * License seats, keyed on the asset they are attached to where there is one.
+     *
+     * `license_seats.assigned_to` is denormalised and unreliable in both directions:
+     * the API asset-checkout path attaches a seat without ever stamping the holder, and
+     * five checkin paths clear it while deliberately leaving `asset_id` set. So a seat
+     * with an `asset_id` takes its holder from that asset's *current* assignment, and
+     * only a seat with no asset falls back to `assigned_to`. Either way a seat yields at
+     * most one pair, so seats carrying both columns cannot double-count.
+     */
+    private static function findLicenseSeatCandidates(RegenerateAcceptancesResult $result): void
+    {
+        LicenseSeat::query()
+            ->whereHas('license.category', fn (Builder $q) => self::scopeToRequestedCategories($q, $result))
+            ->when($result->companyIds, fn (Builder $q) => $q->whereHas('license',
+                fn (Builder $license) => $license->whereIn('licenses.company_id', $result->companyIds)
+            ))
+            ->byAssigned()
+            ->with(['asset.assignedTo', 'user'])
+            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $seats) use ($result): void {
+                $candidates = [];
+
+                foreach ($seats as $seat) {
+                    $user = $seat->asset_id
+                        ? self::resolveHolder($seat->asset)
+                        : $seat->user;
+
+                    if ($user instanceof User) {
+                        $candidates[] = ['item' => $seat, 'user' => $user, 'units' => 1];
+                    }
+                }
+
+                self::classifyChunk($candidates, $result);
+            });
+    }
+
+    /**
+     * Accessories, one pivot row per unit held. Rows assigned to a location are never
+     * candidates; rows assigned to an asset resolve to that asset's holder.
+     */
+    private static function findAccessoryCandidates(RegenerateAcceptancesResult $result): void
+    {
+        Accessory::query()
+            ->whereHas('category', fn (Builder $q) => self::scopeToRequestedCategories($q, $result))
+            ->when($result->companyIds, fn (Builder $q) => $q->whereIn('accessories.company_id', $result->companyIds))
+            ->whereHas('checkouts', fn (Builder $q) => $q->whereIn('assigned_type', [User::class, Asset::class]))
+            ->with(['checkouts' => fn ($q) => $q->whereIn('assigned_type', [User::class, Asset::class])])
+            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $accessories) use ($result): void {
+                $candidates = [];
+
+                foreach ($accessories as $accessory) {
+                    $unitsPerUser = [];
+                    $usersById = [];
+
+                    foreach ($accessory->checkouts as $checkout) {
+                        if (! $user = self::resolveHolder(self::assignedTarget($checkout))) {
+                            continue;
+                        }
+
+                        $usersById[$user->id] = $user;
+                        $unitsPerUser[$user->id] = ($unitsPerUser[$user->id] ?? 0) + 1;
+                    }
+
+                    foreach ($unitsPerUser as $userId => $units) {
+                        $candidates[] = ['item' => $accessory, 'user' => $usersById[$userId], 'units' => $units];
+                    }
+                }
+
+                self::classifyChunk($candidates, $result);
+            });
+    }
+
+    /**
+     * Consumables, one pivot row per unit held. `consumables_users` has no
+     * `assigned_type` column, so consumables are user-only by schema.
+     */
+    private static function findConsumableCandidates(RegenerateAcceptancesResult $result): void
+    {
+        Consumable::query()
+            ->whereHas('category', fn (Builder $q) => self::scopeToRequestedCategories($q, $result))
+            ->when($result->companyIds, fn (Builder $q) => $q->whereIn('consumables.company_id', $result->companyIds))
+            ->has('users')
+            ->with('users')
+            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $consumables) use ($result): void {
+                $candidates = [];
+
+                foreach ($consumables as $consumable) {
+                    $unitsPerUser = [];
+                    $usersById = [];
+
+                    foreach ($consumable->users as $user) {
+                        $usersById[$user->id] = $user;
+                        $unitsPerUser[$user->id] = ($unitsPerUser[$user->id] ?? 0) + 1;
+                    }
+
+                    foreach ($unitsPerUser as $userId => $units) {
+                        $candidates[] = ['item' => $consumable, 'user' => $usersById[$userId], 'units' => $units];
+                    }
+                }
+
+                self::classifyChunk($candidates, $result);
+            });
+    }
+
+    /**
+     * Components, whose holders are always reached through an asset. Unlike the other
+     * pivots, `components_assets` carries an `assigned_qty` column rather than writing
+     * one row per unit, so units are summed from that column.
+     */
+    private static function findComponentCandidates(RegenerateAcceptancesResult $result): void
+    {
+        Component::query()
+            ->whereHas('category', fn (Builder $q) => self::scopeToRequestedCategories($q, $result))
+            ->when($result->companyIds, fn (Builder $q) => $q->whereIn('components.company_id', $result->companyIds))
+            ->has('assets')
+            ->with('assets.assignedTo')
+            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $components) use ($result): void {
+                $candidates = [];
+
+                foreach ($components as $component) {
+                    $unitsPerUser = [];
+                    $usersById = [];
+
+                    foreach ($component->assets as $asset) {
+                        if (! $user = self::resolveHolder($asset)) {
+                            continue;
+                        }
+
+                        $usersById[$user->id] = $user;
+                        $unitsPerUser[$user->id] = ($unitsPerUser[$user->id] ?? 0) + (int) $asset->pivot->assigned_qty;
+                    }
+
+                    foreach ($unitsPerUser as $userId => $units) {
+                        $candidates[] = ['item' => $component, 'user' => $usersById[$userId], 'units' => $units];
+                    }
+                }
+
+                self::classifyChunk($candidates, $result);
+            });
+    }
+
+    /**
+     * Classifies one builder's chunk of candidates, tallies each outcome, and creates
+     * the rows for the ones to re-request unless this is a dry run.
+     *
+     * Creating inside the chunk keeps the run's memory bounded by the chunk rather than
+     * by the size of the send set. It is safe against the chunking itself: a new
+     * acceptance row cannot change which items a later chunk of items returns, and a
+     * pair is only ever classified once, by exactly one builder.
+     *
+     * @param  array<int, Candidate>  $candidates
+     */
+    private static function classifyChunk(array $candidates, RegenerateAcceptancesResult $result): void
+    {
+        if ($candidates === []) {
+            return;
+        }
+
+        $history = self::acceptanceHistory($candidates);
+
+        foreach ($candidates as $candidate) {
+            $key = self::pairKey($candidate['item']->getKey(), $candidate['user']->getKey());
+
+            $pair = self::classify($candidate, $history[$key] ?? new EloquentCollection, $result);
+
+            self::recordOutcome($pair, $result);
+
+            if ($pair['outcome'] === self::OUTCOME_SEND && ! $result->dryRun) {
+                self::createAcceptance($pair, $result);
+            }
+        }
+    }
+
+    /**
+     * Decides what to do with one pair by comparing the units it holds against the
+     * pending acceptance rows that already cover them.
+     *
+     * Accepted rows deliberately do not count as coverage — re-asking a holder who
+     * accepted is the whole point. Only an in-flight *pending* ask counts, and it counts
+     * by quantity rather than existence: a user holding three accessory units with one
+     * pending unit is still under-covered for two, so the shortfall is what gets
+     * re-requested and the existing pending row is left alone. Where a holder can only
+     * ever hold one of a thing (an asset, a license seat) the quantity comparison
+     * collapses into "is there a pending row".
+     *
+     * @param  Candidate  $candidate
+     * @param  EloquentCollection<int, CheckoutAcceptance>  $history
+     * @return ClassifiedCandidate
+     */
+    private static function classify(array $candidate, EloquentCollection $history, RegenerateAcceptancesResult $result): array
+    {
+        $pendingCoverage = $history
+            ->filter(fn (CheckoutAcceptance $acceptance) => $acceptance->isPending())
+            ->sum(fn (CheckoutAcceptance $acceptance) => $acceptance->qty ?? 1);
+
+        $shortfall = $candidate['units'] - $pendingCoverage;
+        $declined = self::latestResponse($history)?->declined_at !== null;
+
+        return [
+            ...$candidate,
+            'qty' => $shortfall,
+            'declined' => $declined,
+            'outcome' => match (true) {
+                $shortfall <= 0 => self::OUTCOME_COVERED,
+                $declined && $result->excludeDeclined => self::OUTCOME_DECLINED_EXCLUDED,
+                default => self::OUTCOME_SEND,
+            },
+        ];
+    }
+
+    /**
+     * Tallies one classified pair, adding a report row when it is one to re-request.
+     *
+     * @param  ClassifiedCandidate  $pair
+     */
+    private static function recordOutcome(array $pair, RegenerateAcceptancesResult $result): void
+    {
+        $result->candidateCount++;
+
+        if ($pair['outcome'] === self::OUTCOME_COVERED) {
+            $result->alreadyCovered++;
+
+            return;
+        }
+
+        if ($pair['declined']) {
+            $result->previouslyDeclined++;
+        }
+
+        if ($pair['outcome'] === self::OUTCOME_DECLINED_EXCLUDED) {
+            $result->declinedAndExcluded++;
+
+            return;
+        }
+
+        $type = class_basename($pair['item']);
+        $result->sendCountsByType[$type] = ($result->sendCountsByType[$type] ?? 0) + 1;
+
+        $result->reportRows[] = [
+            $pair['user']->present()->fullName,
+            $pair['item']->present()->name,
+            $type,
+            $pair['units'],
+            $pair['qty'],
+        ];
+    }
+
+    /**
+     * Creates the pending row that re-requests acceptance from one holder.
+     *
+     * The row deliberately carries no `alert_on_response_id`, so nobody is emailed when
+     * the holder answers. That id names whoever *performed a checkout*, which is why the
+     * listener reads it from `auth()->id()` — and a console run has no actor to read.
+     * Carrying the last checkout's admin forward would invent an answer: the column holds
+     * a single id, so aggregating a pair's several prior rows into one re-request has to
+     * drop every admin but one, silently. Leaving it null keeps that decision unmade
+     * rather than making it wrong, and adding a recipient later is additive.
+     *
+     * @param  ClassifiedCandidate  $pair
+     */
+    private static function createAcceptance(array $pair, RegenerateAcceptancesResult $result): void
+    {
+        CreateCheckoutAcceptanceAction::run(
+            $pair['item'],
+            $pair['user'],
+            self::creationQty($pair['item'], $pair['qty']),
+        );
+
+        $result->created++;
+
+        $holder = $pair['user'];
+        $result->holdersToNotify[$holder->id]['user'] = $holder;
+        $result->holdersToNotify[$holder->id]['items'][] = [
+            'name' => $pair['item']->present()->name,
+            'type' => self::itemType($pair['item']),
+            'qty' => self::creationQty($pair['item'], $pair['qty']),
+        ];
+    }
+
+    /**
+     * Which kind of thing this is, as the token the mail turns into a word.
+     *
+     * @param  Checkoutable  $item
+     * @return 'asset'|'license'|'accessory'|'consumable'|'component'
+     */
+    private static function itemType(Model $item): string
+    {
+        return match (true) {
+            $item instanceof Asset => 'asset',
+            $item instanceof LicenseSeat => 'license',
+            $item instanceof Accessory => 'accessory',
+            $item instanceof Consumable => 'consumable',
+            $item instanceof Component => 'component',
+        };
+    }
+
+    /**
+     * Emails the holders this run created rows for, when notification was asked for.
+     *
+     * One message per holder, never one per row: a holder re-requested for three items
+     * is asked once, for three items. A holder with no email address still keeps their
+     * rows — they will see them on /account/accept at their next login, just without the
+     * nudge — and is recorded on the run instead, for the caller to report.
+     */
+    private static function notifyHolders(RegenerateAcceptancesResult $result): void
+    {
+        if (! $result->notify) {
+            return;
+        }
+
+        foreach ($result->holdersToNotify as $holder) {
+            $user = $holder['user'];
+
+            if (! $user->email) {
+                $result->holdersWithoutEmail[] = [$user->id, $user->present()->fullName];
+
+                continue;
+            }
+
+            $mail = new AcceptanceReRequestMail($user, $holder['items']);
+
+            Mail::to($user->email)->send($user->locale ? $mail->locale($user->locale) : $mail);
+
+            $result->notified++;
+        }
+    }
+
+    /**
+     * The `qty` to stamp on the new row: the shortfall for the types a holder can hold
+     * several of, and null for an asset or a license seat.
+     *
+     * Null is what today's asset and license-seat checkout paths write — an asset or a
+     * seat is a single thing — and null already means one unit everywhere it is read.
+     * Writing the shortfall there instead would make this command's rows differ from a
+     * live checkout's for no gain.
+     *
+     * @param  Checkoutable  $item
+     */
+    private static function creationQty(Model $item, int $shortfall): ?int
+    {
+        return $item instanceof Asset || $item instanceof LicenseSeat
+            ? null
+            : $shortfall;
+    }
+
+    /**
+     * The pair's most recent answered acceptance, or null when they never answered one.
+     *
+     * "Most recent" is the highest id — acceptance timestamps have second granularity
+     * and nothing backdates a row. Pending rows are skipped rather than treated as the
+     * latest word, because a re-request's own pending row would otherwise bury the
+     * decline it superseded and make a decliner look like someone who never answered.
+     *
+     * @param  EloquentCollection<int, CheckoutAcceptance>  $history
+     */
+    private static function latestResponse(EloquentCollection $history): ?CheckoutAcceptance
+    {
+        return $history
+            ->reject(fn (CheckoutAcceptance $acceptance) => $acceptance->isPending())
+            ->sortByDesc('id')
+            ->first();
+    }
+
+    /**
+     * Every acceptance row belonging to a pair in this chunk, keyed by (item, user).
+     *
+     * A chunk always comes from one builder, so one `checkoutable_type` covers it. The
+     * query over-fetches — cross pairs (item A × user 2 when only A × 1 and B × 2 are
+     * wanted) and each pair's full history — which is harmless and much cheaper than a
+     * query per pair. Soft-deleted rows stay invisible: a trashed accepted row making
+     * its pair look never-asked is what compliance wants.
+     *
+     * @param  array<int, Candidate>  $candidates
+     * @return array<string, EloquentCollection<int, CheckoutAcceptance>>
+     */
+    private static function acceptanceHistory(array $candidates): array
+    {
+        $itemIds = [];
+        $userIds = [];
+
+        foreach ($candidates as $candidate) {
+            $itemIds[] = $candidate['item']->getKey();
+            $userIds[] = $candidate['user']->getKey();
+        }
+
+        return CheckoutAcceptance::query()
+            ->where('checkoutable_type', $candidates[0]['item']->getMorphClass())
+            ->whereIn('checkoutable_id', array_unique($itemIds))
+            ->whereIn('assigned_to_id', array_unique($userIds))
+            ->get()
+            ->groupBy(fn (CheckoutAcceptance $acceptance) => self::pairKey(
+                $acceptance->checkoutable_id,
+                $acceptance->assigned_to_id,
+            ))
+            ->all();
+    }
+
+    /**
+     * The (checkoutable, user) pair as one lookup key, scoped to a single chunk.
+     */
+    private static function pairKey(int|string $itemId, int|string $userId): string
+    {
+        return $itemId.'|'.$userId;
+    }
+
+    /**
+     * Reads a model's assignment target, eager-loaded or not.
+     *
+     * `Asset::assignedTo()` and `AccessoryCheckout::assignedTo()` are declared
+     * `morphTo('assigned', ...)`, so the morph name and the method name differ. Eager
+     * loading stores the result under the *morph* name — `with('assignedTo')` leaves
+     * `$model->assignedTo` null and puts the real model on `$model->assigned`, which is
+     * why AssetsTransformer::transformAssignedTo() reads `$asset->assigned`. Reading the
+     * loaded relation when it is there and falling back to the method otherwise keeps
+     * this correct whether or not the caller eager-loaded it.
+     */
+    private static function assignedTarget(Asset|AccessoryCheckout $model): ?Model
+    {
+        return $model->relationLoaded('assigned')
+            ? $model->getRelation('assigned')
+            : $model->assignedTo;
+    }
+
+    /**
+     * Walks a checkout target down to the user who holds it, mirroring
+     * CheckoutableListener::resolveAcceptanceTarget(). A user holds their own items;
+     * an asset's items are held by whoever that asset is assigned to. Anything else
+     * — a location, an unassigned asset — has no holder. Soft-deleted users are not
+     * holders either: every relation this walks is declared withTrashed(), so a deleted
+     * user would otherwise come back and be re-asked to accept.
+     */
+    private static function resolveHolder(?Model $target): ?User
+    {
+        if ($target instanceof User) {
+            return $target->trashed() ? null : $target;
+        }
+
+        if ($target instanceof Asset) {
+            $holder = self::assignedTarget($target);
+
+            return $holder instanceof User ? self::resolveHolder($holder) : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Narrows a Category query to the categories this run cares about.
+     *
+     * @param  Builder<Category>  $query
+     * @return Builder<Category>
+     */
+    private static function scopeToRequestedCategories(Builder $query, RegenerateAcceptancesResult $result): Builder
+    {
+        return $query->requiresAcceptance()
+            ->when($result->categoryIds, function (Builder $query) use ($result) {
+                return $query->whereIn('categories.id', $result->categoryIds);
+            });
+    }
+}

--- a/app/Actions/Acceptances/RegenerateAcceptancesResult.php
+++ b/app/Actions/Acceptances/RegenerateAcceptancesResult.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Actions\Acceptances;
+
+use App\Models\User;
+
+/**
+ * One run of `RegenerateAcceptancesAction`: what it was asked to do, and what it did.
+ *
+ * `.ai/rules/actions.md` requires an Action to be a stateless static `run()`, so this is
+ * what carries state through the five builders and back out to the caller. The options
+ * are fixed at construction; everything below them is a tally the Action fills in.
+ *
+ * The caller decides how to present any of it. Nothing here writes to a console, which
+ * is what lets an HTTP controller use the same run as the Artisan command.
+ *
+ * @phpstan-type ItemLine array{name: string, type: 'asset'|'license'|'accessory'|'consumable'|'component', qty: int|null}
+ */
+class RegenerateAcceptancesResult
+{
+    /**
+     * The holders this run created rows for, keyed by user id, each with the items they
+     * were re-requested for. Keying by holder is what keeps a holder re-requested for
+     * three items to one email rather than three.
+     *
+     * The items are scalars, never the models: holding a checkoutable per created row
+     * would pin every item this run touches in memory and undo the chunking that bounds
+     * the work.
+     *
+     * @var array<int, array{user: User, items: array<int, ItemLine>}>
+     */
+    public array $holdersToNotify = [];
+
+    /**
+     * Holders who got rows but could not be emailed, as ID/name pairs.
+     *
+     * @var array<int, array{0: int, 1: string}>
+     */
+    public array $holdersWithoutEmail = [];
+
+    /**
+     * The rows this run re-requested, in the order the builders found them. Under a dry
+     * run they are the rows it would have created.
+     *
+     * @var array<int, array{0: string, 1: string, 2: string, 3: int, 4: int}>
+     */
+    public array $reportRows = [];
+
+    /**
+     * How many pairs each checkoutable type contributed.
+     *
+     * @var array<string, int>
+     */
+    public array $sendCountsByType = [];
+
+    public int $candidateCount = 0;
+
+    public int $previouslyDeclined = 0;
+
+    public int $alreadyCovered = 0;
+
+    public int $declinedAndExcluded = 0;
+
+    public int $created = 0;
+
+    public int $notified = 0;
+
+    /**
+     * @param  array<int, int|string>  $categoryIds  Empty means every category requiring acceptance.
+     * @param  array<int, int|string>  $companyIds  Empty means every company.
+     */
+    public function __construct(
+        public readonly array $categoryIds = [],
+        public readonly array $companyIds = [],
+        public readonly bool $excludeDeclined = false,
+        public readonly bool $dryRun = false,
+        public readonly bool $notify = false,
+    ) {}
+}

--- a/app/Console/Commands/RegenerateAcceptances.php
+++ b/app/Console/Commands/RegenerateAcceptances.php
@@ -78,7 +78,7 @@ class RegenerateAcceptances extends Command
      * would pin every item this run touches in memory and undo the chunking that bounds
      * the command.
      *
-     * @var array<int, array{user: User, items: array<int, array{name: string, type: class-string, qty: int|null}>}>
+     * @var array<int, array{user: User, items: array<int, array{name: string, type: 'asset'|'license'|'accessory'|'consumable'|'component', qty: int|null}>}>
      */
     private array $holdersToNotify = [];
 
@@ -443,9 +443,26 @@ class RegenerateAcceptances extends Command
         $this->holdersToNotify[$holder->id]['user'] = $holder;
         $this->holdersToNotify[$holder->id]['items'][] = [
             'name' => $pair['item']->present()->name,
-            'type' => $pair['item']::class,
+            'type' => $this->itemType($pair['item']),
             'qty' => $this->creationQty($pair['item'], $pair['qty']),
         ];
+    }
+
+    /**
+     * Which kind of thing this is, as the token the mail turns into a word.
+     *
+     * @param  Checkoutable  $item
+     * @return 'asset'|'license'|'accessory'|'consumable'|'component'
+     */
+    private function itemType(Model $item): string
+    {
+        return match (true) {
+            $item instanceof Asset => 'asset',
+            $item instanceof LicenseSeat => 'license',
+            $item instanceof Accessory => 'accessory',
+            $item instanceof Consumable => 'consumable',
+            $item instanceof Component => 'component',
+        };
     }
 
     /**

--- a/app/Console/Commands/RegenerateAcceptances.php
+++ b/app/Console/Commands/RegenerateAcceptances.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Actions\Acceptances\CreateCheckoutAcceptanceAction;
+use App\Mail\AcceptanceReRequestMail;
 use App\Models\Accessory;
 use App\Models\AccessoryCheckout;
 use App\Models\Asset;
@@ -16,6 +17,7 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Mail;
 
 /**
  * Re-requests EULA acceptance from users who currently hold items.
@@ -30,7 +32,8 @@ class RegenerateAcceptances extends Command
         {--category=* : Limit to these category ids (default: all categories requiring acceptance)}
         {--company=* : Limit to these company ids (default: all companies)}
         {--dry-run : Print the report; create nothing}
-        {--exclude-declined : Skip users whose latest response was a decline (default: re-ask them)}';
+        {--exclude-declined : Skip users whose latest response was a decline (default: re-ask them)}
+        {--notify : Also email each affected user}';
 
     protected $description = 'Re-request EULA acceptance from users who currently hold items';
 
@@ -64,6 +67,24 @@ class RegenerateAcceptances extends Command
 
     private bool $dryRun = false;
 
+    private bool $notify = false;
+
+    /**
+     * The holders this run created rows for, keyed by user id, each with how many rows
+     * they got. Keying by holder is what keeps a holder re-requested for three items to
+     * one email rather than three.
+     *
+     * @var array<int, array{user: User, count: int}>
+     */
+    private array $holdersToNotify = [];
+
+    /**
+     * Holders who got rows but could not be emailed, as ID/name table rows.
+     *
+     * @var array<int, array{0: int, 1: string}>
+     */
+    private array $holdersWithoutEmail = [];
+
     /**
      * The rows this run re-requested, in the order the builders found them. Under
      * --dry-run they are the rows it would have created.
@@ -89,18 +110,23 @@ class RegenerateAcceptances extends Command
 
     private int $created = 0;
 
+    private int $notified = 0;
+
     public function handle(): int
     {
         $this->categoryIds = $this->option('category');
         $this->companyIds = $this->option('company');
         $this->excludeDeclined = (bool) $this->option('exclude-declined');
         $this->dryRun = (bool) $this->option('dry-run');
+        $this->notify = (bool) $this->option('notify');
 
         $this->findAssetCandidates();
         $this->findLicenseSeatCandidates();
         $this->findAccessoryCandidates();
         $this->findConsumableCandidates();
         $this->findComponentCandidates();
+
+        $this->notifyHolders();
 
         return $this->printReport();
     }
@@ -408,6 +434,43 @@ class RegenerateAcceptances extends Command
         );
 
         $this->created++;
+
+        $holder = $pair['user'];
+        $this->holdersToNotify[$holder->id] = [
+            'user' => $holder,
+            'count' => ($this->holdersToNotify[$holder->id]['count'] ?? 0) + 1,
+        ];
+    }
+
+    /**
+     * Emails the holders this run created rows for, when --notify was passed.
+     *
+     * One message per holder, never one per row: a holder re-requested for three items
+     * is asked once, for three items. A holder with no email address still keeps their
+     * rows — they will see them on /account/accept at their next login, just without the
+     * nudge — and is reported instead.
+     */
+    private function notifyHolders(): void
+    {
+        if (! $this->notify) {
+            return;
+        }
+
+        foreach ($this->holdersToNotify as $holder) {
+            $user = $holder['user'];
+
+            if (! $user->email) {
+                $this->holdersWithoutEmail[] = [$user->id, $user->present()->fullName];
+
+                continue;
+            }
+
+            $mail = new AcceptanceReRequestMail($user, $holder['count']);
+
+            Mail::to($user->email)->send($user->locale ? $mail->locale($user->locale) : $mail);
+
+            $this->notified++;
+        }
     }
 
     /**
@@ -517,6 +580,15 @@ class RegenerateAcceptances extends Command
         }
 
         $this->info($this->dryRun ? 'Nothing was created.' : 'Created: '.$this->created.'.');
+
+        if ($this->notify) {
+            $this->info('Notified: '.$this->notified.'.');
+
+            if ($this->holdersWithoutEmail !== []) {
+                $this->info('The following users do not have an email address:');
+                $this->table(['ID', 'Name'], $this->holdersWithoutEmail);
+            }
+        }
 
         return 0;
     }

--- a/app/Console/Commands/RegenerateAcceptances.php
+++ b/app/Console/Commands/RegenerateAcceptances.php
@@ -4,7 +4,12 @@ namespace App\Console\Commands;
 
 use App\Actions\Acceptances\RegenerateAcceptancesAction;
 use App\Actions\Acceptances\RegenerateAcceptancesResult;
+use App\Models\Category;
+use App\Models\Company;
 use Illuminate\Console\Command;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\multiselect;
 
 class RegenerateAcceptances extends Command
 {
@@ -17,21 +22,166 @@ class RegenerateAcceptances extends Command
 
     protected $description = 'Re-request EULA acceptance from users who currently hold items';
 
+    /**
+     * Category ids, empty when the operator did not narrow the run.
+     *
+     * @var array<int, int|string>
+     */
+    private array $categoryIds = [];
+
+    /**
+     * Company ids, empty when the operator did not narrow the run.
+     *
+     * @var array<int, int|string>
+     */
+    private array $companyIds = [];
+
+    private bool $excludeDeclined = false;
+
+    private bool $dryRun = false;
+
+    private bool $notify = false;
+
     public function handle(): int
     {
-        $result = RegenerateAcceptancesAction::run(
-            categoryIds: $this->option('category'),
-            companyIds: $this->option('company'),
-            excludeDeclined: (bool) $this->option('exclude-declined'),
-            dryRun: (bool) $this->option('dry-run'),
-            notify: (bool) $this->option('notify'),
-        );
+        $this->categoryIds = $this->option('category');
+        $this->companyIds = $this->option('company');
+        $this->excludeDeclined = (bool) $this->option('exclude-declined');
+        $this->dryRun = (bool) $this->option('dry-run');
+        $this->notify = (bool) $this->option('notify');
 
-        return $this->printReport($result);
+        if ($this->input->isInteractive() && ! $this->runWizard()) {
+            return 0;
+        }
+
+        return $this->printReport($this->regenerate(dryRun: $this->dryRun));
     }
 
     /**
-     * Prints what the run re-requested, or under --dry-run what it would have.
+     * One pass of the Action with whatever options are settled by now.
+     */
+    private function regenerate(bool $dryRun): RegenerateAcceptancesResult
+    {
+        return RegenerateAcceptancesAction::run(
+            categoryIds: $this->categoryIds,
+            companyIds: $this->companyIds,
+            excludeDeclined: $this->excludeDeclined,
+            dryRun: $dryRun,
+            notify: $this->notify,
+        );
+    }
+
+    /**
+     * Walks the operator through the options no flag already answered, previews what
+     * the run would do, and asks whether to go ahead.
+     *
+     * Every step is walked in order, and one whose flag was passed announces itself and
+     * moves on, so the operator sees the same sequence whatever they typed. The preview
+     * is a real dry run, so confirming costs a second pass over the same items — the
+     * alternative, holding every send pair in memory until the operator answers, would
+     * undo the chunking that bounds the Action on a large install.
+     *
+     * The gate on this is the caller's `isInteractive()` check rather than anything
+     * Prompts does on its own: `ConfiguresPrompts` forces Prompts interactive whenever
+     * the app is running unit tests, so a prompt reached under test hits a mocked
+     * question helper and throws rather than taking its default. Nothing here may run
+     * before that check.
+     *
+     * @return bool whether to go on and create the rows
+     */
+    private function runWizard(): bool
+    {
+        $this->askForCategories();
+        $this->askForCompanies();
+        $this->askWhetherToExcludeDeclined();
+        $this->askWhetherToNotify();
+
+        $this->printReport($this->regenerate(dryRun: true));
+
+        if ($this->dryRun) {
+            return false;
+        }
+
+        if (! confirm(label: 'Create these acceptance requests?', default: false)) {
+            $this->info('Nothing was created.');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function askForCategories(): void
+    {
+        if ($this->categoryIds !== []) {
+            $this->line('--category passed — skipping');
+
+            return;
+        }
+
+        $categories = Category::requiresAcceptance()->orderBy('name')->pluck('name', 'id');
+
+        if ($categories->isEmpty()) {
+            return;
+        }
+
+        $this->categoryIds = multiselect(
+            label: 'Which categories should this run cover?',
+            options: $categories->all(),
+            hint: 'Select none to cover every category requiring acceptance.',
+        );
+    }
+
+    private function askForCompanies(): void
+    {
+        if ($this->companyIds !== []) {
+            $this->line('--company passed — skipping');
+
+            return;
+        }
+
+        $companies = Company::orderBy('name')->pluck('name', 'id');
+
+        if ($companies->isEmpty()) {
+            return;
+        }
+
+        $this->companyIds = multiselect(
+            label: 'Which companies should this run cover?',
+            options: $companies->all(),
+            hint: 'Select none to cover every company.',
+        );
+    }
+
+    private function askWhetherToExcludeDeclined(): void
+    {
+        if ($this->option('exclude-declined')) {
+            $this->line('--exclude-declined passed — skipping');
+
+            return;
+        }
+
+        $this->excludeDeclined = confirm(
+            label: 'Skip holders whose latest response was a decline?',
+            default: false,
+            yes: 'Yes — leave decliners alone',
+            no: 'No — re-ask them too',
+        );
+    }
+
+    private function askWhetherToNotify(): void
+    {
+        if ($this->option('notify')) {
+            $this->line('--notify passed — skipping');
+
+            return;
+        }
+
+        $this->notify = confirm(label: 'Email each affected holder?', default: false);
+    }
+
+    /**
+     * Prints what the run re-requested, or under a dry run what it would have.
      */
     private function printReport(RegenerateAcceptancesResult $result): int
     {

--- a/app/Console/Commands/RegenerateAcceptances.php
+++ b/app/Console/Commands/RegenerateAcceptances.php
@@ -1,0 +1,517 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Accessory;
+use App\Models\AccessoryCheckout;
+use App\Models\Asset;
+use App\Models\Category;
+use App\Models\CheckoutAcceptance;
+use App\Models\Component;
+use App\Models\Consumable;
+use App\Models\LicenseSeat;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Re-requests EULA acceptance from users who currently hold items.
+ *
+ * @phpstan-type Checkoutable Accessory|Asset|Component|Consumable|LicenseSeat
+ * @phpstan-type Candidate array{item: Checkoutable, user: User, units: int}
+ * @phpstan-type ClassifiedCandidate array{item: Checkoutable, user: User, units: int, qty: int, outcome: string, declined: bool}
+ */
+class RegenerateAcceptances extends Command
+{
+    protected $signature = 'snipeit:regenerate-acceptances
+        {--category=* : Limit to these category ids (default: all categories requiring acceptance)}
+        {--company=* : Limit to these company ids (default: all companies)}
+        {--exclude-declined : Skip users whose latest response was a decline (default: re-ask them)}';
+
+    protected $description = 'Re-request EULA acceptance from users who currently hold items';
+
+    /**
+     * How many items to load per builder query. Each chunk of items costs one
+     * acceptance-history query, however many holders those items turn out to have.
+     */
+    private const CHUNK_SIZE = 500;
+
+    private const OUTCOME_SEND = 'send';
+
+    private const OUTCOME_COVERED = 'covered';
+
+    private const OUTCOME_DECLINED_EXCLUDED = 'declined_excluded';
+
+    /**
+     * Category ids passed via --category, empty when the operator did not filter.
+     *
+     * @var array<int, string>
+     */
+    private array $categoryIds = [];
+
+    /**
+     * Company ids passed via --company, empty when the operator did not filter.
+     *
+     * @var array<int, string>
+     */
+    private array $companyIds = [];
+
+    private bool $excludeDeclined = false;
+
+    /**
+     * The would-be rows of the preview table, in the order the builders found them.
+     *
+     * @var array<int, array{0: string, 1: string, 2: string, 3: int, 4: int}>
+     */
+    private array $previewRows = [];
+
+    /**
+     * How many pairs each checkoutable type contributed to the preview.
+     *
+     * @var array<string, int>
+     */
+    private array $sendCountsByType = [];
+
+    private int $candidateCount = 0;
+
+    private int $previouslyDeclined = 0;
+
+    private int $alreadyCovered = 0;
+
+    private int $declinedAndExcluded = 0;
+
+    public function handle(): int
+    {
+        $this->categoryIds = $this->option('category');
+        $this->companyIds = $this->option('company');
+        $this->excludeDeclined = (bool) $this->option('exclude-declined');
+
+        $this->findAssetCandidates();
+        $this->findLicenseSeatCandidates();
+        $this->findAccessoryCandidates();
+        $this->findConsumableCandidates();
+        $this->findComponentCandidates();
+
+        return $this->printPreview();
+    }
+
+    /**
+     * Assets assigned directly to a user, plus assets assigned to another asset
+     * that is itself assigned to a user.
+     *
+     * The category is reached through `model.category` rather than the tidier
+     * `Asset::category()` relation because `Asset::category()` is a `hasOneThrough`,
+     * so Laravel adds a `SoftDeletableHasManyThrough` global scope that excludes
+     * assets whose AssetModel is soft-deleted.
+     * A live checkout of such an asset asks `requireAcceptance()`
+     * instead, which reads `$this->model->category` where `model()` is
+     * `belongsTo(...)->withTrashed()` — so it says yes and creates an acceptance row.
+     * Going through the relation would make this command regenerate a smaller set than
+     * a live checkout creates, which is the divergence it exists to remove.
+     */
+    private function findAssetCandidates(): void
+    {
+        Asset::query()
+            ->whereHas('model.category', fn (Builder $q) => $this->scopeToRequestedCategories($q))
+            ->when($this->companyIds, fn (Builder $q) => $q->whereIn('assets.company_id', $this->companyIds))
+            // ->whereNotNull('assets.assigned_to')
+            ->whereIn('assets.assigned_type', [User::class, Asset::class])
+            ->with('assignedTo')
+            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $assets): void {
+                $candidates = [];
+
+                foreach ($assets as $asset) {
+                    if ($user = $this->resolveHolder($this->assignedTarget($asset))) {
+                        $candidates[] = ['item' => $asset, 'user' => $user, 'units' => 1];
+                    }
+                }
+
+                $this->classifyChunk($candidates);
+            });
+    }
+
+    /**
+     * License seats, keyed on the asset they are attached to where there is one.
+     *
+     * `license_seats.assigned_to` is denormalised and unreliable in both directions:
+     * the API asset-checkout path attaches a seat without ever stamping it, and five
+     * checkin paths clear it while deliberately leaving `asset_id` set. So a seat with
+     * an `asset_id` takes its holder from that asset's *current* assignment, and only a
+     * seat with no asset falls back to `assigned_to`. Either way a seat yields at most
+     * one pair, so seats carrying both columns cannot double-count.
+     */
+    private function findLicenseSeatCandidates(): void
+    {
+        LicenseSeat::query()
+            ->whereHas('license.category', fn (Builder $q) => $this->scopeToRequestedCategories($q))
+            ->when($this->companyIds, fn (Builder $q) => $q->whereHas('license',
+                fn (Builder $license) => $license->whereIn('licenses.company_id', $this->companyIds)
+            ))
+            ->byAssigned()
+            ->with(['asset.assignedTo', 'user'])
+            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $seats): void {
+                $candidates = [];
+
+                foreach ($seats as $seat) {
+                    $user = $seat->asset_id
+                        ? $this->resolveHolder($seat->asset)
+                        : $seat->user;
+
+                    if ($user instanceof User) {
+                        $candidates[] = ['item' => $seat, 'user' => $user, 'units' => 1];
+                    }
+                }
+
+                $this->classifyChunk($candidates);
+            });
+    }
+
+    /**
+     * Accessories, one pivot row per unit held. Rows assigned to a location are never
+     * candidates; rows assigned to an asset resolve to that asset's holder.
+     */
+    private function findAccessoryCandidates(): void
+    {
+        Accessory::query()
+            ->whereHas('category', fn (Builder $q) => $this->scopeToRequestedCategories($q))
+            ->when($this->companyIds, fn (Builder $q) => $q->whereIn('accessories.company_id', $this->companyIds))
+            ->whereHas('checkouts', fn (Builder $q) => $q->whereIn('assigned_type', [User::class, Asset::class]))
+            ->with(['checkouts' => fn ($q) => $q->whereIn('assigned_type', [User::class, Asset::class])])
+            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $accessories): void {
+                $candidates = [];
+
+                foreach ($accessories as $accessory) {
+                    $unitsPerUser = [];
+                    $usersById = [];
+
+                    foreach ($accessory->checkouts as $checkout) {
+                        if (! $user = $this->resolveHolder($this->assignedTarget($checkout))) {
+                            continue;
+                        }
+
+                        $usersById[$user->id] = $user;
+                        $unitsPerUser[$user->id] = ($unitsPerUser[$user->id] ?? 0) + 1;
+                    }
+
+                    foreach ($unitsPerUser as $userId => $units) {
+                        $candidates[] = ['item' => $accessory, 'user' => $usersById[$userId], 'units' => $units];
+                    }
+                }
+
+                $this->classifyChunk($candidates);
+            });
+    }
+
+    /**
+     * Consumables, one pivot row per unit held. `consumables_users` has no
+     * `assigned_type` column, so consumables are user-only by schema.
+     */
+    private function findConsumableCandidates(): void
+    {
+        Consumable::query()
+            ->whereHas('category', fn (Builder $q) => $this->scopeToRequestedCategories($q))
+            ->when($this->companyIds, fn (Builder $q) => $q->whereIn('consumables.company_id', $this->companyIds))
+            ->has('users')
+            ->with('users')
+            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $consumables): void {
+                $candidates = [];
+
+                foreach ($consumables as $consumable) {
+                    $unitsPerUser = [];
+                    $usersById = [];
+
+                    foreach ($consumable->users as $user) {
+                        $usersById[$user->id] = $user;
+                        $unitsPerUser[$user->id] = ($unitsPerUser[$user->id] ?? 0) + 1;
+                    }
+
+                    foreach ($unitsPerUser as $userId => $units) {
+                        $candidates[] = ['item' => $consumable, 'user' => $usersById[$userId], 'units' => $units];
+                    }
+                }
+
+                $this->classifyChunk($candidates);
+            });
+    }
+
+    /**
+     * Components, whose holders are always reached through an asset. Unlike the other
+     * pivots, `components_assets` carries an `assigned_qty` column rather than writing
+     * one row per unit, so units are summed from that column.
+     */
+    private function findComponentCandidates(): void
+    {
+        Component::query()
+            ->whereHas('category', fn (Builder $q) => $this->scopeToRequestedCategories($q))
+            ->when($this->companyIds, fn (Builder $q) => $q->whereIn('components.company_id', $this->companyIds))
+            ->has('assets')
+            ->with('assets.assignedTo')
+            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $components): void {
+                $candidates = [];
+
+                foreach ($components as $component) {
+                    $unitsPerUser = [];
+                    $usersById = [];
+
+                    foreach ($component->assets as $asset) {
+                        if (! $user = $this->resolveHolder($asset)) {
+                            continue;
+                        }
+
+                        $usersById[$user->id] = $user;
+                        $unitsPerUser[$user->id] = ($unitsPerUser[$user->id] ?? 0) + (int) $asset->pivot->assigned_qty;
+                    }
+
+                    foreach ($unitsPerUser as $userId => $units) {
+                        $candidates[] = ['item' => $component, 'user' => $usersById[$userId], 'units' => $units];
+                    }
+                }
+
+                $this->classifyChunk($candidates);
+            });
+    }
+
+    /**
+     * Classifies one builder's chunk of candidates and folds them into the preview.
+     *
+     * @param  array<int, Candidate>  $candidates
+     */
+    private function classifyChunk(array $candidates): void
+    {
+        if ($candidates === []) {
+            return;
+        }
+
+        $history = $this->acceptanceHistory($candidates);
+
+        foreach ($candidates as $candidate) {
+            $key = $this->pairKey($candidate['item']->getKey(), $candidate['user']->getKey());
+
+            $this->recordOutcome($this->classify($candidate, $history[$key] ?? new EloquentCollection));
+        }
+    }
+
+    /**
+     * Decides what to do with one pair by comparing the units it holds against the
+     * pending acceptance rows that already cover them.
+     *
+     * Accepted rows deliberately do not count as coverage — re-asking a holder who
+     * accepted is the whole point of the command. Only an in-flight *pending* ask
+     * counts, and it counts by quantity rather than existence: a user holding three
+     * accessory units with one pending unit is still under-covered for two, so the
+     * shortfall is what gets re-requested and the existing pending row is left alone.
+     * Where a holder can only ever hold one of a thing (an asset, a license seat) the
+     * quantity comparison collapses into "is there a pending row".
+     *
+     * @param  Candidate  $candidate
+     * @param  EloquentCollection<int, CheckoutAcceptance>  $history
+     * @return ClassifiedCandidate
+     */
+    private function classify(array $candidate, EloquentCollection $history): array
+    {
+        $pendingCoverage = $history
+            ->filter(fn (CheckoutAcceptance $acceptance) => $acceptance->isPending())
+            ->sum(fn (CheckoutAcceptance $acceptance) => $acceptance->qty ?? 1);
+
+        $shortfall = $candidate['units'] - $pendingCoverage;
+        $declined = $this->latestResponse($history)?->declined_at !== null;
+
+        return [
+            ...$candidate,
+            'qty' => $shortfall,
+            'declined' => $declined,
+            'outcome' => match (true) {
+                $shortfall <= 0 => self::OUTCOME_COVERED,
+                $declined && $this->excludeDeclined => self::OUTCOME_DECLINED_EXCLUDED,
+                default => self::OUTCOME_SEND,
+            },
+        ];
+    }
+
+    /**
+     * Tallies one classified pair, adding a preview row when it is one to re-request.
+     *
+     * @param  ClassifiedCandidate  $pair
+     */
+    private function recordOutcome(array $pair): void
+    {
+        $this->candidateCount++;
+
+        if ($pair['outcome'] === self::OUTCOME_COVERED) {
+            $this->alreadyCovered++;
+
+            return;
+        }
+
+        if ($pair['declined']) {
+            $this->previouslyDeclined++;
+        }
+
+        if ($pair['outcome'] === self::OUTCOME_DECLINED_EXCLUDED) {
+            $this->declinedAndExcluded++;
+
+            return;
+        }
+
+        $type = class_basename($pair['item']);
+        $this->sendCountsByType[$type] = ($this->sendCountsByType[$type] ?? 0) + 1;
+
+        $this->previewRows[] = [
+            $pair['user']->present()->fullName,
+            $pair['item']->present()->name,
+            $type,
+            $pair['units'],
+            $pair['qty'],
+        ];
+    }
+
+    /**
+     * The pair's most recent answered acceptance, or null when they never answered one.
+     *
+     * "Most recent" is the highest id — acceptance timestamps have second granularity
+     * and nothing backdates a row. Pending rows are skipped rather than treated as the
+     * latest word, because a re-request's own pending row would otherwise bury the
+     * decline it superseded and make a decliner look like someone who never answered.
+     *
+     * @param  EloquentCollection<int, CheckoutAcceptance>  $history
+     */
+    private function latestResponse(EloquentCollection $history): ?CheckoutAcceptance
+    {
+        return $history
+            ->reject(fn (CheckoutAcceptance $acceptance) => $acceptance->isPending())
+            ->sortByDesc('id')
+            ->first();
+    }
+
+    /**
+     * Every acceptance row belonging to a pair in this chunk, keyed by (item, user).
+     *
+     * A chunk always comes from one builder, so one `checkoutable_type` covers it. The
+     * query over-fetches — cross pairs (item A × user 2 when only A × 1 and B × 2 are
+     * wanted) and each pair's full history — which is harmless and much cheaper than a
+     * query per pair. Soft-deleted rows stay invisible: a trashed accepted row making
+     * its pair look never-asked is what compliance wants.
+     *
+     * @param  array<int, Candidate>  $candidates
+     * @return array<string, EloquentCollection<int, CheckoutAcceptance>>
+     */
+    private function acceptanceHistory(array $candidates): array
+    {
+        $itemIds = [];
+        $userIds = [];
+
+        foreach ($candidates as $candidate) {
+            $itemIds[] = $candidate['item']->getKey();
+            $userIds[] = $candidate['user']->getKey();
+        }
+
+        return CheckoutAcceptance::query()
+            ->where('checkoutable_type', $candidates[0]['item']->getMorphClass())
+            ->whereIn('checkoutable_id', array_unique($itemIds))
+            ->whereIn('assigned_to_id', array_unique($userIds))
+            ->get()
+            ->groupBy(fn (CheckoutAcceptance $acceptance) => $this->pairKey(
+                $acceptance->checkoutable_id,
+                $acceptance->assigned_to_id,
+            ))
+            ->all();
+    }
+
+    /**
+     * The (checkoutable, user) pair as one lookup key, scoped to a single chunk.
+     */
+    private function pairKey(int|string $itemId, int|string $userId): string
+    {
+        return $itemId.'|'.$userId;
+    }
+
+    /**
+     * Prints what this run would re-request, and creates nothing.
+     */
+    private function printPreview(): int
+    {
+        if ($this->candidateCount === 0) {
+            $this->info('No users currently hold items requiring acceptance in that scope.');
+
+            return 0;
+        }
+
+        if ($this->previewRows !== []) {
+            $this->table(['User', 'Item', 'Type', 'Units held', 'Qty'], $this->previewRows);
+        }
+
+        $this->info('To re-request: '.count($this->previewRows).'.');
+
+        foreach ($this->sendCountsByType as $type => $count) {
+            $this->line('  '.$type.': '.$count);
+        }
+
+        $this->info('Previously declined: '.$this->previouslyDeclined.'.');
+        $this->info('Already covered by a pending request: '.$this->alreadyCovered.'.');
+
+        if ($this->excludeDeclined) {
+            $this->info('Previously declined and excluded: '.$this->declinedAndExcluded.'.');
+        }
+
+        $this->info('Nothing was created.');
+
+        return 0;
+    }
+
+    /**
+     * Reads a model's assignment target, eager-loaded or not.
+     *
+     * `Asset::assignedTo()` and `AccessoryCheckout::assignedTo()` are declared
+     * `morphTo('assigned', ...)`, so the morph name and the method name differ. Eager
+     * loading stores the result under the *morph* name — `with('assignedTo')` leaves
+     * `$model->assignedTo` null and puts the real model on `$model->assigned`, which is
+     * why AssetsTransformer::transformAssignedTo() reads `$asset->assigned`. Reading the
+     * loaded relation when it is there and falling back to the method otherwise keeps
+     * this correct whether or not the caller eager-loaded it.
+     */
+    private function assignedTarget(Asset|AccessoryCheckout $model): ?Model
+    {
+        return $model->relationLoaded('assigned')
+            ? $model->getRelation('assigned')
+            : $model->assignedTo;
+    }
+
+    /**
+     * Walks a checkout target down to the user who holds it, mirroring
+     * CheckoutableListener::resolveAcceptanceTarget(). A user holds their own items;
+     * an asset's items are held by whoever that asset is assigned to. Anything else
+     * — a location, an unassigned asset — has no holder. Soft-deleted users are not
+     * holders either: every relation this walks is declared withTrashed(), so a deleted
+     * user would otherwise come back and be re-asked to accept.
+     */
+    private function resolveHolder(?Model $target): ?User
+    {
+        if ($target instanceof User) {
+            return $target->trashed() ? null : $target;
+        }
+
+        if ($target instanceof Asset) {
+            $holder = $this->assignedTarget($target);
+
+            return $holder instanceof User ? $this->resolveHolder($holder) : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Narrows a Category query to the categories this run cares about.
+     *
+     * @param  Builder<Category>  $query
+     * @return Builder<Category>
+     */
+    private function scopeToRequestedCategories(Builder $query): Builder
+    {
+        return $query->requiresAcceptance()
+            ->when($this->categoryIds, function (Builder $query) {
+                return $query->whereIn('categories.id', $this->categoryIds);
+            });
+    }
+}

--- a/app/Console/Commands/RegenerateAcceptances.php
+++ b/app/Console/Commands/RegenerateAcceptances.php
@@ -2,30 +2,10 @@
 
 namespace App\Console\Commands;
 
-use App\Actions\Acceptances\CreateCheckoutAcceptanceAction;
-use App\Mail\AcceptanceReRequestMail;
-use App\Models\Accessory;
-use App\Models\AccessoryCheckout;
-use App\Models\Asset;
-use App\Models\Category;
-use App\Models\CheckoutAcceptance;
-use App\Models\Component;
-use App\Models\Consumable;
-use App\Models\LicenseSeat;
-use App\Models\User;
+use App\Actions\Acceptances\RegenerateAcceptancesAction;
+use App\Actions\Acceptances\RegenerateAcceptancesResult;
 use Illuminate\Console\Command;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Mail;
 
-/**
- * Re-requests EULA acceptance from users who currently hold items.
- *
- * @phpstan-type Checkoutable Accessory|Asset|Component|Consumable|LicenseSeat
- * @phpstan-type Candidate array{item: Checkoutable, user: User, units: int}
- * @phpstan-type ClassifiedCandidate array{item: Checkoutable, user: User, units: int, qty: int, outcome: string, declined: bool}
- */
 class RegenerateAcceptances extends Command
 {
     protected $signature = 'snipeit:regenerate-acceptances
@@ -37,637 +17,58 @@ class RegenerateAcceptances extends Command
 
     protected $description = 'Re-request EULA acceptance from users who currently hold items';
 
-    /**
-     * How many items to load per builder query. Each chunk of items costs one
-     * acceptance-history query, however many holders those items turn out to have.
-     */
-    private const CHUNK_SIZE = 500;
-
-    private const OUTCOME_SEND = 'send';
-
-    private const OUTCOME_COVERED = 'covered';
-
-    private const OUTCOME_DECLINED_EXCLUDED = 'declined_excluded';
-
-    /**
-     * Category ids passed via --category, empty when the operator did not filter.
-     *
-     * @var array<int, string>
-     */
-    private array $categoryIds = [];
-
-    /**
-     * Company ids passed via --company, empty when the operator did not filter.
-     *
-     * @var array<int, string>
-     */
-    private array $companyIds = [];
-
-    private bool $excludeDeclined = false;
-
-    private bool $dryRun = false;
-
-    private bool $notify = false;
-
-    /**
-     * The holders this run created rows for, keyed by user id, each with the items they
-     * were re-requested for. Keying by holder is what keeps a holder re-requested for
-     * three items to one email rather than three.
-     *
-     * The items are scalars, never the models: holding a checkoutable per created row
-     * would pin every item this run touches in memory and undo the chunking that bounds
-     * the command.
-     *
-     * @var array<int, array{user: User, items: array<int, array{name: string, type: 'asset'|'license'|'accessory'|'consumable'|'component', qty: int|null}>}>
-     */
-    private array $holdersToNotify = [];
-
-    /**
-     * Holders who got rows but could not be emailed, as ID/name table rows.
-     *
-     * @var array<int, array{0: int, 1: string}>
-     */
-    private array $holdersWithoutEmail = [];
-
-    /**
-     * The rows this run re-requested, in the order the builders found them. Under
-     * --dry-run they are the rows it would have created.
-     *
-     * @var array<int, array{0: string, 1: string, 2: string, 3: int, 4: int}>
-     */
-    private array $reportRows = [];
-
-    /**
-     * How many pairs each checkoutable type contributed to the report.
-     *
-     * @var array<string, int>
-     */
-    private array $sendCountsByType = [];
-
-    private int $candidateCount = 0;
-
-    private int $previouslyDeclined = 0;
-
-    private int $alreadyCovered = 0;
-
-    private int $declinedAndExcluded = 0;
-
-    private int $created = 0;
-
-    private int $notified = 0;
-
     public function handle(): int
     {
-        $this->categoryIds = $this->option('category');
-        $this->companyIds = $this->option('company');
-        $this->excludeDeclined = (bool) $this->option('exclude-declined');
-        $this->dryRun = (bool) $this->option('dry-run');
-        $this->notify = (bool) $this->option('notify');
-
-        $this->findAssetCandidates();
-        $this->findLicenseSeatCandidates();
-        $this->findAccessoryCandidates();
-        $this->findConsumableCandidates();
-        $this->findComponentCandidates();
-
-        $this->notifyHolders();
-
-        return $this->printReport();
-    }
-
-    /**
-     * Assets assigned directly to a user, plus assets assigned to another asset
-     * that is itself assigned to a user.
-     *
-     * The category is reached through `model.category` rather than the tidier
-     * `Asset::category()` relation because `Asset::category()` is a `hasOneThrough`,
-     * so Laravel adds a `SoftDeletableHasManyThrough` global scope that excludes
-     * assets whose AssetModel is soft-deleted.
-     * A live checkout of such an asset asks `requireAcceptance()`
-     * instead, which reads `$this->model->category` where `model()` is
-     * `belongsTo(...)->withTrashed()` — so it says yes and creates an acceptance row.
-     * Going through the relation would make this command regenerate a smaller set than
-     * a live checkout creates, which is the divergence it exists to remove.
-     */
-    private function findAssetCandidates(): void
-    {
-        Asset::query()
-            ->whereHas('model.category', fn (Builder $q) => $this->scopeToRequestedCategories($q))
-            ->when($this->companyIds, fn (Builder $q) => $q->whereIn('assets.company_id', $this->companyIds))
-            ->whereIn('assets.assigned_type', [User::class, Asset::class])
-            ->with('assignedTo')
-            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $assets): void {
-                $candidates = [];
-
-                foreach ($assets as $asset) {
-                    if ($user = $this->resolveHolder($this->assignedTarget($asset))) {
-                        $candidates[] = ['item' => $asset, 'user' => $user, 'units' => 1];
-                    }
-                }
-
-                $this->classifyChunk($candidates);
-            });
-    }
-
-    /**
-     * License seats, keyed on the asset they are attached to where there is one.
-     *
-     * `license_seats.assigned_to` is denormalised and unreliable in both directions:
-     * the API asset-checkout path attaches a seat without ever stamping it, and five
-     * checkin paths clear it while deliberately leaving `asset_id` set. So a seat with
-     * an `asset_id` takes its holder from that asset's *current* assignment, and only a
-     * seat with no asset falls back to `assigned_to`. Either way a seat yields at most
-     * one pair, so seats carrying both columns cannot double-count.
-     */
-    private function findLicenseSeatCandidates(): void
-    {
-        LicenseSeat::query()
-            ->whereHas('license.category', fn (Builder $q) => $this->scopeToRequestedCategories($q))
-            ->when($this->companyIds, fn (Builder $q) => $q->whereHas('license',
-                fn (Builder $license) => $license->whereIn('licenses.company_id', $this->companyIds)
-            ))
-            ->byAssigned()
-            ->with(['asset.assignedTo', 'user'])
-            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $seats): void {
-                $candidates = [];
-
-                foreach ($seats as $seat) {
-                    $user = $seat->asset_id
-                        ? $this->resolveHolder($seat->asset)
-                        : $seat->user;
-
-                    if ($user instanceof User) {
-                        $candidates[] = ['item' => $seat, 'user' => $user, 'units' => 1];
-                    }
-                }
-
-                $this->classifyChunk($candidates);
-            });
-    }
-
-    /**
-     * Accessories, one pivot row per unit held. Rows assigned to a location are never
-     * candidates; rows assigned to an asset resolve to that asset's holder.
-     */
-    private function findAccessoryCandidates(): void
-    {
-        Accessory::query()
-            ->whereHas('category', fn (Builder $q) => $this->scopeToRequestedCategories($q))
-            ->when($this->companyIds, fn (Builder $q) => $q->whereIn('accessories.company_id', $this->companyIds))
-            ->whereHas('checkouts', fn (Builder $q) => $q->whereIn('assigned_type', [User::class, Asset::class]))
-            ->with(['checkouts' => fn ($q) => $q->whereIn('assigned_type', [User::class, Asset::class])])
-            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $accessories): void {
-                $candidates = [];
-
-                foreach ($accessories as $accessory) {
-                    $unitsPerUser = [];
-                    $usersById = [];
-
-                    foreach ($accessory->checkouts as $checkout) {
-                        if (! $user = $this->resolveHolder($this->assignedTarget($checkout))) {
-                            continue;
-                        }
-
-                        $usersById[$user->id] = $user;
-                        $unitsPerUser[$user->id] = ($unitsPerUser[$user->id] ?? 0) + 1;
-                    }
-
-                    foreach ($unitsPerUser as $userId => $units) {
-                        $candidates[] = ['item' => $accessory, 'user' => $usersById[$userId], 'units' => $units];
-                    }
-                }
-
-                $this->classifyChunk($candidates);
-            });
-    }
-
-    /**
-     * Consumables, one pivot row per unit held. `consumables_users` has no
-     * `assigned_type` column, so consumables are user-only by schema.
-     */
-    private function findConsumableCandidates(): void
-    {
-        Consumable::query()
-            ->whereHas('category', fn (Builder $q) => $this->scopeToRequestedCategories($q))
-            ->when($this->companyIds, fn (Builder $q) => $q->whereIn('consumables.company_id', $this->companyIds))
-            ->has('users')
-            ->with('users')
-            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $consumables): void {
-                $candidates = [];
-
-                foreach ($consumables as $consumable) {
-                    $unitsPerUser = [];
-                    $usersById = [];
-
-                    foreach ($consumable->users as $user) {
-                        $usersById[$user->id] = $user;
-                        $unitsPerUser[$user->id] = ($unitsPerUser[$user->id] ?? 0) + 1;
-                    }
-
-                    foreach ($unitsPerUser as $userId => $units) {
-                        $candidates[] = ['item' => $consumable, 'user' => $usersById[$userId], 'units' => $units];
-                    }
-                }
-
-                $this->classifyChunk($candidates);
-            });
-    }
-
-    /**
-     * Components, whose holders are always reached through an asset. Unlike the other
-     * pivots, `components_assets` carries an `assigned_qty` column rather than writing
-     * one row per unit, so units are summed from that column.
-     */
-    private function findComponentCandidates(): void
-    {
-        Component::query()
-            ->whereHas('category', fn (Builder $q) => $this->scopeToRequestedCategories($q))
-            ->when($this->companyIds, fn (Builder $q) => $q->whereIn('components.company_id', $this->companyIds))
-            ->has('assets')
-            ->with('assets.assignedTo')
-            ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $components): void {
-                $candidates = [];
-
-                foreach ($components as $component) {
-                    $unitsPerUser = [];
-                    $usersById = [];
-
-                    foreach ($component->assets as $asset) {
-                        if (! $user = $this->resolveHolder($asset)) {
-                            continue;
-                        }
-
-                        $usersById[$user->id] = $user;
-                        $unitsPerUser[$user->id] = ($unitsPerUser[$user->id] ?? 0) + (int) $asset->pivot->assigned_qty;
-                    }
-
-                    foreach ($unitsPerUser as $userId => $units) {
-                        $candidates[] = ['item' => $component, 'user' => $usersById[$userId], 'units' => $units];
-                    }
-                }
-
-                $this->classifyChunk($candidates);
-            });
-    }
-
-    /**
-     * Classifies one builder's chunk of candidates, tallies each outcome, and creates
-     * the rows for the ones to re-request unless this is a --dry-run.
-     *
-     * Creating inside the chunk keeps the run's memory bounded by the chunk rather than
-     * by the size of the send set. It is safe against the chunking itself: a new
-     * acceptance row cannot change which items a later chunk of items returns, and a
-     * pair is only ever classified once, by exactly one builder.
-     *
-     * @param  array<int, Candidate>  $candidates
-     */
-    private function classifyChunk(array $candidates): void
-    {
-        if ($candidates === []) {
-            return;
-        }
-
-        $history = $this->acceptanceHistory($candidates);
-
-        foreach ($candidates as $candidate) {
-            $key = $this->pairKey($candidate['item']->getKey(), $candidate['user']->getKey());
-
-            $pair = $this->classify($candidate, $history[$key] ?? new EloquentCollection);
-
-            $this->recordOutcome($pair);
-
-            if ($pair['outcome'] === self::OUTCOME_SEND && ! $this->dryRun) {
-                $this->createAcceptance($pair);
-            }
-        }
-    }
-
-    /**
-     * Decides what to do with one pair by comparing the units it holds against the
-     * pending acceptance rows that already cover them.
-     *
-     * Accepted rows deliberately do not count as coverage — re-asking a holder who
-     * accepted is the whole point of the command. Only an in-flight *pending* ask
-     * counts, and it counts by quantity rather than existence: a user holding three
-     * accessory units with one pending unit is still under-covered for two, so the
-     * shortfall is what gets re-requested and the existing pending row is left alone.
-     * Where a holder can only ever hold one of a thing (an asset, a license seat) the
-     * quantity comparison collapses into "is there a pending row".
-     *
-     * @param  Candidate  $candidate
-     * @param  EloquentCollection<int, CheckoutAcceptance>  $history
-     * @return ClassifiedCandidate
-     */
-    private function classify(array $candidate, EloquentCollection $history): array
-    {
-        $pendingCoverage = $history
-            ->filter(fn (CheckoutAcceptance $acceptance) => $acceptance->isPending())
-            ->sum(fn (CheckoutAcceptance $acceptance) => $acceptance->qty ?? 1);
-
-        $shortfall = $candidate['units'] - $pendingCoverage;
-        $declined = $this->latestResponse($history)?->declined_at !== null;
-
-        return [
-            ...$candidate,
-            'qty' => $shortfall,
-            'declined' => $declined,
-            'outcome' => match (true) {
-                $shortfall <= 0 => self::OUTCOME_COVERED,
-                $declined && $this->excludeDeclined => self::OUTCOME_DECLINED_EXCLUDED,
-                default => self::OUTCOME_SEND,
-            },
-        ];
-    }
-
-    /**
-     * Tallies one classified pair, adding a report row when it is one to re-request.
-     *
-     * @param  ClassifiedCandidate  $pair
-     */
-    private function recordOutcome(array $pair): void
-    {
-        $this->candidateCount++;
-
-        if ($pair['outcome'] === self::OUTCOME_COVERED) {
-            $this->alreadyCovered++;
-
-            return;
-        }
-
-        if ($pair['declined']) {
-            $this->previouslyDeclined++;
-        }
-
-        if ($pair['outcome'] === self::OUTCOME_DECLINED_EXCLUDED) {
-            $this->declinedAndExcluded++;
-
-            return;
-        }
-
-        $type = class_basename($pair['item']);
-        $this->sendCountsByType[$type] = ($this->sendCountsByType[$type] ?? 0) + 1;
-
-        $this->reportRows[] = [
-            $pair['user']->present()->fullName,
-            $pair['item']->present()->name,
-            $type,
-            $pair['units'],
-            $pair['qty'],
-        ];
-    }
-
-    /**
-     * Creates the pending row that re-requests acceptance from one holder.
-     *
-     * The row deliberately carries no `alert_on_response_id`, so nobody is emailed when
-     * the holder answers. That id names whoever *performed a checkout*, which is why the
-     * listener reads it from `auth()->id()` — and a console run has no actor to read.
-     * Carrying the last checkout's admin forward would invent an answer: the column holds
-     * a single id, so aggregating a pair's several prior rows into one re-request has to
-     * drop every admin but one, silently. Leaving it null keeps that decision unmade
-     * rather than making it wrong, and adding a recipient later is additive.
-     *
-     * @param  ClassifiedCandidate  $pair
-     */
-    private function createAcceptance(array $pair): void
-    {
-        CreateCheckoutAcceptanceAction::run(
-            $pair['item'],
-            $pair['user'],
-            $this->creationQty($pair['item'], $pair['qty']),
+        $result = RegenerateAcceptancesAction::run(
+            categoryIds: $this->option('category'),
+            companyIds: $this->option('company'),
+            excludeDeclined: (bool) $this->option('exclude-declined'),
+            dryRun: (bool) $this->option('dry-run'),
+            notify: (bool) $this->option('notify'),
         );
 
-        $this->created++;
-
-        $holder = $pair['user'];
-        $this->holdersToNotify[$holder->id]['user'] = $holder;
-        $this->holdersToNotify[$holder->id]['items'][] = [
-            'name' => $pair['item']->present()->name,
-            'type' => $this->itemType($pair['item']),
-            'qty' => $this->creationQty($pair['item'], $pair['qty']),
-        ];
+        return $this->printReport($result);
     }
 
     /**
-     * Which kind of thing this is, as the token the mail turns into a word.
-     *
-     * @param  Checkoutable  $item
-     * @return 'asset'|'license'|'accessory'|'consumable'|'component'
+     * Prints what the run re-requested, or under --dry-run what it would have.
      */
-    private function itemType(Model $item): string
+    private function printReport(RegenerateAcceptancesResult $result): int
     {
-        return match (true) {
-            $item instanceof Asset => 'asset',
-            $item instanceof LicenseSeat => 'license',
-            $item instanceof Accessory => 'accessory',
-            $item instanceof Consumable => 'consumable',
-            $item instanceof Component => 'component',
-        };
-    }
-
-    /**
-     * Emails the holders this run created rows for, when --notify was passed.
-     *
-     * One message per holder, never one per row: a holder re-requested for three items
-     * is asked once, for three items. A holder with no email address still keeps their
-     * rows — they will see them on /account/accept at their next login, just without the
-     * nudge — and is reported instead.
-     */
-    private function notifyHolders(): void
-    {
-        if (! $this->notify) {
-            return;
-        }
-
-        foreach ($this->holdersToNotify as $holder) {
-            $user = $holder['user'];
-
-            if (! $user->email) {
-                $this->holdersWithoutEmail[] = [$user->id, $user->present()->fullName];
-
-                continue;
-            }
-
-            $mail = new AcceptanceReRequestMail($user, $holder['items']);
-
-            Mail::to($user->email)->send($user->locale ? $mail->locale($user->locale) : $mail);
-
-            $this->notified++;
-        }
-    }
-
-    /**
-     * The `qty` to stamp on the new row: the shortfall for the types a holder can hold
-     * several of, and null for an asset or a license seat.
-     *
-     * Null is what today's asset and license-seat checkout paths write — an asset or a
-     * seat is a single thing — and null already means one unit everywhere it is read.
-     * Writing the shortfall there instead would make this command's rows differ from a
-     * live checkout's for no gain.
-     *
-     * @param  Checkoutable  $item
-     */
-    private function creationQty(Model $item, int $shortfall): ?int
-    {
-        return $item instanceof Asset || $item instanceof LicenseSeat
-            ? null
-            : $shortfall;
-    }
-
-    /**
-     * The pair's most recent answered acceptance, or null when they never answered one.
-     *
-     * "Most recent" is the highest id — acceptance timestamps have second granularity
-     * and nothing backdates a row. Pending rows are skipped rather than treated as the
-     * latest word, because a re-request's own pending row would otherwise bury the
-     * decline it superseded and make a decliner look like someone who never answered.
-     *
-     * @param  EloquentCollection<int, CheckoutAcceptance>  $history
-     */
-    private function latestResponse(EloquentCollection $history): ?CheckoutAcceptance
-    {
-        return $history
-            ->reject(fn (CheckoutAcceptance $acceptance) => $acceptance->isPending())
-            ->sortByDesc('id')
-            ->first();
-    }
-
-    /**
-     * Every acceptance row belonging to a pair in this chunk, keyed by (item, user).
-     *
-     * A chunk always comes from one builder, so one `checkoutable_type` covers it. The
-     * query over-fetches — cross pairs (item A × user 2 when only A × 1 and B × 2 are
-     * wanted) and each pair's full history — which is harmless and much cheaper than a
-     * query per pair. Soft-deleted rows stay invisible: a trashed accepted row making
-     * its pair look never-asked is what compliance wants.
-     *
-     * @param  array<int, Candidate>  $candidates
-     * @return array<string, EloquentCollection<int, CheckoutAcceptance>>
-     */
-    private function acceptanceHistory(array $candidates): array
-    {
-        $itemIds = [];
-        $userIds = [];
-
-        foreach ($candidates as $candidate) {
-            $itemIds[] = $candidate['item']->getKey();
-            $userIds[] = $candidate['user']->getKey();
-        }
-
-        return CheckoutAcceptance::query()
-            ->where('checkoutable_type', $candidates[0]['item']->getMorphClass())
-            ->whereIn('checkoutable_id', array_unique($itemIds))
-            ->whereIn('assigned_to_id', array_unique($userIds))
-            ->get()
-            ->groupBy(fn (CheckoutAcceptance $acceptance) => $this->pairKey(
-                $acceptance->checkoutable_id,
-                $acceptance->assigned_to_id,
-            ))
-            ->all();
-    }
-
-    /**
-     * The (checkoutable, user) pair as one lookup key, scoped to a single chunk.
-     */
-    private function pairKey(int|string $itemId, int|string $userId): string
-    {
-        return $itemId.'|'.$userId;
-    }
-
-    /**
-     * Prints what this run re-requested, or under --dry-run what it would have.
-     */
-    private function printReport(): int
-    {
-        if ($this->candidateCount === 0) {
+        if ($result->candidateCount === 0) {
             $this->info('No users currently hold items requiring acceptance in that scope.');
 
             return 0;
         }
 
-        if ($this->reportRows !== []) {
-            $this->table(['User', 'Item', 'Type', 'Units held', 'Qty'], $this->reportRows);
+        if ($result->reportRows !== []) {
+            $this->table(['User', 'Item', 'Type', 'Units held', 'Qty'], $result->reportRows);
         }
 
-        $this->info('To re-request: '.count($this->reportRows).'.');
+        $this->info('To re-request: '.count($result->reportRows).'.');
 
-        foreach ($this->sendCountsByType as $type => $count) {
+        foreach ($result->sendCountsByType as $type => $count) {
             $this->line('  '.$type.': '.$count);
         }
 
-        $this->info('Previously declined: '.$this->previouslyDeclined.'.');
-        $this->info('Already covered by a pending request: '.$this->alreadyCovered.'.');
+        $this->info('Previously declined: '.$result->previouslyDeclined.'.');
+        $this->info('Already covered by a pending request: '.$result->alreadyCovered.'.');
 
-        if ($this->excludeDeclined) {
-            $this->info('Previously declined and excluded: '.$this->declinedAndExcluded.'.');
+        if ($result->excludeDeclined) {
+            $this->info('Previously declined and excluded: '.$result->declinedAndExcluded.'.');
         }
 
-        $this->info($this->dryRun ? 'Nothing was created.' : 'Created: '.$this->created.'.');
+        $this->info($result->dryRun ? 'Nothing was created.' : 'Created: '.$result->created.'.');
 
-        if ($this->notify) {
-            $this->info('Notified: '.$this->notified.'.');
+        if ($result->notify) {
+            $this->info('Notified: '.$result->notified.'.');
 
-            if ($this->holdersWithoutEmail !== []) {
+            if ($result->holdersWithoutEmail !== []) {
                 $this->info('The following users do not have an email address:');
-                $this->table(['ID', 'Name'], $this->holdersWithoutEmail);
+                $this->table(['ID', 'Name'], $result->holdersWithoutEmail);
             }
         }
 
         return 0;
-    }
-
-    /**
-     * Reads a model's assignment target, eager-loaded or not.
-     *
-     * `Asset::assignedTo()` and `AccessoryCheckout::assignedTo()` are declared
-     * `morphTo('assigned', ...)`, so the morph name and the method name differ. Eager
-     * loading stores the result under the *morph* name — `with('assignedTo')` leaves
-     * `$model->assignedTo` null and puts the real model on `$model->assigned`, which is
-     * why AssetsTransformer::transformAssignedTo() reads `$asset->assigned`. Reading the
-     * loaded relation when it is there and falling back to the method otherwise keeps
-     * this correct whether or not the caller eager-loaded it.
-     */
-    private function assignedTarget(Asset|AccessoryCheckout $model): ?Model
-    {
-        return $model->relationLoaded('assigned')
-            ? $model->getRelation('assigned')
-            : $model->assignedTo;
-    }
-
-    /**
-     * Walks a checkout target down to the user who holds it, mirroring
-     * CheckoutableListener::resolveAcceptanceTarget(). A user holds their own items;
-     * an asset's items are held by whoever that asset is assigned to. Anything else
-     * — a location, an unassigned asset — has no holder. Soft-deleted users are not
-     * holders either: every relation this walks is declared withTrashed(), so a deleted
-     * user would otherwise come back and be re-asked to accept.
-     */
-    private function resolveHolder(?Model $target): ?User
-    {
-        if ($target instanceof User) {
-            return $target->trashed() ? null : $target;
-        }
-
-        if ($target instanceof Asset) {
-            $holder = $this->assignedTarget($target);
-
-            return $holder instanceof User ? $this->resolveHolder($holder) : null;
-        }
-
-        return null;
-    }
-
-    /**
-     * Narrows a Category query to the categories this run cares about.
-     *
-     * @param  Builder<Category>  $query
-     * @return Builder<Category>
-     */
-    private function scopeToRequestedCategories(Builder $query): Builder
-    {
-        return $query->requiresAcceptance()
-            ->when($this->categoryIds, function (Builder $query) {
-                return $query->whereIn('categories.id', $this->categoryIds);
-            });
     }
 }

--- a/app/Console/Commands/RegenerateAcceptances.php
+++ b/app/Console/Commands/RegenerateAcceptances.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Actions\Acceptances\CreateCheckoutAcceptanceAction;
 use App\Models\Accessory;
 use App\Models\AccessoryCheckout;
 use App\Models\Asset;
@@ -28,6 +29,7 @@ class RegenerateAcceptances extends Command
     protected $signature = 'snipeit:regenerate-acceptances
         {--category=* : Limit to these category ids (default: all categories requiring acceptance)}
         {--company=* : Limit to these company ids (default: all companies)}
+        {--dry-run : Print the report; create nothing}
         {--exclude-declined : Skip users whose latest response was a decline (default: re-ask them)}';
 
     protected $description = 'Re-request EULA acceptance from users who currently hold items';
@@ -60,15 +62,18 @@ class RegenerateAcceptances extends Command
 
     private bool $excludeDeclined = false;
 
+    private bool $dryRun = false;
+
     /**
-     * The would-be rows of the preview table, in the order the builders found them.
+     * The rows this run re-requested, in the order the builders found them. Under
+     * --dry-run they are the rows it would have created.
      *
      * @var array<int, array{0: string, 1: string, 2: string, 3: int, 4: int}>
      */
-    private array $previewRows = [];
+    private array $reportRows = [];
 
     /**
-     * How many pairs each checkoutable type contributed to the preview.
+     * How many pairs each checkoutable type contributed to the report.
      *
      * @var array<string, int>
      */
@@ -82,11 +87,14 @@ class RegenerateAcceptances extends Command
 
     private int $declinedAndExcluded = 0;
 
+    private int $created = 0;
+
     public function handle(): int
     {
         $this->categoryIds = $this->option('category');
         $this->companyIds = $this->option('company');
         $this->excludeDeclined = (bool) $this->option('exclude-declined');
+        $this->dryRun = (bool) $this->option('dry-run');
 
         $this->findAssetCandidates();
         $this->findLicenseSeatCandidates();
@@ -94,7 +102,7 @@ class RegenerateAcceptances extends Command
         $this->findConsumableCandidates();
         $this->findComponentCandidates();
 
-        return $this->printPreview();
+        return $this->printReport();
     }
 
     /**
@@ -116,7 +124,6 @@ class RegenerateAcceptances extends Command
         Asset::query()
             ->whereHas('model.category', fn (Builder $q) => $this->scopeToRequestedCategories($q))
             ->when($this->companyIds, fn (Builder $q) => $q->whereIn('assets.company_id', $this->companyIds))
-            // ->whereNotNull('assets.assigned_to')
             ->whereIn('assets.assigned_type', [User::class, Asset::class])
             ->with('assignedTo')
             ->chunkById(self::CHUNK_SIZE, function (EloquentCollection $assets): void {
@@ -274,7 +281,13 @@ class RegenerateAcceptances extends Command
     }
 
     /**
-     * Classifies one builder's chunk of candidates and folds them into the preview.
+     * Classifies one builder's chunk of candidates, tallies each outcome, and creates
+     * the rows for the ones to re-request unless this is a --dry-run.
+     *
+     * Creating inside the chunk keeps the run's memory bounded by the chunk rather than
+     * by the size of the send set. It is safe against the chunking itself: a new
+     * acceptance row cannot change which items a later chunk of items returns, and a
+     * pair is only ever classified once, by exactly one builder.
      *
      * @param  array<int, Candidate>  $candidates
      */
@@ -289,7 +302,13 @@ class RegenerateAcceptances extends Command
         foreach ($candidates as $candidate) {
             $key = $this->pairKey($candidate['item']->getKey(), $candidate['user']->getKey());
 
-            $this->recordOutcome($this->classify($candidate, $history[$key] ?? new EloquentCollection));
+            $pair = $this->classify($candidate, $history[$key] ?? new EloquentCollection);
+
+            $this->recordOutcome($pair);
+
+            if ($pair['outcome'] === self::OUTCOME_SEND && ! $this->dryRun) {
+                $this->createAcceptance($pair);
+            }
         }
     }
 
@@ -331,7 +350,7 @@ class RegenerateAcceptances extends Command
     }
 
     /**
-     * Tallies one classified pair, adding a preview row when it is one to re-request.
+     * Tallies one classified pair, adding a report row when it is one to re-request.
      *
      * @param  ClassifiedCandidate  $pair
      */
@@ -358,13 +377,55 @@ class RegenerateAcceptances extends Command
         $type = class_basename($pair['item']);
         $this->sendCountsByType[$type] = ($this->sendCountsByType[$type] ?? 0) + 1;
 
-        $this->previewRows[] = [
+        $this->reportRows[] = [
             $pair['user']->present()->fullName,
             $pair['item']->present()->name,
             $type,
             $pair['units'],
             $pair['qty'],
         ];
+    }
+
+    /**
+     * Creates the pending row that re-requests acceptance from one holder.
+     *
+     * The row deliberately carries no `alert_on_response_id`, so nobody is emailed when
+     * the holder answers. That id names whoever *performed a checkout*, which is why the
+     * listener reads it from `auth()->id()` — and a console run has no actor to read.
+     * Carrying the last checkout's admin forward would invent an answer: the column holds
+     * a single id, so aggregating a pair's several prior rows into one re-request has to
+     * drop every admin but one, silently. Leaving it null keeps that decision unmade
+     * rather than making it wrong, and adding a recipient later is additive.
+     *
+     * @param  ClassifiedCandidate  $pair
+     */
+    private function createAcceptance(array $pair): void
+    {
+        CreateCheckoutAcceptanceAction::run(
+            $pair['item'],
+            $pair['user'],
+            $this->creationQty($pair['item'], $pair['qty']),
+        );
+
+        $this->created++;
+    }
+
+    /**
+     * The `qty` to stamp on the new row: the shortfall for the types a holder can hold
+     * several of, and null for an asset or a license seat.
+     *
+     * Null is what today's asset and license-seat checkout paths write — an asset or a
+     * seat is a single thing — and null already means one unit everywhere it is read.
+     * Writing the shortfall there instead would make this command's rows differ from a
+     * live checkout's for no gain.
+     *
+     * @param  Checkoutable  $item
+     */
+    private function creationQty(Model $item, int $shortfall): ?int
+    {
+        return $item instanceof Asset || $item instanceof LicenseSeat
+            ? null
+            : $shortfall;
     }
 
     /**
@@ -428,9 +489,9 @@ class RegenerateAcceptances extends Command
     }
 
     /**
-     * Prints what this run would re-request, and creates nothing.
+     * Prints what this run re-requested, or under --dry-run what it would have.
      */
-    private function printPreview(): int
+    private function printReport(): int
     {
         if ($this->candidateCount === 0) {
             $this->info('No users currently hold items requiring acceptance in that scope.');
@@ -438,11 +499,11 @@ class RegenerateAcceptances extends Command
             return 0;
         }
 
-        if ($this->previewRows !== []) {
-            $this->table(['User', 'Item', 'Type', 'Units held', 'Qty'], $this->previewRows);
+        if ($this->reportRows !== []) {
+            $this->table(['User', 'Item', 'Type', 'Units held', 'Qty'], $this->reportRows);
         }
 
-        $this->info('To re-request: '.count($this->previewRows).'.');
+        $this->info('To re-request: '.count($this->reportRows).'.');
 
         foreach ($this->sendCountsByType as $type => $count) {
             $this->line('  '.$type.': '.$count);
@@ -455,7 +516,7 @@ class RegenerateAcceptances extends Command
             $this->info('Previously declined and excluded: '.$this->declinedAndExcluded.'.');
         }
 
-        $this->info('Nothing was created.');
+        $this->info($this->dryRun ? 'Nothing was created.' : 'Created: '.$this->created.'.');
 
         return 0;
     }

--- a/app/Console/Commands/RegenerateAcceptances.php
+++ b/app/Console/Commands/RegenerateAcceptances.php
@@ -70,11 +70,15 @@ class RegenerateAcceptances extends Command
     private bool $notify = false;
 
     /**
-     * The holders this run created rows for, keyed by user id, each with how many rows
-     * they got. Keying by holder is what keeps a holder re-requested for three items to
-     * one email rather than three.
+     * The holders this run created rows for, keyed by user id, each with the items they
+     * were re-requested for. Keying by holder is what keeps a holder re-requested for
+     * three items to one email rather than three.
      *
-     * @var array<int, array{user: User, count: int}>
+     * The items are scalars, never the models: holding a checkoutable per created row
+     * would pin every item this run touches in memory and undo the chunking that bounds
+     * the command.
+     *
+     * @var array<int, array{user: User, items: array<int, array{name: string, type: class-string, qty: int|null}>}>
      */
     private array $holdersToNotify = [];
 
@@ -436,9 +440,11 @@ class RegenerateAcceptances extends Command
         $this->created++;
 
         $holder = $pair['user'];
-        $this->holdersToNotify[$holder->id] = [
-            'user' => $holder,
-            'count' => ($this->holdersToNotify[$holder->id]['count'] ?? 0) + 1,
+        $this->holdersToNotify[$holder->id]['user'] = $holder;
+        $this->holdersToNotify[$holder->id]['items'][] = [
+            'name' => $pair['item']->present()->name,
+            'type' => $pair['item']::class,
+            'qty' => $this->creationQty($pair['item'], $pair['qty']),
         ];
     }
 
@@ -465,7 +471,7 @@ class RegenerateAcceptances extends Command
                 continue;
             }
 
-            $mail = new AcceptanceReRequestMail($user, $holder['count']);
+            $mail = new AcceptanceReRequestMail($user, $holder['items']);
 
             Mail::to($user->email)->send($user->locale ? $mail->locale($user->locale) : $mail);
 

--- a/app/Mail/AcceptanceReRequestMail.php
+++ b/app/Mail/AcceptanceReRequestMail.php
@@ -2,6 +2,10 @@
 
 namespace App\Mail;
 
+use App\Models\Accessory;
+use App\Models\Asset;
+use App\Models\Consumable;
+use App\Models\LicenseSeat;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailables\Address;
@@ -10,20 +14,21 @@ use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
-/**
- * Asks a holder to accept the terms again for items they already hold.
- *
- * Deliberately not the unaccepted-items reminder: a holder who accepted a year ago
- * and is being asked again reads "Reminder: You have Unaccepted Items" as a bug, so
- * this is framed as a fresh request rather than a nudge about something they ignored.
- */
 class AcceptanceReRequestMail extends BaseMailable
 {
     use Queueable, SerializesModels;
 
+    /**
+     * How many items the message names before it stops listing and counts the rest.
+     */
+    private const ITEM_LIST_LIMIT = 10;
+
+    /**
+     * @param  array<int, array{name: string, type: class-string, qty: int|null}>  $items
+     */
     public function __construct(
         public readonly User $holder,
-        public readonly int $itemCount,
+        public readonly array $items,
     ) {}
 
     /**
@@ -46,10 +51,39 @@ class AcceptanceReRequestMail extends BaseMailable
             markdown: 'notifications.markdown.acceptance-re-request',
             with: [
                 'assigned_to' => $this->holder->present()->fullName,
-                'count' => $this->itemCount,
+                'count' => count($this->items),
+                'shown_items' => array_map(
+                    fn (array $item) => [
+                        'name' => $item['name'],
+                        'type' => $this->typeLabel($item['type']),
+                        'qty' => $item['qty'],
+                    ],
+                    array_slice($this->items, 0, self::ITEM_LIST_LIMIT),
+                ),
+                'remaining' => max(count($this->items) - self::ITEM_LIST_LIMIT, 0),
                 'accept_url' => route('account.accept'),
             ],
         );
+    }
+
+    /**
+     * What a holder calls the kind of thing they hold.
+     *
+     * `class_basename()` is what the operator's report table prints, but "LicenseSeat"
+     * is not a word anyone outside this codebase uses. This runs while the mailable is
+     * being rendered, so it is already inside the holder's locale.
+     *
+     * @param  class-string  $type
+     */
+    private function typeLabel(string $type): string
+    {
+        return match ($type) {
+            Asset::class => trans('general.asset'),
+            LicenseSeat::class => trans('general.license'),
+            Accessory::class => trans('general.accessory'),
+            Consumable::class => trans('general.consumable'),
+            default => trans('general.component'),
+        };
     }
 
     /**

--- a/app/Mail/AcceptanceReRequestMail.php
+++ b/app/Mail/AcceptanceReRequestMail.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Asks a holder to accept the terms again for items they already hold.
+ *
+ * Deliberately not the unaccepted-items reminder: a holder who accepted a year ago
+ * and is being asked again reads "Reminder: You have Unaccepted Items" as a bug, so
+ * this is framed as a fresh request rather than a nudge about something they ignored.
+ */
+class AcceptanceReRequestMail extends BaseMailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly User $holder,
+        public readonly int $itemCount,
+    ) {}
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            from: new Address(config('mail.from.address'), config('mail.from.name')),
+            subject: trans('mail.acceptance_re_request'),
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'notifications.markdown.acceptance-re-request',
+            with: [
+                'assigned_to' => $this->holder->present()->fullName,
+                'count' => $this->itemCount,
+                'accept_url' => route('account.accept'),
+            ],
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Mail/AcceptanceReRequestMail.php
+++ b/app/Mail/AcceptanceReRequestMail.php
@@ -2,10 +2,6 @@
 
 namespace App\Mail;
 
-use App\Models\Accessory;
-use App\Models\Asset;
-use App\Models\Consumable;
-use App\Models\LicenseSeat;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailables\Address;
@@ -24,7 +20,7 @@ class AcceptanceReRequestMail extends BaseMailable
     private const ITEM_LIST_LIMIT = 10;
 
     /**
-     * @param  array<int, array{name: string, type: class-string, qty: int|null}>  $items
+     * @param  array<int, array{name: string, type: 'asset'|'license'|'accessory'|'consumable'|'component', qty: int|null}>  $items
      */
     public function __construct(
         public readonly User $holder,
@@ -52,18 +48,28 @@ class AcceptanceReRequestMail extends BaseMailable
             with: [
                 'assigned_to' => $this->holder->present()->fullName,
                 'count' => count($this->items),
-                'shown_items' => array_map(
-                    fn (array $item) => [
-                        'name' => $item['name'],
-                        'type' => $this->typeLabel($item['type']),
-                        'qty' => $item['qty'],
-                    ],
-                    array_slice($this->items, 0, self::ITEM_LIST_LIMIT),
-                ),
+                'shown_items' => $this->shownItems(),
                 'remaining' => max(count($this->items) - self::ITEM_LIST_LIMIT, 0),
                 'accept_url' => route('account.accept'),
             ],
         );
+    }
+
+    /**
+     * The items the message names, each labelled in words a holder uses.
+     *
+     * @return array<int, array{name: string, type: string, qty: int|null}>
+     */
+    private function shownItems(): array
+    {
+        return collect($this->items)
+            ->take(self::ITEM_LIST_LIMIT)
+            ->map(fn (array $item) => [
+                'name' => $item['name'],
+                'type' => $this->typeLabel($item['type']),
+                'qty' => $item['qty'],
+            ])
+            ->all();
     }
 
     /**
@@ -73,16 +79,16 @@ class AcceptanceReRequestMail extends BaseMailable
      * is not a word anyone outside this codebase uses. This runs while the mailable is
      * being rendered, so it is already inside the holder's locale.
      *
-     * @param  class-string  $type
+     * @param  'asset'|'license'|'accessory'|'consumable'|'component'  $type
      */
     private function typeLabel(string $type): string
     {
         return match ($type) {
-            Asset::class => trans('general.asset'),
-            LicenseSeat::class => trans('general.license'),
-            Accessory::class => trans('general.accessory'),
-            Consumable::class => trans('general.consumable'),
-            default => trans('general.component'),
+            'asset' => trans('general.asset'),
+            'license' => trans('general.license'),
+            'accessory' => trans('general.accessory'),
+            'consumable' => trans('general.consumable'),
+            'component' => trans('general.component'),
         };
     }
 

--- a/database/factories/CheckoutAcceptanceFactory.php
+++ b/database/factories/CheckoutAcceptanceFactory.php
@@ -80,6 +80,14 @@ class CheckoutAcceptanceFactory extends Factory
         ]);
     }
 
+    public function declined()
+    {
+        return $this->state([
+            'accepted_at' => null,
+            'declined_at' => now()->subDay(),
+        ]);
+    }
+
     public function withoutAlerting()
     {
         return $this->state(function () {

--- a/resources/lang/en-US/mail.php
+++ b/resources/lang/en-US/mail.php
@@ -38,6 +38,8 @@ return [
     'acceptance_declined' => 'DECLINED: :user has declined :item',
     'acceptance_accepted_greeting' => ':user has accepted an item:',
     'acceptance_declined_greeting' => ':user has declined an item',
+    'acceptance_re_request' => 'Action Required: Please Re-Accept Your Assigned Items',
+    'acceptance_re_request_intro' => 'Please re-accept the terms for the :count item currently assigned to you. Click the link below to accept or decline it.|Please re-accept the terms for the :count items currently assigned to you. Click the link below to accept or decline them.',
     'send_pdf_copy' => 'Send a copy of this acceptance to my email address',
     'accessory_name' => 'Accessory Name',
     'additional_notes' => 'Additional Notes',

--- a/resources/lang/en-US/mail.php
+++ b/resources/lang/en-US/mail.php
@@ -40,6 +40,7 @@ return [
     'acceptance_declined_greeting' => ':user has declined an item',
     'acceptance_re_request' => 'Action Required: Please Re-Accept Your Assigned Items',
     'acceptance_re_request_intro' => 'Please re-accept the terms for the :count item currently assigned to you. Click the link below to accept or decline it.|Please re-accept the terms for the :count items currently assigned to you. Click the link below to accept or decline them.',
+    'acceptance_re_request_more_items' => '...and :count more item.|...and :count more items.',
     'send_pdf_copy' => 'Send a copy of this acceptance to my email address',
     'accessory_name' => 'Accessory Name',
     'additional_notes' => 'Additional Notes',

--- a/resources/views/notifications/markdown/acceptance-re-request.blade.php
+++ b/resources/views/notifications/markdown/acceptance-re-request.blade.php
@@ -2,6 +2,15 @@
 # {{ trans('mail.hello') }} {{ $assigned_to }},
 
 {{ trans_choice('mail.acceptance_re_request_intro', $count, ['count' => $count]) }}
+
+@foreach ($shown_items as $item)
+- {{ $item['name'] }} ({{ $item['type'] }}){{ $item['qty'] > 1 ? ' × '.$item['qty'] : '' }}
+@endforeach
+
+@if ($remaining > 0)
+{{ trans_choice('mail.acceptance_re_request_more_items', $remaining, ['count' => $remaining]) }}
+@endif
+
 [{{ trans('general.click_here') }}]({{ $accept_url }})
 
 {{ trans('mail.best_regards') }}

--- a/resources/views/notifications/markdown/acceptance-re-request.blade.php
+++ b/resources/views/notifications/markdown/acceptance-re-request.blade.php
@@ -1,0 +1,11 @@
+@component('mail::message')
+# {{ trans('mail.hello') }} {{ $assigned_to }},
+
+{{ trans_choice('mail.acceptance_re_request_intro', $count, ['count' => $count]) }}
+[{{ trans('general.click_here') }}]({{ $accept_url }})
+
+{{ trans('mail.best_regards') }}
+
+{{ $snipeSettings->site_name }}
+
+@endcomponent

--- a/tests/Feature/Console/RegenerateAcceptancesTest.php
+++ b/tests/Feature/Console/RegenerateAcceptancesTest.php
@@ -725,15 +725,62 @@ class RegenerateAcceptancesTest extends TestCase
 
         Mail::assertSent(AcceptanceReRequestMail::class, function (AcceptanceReRequestMail $mail) {
             return $mail->hasTo('alice@example.test')
-                && $mail->itemCount === 2
+                && count($mail->items) === 2
                 && $mail->hasSubject(trans('mail.acceptance_re_request'))
                 && str_contains($mail->render(), trans_choice('mail.acceptance_re_request_intro', 2, ['count' => 2]));
         });
         Mail::assertSent(
             AcceptanceReRequestMail::class,
-            fn (AcceptanceReRequestMail $mail) => $mail->hasTo('bob@example.test') && $mail->itemCount === 1,
+            fn (AcceptanceReRequestMail $mail) => $mail->hasTo('bob@example.test') && count($mail->items) === 1,
         );
         Mail::assertSent(AcceptanceReRequestMail::class, 2);
+    }
+
+    public function test_the_email_names_every_item_the_holder_was_re_requested_for(): void
+    {
+        Mail::fake();
+        $company = Company::factory()->create();
+        $holder = User::factory()->create(['email' => 'holder@example.test']);
+        $this->heldAsset($holder, $this->acceptanceCategory('asset'), $company, 'Alice laptop');
+        $mouse = $this->heldAccessory($holder, $this->acceptanceCategory('accessory'), $company, 'Mouse');
+        $mouse->checkouts()->create(['assigned_to' => $holder->id, 'assigned_type' => User::class]);
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--notify' => true])->assertExitCode(0);
+
+        Mail::assertSent(AcceptanceReRequestMail::class, function (AcceptanceReRequestMail $mail) {
+            $body = $mail->render();
+
+            return str_contains($body, 'Alice laptop')
+                && str_contains($body, trans('general.asset'))
+                && str_contains($body, 'Mouse ('.trans('general.accessory').') × 2')
+                && ! str_contains($body, trans_choice('mail.acceptance_re_request_more_items', 1, ['count' => 1]));
+        });
+    }
+
+    public function test_the_email_lists_ten_items_then_counts_the_rest(): void
+    {
+        Mail::fake();
+        $company = Company::factory()->create();
+        $category = $this->acceptanceCategory('asset');
+        $holder = User::factory()->create(['email' => 'holder@example.test']);
+
+        foreach (range(1, 12) as $number) {
+            $this->heldAsset($holder, $category, $company, 'Laptop '.$number);
+        }
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--notify' => true])->assertExitCode(0);
+
+        Mail::assertSent(AcceptanceReRequestMail::class, function (AcceptanceReRequestMail $mail) {
+            $body = $mail->render();
+            $named = array_filter(
+                range(1, 12),
+                fn (int $number) => str_contains($body, 'Laptop '.$number.' #'),
+            );
+
+            return count($mail->items) === 12
+                && count($named) === 10
+                && str_contains($body, trans_choice('mail.acceptance_re_request_more_items', 2, ['count' => 2]));
+        });
     }
 
     public function test_nothing_is_emailed_without_the_notify_flag(): void

--- a/tests/Feature/Console/RegenerateAcceptancesTest.php
+++ b/tests/Feature/Console/RegenerateAcceptancesTest.php
@@ -30,7 +30,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => User::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsTable(
                 ['User', 'Item', 'Type', 'Units held', 'Qty'],
                 [[$holder->present()->fullName, $asset->present()->name, 'Asset', 1, 1]],
@@ -50,7 +50,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => Asset::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutputToContain($dock->present()->name)
             ->assertExitCode(0);
     }
@@ -63,7 +63,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => Asset::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
             ->assertExitCode(0);
     }
@@ -75,7 +75,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => Location::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
             ->assertExitCode(0);
     }
@@ -92,7 +92,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => User::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
             ->assertExitCode(0);
     }
@@ -118,7 +118,7 @@ class RegenerateAcceptancesTest extends TestCase
 
         $this->assertTrue((bool) $asset->fresh()->requireAcceptance());
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsTable(
                 ['User', 'Item', 'Type', 'Units held', 'Qty'],
                 [[$holder->present()->fullName, $asset->present()->name, 'Asset', 1, 1]],
@@ -135,7 +135,7 @@ class RegenerateAcceptancesTest extends TestCase
         ]);
         $holder->delete();
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
             ->assertExitCode(0);
     }
@@ -154,7 +154,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_to' => null,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutputToContain($holder->present()->fullName)
             ->assertExitCode(0);
     }
@@ -174,7 +174,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_to' => $holder->id,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutputToContain('To re-request: 1.')
             ->assertExitCode(0);
     }
@@ -194,7 +194,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_to' => $staleHolder->id,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutputToContain($currentHolder->present()->fullName)
             ->doesntExpectOutputToContain($staleHolder->present()->fullName)
             ->assertExitCode(0);
@@ -210,7 +210,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_to' => $holder->id,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutputToContain($holder->present()->fullName)
             ->assertExitCode(0);
     }
@@ -224,7 +224,7 @@ class RegenerateAcceptancesTest extends TestCase
             ['assigned_to' => $holder->id, 'assigned_type' => User::class],
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsTable(
                 ['User', 'Item', 'Type', 'Units held', 'Qty'],
                 [[$holder->present()->fullName, $accessory->present()->name, 'Accessory', 2, 2]],
@@ -242,7 +242,7 @@ class RegenerateAcceptancesTest extends TestCase
         $accessory = Accessory::factory()->create(['category_id' => $this->acceptanceCategory('accessory')->id]);
         $accessory->checkouts()->create(['assigned_to' => $laptop->id, 'assigned_type' => Asset::class]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutputToContain($accessory->present()->name)
             ->assertExitCode(0);
     }
@@ -255,7 +255,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => Location::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
             ->assertExitCode(0);
     }
@@ -266,7 +266,7 @@ class RegenerateAcceptancesTest extends TestCase
         $consumable = Consumable::factory()->create(['category_id' => $this->acceptanceCategory('consumable')->id]);
         $consumable->users()->attach([$holder->id, $holder->id], ['created_by' => $holder->id]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsTable(
                 ['User', 'Item', 'Type', 'Units held', 'Qty'],
                 [[$holder->present()->fullName, $consumable->present()->name, 'Consumable', 2, 2]],
@@ -285,7 +285,7 @@ class RegenerateAcceptancesTest extends TestCase
         $component->assets()->attach($laptop->id, ['assigned_qty' => 3, 'created_by' => $holder->id]);
         $component->assets()->attach($desktop->id, ['assigned_qty' => 3, 'created_by' => $holder->id]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsTable(
                 ['User', 'Item', 'Type', 'Units held', 'Qty'],
                 [
@@ -303,7 +303,7 @@ class RegenerateAcceptancesTest extends TestCase
         $component = Component::factory()->create(['category_id' => $this->acceptanceCategory('component')->id]);
         $component->assets()->attach($parked->id, ['assigned_qty' => 2, 'created_by' => 1]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
             ->assertExitCode(0);
     }
@@ -321,7 +321,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->heldAsset($holder, $wanted, Company::factory()->create(), 'In scope asset');
         $this->heldAsset($holder, $this->acceptanceCategory('asset'), Company::factory()->create(), 'Out of scope asset');
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--category' => [$wanted->id]])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--category' => [$wanted->id]])
             ->expectsOutputToContain('In scope asset')
             ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
@@ -336,7 +336,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->heldAsset($holder, $category, $wanted, 'In scope asset');
         $this->heldAsset($holder, $category, Company::factory()->create(), 'Out of scope asset');
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--company' => [$wanted->id]])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--company' => [$wanted->id]])
             ->expectsOutputToContain('In scope asset')
             ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
@@ -350,7 +350,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->heldLicenseSeat($holder, $wanted, Company::factory()->create(), 'In scope licence');
         $this->heldLicenseSeat($holder, $this->acceptanceCategory('license'), Company::factory()->create(), 'Out of scope licence');
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--category' => [$wanted->id]])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--category' => [$wanted->id]])
             ->expectsOutputToContain('In scope licence')
             ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
@@ -368,7 +368,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->heldLicenseSeat($holder, $category, $wanted, 'In scope licence');
         $this->heldLicenseSeat($holder, $category, Company::factory()->create(), 'Out of scope licence');
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--company' => [$wanted->id]])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--company' => [$wanted->id]])
             ->expectsOutputToContain('In scope licence')
             ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
@@ -382,7 +382,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->heldAccessory($holder, $wanted, Company::factory()->create(), 'In scope accessory');
         $this->heldAccessory($holder, $this->acceptanceCategory('accessory'), Company::factory()->create(), 'Out of scope accessory');
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--category' => [$wanted->id]])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--category' => [$wanted->id]])
             ->expectsOutputToContain('In scope accessory')
             ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
@@ -397,7 +397,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->heldAccessory($holder, $category, $wanted, 'In scope accessory');
         $this->heldAccessory($holder, $category, Company::factory()->create(), 'Out of scope accessory');
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--company' => [$wanted->id]])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--company' => [$wanted->id]])
             ->expectsOutputToContain('In scope accessory')
             ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
@@ -411,7 +411,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->heldConsumable($holder, $wanted, Company::factory()->create(), 'In scope consumable');
         $this->heldConsumable($holder, $this->acceptanceCategory('consumable'), Company::factory()->create(), 'Out of scope consumable');
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--category' => [$wanted->id]])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--category' => [$wanted->id]])
             ->expectsOutputToContain('In scope consumable')
             ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
@@ -426,7 +426,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->heldConsumable($holder, $category, $wanted, 'In scope consumable');
         $this->heldConsumable($holder, $category, Company::factory()->create(), 'Out of scope consumable');
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--company' => [$wanted->id]])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--company' => [$wanted->id]])
             ->expectsOutputToContain('In scope consumable')
             ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
@@ -440,7 +440,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->heldComponent($holder, $wanted, Company::factory()->create(), 'In scope component');
         $this->heldComponent($holder, $this->acceptanceCategory('component'), Company::factory()->create(), 'Out of scope component');
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--category' => [$wanted->id]])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--category' => [$wanted->id]])
             ->expectsOutputToContain('In scope component')
             ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
@@ -455,7 +455,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->heldComponent($holder, $category, $wanted, 'In scope component');
         $this->heldComponent($holder, $category, Company::factory()->create(), 'Out of scope component');
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--company' => [$wanted->id]])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--company' => [$wanted->id]])
             ->expectsOutputToContain('In scope component')
             ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
@@ -484,7 +484,7 @@ class RegenerateAcceptancesTest extends TestCase
         ]);
         $this->acceptanceFor($asset, $holder)->pending()->create();
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('To re-request: 0.')
             ->expectsOutput('Already covered by a pending request: 1.')
             ->assertExitCode(0);
@@ -499,7 +499,7 @@ class RegenerateAcceptancesTest extends TestCase
         ]);
         $this->acceptanceFor($asset, $holder)->accepted()->create();
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('To re-request: 1.')
             ->expectsOutput('Already covered by a pending request: 0.')
             ->assertExitCode(0);
@@ -514,7 +514,7 @@ class RegenerateAcceptancesTest extends TestCase
         ]);
         $this->acceptanceFor($asset, $holder)->pending()->create()->delete();
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
     }
@@ -530,7 +530,7 @@ class RegenerateAcceptancesTest extends TestCase
         ]);
         $pending = $this->acceptanceFor($accessory, $holder)->pending()->create(['qty' => 1]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsTable(
                 ['User', 'Item', 'Type', 'Units held', 'Qty'],
                 [[$holder->present()->fullName, $accessory->present()->name, 'Accessory', 3, 2]],
@@ -563,7 +563,7 @@ class RegenerateAcceptancesTest extends TestCase
         ]);
         $this->acceptanceFor($accessory, $holder)->pending()->create(['qty' => null]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsTable(
                 ['User', 'Item', 'Type', 'Units held', 'Qty'],
                 [[$holder->present()->fullName, $accessory->present()->name, 'Accessory', 2, 1]],
@@ -585,7 +585,7 @@ class RegenerateAcceptancesTest extends TestCase
         $accessory->checkouts()->create(['assigned_to' => $holder->id, 'assigned_type' => User::class]);
         $this->acceptanceFor($accessory, User::factory()->create())->pending()->create(['qty' => 5]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsTable(
                 ['User', 'Item', 'Type', 'Units held', 'Qty'],
                 [[$holder->present()->fullName, $accessory->present()->name, 'Accessory', 1, 1]],
@@ -602,7 +602,7 @@ class RegenerateAcceptancesTest extends TestCase
         ]);
         $this->acceptanceFor($asset, $holder)->declined()->create();
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('To re-request: 1.')
             ->expectsOutput('Previously declined: 1.')
             ->assertExitCode(0);
@@ -617,7 +617,7 @@ class RegenerateAcceptancesTest extends TestCase
         ]);
         $this->acceptanceFor($asset, $holder)->declined()->create();
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--exclude-declined' => true])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--exclude-declined' => true])
             ->expectsOutput('To re-request: 0.')
             ->expectsOutput('Previously declined: 1.')
             ->expectsOutput('Previously declined and excluded: 1.')
@@ -634,7 +634,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->acceptanceFor($asset, $holder)->declined()->create();
         $this->acceptanceFor($asset, $holder)->accepted()->create();
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--exclude-declined' => true])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--exclude-declined' => true])
             ->expectsOutput('To re-request: 1.')
             ->expectsOutput('Previously declined: 0.')
             ->assertExitCode(0);
@@ -648,7 +648,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => User::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--dry-run' => true])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--dry-run' => true])
             ->expectsOutput('To re-request: 1.')
             ->expectsOutput('Nothing was created.')
             ->assertExitCode(0);
@@ -664,7 +664,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => User::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('Created: 1.')
             ->assertExitCode(0);
 
@@ -683,7 +683,7 @@ class RegenerateAcceptancesTest extends TestCase
         ]);
         $this->acceptanceFor($asset, $holder)->declined()->create();
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--exclude-declined' => true])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--exclude-declined' => true])
             ->expectsOutput('Created: 0.')
             ->assertExitCode(0);
 
@@ -703,7 +703,7 @@ class RegenerateAcceptancesTest extends TestCase
         ]);
         $this->acceptanceFor($asset, $holder)->accepted()->withAlertingTo($admin)->create();
 
-        $this->artisan('snipeit:regenerate-acceptances')->assertExitCode(0);
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])->assertExitCode(0);
 
         $this->assertNull($this->newestAcceptance()->alert_on_response_id);
     }
@@ -718,7 +718,7 @@ class RegenerateAcceptancesTest extends TestCase
         $this->heldAccessory($alice, $this->acceptanceCategory('accessory'), $company, 'Mouse');
         $this->heldAsset($bob, $this->acceptanceCategory('asset'), $company, 'Bob laptop');
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--notify' => true])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--notify' => true])
             ->expectsOutput('Created: 3.')
             ->expectsOutput('Notified: 2.')
             ->assertExitCode(0);
@@ -745,7 +745,7 @@ class RegenerateAcceptancesTest extends TestCase
         $mouse = $this->heldAccessory($holder, $this->acceptanceCategory('accessory'), $company, 'Mouse');
         $mouse->checkouts()->create(['assigned_to' => $holder->id, 'assigned_type' => User::class]);
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--notify' => true])->assertExitCode(0);
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--notify' => true])->assertExitCode(0);
 
         Mail::assertSent(AcceptanceReRequestMail::class, function (AcceptanceReRequestMail $mail) {
             $body = $mail->render();
@@ -768,7 +768,7 @@ class RegenerateAcceptancesTest extends TestCase
             $this->heldAsset($holder, $category, $company, 'Laptop '.$number);
         }
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--notify' => true])->assertExitCode(0);
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--notify' => true])->assertExitCode(0);
 
         Mail::assertSent(AcceptanceReRequestMail::class, function (AcceptanceReRequestMail $mail) {
             $body = $mail->render();
@@ -792,7 +792,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => User::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('Created: 1.')
             ->doesntExpectOutput('Notified: 1.')
             ->assertExitCode(0);
@@ -809,7 +809,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => User::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--dry-run' => true, '--notify' => true])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--dry-run' => true, '--notify' => true])
             ->expectsOutput('Nothing was created.')
             ->expectsOutput('Notified: 0.')
             ->assertExitCode(0);
@@ -826,7 +826,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => User::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--notify' => true])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--notify' => true])
             ->expectsOutput('Created: 1.')
             ->expectsOutput('Notified: 0.')
             ->expectsOutput('The following users do not have an email address:')
@@ -849,7 +849,7 @@ class RegenerateAcceptancesTest extends TestCase
             'assigned_type' => User::class,
         ]);
 
-        $this->artisan('snipeit:regenerate-acceptances', ['--notify' => true])
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true, '--notify' => true])
             ->expectsOutput('Notified: 1.')
             ->doesntExpectOutput('The following users do not have an email address:')
             ->assertExitCode(0);
@@ -934,7 +934,7 @@ class RegenerateAcceptancesTest extends TestCase
         // And this one is on the shelf.
         $this->assetIn($assetCategory);
 
-        $this->artisan('snipeit:regenerate-acceptances')
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
             ->expectsOutput('To re-request: 8.')
             ->expectsOutput('  Asset: 3')
             ->expectsOutput('  LicenseSeat: 1')

--- a/tests/Feature/Console/RegenerateAcceptancesTest.php
+++ b/tests/Feature/Console/RegenerateAcceptancesTest.php
@@ -542,7 +542,13 @@ class RegenerateAcceptancesTest extends TestCase
             'declined_at' => null,
             'deleted_at' => null,
         ]);
-        $this->assertSame(1, CheckoutAcceptance::count());
+
+        $expected = [
+            'Accessory #'.$accessory->id.' -> user #'.$holder->id.' qty 1',
+            'Accessory #'.$accessory->id.' -> user #'.$holder->id.' qty 2',
+        ];
+
+        $this->assertSame($expected, $this->acceptanceRows());
     }
 
     public function test_pending_acceptance_with_a_null_qty_covers_one_unit(): void
@@ -632,9 +638,222 @@ class RegenerateAcceptancesTest extends TestCase
             ->assertExitCode(0);
     }
 
-    private function heldAsset(User $holder, Category $category, Company $company, string $name): void
+    public function test_dry_run_creates_nothing(): void
     {
-        Asset::factory()->create([
+        $holder = User::factory()->create();
+        $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--dry-run' => true])
+            ->expectsOutput('To re-request: 1.')
+            ->expectsOutput('Nothing was created.')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseEmpty('checkout_acceptances');
+    }
+
+    public function test_asset_re_request_is_created_with_a_null_qty(): void
+    {
+        $holder = User::factory()->create();
+        $asset = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('Created: 1.')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            ['Asset #'.$asset->id.' -> user #'.$holder->id.' qty null'],
+            $this->acceptanceRows(),
+        );
+    }
+
+    public function test_declined_pair_excluded_from_the_run_creates_nothing(): void
+    {
+        $holder = User::factory()->create();
+        $asset = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $this->acceptanceFor($asset, $holder)->declined()->create();
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--exclude-declined' => true])
+            ->expectsOutput('Created: 0.')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            ['Asset #'.$asset->id.' -> user #'.$holder->id.' qty null declined'],
+            $this->acceptanceRows(),
+        );
+    }
+
+    public function test_re_requested_row_carries_no_alert_recipient(): void
+    {
+        $admin = User::factory()->create();
+        $holder = User::factory()->create();
+        $asset = $this->assetIn($this->acceptanceCategory('asset', ['alert_on_response' => true]), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $this->acceptanceFor($asset, $holder)->accepted()->withAlertingTo($admin)->create();
+
+        $this->artisan('snipeit:regenerate-acceptances')->assertExitCode(0);
+
+        $this->assertNull($this->newestAcceptance()->alert_on_response_id);
+    }
+
+    /**
+     * One realistic install, run for real.
+     *
+     * Every test above proves one rule against one builder. This one proves the five
+     * builders *compose*: that a run over a mixed install creates exactly the rows it
+     * should and no others. It exists because a key-collision bug between the builders
+     * passed every rule test and surfaced only because one fixture happened to hold two
+     * types — rule tests cannot see the seams, so this asserts the created row set.
+     *
+     * Bob is the composition case: one asset he holds is a candidate in its own right
+     * *and* the route to three more (a seat, an accessory and a component).
+     */
+    public function test_a_mixed_install_creates_exactly_the_rows_it_should(): void
+    {
+        $company = Company::factory()->create();
+        $assetCategory = $this->acceptanceCategory('asset');
+        $licenseCategory = $this->acceptanceCategory('license');
+        $accessoryCategory = $this->acceptanceCategory('accessory');
+        $consumableCategory = $this->acceptanceCategory('consumable');
+        $componentCategory = $this->acceptanceCategory('component');
+
+        // Alice holds three types, and one of her three mice is already spoken for.
+        $alice = User::factory()->create();
+        $aliceLaptop = $this->heldAsset($alice, $assetCategory, $company, 'Alice laptop');
+        $mouse = $this->heldAccessory($alice, $accessoryCategory, $company, 'Mouse');
+        $mouse->checkouts()->createMany([
+            ['assigned_to' => $alice->id, 'assigned_type' => User::class],
+            ['assigned_to' => $alice->id, 'assigned_type' => User::class],
+        ]);
+        $toner = $this->heldConsumable($alice, $consumableCategory, $company, 'Toner');
+        $this->acceptanceFor($mouse, $alice)->pending()->create(['qty' => 1]);
+
+        // A fourth mouse sits at a location, which is nobody's to accept.
+        $mouse->checkouts()->create([
+            'assigned_to' => Location::factory()->create()->id,
+            'assigned_type' => Location::class,
+        ]);
+
+        // Bob holds one asset, and it carries a seat, an accessory and a component.
+        $bob = User::factory()->create();
+        $bobLaptop = $this->heldAsset($bob, $assetCategory, $company, 'Bob laptop');
+        $bobSeat = LicenseSeat::factory()->create([
+            'license_id' => License::factory()->create([
+                'name' => 'CAD',
+                'category_id' => $licenseCategory->id,
+                'company_id' => $company->id,
+            ])->id,
+            'asset_id' => $bobLaptop->id,
+            'assigned_to' => null,
+        ]);
+        $keyboard = Accessory::factory()->create([
+            'name' => 'Keyboard',
+            'category_id' => $accessoryCategory->id,
+            'company_id' => $company->id,
+        ]);
+        $keyboard->checkouts()->create([
+            'assigned_to' => $bobLaptop->id,
+            'assigned_type' => Asset::class,
+        ]);
+        $memory = Component::factory()->create([
+            'name' => 'RAM',
+            'category_id' => $componentCategory->id,
+            'company_id' => $company->id,
+        ]);
+        $memory->assets()->attach($bobLaptop->id, ['assigned_qty' => 2, 'created_by' => $bob->id]);
+
+        // Carol declined last time and still holds the asset, so a default run re-asks her.
+        $carol = User::factory()->create();
+        $carolPhone = $this->heldAsset($carol, $assetCategory, $company, 'Carol phone');
+        $this->acceptanceFor($carolPhone, $carol)->declined()->create();
+
+        // Dan is already covered by an in-flight request.
+        $dan = User::factory()->create();
+        $danTablet = $this->heldAsset($dan, $assetCategory, $company, 'Dan tablet');
+        $this->acceptanceFor($danTablet, $dan)->pending()->create();
+
+        // And this one is on the shelf.
+        $this->assetIn($assetCategory);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('To re-request: 8.')
+            ->expectsOutput('  Asset: 3')
+            ->expectsOutput('  LicenseSeat: 1')
+            ->expectsOutput('  Accessory: 2')
+            ->expectsOutput('  Consumable: 1')
+            ->expectsOutput('  Component: 1')
+            ->expectsOutput('Previously declined: 1.')
+            ->expectsOutput('Already covered by a pending request: 1.')
+            ->expectsOutput('Created: 8.')
+            ->assertExitCode(0);
+
+        $expected = [
+            // the eight rows this run created
+            'Asset #'.$aliceLaptop->id.' -> user #'.$alice->id.' qty null',
+            'Accessory #'.$mouse->id.' -> user #'.$alice->id.' qty 2',
+            'Consumable #'.$toner->id.' -> user #'.$alice->id.' qty 1',
+            'Asset #'.$bobLaptop->id.' -> user #'.$bob->id.' qty null',
+            'LicenseSeat #'.$bobSeat->id.' -> user #'.$bob->id.' qty null',
+            'Accessory #'.$keyboard->id.' -> user #'.$bob->id.' qty 1',
+            'Component #'.$memory->id.' -> user #'.$bob->id.' qty 2',
+            'Asset #'.$carolPhone->id.' -> user #'.$carol->id.' qty null',
+            // and the three it left alone
+            'Accessory #'.$mouse->id.' -> user #'.$alice->id.' qty 1',
+            'Asset #'.$carolPhone->id.' -> user #'.$carol->id.' qty null declined',
+            'Asset #'.$danTablet->id.' -> user #'.$dan->id.' qty null',
+        ];
+        sort($expected);
+
+        $this->assertSame($expected, $this->acceptanceRows());
+    }
+
+    /**
+     * Every acceptance row in the database, one readable line each and sorted, so an
+     * assertion states the whole row set rather than an insertion order.
+     *
+     * @return array<int, string>
+     */
+    private function acceptanceRows(): array
+    {
+        $rows = CheckoutAcceptance::query()
+            ->get()
+            ->map(fn (CheckoutAcceptance $acceptance) => sprintf(
+                '%s #%d -> user #%d qty %s%s',
+                class_basename($acceptance->checkoutable_type),
+                $acceptance->checkoutable_id,
+                $acceptance->assigned_to_id,
+                $acceptance->qty ?? 'null',
+                match (true) {
+                    $acceptance->declined_at !== null => ' declined',
+                    $acceptance->accepted_at !== null => ' accepted',
+                    default => '',
+                },
+            ))
+            ->all();
+
+        sort($rows);
+
+        return $rows;
+    }
+
+    private function newestAcceptance(): CheckoutAcceptance
+    {
+        return CheckoutAcceptance::query()->orderByDesc('id')->firstOrFail();
+    }
+
+    private function heldAsset(User $holder, Category $category, Company $company, string $name): Asset
+    {
+        return Asset::factory()->create([
             'name' => $name,
             'model_id' => AssetModel::factory()->create(['category_id' => $category->id]),
             'company_id' => $company->id,
@@ -643,7 +862,7 @@ class RegenerateAcceptancesTest extends TestCase
         ]);
     }
 
-    private function heldLicenseSeat(User $holder, Category $category, Company $company, string $name): void
+    private function heldLicenseSeat(User $holder, Category $category, Company $company, string $name): LicenseSeat
     {
         $license = License::factory()->create([
             'name' => $name,
@@ -651,32 +870,40 @@ class RegenerateAcceptancesTest extends TestCase
             'company_id' => $company->id,
         ]);
 
-        LicenseSeat::factory()->create([
+        return LicenseSeat::factory()->create([
             'license_id' => $license->id,
             'asset_id' => null,
             'assigned_to' => $holder->id,
         ]);
     }
 
-    private function heldAccessory(User $holder, Category $category, Company $company, string $name): void
+    private function heldAccessory(User $holder, Category $category, Company $company, string $name): Accessory
     {
-        Accessory::factory()->create([
+        $accessory = Accessory::factory()->create([
             'name' => $name,
             'category_id' => $category->id,
             'company_id' => $company->id,
-        ])->checkouts()->create([
+        ]);
+
+        $accessory->checkouts()->create([
             'assigned_to' => $holder->id,
             'assigned_type' => User::class,
         ]);
+
+        return $accessory;
     }
 
-    private function heldConsumable(User $holder, Category $category, Company $company, string $name): void
+    private function heldConsumable(User $holder, Category $category, Company $company, string $name): Consumable
     {
-        Consumable::factory()->create([
+        $consumable = Consumable::factory()->create([
             'name' => $name,
             'category_id' => $category->id,
             'company_id' => $company->id,
-        ])->users()->attach($holder->id, ['created_by' => $holder->id]);
+        ]);
+
+        $consumable->users()->attach($holder->id, ['created_by' => $holder->id]);
+
+        return $consumable;
     }
 
     /**
@@ -684,26 +911,30 @@ class RegenerateAcceptancesTest extends TestCase
      * in a category that does not require acceptance — otherwise it becomes a candidate
      * in its own right and the assertions count it.
      */
-    private function heldComponent(User $holder, Category $category, Company $company, string $name): void
+    private function heldComponent(User $holder, Category $category, Company $company, string $name): Component
     {
         $carrier = $this->assetIn(
             Category::factory()->create(['category_type' => 'asset', 'require_acceptance' => false]),
             ['assigned_to' => $holder->id, 'assigned_type' => User::class],
         );
 
-        Component::factory()->create([
+        $component = Component::factory()->create([
             'name' => $name,
             'category_id' => $category->id,
             'company_id' => $company->id,
-        ])->assets()->attach($carrier->id, ['assigned_qty' => 1, 'created_by' => $holder->id]);
+        ]);
+
+        $component->assets()->attach($carrier->id, ['assigned_qty' => 1, 'created_by' => $holder->id]);
+
+        return $component;
     }
 
-    private function acceptanceCategory(string $type): Category
+    private function acceptanceCategory(string $type, array $attributes = []): Category
     {
-        return Category::factory()->create([
+        return Category::factory()->create(array_merge([
             'category_type' => $type,
             'require_acceptance' => true,
-        ]);
+        ], $attributes));
     }
 
     private function assetIn(Category $category, array $attributes = []): Asset

--- a/tests/Feature/Console/RegenerateAcceptancesTest.php
+++ b/tests/Feature/Console/RegenerateAcceptancesTest.php
@@ -1,0 +1,535 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\Accessory;
+use App\Models\Asset;
+use App\Models\AssetModel;
+use App\Models\Category;
+use App\Models\CheckoutAcceptance;
+use App\Models\Company;
+use App\Models\Component;
+use App\Models\Consumable;
+use App\Models\License;
+use App\Models\LicenseSeat;
+use App\Models\Location;
+use App\Models\User;
+use Database\Factories\CheckoutAcceptanceFactory;
+use Illuminate\Database\Eloquent\Model;
+use Tests\TestCase;
+
+class RegenerateAcceptancesTest extends TestCase
+{
+    public function test_asset_assigned_directly_to_a_user_is_a_candidate(): void
+    {
+        $holder = User::factory()->create();
+        $asset = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsTable(
+                ['User', 'Item', 'Type', 'Units held', 'Qty'],
+                [[$holder->present()->fullName, $asset->present()->name, 'Asset', 1, 1]],
+            )
+            ->assertExitCode(0);
+    }
+
+    public function test_asset_assigned_to_another_asset_resolves_to_that_assets_holder(): void
+    {
+        $holder = User::factory()->create();
+        $laptop = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $dock = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $laptop->id,
+            'assigned_type' => Asset::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutputToContain($dock->present()->name)
+            ->assertExitCode(0);
+    }
+
+    public function test_asset_assigned_to_an_unassigned_asset_is_not_a_candidate(): void
+    {
+        $parked = $this->assetIn($this->acceptanceCategory('asset'));
+        $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $parked->id,
+            'assigned_type' => Asset::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
+            ->assertExitCode(0);
+    }
+
+    public function test_asset_assigned_to_a_location_is_not_a_candidate(): void
+    {
+        $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => Location::factory()->create()->id,
+            'assigned_type' => Location::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
+            ->assertExitCode(0);
+    }
+
+    public function test_asset_in_a_category_not_requiring_acceptance_is_not_a_candidate(): void
+    {
+        $category = Category::factory()->create([
+            'category_type' => 'asset',
+            'require_acceptance' => false,
+        ]);
+
+        $this->assetIn($category, [
+            'assigned_to' => User::factory()->create()->id,
+            'assigned_type' => User::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
+            ->assertExitCode(0);
+    }
+
+    /**
+     * `Asset::category()` is a hasOneThrough, so Laravel excludes assets whose AssetModel
+     * is soft-deleted. A live checkout asks `requireAcceptance()`, which reads
+     * `$this->model->category` through a `withTrashed()` belongsTo and creates the
+     * acceptance row anyway — so the builder must reach the category the same way or it
+     * regenerates a smaller set than a checkout creates.
+     */
+    public function test_asset_whose_model_is_soft_deleted_is_still_a_candidate(): void
+    {
+        $holder = User::factory()->create();
+        $model = AssetModel::factory()->create(['category_id' => $this->acceptanceCategory('asset')->id]);
+        $asset = Asset::factory()->create([
+            'model_id' => $model->id,
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+
+        $model->delete();
+
+        $this->assertTrue((bool) $asset->fresh()->requireAcceptance());
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsTable(
+                ['User', 'Item', 'Type', 'Units held', 'Qty'],
+                [[$holder->present()->fullName, $asset->present()->name, 'Asset', 1, 1]],
+            )
+            ->assertExitCode(0);
+    }
+
+    public function test_soft_deleted_holders_are_not_candidates(): void
+    {
+        $holder = User::factory()->create();
+        $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $holder->delete();
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
+            ->assertExitCode(0);
+    }
+
+    public function test_license_seat_attached_only_to_an_asset_resolves_to_the_assets_holder(): void
+    {
+        $holder = User::factory()->create();
+        $laptop = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $license = License::factory()->create(['category_id' => $this->acceptanceCategory('license')->id]);
+        LicenseSeat::factory()->create([
+            'license_id' => $license->id,
+            'asset_id' => $laptop->id,
+            'assigned_to' => null,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutputToContain($holder->present()->fullName)
+            ->assertExitCode(0);
+    }
+
+    public function test_license_seat_carrying_both_columns_yields_one_pair(): void
+    {
+        $holder = User::factory()->create();
+        $carrier = Category::factory()->create(['category_type' => 'asset', 'require_acceptance' => false]);
+        $laptop = $this->assetIn($carrier, [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $license = License::factory()->create(['category_id' => $this->acceptanceCategory('license')->id]);
+        LicenseSeat::factory()->create([
+            'license_id' => $license->id,
+            'asset_id' => $laptop->id,
+            'assigned_to' => $holder->id,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutputToContain('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_license_seat_keys_on_the_assets_current_holder_not_a_stale_assigned_to(): void
+    {
+        $currentHolder = User::factory()->create();
+        $staleHolder = User::factory()->create();
+        $laptop = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $currentHolder->id,
+            'assigned_type' => User::class,
+        ]);
+        $license = License::factory()->create(['category_id' => $this->acceptanceCategory('license')->id]);
+        LicenseSeat::factory()->create([
+            'license_id' => $license->id,
+            'asset_id' => $laptop->id,
+            'assigned_to' => $staleHolder->id,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutputToContain($currentHolder->present()->fullName)
+            ->doesntExpectOutputToContain($staleHolder->present()->fullName)
+            ->assertExitCode(0);
+    }
+
+    public function test_license_seat_assigned_directly_to_a_user_is_a_candidate(): void
+    {
+        $holder = User::factory()->create();
+        $license = License::factory()->create(['category_id' => $this->acceptanceCategory('license')->id]);
+        LicenseSeat::factory()->create([
+            'license_id' => $license->id,
+            'asset_id' => null,
+            'assigned_to' => $holder->id,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutputToContain($holder->present()->fullName)
+            ->assertExitCode(0);
+    }
+
+    public function test_accessory_units_are_counted_per_pivot_row(): void
+    {
+        $holder = User::factory()->create();
+        $accessory = Accessory::factory()->create(['category_id' => $this->acceptanceCategory('accessory')->id]);
+        $accessory->checkouts()->createMany([
+            ['assigned_to' => $holder->id, 'assigned_type' => User::class],
+            ['assigned_to' => $holder->id, 'assigned_type' => User::class],
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsTable(
+                ['User', 'Item', 'Type', 'Units held', 'Qty'],
+                [[$holder->present()->fullName, $accessory->present()->name, 'Accessory', 2, 2]],
+            )
+            ->assertExitCode(0);
+    }
+
+    public function test_accessory_checked_out_to_an_asset_resolves_to_that_assets_holder(): void
+    {
+        $holder = User::factory()->create();
+        $laptop = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $accessory = Accessory::factory()->create(['category_id' => $this->acceptanceCategory('accessory')->id]);
+        $accessory->checkouts()->create(['assigned_to' => $laptop->id, 'assigned_type' => Asset::class]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutputToContain($accessory->present()->name)
+            ->assertExitCode(0);
+    }
+
+    public function test_accessory_checked_out_to_a_location_is_not_a_candidate(): void
+    {
+        $accessory = Accessory::factory()->create(['category_id' => $this->acceptanceCategory('accessory')->id]);
+        $accessory->checkouts()->create([
+            'assigned_to' => Location::factory()->create()->id,
+            'assigned_type' => Location::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
+            ->assertExitCode(0);
+    }
+
+    public function test_consumable_units_are_counted_per_pivot_row(): void
+    {
+        $holder = User::factory()->create();
+        $consumable = Consumable::factory()->create(['category_id' => $this->acceptanceCategory('consumable')->id]);
+        $consumable->users()->attach([$holder->id, $holder->id], ['created_by' => $holder->id]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsTable(
+                ['User', 'Item', 'Type', 'Units held', 'Qty'],
+                [[$holder->present()->fullName, $consumable->present()->name, 'Consumable', 2, 2]],
+            )
+            ->assertExitCode(0);
+    }
+
+    public function test_component_units_sum_assigned_qty_across_the_users_assets(): void
+    {
+        $holder = User::factory()->create();
+        $category = $this->acceptanceCategory('asset');
+        $laptop = $this->assetIn($category, ['assigned_to' => $holder->id, 'assigned_type' => User::class]);
+        $desktop = $this->assetIn($category, ['assigned_to' => $holder->id, 'assigned_type' => User::class]);
+
+        $component = Component::factory()->create(['category_id' => $this->acceptanceCategory('component')->id]);
+        $component->assets()->attach($laptop->id, ['assigned_qty' => 3, 'created_by' => $holder->id]);
+        $component->assets()->attach($desktop->id, ['assigned_qty' => 3, 'created_by' => $holder->id]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsTable(
+                ['User', 'Item', 'Type', 'Units held', 'Qty'],
+                [
+                    [$holder->present()->fullName, $laptop->present()->name, 'Asset', 1, 1],
+                    [$holder->present()->fullName, $desktop->present()->name, 'Asset', 1, 1],
+                    [$holder->present()->fullName, $component->present()->name, 'Component', 6, 6],
+                ],
+            )
+            ->assertExitCode(0);
+    }
+
+    public function test_component_on_an_unassigned_asset_is_not_a_candidate(): void
+    {
+        $parked = $this->assetIn($this->acceptanceCategory('asset'));
+        $component = Component::factory()->create(['category_id' => $this->acceptanceCategory('component')->id]);
+        $component->assets()->attach($parked->id, ['assigned_qty' => 2, 'created_by' => 1]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('No users currently hold items requiring acceptance in that scope.')
+            ->assertExitCode(0);
+    }
+
+    public function test_category_filter_limits_the_candidate_set(): void
+    {
+        $holder = User::factory()->create();
+        $wanted = $this->acceptanceCategory('asset');
+        $unwanted = $this->acceptanceCategory('asset');
+
+        $this->assetIn($wanted, ['assigned_to' => $holder->id, 'assigned_type' => User::class]);
+        $this->assetIn($unwanted, ['assigned_to' => $holder->id, 'assigned_type' => User::class]);
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--category' => [$wanted->id]])
+            ->expectsOutputToContain('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_company_filter_reaches_license_seats_through_the_license(): void
+    {
+        $holder = User::factory()->create();
+        $wanted = Company::factory()->create();
+        $unwanted = Company::factory()->create();
+
+        $category = $this->acceptanceCategory('license');
+
+        foreach ([$wanted, $unwanted] as $company) {
+            $license = License::factory()->create([
+                'category_id' => $category->id,
+                'company_id' => $company->id,
+            ]);
+            LicenseSeat::factory()->create([
+                'license_id' => $license->id,
+                'asset_id' => null,
+                'assigned_to' => $holder->id,
+            ]);
+        }
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--company' => [$wanted->id]])
+            ->expectsOutputToContain('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_pending_acceptance_covering_the_units_held_is_skipped(): void
+    {
+        $holder = User::factory()->create();
+        $asset = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $this->acceptanceFor($asset, $holder)->pending()->create();
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('To re-request: 0.')
+            ->expectsOutput('Already covered by a pending request: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_pair_that_already_accepted_is_re_requested(): void
+    {
+        $holder = User::factory()->create();
+        $asset = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $this->acceptanceFor($asset, $holder)->accepted()->create();
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('To re-request: 1.')
+            ->expectsOutput('Already covered by a pending request: 0.')
+            ->assertExitCode(0);
+    }
+
+    public function test_trashed_acceptance_does_not_count_toward_pending_coverage(): void
+    {
+        $holder = User::factory()->create();
+        $asset = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $this->acceptanceFor($asset, $holder)->pending()->create()->delete();
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_partially_covered_accessory_re_requests_only_the_shortfall(): void
+    {
+        $holder = User::factory()->create();
+        $accessory = Accessory::factory()->create(['category_id' => $this->acceptanceCategory('accessory')->id]);
+        $accessory->checkouts()->createMany([
+            ['assigned_to' => $holder->id, 'assigned_type' => User::class],
+            ['assigned_to' => $holder->id, 'assigned_type' => User::class],
+            ['assigned_to' => $holder->id, 'assigned_type' => User::class],
+        ]);
+        $pending = $this->acceptanceFor($accessory, $holder)->pending()->create(['qty' => 1]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsTable(
+                ['User', 'Item', 'Type', 'Units held', 'Qty'],
+                [[$holder->present()->fullName, $accessory->present()->name, 'Accessory', 3, 2]],
+            )
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('checkout_acceptances', [
+            'id' => $pending->id,
+            'qty' => 1,
+            'accepted_at' => null,
+            'declined_at' => null,
+            'deleted_at' => null,
+        ]);
+        $this->assertSame(1, CheckoutAcceptance::count());
+    }
+
+    public function test_pending_acceptance_with_a_null_qty_covers_one_unit(): void
+    {
+        $holder = User::factory()->create();
+        $accessory = Accessory::factory()->create(['category_id' => $this->acceptanceCategory('accessory')->id]);
+        $accessory->checkouts()->createMany([
+            ['assigned_to' => $holder->id, 'assigned_type' => User::class],
+            ['assigned_to' => $holder->id, 'assigned_type' => User::class],
+        ]);
+        $this->acceptanceFor($accessory, $holder)->pending()->create(['qty' => null]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsTable(
+                ['User', 'Item', 'Type', 'Units held', 'Qty'],
+                [[$holder->present()->fullName, $accessory->present()->name, 'Accessory', 2, 1]],
+            )
+            ->assertExitCode(0);
+    }
+
+    /**
+     * `acceptanceHistory()` deliberately over-fetches — it queries every candidate item id
+     * against every candidate user id, a cross product — so rows belonging to other
+     * holders of the same accessory arrive in the same result set and have to be split
+     * apart in PHP. The other pair's row is worth 5 against this holder's single unit, so
+     * a keying mistake flips this pair to "already covered" instead of shaving a unit off.
+     */
+    public function test_another_pairs_pending_acceptance_does_not_count_toward_this_pairs_coverage(): void
+    {
+        $holder = User::factory()->create();
+        $accessory = Accessory::factory()->create(['category_id' => $this->acceptanceCategory('accessory')->id]);
+        $accessory->checkouts()->create(['assigned_to' => $holder->id, 'assigned_type' => User::class]);
+        $this->acceptanceFor($accessory, User::factory()->create())->pending()->create(['qty' => 5]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsTable(
+                ['User', 'Item', 'Type', 'Units held', 'Qty'],
+                [[$holder->present()->fullName, $accessory->present()->name, 'Accessory', 1, 1]],
+            )
+            ->assertExitCode(0);
+    }
+
+    public function test_pair_that_declined_is_re_requested_by_default(): void
+    {
+        $holder = User::factory()->create();
+        $asset = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $this->acceptanceFor($asset, $holder)->declined()->create();
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('To re-request: 1.')
+            ->expectsOutput('Previously declined: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_pair_that_declined_is_excluded_and_counted_under_exclude_declined(): void
+    {
+        $holder = User::factory()->create();
+        $asset = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $this->acceptanceFor($asset, $holder)->declined()->create();
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--exclude-declined' => true])
+            ->expectsOutput('To re-request: 0.')
+            ->expectsOutput('Previously declined: 1.')
+            ->expectsOutput('Previously declined and excluded: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_a_decline_answered_again_later_is_not_treated_as_declined(): void
+    {
+        $holder = User::factory()->create();
+        $asset = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+        $this->acceptanceFor($asset, $holder)->declined()->create();
+        $this->acceptanceFor($asset, $holder)->accepted()->create();
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--exclude-declined' => true])
+            ->expectsOutput('To re-request: 1.')
+            ->expectsOutput('Previously declined: 0.')
+            ->assertExitCode(0);
+    }
+
+    /**
+     * A CheckoutAcceptance factory already keyed to one (item, user) pair. The action
+     * log the factory would otherwise write is irrelevant to classification, so it is
+     * turned off rather than left to stamp the asset's assignment a second time.
+     */
+    private function acceptanceFor(Model $item, User $user): CheckoutAcceptanceFactory
+    {
+        return CheckoutAcceptance::factory()->withoutActionLog()->state([
+            'checkoutable_type' => $item->getMorphClass(),
+            'checkoutable_id' => $item->getKey(),
+            'assigned_to_id' => $user->id,
+        ]);
+    }
+
+    private function acceptanceCategory(string $type): Category
+    {
+        return Category::factory()->create([
+            'category_type' => $type,
+            'require_acceptance' => true,
+        ]);
+    }
+
+    private function assetIn(Category $category, array $attributes = []): Asset
+    {
+        return Asset::factory()->create(array_merge([
+            'model_id' => AssetModel::factory()->create(['category_id' => $category->id]),
+        ], $attributes));
+    }
+}

--- a/tests/Feature/Console/RegenerateAcceptancesTest.php
+++ b/tests/Feature/Console/RegenerateAcceptancesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Console;
 
+use App\Mail\AcceptanceReRequestMail;
 use App\Models\Accessory;
 use App\Models\Asset;
 use App\Models\AssetModel;
@@ -16,6 +17,7 @@ use App\Models\Location;
 use App\Models\User;
 use Database\Factories\CheckoutAcceptanceFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
 class RegenerateAcceptancesTest extends TestCase
@@ -704,6 +706,106 @@ class RegenerateAcceptancesTest extends TestCase
         $this->artisan('snipeit:regenerate-acceptances')->assertExitCode(0);
 
         $this->assertNull($this->newestAcceptance()->alert_on_response_id);
+    }
+
+    public function test_notify_sends_one_email_per_holder_however_many_rows_they_got(): void
+    {
+        Mail::fake();
+        $company = Company::factory()->create();
+        $alice = User::factory()->create(['email' => 'alice@example.test']);
+        $bob = User::factory()->create(['email' => 'bob@example.test']);
+        $this->heldAsset($alice, $this->acceptanceCategory('asset'), $company, 'Alice laptop');
+        $this->heldAccessory($alice, $this->acceptanceCategory('accessory'), $company, 'Mouse');
+        $this->heldAsset($bob, $this->acceptanceCategory('asset'), $company, 'Bob laptop');
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--notify' => true])
+            ->expectsOutput('Created: 3.')
+            ->expectsOutput('Notified: 2.')
+            ->assertExitCode(0);
+
+        Mail::assertSent(AcceptanceReRequestMail::class, function (AcceptanceReRequestMail $mail) {
+            return $mail->hasTo('alice@example.test')
+                && $mail->itemCount === 2
+                && $mail->hasSubject(trans('mail.acceptance_re_request'))
+                && str_contains($mail->render(), trans_choice('mail.acceptance_re_request_intro', 2, ['count' => 2]));
+        });
+        Mail::assertSent(
+            AcceptanceReRequestMail::class,
+            fn (AcceptanceReRequestMail $mail) => $mail->hasTo('bob@example.test') && $mail->itemCount === 1,
+        );
+        Mail::assertSent(AcceptanceReRequestMail::class, 2);
+    }
+
+    public function test_nothing_is_emailed_without_the_notify_flag(): void
+    {
+        Mail::fake();
+        $holder = User::factory()->create();
+        $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsOutput('Created: 1.')
+            ->doesntExpectOutput('Notified: 1.')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_dry_run_with_notify_emails_nobody(): void
+    {
+        Mail::fake();
+        $holder = User::factory()->create();
+        $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--dry-run' => true, '--notify' => true])
+            ->expectsOutput('Nothing was created.')
+            ->expectsOutput('Notified: 0.')
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_holder_without_an_email_still_gets_their_row_and_is_reported(): void
+    {
+        Mail::fake();
+        $holder = User::factory()->create(['email' => '']);
+        $asset = $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--notify' => true])
+            ->expectsOutput('Created: 1.')
+            ->expectsOutput('Notified: 0.')
+            ->expectsOutput('The following users do not have an email address:')
+            ->expectsTable(['ID', 'Name'], [[$holder->id, $holder->present()->fullName]])
+            ->assertExitCode(0);
+
+        Mail::assertNothingSent();
+        $this->assertSame(
+            ['Asset #'.$asset->id.' -> user #'.$holder->id.' qty null'],
+            $this->acceptanceRows(),
+        );
+    }
+
+    public function test_the_no_email_table_is_not_printed_when_every_holder_has_an_email(): void
+    {
+        Mail::fake();
+        $holder = User::factory()->create(['email' => 'holder@example.test']);
+        $this->assetIn($this->acceptanceCategory('asset'), [
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--notify' => true])
+            ->expectsOutput('Notified: 1.')
+            ->doesntExpectOutput('The following users do not have an email address:')
+            ->assertExitCode(0);
     }
 
     /**

--- a/tests/Feature/Console/RegenerateAcceptancesTest.php
+++ b/tests/Feature/Console/RegenerateAcceptancesTest.php
@@ -18,6 +18,7 @@ use App\Models\User;
 use Database\Factories\CheckoutAcceptanceFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Testing\PendingCommand;
 use Tests\TestCase;
 
 class RegenerateAcceptancesTest extends TestCase
@@ -853,6 +854,198 @@ class RegenerateAcceptancesTest extends TestCase
             ->expectsOutput('Notified: 1.')
             ->doesntExpectOutput('The following users do not have an email address:')
             ->assertExitCode(0);
+    }
+
+    /**
+     * The wizard's prompts, pre-answered in the order `runWizard()` walks them.
+     *
+     * `multiselect()` falls back to a single `choice()` call under test, so each picker
+     * is one `expectsQuestion` taking an array of ids. The two pickers are only asked
+     * when there is something to pick, so a fixture with no company never sees the
+     * company step.
+     *
+     * @param  array<int, int>  $categoryIds
+     * @param  array<int, int>  $companyIds
+     */
+    private function runWizard(
+        array $categoryIds = [],
+        array $companyIds = [],
+        bool $excludeDeclined = false,
+        bool $notify = false,
+        bool $confirm = true,
+    ): PendingCommand {
+        return $this->artisan('snipeit:regenerate-acceptances')
+            ->expectsQuestion('Which categories should this run cover?', $categoryIds)
+            ->expectsQuestion('Which companies should this run cover?', $companyIds)
+            ->expectsConfirmation('Skip holders whose latest response was a decline?', $excludeDeclined ? 'yes' : 'no')
+            ->expectsConfirmation('Email each affected holder?', $notify ? 'yes' : 'no')
+            ->expectsConfirmation('Create these acceptance requests?', $confirm ? 'yes' : 'no');
+    }
+
+    public function test_wizard_creates_the_rows_it_previewed_when_confirmed(): void
+    {
+        $company = Company::factory()->create();
+        $holder = User::factory()->create();
+        $asset = $this->heldAsset($holder, $this->acceptanceCategory('asset'), $company, 'Wizard laptop');
+
+        $this->runWizard()
+            ->expectsOutput('Created: 1.')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            ['Asset #'.$asset->id.' -> user #'.$holder->id.' qty null'],
+            $this->acceptanceRows(),
+        );
+    }
+
+    public function test_wizard_creates_nothing_when_the_operator_aborts(): void
+    {
+        $company = Company::factory()->create();
+        $holder = User::factory()->create();
+        $this->heldAsset($holder, $this->acceptanceCategory('asset'), $company, 'Wizard laptop');
+
+        $this->runWizard(confirm: false)
+            ->expectsOutput('Nothing was created.')
+            ->doesntExpectOutput('Created: 1.')
+            ->assertExitCode(0);
+
+        $this->assertSame([], $this->acceptanceRows());
+    }
+
+    public function test_wizard_sends_nothing_when_the_operator_aborts(): void
+    {
+        Mail::fake();
+        $company = Company::factory()->create();
+        $holder = User::factory()->create(['email' => 'holder@example.test']);
+        $this->heldAsset($holder, $this->acceptanceCategory('asset'), $company, 'Wizard laptop');
+
+        $this->runWizard(notify: true, confirm: false)->assertExitCode(0);
+
+        Mail::assertNothingSent();
+    }
+
+    /**
+     * The preview is a dry run, so a confirmed wizard run scans twice.
+     *
+     * "Nothing was created." is the dry pass's footer and "Created: 1." the real one;
+     * seeing both in a run the operator confirmed is what proves the preview happened
+     * before the rows did.
+     */
+    public function test_wizard_previews_as_a_dry_run_then_creates_for_real(): void
+    {
+        $company = Company::factory()->create();
+        $holder = User::factory()->create();
+        $this->heldAsset($holder, $this->acceptanceCategory('asset'), $company, 'Wizard laptop');
+
+        $this->runWizard()
+            ->expectsOutput('Nothing was created.')
+            ->expectsOutput('Created: 1.')
+            ->assertExitCode(0);
+
+        $this->assertCount(1, $this->acceptanceRows());
+    }
+
+    public function test_wizard_answers_carry_into_the_run(): void
+    {
+        Mail::fake();
+        $company = Company::factory()->create();
+        $holder = User::factory()->create(['email' => 'holder@example.test']);
+        $this->heldAsset($holder, $this->acceptanceCategory('asset'), $company, 'Wizard laptop');
+
+        $this->runWizard(notify: true)
+            ->expectsOutput('Notified: 1.')
+            ->assertExitCode(0);
+
+        Mail::assertSent(AcceptanceReRequestMail::class, 1);
+    }
+
+    public function test_wizard_excludes_decliners_when_the_operator_says_so(): void
+    {
+        $company = Company::factory()->create();
+        $holder = User::factory()->create();
+        $asset = $this->heldAsset($holder, $this->acceptanceCategory('asset'), $company, 'Wizard laptop');
+        $this->acceptanceFor($asset, $holder)->declined()->create();
+
+        $this->runWizard(excludeDeclined: true)
+            ->expectsOutput('Previously declined and excluded: 1.')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            ['Asset #'.$asset->id.' -> user #'.$holder->id.' qty null declined'],
+            $this->acceptanceRows(),
+        );
+    }
+
+    /**
+     * Decision 16's announce-and-skip: a flag answers its step, and the step is not asked.
+     *
+     * Every prompt the wizard could reach is left unanswered here except the final
+     * confirm. If a skipped step were actually asked, it would reach the mocked question
+     * helper and throw rather than silently taking a default.
+     */
+    public function test_wizard_announces_and_skips_every_step_a_flag_answered(): void
+    {
+        Mail::fake();
+        $company = Company::factory()->create();
+        $category = $this->acceptanceCategory('asset');
+        $holder = User::factory()->create(['email' => 'holder@example.test']);
+        $this->heldAsset($holder, $category, $company, 'Wizard laptop');
+
+        $this->artisan('snipeit:regenerate-acceptances', [
+            '--category' => [$category->id],
+            '--company' => [$company->id],
+            '--exclude-declined' => true,
+            '--notify' => true,
+        ])
+            ->expectsConfirmation('Create these acceptance requests?', 'yes')
+            ->expectsOutput('--category passed — skipping')
+            ->expectsOutput('--company passed — skipping')
+            ->expectsOutput('--exclude-declined passed — skipping')
+            ->expectsOutput('--notify passed — skipping')
+            ->expectsOutput('Notified: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_interactive_dry_run_stops_at_the_preview_without_confirming(): void
+    {
+        $company = Company::factory()->create();
+        $holder = User::factory()->create();
+        $this->heldAsset($holder, $this->acceptanceCategory('asset'), $company, 'Wizard laptop');
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--dry-run' => true])
+            ->expectsQuestion('Which categories should this run cover?', [])
+            ->expectsQuestion('Which companies should this run cover?', [])
+            ->expectsConfirmation('Skip holders whose latest response was a decline?', 'no')
+            ->expectsConfirmation('Email each affected holder?', 'no')
+            ->expectsOutput('Nothing was created.')
+            ->assertExitCode(0);
+
+        $this->assertSame([], $this->acceptanceRows());
+    }
+
+    /**
+     * Decision C parity: a --no-interaction run is slice 3's run, unchanged.
+     *
+     * The wizard never starts, so no prompt is pre-answered here; reaching one would
+     * throw. The flag defaults are the ones that applied before the wizard existed.
+     */
+    public function test_no_interaction_run_behaves_exactly_as_it_did_before_the_wizard(): void
+    {
+        Mail::fake();
+        $company = Company::factory()->create();
+        $holder = User::factory()->create(['email' => 'holder@example.test']);
+        $asset = $this->heldAsset($holder, $this->acceptanceCategory('asset'), $company, 'Wizard laptop');
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--no-interaction' => true])
+            ->expectsOutput('Created: 1.')
+            ->doesntExpectOutput('Notified: 1.')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            ['Asset #'.$asset->id.' -> user #'.$holder->id.' qty null'],
+            $this->acceptanceRows(),
+        );
+        Mail::assertNothingSent();
     }
 
     /**

--- a/tests/Feature/Console/RegenerateAcceptancesTest.php
+++ b/tests/Feature/Console/RegenerateAcceptancesTest.php
@@ -306,43 +306,171 @@ class RegenerateAcceptancesTest extends TestCase
             ->assertExitCode(0);
     }
 
-    public function test_category_filter_limits_the_candidate_set(): void
+    /**
+     * Each builder names its own category path — `model.category` for assets,
+     * `license.category` for seats, `category` for the other three — and its own
+     * company column, so both filters are pinned per type rather than once.
+     */
+    public function test_assets_can_be_filtered_by_category(): void
     {
         $holder = User::factory()->create();
         $wanted = $this->acceptanceCategory('asset');
-        $unwanted = $this->acceptanceCategory('asset');
 
-        $this->assetIn($wanted, ['assigned_to' => $holder->id, 'assigned_type' => User::class]);
-        $this->assetIn($unwanted, ['assigned_to' => $holder->id, 'assigned_type' => User::class]);
+        $this->heldAsset($holder, $wanted, Company::factory()->create(), 'In scope asset');
+        $this->heldAsset($holder, $this->acceptanceCategory('asset'), Company::factory()->create(), 'Out of scope asset');
 
         $this->artisan('snipeit:regenerate-acceptances', ['--category' => [$wanted->id]])
-            ->expectsOutputToContain('To re-request: 1.')
+            ->expectsOutputToContain('In scope asset')
+            ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
     }
 
-    public function test_company_filter_reaches_license_seats_through_the_license(): void
+    public function test_assets_can_be_filtered_by_company(): void
     {
         $holder = User::factory()->create();
+        $category = $this->acceptanceCategory('asset');
         $wanted = Company::factory()->create();
-        $unwanted = Company::factory()->create();
 
-        $category = $this->acceptanceCategory('license');
-
-        foreach ([$wanted, $unwanted] as $company) {
-            $license = License::factory()->create([
-                'category_id' => $category->id,
-                'company_id' => $company->id,
-            ]);
-            LicenseSeat::factory()->create([
-                'license_id' => $license->id,
-                'asset_id' => null,
-                'assigned_to' => $holder->id,
-            ]);
-        }
+        $this->heldAsset($holder, $category, $wanted, 'In scope asset');
+        $this->heldAsset($holder, $category, Company::factory()->create(), 'Out of scope asset');
 
         $this->artisan('snipeit:regenerate-acceptances', ['--company' => [$wanted->id]])
-            ->expectsOutputToContain('To re-request: 1.')
+            ->expectsOutputToContain('In scope asset')
+            ->expectsOutput('To re-request: 1.')
             ->assertExitCode(0);
+    }
+
+    public function test_license_seats_can_be_filtered_by_category(): void
+    {
+        $holder = User::factory()->create();
+        $wanted = $this->acceptanceCategory('license');
+
+        $this->heldLicenseSeat($holder, $wanted, Company::factory()->create(), 'In scope licence');
+        $this->heldLicenseSeat($holder, $this->acceptanceCategory('license'), Company::factory()->create(), 'Out of scope licence');
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--category' => [$wanted->id]])
+            ->expectsOutputToContain('In scope licence')
+            ->expectsOutput('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    /**
+     * `license_seats` has no `company_id` column, so this one hops through the license.
+     */
+    public function test_license_seats_can_be_filtered_by_company(): void
+    {
+        $holder = User::factory()->create();
+        $category = $this->acceptanceCategory('license');
+        $wanted = Company::factory()->create();
+
+        $this->heldLicenseSeat($holder, $category, $wanted, 'In scope licence');
+        $this->heldLicenseSeat($holder, $category, Company::factory()->create(), 'Out of scope licence');
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--company' => [$wanted->id]])
+            ->expectsOutputToContain('In scope licence')
+            ->expectsOutput('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_accessories_can_be_filtered_by_category(): void
+    {
+        $holder = User::factory()->create();
+        $wanted = $this->acceptanceCategory('accessory');
+
+        $this->heldAccessory($holder, $wanted, Company::factory()->create(), 'In scope accessory');
+        $this->heldAccessory($holder, $this->acceptanceCategory('accessory'), Company::factory()->create(), 'Out of scope accessory');
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--category' => [$wanted->id]])
+            ->expectsOutputToContain('In scope accessory')
+            ->expectsOutput('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_accessories_can_be_filtered_by_company(): void
+    {
+        $holder = User::factory()->create();
+        $category = $this->acceptanceCategory('accessory');
+        $wanted = Company::factory()->create();
+
+        $this->heldAccessory($holder, $category, $wanted, 'In scope accessory');
+        $this->heldAccessory($holder, $category, Company::factory()->create(), 'Out of scope accessory');
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--company' => [$wanted->id]])
+            ->expectsOutputToContain('In scope accessory')
+            ->expectsOutput('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_consumables_can_be_filtered_by_category(): void
+    {
+        $holder = User::factory()->create();
+        $wanted = $this->acceptanceCategory('consumable');
+
+        $this->heldConsumable($holder, $wanted, Company::factory()->create(), 'In scope consumable');
+        $this->heldConsumable($holder, $this->acceptanceCategory('consumable'), Company::factory()->create(), 'Out of scope consumable');
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--category' => [$wanted->id]])
+            ->expectsOutputToContain('In scope consumable')
+            ->expectsOutput('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_consumables_can_be_filtered_by_company(): void
+    {
+        $holder = User::factory()->create();
+        $category = $this->acceptanceCategory('consumable');
+        $wanted = Company::factory()->create();
+
+        $this->heldConsumable($holder, $category, $wanted, 'In scope consumable');
+        $this->heldConsumable($holder, $category, Company::factory()->create(), 'Out of scope consumable');
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--company' => [$wanted->id]])
+            ->expectsOutputToContain('In scope consumable')
+            ->expectsOutput('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_components_can_be_filtered_by_category(): void
+    {
+        $holder = User::factory()->create();
+        $wanted = $this->acceptanceCategory('component');
+
+        $this->heldComponent($holder, $wanted, Company::factory()->create(), 'In scope component');
+        $this->heldComponent($holder, $this->acceptanceCategory('component'), Company::factory()->create(), 'Out of scope component');
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--category' => [$wanted->id]])
+            ->expectsOutputToContain('In scope component')
+            ->expectsOutput('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    public function test_components_can_be_filtered_by_company(): void
+    {
+        $holder = User::factory()->create();
+        $category = $this->acceptanceCategory('component');
+        $wanted = Company::factory()->create();
+
+        $this->heldComponent($holder, $category, $wanted, 'In scope component');
+        $this->heldComponent($holder, $category, Company::factory()->create(), 'Out of scope component');
+
+        $this->artisan('snipeit:regenerate-acceptances', ['--company' => [$wanted->id]])
+            ->expectsOutputToContain('In scope component')
+            ->expectsOutput('To re-request: 1.')
+            ->assertExitCode(0);
+    }
+
+    /**
+     * A CheckoutAcceptance factory already keyed to one (item, user) pair. The action
+     * log the factory would otherwise write is irrelevant to classification, so it is
+     * turned off rather than left to stamp the asset's assignment a second time.
+     */
+    private function acceptanceFor(Model $item, User $user): CheckoutAcceptanceFactory
+    {
+        return CheckoutAcceptance::factory()->withoutActionLog()->state([
+            'checkoutable_type' => $item->getMorphClass(),
+            'checkoutable_id' => $item->getKey(),
+            'assigned_to_id' => $user->id,
+        ]);
     }
 
     public function test_pending_acceptance_covering_the_units_held_is_skipped(): void
@@ -504,18 +632,70 @@ class RegenerateAcceptancesTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /**
-     * A CheckoutAcceptance factory already keyed to one (item, user) pair. The action
-     * log the factory would otherwise write is irrelevant to classification, so it is
-     * turned off rather than left to stamp the asset's assignment a second time.
-     */
-    private function acceptanceFor(Model $item, User $user): CheckoutAcceptanceFactory
+    private function heldAsset(User $holder, Category $category, Company $company, string $name): void
     {
-        return CheckoutAcceptance::factory()->withoutActionLog()->state([
-            'checkoutable_type' => $item->getMorphClass(),
-            'checkoutable_id' => $item->getKey(),
-            'assigned_to_id' => $user->id,
+        Asset::factory()->create([
+            'name' => $name,
+            'model_id' => AssetModel::factory()->create(['category_id' => $category->id]),
+            'company_id' => $company->id,
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
         ]);
+    }
+
+    private function heldLicenseSeat(User $holder, Category $category, Company $company, string $name): void
+    {
+        $license = License::factory()->create([
+            'name' => $name,
+            'category_id' => $category->id,
+            'company_id' => $company->id,
+        ]);
+
+        LicenseSeat::factory()->create([
+            'license_id' => $license->id,
+            'asset_id' => null,
+            'assigned_to' => $holder->id,
+        ]);
+    }
+
+    private function heldAccessory(User $holder, Category $category, Company $company, string $name): void
+    {
+        Accessory::factory()->create([
+            'name' => $name,
+            'category_id' => $category->id,
+            'company_id' => $company->id,
+        ])->checkouts()->create([
+            'assigned_to' => $holder->id,
+            'assigned_type' => User::class,
+        ]);
+    }
+
+    private function heldConsumable(User $holder, Category $category, Company $company, string $name): void
+    {
+        Consumable::factory()->create([
+            'name' => $name,
+            'category_id' => $category->id,
+            'company_id' => $company->id,
+        ])->users()->attach($holder->id, ['created_by' => $holder->id]);
+    }
+
+    /**
+     * A component's holder is always reached through an asset, so the carrier asset goes
+     * in a category that does not require acceptance — otherwise it becomes a candidate
+     * in its own right and the assertions count it.
+     */
+    private function heldComponent(User $holder, Category $category, Company $company, string $name): void
+    {
+        $carrier = $this->assetIn(
+            Category::factory()->create(['category_type' => 'asset', 'require_acceptance' => false]),
+            ['assigned_to' => $holder->id, 'assigned_type' => User::class],
+        );
+
+        Component::factory()->create([
+            'name' => $name,
+            'category_id' => $category->id,
+            'company_id' => $company->id,
+        ])->assets()->attach($carrier->id, ['assigned_qty' => 1, 'created_by' => $holder->id]);
     }
 
     private function acceptanceCategory(string $type): Category


### PR DESCRIPTION
This PR introduces the ability to regenerate checkout acceptances for items that are currently checked out to them.

---

This is facilitated through a new artisan command, `snipeit:regenerate-acceptances`, that can be called with flags or walked through via a wizard.

The pool of potential candidates is queried from current assignments for categories that require acceptance at the time the command is run. Meaning if a checkout happened for a category that did not require acceptance, then the category was updated to require acceptance, and later the command was run then that checkout would be included.

In addition to assets, license seats, accessories, and consumables, users that have items checked out to items they hold are included. For example, components assigned to an asset that a user holds will be included if they require acceptance.

This PR is focused on acceptances that were responded to either by accepting or declining so *pending* acceptances are not included but declined acceptances where the user still holds the item are included by default. They can be skipped via the wizard or the `--exclude-declined` flag. The handling of pending acceptances is not included because it involves a little bit more work around if we should re-up the existing row or supersede it, etc.

The command is aware of quantity for things like accessories. If someone has 3 of an accessory across 2 checkouts where they didn't accept 2 of them then the command will generate a new acceptance with a quantity of 1.

Importantly, the new checkout acceptances do not include the previous `alert_on_response_id`.

The flags that can be passed:
- `--category` (can be comma separated)
- `--company` (can be comma separated)
- `--dry-run`
- `--exclude-declined`
- `--notify`
- `--no-interaction`

One email is sent per user containing all of the items that require re-acceptance. The email is basic but can be improve upon later.

---

Here are some screenshots of the wizard. 

<img width="798" height="312" alt="image" src="https://github.com/user-attachments/assets/bd20179c-7ded-4fdd-9e15-6223074ecd16" />

<img width="832" height="362" alt="image" src="https://github.com/user-attachments/assets/2d0d6ca0-d9f7-48a9-bb41-237c1672f24b" />

> As you can see with the categories selection, `prompts` hardcodes "None" if nothing is selected but in our case that means "all" so there is help text under it to explain. (not ideal)

<img width="838" height="170" alt="image" src="https://github.com/user-attachments/assets/67197805-5996-4e03-ade9-1a2c42ccded9" />

<img width="852" height="106" alt="image" src="https://github.com/user-attachments/assets/95796b25-40e8-4b77-bc83-d86c71e94b17" />

<img width="1548" height="1154" alt="image" src="https://github.com/user-attachments/assets/650b8502-4218-4073-a1f7-0706da8c9be4" />

<img width="1508" height="1294" alt="image" src="https://github.com/user-attachments/assets/7e577c7e-e1dc-4a52-9221-7e3c0117fc15" />

---

The mail received is simple for now.
<img width="1966" height="1258" alt="image" src="https://github.com/user-attachments/assets/5f87c849-ddeb-445c-ad70-9183701e4280" />


---

AI Disclosure: I used Claude Code to help investigate code paths as well as write most of the code.

---

Fixes #19080
